### PR TITLE
Large Types IRGen Pass: bugfixes for global large type

### DIFF
--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -184,7 +184,8 @@ public struct MUseStruct {
   internal let callInternalLet: () -> BigStruct?
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases18stringAndSubstringSS_s0G0VtyF(<{ %TSS, %Ts9SubstringV }>* noalias nocapture sret) #0 {
+// CHECK-LABEL-64: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases18stringAndSubstringSS_s0G0VtyF(<{ %TSS, %Ts9SubstringV }>* noalias nocapture sret) #0 {
+// CHECK-LABEL-32: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases18stringAndSubstringSS_s0G0VtyF(<{ %TSS, [4 x i8], %Ts9SubstringV }>* noalias nocapture sret) #0 {
 // CHECK: alloca %Ts9SubstringV
 // CHECK: alloca %Ts9SubstringV
 // CHECK: ret void

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -33,6 +33,15 @@ class OptionalInoutFuncType {
   }
 }
 
+// CHECK-LABEL: define{{( protected)?}} i32 @main(i32, i8**) #0 {
+// CHECK: call void @llvm.lifetime.start
+// CHECK: call void @llvm.memcpy
+// CHECK: call void @llvm.lifetime.end
+// CHECK: ret i32 0
+let bigStructGlobalArray : [BigStruct] = [
+  BigStruct()
+]
+
 // CHECK-LABEL: define{{( protected)?}} internal swiftcc void @_T022big_types_corner_cases21OptionalInoutFuncTypeC7executeys5Error_pSgFyycfU_(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases21OptionalInoutFuncTypeC*, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIxcx_Sg* nocapture dereferenceable({{.*}})
 // CHECK: call void @_T0SqWy
 // CHECK: call void @_T0SqWe

--- a/test/IRGen/big_types_corner_cases_as_library.swift
+++ b/test/IRGen/big_types_corner_cases_as_library.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+public struct BigStruct {
+  var i0 : Int32 = 0
+  var i1 : Int32 = 1
+  var i2 : Int32 = 2
+  var i3 : Int32 = 3
+  var i4 : Int32 = 4
+  var i5 : Int32 = 5
+  var i6 : Int32 = 6
+  var i7 : Int32 = 7
+  var i8 : Int32 = 8
+}
+
+// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %swift.opaque* @_T033big_types_corner_cases_as_library9BigStructVwCP
+// CHECK: [[RETVAL:%.*]] = bitcast %T33big_types_corner_cases_as_library9BigStructV* {{.*}} to %swift.opaque*
+// CHECK: ret %swift.opaque* [[RETVAL]]
+let bigStructGlobalArray : [BigStruct] = [
+  BigStruct()
+]


### PR DESCRIPTION
radar rdar://problem/28680453

Add support for calling functions that contain a large type as the return value from inside functions that maintain the old calling conventions + Adds support for the this case when parsed as a library: handling builtin instructions.

This also resolves a test-case failure on some 32-bit targets