### PR TITLE
[GSB] Detect self-derived conformances within same-type requirements

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1096,11 +1096,17 @@ public:
   bool isSelfDerivedSource(PotentialArchetype *pa,
                            bool &derivedViaConcrete) const;
 
-  /// Determine whether a requirement \c pa: proto, when formed from this
-  /// requirement source, is dependent on itself.
-  bool isSelfDerivedConformance(PotentialArchetype *pa,
-                                ProtocolDecl *proto,
-                                bool &derivedViaConcrete) const;
+  /// For a requirement source that describes the requirement \c pa:proto,
+  /// retrieve the minimal subpath of this requirement source that will
+  /// compute that requirement.
+  ///
+  /// When the result is different from (i.e., a subpath of) \c this or is
+  /// nullptr (indicating an embedded, distinct self-derived subpath), the
+  /// conformance requirement is considered to be "self-derived".
+  const RequirementSource *getMinimalConformanceSource(
+                                            PotentialArchetype *pa,
+                                            ProtocolDecl *proto,
+                                            bool &derivedViaConcrete) const;
 
   /// Retrieve a source location that corresponds to the requirement.
   SourceLoc getLoc() const;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -391,12 +391,12 @@ static PotentialArchetype *replaceSelfWithPotentialArchetype(
   return selfPA;
 }
 
