### PR TITLE
[silgen] RValue::{borrow,copy} should not accept special state RValues.

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -673,8 +673,7 @@ void RValue::extractElements(SmallVectorImpl<RValue> &elements) && {
 }
 
 RValue RValue::copy(SILGenFunction &SGF, SILLocation loc) const & {
-  assert((isComplete() || isInSpecialState()) &&
-         "can't copy an incomplete rvalue");
+  assert(isComplete() && "can't copy an incomplete rvalue");
   std::vector<ManagedValue> copiedValues;
   copiedValues.reserve(values.size());
   for (ManagedValue v : values) {
@@ -684,8 +683,7 @@ RValue RValue::copy(SILGenFunction &SGF, SILLocation loc) const & {
 }
 
 RValue RValue::borrow(SILGenFunction &SGF, SILLocation loc) const & {
-  assert((isComplete() || isInSpecialState()) &&
-         "can't borrow incomplete rvalue");
+  assert(isComplete() && "can't borrow an incomplete rvalue");
   std::vector<ManagedValue> borrowedValues;
   borrowedValues.reserve(values.size());
   for (ManagedValue v : values) {


### PR DESCRIPTION
I originally cargo-culted this from the old RValue copy implementation. There
really isn't a way to copy or borrow a null or incontext RValue.

This fixes JohnM's feedback from d810b578d6d1b310757284bd5597232c8db1fff5.

rdar://33358110