### PR TITLE
[SourceKit] Add subscript to doc structure (SR-5035)

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -92,6 +92,7 @@ enum class SyntaxStructureKind : uint8_t {
   ClassVariable,
   EnumCase,
   EnumElement,
+  Subscript,
 
   ForEachStatement,
   ForStatement,

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -954,6 +954,14 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
         popStructureNode();
       }
     }
+  } else if (auto *SubscriptDeclD = dyn_cast<SubscriptDecl>(D)) {
+      SyntaxStructureNode SN;
+      SN.Dcl = SubscriptDeclD;
+      SN.Kind = SyntaxStructureKind::Subscript;
+      SN.Range = charSourceRangeFromSourceRange(SM,
+                                            SubscriptDeclD->getSourceRange());
+      SN.Attrs = SubscriptDeclD->getAttrs();
+      pushStructureNode(SN, SubscriptDeclD);
   }
 
   return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -375,6 +375,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclEnumCase;
     case SyntaxStructureKind::EnumElement:
       return KindDeclEnumElement;
+    case SyntaxStructureKind::Subscript:
+      return KindDeclSubscript;
     case SyntaxStructureKind::Parameter:
       return KindDeclVarParam;
     case SyntaxStructureKind::ForEachStatement:


### PR DESCRIPTION
This adds `subscript` to the structure reported by SourceKit.

For example, for this file:

```swift
struct Thing {
    subscript(index: Int) -> Int {
        return 2
    }
}
```

We get this response with `source.request.editor.open` (using `sourcekitd-repl`):

```
{
  key.offset: 0,
  key.length: 64,
  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
  key.syntaxmap: [
    {
      key.kind: source.lang.swift.syntaxtype.keyword,
      key.offset: 0,
      key.length: 6
    },
    {
      key.kind: source.lang.swift.syntaxtype.identifier,
      key.offset: 7,
      key.length: 5
    },
    {
      key.kind: source.lang.swift.syntaxtype.keyword,
      key.offset: 16,
      key.length: 9
    },
    {
      key.kind: source.lang.swift.syntaxtype.identifier,
      key.offset: 26,
      key.length: 5
    },
    {
      key.kind: source.lang.swift.syntaxtype.typeidentifier,
      key.offset: 33,
      key.length: 3
    },
    {
      key.kind: source.lang.swift.syntaxtype.typeidentifier,
      key.offset: 41,
      key.length: 3
    },
    {
      key.kind: source.lang.swift.syntaxtype.keyword,
      key.offset: 50,
      key.length: 6
    },
    {
      key.kind: source.lang.swift.syntaxtype.number,
      key.offset: 57,
      key.length: 1
    }
  ],
  key.substructure: [
    {
      key.kind: source.lang.swift.decl.struct,
      key.accessibility: source.lang.swift.accessibility.internal,
      key.name: "Thing",
      key.offset: 0,
      key.length: 63,
      key.nameoffset: 7,
      key.namelength: 5,
      key.bodyoffset: 14,
      key.bodylength: 48,
      key.substructure: [
        {
          key.kind: source.lang.swift.decl.function.subscript,
          key.accessibility: source.lang.swift.accessibility.internal,
          key.name: "subscript(_:)",
          key.offset: 16,
          key.length: 45,
          key.nameoffset: 0,
          key.namelength: 0,
          key.substructure: [
            {
              key.kind: source.lang.swift.decl.var.parameter,
              key.name: "index",
              key.offset: 26,
              key.length: 10,
              key.typename: "Int",
              key.nameoffset: 0,
              key.namelength: 0
            }
          ]
        }
      ]
    }
  ]
}
```

Resolves [SR-5035](https://bugs.swift.org/browse/SR-5035).

PS: I'm using the generated Xcode project, but haven't found a way to run the tests (this is my first contribution!), so they will likely fail. Some help would be really appreciated. 
Also, this wouldn't be possible if @johnfairh didn't reach out and offered some advice on how to start and pointed to [his PR](https://github.com/apple/swift/pull/11143). Thanks so much 🙌 