### PR TITLE
[AppKit overlay] Use NSColor(red:green:blue:alpha:) for color literals.

### DIFF
--- a/stdlib/public/SDK/AppKit/AppKit.swift
+++ b/stdlib/public/SDK/AppKit/AppKit.swift
@@ -81,7 +81,7 @@ extension NSColor : _ExpressibleByColorLiteral {
   @nonobjc
   public required convenience init(_colorLiteralRed red: Float, green: Float,
                                    blue: Float, alpha: Float) {
-    self.init(srgbRed: CGFloat(red), green: CGFloat(green),
+    self.init(red: CGFloat(red), green: CGFloat(green),
               blue: CGFloat(blue), alpha: CGFloat(alpha))
   }
 }

--- a/test/stdlib/AppKit_Swift4.swift
+++ b/test/stdlib/AppKit_Swift4.swift
@@ -94,4 +94,15 @@ AppKitTests.test("NSRectFills") {
   expectEqual(bitmapImage.colorAt(x: 2, y: 2), blue)
 }
 
+AppKitTests.test("NSColor.Literals") {
+  if #available(macOS 10.12, *) {
+    // Color literal in the extended sRGB color space.
+    let c1 = #colorLiteral(red: 1.358, green: -0.074, blue: -0.012, alpha: 1.0)
+    
+    var printedC1 = ""
+    print(c1, to: &printedC1)
+    expectTrue(printedC1.contains("extended"))
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
This initializer, which is the same on iOS, allows negative values and
values > 1.0 to support the extended sRGB color space.

Fixes rdar://problem/33500905.
