### PR TITLE
Report nested inout paren types as non-materializable

### DIFF
--- a/validation-test/compiler_crashers_fixed/28827-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
+++ b/validation-test/compiler_crashers_fixed/28827-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 [(Int
 (t:&_


### PR DESCRIPTION
Workaround for a corner case wherein types such as

```
(tuple_type num_elements=2
  (tuple_type_elt
    (metatype_type
      (struct_type decl=Swift.(file).Int)))
  (tuple_type_elt
    (tuple_type num_elements=1
      (tuple_type_elt name=t
        (inout_type
          (type_variable_type id=0))))))
```

were being reported as materializable.  Because this is effectively a TupleType of a ParenType, look through to its underlying element flags for materializability information.