### PR TITLE
[Frontend] Emit tbd as an extra output, not a frontend action.

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -119,6 +119,9 @@ public:
   /// The path to which we should output a loaded module trace file.
   std::string LoadedModuleTracePath;
 
+  /// The path to which we should output a TBD file.
+  std::string TBDPath;
+
   /// Arguments which should be passed in immediate mode.
   std::vector<std::string> ImmediateArgv;
 
@@ -171,7 +174,6 @@ public:
     /// Parse, type-check, and dump type refinement context hierarchy
     DumpTypeRefinementContexts,
 
-    EmitTBD, ///< Emit a TBD file for this module
     EmitImportedModules, ///< Emit the modules that this one imports
     EmitPCH, ///< Emit PCH of imported bridging header
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -209,6 +209,16 @@ def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-pa
 def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-path=">,
   Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_loaded_module_trace_path>;
 
+def emit_tbd : Flag<["-"], "emit-tbd">,
+  HelpText<"Emit a TBD file">,
+  Flags<[FrontendOption, NoInteractiveOption]>;
+def emit_tbd_path : Separate<["-"], "emit-tbd-path">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Emit the TBD file to <path>">,
+  MetaVarName<"<path>">;
+def emit_tbd_path_EQ : Joined<["-"], "emit-tbd-path=">,
+  Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_tbd_path>;
+
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Serialize diagnostics in a binary format">;
@@ -531,9 +541,6 @@ def emit_sibgen : Flag<["-"], "emit-sibgen">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def emit_imported_modules : Flag<["-"], "emit-imported-modules">,
   HelpText<"Emit a list of the imported modules">, ModeOpt,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
-def emit_tbd : Flag<["-"], "emit-tbd">,
-  HelpText<"Emit a TBD file">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
 def c : Flag<["-"], "c">, Alias<emit_object>,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1146,13 +1146,6 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerMode = OutputInfo::Mode::SingleCompile;
       break;
 
-    case options::OPT_emit_tbd:
-      OI.CompilerOutputType = types::TY_TBD;
-      // We want the symbols from the whole module, so let's do it in one
-      // invocation.
-      OI.CompilerMode = OutputInfo::Mode::SingleCompile;
-      break;
-
     // BEGIN APPLE-ONLY OUTPUT ACTIONS
     case options::OPT_index_file:
       OI.CompilerMode = OutputInfo::Mode::SingleCompile;
@@ -2258,6 +2251,20 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
       }
 
       Output->setAdditionalOutputForType(types::TY_ModuleTrace, filename);
+    }
+
+    if (C.getArgs().hasArg(options::OPT_emit_tbd, options::OPT_emit_tbd_path)) {
+      if (OI.CompilerMode != OutputInfo::Mode::SingleCompile) {
+        llvm::outs() << "TBD emission has been disabled, because it requires a "
+                     << "single compiler invocation: consider enabling the "
+                     << "-whole-module-optimization flag.\n";
+      } else {
+        auto filename = *getOutputFilenameFromPathArgOrAsTopLevel(
+            OI, C.getArgs(), options::OPT_emit_tbd_path, types::TY_TBD,
+            /*TreatAsTopLevelOutput=*/true, "tbd", Buf);
+
+        Output->setAdditionalOutputForType(types::TY_TBD, filename);
+      }
     }
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -231,9 +231,6 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_ImportedModules:
       FrontendModeOption = "-emit-imported-modules";
       break;
-    case types::TY_TBD:
-      FrontendModeOption = "-emit-tbd";
-      break;
 
     // BEGIN APPLE-ONLY OUTPUT TYPES
     case types::TY_IndexData:
@@ -263,6 +260,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_Image:
     case types::TY_SwiftDeps:
     case types::TY_ModuleTrace:
+    case types::TY_TBD:
       llvm_unreachable("Output type can never be primary output.");
     case types::TY_INVALID:
       llvm_unreachable("Invalid type ID");
