### PR TITLE
[PrintAsObjC] Print availability on classes, protocols, and categories

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -710,117 +710,16 @@ private:
       hasPrintedAnything = true;
     };
 
-    for (auto Attr : D->getAttrs()) {
-      if (auto AvAttr = dyn_cast<AvailableAttr>(Attr)) {
-        if (AvAttr->isInvalid()) continue;
-        if (AvAttr->Platform == PlatformKind::none) {
-          if (AvAttr->PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
-            // Availability for *
-            if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
-              // NB: Don't bother getting obj-c names, we can't get one for the
-              // rename
-              maybePrintLeadingSpace();
-              os << "SWIFT_UNAVAILABLE_MSG(\"'"
-                 << cast<ValueDecl>(D)->getBaseName()
-                 << "' has been renamed to '";
-              printEncodedString(AvAttr->Rename, false);
-              os << '\'';
-              if (!AvAttr->Message.empty()) {
-                os << ": ";
-                printEncodedString(AvAttr->Message, false);
-              }
-              os << "\")";
-            } else if (!AvAttr->Message.empty()) {
-              maybePrintLeadingSpace();
-              os << "SWIFT_UNAVAILABLE_MSG(";
-              printEncodedString(AvAttr->Message);
-              os << ")";
-            } else {
-              maybePrintLeadingSpace();
-              os << "SWIFT_UNAVAILABLE";
-            }
-            break;
-          }
-          if (AvAttr->isUnconditionallyDeprecated()) {
-            if (!AvAttr->Rename.empty() || !AvAttr->Message.empty()) {
-              maybePrintLeadingSpace();
-              os << "SWIFT_DEPRECATED_MSG(";
-              printEncodedString(AvAttr->Message);
-              if (!AvAttr->Rename.empty()) {
-                os << ", ";
-                printEncodedString(AvAttr->Rename);
-              }
-              os << ")";
-            } else {
-              maybePrintLeadingSpace();
-              os << "SWIFT_DEPRECATED";
-            }
-          }
-          continue;
-        }
-        // Availability for a specific platform
-        if (!AvAttr->Introduced.hasValue()
-            && !AvAttr->Deprecated.hasValue()
-            && !AvAttr->Obsoleted.hasValue()
-            && !AvAttr->isUnconditionallyDeprecated()
-            && !AvAttr->isUnconditionallyUnavailable()) {
-          continue;
-        }
-        const char *plat = nullptr;
-        switch (AvAttr->Platform) {
-        case PlatformKind::OSX:
-          plat = "macos";
-          break;
-        case PlatformKind::iOS:
-          plat = "ios";
-          break;
-        case PlatformKind::tvOS:
-          plat = "tvos";
-          break;
-        case PlatformKind::watchOS:
-          plat = "watchos";
-          break;
-        case PlatformKind::OSXApplicationExtension:
-          plat = "macos_app_extension";
-          break;
-        case PlatformKind::iOSApplicationExtension:
-          plat = "ios_app_extension";
-          break;
-        case PlatformKind::tvOSApplicationExtension:
-          plat = "tvos_app_extension";
-          break;
-        case PlatformKind::watchOSApplicationExtension:
-          plat = "watchos_app_extension";
-          break;
-        default:
-          break;
-        }
-        if (!plat) continue;
-        maybePrintLeadingSpace();
-        os << "SWIFT_AVAILABILITY(" << plat;
-        if (AvAttr->isUnconditionallyUnavailable()) {
-          os << ",unavailable";
-        } else {
-          if (AvAttr->Introduced.hasValue()) {
-            os << ",introduced=" << AvAttr->Introduced.getValue().getAsString();
-          }
-          if (AvAttr->Deprecated.hasValue()) {
-            os << ",deprecated=" << AvAttr->Deprecated.getValue().getAsString();
-          } else if (AvAttr->isUnconditionallyDeprecated()) {
-            // We need to specify some version, we can't just say deprecated.
-            // We also can't deprecate it before it's introduced.
-            if (AvAttr->Introduced.hasValue()) {
-              os << ",deprecated=" << AvAttr->Introduced.getValue().getAsString();
-            } else {
-              os << ",deprecated=0.0.1";
-            }
-          }
-          if (AvAttr->Obsoleted.hasValue()) {
-            os << ",obsoleted=" << AvAttr->Obsoleted.getValue().getAsString();
-          }
+    for (auto AvAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
+      if (AvAttr->Platform == PlatformKind::none) {
+        if (AvAttr->PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
+          // Availability for *
           if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
-            // NB: Don't bother getting obj-c names, we can't get one for the rename
-            os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
+            // NB: Don't bother getting obj-c names, we can't get one for the
+            // rename
+            maybePrintLeadingSpace();
+            os << "SWIFT_UNAVAILABLE_MSG(\"'"
+               << cast<ValueDecl>(D)->getBaseName()
                << "' has been renamed to '";
             printEncodedString(AvAttr->Rename, false);
             os << '\'';
@@ -828,14 +727,114 @@ private:
               os << ": ";
               printEncodedString(AvAttr->Message, false);
             }
-            os << "\"";
+            os << "\")";
           } else if (!AvAttr->Message.empty()) {
-            os << ",message=";
+            maybePrintLeadingSpace();
+            os << "SWIFT_UNAVAILABLE_MSG(";
             printEncodedString(AvAttr->Message);
+            os << ")";
+          } else {
+            maybePrintLeadingSpace();
+            os << "SWIFT_UNAVAILABLE";
+          }
+          break;
+        }
+        if (AvAttr->isUnconditionallyDeprecated()) {
+          if (!AvAttr->Rename.empty() || !AvAttr->Message.empty()) {
+            maybePrintLeadingSpace();
+            os << "SWIFT_DEPRECATED_MSG(";
+            printEncodedString(AvAttr->Message);
+            if (!AvAttr->Rename.empty()) {
+              os << ", ";
+              printEncodedString(AvAttr->Rename);
+            }
+            os << ")";
+          } else {
+            maybePrintLeadingSpace();
+            os << "SWIFT_DEPRECATED";
           }
         }
-        os << ")";
+        continue;
       }
+
+      // Availability for a specific platform
+      if (!AvAttr->Introduced.hasValue()
+          && !AvAttr->Deprecated.hasValue()
+          && !AvAttr->Obsoleted.hasValue()
+          && !AvAttr->isUnconditionallyDeprecated()
+          && !AvAttr->isUnconditionallyUnavailable()) {
+        continue;
+      }
+      const char *plat = nullptr;
+      switch (AvAttr->Platform) {
+      case PlatformKind::OSX:
+        plat = "macos";
+        break;
+      case PlatformKind::iOS:
+        plat = "ios";
+        break;
+      case PlatformKind::tvOS:
+        plat = "tvos";
+        break;
+      case PlatformKind::watchOS:
+        plat = "watchos";
+        break;
+      case PlatformKind::OSXApplicationExtension:
+        plat = "macos_app_extension";
+        break;
+      case PlatformKind::iOSApplicationExtension:
+        plat = "ios_app_extension";
+        break;
+      case PlatformKind::tvOSApplicationExtension:
+        plat = "tvos_app_extension";
+        break;
+      case PlatformKind::watchOSApplicationExtension:
+        plat = "watchos_app_extension";
+        break;
+      default:
+        break;
+      }
+      if (!plat) continue;
+
+      maybePrintLeadingSpace();
+      os << "SWIFT_AVAILABILITY(" << plat;
+      if (AvAttr->isUnconditionallyUnavailable()) {
+        os << ",unavailable";
+      } else {
+        if (AvAttr->Introduced.hasValue()) {
+          os << ",introduced=" << AvAttr->Introduced.getValue().getAsString();
+        }
+        if (AvAttr->Deprecated.hasValue()) {
+          os << ",deprecated=" << AvAttr->Deprecated.getValue().getAsString();
+        } else if (AvAttr->isUnconditionallyDeprecated()) {
+          // We need to specify some version, we can't just say deprecated.
+          // We also can't deprecate it before it's introduced.
+          if (AvAttr->Introduced.hasValue()) {
+            os << ",deprecated=" << AvAttr->Introduced.getValue().getAsString();
+          } else {
+            os << ",deprecated=0.0.1";
+          }
+        }
+        if (AvAttr->Obsoleted.hasValue()) {
+          os << ",obsoleted=" << AvAttr->Obsoleted.getValue().getAsString();
+        }
+        if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
+          // NB: Don't bother getting obj-c names, we can't get one for the rename
+          os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
+             << "' has been renamed to '";
+          printEncodedString(AvAttr->Rename, false);
+          os << '\'';
+          if (!AvAttr->Message.empty()) {
+            os << ": ";
+            printEncodedString(AvAttr->Message, false);
+          }
+          os << "\"";
+        } else if (!AvAttr->Message.empty()) {
+          os << ",message=";
+          printEncodedString(AvAttr->Message);
+        }
+      }
+      os << ")";
     }
     return hasPrintedAnything;
   }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -818,21 +818,21 @@ private:
         if (AvAttr->Obsoleted.hasValue()) {
           os << ",obsoleted=" << AvAttr->Obsoleted.getValue().getAsString();
         }
