### PR TITLE
[SourceKit] [NFC] Rename DEPENDS to LINK_LIBRARIES throughout SourceKit

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -114,18 +114,18 @@ endfunction()
 # Add a new SourceKit library.
 #
 # Usage:
-#   add_sourcekit_library(name       # Name of the library
-#     [DEPENDS dep1 ...]             # Libraries this library will be linked with
-#     [TARGET_DEPENDS dep1 ...]      # Targets this library depends on
+#   add_sourcekit_library(name     # Name of the library
+#     [LINK_LIBS dep1 ...]         # Libraries this library will be linked with
+#     [DEPENDS dep1 ...]           # Targets this library depends on
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]  # LLVM components this library depends on
-#     [INSTALL_IN_COMPONENT comp]    # The Swift installation component that this library belongs to.
+#     [INSTALL_IN_COMPONENT comp]  # The Swift installation component that this library belongs to.
 #     [SHARED]
 #     source1 [source2 source3 ...]) # Sources to add into this library
 macro(add_sourcekit_library name)
   cmake_parse_arguments(SOURCEKITLIB
       "SHARED"
       "INSTALL_IN_COMPONENT"
-      "DEPENDS;TARGET_DEPENDS;LLVM_COMPONENT_DEPENDS"
+      "LINK_LIBS;DEPENDS;LLVM_COMPONENT_DEPENDS"
       ${ARGN})
   set(srcs ${SOURCEKITLIB_UNPARSED_ARGUMENTS})
 
@@ -170,23 +170,23 @@ macro(add_sourcekit_library name)
     add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
   endif(LLVM_COMMON_DEPENDS)
 
-  if(SOURCEKITLIB_TARGET_DEPENDS)
-    add_dependencies(${name} ${SOURCEKITLIB_TARGET_DEPENDS})
-  endif(SOURCEKITLIB_TARGET_DEPENDS)
+  if(SOURCEKITLIB_DEPENDS)
+    add_dependencies(${name} ${SOURCEKITLIB_DEPENDS})
+  endif(SOURCEKITLIB_DEPENDS)
 
   set(prefixed_link_libraries)
-  foreach(dep ${SOURCEKITLIB_DEPENDS})
+  foreach(dep ${SOURCEKITLIB_LINK_LIBS})
     if("${dep}" MATCHES "^clang")
       set(dep "${LLVM_LIBRARY_OUTPUT_INTDIR}/lib${dep}.a")
     endif()
     list(APPEND prefixed_link_libraries "${dep}")
   endforeach()
-  set(SOURCEKITLIB_DEPENDS "${prefixed_link_libraries}")
+  set(SOURCEKITLIB_LINK_LIBS "${prefixed_link_libraries}")
 
   if("${libkind}" STREQUAL "SHARED")
-    target_link_libraries("${name}" PRIVATE ${SOURCEKITLIB_DEPENDS})
+    target_link_libraries("${name}" PRIVATE ${SOURCEKITLIB_LINK_LIBS})
   else()
-    target_link_libraries("${name}" INTERFACE ${SOURCEKITLIB_DEPENDS})
+    target_link_libraries("${name}" INTERFACE ${SOURCEKITLIB_LINK_LIBS})
   endif()
 
   swift_common_llvm_config(${name} ${SOURCEKITLIB_LLVM_COMPONENT_DEPENDS})
@@ -228,10 +228,10 @@ endmacro()
 # Add a new SourceKit executable.
 #
 # Usage:
-#   add_sourcekit_executable(name     # Name of the executable
-#     [DEPENDS dep1 ...]              # Libraries this executable depends on
-#     [LLVM_COMPONENT_DEPENDS comp1 ...]   # LLVM components this executable
-#                                     # depends on
+#   add_sourcekit_executable(name        # Name of the executable
+#     [LINK_LIBS dep1 ...]               # Libraries this executable depends on
+#     [LLVM_COMPONENT_DEPENDS comp1 ...] # LLVM components this executable
+#                                        # depends on
 #     [EXCLUDE_FROM_ALL]              # Whether to exclude this executable from
 #                                     # the ALL_BUILD target
 #     source1 [source2 source3 ...])  # Sources to add into this executable
@@ -239,7 +239,7 @@ macro(add_sourcekit_executable name)
   cmake_parse_arguments(SOURCEKITEXE
     "EXCLUDE_FROM_ALL"
     ""
-    "DEPENDS;LLVM_COMPONENT_DEPENDS"
+    "LINK_LIBS;LLVM_COMPONENT_DEPENDS"
     ${ARGN})
 
   if (${SOURCEKITEXE_EXCLUDE_FROM_ALL})
@@ -257,7 +257,7 @@ macro(add_sourcekit_executable name)
     add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
   endif()
 
-  target_link_libraries(${name} ${SOURCEKITEXE_DEPENDS})
+  target_link_libraries(${name} ${SOURCEKITEXE_LINK_LIBS})
   swift_common_llvm_config(${name} ${SOURCEKITEXE_LLVM_COMPONENT_DEPENDS})
   target_link_libraries(${name} ${LLVM_COMMON_LIBS})
 
