### PR TITLE
Parse: Fix capture list parsing with 'self'

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2279,7 +2279,7 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
           if (!consumeIf(tok::r_paren))
             diagnose(Tok, diag::attr_unowned_expected_rparen);
         }
-      } else if (Tok.is(tok::identifier) &&
+      } else if (Tok.isAny(tok::identifier, tok::kw_self) &&
                  peekToken().isAny(tok::equal, tok::comma, tok::r_square)) {
         // "x = 42", "x," and "x]" are all strong captures of x.
         loc = Tok.getLoc();

--- a/test/Sema/diag_invalid_inout_captures.swift
+++ b/test/Sema/diag_invalid_inout_captures.swift
@@ -7,7 +7,14 @@ struct you_cry_in_your_tea {
   mutating func which_you_hurl_in_the_sea_when_you_see_me_go_by() {
     no_escape { _ = self } // OK
     do_escape { _ = self } // expected-error {{closure cannot implicitly capture a mutating self parameter}}
+    do_escape {
+      [self] in
+      _ = self // OK
+      self.other_mutator() // expected-error {{cannot use mutating member on immutable value: 'self' is an immutable capture}}
+    }
   }
+
+  mutating func other_mutator() {}
 }
 
 func why_so_sad(line: inout String) {


### PR DESCRIPTION
We accepted the following capture lists:

- [x]
- [weak x]
- [weak self]

But not [self]. I think this is an oversight.