### PR TITLE
Ensure RawSyntax macro parameters are the same with NDEBUG

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -46,7 +46,7 @@ using llvm::StringRef;
 #define syntax_assert_child_kind(Raw, Cursor, ExpectedKind)                    \
   (assert(Raw->getChild(Cursor)->Kind == ExpectedKind));
 #else
-#define syntax_assert_child_kind(Raw, Cursor, Kind) ({});
+#define syntax_assert_child_kind(Raw, Cursor, ExpectedKind) ({});
 #endif
 
 #ifndef NDEBUG
@@ -66,7 +66,7 @@ using llvm::StringRef;
     }                                                                          \
   })
 #else
-#define syntax_assert_child_token(Raw, Cursor, ...) ({});
+#define syntax_assert_child_token(Raw, CursorName, ...) ({});
 #endif
 
 #ifndef NDEBUG
@@ -87,7 +87,7 @@ using llvm::StringRef;
     }                                                                          \
   })
 #else
-#define syntax_assert_child_token_text(Raw, Cursor, TokenKind, Text) ({});
+#define syntax_assert_child_token_text(Raw, CursorName, TokenKind, ...) ({});
 #endif
 
 #ifndef NDEBUG


### PR DESCRIPTION
(@harlanhaskins committing with @CodaFi's account -- thanks!)

I forgot to reset the macro parameters after converting them to
varargs, which didn't get caught running PR testing.

This patch ensures they're all the same, and fixes the bots.

rdar://33531765