### PR TITLE
[4.0] Mark _AppendKeyPath as visible in interface

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1347,6 +1347,7 @@ func _projectKeyPathReferenceWritable<Root, Value>(
 // constrained by being overrides, and so that we can use exact-type constraints
 // on `Self` to prevent dynamically-typed methods from being inherited by
 // statically-typed key paths.
+@_show_in_interface
 public protocol _AppendKeyPath {}
 
 extension _AppendKeyPath where Self == AnyKeyPath {


### PR DESCRIPTION
This is a cherry pick of #11233.

- Explanation: Adds the `@_show_in_interface` attribute to the `_AppendKeyPath` protocol. This allows the `appending(path:)` methods to appear in the generated interface and downstream documentation.
- Scope: This has no functional change beyond changing the visibility of the `_AppendKeyPath` protocol.
- Radar/SR: rdar://problem/33592582
- Risk: Very Low
- Testing: Unit and validation tests.