### PR TITLE
[swift-4.0-branch][stdlib] Implement BinaryInteger.words

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2744,25 +2744,20 @@ ${assignmentOperatorComment(x.operator, True)}
     public typealias Indices = CountableRange<Int>
     public typealias SubSequence = BidirectionalSlice<${Self}.Words>
 
-    public var _value: ${Self}
+    var _value: ${Self}
 
-    @_transparent
     public init(_ value: ${Self}) {
       self._value = value
     }
 
-    @_transparent
     public var count: Int {
       return (${bits} + ${word_bits} - 1) / ${word_bits}
     }
 
-    @_transparent
     public var startIndex: Int { return 0 }
 
-    @_transparent
     public var endIndex: Int { return count }
 
-    @_transparent
     public var indices: Indices { return startIndex ..< endIndex }
 
     @_transparent
@@ -2772,7 +2767,6 @@ ${assignmentOperatorComment(x.operator, True)}
     public func index(before i: Int) -> Int { return i - 1 }
 
     public subscript(position: Int) -> UInt {
-      @_transparent
       get {
         _precondition(position >= 0, "Negative word index")
         _precondition(position < endIndex, "Word index out of range")

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2738,7 +2738,6 @@ ${assignmentOperatorComment(x.operator, True)}
       )._lowWord._value)
   }
 
-% if Self == 'UInt' or (bits > word_bits and not signed):
   // FIXME should be RandomAccessCollection
   public struct Words : BidirectionalCollection {
     public typealias Indices = CountableRange<Int>
@@ -2781,21 +2780,6 @@ ${assignmentOperatorComment(x.operator, True)}
   public var words: Words {
     return Words(self)
   }
-% elif bits > word_bits:
-  public typealias Words = ${OtherSelf}.Words
-
-  @_transparent
-  public var words: Words {
-    return Words(${OtherSelf}(self._value))
-  }
-% else:
-  public typealias Words = UInt.Words
-
-  @_transparent
-  public var words: Words {
-    return Words(self._lowWord)
-  }
-% end
 
   @_transparent
   public // transparent

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1440,7 +1440,7 @@ public protocol BinaryInteger :
   var words: Words { get }
 
   /// The least significant word in this value's binary representation.
-  var _lowUWord: UInt { get }
+  var _lowWord: UInt { get }
 
   /// The number of bits in the current binary representation of this value.
   ///
@@ -1538,7 +1538,7 @@ extension BinaryInteger {
   }
 
   @_transparent
-  public var _lowUWord: UInt {
+  public var _lowWord: UInt {
     var it = words.makeIterator()
     return it.next() ?? 0
   }
@@ -2261,13 +2261,13 @@ ${unsafeOperationComment(x.operator)}
   @_transparent
   public init<T : BinaryInteger>(extendingOrTruncating source: T) {
     if Self.bitWidth <= ${word_bits} || source.bitWidth <= ${word_bits} {
-      self = Self.init(_truncatingBits: source._lowUWord)
+      self = Self.init(_truncatingBits: source._lowWord)
     }
     else {
       let neg = source < (0 as T)
       var result: Self = neg ? ~0 : 0
       var shift: Self = 0
-      let width = Self(_truncatingBits: Self.bitWidth._lowUWord)
+      let width = Self(_truncatingBits: Self.bitWidth._lowWord)
       for word in source.words {
         guard shift < width else { break }
         // masking shift is OK here because we have already ensured
@@ -2719,7 +2719,7 @@ ${assignmentOperatorComment(x.operator, True)}
     return Int(
       ${Self}(
         Builtin.int_ctlz_Int${bits}(self._value, false._value)
-      )._lowUWord._value)
+      )._lowWord._value)
   }
 
   @_transparent
@@ -2727,7 +2727,7 @@ ${assignmentOperatorComment(x.operator, True)}
     return Int(
       ${Self}(
         Builtin.int_cttz_Int${bits}(self._value, false._value)
-      )._lowUWord._value)
+      )._lowWord._value)
   }
 
   @_transparent