-bool RequirementSource::isSelfDerivedConformance(
+const RequirementSource *RequirementSource::getMinimalConformanceSource(
                                              PotentialArchetype *currentPA,
                                              ProtocolDecl *proto,
                                              bool &derivedViaConcrete) const {
   /// Keep track of all of the requirements we've seen along the way. If
-  /// we see the same requirement twice, it's a self-derived conformance.
+  /// we see the same requirement twice, we have found a shorter path.
   llvm::DenseSet<std::pair<PotentialArchetype *, ProtocolDecl *>>
     constraintsSeen;
 
@@ -413,17 +413,13 @@ bool RequirementSource::isSelfDerivedConformance(
   bool sawProtocolRequirement = false;
 
   PotentialArchetype *rootPA = nullptr;
+  const RequirementSource *minimalSource = nullptr;
   auto resultPA = visitPotentialArchetypesAlongPath(
                     [&](PotentialArchetype *parentPA,
                         const RequirementSource *source) {
     switch (source->kind) {
     case ProtocolRequirement:
     case InferredProtocolRequirement: {
-      // For a requirement signature, we ignore the 'Self: P' requirement
-      // for the purposes of the self-derived check.
-      if (source->parent->kind == RequirementSource::RequirementSignatureSelf)
-        return false;
-
       // Note that we've seen a protocol requirement.
       sawProtocolRequirement = true;
 
@@ -432,8 +428,14 @@ bool RequirementSource::isSelfDerivedConformance(
         derivedViaConcrete = true;
 
       // The parent potential archetype must conform to the protocol in which
-      // this requirement resides.
-      return addConstraint(parentPA, source->getProtocolDecl());
+      // this requirement resides. Add this constraint.
+      if (!addConstraint(parentPA, source->getProtocolDecl())) return false;
+
+      // We found the shortest source to derive this information; record it
+      // and stop the algorithm.
+      if (source->getProtocolDecl() == proto)
+        minimalSource = source->parent;
+      return true;
     }
 
     case Concrete:
@@ -452,21 +454,21 @@ bool RequirementSource::isSelfDerivedConformance(
   });
 
   // If we saw a constraint twice, it's self-derived.
-  if (!resultPA) return true;
+  if (!resultPA) return minimalSource;
 
   // If we haven't seen a protocol requirement, we're done.
-  if (!sawProtocolRequirement) return false;
+  if (!sawProtocolRequirement) return this;
 
   // The root archetype might be a nested type, which implies constraints
   // for each of the protocols of the associated types referenced (if any).
   for (auto pa = rootPA; pa->getParent(); pa = pa->getParent()) {
     if (auto assocType = pa->getResolvedAssociatedType()) {
       if (addConstraint(pa->getParent(), assocType->getProtocol()))
-        return true;
+        return nullptr;
     }
   }
 
-  return false;
+  return this;
 }
 
 #define REQUIREMENT_SOURCE_FACTORY_BODY(ProfileArgs, ConstructorArgs,      \
@@ -4397,29 +4399,68 @@ void GenericSignatureBuilder::checkConformanceConstraints(
   for (auto &entry : equivClass->conformsTo) {
     // Remove self-derived constraints.
     assert(!entry.second.empty() && "No constraints to work with?");
+
+    // Local function to establish whether a conformance constraint is
+    // self-derived.
     Optional<Constraint<ProtocolDecl *>> remainingConcrete;
+    SmallVector<Constraint<ProtocolDecl *>, 4> minimalSources;
+    auto isSelfDerived =
+      [&](const Constraint<ProtocolDecl *> &constraint) {
+        // Determine whether there is a subpath of this requirement source that
+        // derives the same conformance.
+        bool derivedViaConcrete;
+        auto minimalSource =
+          constraint.source->getMinimalConformanceSource(constraint.archetype,
+                                                         entry.first,
+                                                         derivedViaConcrete);
+        if (minimalSource != constraint.source) {
+          // The minimal source is smaller than the original source, so the
+          // original source is self-derived.
+          ++NumSelfDerived;
+
+          if (minimalSource) {
+            // Record a constraint with a minimized source.
+            minimalSources.push_back(
+                             {minimalSource->getAffectedPotentialArchetype(),
+                              constraint.value,
+                              minimalSource});
+          }
+
+          return true;
+        }
+
+        if (!derivedViaConcrete)
+          return false;
+
+        // Drop derived-via-concrete requirements.
+        if (!remainingConcrete)
+          remainingConcrete = constraint;
+
+        ++NumSelfDerived;
+        return true;
+      };
+
+    // Erase all self-derived constraints.
     entry.second.erase(
-      std::remove_if(entry.second.begin(), entry.second.end(),
-                     [&](const Constraint<ProtocolDecl *> &constraint) {
-                       bool derivedViaConcrete;
-                       if (constraint.source->isSelfDerivedConformance(
-                                constraint.archetype, entry.first,
-                                derivedViaConcrete)) {
-                         ++NumSelfDerived;
-                         return true;
-                       }
-
-                       if (!derivedViaConcrete)
-                         return false;
-
-                       // Drop derived-via-concrete requirements.
-                       if (!remainingConcrete)
-                         remainingConcrete = constraint;
-
-                       ++NumSelfDerived;
-                       return true;
-                     }),
+      std::remove_if(entry.second.begin(), entry.second.end(), isSelfDerived),
       entry.second.end());
+
+    // If we found any mininal sources, add them now, avoiding introducing any
+    // redundant sources.
+    if (!minimalSources.empty()) {
+      // Collect the sources we already know about.
+      SmallPtrSet<const RequirementSource *, 4> sources;
+      for (const auto &constraint : entry.second) {
+        sources.insert(constraint.source);
+      }
+
+      // Add any minimal sources we didn't know about.
+      for (const auto &minimalSource : minimalSources) {
+        if (sources.insert(minimalSource.source).second) {
+          entry.second.push_back(minimalSource);
+        }
+      }
+    }
 
     // If we only had concrete conformances, put one back.
     if (entry.second.empty() && remainingConcrete)

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -26,3 +26,15 @@ protocol P2 {
   associatedtype Y : P1 where Y.X == Self
   associatedtype Z : P1
 }
+
+// SR-5473
+protocol P3 {
+	associatedtype X : P4
+}
+
+// CHECK: .P4@
+// CHECK: Requirement signature: <Self where Self == Self.Y.X, Self.Y : P3, Self.Z : P3, Self.Y.X == Self.Z.X>
+protocol P4 {
+	associatedtype Y: P3 where Y.X == Self
+	associatedtype Z: P3 where Z.X == Self
+}

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -1,4 +1,6 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %FileCheck %s < %t.dump
 
 protocol P {
   associatedtype Assoc : P
@@ -17,7 +19,10 @@ func testP<T: P>(_ t: T) {
 protocol P1 {
   associatedtype X : P2
 }
+
+// CHECK: P2
+// CHECK: Requirement signature: <Self where Self == Self.Y.X, Self.Y : P1, Self.Z : P1>
 protocol P2 {
-  associatedtype Y : P1 where Y.X == Self // expected-note{{conformance constraint 'Self.Z': 'P1' implied here}}
-  associatedtype Z : P1 // expected-warning{{redundant conformance constraint 'Self.Z': 'P1'}}
+  associatedtype Y : P1 where Y.X == Self
+  associatedtype Z : P1
 }


### PR DESCRIPTION
Two related fixes for recursive constraints:

* More correctly fix SR-5485: we were retaining self-derived conformance
sources when we shouldn't, which led to spurious "redundant
conformance" diagnostics and (much worse) incorrect minimized generic
signatures. Now, when we detect a self-derived conformance source,
return the minimal source that will derive the same conformance... and
retain that one if it's new.
* Detect requirement sources that are internally self-derived for
(e.g.) handling of requirement sources for same-type constraints and
superclass constraints. This eliminates some incorrect warnings about
redundant same-type constraints involving recursive protocols, which
(more importantly) were a symptom of incorrect generic signature
minimization. Fixes SR-5473