### PR TITLE
[SourceKit] Add local variables to structure (SR-5057)

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -90,6 +90,7 @@ enum class SyntaxStructureKind : uint8_t {
   InstanceVariable,
   StaticVariable,
   ClassVariable,
+  LocalVariable,
   EnumCase,
   EnumElement,
   TypeAlias,
@@ -146,6 +147,7 @@ struct SyntaxStructureNode {
     case SyntaxStructureKind::InstanceVariable:
     case SyntaxStructureKind::StaticVariable:
     case SyntaxStructureKind::ClassVariable:
+    case SyntaxStructureKind::LocalVariable:
     case SyntaxStructureKind::Parameter:
     case SyntaxStructureKind::Subscript:
       return true;

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -813,41 +813,41 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     pushStructureNode(SN, PD);
   } else if (auto *VD = dyn_cast<VarDecl>(D)) {
     const DeclContext *DC = VD->getDeclContext();
-    if (DC->isTypeContext() || DC->isModuleScopeContext()) {
-      SyntaxStructureNode SN;
-      setDecl(SN, D);
-      SourceRange SR;
-      if (auto *PBD = VD->getParentPatternBinding())
-        SR = PBD->getSourceRange();
-      else
-        SR = VD->getSourceRange();
-      SN.Range = charSourceRangeFromSourceRange(SM, SR);
-      if (VD->hasAccessorFunctions())
-        SN.BodyRange = innerCharSourceRangeFromSourceRange(SM,
-                                                           VD->getBracesRange());
-      SourceLoc NRStart = VD->getNameLoc();
-      SourceLoc NREnd = NRStart.getAdvancedLoc(VD->getName().getLength());
-      SN.NameRange = CharSourceRange(SM, NRStart, NREnd);
-      SN.TypeRange = charSourceRangeFromSourceRange(SM,
+    SyntaxStructureNode SN;
+    setDecl(SN, D);
+    SourceRange SR;
+    if (auto *PBD = VD->getParentPatternBinding())
+      SR = PBD->getSourceRange();
+    else
+      SR = VD->getSourceRange();
+    SN.Range = charSourceRangeFromSourceRange(SM, SR);
+    if (VD->hasAccessorFunctions())
+      SN.BodyRange = innerCharSourceRangeFromSourceRange(SM,
+                                                         VD->getBracesRange());
+    SourceLoc NRStart = VD->getNameLoc();
+    SourceLoc NREnd = NRStart.getAdvancedLoc(VD->getName().getLength());
+    SN.NameRange = CharSourceRange(SM, NRStart, NREnd);
+    SN.TypeRange = charSourceRangeFromSourceRange(SM,
                                         VD->getTypeSourceRangeForDiagnostics());
 
-      if (DC->isTypeContext()) {
-        if (VD->isStatic()) {
-          StaticSpellingKind Spell = StaticSpellingKind::KeywordStatic;
-          if (auto *PBD = VD->getParentPatternBinding())
-            Spell = PBD->getStaticSpelling();
-          if (Spell == StaticSpellingKind::KeywordClass)
-            SN.Kind = SyntaxStructureKind::ClassVariable;
-          else
-            SN.Kind = SyntaxStructureKind::StaticVariable;
-        } else {
-          SN.Kind = SyntaxStructureKind::InstanceVariable;
-        }
+    if (DC->isLocalContext()) {
+      SN.Kind = SyntaxStructureKind::LocalVariable;
+    } else if (DC->isTypeContext()) {
+      if (VD->isStatic()) {
+        StaticSpellingKind Spell = StaticSpellingKind::KeywordStatic;
+        if (auto *PBD = VD->getParentPatternBinding())
+          Spell = PBD->getStaticSpelling();
+        if (Spell == StaticSpellingKind::KeywordClass)
+          SN.Kind = SyntaxStructureKind::ClassVariable;
+        else
+          SN.Kind = SyntaxStructureKind::StaticVariable;
       } else {
-        SN.Kind = SyntaxStructureKind::GlobalVariable;
+        SN.Kind = SyntaxStructureKind::InstanceVariable;
       }
-      pushStructureNode(SN, VD);
+    } else {
+      SN.Kind = SyntaxStructureKind::GlobalVariable;
     }
+    pushStructureNode(SN, VD);
 
   } else if (auto *ConfigD = dyn_cast<IfConfigDecl>(D)) {
     for (auto &Clause : ConfigD->getClauses()) {

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -10,7 +10,7 @@ class MyCls : OtherClass {
   class var cbar : Int = 0
 
   // CHECK:   <ifunc>func <name>foo(<param>_ arg1: Int</param>, <param><name>name</name>: String</param>, <param><name>param</name> par: String</param>)</name> {
-  // CHECK:     var abc
+  // CHECK:     <lvar>var <name>abc</name></lvar>
   // CHECK:     <if>if <elem-condexpr>1</elem-condexpr> <brace>{
   // CHECK:       <call><name>foo</name>(<arg>1</arg>, <arg><name>name</name>:"test"</arg>, <arg><name>param</name>:"test2"</arg>)</call>
   // CHECK:     }</brace>
@@ -64,29 +64,24 @@ var gvar : Int = 0
 // CHECK: <ffunc>func <name>ffoo()</name> {}</ffunc>
 func ffoo() {}
 
-// CHECK: <foreach>for <elem-id>i</elem-id> in <elem-expr>0...5</elem-expr> <brace>{}</brace></foreach>
+// CHECK: <foreach>for <elem-id><lvar><name>i</name></lvar></elem-id> in <elem-expr>0...5</elem-expr> <brace>{}</brace></foreach>
 for i in 0...5 {}
-// CHECK: <foreach>for <elem-id>var (i, j)</elem-id> in <elem-expr>array</elem-expr> <brace>{}</brace></foreach>
+// CHECK: <foreach>for <elem-id>var (<lvar><name>i</name></lvar>, <lvar><name>j</name></lvar>)</elem-id> in <elem-expr>array</elem-expr> <brace>{}</brace></foreach>
 for var (i, j) in array {}
-// CHECK: <foreach>for <elem-id>var i</elem-id> = 0, i2 = 1; i == 0; ++i <brace>{}</brace></foreach>
-for var i = 0, i2 = 1; i == 0; ++i {}
-// CHECK: <foreach>for <elem-id>var (i,i2)</elem-id> = (0,0), i3 = 1; i == 0; ++i <brace>{}</brace></foreach>
-for var (i,i2) = (0,0), i3 = 1; i == 0; ++i {}
 
-for i = 0; i == 0; ++i {}
-// CHECK: <while>while <elem-condexpr>var v = o, z = o where v > z</elem-condexpr> <brace>{}</brace></while>
+// CHECK: <while>while <elem-condexpr>var <lvar><name>v</name></lvar> = o, <lvar><name>z</name></lvar> = o where v > z</elem-condexpr> <brace>{}</brace></while>
 while var v = o, z = o where v > z {}
 // CHECK: <while>while <elem-condexpr>v == 0</elem-condexpr> <brace>{}</brace></while>
 while v == 0 {}
 // CHECK: <repeat-while>repeat <brace>{}</brace> while <elem-expr>v == 0</elem-expr></repeat-while>
 repeat {} while v == 0
-// CHECK: <if>if <elem-condexpr>var v = o, z = o where v > z</elem-condexpr> <brace>{}</brace></if>
+// CHECK: <if>if <elem-condexpr>var <lvar><name>v</name></lvar> = o, <lvar><name>z</name></lvar> = o where v > z</elem-condexpr> <brace>{}</brace></if>
 if var v = o, z = o where v > z {}
 
 // CHECK: <switch>switch <elem-expr>v</elem-expr> {
 // CHECK:   <case>case <elem-pattern>1</elem-pattern>: break;</case>
 // CHECK:   <case>case <elem-pattern>2</elem-pattern>, <elem-pattern>3</elem-pattern>: break;</case>
-// CHECK:   <case>case <elem-pattern><call><name>Foo</name>(<arg>var x</arg>, <arg>var y</arg>)</call> where x < y</elem-pattern>: break;</case>
+// CHECK:   <case>case <elem-pattern><call><name>Foo</name>(<arg>var <lvar><name>x</name></lvar></arg>, <arg>var <lvar><name>y</name></lvar></arg>)</call> where x < y</elem-pattern>: break;</case>
 // CHECK:   <case>case <elem-pattern>2 where <call><name>foo</name>()</call></elem-pattern>, <elem-pattern>3 where <call><name>bar</name>()</call></elem-pattern>: break;</case>
 // CHECK:   <case><elem-pattern>default</elem-pattern>: break;</case>
 // CHECK: }</switch>
@@ -114,7 +109,7 @@ for {}
 class <#MyCls#> : <#OtherClass#> {}
 
 // CHECK: <ffunc>func <name><#test1#> ()</name> {
-// CHECK:   <foreach>for <elem-id><#name#></elem-id> in <elem-expr><#items#></elem-expr> <brace>{}</brace></foreach>
+// CHECK:   <foreach>for <elem-id><lvar><name><#name#></name></lvar></elem-id> in <elem-expr><#items#></elem-expr> <brace>{}</brace></foreach>
 // CHECK: }</ffunc>
 func <#test1#> () {
   for <#name#> in <#items#> {}

--- a/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
@@ -58,6 +58,14 @@
           ],
           key.substructure: [
             {
+              key.kind: source.lang.swift.decl.var.local,
+              key.name: "<#name#>",
+              key.offset: 63,
+              key.length: 8,
+              key.nameoffset: 63,
+              key.namelength: 8
+            },
+            {
               key.kind: source.lang.swift.stmt.brace,
               key.offset: 85,
               key.length: 2,

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -613,6 +613,14 @@
       ],
       key.substructure: [
         {
+          key.kind: source.lang.swift.decl.var.local,
+          key.name: "i",
+          key.offset: 1118,
+          key.length: 1,
+          key.nameoffset: 1118,
+          key.namelength: 1
+        },
+        {
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1129,
           key.length: 2,
@@ -638,6 +646,14 @@
       ],
       key.substructure: [
         {
+          key.kind: source.lang.swift.decl.var.local,
+          key.name: "i",
+          key.offset: 1140,
+          key.length: 1,
+          key.nameoffset: 1140,
+          key.namelength: 1
+        },
+        {
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1167,
           key.length: 2,
@@ -662,6 +678,22 @@
         }
       ],
       key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.local,
+          key.name: "v",
+          key.offset: 1180,
+          key.length: 1,
+          key.nameoffset: 1180,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.local,
+          key.name: "z",
+          key.offset: 1191,
+          key.length: 1,
+          key.nameoffset: 1191,
+          key.namelength: 1
+        },
         {
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1204,
@@ -712,6 +744,22 @@
         }
       ],
       key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.local,
+          key.name: "v",
+          key.offset: 1237,
+          key.length: 1,
+          key.nameoffset: 1237,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.local,
+          key.name: "z",
+          key.offset: 1248,
+          key.length: 1,
+          key.nameoffset: 1248,
+          key.namelength: 1
+        },
         {
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1261,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1039,7 +1039,8 @@ public:
     UIdent Kind = SwiftLangSupport::getUIDForSyntaxStructureKind(Node.Kind);
     UIdent AccessLevel;
     UIdent SetterAccessLevel;
-    if (Node.Kind != SyntaxStructureKind::Parameter) {
+    if (Node.Kind != SyntaxStructureKind::Parameter &&
+        Node.Kind != SyntaxStructureKind::LocalVariable) {
       if (auto *VD = dyn_cast_or_null<ValueDecl>(Node.Dcl)) {
         AccessLevel = getAccessibilityUID(inferAccessibility(VD));
       } else if (auto *ED = dyn_cast_or_null<ExtensionDecl>(Node.Dcl)) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -371,6 +371,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclVarStatic;
     case SyntaxStructureKind::ClassVariable:
       return KindDeclVarClass;
+    case SyntaxStructureKind::LocalVariable:
+      return KindDeclVarLocal;
     case SyntaxStructureKind::EnumCase:
       return KindDeclEnumCase;
     case SyntaxStructureKind::EnumElement:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1067,6 +1067,7 @@ private:
       case SyntaxStructureKind::InstanceVariable: return "property";
       case SyntaxStructureKind::StaticVariable: return "svar";
       case SyntaxStructureKind::ClassVariable: return "cvar";
+      case SyntaxStructureKind::LocalVariable: return "lvar";
       case SyntaxStructureKind::EnumCase: return "enum-case";
       case SyntaxStructureKind::EnumElement: return "enum-elem";
       case SyntaxStructureKind::TypeAlias: return "typealias";


### PR DESCRIPTION
This PR includes local variables (`source.lang.swift.decl.var.local`) to structures provided by SourceKit. This also makes variables declared in `for` and `while` statements available in the structure.

Resolves [SR-5057](https://bugs.swift.org/browse/SR-5057).

This is super important for [SwiftLint](https://github.com/realm/SwiftLint), as you can see on https://github.com/realm/SwiftLint/issues/136 and all duplicated issues. I'm not sure if there's a historical reason for this not be included until now.
