### PR TITLE
[SourceKit] Add subscript to doc structure (SR-5035)

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -93,6 +93,7 @@ enum class SyntaxStructureKind : uint8_t {
   EnumCase,
   EnumElement,
   TypeAlias,
+  Subscript,
 
   ForEachStatement,
   ForStatement,
@@ -139,13 +140,14 @@ struct SyntaxStructureNode {
   std::vector<CharSourceRange> InheritedTypeRanges;
   std::vector<SyntaxStructureElement> Elements;
 
-  bool isVariable() const {
+  bool hasSubstructure() const {
     switch (Kind) {
     case SyntaxStructureKind::GlobalVariable:
     case SyntaxStructureKind::InstanceVariable:
     case SyntaxStructureKind::StaticVariable:
     case SyntaxStructureKind::ClassVariable:
     case SyntaxStructureKind::Parameter:
+    case SyntaxStructureKind::Subscript:
       return true;
     default:
       return false;

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -964,6 +964,16 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
                                    TypeAliasD->getName().getLength());
     SN.Attrs = TypeAliasD->getAttrs();
     pushStructureNode(SN, TypeAliasD);
+  } else if (auto *SubscriptD = dyn_cast<SubscriptDecl>(D)) {
+    SyntaxStructureNode SN;
+    SN.Dcl = SubscriptD;
+    SN.Kind = SyntaxStructureKind::Subscript;
+    SN.Range = charSourceRangeFromSourceRange(SM,
+                                              SubscriptD->getSourceRange());
+    SN.BodyRange = innerCharSourceRangeFromSourceRange(SM,
+                                               SubscriptD->getBracesRange());
+    SN.Attrs = SubscriptD->getAttrs();
+    pushStructureNode(SN, SubscriptD);
   }
 
   return true;
@@ -1253,7 +1263,7 @@ bool ModelASTWalker::popStructureNode() {
 
   // VarDecls are popped before we see their TypeRepr, so if we pass the token
   // nodes now they will not change from identifier to a type-identifier.
-  if (!Node.isVariable()) {
+  if (!Node.hasSubstructure()) {
     if (!passTokenNodesUntil(Node.Range.getEnd(), IncludeNodeAtLocation))
       return false;
   }

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -187,3 +187,28 @@ class A {
 
 // CHECK: <typealias>typealias <name>OtherA</name> = A</typealias>
 typealias OtherA = A
+
+class SubscriptTest {
+  subscript(index: Int) -> Int {
+    return 0
+  }
+  // CHECK: <subscript>subscript(<param>index: Int</param>) -> Int {
+  // CHECK:  return 0
+  // CHECK: }</subscript>
+
+  subscript(string: String) -> Int {
+    get {
+      return 0
+    }
+    set(value) {
+      print(value)
+    }
+  }
+  // CHECK: <subscript>subscript(<param>string: String</param>) -> Int {
+  // CHECK: get {
+  // CHECK:   return 0
+  // CHECK: }
+  // CHECK: set(<param>value</param>) {
+  // CHECK:   <call><name>print</name>(value)</call>
+  // CHECK: }</subscript>
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -377,6 +377,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclEnumElement;
     case SyntaxStructureKind::TypeAlias:
       return KindDeclTypeAlias;
+    case SyntaxStructureKind::Subscript:
+      return KindDeclSubscript;
     case SyntaxStructureKind::Parameter:
       return KindDeclVarParam;
     case SyntaxStructureKind::ForEachStatement:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1070,6 +1070,7 @@ private:
       case SyntaxStructureKind::EnumCase: return "enum-case";
       case SyntaxStructureKind::EnumElement: return "enum-elem";
       case SyntaxStructureKind::TypeAlias: return "typealias";
+      case SyntaxStructureKind::Subscript: return "subscript";
       case SyntaxStructureKind::Parameter: return "param";
       case SyntaxStructureKind::ForEachStatement: return "foreach";
       case SyntaxStructureKind::ForStatement: return "for";


### PR DESCRIPTION
This adds `subscript` to the structure reported by SourceKit.

For example, for this file:
```swift
class Foo {
    subscript(index: Int) -> Int {
        get {
            return 0
        }
        set {
            print(newValue)
        }
    }
}
```

We get this structure now:
```
{
  key.offset: 0,
  key.length: 104,
  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
  key.substructure: [
    {
      key.kind: source.lang.swift.decl.class,
      key.accessibility: source.lang.swift.accessibility.internal,
      key.name: "Foo",
      key.offset: 0,
      key.length: 103,
      key.runtime_name: "_TtC8__main__3Foo",
      key.nameoffset: 6,
      key.namelength: 3,
      key.bodyoffset: 11,
      key.bodylength: 91,
      key.substructure: [
        {
          key.kind: source.lang.swift.decl.function.subscript,
          key.accessibility: source.lang.swift.accessibility.internal,
          key.setter_accessibility: source.lang.swift.accessibility.internal,
          key.name: "subscript(_:)",
          key.offset: 13,
          key.length: 88,
          key.nameoffset: 0,
          key.namelength: 0,
          key.bodyoffset: 43,
          key.bodylength: 57,
          key.substructure: [
            {
              key.kind: source.lang.swift.decl.var.parameter,
              key.name: "index",
              key.offset: 23,
              key.length: 10,
              key.typename: "Int",
              key.nameoffset: 0,
              key.namelength: 0
            }
          ]
        },
        {
          key.kind: source.lang.swift.expr.call,
          key.name: "print",
          key.offset: 79,
          key.length: 15,
          key.nameoffset: 79,
          key.namelength: 5,
          key.bodyoffset: 85,
          key.bodylength: 8
        }
      ]
    }
  ]
}
```

Resolves [SR-5035](https://bugs.swift.org/browse/SR-5035).

This wouldn't be possible without the help from @johnfairh and @CodaFi. Thanks so much! 🙌 