### PR TITLE
[4.0]Have Substring.filter return a String

### DIFF
--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -428,6 +428,12 @@ extension Substring {
   public func uppercased() -> String {
     return String(self).uppercased()
   }
+  
+  public func filter(
+  _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> String {
+      return try String(self.lazy.filter(isIncluded))
+  }
 }
 
 extension Substring : TextOutputStream {

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -92,6 +92,14 @@ SubstringTests.test("Comparison") {
 		["apple", "pen", "pen", "pineapple"])
 }
 
+SubstringTests.test("Filter") {
+	var name = "😂Edward Woodward".dropFirst()
+	var filtered = name.filter { $0 != "d" }
+	expectType(Substring.self, &name)
+	expectType(String.self, &filtered)
+	expectEqual("Ewar Woowar", filtered)
+}
+
 SubstringTests.test("CharacterView") {
   let s = "abcdefg"
   var t = s.characters.dropFirst(2)


### PR DESCRIPTION
Per SE-183

* Explanation: `Substring.filter` should return a `String`, as this involves the fresh creation of the string not a view onto the existing string.
* Scope of Issue: Adding a concrete overload.
* Risk: Minimal
* Reviewed By: Max Moiseev
* Testing: Automated test suite + additional test
* Bug: https://bugs.swift.org/browse/SR-4933
* Radar: <rdar://problem/32285011>