### PR TITLE
[4.0] [ConstraintSolver] Prefer same name class properties found on subclass over superclass

### DIFF
--- a/test/Sema/Inputs/rdar32973206_a.swift
+++ b/test/Sema/Inputs/rdar32973206_a.swift
@@ -1,0 +1,8 @@
+public class A {
+}
+
+public class B : A {
+}
+
+public class C : B {
+}

--- a/test/Sema/Inputs/rdar32973206_b.swift
+++ b/test/Sema/Inputs/rdar32973206_b.swift
@@ -1,0 +1,5 @@
+import rdar32973206_a
+
+public extension A {
+  public class var foo: Int { get { return 42 } }
+}

--- a/test/Sema/Inputs/rdar32973206_c.swift
+++ b/test/Sema/Inputs/rdar32973206_c.swift
@@ -1,0 +1,5 @@
+import rdar32973206_a
+
+public extension B {
+  public class var foo: Int { get { return 0 } }
+}

--- a/test/Sema/subclass_property_import.swift
+++ b/test/Sema/subclass_property_import.swift
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t/rdar32973206_a.swiftmodule %S/Inputs/rdar32973206_a.swift
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/rdar32973206_b.swiftmodule %S/Inputs/rdar32973206_b.swift
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/rdar32973206_c.swiftmodule %S/Inputs/rdar32973206_c.swift
+// RUN: %target-swift-frontend -I %t -emit-sil -verify %s | %FileCheck %s
+
+import rdar32973206_a
+import rdar32973206_b
+import rdar32973206_c
+
+// CHECK: A.foo
+let _ = A.foo
+
+// CHECK: B.foo
+let _ = B.foo
+
+// CHECK: B.foo
+let _ = C.foo


### PR DESCRIPTION
* Description: If class property with the same name has been found on both subclass and superclass,
let's always prefer subclass with all else equal, because subclass property
could only be found if requested directly.

* Origination: If different classes in the inheritance hierarchy have class properties with the same name, such properties are impossible to refer to, and are considered ambiguous because lookup happens over whole type hierarchy. This patch prefers subclass properties over superclass properties with the same name to resolve such ambiguity.

* Risk: Low.

* Tested: Added new tests, Swift CI.

* Reviewed by: Mark Lacey, Jordan Rose.

* Resolves: rdar://problem/32973206
(cherry picked from commit 96c4bcd411c23ee021537f97506e9cedad6958ed)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
