### PR TITLE
[test] Disable pointer_conversion.swift with an unoptimized stdlib.

### DIFF
--- a/test/SILOptimizer/pointer_conversion.swift
+++ b/test/SILOptimizer/pointer_conversion.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+// REQUIRES: optimized_stdlib
 
 // Opaque, unoptimizable functions to call.
 @_silgen_name("takesConstRawPointer")


### PR DESCRIPTION
I looked at trying to make the matches more flexible, but there are actually some suspicious bits that I'm not so sure about. I'll just disable the test for now.

rdar://problem/33531741