@@ -280,14 +280,14 @@ endmacro()
 #
 # Usage:
 #   add_sourcekit_framework(name     # Name of the framework
-#     [DEPENDS dep1 ...]             # Libraries this framework depends on
+#     [LINK_LIBS dep1 ...]           # Libraries this framework will link with
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]  # LLVM components this framework depends on
 #     [MODULEMAP modulemap]          # Module map file for this framework
 #     [INSTALL_IN_COMPONENT comp]    # The Swift installation component that this framework belongs to.
 #     source1 [source2 source3 ...]) # Sources to add into this framework
 macro(add_sourcekit_framework name)
   cmake_parse_arguments(SOURCEKITFW
-    "" "MODULEMAP;INSTALL_IN_COMPONENT" "DEPENDS;LLVM_COMPONENT_DEPENDS" ${ARGN})
+    "" "MODULEMAP;INSTALL_IN_COMPONENT" "LINK_LIBS;LLVM_COMPONENT_DEPENDS" ${ARGN})
   set(srcs ${SOURCEKITFW_UNPARSED_ARGUMENTS})
 
   set(lib_dir ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR})
@@ -329,7 +329,7 @@ macro(add_sourcekit_framework name)
     add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
   endif(LLVM_COMMON_DEPENDS)
 
-  target_link_libraries(${name} PRIVATE ${SOURCEKITFW_DEPENDS})
+  target_link_libraries(${name} PRIVATE ${SOURCEKITFW_LINK_LIBS})
   swift_common_llvm_config(${name} ${SOURCEKITFW_LLVM_COMPONENT_DEPENDS})
 
   if (EXPORTED_SYMBOL_FILE)
@@ -395,12 +395,12 @@ endmacro(add_sourcekit_framework)
 # Add a new SourceKit XPC service to a framework.
 #
 # Usage:
-#   add_sourcekit_xpc_service(name    # Name of the XPC service
-#     [DEPENDS dep1 ...]              # Libraries this service depends on
+#   add_sourcekit_xpc_service(name      # Name of the XPC service
+#     [LINK_LIBS dep1 ...]              # Libraries this service will link with
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]   # LLVM components this service depends on
-#     source1 [source2 source3 ...])  # Sources to add into this service
+#     source1 [source2 source3 ...])    # Sources to add into this service
 macro(add_sourcekit_xpc_service name framework_target)
-  cmake_parse_arguments(SOURCEKITXPC "" "" "DEPENDS;LLVM_COMPONENT_DEPENDS" ${ARGN})
+  cmake_parse_arguments(SOURCEKITXPC "" "" "LINK_LIBS;LLVM_COMPONENT_DEPENDS" ${ARGN})
   set(srcs ${SOURCEKITXPC_UNPARSED_ARGUMENTS})
 
   set(lib_dir ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR})
@@ -441,7 +441,7 @@ macro(add_sourcekit_xpc_service name framework_target)
     add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
   endif(LLVM_COMMON_DEPENDS)
 
-  target_link_libraries(${name} ${SOURCEKITXPC_DEPENDS})
+  target_link_libraries(${name} ${SOURCEKITXPC_LINK_LIBS})
   swift_common_llvm_config(${name} ${SOURCEKITXPC_LLVM_COMPONENT_DEPENDS})
   target_link_libraries(${name} ${LLVM_COMMON_LIBS})
 

--- a/tools/SourceKit/lib/Core/CMakeLists.txt
+++ b/tools/SourceKit/lib/Core/CMakeLists.txt
@@ -3,5 +3,5 @@ add_sourcekit_library(SourceKitCore
   Context.cpp
   LangSupport.cpp
   NotificationCenter.cpp
-  DEPENDS SourceKitSupport
+  LINK_LIBS SourceKitSupport
 )

--- a/tools/SourceKit/lib/Support/CMakeLists.txt
+++ b/tools/SourceKit/lib/Support/CMakeLists.txt
@@ -15,6 +15,6 @@ endif()
 
 add_sourcekit_library(SourceKitSupport
   ${SourceKitSupport_sources}
-  TARGET_DEPENDS swift-syntax-generated-headers
-  DEPENDS ${SOURCEKIT_SUPPORT_DEPEND}
+  DEPENDS swift-syntax-generated-headers
+  LINK_LIBS ${SOURCEKIT_SUPPORT_DEPEND}
 )

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -8,11 +8,12 @@ add_sourcekit_library(SourceKitSwiftLang
   SwiftIndexing.cpp
   SwiftLangSupport.cpp
   SwiftSourceDocInfo.cpp
-  TARGET_DEPENDS swift-syntax-generated-headers
-  DEPENDS SourceKitCore swiftDriver swiftFrontend swiftClangImporter swiftIDE
-          swiftAST swiftMarkup swiftParse swiftParseSIL swiftSIL swiftSILGen
-          swiftSILOptimizer swiftIRGen swiftSema swiftBasic swiftSerialization
-          swiftSyntax swiftOption libcmark_static
+  DEPENDS swift-syntax-generated-headers
+  LINK_LIBS
+    SourceKitCore swiftDriver swiftFrontend swiftClangImporter swiftIDE
+    swiftAST swiftMarkup swiftParse swiftParseSIL swiftSIL swiftSILGen
+    swiftSILOptimizer swiftIRGen swiftSema swiftBasic swiftSerialization
+    swiftSyntax swiftOption libcmark_static
     # Clang dependencies.
       clangIndex
       clangFormat

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -1,16 +1,16 @@
 if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
-  set(SOURCEKITD_TEST_DEPEND sourcekitdInProc)
+  set(SOURCEKITD_TEST_LINK_LIBS sourcekitdInProc)
 else()
-  set(SOURCEKITD_TEST_DEPEND sourcekitd)
+  set(SOURCEKITD_TEST_LINK_LIBS sourcekitd)
 endif()
 
 if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  set(SOURCEKITD_TEST_DEPEND ${SOURCEKITD_TEST_DEPEND} dispatch swiftCore)
+  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch swiftCore)
 endif()
 
 add_sourcekit_executable(complete-test
   complete-test.cpp
-  DEPENDS ${SOURCEKITD_TEST_DEPEND}
+  LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS}
   LLVM_COMPONENT_DEPENDS support option coverage lto
 )
 

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -3,18 +3,18 @@ check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
 
 if(HAVE_UNICODE_LIBEDIT)
   if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
