### PR TITLE
Update CSDiag to use the proper InOutType convention

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4597,7 +4597,10 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
     if (!elExpr) return nullptr; // already diagnosed.
     
     resultElts.push_back(elExpr);
-    resultEltTys.push_back({CS.getType(elExpr), TE->getElementName(i)});
+    auto resFlags =
+        ParameterTypeFlags().withInOut(elExpr->isSemanticallyInOutExpr());
+    resultEltTys.push_back({CS.getType(elExpr)->getInOutObjectType(),
+                            TE->getElementName(i), resFlags});
   }
 
   auto TT = TupleType::get(resultEltTys, CS.getASTContext());

--- a/validation-test/compiler_crashers_fixed/28820-fl-isinout-caller-did-not-set-flags-correctly.swift
+++ b/validation-test/compiler_crashers_fixed/28820-fl-isinout-caller-did-not-set-flags-correctly.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 .a.i(t:&_


### PR DESCRIPTION
A quick spot fix for some CSDiag code that didn't get updated in the big sweep.  This caused a crash that @practicalswift's fuzzer managed to find.