-        if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
-          // NB: Don't bother getting obj-c names, we can't get one for the rename
-          os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
-             << "' has been renamed to '";
-          printEncodedString(AvAttr->Rename, false);
-          os << '\'';
-          if (!AvAttr->Message.empty()) {
-            os << ": ";
-            printEncodedString(AvAttr->Message, false);
-          }
-          os << "\"";
-        } else if (!AvAttr->Message.empty()) {
-          os << ",message=";
-          printEncodedString(AvAttr->Message);
+      }
+      if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
+        // NB: Don't bother getting obj-c names, we can't get one for the rename
+        os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
+           << "' has been renamed to '";
+        printEncodedString(AvAttr->Rename, false);
+        os << '\'';
+        if (!AvAttr->Message.empty()) {
+          os << ": ";
+          printEncodedString(AvAttr->Message, false);
         }
+        os << "\"";
+      } else if (!AvAttr->Message.empty()) {
+        os << ",message=";
+        printEncodedString(AvAttr->Message);
       }
       os << ")";
     }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -310,11 +310,13 @@ private:
     StringRef customName = getNameForObjC(CD, CustomNamesOnly);
     if (customName.empty()) {
       llvm::SmallString<32> scratch;
-      os << "SWIFT_CLASS(\"" << CD->getObjCRuntimeName(scratch) << "\")\n"
-         << "@interface " << CD->getName();
+      os << "SWIFT_CLASS(\"" << CD->getObjCRuntimeName(scratch) << "\")";
+      printAvailability(CD);
+      os << "\n@interface " << CD->getName();
     } else {
-      os << "SWIFT_CLASS_NAMED(\"" << CD->getName() << "\")\n"
-         << "@interface " << customName;
+      os << "SWIFT_CLASS_NAMED(\"" << CD->getName() << "\")";
+      printAvailability(CD);
+      os << "\n@interface " << customName;
     }
 
     if (Type superTy = CD->getSuperclass())
