### PR TITLE
[stdlib] Mark _AppendKeyPath as visible in interface

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1347,6 +1347,7 @@ func _projectKeyPathReferenceWritable<Root, Value>(
 // constrained by being overrides, and so that we can use exact-type constraints
 // on `Self` to prevent dynamically-typed methods from being inherited by
 // statically-typed key paths.
+@_show_in_interface
 public protocol _AppendKeyPath {}
 
 extension _AppendKeyPath where Self == AnyKeyPath {


### PR DESCRIPTION
This marks the `_AppendKeyPath` protocol as `@_show_in_interface`, so that the `appending(path:)` methods that it defines can show up correctly in the generated interface and documentation downstream.