### PR TITLE
Parse: Relax a recently-added assertion

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2067,7 +2067,12 @@ Expr *Parser::parseExprIdentifier() {
     auto refKind = DeclRefKind::Ordinary;
     E = new (Context) UnresolvedDeclRefExpr(name, refKind, loc);
   } else if (auto TD = dyn_cast<TypeDecl>(D)) {
-    assert(!TD->getDeclContext()->isTypeContext());
+    // When parsing default argument expressions for generic functions,
+    // we haven't built a FuncDecl or re-parented the GenericTypeParamDecls
+    // to the FuncDecl yet. Other than that, we should only ever find
+    // global or local declarations here.
+    assert(!TD->getDeclContext()->isTypeContext() ||
+           isa<GenericTypeParamDecl>(TD));
     E = TypeExpr::createForDecl(loc.getBaseNameLoc(), TD, /*DC*/nullptr,
                                 /*implicit*/false);
   } else {

--- a/test/decl/func/default-values-swift4.swift
+++ b/test/decl/func/default-values-swift4.swift
@@ -78,3 +78,8 @@ public func publicFunctionWithDefaultValue(
     }(),
     y: Int = internalIntFunction()) {}
     // expected-error@-1 {{global function 'internalIntFunction()' is internal and cannot be referenced from a default argument value}}
+
+// https://bugs.swift.org/browse/SR-5559
+public class MyClass {
+  public func method<T>(_: T.Type = T.self) -> T { }
+}


### PR DESCRIPTION
We parse default argument expressions before building a
FuncDecl, so we might see GenericTypeParamDecls that have
not yet been re-parented to the FuncDecl's context.

Fixes <https://bugs.swift.org/browse/SR-5559>,
<rdar://problem/33539464>.