### PR TITLE
Sema: Stricter superclass constraints when opening a generic signature [4.0]

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3387,9 +3387,16 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
         // Nothing else can appear outside of @_specialize yet, and Sema
         // doesn't know how to check.
         break;
-      case RequirementKind::Superclass:
+      case RequirementKind::Superclass: {
         createMemberConstraint(Req, ConstraintKind::Subtype);
+
+        auto First = resolveType(Req.getFirstType());
+        CS.addConstraint(ConstraintKind::ConformsTo, First,
+                         CS.getASTContext().getAnyObjectType(),
+                         Loc);
+
         break;
+      }
       case RequirementKind::SameType:
         createMemberConstraint(Req, ConstraintKind::Equal);
         break;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1046,6 +1046,9 @@ void ConstraintSystem::openGeneric(
       auto subjectTy = openType(req.getFirstType(), replacements);
       auto boundTy = openType(req.getSecondType(), replacements);
       addConstraint(ConstraintKind::Subtype, subjectTy, boundTy, locatorPtr);
+      addConstraint(ConstraintKind::ConformsTo, subjectTy,
+                    TC.Context.getAnyObjectType(),
+                    locatorPtr);
       break;
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2807,6 +2807,21 @@ bool TypeChecker::isSubtypeOf(Type type1, Type type2, DeclContext *dc) {
                                 ConstraintKind::Subtype, dc);
 }
 
+bool TypeChecker::isSubclassOf(Type type1, Type type2, DeclContext *dc) {
+  assert(type2->getClassOrBoundGenericClass());
+
+  if (!typesSatisfyConstraint(type1,
+                              Context.getAnyObjectType(),
+                              /*openArchetypes=*/false,
+                              ConstraintKind::ConformsTo, dc)) {
+    return false;
+  }
+
+  return typesSatisfyConstraint(type1, type2,
+                                /*openArchetypes=*/false,
+                                ConstraintKind::Subtype, dc);
+}
+
 bool TypeChecker::isConvertibleTo(Type type1, Type type2, DeclContext *dc,
                                   bool *unwrappedIUO) {
   return typesSatisfyConstraint(type1, type2,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1342,7 +1342,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
 
     case RequirementKind::Superclass:
       // Superclass requirements.
-      if (!isSubtypeOf(firstType, secondType, dc)) {
+      if (!isSubclassOf(firstType, secondType, dc)) {
         if (loc.isValid()) {
           // FIXME: Poor source-location information.
           diagnose(loc, diag::type_does_not_inherit, owner, firstType,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3452,6 +3452,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(
       switch (reqt.getKind()) {
       case RequirementKind::Conformance:
       case RequirementKind::Superclass:
+        // FIXME: This is the wrong check
         if (selfTy->isEqual(reqt.getFirstType())
             && !TC.isSubtypeOf(Conformance->getType(),reqt.getSecondType(), DC))
           return false;
@@ -4064,7 +4065,7 @@ compareDeclsForInference(TypeChecker &TC, DeclContext *DC,
     if (!t2)
       return true;
     
-    return TC.isSubtypeOf(t1, t2, DC);
+    return TC.isSubclassOf(t1, t2, DC);
   };
   
   bool protos1AreSubsetOf2 = protos1.empty();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1124,6 +1124,15 @@ public:
   /// \returns true if \c t1 is a subtype of \c t2.
   bool isSubtypeOf(Type t1, Type t2, DeclContext *dc);
 
+  /// \brief Determine whether one type is a subclass of another.
+  ///
+  /// \param t1 The potential subtype.
+  /// \param t2 The potential supertype.
+  /// \param dc The context of the check.
+  ///
+  /// \returns true if \c t1 is a subtype of \c t2.
+  bool isSubclassOf(Type t1, Type t2, DeclContext *dc);
+  
   /// \brief Determine whether one type is implicitly convertible to another.
   ///
   /// \param t1 The potential source type of the conversion.

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -538,3 +538,13 @@ func takesBaseIntAndPArray(_: [Base<Int> & P2]) {}
 func passesBaseIntAndPArray() {
   takesBaseIntAndPArray([Base<Int> & P2]())
 }
+
+//
+// Superclass constrained generic parameters
+//
+
+struct DerivedBox<T : Derived> {}
+// expected-note@-1 {{requirement specified as 'T' : 'Derived' [with T = Derived & P3]}}
+
+func takesBoxWithP3(_: DerivedBox<Derived & P3>) {}
+// expected-error@-1 {{'DerivedBox' requires that 'Derived & P3' inherit from 'Derived'}}


### PR DESCRIPTION
* Description: Fixes a crash-on-invalid when we bind a class-constrained generic parameter to a class-constrained existential.

* Origination: Class-constrained existentials are a new feature in Swift 4.0.

* Risk: Low, we're introducing a new constraint in a few places and this code path should be well tested.

* Reviewed by: @DougGregor 

* Tested: New test added

* Radar: <rdar://problem/32617814>