### PR TITLE
Large Loadable Types: Use old ABI for block calling convention

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2495,6 +2495,10 @@ void LoadableByAddress::run() {
                 builtinInstrs.insert(instr);
                 break;
               }
+              case ValueKind::DebugValueAddrInst:
+              case ValueKind::DebugValueInst: {
+                break;
+              }
               default:
                 llvm_unreachable("Unhandled use of FunctionRefInst");
               }

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -87,6 +87,10 @@ static bool modifiableFunction(CanSILFunctionType funcType) {
     // ObjC functions should use the old ABI
     return false;
   }
+  if (funcType->getLanguage() == SILFunctionLanguage::C) {
+    // C functions should use the old ABI
+    return false;
+  }
   if (funcType->getRepresentation() ==
       SILFunctionTypeRepresentation::CFunctionPointer) {
     // C functions should use the old ABI
@@ -565,6 +569,9 @@ static bool modifiableApply(ApplySite applySite, irgen::IRGenModule &Mod) {
       SILFunctionTypeRepresentation::ObjCMethod) {
     return false;
   }
+  if (applySite.getSubstCalleeType()->getLanguage() == SILFunctionLanguage::C) {
+    return false;
+  }
   if (applySite.getSubstCalleeType()->getRepresentation() ==
       SILFunctionTypeRepresentation::CFunctionPointer) {
     return false;
@@ -631,6 +638,10 @@ static bool isMethodInstUnmodifiable(MethodInst *instr) {
       ApplySite applySite = ApplySite(user->getUser());
       if (applySite.getSubstCalleeType()->getRepresentation() ==
           SILFunctionTypeRepresentation::ObjCMethod) {
+        return true;
+      }
+      if (applySite.getSubstCalleeType()->getLanguage() ==
+          SILFunctionLanguage::C) {
         return true;
       }
       if (applySite.getSubstCalleeType()->getRepresentation() ==

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s --check-prefix=CHECK-%target-cpu
+// UNSUPPORTED: resilient_stdlib
+
+sil_stage canonical
+import c_layout
+
+// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testBitfieldInBlock
+// CHECK-x86_64:         call void {{%.*}}(%TSC11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSC11BitfieldOneV* byval align 8 {{%.*}})
+sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
+entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
+  %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne
+  return %r : $BitfieldOne
+}

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// UNSUPPORTED: resilient_stdlib
 
 public struct BigStruct {
   var i0 : Int32 = 0

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -194,3 +194,13 @@ public func stringAndSubstring() -> (String, Substring) {
   let a = Substring(s).dropFirst()
   return (s, a)
 }
+
+func bigStructGet() -> BigStruct {
+  return BigStruct()
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases11testGetFuncyyF() #0 {
+// CHECK: ret void
+public func testGetFunc() {
+  let testGetPtr: @convention(thin) () -> BigStruct = bigStructGet
+}

--- a/test/IRGen/big_types_corner_cases_as_library.swift
+++ b/test/IRGen/big_types_corner_cases_as_library.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// UNSUPPORTED: resilient_stdlib
 
 public struct BigStruct {
   var i0 : Int32 = 0


### PR DESCRIPTION
radar rdar://problem/28680453

Ignores debug instructions when re-creating function_ref instructions + makes sure that convention block functions / instructions use the old ABI