### PR TITLE
[stdlib] Conform fixed-width integer types to LosslessStringConvertible

### DIFF
--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -102,7 +102,7 @@ extension FixedWidthInteger {
   ///
   /// The string passed as `text` may begin with a plus or minus sign character
   /// (`+` or `-`), followed by one or more numeric digits (`0-9`) or letters
-  /// (`a-z` or `A-Z`). The string is case-insensitive.
+  /// (`a-z` or `A-Z`). Parsing of the string is case insensitive.
   ///
   ///     let x = Int("123")
   ///     // x == 123
@@ -116,7 +116,7 @@ extension FixedWidthInteger {
   ///     // z == 123
   ///
   /// If `text` is in an invalid format or contains characters that are out of
-  /// range for the given `radix`, or if the value it denotes in the given
+  /// bounds for the given `radix`, or if the value it denotes in the given
   /// `radix` is not representable, the result is `nil`. For example, the
   /// following conversions result in `nil`:
   ///
@@ -171,8 +171,9 @@ extension FixedWidthInteger {
   ///     Int(" 100")                       // Includes whitespace
   ///     Int("21-50")                      // Invalid format
   ///     Int("ff6600")                     // Characters out of bounds
+  ///     Int("10000000000000000000000000") // Out of range
   ///
-  /// - Parameter description: The ASCII representation of a number in base 10.
+  /// - Parameter description: The ASCII representation of a number.
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
   public init?(_ description: String) {

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -102,7 +102,7 @@ extension FixedWidthInteger {
   ///
   /// The string passed as `text` may begin with a plus or minus sign character
   /// (`+` or `-`), followed by one or more numeric digits (`0-9`) or letters
-  /// (`a-z` or `A-Z`). The string is case insensitive.
+  /// (`a-z` or `A-Z`). The string is case-insensitive.
   ///
   ///     let x = Int("123")
   ///     // x == 123
@@ -154,5 +154,28 @@ extension FixedWidthInteger {
     }
     guard _fastPath(result != nil) else { return nil }
     self = result!
+  }
+
+  /// Creates a new integer value from the given string.
+  ///
+  /// The string passed as `description` may begin with a plus or minus sign
+  /// character (`+` or `-`), followed by one or more numeric digits (`0-9`).
+  ///
+  ///     let x = Int("123")
+  ///     // x == 123
+  ///
+  /// If `description` is in an invalid format, or if the value it denotes in
+  /// base 10 is not representable, the result is `nil`. For example, the
+  /// following conversions result in `nil`:
+  ///
+  ///     Int(" 100")                       // Includes whitespace
+  ///     Int("21-50")                      // Invalid format
+  ///     Int("ff6600")                     // Characters out of bounds
+  ///
+  /// - Parameter description: The ASCII representation of a number in base 10.
+  @_semantics("optimize.sil.specialize.generic.partial.never")
+  @inline(__always)
+  public init?(_ description: String) {
+    self.init(description, radix: 10)
   }
 }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1969,7 +1969,8 @@ public enum ArithmeticOverflow {
 /// customization points for arithmetic operations. When you provide just those
 /// methods, the standard library provides default implementations for all
 /// other arithmetic methods and operators.
-public protocol FixedWidthInteger : BinaryInteger, _BitwiseOperations
+public protocol FixedWidthInteger :
+  BinaryInteger, LosslessStringConvertible, _BitwiseOperations
   where Magnitude : FixedWidthInteger
 {
   /// The number of bits used for the underlying binary representation of

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -369,14 +369,8 @@ tests.test("Parsing/LosslessStringConvertible") {
     return text.split(separator: " ").map { T(String($0)) }.flatMap { $0 }
   }
 
-  let i: [Int] = _toArray("1 2 3")
-  expectEqual(i.count, 3)
-  expectEqual(i[0], 1)
-  expectEqual(i[1], 2)
-  expectEqual(i[2], 3)
-
-  let j: [Int] = _toArray("21-50 ff6600 10000000000000000000000000")
-  expectEqual(j.count, 0)
+  expectEqualSequence([1, 2, 3], _toArray("1 2 3"))
+  expectEqualSequence([], _toArray("21-50 ff6600 10000000000000000000000000"))
 }
 
 tests.test("HeterogeneousEquality") {

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -364,6 +364,21 @@ tests.test("extendingOrTruncating") {
   expectEqual(129, UInt8(extendingOrTruncating: 129 + 1024 as UDWord))
 }
 
+tests.test("Parsing/LosslessStringConvertible") {
+  func _toArray<T: LosslessStringConvertible>(_ text: String) -> [T] {
+    return text.split(separator: " ").map { T(String($0)) }.flatMap { $0 }
+  }
+
+  let i: [Int] = _toArray("1 2 3")
+  expectEqual(i.count, 3)
+  expectEqual(i[0], 1)
+  expectEqual(i[1], 2)
+  expectEqual(i[2], 3)
+
+  let j: [Int] = _toArray("21-50 ff6600 10000000000000000000000000")
+  expectEqual(j.count, 0)
+}
+
 tests.test("HeterogeneousEquality") {
   expectTrue(-1 as DWord != UDWord.max)
   expectTrue(DWord.max == UDWord.max / 2)

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -370,7 +370,8 @@ tests.test("Parsing/LosslessStringConvertible") {
   }
 
   expectEqualSequence([1, 2, 3], _toArray("1 2 3"))
-  expectEqualSequence([], _toArray("21-50 ff6600 10000000000000000000000000"))
+  expectEqualSequence(
+    [Int](), _toArray("21-50 ff6600 10000000000000000000000000"))
 }
 
 tests.test("HeterogeneousEquality") {

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -369,9 +369,9 @@ tests.test("Parsing/LosslessStringConvertible") {
     return text.split(separator: " ").map { T(String($0)) }.flatMap { $0 }
   }
 
-  expectEqualSequence([1, 2, 3], _toArray("1 2 3"))
+  expectEqualSequence([1, 2, 3], _toArray("1 2 3") as [Int])
   expectEqualSequence(
-    [Int](), _toArray("21-50 ff6600 10000000000000000000000000"))
+    [Int](), _toArray("21-50 ff6600 10000000000000000000000000") as [Int])
 }
 
 tests.test("HeterogeneousEquality") {


### PR DESCRIPTION
As approved in [SE-0089](https://github.com/apple/swift-evolution/blob/master/proposals/0089-rename-string-reflection-init.md), `Int` and its friends should conform to `LosslessStringConvertible`.

Since `init?(_:radix:)` is now implemented on `FixedWidthInteger`, this PR adopts the following design:

1. `FixedWidthInteger` now refines `LosslessStringConvertible`
2. The required initializer `init?(_:)` has a default implementation that calls `init?(_:radix:)`.

There's clearly a test that can be added to test this conformance. What's going to be even more critical is assuring source compatibility.

> Note: Currently, a method `foo(x: Int, y: Int = 42)` cannot satisfy a protocol requirement for `foo(x: Int)`; however, both can co-exist without the compiler complaining about ambiguity.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->