### PR TITLE
[SourceKit] Make SourceKitSwiftLang depend on swift-syntax-generated-headers

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -115,7 +115,8 @@ endfunction()
 #
 # Usage:
 #   add_sourcekit_library(name       # Name of the library
-#     [DEPENDS dep1 ...]             # Libraries this library depends on
+#     [DEPENDS dep1 ...]             # Libraries this library will be linked with
+#     [TARGET_DEPENDS dep1 ...]      # Targets this library depends on
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]  # LLVM components this library depends on
 #     [INSTALL_IN_COMPONENT comp]    # The Swift installation component that this library belongs to.
 #     [SHARED]
@@ -124,7 +125,7 @@ macro(add_sourcekit_library name)
   cmake_parse_arguments(SOURCEKITLIB
       "SHARED"
       "INSTALL_IN_COMPONENT"
-      "DEPENDS;LLVM_COMPONENT_DEPENDS"
+      "DEPENDS;TARGET_DEPENDS;LLVM_COMPONENT_DEPENDS"
       ${ARGN})
   set(srcs ${SOURCEKITLIB_UNPARSED_ARGUMENTS})
 
@@ -168,6 +169,10 @@ macro(add_sourcekit_library name)
   if(LLVM_COMMON_DEPENDS)
     add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
   endif(LLVM_COMMON_DEPENDS)
+
+  if(SOURCEKITLIB_TARGET_DEPENDS)
+    add_dependencies(${name} ${SOURCEKITLIB_TARGET_DEPENDS})
+  endif(SOURCEKITLIB_TARGET_DEPENDS)
 
   set(prefixed_link_libraries)
   foreach(dep ${SOURCEKITLIB_DEPENDS})

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -8,6 +8,7 @@ add_sourcekit_library(SourceKitSwiftLang
   SwiftIndexing.cpp
   SwiftLangSupport.cpp
   SwiftSourceDocInfo.cpp
+  TARGET_DEPENDS swift-syntax-generated-headers
   DEPENDS SourceKitCore swiftDriver swiftFrontend swiftClangImporter swiftIDE
           swiftAST swiftMarkup swiftParse swiftParseSIL swiftSIL swiftSILGen
           swiftSILOptimizer swiftIRGen swiftSema swiftBasic swiftSerialization


### PR DESCRIPTION
This ensures that libSyntax's header generation happens before SourceKitSwiftLang is built.

The proper fix for this is to rename the `DEPENDS` argument in all the `add_sourcekit` macros to `LINK_LIBRARIES`, because that's the expected behavior from `add_swift_*` and the `DEPENDS` argument doesn't currently actually introduce any dependencies.