### PR TITLE
[swiftc (51 vs. 5582)] Add crasher in swift::constraints::ConstraintSystem::setMustBeMaterializableRecursive(...)

### DIFF
--- a/validation-test/compiler_crashers/28827-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
+++ b/validation-test/compiler_crashers/28827-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[(Int
+(t:&_


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::setMustBeMaterializableRecursive(...)`.

Current number of unresolved compiler crashers: 51 (5582 resolved)

/cc Chris Willmore - just wanted to let you know that this crasher caused an assertion failure for the assertion `type->isMaterializable() && "argument to setMustBeMaterializableRecursive may not be inherently " "non-materializable"` added on 2015-05-21 by you in commit df9136e0 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 181)`](https://github.com/apple/swift/blob/6d0679292ffb846b29e4c8bb07be8abd735b2b46/lib/Sema/ConstraintSystem.cpp#L181):

```
Assertion `type->isMaterializable() && "argument to setMustBeMaterializableRecursive may not be inherently " "non-materializable"' failed.

When executing: void swift::constraints::ConstraintSystem::setMustBeMaterializableRecursive(swift::Type)
```

Assertion context:

```c++

void ConstraintSystem::setMustBeMaterializableRecursive(Type type)
{
  assert(type->isMaterializable() &&
         "argument to setMustBeMaterializableRecursive may not be inherently "
         "non-materializable");
  type = getFixedTypeRecursive(type, /*wantRValue=*/false);
  type = type->lookThroughAllAnyOptionalTypes();

  if (auto typeVar = type->getAs<TypeVariableType>()) {
    typeVar->getImpl().setMustBeMaterializable(getSavedBindings());
```
Stack trace:

```
0 0x0000000003aeda68 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3aeda68)
1 0x0000000003aee1a6 SignalHandler(int) (/path/to/swift/bin/swift+0x3aee1a6)
2 0x00007fd58d755390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fd58bc7a428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd58bc7c02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd58bc72bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fd58bc72c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000011a8732 swift::constraints::ConstraintSystem::setMustBeMaterializableRecursive(swift::Type) (/path/to/swift/bin/swift+0x11a8732)
8 0x00000000011a86e3 swift::constraints::ConstraintSystem::setMustBeMaterializableRecursive(swift::Type) (/path/to/swift/bin/swift+0x11a86e3)
9 0x00000000011723fc swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x11723fc)
10 0x0000000001181ee8 swift::constraints::ConstraintSystem::addConstraintImpl(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x1181ee8)
11 0x0000000001178aed swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x1178aed)
12 0x0000000001189648 swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1189648)
13 0x000000000118d5a4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118d5a4)
14 0x0000000001189c33 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1189c33)
15 0x000000000118969c swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118969c)
16 0x000000000118d5a4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118d5a4)
17 0x0000000001189c33 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1189c33)
18 0x000000000118b6b8 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118b6b8)
19 0x000000000118d253 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118d253)
20 0x00000000011c0ca7 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x11c0ca7)
21 0x00000000011c4b15 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x11c4b15)
22 0x000000000124c170 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x124c170)
23 0x000000000124b976 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x124b976)
24 0x000000000126a030 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x126a030)
25 0x0000000000fb6477 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb6477)
26 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
27 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
28 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
29 0x00007fd58bc65830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```