### PR TITLE
[4.0] [AppKit overlay] Use NSColor(red:green:blue:alpha:) for color literals.

### DIFF
--- a/stdlib/public/SDK/AppKit/AppKit.swift
+++ b/stdlib/public/SDK/AppKit/AppKit.swift
@@ -81,7 +81,7 @@ extension NSColor : _ExpressibleByColorLiteral {
   @nonobjc
   public required convenience init(_colorLiteralRed red: Float, green: Float,
                                    blue: Float, alpha: Float) {
-    self.init(srgbRed: CGFloat(red), green: CGFloat(green),
+    self.init(red: CGFloat(red), green: CGFloat(green),
               blue: CGFloat(blue), alpha: CGFloat(alpha))
   }
 }

--- a/test/stdlib/AppKit_Swift4.swift
+++ b/test/stdlib/AppKit_Swift4.swift
@@ -94,4 +94,15 @@ AppKitTests.test("NSRectFills") {
   expectEqual(bitmapImage.colorAt(x: 2, y: 2), blue)
 }
 
+AppKitTests.test("NSColor.Literals") {
+  if #available(macOS 10.12, *) {
+    // Color literal in the extended sRGB color space.
+    let c1 = #colorLiteral(red: 1.358, green: -0.074, blue: -0.012, alpha: 1.0)
+    
+    var printedC1 = ""
+    print(c1, to: &printedC1)
+    expectTrue(printedC1.contains("extended"))
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
**Explanation**: When mapping color literals to `NSColor`, use the `NSColor(red:green:blue:alpha:)` initializer, which supports extended sRGB.
**Scope**: Extremely narrow: only affects color literals whose components are negative or > 1.0.
**Radar**:  rdar://problem/33500905
**Risk**: Effectively zero; we're just switching to a more-widely-applicable `NSColor` initializer.
**Reviewed By**: @jrose-apple 
**Testing**: Compiler regression tests.