### PR TITLE
[gardening] Fix typos

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -725,7 +725,7 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   // FIXME: The following attempts to do an initial ReadAST invocation to verify
   // the PCH, without affecting the existing CompilerInstance.
   // Look into combining creating the ASTReader along with verification + update
-  // if necesary, so that we can create and use one ASTReader in the common case
+  // if necessary, so that we can create and use one ASTReader in the common case
   // when there is no need for update.
 
   CompilerInstance &CI = *Impl.Instance;

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -50,7 +50,7 @@ namespace swift {
 struct SerializedSwiftName {
   /// The kind of the name if it is a special name
   DeclBaseName::Kind Kind;
-  /// The name of the idenifier if it is not a special name
+  /// The name of the identifier if it is not a special name
   StringRef Name;
 
   SerializedSwiftName() : Kind(DeclBaseName::Kind::Normal), Name(StringRef()) {}

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -285,7 +285,7 @@ void SerializedDiagnosticConsumer::addRangeToRecord(CharSourceRange Range,
   addLocToRecord(Range.getEnd(), SM, Filename, Record);
 }
 
-/// \brief Map a Swift DiagosticKind to the diagnostic level expected
+/// \brief Map a Swift DiagnosticKind to the diagnostic level expected
 /// for serialized diagnostics.
 static clang::serialized_diags::Level getDiagnosticLevel(DiagnosticKind Kind) {
   switch (Kind) {


### PR DESCRIPTION
Fix typos: 

* necesary -> necessary
* idenifier -> identifier
* DiagosticKind -> DiagnosticKind

