### PR TITLE
[SE-0157] Enable recursive protocol constraints

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1668,8 +1668,6 @@ ERROR(requires_generic_param_made_equal_to_concrete,none,
       (Type))
 ERROR(recursive_type_reference,none,
       "%0 %1 references itself", (DescriptiveDeclKind, Identifier))
-ERROR(recursive_requirement_reference,none,
-      "type may not reference itself as a requirement",())
 ERROR(recursive_same_type_constraint,none,
       "same-type constraint %0 == %1 is recursive", (Type, Type))
 ERROR(recursive_superclass_constraint,none,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -426,10 +426,6 @@ private:
   template<typename F>
   void visitPotentialArchetypes(F f);
 
-  void markPotentialArchetypeRecursive(PotentialArchetype *pa,
-                                       ProtocolDecl *proto,
-                                       const RequirementSource *source);
-
 public:
   /// Construct a new generic signature builder.
   ///
@@ -1358,23 +1354,20 @@ class GenericSignatureBuilder::PotentialArchetype {
   /// that share a name.
   llvm::MapVector<Identifier, StoredNestedType> NestedTypes;
 
-  /// \brief Recursively conforms to itself.
-  unsigned IsRecursive : 1;
-
   /// \brief Construct a new potential archetype for an unresolved
   /// associated type.
   PotentialArchetype(PotentialArchetype *parent, Identifier name);
 
   /// \brief Construct a new potential archetype for an associated type.
   PotentialArchetype(PotentialArchetype *parent, AssociatedTypeDecl *assocType)
-    : parentOrBuilder(parent), identifier(assocType), IsRecursive(false)
+    : parentOrBuilder(parent), identifier(assocType)
   {
     assert(parent != nullptr && "Not an associated type?");
   }
 
   /// \brief Construct a new potential archetype for a concrete declaration.
   PotentialArchetype(PotentialArchetype *parent, TypeDecl *concreteDecl)
-    : parentOrBuilder(parent), identifier(concreteDecl), IsRecursive(false)
+    : parentOrBuilder(parent), identifier(concreteDecl)
   {
     assert(parent != nullptr && "Not an associated type?");
   }
@@ -1382,8 +1375,7 @@ class GenericSignatureBuilder::PotentialArchetype {
   /// \brief Construct a new potential archetype for a generic parameter.
   PotentialArchetype(GenericSignatureBuilder *builder,
                      GenericParamKey genericParam)
-    : parentOrBuilder(builder), identifier(genericParam),
-      IsRecursive(false)
+    : parentOrBuilder(builder), identifier(genericParam)
   {
   }
 
@@ -1625,9 +1617,6 @@ public:
 
     return Type();
   }
-
-  void setIsRecursive() { IsRecursive = true; }
-  bool isRecursive() const { return IsRecursive; }
 
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -175,6 +175,10 @@ public:
     /// only the derived same-type constraints in the graph.
     std::vector<DerivedSameTypeComponent> derivedSameTypeComponents;
 
+    /// Delayed requirements that could be resolved by a change to this
+    /// equivalence class.
+    std::vector<DelayedRequirement> delayedRequirements;
+
     /// Whether we have detected recursion during the substitution of
     /// the concrete type.
     unsigned recursiveConcreteType : 1;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -260,9 +260,9 @@ public:
     /// "resolved" at this point.
     GenerateConstraints = 0,
 
-    /// Do not generate a new constraint; rather, return
-    /// \c ConstraintResult::Unresolved and let the caller handle it.
-    ReturnUnresolved = 1,
+    /// Generate an unresolved constraint but still return
+    /// \c ConstraintResult::Unresolved so the caller knows what happened.
+    GenerateUnresolved = 1,
   };
 
 private:

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -190,6 +190,9 @@ public:
     /// potential archetype (which represents itself).
     EquivalenceClass(PotentialArchetype *representative);
 
+    /// Note that this equivalence class has been modified.
+    void modified(GenericSignatureBuilder &builder);
+
     /// Find a source of the same-type constraint that maps a potential
     /// archetype in this equivalence class to a concrete type along with
     /// that concrete type as written.
@@ -561,9 +564,6 @@ public:
   void processDelayedRequirements();
 
 private:
-  /// Bump the generation count due to a change.
-  void bumpGeneration();
-
   /// Describes the relationship between a given constraint and
   /// the canonical constraint of the equivalence class.
   enum class ConstraintRelation {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -210,9 +210,6 @@ namespace swift {
     /// Should we use \c ASTScope-based resolution for unqualified name lookup?
     bool EnableASTScopeLookup = false;
 
-    /// Enable SE-0157: Recursive Protocol Constraints.
-    bool EnableRecursiveConstraints = false;
-
     /// Whether to use the import as member inference system
     ///
     /// When importing a global, try to infer whether we can import it as a

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -109,9 +109,6 @@ def disable_target_os_checking :
 def enable_astscope_lookup : Flag<["-"], "enable-astscope-lookup">,
   HelpText<"Enable ASTScope-based unqualified name lookup">;
 
-def enable_recursive_constraints : Flag<["-"], "enable-recursive-constraints">,
-  HelpText<"Enable SE-0157: Recursive Protocol Constraints">;
-
 def print_clang_stats : Flag<["-"], "print-clang-stats">,
   HelpText<"Print Clang importer statistics">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1014,8 +1014,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   
   Opts.EnableASTScopeLookup |= Args.hasArg(OPT_enable_astscope_lookup);
-  Opts.EnableRecursiveConstraints |=
-    Args.hasArg(OPT_enable_recursive_constraints);
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.EnableConstraintPropagation |= Args.hasArg(OPT_propagate_constraints);
   Opts.IterativeTypeChecker |= Args.hasArg(OPT_iterative_type_checker);

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -154,7 +154,7 @@ extension Dictionary {
 
 // rdar://problem/19245317
 protocol P {
-	associatedtype T: P // expected-error{{type may not reference itself as a requirement}}
+	associatedtype T: P
 }
 
 struct S<A: P> {

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -3,7 +3,7 @@
 // -----
 
 protocol Foo {
-  associatedtype Bar : Foo // expected-error{{type may not reference itself as a requirement}}
+  associatedtype Bar : Foo
 }
 
 struct Oroborous : Foo {
@@ -13,7 +13,7 @@ struct Oroborous : Foo {
 // -----
 
 protocol P {
- associatedtype A : P // expected-error{{type may not reference itself as a requirement}}
+ associatedtype A : P
 }
 
 struct X<T: P> {
@@ -26,7 +26,7 @@ func f<T : P>(_ z: T) {
 // -----
 
 protocol PP2 {
-  associatedtype A : P2 = Self // expected-error{{type may not reference itself as a requirement}}
+  associatedtype A : P2 = Self
 }
 
 protocol P2 : PP2 {
@@ -41,13 +41,13 @@ struct Y2 : P2 {
 }
 
 func f<T : P2>(_ z: T) {
- _ = X2<T.A>() // expected-error{{type 'T.A' does not conform to protocol 'P2'}}
+ _ = X2<T.A>()
 }
 
 // -----
 
 protocol P3 {
- associatedtype A: P4 = Self // expected-error{{type may not reference itself as a requirement}}
+ associatedtype A: P4 = Self
 }
 
 protocol P4 : P3 {}

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-recursive-constraints
+// RUN: %target-typecheck-verify-swift
 
 protocol P {
   associatedtype Assoc : P


### PR DESCRIPTION
Optimize the `GenericSignatureBuilder`'s reprocessing of requirements by only reprocessing delayed requirements that are likely to be resolvable. The scheme is fairly simple:

* We only delay the processing of a requirement when we refuse to create a new type in the type graph (i.e., we refuse to create a new `PotentialArchetype` that is a nested type of another, parent `PotentialArchetype`). In these cases, record the delayed requirement in the `EquivalenceClass` of the parent `PotentialArchetype` for later processing.
* All modifications due to processing a requirement change an `EquivalenceClass`. When a modification occurs, move all of the delayed requirements from the `EquivalenceClass` to the global delayed-requirements queue.
* `processDelayedRequirements` looks at the global delayed-requirements queue, only. These are delayed requirements that have a chance of being resolved now.

With this change, type-checking the standard library is 4% faster than it was prior to this patch series, because the number of reprocessed-but-still-unresolved requirements has been drastically reduced: from 225M (with `-enable-recursive-constraints`) and 191k (without `-enable-recursive-constraints`) before this PR to 57k after this PR (where recursive constraints are always enabled).