### PR TITLE
[stdlib] Give Substring its own views

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -28,6 +28,19 @@ import Glibc
 import ObjectiveC
 #endif
 
+extension String {
+  /// Returns the lines in `self`.
+  public var _lines : [String] {
+    return _split(separator: "\n")
+  }
+
+  /// Splits `self` at occurrences of `separator`.
+  public func _split(separator: Unicode.Scalar) -> [String] {
+    let scalarSlices = unicodeScalars.split { $0 == separator }
+    return scalarSlices.map { String(String.UnicodeScalarView($0)) }
+  }
+}
+
 public struct SourceLoc {
   public let file: String
   public let line: UInt

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -57,15 +57,6 @@ extension String {
     }
   }
 
-  public var _lines : [String] {
-    return _split(separator: "\n")
-  }
-  
-  public func _split(separator: Unicode.Scalar) -> [String] {
-    let scalarSlices = unicodeScalars.split { $0 == separator }
-    return scalarSlices.map { String($0) }
-  }
-
   /// A Boolean value indicating whether a string has no characters.
   public var isEmpty: Bool {
     return _core.count == 0

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -244,18 +244,6 @@ extension String {
     }
 #endif
 
-    /// Accesses the contiguous subrange of elements enclosed by the specified
-    /// range.
-    ///
-    /// - Complexity: O(*n*) if the underlying string is bridged from
-    ///   Objective-C, where *n* is the length of the string; otherwise, O(1).
-    public subscript(bounds: Range<Index>) -> UTF16View {
-      return UTF16View(
-        _core,
-        offset: _internalIndex(at: bounds.lowerBound.encodedOffset),
-        length: bounds.upperBound.encodedOffset - bounds.lowerBound.encodedOffset)
-    }
-
     internal init(_ _core: _StringCore) {
       self.init(_core, offset: 0, length: _core.count)
     }
@@ -309,19 +297,33 @@ extension String {
   /// slice of the `picnicGuest.utf16` view.
   ///
   /// - Parameter utf16: A UTF-16 code sequence.
+  @available(swift, deprecated: 3.2, obsoleted: 4.0)
   public init?(_ utf16: UTF16View) {
-    let wholeString = String(utf16._core)
+    // Attempt to recover the whole string, the better to implement the actual
+    // Swift 3.1 semantics, which are not as documented above!  Full Swift 3.1
+    // semantics may be impossible to preserve in the case of string literals,
+    // since we no longer have access to the length of the original string when
+    // there is no owner and elements are dropped from the end.
+    let wholeString = utf16._core.nativeBuffer.map { String(_StringCore($0)) }
+       ?? String(utf16._core)
 
     guard
-      let start = UTF16Index(encodedOffset: utf16._offset)
+      let start = UTF16Index(_offset: utf16._offset)
         .samePosition(in: wholeString),
-      let end = UTF16Index(encodedOffset: utf16._offset + utf16._length)
+      let end = UTF16Index(_offset: utf16._offset + utf16._length)
         .samePosition(in: wholeString)
       else
     {
         return nil
     }
-    self = String(wholeString[start..<end])
+    self = wholeString[start..<end]
+
+  }
+
+  /// Creates a string corresponding to the given sequence of UTF-16 code units.
+  @available(swift, introduced: 4.0)
+  public init(_ utf16: UTF16View) {
+    self = String(utf16._core)
   }
 
   /// The index type for subscripting a string's `utf16` view.
@@ -507,5 +509,35 @@ extension String.UTF16View {
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional index")
   public subscript(i: Index?) -> Unicode.UTF16.CodeUnit {
     return self[i!]
+  }
+}
+
+//===--- Slicing Support --------------------------------------------------===//
+/// In Swift 3.2, in the absence of type context,
+///
+///   someString.utf16[someString.utf16.startIndex..<someString.utf16.endIndex]
+///
+/// was deduced to be of type `String.UTF16View`.  Provide a more-specific
+/// Swift-3-only `subscript` overload that continues to produce
+/// `String.UTF16View`.
+extension String.UTF16View {
+  public typealias SubSequence = Substring.UTF16View
+
+  @available(swift, introduced: 4)
+  public subscript(r: Range<Index>) -> String.UTF16View.SubSequence {
+    return String.UTF16View.SubSequence(self, _bounds: r)
+  }
+
+  @available(swift, obsoleted: 4)
+  public subscript(bounds: Range<Index>) -> String.UTF16View {
+    return String.UTF16View(
+      _core,
+      offset: _internalIndex(at: bounds.lowerBound.encodedOffset),
+      length: bounds.upperBound.encodedOffset - bounds.lowerBound.encodedOffset)
+  }
+
+  @available(swift, obsoleted: 4)
+  public subscript(bounds: ClosedRange<Index>) -> String.UTF16View {
+    return self[bounds.relative(to: self)]
   }
 }

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -377,28 +377,6 @@ extension String {
   ///
   /// If `utf8` is an ill-formed UTF-8 code sequence, the result is `nil`.
   ///
-  /// You can use this initializer to create a new string from
-  /// another string's `utf8` view.
-  ///
-  ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.utf8.index(of: 32) {
-  ///         let adjective = String(picnicGuest.utf8[..<i])
-  ///         print(adjective)
-  ///     }
-  ///     // Prints "Optional(Deserving)"
-  ///
-  /// The `adjective` constant is created by calling this initializer with a
-  /// slice of the `picnicGuest.utf8` view.
-  ///
-  /// - Parameter utf8: A UTF-8 code sequence.
-  public init(_ utf8: UTF8View) {
-    self = String(utf8._core)
-  }
-
-  /// Creates a string corresponding to the given sequence of UTF-8 code units.
-  ///
-  /// If `utf8` is an ill-formed UTF-8 code sequence, the result is `nil`.
-  ///
   /// You can use this initializer to create a new string from a slice of
   /// another string's `utf8` view.
   ///
@@ -413,14 +391,38 @@ extension String {
   /// slice of the `picnicGuest.utf8` view.
   ///
   /// - Parameter utf8: A UTF-8 code sequence.
-  public init?(_ utf8: UTF8View.SubSequence) {
-    let wholeString = String(utf8.base._core)
-    if let start = utf8.startIndex.samePosition(in: wholeString),
-       let end = utf8.endIndex.samePosition(in: wholeString) {
-      self = String(wholeString[start..<end])
-      return
+  @available(swift, deprecated: 3.2, obsoleted: 4.0)
+  public init?(_ utf8: UTF8View) {
+    if utf8.startIndex._transcodedOffset != 0
+    || utf8.endIndex._transcodedOffset != 0 {
+      return nil
     }
-    return nil
+    // Attempt to recover the whole string, the better to implement the actual
+    // Swift 3.1 semantics, which are not as documented above!  Full Swift 3.1
+    // semantics may be impossible to preserve in the case of string literals,
+    // since we no longer have access to the length of the original string when
+    // there is no owner and elements have been dropped from the end.
+    if let nativeBuffer = utf8._core.nativeBuffer {
+      let wholeString = String(_StringCore(nativeBuffer))
+      let offset = (utf8._core._baseAddress! - nativeBuffer.start)
+        &>> utf8._core.elementShift
+
+      if Index(
+        encodedOffset: utf8.startIndex.encodedOffset + offset
+      ).samePosition(in: wholeString) == nil
+      || Index(
+        encodedOffset: utf8.endIndex.encodedOffset + offset
+      ).samePosition(in: wholeString) == nil {
+        return nil
+      }
+    }
+    self = String(utf8._core)
+  }
+
+  /// Creates a string corresponding to the given sequence of UTF-8 code units.
+  @available(swift, introduced: 4.0)
+  public init(_ utf8: UTF8View) {
+    self = String(utf8._core)
   }
 
   /// The index type for subscripting a string's `utf8` view.
@@ -655,17 +657,17 @@ extension String.UTF8View {
 //===--- Slicing Support --------------------------------------------------===//
 /// In Swift 3.2, in the absence of type context,
 ///
-///     someString.utf8[someString.startIndex..<someString.endIndex]
+///   someString.utf8[someString.utf8.startIndex..<someString.utf8.endIndex]
 ///
 /// was deduced to be of type `String.UTF8View`.  Provide a more-specific
 /// Swift-3-only `subscript` overload that continues to produce
 /// `String.UTF8View`.
 extension String.UTF8View {
-  public typealias SubSequence = BidirectionalSlice<String.UTF8View>
+  public typealias SubSequence = Substring.UTF8View
   
   @available(swift, introduced: 4)
   public subscript(r: Range<Index>) -> String.UTF8View.SubSequence {
-    return String.UTF8View.SubSequence(base: self, bounds: r)
+    return String.UTF8View.SubSequence(self, _bounds: r)
   }
 
   @available(swift, obsoleted: 4)

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -134,15 +134,19 @@ extension String {
     ///
     /// In an empty UTF-8 view, `endIndex` is equal to `startIndex`.
     public var endIndex: Index {
+      _sanityCheck(_legacyOffsets.end >= -3 && _legacyOffsets.end <= 0,
+        "out of bounds legacy end")
+
       var r = Index(encodedOffset: _core.endIndex)
+      if _fastPath(_legacyOffsets.end == 0) {
+        return r
+      }
       switch _legacyOffsets.end {
-      case 0: return r
       case -3: r = index(before: r); fallthrough
       case -2: r = index(before: r); fallthrough
-      case -1: r = index(before: r); fallthrough
-      default: break
+      case -1: return index(before: r)
+      default: Builtin.unreachable()
       }
-      return r
     }
 
     @_versioned

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -227,7 +227,7 @@ public struct Substring : StringProtocol {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   public func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
-    return try _slice._base._core._withCSubstringAndLength(
+    return try _wholeString._core._withCSubstringAndLength(
       in: startIndex.encodedOffset..<endIndex.encodedOffset,
       encoding: UTF8.self) {
       p, length in try p.withMemoryRebound(to: CChar.self, capacity: length) {
@@ -256,15 +256,15 @@ public struct Substring : StringProtocol {
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) rethrows -> Result {
-    return try _slice._base._core._withCSubstring(
+    return try _wholeString._core._withCSubstring(
       in: startIndex.encodedOffset..<endIndex.encodedOffset,
       encoding: targetEncoding, body)
   }
 }
 
 extension Substring : _SwiftStringView {
-  var _persistentContent : String {
-    let wholeCore = _slice._base._core
+  var _persistentContent: String {
+    let wholeCore = _wholeString._core
     let native = wholeCore.nativeBuffer
     if _fastPath(native != nil) {
       let wholeString = String(wholeCore)
@@ -284,9 +284,9 @@ extension Substring : _SwiftStringView {
     return r
   }
 
-  public // @testablw
-  var _ephemeralContent : String {
-    let wholeCore = _slice._base._core
+  public // @testable
+  var _ephemeralContent: String {
+    let wholeCore = _wholeString._core
     let subCore : _StringCore = wholeCore[
       startIndex.encodedOffset..<endIndex.encodedOffset]
     // Check that we haven't allocated a new buffer for the result, if we have
@@ -295,6 +295,11 @@ extension Substring : _SwiftStringView {
       subCore._owner === wholeCore._owner || !wholeCore.hasContiguousStorage)
 
     return String(subCore)
+  }
+
+  internal
+  var _wholeString: String {
+    return _slice._base
   }
 }
 
@@ -362,24 +367,107 @@ extension StringProtocol {
   }
 }
 
-extension Substring {
 % for (property, ViewPrefix) in [
 %   ('utf8', 'UTF8'),
 %   ('utf16', 'UTF16'),
 %   ('unicodeScalars', 'UnicodeScalar'),
-%   ('characters', 'Character')]:
-  public typealias ${ViewPrefix}Index = String.${ViewPrefix}View.Index
+%   ('characters', 'Character')
+% ]:
+%   View = ViewPrefix + 'View'
+%   RangeReplaceable = 'RangeReplaceable' if property == 'unicodeScalars' else ''
+extension Substring {
+  public struct ${View} {
+    var _slice: ${RangeReplaceable}BidirectionalSlice<String.${View}>
+  }
+}
 
-  public var ${property}: String.${ViewPrefix}View {
+extension Substring.${View} : BidirectionalCollection {
+  public typealias Index = String.Index
+  public typealias SubSequence = Substring.${View}
+
+  /// Creates an instance that slices `base` at `_bounds`.
+  internal init(_ base: String.${View}, _bounds: Range<Index>) {
+    _slice = ${RangeReplaceable}BidirectionalSlice(
+      base: String(base._core).${property},
+      bounds: _bounds)
+  }
+
+  /// The entire String onto whose slice this view is a projection.
+  internal var _wholeString: String {
+    return String(_slice._base._core)
+  }
+
+  public var startIndex: Index { return _slice.startIndex }
+  public var endIndex: Index { return _slice.endIndex }
+  public func index(after i: Index) -> Index {
+    return _slice.index(after: i)
+  }
+  public func index(before i: Index) -> Index {
+    return _slice.index(before: i)
+  }
+  public subscript(i: Index) -> String.${View}.Element {
+    return _slice[i]
+  }
+  public subscript(r: Range<Index>) -> SubSequence {
+    return Substring.${View}(_wholeString.${property}, _bounds: r)
+  }
+}
+
+extension Substring {
+  public var ${property}: ${View} {
     get {
-      return String(self).${property}
+      return ${View}(_wholeString.${property}, _bounds: startIndex..<endIndex)
     }
     set {
-      let base = String(describing: newValue)
-      self = Substring(_base: base, base.startIndex ..< base.endIndex)
+      self = Substring(newValue)
     }
   }
+
+  /// Creates a Substring having the given content.
+  ///
+  /// - Complexity: O(1)
+  public init(_ content: ${View}) {
+    self = content._wholeString[content.startIndex..<content.endIndex]
+  }
+}
+
+extension String {
+  % if property in ('utf8', 'utf16'):
+  /// Creates a String having the given content.
+  ///
+  /// If `codeUnits` is an ill-formed code unit sequence, the result is `nil`.
+  ///
+  /// - Complexity: O(N), where N is the length of the resulting `String`'s
+  ///   UTF-16.
+  public init?(_ codeUnits: Substring.${View}) {
+    let wholeString = codeUnits._wholeString
+    guard
+      codeUnits.startIndex.samePosition(in: wholeString.unicodeScalars) != nil
+      && codeUnits.endIndex.samePosition(in: wholeString.unicodeScalars) != nil
+    else { return nil }
+    self = String(Substring(codeUnits))
+  }
+  % else:
+  /// Creates a String having the given content.
+  ///
+  /// - Complexity: O(N), where N is the length of the resulting `String`'s
+  ///   UTF-16.
+  public init(_ content: Substring.${View}) {
+    self = String(Substring(content))
+  }
+  % end
+}
 % end
+
+// FIXME: The other String views should be RangeReplaceable too.
+extension Substring.UnicodeScalarView : RangeReplaceableCollection {
+  public init() { _slice = RangeReplaceableBidirectionalSlice.init() }
+
+  public mutating func replaceSubrange<C : Collection>(
+    _ target: Range<Index>, with replacement: C
+  ) where C.Element == Element {
+    _slice.replaceSubrange(target, with: replacement)
+  }
 }
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -19,7 +19,17 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the length of `substring`.
   public init(_ substring: Substring) {
-    self = String(substring._slice)
+    let x = substring._wholeString
+    let start = substring.startIndex
+    let end = substring.endIndex
+    let u16 = x._core[start.encodedOffset..<end.encodedOffset]
+    if start.samePosition(in: x.unicodeScalars) != nil
+    && end.samePosition(in: x.unicodeScalars) != nil {
+      self = String(_StringCore(u16))
+    }
+    else {
+      self = String(decoding: u16, as: UTF16.self)
+    }
   }
 }
 

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -156,19 +156,17 @@ ${Suite}.test("${ArrayType}/filter") {
     let arr: ${ArrayType}<Int> = [ 0, 30, 10, 90 ]
     let result = arr.filter() { (x: Int) -> Bool in true }
     expectEqual([ 0, 30, 10, 90 ], result)
-    expectGE(2 * result.count, result.capacity)
   }
   do {
     let arr: ${ArrayType}<Int> = [ 0, 30, 10, 90 ]
     let result = arr.filter() { (x: Int) -> Bool in false }
     expectEqual([], result)
-    expectGE(2 * result.count, result.capacity)
+    expectEqual(0, result.capacity)
   }
   do {
     let arr: ${ArrayType}<Int> = [ 0, 30, 10, 90 ]
     let result = arr.filter() { $0 % 3 == 0 }
     expectEqual([ 0, 30, 90 ], result)
-    expectGE(2 * result.count, result.capacity)
   }
 }
 

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -397,6 +397,105 @@ StringTests.test("Regression/rdar-33276845") {
   }
 }
 
+StringTests.test("Regression/corelibs-foundation") {
+  struct NSRange { var location, length: Int }
+
+  func NSFakeRange(_ location: Int, _ length: Int) -> NSRange {
+    return NSRange(location: location, length: length)
+  }
+
+  func substring(of _storage: String, with range: NSRange) -> String {
+    let start = _storage.utf16.startIndex
+    let min = _storage.utf16.index(start, offsetBy: range.location)
+    let max = _storage.utf16.index(
+      start, offsetBy: range.location + range.length)
+
+    if let substr = String(_storage.utf16[min..<max]) {
+      return substr
+    }
+    //If we come here, then the range has created unpaired surrogates on either end.
+    //An unpaired surrogate is replaced by OXFFFD - the Unicode Replacement Character.
+    //The CRLF ("\r\n") sequence is also treated like a surrogate pair, but its constinuent
+    //characters "\r" and "\n" can exist outside the pair!
+
+    let replacementCharacter = String(describing: UnicodeScalar(0xFFFD)!)
+    let CR: UInt16 = 13  //carriage return
+    let LF: UInt16 = 10  //new line
+
+    //make sure the range is of non-zero length
+    guard range.length > 0 else { return "" }
+
+    //if the range is pointing to a single unpaired surrogate
+    if range.length == 1 {
+      switch _storage.utf16[min] {
+      case CR: return "\r"
+      case LF: return "\n"
+      default: return replacementCharacter
+      }
+    }
+
+    //set the prefix and suffix characters
+    let prefix = _storage.utf16[min] == LF ? "\n" : replacementCharacter
+    let suffix = _storage.utf16[_storage.utf16.index(before: max)] == CR
+      ? "\r" : replacementCharacter
+
+    let postMin = _storage.utf16.index(after: min)
+
+    //if the range breaks a surrogate pair at the beginning of the string
+    if let substrSuffix = String(
+      _storage.utf16[postMin..<max]) {
+      return prefix + substrSuffix
+    }
+
+    let preMax = _storage.utf16.index(before: max)
+    //if the range breaks a surrogate pair at the end of the string
+    if let substrPrefix = String(_storage.utf16[min..<preMax]) {
+      return substrPrefix + suffix
+    }
+
+    //the range probably breaks surrogate pairs at both the ends
+    guard postMin <= preMax else { return prefix + suffix }
+
+    let substr =  String(_storage.utf16[postMin..<preMax])!
+    return prefix + substr + suffix
+  }
+
+  let trivial = "swift.org"
+  expectEqual(substring(of: trivial, with: NSFakeRange(0, 5)), "swift")
+
+  let surrogatePairSuffix = "Hurray🎉"
+  expectEqual(substring(of: surrogatePairSuffix, with: NSFakeRange(0, 7)), "Hurray�")
+
+  let surrogatePairPrefix = "🐱Cat"
+  expectEqual(substring(of: surrogatePairPrefix, with: NSFakeRange(1, 4)), "�Cat")
+
+  let singleChar = "😹"
+  expectEqual(substring(of: singleChar, with: NSFakeRange(0,1)), "�")
+
+  let crlf = "\r\n"
+  expectEqual(substring(of: crlf, with: NSFakeRange(0,1)), "\r")
+  expectEqual(substring(of: crlf, with: NSFakeRange(1,1)), "\n")
+  expectEqual(substring(of: crlf, with: NSFakeRange(1,0)), "")
+
+  let bothEnds1 = "😺😺"
+  expectEqual(substring(of: bothEnds1, with: NSFakeRange(1,2)), "��")
+
+  let s1 = "😺\r\n"
+  expectEqual(substring(of: s1, with: NSFakeRange(1,2)), "�\r")
+
+  let s2 = "\r\n😺"
+  expectEqual(substring(of: s2, with: NSFakeRange(1,2)), "\n�")
+
+  let s3 = "😺cats😺"
+  expectEqual(substring(of: s3, with: NSFakeRange(1,6)), "�cats�")
+
+  let s4 = "😺cats\r\n"
+  expectEqual(substring(of: s4, with: NSFakeRange(1,6)), "�cats\r")
+
+  let s5 = "\r\ncats😺"
+  expectEqual(substring(of: s5, with: NSFakeRange(1,6)), "\ncats�")
+}
+
 var CStringTests = TestSuite("CStringTests")
 
 func getNullUTF8() -> UnsafeMutablePointer<UInt8>? {

--- a/test/stdlib/StringReallocation.swift
+++ b/test/stdlib/StringReallocation.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
+import StdlibUnittest
+
 // CHECK-NOT: Reallocations exceeded 30
 func testReallocation() {
   var x = "The quick brown fox jumped over the lazy dog\n"._split(separator: " ")

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -59,7 +59,7 @@ StringTests.test("AssociatedTypes-UTF8View") {
   expectCollectionAssociatedTypes(
     collectionType: View.self,
     iteratorType: View.Iterator.self,
-    subSequenceType: BidirectionalSlice<View>.self,
+    subSequenceType: Substring.UTF8View.self,
     indexType: View.Index.self,
     indexDistanceType: Int.self,
     indicesType: DefaultBidirectionalIndices<View>.self)
@@ -70,7 +70,7 @@ StringTests.test("AssociatedTypes-UTF16View") {
   expectCollectionAssociatedTypes(
     collectionType: View.self,
     iteratorType: IndexingIterator<View>.self,
-    subSequenceType: View.self,
+    subSequenceType: Substring.UTF16View.self,
     indexType: View.Index.self,
     indexDistanceType: Int.self,
     indicesType: View.Indices.self)
@@ -81,7 +81,7 @@ StringTests.test("AssociatedTypes-UnicodeScalarView") {
   expectCollectionAssociatedTypes(
     collectionType: View.self,
     iteratorType: View.Iterator.self,
-    subSequenceType: View.self,
+    subSequenceType: Substring.UnicodeScalarView.self,
     indexType: View.Index.self,
     indexDistanceType: Int.self,
     indicesType: DefaultBidirectionalIndices<View>.self)

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -466,7 +466,7 @@ StringTests.test("appendToSubstringBug") {
   }
 
   do {
-    var (s, unused) = { ()->(String, Int) in
+    var (s, _) = { ()->(String, Int) in
       let (s0, unused) = stringWithUnusedCapacity()
       return (s0[s0.index(_nth: 5)..<s0.endIndex], unused)
     }()
@@ -478,7 +478,7 @@ StringTests.test("appendToSubstringBug") {
   }
 
   do {
-    var (s, unused) = { ()->(Substring, Int) in
+    var (s, _) = { ()->(Substring, Int) in
       let (s0, unused) = stringWithUnusedCapacity()
       return (s0[s0.index(_nth: 5)..<s0.endIndex], unused)
     }()
@@ -503,6 +503,7 @@ StringTests.test("appendToSubstringBug") {
     expectEqual(originalID, s.bufferID)
     s += "."
     expectNotEqual(originalID, s.bufferID)
+    unused += 0 // warning suppression
   }
 }
 
@@ -640,7 +641,7 @@ StringTests.test("COW/removeSubrange/end") {
 StringTests.test("COW/replaceSubrange/end") {
   // Check literal-to-heap reallocation.
   do {
-    var str = "12345678"
+    let str = "12345678"
     let literalIdentity = str.bufferID
 
     var slice = str[str.startIndex..<str.index(_nth: 7)]
@@ -772,7 +773,7 @@ StringTests.test("stringCoreReserve")
     }
     expectEqual(!base._core.hasCocoaBuffer, startedNative)
     
-    var originalBuffer = base.bufferID
+    let originalBuffer = base.bufferID
     let startedUnique = startedNative && base._core._owner != nil
       && isKnownUniquelyReferenced(&base._core._owner!)
     
@@ -975,10 +976,11 @@ StringTests.test("growth") {
   var s = ""
   var s2 = s
 
-  for i in 0..<20 {
+  for _ in 0..<20 {
     s += "x"
     s2 = s
   }
+  expectEqual(s2, s)
   expectLE(s.nativeCapacity, 34)
 }
 
@@ -988,20 +990,20 @@ StringTests.test("Construction") {
 
 StringTests.test("Conversions") {
   do {
-    var c: Character = "a"
+    let c: Character = "a"
     let x = String(c)
     expectTrue(x._core.isASCII)
 
-    var s: String = "a"
+    let s: String = "a"
     expectEqual(s, x)
   }
 
   do {
-    var c: Character = "\u{B977}"
+    let c: Character = "\u{B977}"
     let x = String(c)
     expectFalse(x._core.isASCII)
 
-    var s: String = "\u{B977}"
+    let s: String = "\u{B977}"
     expectEqual(s, x)
   }
 }

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -687,6 +687,8 @@ tests.test("UTF16->String") {
           continue
         }
       }
+      // This tests for the Swift 3 semantics, which don't match the documented
+      // semantics!
       expectNil(String(v[i..<j]))
     }
   }
@@ -695,14 +697,20 @@ tests.test("UTF16->String") {
 tests.test("UTF8->String") {
   let s = summer + winter + winter + summer
   let v = s.utf8
+
   for i in v.indices {
     for j in v.indices[i..<v.endIndex] {
       if let si = i.samePosition(in: s) {
         if let sj = j.samePosition(in: s) {
-          expectEqual(s[si..<sj], String(v[i..<j])!)
+          expectEqual(
+            s[si..<sj], String(v[i..<j])!,
+            "\(String(reflecting: s))[\n  \(si..<sj)\n] != String(\n  \(String(reflecting: v))[\n    \(i..<j)\n  ])!"
+          )
           continue
         }
       }
+      // This tests for the Swift 3 semantics, which don't match the documented
+      // semantics!
       expectNil(String(v[i..<j]))
     }
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a rebase, squash, and refactoring of https://github.com/apple/swift/pull/11088

Substring now has distinct views inside of it. String's view's SubSequences are the same as Substring's respective views, lending a consistent API that also encourages/enforces thinking about slices holding onto memory.

Included are some compatibility additions, extra sanity checks, updated tests, and a few miscellaneous fixes exposed by this change.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->