### PR TITLE
[4.0] [stdlib] Fix bug in Substring's _persistentContent

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -150,13 +150,6 @@ extension StringProtocol {
     }
     return String(String.CharacterView(self))
   }
-
-  internal var _persistentString : String {
-    if _fastPath(self is _SwiftStringView) {
-      return (self as! _SwiftStringView)._persistentContent
-    }
-    return String(String.CharacterView(self))
-  }
 }
 
 extension String : _SwiftStringView {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -266,10 +266,16 @@ extension Substring : _SwiftStringView {
   var _persistentContent : String {
     let wholeCore = _slice._base._core
     let native = wholeCore.nativeBuffer
-    if _fastPath(native != nil), let n = native {
+    if _fastPath(native != nil) {
+      let wholeString = String(wholeCore)
+      let n = native._unsafelyUnwrappedUnchecked
       if _fastPath(
-        n.start == wholeCore._baseAddress && n.usedCount == wholeCore.count) {
-        return String(wholeCore)
+        n.start == wholeCore._baseAddress
+        && n.usedCount == wholeCore.count
+        && _slice.startIndex == wholeString.startIndex
+        && _slice.endIndex == wholeString.endIndex
+      ) {
+        return wholeString
       }
     }
     var r = String()

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -182,4 +182,11 @@ SubstringTests.test("UTF8View") {
   expectEqual("", String(u.dropLast(10))!)
 }
 
+SubstringTests.test("Persistent Content") {
+  var str = "abc"
+  str += "def"
+  expectEqual("bcdefg", str.dropFirst(1) + "g")
+  expectEqual("bcdefg", (str.dropFirst(1) + "g") as String)
+}
+
 runAllTests()


### PR DESCRIPTION
(this is a 4.0 cherry-pick of https://github.com/apple/swift/pull/11191)

CCC
Explanation: This fixes a bug in Substring, where some modifications would fail to recognize when the Substring represented the entire String. This change fixes that recognition logic.
Scope: Small, limited to Substring's append(contentsOf:)
SR: https://bugs.swift.org/browse/SR-5530
Risk: Low. Change is specifically to avoid an optimization when it might trigger incorrect behavior
Testing: Full CI testing.

----

(from original PR)

Substring's _persistentContent has a fast path that avoids a copy when
the Substring represents the entire outer String. It correctly
detected situations where the wrapped _StringCore was not itself a
slice, but was omitting the extra checks to make sure the Substring's
own range covered the entire String.

Test added.