### PR TITLE
Parse: Fix dictionary with generic key type in expression context [4.0]

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1144,6 +1144,7 @@ static bool isGenericTypeDisambiguatingToken(Parser &P) {
   case tok::code_complete:
   case tok::exclaim_postfix:
   case tok::question_postfix:
+  case tok::colon:
     return true;
 
   case tok::oper_binary_spaced:

--- a/test/type/dictionary.swift
+++ b/test/type/dictionary.swift
@@ -33,3 +33,13 @@ var y2: [String : ] // expected-error{{expected dictionary value type}}
 struct NotHashable { }
 
 var nh1 : [NotHashable : Int] // expected-error{{'NotHashable' does not conform to protocol 'Hashable'}}
+
+struct Y<T> : Hashable {
+  var hashValue: Int { return 0 }
+
+  static func ==(this: Y<T>, other: Y<T>) -> Bool { return true }
+}
+
+let _ = [Y<Int>: Int]()
+let _ = [Y<Int> : Int]()
+let _ = [Y<Int> :Int]()


### PR DESCRIPTION
* Description: Fixes a case where a dictionary type was not parsed correctly in expression context. We fixed some issues with this in 4.0, but this was a case we missed.

* Origination: Probably has been there forever.

* Tested: New test added.

* Reviewed by: @DougGregor 

* Risk: Very low, ':' is already not a valid operator so we should not be rejecting anything that was previously valid.

* Radar: <rdar://problem/33506631>