### PR TITLE
[master-next] Trivial updates in getting master-next to build

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -102,7 +102,6 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::RTEMS:
   case llvm::Triple::NaCl:
   case llvm::Triple::CNK:
-  case llvm::Triple::Bitrig:
   case llvm::Triple::AIX:
   case llvm::Triple::CUDA:
   case llvm::Triple::NVCL:

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -243,8 +243,8 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
   // We can ignore mayTrap().
   bool any_in_guaranteed_params = false;
   for (auto op : enumerate(AI->getArgumentOperands())) {
-    if (op.Value.get() == V &&
-        AI->getSubstCalleeConv().getSILArgumentConvention(op.Index) == swift::SILArgumentConvention::Indirect_In_Guaranteed) {
+    if (op.value().get() == V &&
+        AI->getSubstCalleeConv().getSILArgumentConvention(op.index()) == swift::SILArgumentConvention::Indirect_In_Guaranteed) {
       any_in_guaranteed_params = true;
       break;
     }

--- a/test/ClangImporter/MixedSource/mixed-target-using-module.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-module.swift
@@ -4,8 +4,7 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-AUTOLINK: !{{[0-9]+}} = !{i32 {{[0-9]+}}, !"Linker Options", ![[LINK_LIST:[0-9]+]]}
-// CHECK-AUTOLINK: ![[LINK_LIST]] = !{
+// CHECK-AUTOLINK: !llvm.linker.options = !{
 // CHECK-AUTOLINK-NOT: metadata !"-framework", metadata !"Mixed"
 
 // CHECK-WRONG-NAME: underlying Objective-C module 'WrongName' not found

--- a/test/ClangImporter/autolinking.swift
+++ b/test/ClangImporter/autolinking.swift
@@ -26,8 +26,7 @@ import UsesSubmodule
 _ = LinkFramework.IComeFromLinkFramework
 UsesSubmodule.useSomethingFromSubmodule()
 
-// CHECK: !{{[0-9]+}} = !{i32 6, !"Linker Options", ![[LINK_LIST:[0-9]+]]}
-// CHECK: ![[LINK_LIST]] = !{
+// CHECK: !llvm.linker.options = !{
 
 // CHECK-DAG: !{{[0-9]+}} = !{!"-lLock"}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-lStock"}

--- a/test/ClangImporter/requires.swift
+++ b/test/ClangImporter/requires.swift
@@ -3,5 +3,7 @@
 import Requires.Swift // OK
 import Requires.NotSwift
 // CHECK-NOT: error
+// CHECK: error: module 'Requires.NotSwift' is incompatible with feature 'swift'
+// CHECK-NOT: error
 // CHECK: error: no such module 'Requires.NotSwift'
 // CHECK-NOT: error

--- a/test/DebugInfo/ImportClangSubmodule.swift
+++ b/test/DebugInfo/ImportClangSubmodule.swift
@@ -33,10 +33,10 @@ import OtherClangModule.SubModule
 // submodule's top-level-module, even if we didn't ask for it.
 // CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]]
 // CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[OTHERSUBMODULE]]
-// CHECK: !DIImportedEntity({{.*}}, entity: ![[CLANGMODULE]])
+// CHECK: !DIImportedEntity({{.*}}, entity: ![[CLANGMODULE]]
 // CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]]
 // CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[OTHERSUBMODULE]]
-// CHECK: !DIImportedEntity({{.*}}, entity: ![[OTHERCLANGMODULE]])
+// CHECK: !DIImportedEntity({{.*}}, entity: ![[OTHERCLANGMODULE]]
 // CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]]
 // CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[OTHERSUBMODULE]]
 

--- a/test/IRGen/autolink-coff.swift
+++ b/test/IRGen/autolink-coff.swift
@@ -14,8 +14,7 @@
 import module
 #endif
 
-// CHECK-MSVC-IR: !{{[0-9]+}} = !{i32 {{[0-9]+}}, !"Linker Options", [[NODE:![0-9]+]]}
-// CHECK-MSVC-IR: [[NODE]] = !{[[LIST:![0-9]+]]}
+// CHECK-MSVC-IR: !llvm.linker.options = !{[[LIST:![0-9]+]]}
 // CHECK-MSVC-IR: [[LIST]] = !{!"/DEFAULTLIB:module.lib"}
 
 // CHECK-MSVC-ASM: .section .drectve

--- a/test/IRGen/autolink-psei.swift
+++ b/test/IRGen/autolink-psei.swift
@@ -6,7 +6,6 @@
 import module
 #endif
 
-// CHECK-IR: !{{[0-9]+}} = !{i32 {{[0-9]+}}, !"Linker Options", [[NODE:![0-9]+]]}
-// CHECK-IR: [[NODE]] = !{[[LIST:![0-9]+]]}
+// CHECK-IR: !llvm.linker.options = !{[[LIST:![0-9]+]]}
 // CHECK-IR: [[LIST]] = !{!"\01module"}
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -265,7 +265,7 @@ func fence_test() {
   // CHECK: fence acquire
   Builtin.fence_acquire()
 
-  // CHECK: fence singlethread acq_rel
+  // CHECK: fence syncscope("singlethread") acq_rel
   Builtin.fence_acqrel_singlethread()
 }
 
@@ -286,7 +286,7 @@ func cmpxchg_test(_ ptr: Builtin.RawPointer, a: Builtin.Int32, b: Builtin.Int32)
   // CHECK: store i1 [[Y_SUCCESS]], i1* {{.*}}, align 1
   var (y, ySuccess) = Builtin.cmpxchg_monotonic_monotonic_volatile_Int32(ptr, a, b)
 
-  // CHECK: [[X_RES:%.*]] = cmpxchg volatile i32* {{.*}}, i32 {{.*}}, i32 {{.*}} singlethread acquire monotonic
+  // CHECK: [[X_RES:%.*]] = cmpxchg volatile i32* {{.*}}, i32 {{.*}}, i32 {{.*}} syncscope("singlethread") acquire monotonic
   // CHECK: [[X_VAL:%.*]] = extractvalue { i32, i1 } [[X_RES]], 0
   // CHECK: [[X_SUCCESS:%.*]] = extractvalue { i32, i1 } [[X_RES]], 1
   // CHECK: store i32 [[X_VAL]], i32* {{.*}}, align 4
@@ -318,11 +318,11 @@ func atomicrmw_test(_ ptr: Builtin.RawPointer, a: Builtin.Int32,
   // CHECK: atomicrmw volatile max i32* {{.*}}, i32 {{.*}} monotonic
   var y = Builtin.atomicrmw_max_monotonic_volatile_Int32(ptr, a)
   
-  // CHECK: atomicrmw volatile xchg i32* {{.*}}, i32 {{.*}} singlethread acquire
+  // CHECK: atomicrmw volatile xchg i32* {{.*}}, i32 {{.*}} syncscope("singlethread") acquire
   var x = Builtin.atomicrmw_xchg_acquire_volatile_singlethread_Int32(ptr, a)
   
   // rdar://12939803 - ER: support atomic cmpxchg/xchg with pointers
-  // CHECK: atomicrmw volatile xchg i64* {{.*}}, i64 {{.*}} singlethread acquire
+  // CHECK: atomicrmw volatile xchg i64* {{.*}}, i64 {{.*}} syncscope("singlethread") acquire
   var w = Builtin.atomicrmw_xchg_acquire_volatile_singlethread_RawPointer(ptr, ptr2)
 
 }
@@ -790,9 +790,9 @@ func unsafeGuaranteedEnd_test(_ x: Builtin.Int8) {
 func atomicload(_ p: Builtin.RawPointer) {
   // CHECK: [[A:%.*]] = load atomic i8*, i8** {{%.*}} unordered, align 8
   let a: Builtin.RawPointer = Builtin.atomicload_unordered_RawPointer(p)
-  // CHECK: [[B:%.*]] = load atomic i32, i32* {{%.*}} singlethread monotonic, align 4
+  // CHECK: [[B:%.*]] = load atomic i32, i32* {{%.*}} syncscope("singlethread") monotonic, align 4
   let b: Builtin.Int32 = Builtin.atomicload_monotonic_singlethread_Int32(p)
-  // CHECK: [[C:%.*]] = load atomic volatile i64, i64* {{%.*}} singlethread acquire, align 8
+  // CHECK: [[C:%.*]] = load atomic volatile i64, i64* {{%.*}} syncscope("singlethread") acquire, align 8
   let c: Builtin.Int64 =
     Builtin.atomicload_acquire_volatile_singlethread_Int64(p)
   // CHECK: [[D0:%.*]] = load atomic volatile i32, i32* {{%.*}} seq_cst, align 4
@@ -801,9 +801,9 @@ func atomicload(_ p: Builtin.RawPointer) {
 
   // CHECK: store atomic i8* [[A]], i8** {{%.*}} unordered, align 8
   Builtin.atomicstore_unordered_RawPointer(p, a)
-  // CHECK: store atomic i32 [[B]], i32* {{%.*}} singlethread monotonic, align 4
+  // CHECK: store atomic i32 [[B]], i32* {{%.*}} syncscope("singlethread") monotonic, align 4
   Builtin.atomicstore_monotonic_singlethread_Int32(p, b)
-  // CHECK: store atomic volatile i64 [[C]], i64* {{%.*}} singlethread release, align 8
+  // CHECK: store atomic volatile i64 [[C]], i64* {{%.*}} syncscope("singlethread") release, align 8
   Builtin.atomicstore_release_volatile_singlethread_Int64(p, c)
   // CHECK: [[D1:%.*]] = bitcast float [[D]] to i32
   // CHECK: store atomic volatile i32 [[D1]], i32* {{.*}} seq_cst, align 4

--- a/test/IRGen/dependent-library.swift
+++ b/test/IRGen/dependent-library.swift
@@ -1,7 +1,6 @@
 // RUN: %swift -target i686-unknown-windows-msvc -emit-ir -parse-as-library -parse-stdlib -module-name dependent -autolink-library oldnames -autolink-library msvcrt %s -o - | %FileCheck %s
 
-// CHECK: !{i32 6, !"Linker Options", ![[options:[0-9]+]]}
-// CHECK: ![[options]] = !{![[oldnames:[0-9]+]], ![[msvcrtd:[0-9]+]]}
+// CHECK: !llvm.linker.options = !{![[oldnames:[0-9]+]], ![[msvcrtd:[0-9]+]]}
 // CHECK: ![[oldnames]] = !{!"/DEFAULTLIB:oldnames.lib"}
 // CHECK: ![[msvcrtd]] = !{!"/DEFAULTLIB:msvcrt.lib"}
 

--- a/test/IRGen/linker_options_objc.swift
+++ b/test/IRGen/linker_options_objc.swift
@@ -9,6 +9,6 @@ import Empty
 // Check that libobjc is always autolinked together with libswiftCore on
 // platforms that support Objective-C.
 
-// CHECK: !{{.*}} = !{i32 6, !"Linker Options", !{{.*}}}
+// CHECK: !llvm.linker.options =
 // CHECK-DAG: !{{.*}} = !{!"-lswiftCore"}
 // CHECK-DAG: !{{.*}} = !{!"-lobjc"}

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -141,7 +141,7 @@ class WeakObjC {
 // rdar://17528908
 // CHECK:  i32 1, !"Objective-C Version", i32 2}
 // CHECK:  i32 1, !"Objective-C Image Info Version", i32 0}
-// CHECK:  i32 1, !"Objective-C Image Info Section", !"__DATA, __objc_imageinfo, regular, no_dead_strip"}
+// CHECK:  i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
 //   1280 == (5 << 8).  5 is the Swift ABI version.
 // CHECK:  i32 4, !"Objective-C Garbage Collection", i32 1280}
 // CHECK:  i32 1, !"Swift Version", i32 5}

--- a/test/IRGen/objc_globals.swift
+++ b/test/IRGen/objc_globals.swift
@@ -11,8 +11,8 @@ func blackHole<T>(_ t: T) { }
 
 // CHECK-LABEL: @"OBJC_CLASS_$_NSNumber" = external global %objc_class
 // CHECK: @"OBJC_CLASS_$_NSString" = external global {{%.*}}, align
-// CHECK: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = private global %struct._class_t* bitcast (%objc_class* @"OBJC_CLASS_$_NSNumber" to %struct._class_t*), section "__DATA, __objc_classrefs, regular, no_dead_strip"
-// CHECK: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = private global %struct._class_t* bitcast (%objc_class* @"OBJC_CLASS_$_NSString" to %struct._class_t*), section "__DATA, __objc_classrefs, regular, no_dead_strip"
+// CHECK: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = private global %struct._class_t* bitcast (%objc_class* @"OBJC_CLASS_$_NSNumber" to %struct._class_t*), section "__DATA,__objc_classrefs,regular,no_dead_strip"
+// CHECK: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = private global %struct._class_t* bitcast (%objc_class* @"OBJC_CLASS_$_NSString" to %struct._class_t*), section "__DATA,__objc_classrefs,regular,no_dead_strip"
 
 public func testLiterals() {
   blackHole(gadget.giveMeASelector())

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -28,13 +28,11 @@
 
 import someModule
 
-// CHECK: !{{[0-9]+}} = !{i32 6, !"Linker Options", ![[LINK_LIST:[0-9]+]]}
-// CHECK: ![[LINK_LIST]] = !{
+// CHECK: !llvm.linker.options = !{
 // CHECK-DAG: !{{[0-9]+}} = !{!"-lmagic"}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-lmodule"}
 
-// FRAMEWORK: !{{[0-9]+}} = !{i32 6, !"Linker Options", ![[LINK_LIST:[0-9]+]]}
-// FRAMEWORK: ![[LINK_LIST]] = !{
+// FRAMEWORK: !llvm.linker.options = !{
 // FRAMEWORK-DAG: !{{[0-9]+}} = !{!"-lmagic"}
 // FRAMEWORK-DAG: !{{[0-9]+}} = !{!"-lmodule"}
 // FRAMEWORK-DAG: !{{[0-9]+}} = !{!"-framework", !"someModule"}


### PR DESCRIPTION
There's still some real work to do to finish off #10519 (change in how we import macros), as well as three tests whose reason for failure wasn't immediately obvious:

- Interpreter/availability_host_os.swift
- IRGen/clang_inline.swift
- Misc/target-cpu.swift

But this should definitely be an improvement.