@@ -350,6 +352,8 @@ private:
 
     auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
 
+    if (printAvailability(ED, PrintLeadingSpace::No))
+      os << "\n";
     os << "@interface " << getNameForObjC(baseClass);
     maybePrintObjCGenericParameters(baseClass);
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
@@ -365,11 +369,13 @@ private:
     StringRef customName = getNameForObjC(PD, CustomNamesOnly);
     if (customName.empty()) {
       llvm::SmallString<32> scratch;
-      os << "SWIFT_PROTOCOL(\"" << PD->getObjCRuntimeName(scratch) << "\")\n"
-         << "@protocol " << PD->getName();
+      os << "SWIFT_PROTOCOL(\"" << PD->getObjCRuntimeName(scratch) << "\")";
+      printAvailability(PD);
+      os << "\n@protocol " << PD->getName();
     } else {
-      os << "SWIFT_PROTOCOL_NAMED(\"" << PD->getName() << "\")\n"
-         << "@protocol " << customName;
+      os << "SWIFT_PROTOCOL_NAMED(\"" << PD->getName() << "\")";
+      printAvailability(PD);
+      os << "\n@protocol " << customName;
     }
 
     printProtocols(PD->getInheritedProtocols());
@@ -626,7 +632,7 @@ private:
     }
 
     if (!skipAvailability) {
-      appendAvailabilityAttribute(AFD);
+      printAvailability(AFD);
     }
 
     if (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->isAccessor()) {
@@ -683,22 +689,39 @@ private:
       os << " SWIFT_WARN_UNUSED_RESULT";
     }
 
-    appendAvailabilityAttribute(FD);
+    printAvailability(FD);
     
     os << ';';
   }
 
