### PR TITLE
Sema: Fix requirement/witness disambiguation for subclass existentials [4.0]

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "TypeChecker.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -120,27 +121,48 @@ namespace {
       if (!Options.contains(NameLookupFlags::ProtocolMembers) ||
           !isa<ProtocolDecl>(foundDC) ||
           isa<GenericTypeParamDecl>(found) ||
-          (isa<FuncDecl>(found) && cast<FuncDecl>(found)->isOperator()) ||
-          foundInType->isAnyExistentialType()) {
+          (isa<FuncDecl>(found) && cast<FuncDecl>(found)->isOperator())) {
         addResult(found);
         return;
       }
 
       assert(isa<ProtocolDecl>(foundDC));
 
+      auto conformingType = foundInType;
+
+      // When performing a lookup on a subclass existential, we might
+      // find a member of the class that witnesses a requirement on a
+      // protocol that the class conforms to.
+      //
+      // Since subclass existentials don't normally conform to protocols,
+      // pull out the superclass instead, and use that below.
+      if (foundInType->isExistentialType()) {
+        auto layout = foundInType->getExistentialLayout();
+        if (layout.superclass)
+          conformingType = layout.superclass;
+      }
+
       // If we found something within the protocol itself, and our
       // search began somewhere that is not in a protocol or extension
       // thereof, remap this declaration to the witness.
       if (foundInType->is<ArchetypeType>() ||
+          foundInType->isExistentialType() ||
           Options.contains(NameLookupFlags::PerformConformanceCheck)) {
         // Dig out the protocol conformance.
-        auto conformance = TC.conformsToProtocol(foundInType, foundProto, DC,
+        auto conformance = TC.conformsToProtocol(conformingType, foundProto, DC,
                                                  conformanceOptions);
-        if (!conformance)
+        if (!conformance) {
+          // If there's no conformance, we have an existential
+          // and we found a member from one of the protocols, and
+          // not a class constraint if any.
+          assert(foundInType->isExistentialType());
+          addResult(found);
           return;
+        }
 
         if (conformance->isAbstract()) {
-          assert(foundInType->is<ArchetypeType>());
+          assert(foundInType->is<ArchetypeType>() ||
+                 foundInType->isExistentialType());
           addResult(found);
           return;
         }
@@ -161,6 +183,10 @@ namespace {
 
         // FIXME: the "isa<ProtocolDecl>()" check will be wrong for
         // default implementations in protocols.
+        //
+        // If we have an imported conformance or the witness could
+        // not be deserialized, getWitnessDecl() will just return
+        // the requirement, so just drop the lookup result here.
         if (witness && !isa<ProtocolDecl>(witness->getDeclContext()))
           addResult(witness);
 

--- a/test/ClangImporter/subclass_existentials.swift
+++ b/test/ClangImporter/subclass_existentials.swift
@@ -35,3 +35,7 @@ class OldSwiftLaundryService : NSLaundry {
     return g!
   }
 }
+
+// Make sure the method lookup is not ambiguous
+
+_ = Coat.fashionStatement.wear()

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1086,13 +1086,21 @@ typedef enum __attribute__((ns_error_domain(FictionalServerErrorDomain))) Fictio
   FictionalServerErrorMeltedDown = 1
 } FictionalServerErrorCode;
 
+@protocol Wearable
+- (void)wear;
+@end
+
 @protocol Garment
 @end
 
 @protocol Cotton
 @end
 
-@interface Coat
+@interface Coat : NSObject<Wearable>
+
+- (void)wear;
+@property (class) Coat <Wearable> *fashionStatement;
+
 @end
 
 @protocol NSLaundry


### PR DESCRIPTION
* Description: If an imported Objective-C class `C` conforms to an Objective-C protocol `Q` with a requirement `foo()`, a member lookup of `foo` on a value of type `C & P` (where `P` is some unrelated protocol) would be incorrectly reported as ambiguous. This fixes the disambiguation logic that is used for such lookups on a concrete type `C` to also work for a subclass existential `C & P`.

* Scope of the issue: This is a bug in a new feature, but in Swift 4.0 mode, we started importing Objective-C types like `C <P> *` as subclass existentials `C & P`, whereas previously we would import them as an existential type `P`, so code examples that worked in Swift 3.2 mode can now fail to type check.

* Risk: Name lookup is a very tricky piece of code; hopefully the standard library, test suite and source compatibility test suite give us enough coverage here. I deliberately kept this patch for swift-4.0-branch as small as possible; there are other cleanups on master that hopefully make the logic here easier to follow and review.

* Reviewed by: @DougGregor

* Radar: <rdar://problem/33291112>.