@@ -433,6 +431,13 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (!LoadedModuleTracePath.empty()) {
     Arguments.push_back("-emit-loaded-module-trace-path");
     Arguments.push_back(LoadedModuleTracePath.c_str());
+  }
+
+  const std::string &TBDPath =
+      context.Output.getAdditionalOutputForType(types::TY_TBD);
+  if (!TBDPath.empty()) {
+    Arguments.push_back("-emit-tbd-path");
+    Arguments.push_back(TBDPath.c_str());
   }
 
   if (context.Args.hasArg(options::OPT_migrate_keep_objc_visibility)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -310,8 +310,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::EmitPCH;
     } else if (Opt.matches(OPT_emit_imported_modules)) {
       Action = FrontendOptions::EmitImportedModules;
-    } else if (Opt.matches(OPT_emit_tbd)) {
-      Action = FrontendOptions::EmitTBD;
     } else if (Opt.matches(OPT_parse)) {
       Action = FrontendOptions::Parse;
     } else if (Opt.matches(OPT_typecheck)) {
@@ -600,13 +598,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       else
         Suffix = "importedmodules";
       break;
-
-    case FrontendOptions::EmitTBD:
-      if (Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
-      else
-        Suffix = "tbd";
-      break;
     }
 
     if (!Suffix.empty()) {
@@ -716,6 +707,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
                           OPT_emit_loaded_module_trace_path,
                           "trace.json", false);
 
+  determineOutputFilename(Opts.TBDPath, OPT_emit_tbd, OPT_emit_tbd_path, "tbd",
+                          false);
+
   if (const Arg *A = Args.getLastArg(OPT_emit_fixits_path)) {
     Opts.FixitsOutputPath = A->getValue();
   }
@@ -767,7 +761,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }
@@ -799,7 +792,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }
@@ -832,7 +824,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }
@@ -868,7 +859,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -44,7 +44,6 @@ bool FrontendOptions::actionHasOutput() const {
   case EmitBC:
   case EmitObject:
   case EmitImportedModules:
-  case EmitTBD:
     return true;
   }
   llvm_unreachable("Unknown ActionType");
@@ -77,7 +76,6 @@ bool FrontendOptions::actionIsImmediate() const {
   case EmitBC:
   case EmitObject:
   case EmitImportedModules:
-  case EmitTBD:
     return false;
   }
   llvm_unreachable("Unknown ActionType");

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -742,12 +742,12 @@ static bool performCompile(CompilerInstance &Instance,
     return Context.hadError();
   }
 
-  if (Action == FrontendOptions::EmitTBD) {
+  if (!opts.TBDPath.empty()) {
     const auto &silOpts = Invocation.getSILOptions();
     auto hasMultipleIRGenThreads = silOpts.NumThreads > 1;
-    return writeTBD(Instance.getMainModule(), hasMultipleIRGenThreads,
-                    silOpts.SILSerializeWitnessTables,
-                    opts.getSingleOutputFilename());
+    if (writeTBD(Instance.getMainModule(), hasMultipleIRGenThreads,
+                 silOpts.SILSerializeWitnessTables, opts.TBDPath))
+      return true;
   }
 
   assert(Action >= FrontendOptions::EmitSILGen &&

--- a/test/reproducible-builds/swiftc-emit-tbd.swift
+++ b/test/reproducible-builds/swiftc-emit-tbd.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -O -g -module-name foo -emit-tbd %s -o %t/run-1.tbd
-// RUN: %target-build-swift -O -g -module-name foo -emit-tbd %s -o %t/run-2.tbd
+// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-1.tbd -force-single-frontend-invocation
+// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-2.tbd -force-single-frontend-invocation
 // RUN: diff -u %t/run-1.tbd %t/run-2.tbd
 print("foo")


### PR DESCRIPTION
This means it can be emitted during an -emit-module frontend job, which is the
most common place it will be used, so reusing work like this is important for
performance.
