### PR TITLE
[swiftc (52 vs. 5582)] Add crasher in swift::TypeBase::getSuperclassForDecl

### DIFF
--- a/validation-test/compiler_crashers/28828-unreachable-executed-at-swift-lib-ast-type-cpp-3237.swift
+++ b/validation-test/compiler_crashers/28828-unreachable-executed-at-swift-lib-ast-type-cpp-3237.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{class a{extension{protocol P{class a:a{func a:Self.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getSuperclassForDecl`.

Current number of unresolved compiler crashers: 52 (5582 resolved)

Stack trace:

```
0 0x0000000003aee658 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3aee658)
1 0x0000000003aeed96 SignalHandler(int) (/path/to/swift/bin/swift+0x3aeed96)
2 0x00007f2ad12b5390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f2acf7da428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f2acf7dc02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003a8b3dd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3a8b3dd)
6 0x0000000001609a5c swift::TypeBase::getSuperclassForDecl(swift::ClassDecl const*) (/path/to/swift/bin/swift+0x1609a5c)
7 0x000000000125a68d swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x125a68d)
8 0x0000000001212724 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x1212724)
9 0x000000000125c46e resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125c46e)
10 0x000000000125bbda swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125bbda)
11 0x000000000125c997 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x125c997)
12 0x000000000125c89c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125c89c)
13 0x000000000125b250 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125b250)
14 0x000000000120c9a6 checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x120c9a6)
15 0x000000000120c509 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x120c509)
16 0x00000000011f1957 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x11f1957)
17 0x00000000011dc824 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dc824)
18 0x00000000011ee34b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x11ee34b)
19 0x00000000011dc8fe (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dc8fe)
20 0x00000000011ef53b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x11ef53b)
21 0x00000000011dc804 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dc804)
22 0x00000000011edbdb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x11edbdb)
23 0x00000000011dc834 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dc834)
24 0x00000000011ee34b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x11ee34b)
25 0x00000000011dc8fe (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dc8fe)
26 0x00000000011ee34b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x11ee34b)
27 0x00000000011dc8fe (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dc8fe)
28 0x00000000011dc703 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x11dc703)
29 0x000000000126a764 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x126a764)
30 0x0000000000fb6787 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb6787)
31 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
32 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
33 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
34 0x00007f2acf7c5830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
35 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```