-  void appendAvailabilityAttribute(const ValueDecl *VD) {
-    for (auto Attr : VD->getAttrs()) {
+  enum class PrintLeadingSpace : bool {
+    No = false,
+    Yes = true
+  };
+
+  /// Returns \c true if anything was printed.
+  bool printAvailability(
+      const Decl *D,
+      PrintLeadingSpace printLeadingSpace = PrintLeadingSpace::Yes) {
+    bool hasPrintedAnything = false;
+    auto maybePrintLeadingSpace = [&] {
+      if (printLeadingSpace == PrintLeadingSpace::Yes || hasPrintedAnything)
+        os << " ";
+      hasPrintedAnything = true;
+    };
+
+    for (auto Attr : D->getAttrs()) {
       if (auto AvAttr = dyn_cast<AvailableAttr>(Attr)) {
         if (AvAttr->isInvalid()) continue;
         if (AvAttr->Platform == PlatformKind::none) {
           if (AvAttr->PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
             // Availability for *
-            if (!AvAttr->Rename.empty()) {
+            if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
               // NB: Don't bother getting obj-c names, we can't get one for the
               // rename
-              os << " SWIFT_UNAVAILABLE_MSG(\"'" << VD->getBaseName()
+              maybePrintLeadingSpace();
+              os << "SWIFT_UNAVAILABLE_MSG(\"'"
+                 << cast<ValueDecl>(D)->getBaseName()
                  << "' has been renamed to '";
               printEncodedString(AvAttr->Rename, false);
               os << '\'';
@@ -708,17 +731,20 @@ private:
               }
               os << "\")";
             } else if (!AvAttr->Message.empty()) {
-              os << " SWIFT_UNAVAILABLE_MSG(";
+              maybePrintLeadingSpace();
+              os << "SWIFT_UNAVAILABLE_MSG(";
               printEncodedString(AvAttr->Message);
               os << ")";
             } else {
-                os << " SWIFT_UNAVAILABLE";
+              maybePrintLeadingSpace();
+              os << "SWIFT_UNAVAILABLE";
             }
             break;
           }
           if (AvAttr->isUnconditionallyDeprecated()) {
             if (!AvAttr->Rename.empty() || !AvAttr->Message.empty()) {
-              os << " SWIFT_DEPRECATED_MSG(";
+              maybePrintLeadingSpace();
+              os << "SWIFT_DEPRECATED_MSG(";
               printEncodedString(AvAttr->Message);
               if (!AvAttr->Rename.empty()) {
                 os << ", ";
@@ -726,7 +752,8 @@ private:
               }
               os << ")";
             } else {
-              os << " SWIFT_DEPRECATED";
+              maybePrintLeadingSpace();
+              os << "SWIFT_DEPRECATED";
             }
           }
           continue;
@@ -769,7 +796,8 @@ private:
           break;
         }
         if (!plat) continue;
-        os << " SWIFT_AVAILABILITY(" << plat;
+        maybePrintLeadingSpace();
+        os << "SWIFT_AVAILABILITY(" << plat;
         if (AvAttr->isUnconditionallyUnavailable()) {
           os << ",unavailable";
         } else {
@@ -790,9 +818,9 @@ private:
           if (AvAttr->Obsoleted.hasValue()) {
             os << ",obsoleted=" << AvAttr->Obsoleted.getValue().getAsString();
           }
-          if (!AvAttr->Rename.empty()) {
+          if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
             // NB: Don't bother getting obj-c names, we can't get one for the rename
-            os << ",message=\"'" << VD->getBaseName()
+            os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
                << "' has been renamed to '";
             printEncodedString(AvAttr->Rename, false);
             os << '\'';
@@ -809,6 +837,7 @@ private:
         os << ")";
       }
     }
+    return hasPrintedAnything;
   }
 
   void printSwift3ObjCDeprecatedInference(ValueDecl *VD) {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -765,7 +765,8 @@ private:
           && !AvAttr->isUnconditionallyUnavailable()) {
         continue;
       }
-      const char *plat = nullptr;
+
+      const char *plat;
       switch (AvAttr->Platform) {
       case PlatformKind::OSX:
         plat = "macos";
@@ -791,10 +792,9 @@ private:
       case PlatformKind::watchOSApplicationExtension:
         plat = "watchos_app_extension";
         break;
-      default:
-        break;
+      case PlatformKind::none:
+        llvm_unreachable("handled above");
       }
-      if (!plat) continue;
 
       maybePrintLeadingSpace();
       os << "SWIFT_AVAILABILITY(" << plat;

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -38,6 +38,9 @@
 // CHECK-NEXT: - (void)multiPlatCombined
 // CHECK-DAG: SWIFT_AVAILABILITY(macos,introduced=10.6,deprecated=10.8,obsoleted=10.9)
 // CHECK-DAG: SWIFT_AVAILABILITY(ios,introduced=7.0,deprecated=9.0,obsoleted=10.0)
+// CHECK-NEXT: - (void)platUnavailableMessage SWIFT_AVAILABILITY(macos,unavailable,message="help I'm trapped in an availability factory");
+// CHECK-NEXT: - (void)platUnavailableRename SWIFT_AVAILABILITY(macos,unavailable,message="'platUnavailableRename' has been renamed to 'plea'");
+// CHECK-NEXT: - (void)platUnavailableRenameWithMessage SWIFT_AVAILABILITY(macos,unavailable,message="'platUnavailableRenameWithMessage' has been renamed to 'anotherPlea': still trapped");
 // CHECK-NEXT: - (void)extensionUnavailable
 // CHECK-DAG: SWIFT_AVAILABILITY(macos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(ios_app_extension,unavailable)
@@ -126,6 +129,13 @@
     @available(macOS, introduced: 10.6, deprecated: 10.8, obsoleted: 10.9)
     @available(iOS, introduced: 7.0, deprecated: 9.0, obsoleted: 10.0)
     @objc func multiPlatCombined() {}
+
+    @available(macOS, unavailable, message: "help I'm trapped in an availability factory")
+    @objc func platUnavailableMessage() {}
+    @available(macOS, unavailable, renamed: "plea")
+    @objc func platUnavailableRename() {}
+    @available(macOS, unavailable, renamed: "anotherPlea", message: "still trapped")
+    @objc func platUnavailableRenameWithMessage() {}
 
     @available(macOSApplicationExtension, unavailable)
     @available(iOSApplicationExtension, unavailable)

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -46,10 +46,31 @@
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
 // CHECK-NEXT: @end
+
+// CHECK-LABEL: {{^}}SWIFT_AVAILABILITY(macos,introduced=999){{$}}
+// CHECK-NEXT: @interface Availability (SWIFT_EXTENSION(availability))
+// CHECK-NEXT: - (void)extensionAvailability:(WholeClassAvailability * _Nonnull)_;
+// CHECK-NEXT: @end
+
 // CHECK-LABEL: @interface AvailabilitySub
 // CHECK-NEXT: - (nonnull instancetype)init SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ SWIFT_UNAVAILABLE;
 // CHECK-NEXT: @end
+
+// CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=999)
+// CHECK-NEXT: @interface WholeClassAvailability
+// CHECK-NEXT: - (void)wholeClassAvailability:(id <WholeProtoAvailability> _Nonnull)_;
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: @end
+
+// CHECK-LABEL: SWIFT_PROTOCOL("{{.+}}WholeProtoAvailability{{.*}}") 
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=999)
+// CHECK-NEXT: @protocol WholeProtoAvailability
+// CHECK-NEXT: - (void)wholeProtoAvailability:(WholeClassAvailability * _Nonnull)_;
+// CHECK-NEXT: @end
+
+
 @objc class Availability {
     @objc func alwaysAvailable() {}
 
@@ -117,8 +138,25 @@
     @objc init(x _: Int) {}
 }
 
+// Deliberately a high number that the default deployment target will not reach.
+@available(macOS 999, *)
+extension Availability {
+  @objc func extensionAvailability(_: WholeClassAvailability) {}
+}
+
 @objc class AvailabilitySub: Availability {
     private override init() { super.init() }
     @available(macOS 10.10, *)
     private override init(x _: Int) { super.init() }
+}
+
+
+@available(macOS 999, *)
+@objc class WholeClassAvailability {
+  func wholeClassAvailability(_: WholeProtoAvailability) {}
+}
+
+@available(macOS 999, *)
+@objc protocol WholeProtoAvailability {
+  func wholeProtoAvailability(_: WholeClassAvailability)
 }


### PR DESCRIPTION
Now that Clang has availability diagnostics too (-Wpartial-availability and friends) we need to get this correct, or people will get warnings in the generated header!

Also fix up an issue with availability messages being omitted in certain cases.

rdar://problem/33313703