### PR TITLE
[swiftc (53 vs. 5582)] Add crasher in swift::Substitution::Substitution

### DIFF
--- a/validation-test/compiler_crashers/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+&_==nil


### PR DESCRIPTION
Add test case for crash triggered in `swift::Substitution::Substitution`.

Current number of unresolved compiler crashers: 53 (5582 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `Replacement->isMaterializable() && "cannot substitute with a non-materializable type"` added on 2016-09-08 by you in commit 9cba638c :-)

Assertion failure in [`lib/AST/Substitution.cpp (line 43)`](https://github.com/apple/swift/blob/9c9db59c97e069b3645ae9669959d9a506abb014/lib/AST/Substitution.cpp#L43):

```
Assertion `Replacement->isMaterializable() && "cannot substitute with a non-materializable type"' failed.

When executing: swift::Substitution::Substitution(swift::Type, ArrayRef<swift::ProtocolConformanceRef>)
```

Assertion context:

```c++
                           ArrayRef<ProtocolConformanceRef> Conformance)
  : Replacement(Replacement), Conformance(Conformance)
{
  // The replacement type must be materializable.
  assert(Replacement->isMaterializable()
         && "cannot substitute with a non-materializable type");
}

bool Substitution::isCanonical() const {
  if (!getReplacement()->isCanonical())
    return false;
```
Stack trace:

```
0 0x0000000003aee658 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3aee658)
1 0x0000000003aeed96 SignalHandler(int) (/path/to/swift/bin/swift+0x3aeed96)
2 0x00007f2813f88390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f28124ad428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f28124af02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f28124a5bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f28124a5c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015fb4ee swift::Substitution::Substitution(swift::Type, llvm::ArrayRef<swift::ProtocolConformanceRef>) (/path/to/swift/bin/swift+0x15fb4ee)
8 0x000000000159f633 bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const::$_8>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0x159f633)
9 0x000000000159d363 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const::$_4::operator()(swift::CanType) const (/path/to/swift/bin/swift+0x159d363)
10 0x000000000159bf61 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0x159bf61)
11 0x000000000159d532 swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x159d532)
12 0x00000000014d0655 swift::ASTContext::getSpecializedConformance(swift::Type, swift::ProtocolConformance*, swift::SubstitutionMap const&) (/path/to/swift/bin/swift+0x14d0655)
13 0x00000000015d4dd5 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0x15d4dd5)
14 0x000000000121ca41 swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0x121ca41)
15 0x0000000001178e2e swift::constraints::ConstraintSystem::simplifyConformsToConstraint(swift::Type, swift::ProtocolDecl*, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>) (/path/to/swift/bin/swift+0x1178e2e)
16 0x0000000001179b2a swift::constraints::ConstraintSystem::simplifyConformsToConstraint(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>) (/path/to/swift/bin/swift+0x1179b2a)
17 0x0000000001182c72 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) (/path/to/swift/bin/swift+0x1182c72)
18 0x0000000001186db9 swift::constraints::ConstraintSystem::simplify(bool) (/path/to/swift/bin/swift+0x1186db9)
19 0x000000000118a1d2 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118a1d2)
20 0x0000000001189d3c swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1189d3c)
21 0x000000000118dc44 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118dc44)
22 0x000000000118a2d3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118a2d3)
23 0x0000000001189d3c swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1189d3c)
24 0x000000000118dc44 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118dc44)
25 0x000000000118a2d3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118a2d3)
26 0x000000000118e385 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118e385)
27 0x000000000118a2d3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118a2d3)
28 0x000000000118bd58 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118bd58)
29 0x000000000118d8f3 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118d8f3)
30 0x00000000011c1387 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x11c1387)
31 0x00000000011c51f5 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x11c51f5)
32 0x000000000124c910 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x124c910)
33 0x000000000124c116 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x124c116)
34 0x000000000126a7d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x126a7d0)
35 0x0000000000fb6787 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb6787)
36 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
37 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
38 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
39 0x00007f2812498830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
40 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```