### PR TITLE
[Type checker] Propagate type checking errors up from closures.

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1257,7 +1257,7 @@ public:
   bool typeCheckDestructorBodyUntil(DestructorDecl *DD,
                                     SourceLoc EndTypeCheckLoc);
 
-  void typeCheckClosureBody(ClosureExpr *closure);
+  bool typeCheckClosureBody(ClosureExpr *closure);
 
   void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -574,3 +574,10 @@ extension A_SR_5030 {
     // expected-error@-1 {{cannot convert value of type '(idx: (Int))' to closure result type 'Int'}}
   }
 }
+
+// rdar://problem/33296619
+let u = rdar33296619().element //expected-error {{use of unresolved identifier 'rdar33296619'}}
+
+[1].forEach { _ in
+  let _ = "\(u)"
+}


### PR DESCRIPTION
We were failing to propagate errors up when we type check closure
bodies, and that can lead to crashes if we continue executing, calling
into code like performSyntacticExprDiagnostics() which expects a
successfully type-checked AST.
