### PR TITLE
[silgen] Add RValue::isPlus{One,Zero} to distinguish +0 from +1 rvalues.

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -21,6 +21,7 @@
 #include "Initialization.h"
 #include "SILGenFunction.h"
 #include "swift/AST/CanTypeVisitor.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/SIL/AbstractionPattern.h"
 #include "swift/SIL/SILArgument.h"
 
@@ -783,4 +784,22 @@ void RValue::verifyConsistentOwnership() const {
     result = newResult;
   }
 #endif
+}
+
+bool RValue::isPlusOne(SILGenFunction &SGF) const & {
+  return llvm::none_of(values, [&SGF](ManagedValue mv) -> bool {
+    if (mv.getType().isTrivial(SGF.F.getModule()) ||
+        mv.getOwnershipKind() == ValueOwnershipKind::Trivial)
+      return false;
+    return !mv.hasCleanup();
+  });
+}
+
+bool RValue::isPlusZero(SILGenFunction &SGF) const & {
+  return llvm::none_of(values, [&SGF](ManagedValue mv) -> bool {
+    if (mv.getType().isTrivial(SGF.F.getModule()) ||
+        mv.getOwnershipKind() == ValueOwnershipKind::Trivial)
+      return false;
+    return mv.hasCleanup();
+  });
 }

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -204,6 +204,30 @@ public:
     return value;
   }
 
+  /// Returns true if this is an rvalue that can be used safely as a +1 rvalue.
+  ///
+  /// This returns true iff:
+  ///
+  /// 1. All sub-values are trivially typed.
+  /// 2. There exists at least one non-trivial typed sub-value and all such
+  /// sub-values all have cleanups.
+  ///
+  /// *NOTE* Due to 1. isPlusOne and isPlusZero both return true for rvalues
+  /// consisting of only trivial values.
+  bool isPlusOne(SILGenFunction &SGF) const &;
+
+  /// Returns true if this is an rvalue that can be used safely as a +0 rvalue.
+  ///
+  /// Specifically, we return true if:
+  ///
+  /// 1. All sub-values are trivially typed.
+  /// 2. At least 1 subvalue is non-trivial and all such non-trivial values do
+  /// not have a cleanup.
+  ///
+  /// *NOTE* Due to 1. isPlusOne and isPlusZero both return true for rvalues
+  /// consisting of only trivial values.
+  bool isPlusZero(SILGenFunction &SGF) const &;
+
   /// Use this rvalue to initialize an Initialization.
   void forwardInto(SILGenFunction &SGF, SILLocation loc, Initialization *I) &&;
 


### PR DESCRIPTION
I already in a previous commit forced all rvalues to have consistent cleanups
and consistent value ownership kinds. Now that we know all constructed RValues
are consistent, we can safely query that information.

rdar://33358110