### PR TITLE
Remove subsumed CFunctionPointer/ObjCMethod/Block in large loadable types

### DIFF
--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -11,3 +11,12 @@ entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne
   return %r : $BitfieldOne
 }
+
+// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testTupleExtract
+// CHECK-x86_64:         call void {{%.*}}(%TSC11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSC11BitfieldOneV* byval align 8 {{%.*}})
+sil @testTupleExtract : $@convention(thin) (@owned (BitfieldOne, @convention(block) (BitfieldOne) -> BitfieldOne), BitfieldOne) -> BitfieldOne  {
+entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x : $BitfieldOne):
+  %a = tuple_extract %b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), 1
+  %r = apply %a(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne
+  return %r : $BitfieldOne
+}


### PR DESCRIPTION
radar rdar://problem/28680453

Removes subsumed CFunctionPointer/ObjCMethod/Block in large loadable types + adds new test for a old-calling-convetions corner case.