### PR TITLE
[4.0] [Serialization] Recover from ObjC protocols changing inheritance

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 346; // Last change: dependency types for enums
+const uint16_t VERSION_MINOR = 347; // Last change: count inherited conformances
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -1147,10 +1147,11 @@ namespace decls_block {
     DeclContextIDField, // the decl that provided this conformance
     BCVBR<5>, // value mapping count
     BCVBR<5>, // type mapping count
+    BCVBR<5>, // requirement signature conformance count
     BCArray<DeclIDField>
     // The array contains archetype-value pairs, then type declarations.
-    // Inherited conformances follow, then the substitution records for the
-    // associated types.
+    // Requirement signature conformances follow, then the substitution records
+    // for the associated types.
   >;
 
   using SpecializedProtocolConformanceLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1340,6 +1340,9 @@ void Serializer::writeNormalConformance(
     return false;
   });
 
+  unsigned numSignatureConformances =
+      conformance->getSignatureConformances().size();
+
   unsigned abbrCode
     = DeclTypeAbbrCodes[NormalProtocolConformanceLayout::Code];
   auto ownerID = addDeclContextRef(conformance->getDeclContext());
@@ -1347,6 +1350,7 @@ void Serializer::writeNormalConformance(
                                               addDeclRef(protocol), ownerID,
                                               numValueWitnesses,
                                               numTypeWitnesses,
+                                              numSignatureConformances,
                                               data);
 
   // Write requirement signature conformances.

--- a/test/Serialization/Recovery/Inputs/custom-modules/ProtocolInheritance.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/ProtocolInheritance.h
@@ -1,0 +1,42 @@
+@protocol Order2_ConsistentBaseProto
+- (void)consistent;
+@end
+
+@protocol Order4_ConsistentBaseProto
+- (void)consistent;
+@end
+
+@protocol Order1_FickleBaseProto
+- (void)fickle;
+@optional
+- (void)extraFickle;
+@end
+
+@protocol Order3_FickleBaseProto
+- (void)fickle;
+@optional
+- (void)extraFickle;
+@end
+
+@protocol Order5_FickleBaseProto
+- (void)fickle;
+@optional
+- (void)extraFickle;
+@end
+
+// The actual order here is determined by the protocol names.
+#if EXTRA_PROTOCOL_FIRST
+@protocol SubProto <Order1_FickleBaseProto, Order2_ConsistentBaseProto, Order4_ConsistentBaseProto>
+@end
+#elif EXTRA_PROTOCOL_MIDDLE
+@protocol SubProto <Order2_ConsistentBaseProto, Order3_FickleBaseProto, Order4_ConsistentBaseProto>
+@end
+#elif EXTRA_PROTOCOL_LAST
+@protocol SubProto <Order2_ConsistentBaseProto, Order4_ConsistentBaseProto, Order5_FickleBaseProto>
+@end
+#elif NO_EXTRA_PROTOCOLS
+@protocol SubProto <Order2_ConsistentBaseProto, Order4_ConsistentBaseProto>
+@end
+#else
+# error "Missing -D flag"
+#endif

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,4 +1,5 @@
 module Overrides { header "Overrides.h" }
+module ProtocolInheritance { header "ProtocolInheritance.h" }
 module Typedefs { header "Typedefs.h" }
 module TypeRemovalObjC { header "TypeRemovalObjC.h" }
 module Types { header "Types.h" }

--- a/test/Serialization/Recovery/protocol-inheritance.swift
+++ b/test/Serialization/Recovery/protocol-inheritance.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -Xcc -DNO_EXTRA_PROTOCOLS %s
+// RUN: %target-swift-frontend -typecheck -DTEST -Xcc -DNO_EXTRA_PROTOCOLS -I %t -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -DTEST -Xcc -DEXTRA_PROTOCOL_FIRST -I %t -I %S/Inputs/custom-modules %s -o /dev/null
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -Xcc -DEXTRA_PROTOCOL_FIRST %s
+// RUN: %target-swift-frontend -typecheck -DTEST -Xcc -DEXTRA_PROTOCOL_FIRST -I %t -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -DTEST -Xcc -DNO_EXTRA_PROTOCOLS -I %t -I %S/Inputs/custom-modules %s -o /dev/null
+
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -Xcc -DNO_EXTRA_PROTOCOLS %s
+// RUN: %target-swift-frontend -typecheck -DTEST -Xcc -DNO_EXTRA_PROTOCOLS -I %t -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -DTEST -Xcc -DEXTRA_PROTOCOL_MIDDLE -I %t -I %S/Inputs/custom-modules %s -o /dev/null
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -Xcc -DEXTRA_PROTOCOL_MIDDLE %s
+// RUN: %target-swift-frontend -typecheck -DTEST -Xcc -DEXTRA_PROTOCOL_MIDDLE -I %t -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -DTEST -Xcc -DNO_EXTRA_PROTOCOLS -I %t -I %S/Inputs/custom-modules %s -o /dev/null
+
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -Xcc -DNO_EXTRA_PROTOCOLS %s
+// RUN: %target-swift-frontend -typecheck -DTEST -Xcc -DNO_EXTRA_PROTOCOLS -I %t -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -DTEST -Xcc -DEXTRA_PROTOCOL_LAST -I %t -I %S/Inputs/custom-modules %s -o /dev/null
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -Xcc -DEXTRA_PROTOCOL_LAST %s
+// RUN: %target-swift-frontend -typecheck -DTEST -Xcc -DEXTRA_PROTOCOL_LAST -I %t -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-ir -DTEST -Xcc -DNO_EXTRA_PROTOCOLS -I %t -I %S/Inputs/custom-modules %s -o /dev/null
+
+
+// REQUIRES: objc_interop
+
+#if TEST
+
+import Lib
+import ProtocolInheritance
+
+func useSubProto<T: SubProto>(_: T) {}
+func useConsistentProto<T: Order2_ConsistentBaseProto>(_: T) {}
+func useFickleProto<T: Order1_FickleBaseProto>(_: T) {}
+
+func test(obj: Impl) {
+  useConsistentProto(obj)
+  useFickleProto(obj)
+  useSubProto(obj)
+}
+
+protocol ForceDeserializationProto: SubProto {}
+extension Impl: ForceDeserializationProto {}
+
+func test(obj: PartialImpl) {
+  useConsistentProto(obj)
+  useSubProto(obj)
+}
+
+extension PartialImpl: ForceDeserializationProto {}
+
+#else // TEST
+
+import ProtocolInheritance
+
+open class Impl: SubProto {
+  public func consistent() {}
+}
+
+extension Impl: Order1_FickleBaseProto, Order3_FickleBaseProto, Order5_FickleBaseProto {
+  public func fickle() {}
+}
+
+open class PartialImpl: SubProto {
+  public func consistent() {}
+  public func fickle() {}
+}
+
+
+#endif // TEST


### PR DESCRIPTION
- **Explanation**: When there's an Objective-C protocol that adopts other protocols, the other protocols become part of the requirement signature. If that can change, Swift conformances to that protocol will get very confused when it comes time to deserialize the conformances that satisfy the requirement signature. This commit allows the Swift compiler to get past such changes…which, for the record, are not safe in Objective-C either, but shouldn't cause crashes.
- **Scope**: Affects Objective-C protocols that inherit other protocols.
- **Issue**: rdar://problem/33356098
- **Reviewed by**: @DougGregor 
- **Risk**: Medium-low. Conformances do get serialized and deserialized plenty, but deserialized conformances to Objective-C aren't actually used for that much.
- **Testing**: Added regression tests, verified that the original test case now passes.