### PR TITLE
[swift-4.0-branch][overlay] Add back INSetProfileInCarIntent.defaultProfile for compatibliity

### DIFF
--- a/stdlib/public/SDK/Intents/INSetProfileInCarIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetProfileInCarIntent.swift
@@ -123,9 +123,15 @@ extension INSetProfileInCarIntent {
         }
     }
 
-    @available(iOS 11.0, *)
-    public final var isDefaultProfile: Bool? {
+    @available(iOS 10.0, *)
+    public var isDefaultProfile: Bool? {
         return __defaultProfile?.boolValue
+    }
+
+    @available(swift, deprecated: 3.2, obsoleted: 4.0,
+      message: "Please use isDefaultProfile instead")
+    public var defaultProfile: Int? {
+      return __defaultProfile?.intValue
     }
 
     @available(iOS 10.0, *)

--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -41,6 +41,17 @@ if #available(iOS 11.0, *) {
       expectUnreachable()
     }
   }
+
+  IntentsTestSuite.test("INSetProfileInCarIntent/defaultProfile availability/\(swiftVersion)") {
+    func f(profile: INSetProfileInCarIntent) {
+      var isDefaultProfile = profile.isDefaultProfile
+      expectType(Bool?.self, &isDefaultProfile)
+#if !swift(>=4)
+      var defaultProfile = profile.defaultProfile
+      expectType(Int?.self, &defaultProfile)
+#endif
+    }
+  }
 }
 #endif
 


### PR DESCRIPTION
* Explanation: Adds back mistakenly deleted defaultProfile property for INSetProfileInCarIntent
* Scope of Issue: Reinstates API backward compatibility
* Risk: Minimal
* Reviewed By: Max Moiseev
* Testing: Automated test suite + a dedicated test case
* Directions for QA: N/A
* Radar: <rdar://problem/33457609>