@@ -2735,7 +2735,7 @@ ${assignmentOperatorComment(x.operator, True)}
     return Int(
       ${Self}(
         Builtin.int_ctpop_Int${bits}(self._value)
-      )._lowUWord._value)
+      )._lowWord._value)
   }
 
 % if Self == 'UInt' or (bits > word_bits and not signed):
@@ -2778,7 +2778,7 @@ ${assignmentOperatorComment(x.operator, True)}
         _precondition(position < endIndex, "Word index out of range")
         let shift = UInt(position._value) &* ${word_bits}
         _sanityCheck(shift < UInt(_value.bitWidth._value))
-        return (_value &>> ${Self}(_truncatingBits: shift))._lowUWord
+        return (_value &>> ${Self}(_truncatingBits: shift))._lowWord
       }
     }
   }
@@ -2799,13 +2799,13 @@ ${assignmentOperatorComment(x.operator, True)}
 
   @_transparent
   public var words: Words {
-    return Words(self._lowUWord)
+    return Words(self._lowWord)
   }
 % end
 
   @_transparent
   public // transparent
-  var _lowUWord: UInt {
+  var _lowWord: UInt {
     % truncOrExt = z + 'ext' if bits <= word_bits else 'trunc'
     return UInt(
       Builtin.${truncOrExt}OrBitCast_Int${bits}_Int${word_bits}(_value)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1426,26 +1426,21 @@ public protocol BinaryInteger :
   /// - Parameter source: An integer to convert to this type.
   init<T : BinaryInteger>(clamping source: T)
 
-  /// Returns the n-th word, counting from the least significant to most
-  /// significant, of this value's binary representation.
-  ///
-  /// The `_word(at:)` method returns negative values in two's complement
-  /// representation, regardless of a type's underlying implementation. If `n`
-  /// is greater than the number of words in this value's current
-  /// representation, the result is `0` for positive numbers and `~0` for
-  /// negative numbers.
-  ///
-  /// - Parameter n: The word to return, counting from the least significant to
-  ///   most significant. `n` must be greater than or equal to zero.
-  /// - Returns: An word-sized, unsigned integer with the bit pattern of the
-  ///   n-th word of this value.
-  func _word(at n: Int) -> UInt
-
-  // FIXME(integers): add doc comments
-  // FIXME: Should be `Words : Collection where Words.Iterator.Element == UInt`
+  // FIXME: Should be `Words : Collection where Words.Element == UInt`
   // See <rdar://problem/31798916> for why it isn't.
-  associatedtype Words
+  /// A type that represents the words of a binary integer. 
+  /// Must implement the `Collection` protocol with an `UInt` element type.
+  associatedtype Words : Sequence where Words.Element == UInt
+
+  /// Returns a collection containing the words of this value's binary
+  /// representation, in order from the least significant to most significant.
+  ///
+  /// Negative values are returned in two's complement representation,
+  /// regardless of the type's underlying implementation.
   var words: Words { get }
+
+  /// The least significant word in this value's binary representation.
+  var _lowUWord: UInt { get }
 
   /// The number of bits in the current binary representation of this value.
   ///
@@ -1542,13 +1537,10 @@ extension BinaryInteger {
     return (self > (0 as Self) ? 1 : 0) - (self < (0 as Self) ? 1 : 0)
   }
 
-  /// The number of words used for the current binary representation of this
-  /// value.
-  ///
-  /// This property is a constant for instances of fixed-width integer types.
   @_transparent
-  public var _countRepresentedWords: Int {
-    return (self.bitWidth + ${word_bits} - 1) / ${word_bits}
+  public var _lowUWord: UInt {
+    var it = words.makeIterator()
+    return it.next() ?? 0
   }
 
   public func quotientAndRemainder(dividingBy rhs: Self)
@@ -1885,19 +1877,6 @@ extension BinaryInteger {
 %   end
 }
 #endif
-
-extension BinaryInteger {
-  // FIXME(integers): inefficient. Should get rid of _word(at:) and
-  // _countRepresentedWords, and make `words` the basic operation.
-  public var words: [UInt] {
-    var result = [UInt]()
-    result.reserveCapacity(_countRepresentedWords)
-    for i in 0..<self._countRepresentedWords {
-      result.append(_word(at: i))
-    }
-    return result
-  }
-}
 
 //===----------------------------------------------------------------------===//
 //===--- FixedWidthInteger ------------------------------------------------===//
@@ -2279,24 +2258,24 @@ ${unsafeOperationComment(x.operator)}
   }
 % end
 
-  @inline(__always)
+  @_transparent
   public init<T : BinaryInteger>(extendingOrTruncating source: T) {
-    if Self.bitWidth <= ${word_bits} {
-      self = Self.init(_truncatingBits: source._word(at: 0))
+    if Self.bitWidth <= ${word_bits} || source.bitWidth <= ${word_bits} {
+      self = Self.init(_truncatingBits: source._lowUWord)
     }
     else {
-      var result: Self = source < (0 as T) ? ~0 : 0
-      // start with the most significant word
-      var n = source._countRepresentedWords
-      while n >= 0 {
-        // masking is OK here because this we have already ensured
-        // that Self.bitWidth > ${word_bits}.  Not masking results in
+      let neg = source < (0 as T)
+      var result: Self = neg ? ~0 : 0
+      var shift: Self = 0
+      let width = Self(_truncatingBits: Self.bitWidth._lowUWord)
+      for word in source.words {
+        guard shift < width else { break }
+        // masking shift is OK here because we have already ensured
+        // that shift < Self.bitWidth. Not masking results in
         // infinite recursion.
-        result &<<= (${word_bits} as Self)
-        result |= Self(_truncatingBits: source._word(at: n))
-        n -= 1
+        result ^= Self(_truncatingBits: neg ? ~word : word) &<< shift
+        shift += ${word_bits}
       }
-
       self = result
     }
   }
@@ -2759,22 +2738,70 @@ ${assignmentOperatorComment(x.operator, True)}
       )._lowUWord._value)
   }
 
-  @_transparent
-  public func _word(at n: Int) -> UInt {
-    _precondition(n >= 0, "Negative word index")
-    if _fastPath(n < _countRepresentedWords) {
-      let shift = UInt(n._value) &* ${word_bits}
-      let bitWidth = UInt(self.bitWidth._value)
-      _sanityCheck(shift < bitWidth)
-      return (self &>> ${Self}(_truncatingBits: shift))._lowUWord
+% if Self == 'UInt' or (bits > word_bits and not signed):
+  // FIXME should be RandomAccessCollection
+  public struct Words : BidirectionalCollection {
+    public typealias Indices = CountableRange<Int>
+    public typealias SubSequence = BidirectionalSlice<${Self}.Words>
+
+    public var _value: ${Self}
+
+    @_transparent
+    public init(_ value: ${Self}) {
+      self._value = value
     }
-% if signed:
-    return self < (0 as ${Self}) ? ~0 : 0
-% else:
-    return 0
-% end
+
+    @_transparent
+    public var count: Int {
+      return (${bits} + ${word_bits} - 1) / ${word_bits}
+    }
+
+    @_transparent
+    public var startIndex: Int { return 0 }
+
+    @_transparent
+    public var endIndex: Int { return count }
+
+    @_transparent
+    public var indices: Indices { return startIndex ..< endIndex }
+
+    @_transparent
+    public func index(after i: Int) -> Int { return i + 1 }
+
+    @_transparent
+    public func index(before i: Int) -> Int { return i - 1 }
+
+    public subscript(position: Int) -> UInt {
+      @_transparent
+      get {
+        _precondition(position >= 0, "Negative word index")
+        _precondition(position < endIndex, "Word index out of range")
+        let shift = UInt(position._value) &* ${word_bits}
+        _sanityCheck(shift < UInt(_value.bitWidth._value))
+        return (_value &>> ${Self}(_truncatingBits: shift))._lowUWord
+      }
+    }
   }
 
+  @_transparent
+  public var words: Words {
+    return Words(self)
+  }
+% elif bits > word_bits:
+  public typealias Words = ${OtherSelf}.Words
+
+  @_transparent
+  public var words: Words {
+    return Words(${OtherSelf}(self._value))
+  }
+% else:
+  public typealias Words = UInt.Words
+
+  @_transparent
+  public var words: Words {
+    return Words(self._lowUWord)
+  }
+% end
 
   @_transparent
   public // transparent

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2258,7 +2258,7 @@ ${unsafeOperationComment(x.operator)}
   }
 % end
 
-  @_transparent
+  @inline(__always)
   public init<T : BinaryInteger>(extendingOrTruncating source: T) {
     if Self.bitWidth <= ${word_bits} || source.bitWidth <= ${word_bits} {
       self = Self.init(_truncatingBits: source._lowWord)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2260,7 +2260,7 @@ ${unsafeOperationComment(x.operator)}
 
   @inline(__always)
   public init<T : BinaryInteger>(extendingOrTruncating source: T) {
-    if Self.bitWidth <= ${word_bits} || source.bitWidth <= ${word_bits} {
+    if Self.bitWidth <= ${word_bits} {
       self = Self.init(_truncatingBits: source._lowWord)
     }
     else {

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -661,10 +661,13 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
 
   public var words: [UInt] {
     _sanityCheck(UInt.bitWidth % Word.bitWidth == 0)
+    let twosComplementData = _dataAsTwosComplement()
     var words: [UInt] = []
+    words.reserveCapacity((twosComplementData.count * Word.bitWidth 
+      + UInt.bitWidth - 1) / UInt.bitWidth)
     var word: UInt = 0
     var shift = 0
-    for w in _dataAsTwosComplement() {
+    for w in twosComplementData {
       word |= UInt(extendingOrTruncating: w) << shift
       shift += Word.bitWidth
       if shift == UInt.bitWidth {
@@ -1862,6 +1865,14 @@ BigIntBitTests.test("Conformances") {
   expectTrue(set.contains(y))
   expectTrue(set.contains(z))
   expectFalse(set.contains(-x))
+}
+
+BigIntBitTests.test("words") {
+  expectEqualSequence([1], (1 as BigIntBit).words)
+  expectEqualSequence([UInt.max, 0], BigIntBit(UInt.max).words)
+  expectEqualSequence([UInt.max >> 1], BigIntBit(UInt.max >> 1).words)
+  expectEqualSequence([0, 1], (BigIntBit(UInt.max) + 1).words)
+  expectEqualSequence([UInt.max], (-1 as BigIntBit).words)
 }
 
 runAllTests()

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -1248,7 +1248,7 @@ struct Bit : FixedWidthInteger, UnsignedInteger {
   }
 
   var trailingZeroBitCount: Int {
-    return value.trailingZeroBitCount
+    return Int(~value & 1)
   }
 
   static var max: Bit {
@@ -1268,7 +1268,7 @@ struct Bit : FixedWidthInteger, UnsignedInteger {
   }
 
   var leadingZeroBitCount: Int {
-    return value.nonzeroBitCount - 7
+    return Int(~value & 1)
   }
 
   var bigEndian: Bit {
@@ -1489,6 +1489,15 @@ BitTests.test("Basics") {
 
   expectEqual(x, x + y)
   expectGT(x, x &+ x)
+  
+  expectEqual(1, x.nonzeroBitCount)
+  expectEqual(0, y.nonzeroBitCount)
+
+  expectEqual(0, x.leadingZeroBitCount)
+  expectEqual(1, y.leadingZeroBitCount)
+
+  expectEqual(0, x.trailingZeroBitCount)
+  expectEqual(1, y.trailingZeroBitCount)
 }
 
 var BigIntTests = TestSuite("BigInt")

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -622,21 +622,4 @@ tests.test("signum/concrete") {
 }
 
 
-dwTests.test("Words") {
-  expectEqualSequence((0 as DoubleWidth<Int8>).words, [0])
-  expectEqualSequence((1 as DoubleWidth<Int8>).words, [1])
-  expectEqualSequence((-1 as DoubleWidth<Int8>).words, [UInt.max])
-  expectEqualSequence((256 as DoubleWidth<Int8>).words, [256])
-  expectEqualSequence((-256 as DoubleWidth<Int8>).words, [UInt.max - 255])
-  expectEqualSequence(DoubleWidth<Int8>.max.words, [32767])
-  expectEqualSequence(DoubleWidth<Int8>.min.words, [UInt.max - 32767])
-
-  expectEqualSequence((0 as Int1024).words, 
-    repeatElement(0 as UInt, count: 1024 / UInt.bitWidth))
-  expectEqualSequence((-1 as Int1024).words,
-    repeatElement(UInt.max, count: 1024 / UInt.bitWidth))
-  expectEqualSequence((1 as Int1024).words, 
-      [1] + Array(repeating: 0, count: 1024 / UInt.bitWidth - 1))
-}
-
 runAllTests()

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -29,18 +29,7 @@ public func _log(_ message: @autoclosure () -> String) {
   // print(message())
 }
 
-extension FixedWidthInteger {
-  @discardableResult
-  // @_transparent
-  public mutating func replaceUWord(_ n: Int, with newBits: UInt) -> Bool {
-    let flippedBits = _word(at: n) ^ newBits
-    self ^= Self(_truncatingBits: flippedBits) << (${word_bits} * n)
-    if _word(at: n) != newBits {
-      _log("###### overflow replacing word \(n) with \(newBits.hex)")
-    }
-    return _word(at: n) == newBits
-  }
-
+extension FixedWidthInteger where Words : Collection {
   /// a hex representation of every bit in the number
   func hexBits(_ bitWidth: Int) -> String {
     let hexDigits: [Unicode.Scalar] = [
@@ -54,12 +43,11 @@ extension FixedWidthInteger {
       if nibbles % 4 == 0 && nibbles != 0 {
         result.insert("_", at: result.startIndex)
       }
-      let lowUWord = x._word(at: 0)
+      let lowUWord = x.words.first ?? 0
       result.insert(
         hexDigits[Int(lowUWord._value) & 0xF],
         at: result.startIndex
       )
-      x.replaceUWord(0, with: lowUWord & ~0xF)
       x /= 16
       nibbles += 1
     }
@@ -84,7 +72,7 @@ func expectEqual<T : FixedWidthInteger>(
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
-) {
+) where T.Words : Collection {
   if expected != actual {
     expectationFailure(
       "expected: \(String(reflecting: expected))"
@@ -493,26 +481,45 @@ tests.test("Basics") {
   expectEqual(32, Int32.bitWidth)
 }
 
-tests.test("word") {
-  let x = UDWord(Int.max)
-  expectEqual(Int.max._lowUWord, x._word(at: 0))
-  expectEqual(0, x._word(at: 1))
-
-  let y = DWord(Int.min)
-  expectEqual(Int.min._lowUWord, y._word(at: 0))
-  expectEqual(~0, y._word(at: 1))
-
-  let z = UInt(~Int.min) + 1
-  expectEqual(Int.min._lowUWord, z._word(at: 0))
-  expectEqual(0, z._word(at: 1))
-}
-
 tests.test("words") {
+  expectEqualSequence([UInt.max], UInt.max.words)
+  expectEqualSequence([0xFF as UInt], UInt8.max.words)
+  expectEqualSequence([0xFFFF as UInt], UInt16.max.words)
+  expectEqualSequence([0xFFFFFFFF as UInt], UInt32.max.words)
+
+  expectEqualSequence([0 as UInt], UInt.min.words)
+  expectEqualSequence([0 as UInt], UInt8.min.words)
+  expectEqualSequence([0 as UInt], UInt16.min.words)
+  expectEqualSequence([0 as UInt], UInt32.min.words)
+
+  expectEqualSequence([UInt.max >> 1], Int.max.words)
+  expectEqualSequence([0x7F as UInt], Int8.max.words)
+  expectEqualSequence([0x7FFF as UInt], Int16.max.words)
+  expectEqualSequence([0x7FFFFFFF as UInt], Int32.max.words)
+
+  expectEqualSequence([UInt.max << (Int.bitWidth - 1)], Int.min.words)
+  expectEqualSequence([UInt.max << 7], Int8.min.words)
+  expectEqualSequence([UInt.max << 15], Int16.min.words)
+  expectEqualSequence([UInt.max << 31], Int32.min.words)
+  
   expectEqualSequence([UInt.max], (-1 as Int).words)
   expectEqualSequence([UInt.max], (-1 as Int8).words)
   expectEqualSequence([UInt.max], (-1 as Int16).words)
   expectEqualSequence([UInt.max], (-1 as Int32).words)
+
+% if int(WORD_BITS) == 64:
+  expectEqualSequence([UInt.max], UInt64.max.words)
+  expectEqualSequence([0 as UInt], UInt64.min.words)
+  expectEqualSequence([UInt.max >> 1], Int64.max.words)
+  expectEqualSequence([(1 as UInt) << 63], Int64.min.words)
   expectEqualSequence([UInt.max], (-1 as Int64).words)
+% else:
+  expectEqualSequence([UInt.max, UInt.max], Int64.max.words)
+  expectEqualSequence([0 as UInt, 0], UInt64.min.words)
+  expectEqualSequence([UInt.max, UInt.max >> 1], Int64.max.words)
+  expectEqualSequence([0 as UInt, 1 << 31], Int64.min.words)
+  expectEqualSequence([UInt.max, UInt.max], (-1 as Int64).words)
+% end
 
   expectEqualSequence([1], 1.words)
   expectEqualSequence([0], 0.words)
@@ -614,5 +621,22 @@ tests.test("signum/concrete") {
 % end
 }
 
+
+dwTests.test("Words") {
+  expectEqualSequence((0 as DoubleWidth<Int8>).words, [0])
+  expectEqualSequence((1 as DoubleWidth<Int8>).words, [1])
+  expectEqualSequence((-1 as DoubleWidth<Int8>).words, [UInt.max])
+  expectEqualSequence((256 as DoubleWidth<Int8>).words, [256])
+  expectEqualSequence((-256 as DoubleWidth<Int8>).words, [UInt.max - 255])
+  expectEqualSequence(DoubleWidth<Int8>.max.words, [32767])
+  expectEqualSequence(DoubleWidth<Int8>.min.words, [UInt.max - 32767])
+
+  expectEqualSequence((0 as Int1024).words, 
+    repeatElement(0 as UInt, count: 1024 / UInt.bitWidth))
+  expectEqualSequence((-1 as Int1024).words,
+    repeatElement(UInt.max, count: 1024 / UInt.bitWidth))
+  expectEqualSequence((1 as Int1024).words, 
+      [1] + Array(repeating: 0, count: 1024 / UInt.bitWidth - 1))
+}
 
 runAllTests()


### PR DESCRIPTION
* Explanation: Implements words property on integer types as part of SE-0104 implementation.
* Scope of Issue: Removes the underscored APIs and instead implements the words collection properly.
* Risk: Minimal
* Reviewed By: Dave Abrahams
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/33292169>