### PR TITLE
[sil-opened-archetypes-tracker] Remove only those archetype definitions that are registered with the current SILOpenedArchetypesTracker

### DIFF
--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -123,7 +123,12 @@ void SILOpenedArchetypesTracker::unregisterOpenedArchetypes(
   assert(I->getFunction() == &F &&
          "Instruction does not belong to a proper SILFunction");
   auto Archetype = getOpenedArchetypeOf(I);
-  if (Archetype)
+  // Remove the archetype definition if it was registered before.
+  // It may happen that this archetype was not registered in the
+  // SILOpenedArchetypesTracker, because the tracker was created
+  // without scanning the whole function and thus may not aware
+  // of all opened archetypes of the function.
+  if (Archetype && getOpenedArchetypeDef(Archetype))
     removeOpenedArchetypeDef(Archetype, I);
 }
 

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -229,3 +229,36 @@ bb0(%0 : $*P):
   return %6 : $()
 } // end sil function 'bar'
 
+// A helper function that does not use its arguments at all
+sil @dont_use_arguments: $@convention(thin) (Int32) -> () {
+bb0(%0 : $Int32):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// Check that dont_use_arguments is inlined into check_removal_of_unregistered_archetype_def
+// and this does not lead to an "Opened archetype definition is not registered in
+// SILFunction" assertion failure, that used to happen because the apply instruction
+// was not aware of the opened archetype definition that becomes unused and gets removed
+// after the inlining.
+//
+// CHECK-LABEL: sil @check_removal_of_unregistered_archetype_def
+// CHECK-NOT: init_existential
+// CHECK-NOT: open_existential
+// CHECK-NOT: function_ref
+// CHECK-NOT: apply
+// CHECK: strong_release
+// CHECK: end sil function 'check_removal_of_unregistered_archetype_def'
+sil @check_removal_of_unregistered_archetype_def : $@convention(thin) (AnyObject) -> () {
+bb0(%0 : $AnyObject):
+  %1 = open_existential_ref %0 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %2 = integer_literal $Builtin.Int32, 1
+  %3 = struct $Int32(%2 : $Builtin.Int32)
+  %4 = mark_dependence %3 : $Int32 on %1 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %5 = function_ref @dont_use_arguments : $@convention(thin) (Int32) -> ()
+  %6 = apply %5(%4) : $@convention(thin) (Int32) -> ()
+  strong_release %0 : $AnyObject
+  %8 = tuple ()
+  return %8 : $()
+} // end sil function 'check_removal_of_unregistered_archetype_def'
+


### PR DESCRIPTION
It may happen that a valid opened archetype was not registered in the SILOpenedArchetypesTracker, because the tracker was created without scanning the whole function and thus may not aware of all opened archetypes of the function. This often happens e.g. during inlining. Therefore, remove the archetype definition only if it was registered before.

Fixes rdar://problem/33513110