-    set(SOURCEKITD_REPL_DEPEND sourcekitdInProc)
+    set(SOURCEKITD_REPL_LINK_LIBS sourcekitdInProc)
   else()
-    set(SOURCEKITD_REPL_DEPEND sourcekitd)
+    set(SOURCEKITD_REPL_LINK_LIBS sourcekitd)
   endif()
 
   if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-    set(SOURCEKITD_REPL_DEPEND ${SOURCEKITD_REPL_DEPEND} dispatch swiftCore)
+    set(SOURCEKITD_REPL_LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} dispatch swiftCore)
   endif()
 
   add_sourcekit_executable(sourcekitd-repl
     sourcekitd-repl.cpp
-    DEPENDS ${SOURCEKITD_REPL_DEPEND} edit
+    LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} edit
     LLVM_COMPONENT_DEPENDS support coverage lto
   )
 

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -3,19 +3,19 @@ swift_tablegen(Options.inc -gen-opt-parser-defs)
 swift_add_public_tablegen_target(sourcekitdTestOptionsTableGen)
 
 if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
-  set(SOURCEKITD_TEST_DEPEND sourcekitdInProc)
+  set(SOURCEKITD_TEST_LINK_LIBS sourcekitdInProc)
 else()
-  set(SOURCEKITD_TEST_DEPEND sourcekitd)
+  set(SOURCEKITD_TEST_LINK_LIBS sourcekitd)
 endif()
 
 if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  set(SOURCEKITD_TEST_DEPEND ${SOURCEKITD_TEST_DEPEND} dispatch swiftCore)
+  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch swiftCore)
 endif()
 
 add_sourcekit_executable(sourcekitd-test
   sourcekitd-test.cpp
   TestOptions.cpp
-  DEPENDS ${SOURCEKITD_TEST_DEPEND} SourceKitSupport
+  LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} SourceKitSupport
     clangRewrite clangLex clangBasic
   LLVM_COMPONENT_DEPENDS core support option coverage lto
 )

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -5,7 +5,7 @@ option(SOURCEKITD_BUILD_STATIC_INPROC
 
 set(sourcekitdInProc_args
   sourcekitdInProc.cpp
-  DEPENDS SourceKitSwiftLang sourcekitdAPI
+  LINK_LIBS SourceKitSwiftLang sourcekitdAPI
   LLVM_COMPONENT_DEPENDS support coverage
 )
 

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/CMakeLists.txt
@@ -10,7 +10,7 @@ set(EXPORTED_SYMBOL_FILE "${SOURCEKITD_SOURCE_DIR}/bin/sourcekitd.exports")
 add_sourcekit_framework(sourcekitd
   ${public_headers}
   sourcekitd.cpp tracer.cpp
-  DEPENDS sourcekitdAPI
+  LINK_LIBS sourcekitdAPI
   LLVM_COMPONENT_DEPENDS support
   MODULEMAP module.modulemap
   INSTALL_IN_COMPONENT sourcekit-xpc-service

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (NOT SOURCEKIT_INSTALLING_INPROC)
   add_sourcekit_xpc_service(SourceKitService sourcekitd
     XPCService.cpp XpcTracing.cpp
-    DEPENDS SourceKitSwiftLang sourcekitdAPI
+    LINK_LIBS SourceKitSwiftLang sourcekitdAPI
     LLVM_COMPONENT_DEPENDS support coverage
   )
 endif()

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -31,6 +31,6 @@ endif()
 
 add_sourcekit_library(sourcekitdAPI
   ${sourcekitdAPI_sources}
-  DEPENDS
+  LINK_LIBS
       SourceKitSupport SourceKitSwiftLang
 )


### PR DESCRIPTION
Currently, SourceKit's CMake functions all use DEPENDS to specify
libraries the targets will link with. This is confusing as it doesn't
behave the same way that add_swift behaves, and implies that
dependencies are created when there aren't.

This is the "proper fix" for #11226.