### PR TITLE
[Clang importer] Map swift_objc_members attribute found on superclasses.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7103,8 +7103,13 @@ void ClangImporter::Implementation::importAttributes(
       return;
     }
 
-    // Map Clang's swift_objc_members attribute to @objcMembers.
-    if (ID->hasAttr<clang::SwiftObjCMembersAttr>()) {
+    // Map Clang's swift_objc_members attribute to @objcMembers. Also handle
+    // inheritance of @objcMembers by looking at the superclass.
+    if (ID->hasAttr<clang::SwiftObjCMembersAttr>() ||
+        (isa<ClassDecl>(MappedDecl) &&
+         cast<ClassDecl>(MappedDecl)->hasSuperclass() &&
+         cast<ClassDecl>(MappedDecl)->getSuperclassDecl()
+           ->getAttrs().hasAttribute<ObjCMembersAttr>())) {
       if (!MappedDecl->getAttrs().hasAttribute<ObjCMembersAttr>()) {
         auto attr = new (C) ObjCMembersAttr(/*IsImplicit=*/true);
         MappedDecl->getAttrs().add(attr);

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -22,6 +22,12 @@ __attribute__((objc_root_class))
 @interface Base
 @end
 
+@interface B : A
+@end
+
+@interface C : B
+@end
+
 #endif // __OBJC__
 
 #import <APINotesFrameworkTest/Classes.h>

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 4
 import APINotesTest
 import APINotesFrameworkTest
 
@@ -7,8 +7,18 @@ extension A {
   func implicitlyObjC() { }
 }
 
+extension C {
+  func alsoImplicitlyObjC() { }
+}
+
+class D : C {
+  func yetAnotherImplicitlyObjC() { }
+}
+
 func testSelectors(a: AnyObject) {
   a.implicitlyObjC?()  // okay: would complain without SwiftObjCMembers
+  a.alsoImplicitlyObjC?()  // okay: would complain without SwiftObjCMembers
+  a.yetAnotherImplicitlyObjC?()  // okay: would complain without SwiftObjCMembers
 }
 #endif
 


### PR DESCRIPTION
Fixes rdar://problem/33514802.
