### PR TITLE
Small crasher fixes

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -701,7 +701,10 @@ CanType ASTContext::getAnyObjectType() const {
 }
 
 CanType ASTContext::getNeverType() const {
-  return getNeverDecl()->getDeclaredType()->getCanonicalType();
+  auto neverDecl = getNeverDecl();
+  if (!neverDecl)
+    return CanType();
+  return neverDecl->getDeclaredType()->getCanonicalType();
 }
 
 TypeAliasDecl *ASTContext::getVoidDecl() const {
@@ -884,6 +887,9 @@ FuncDecl *ASTContext::getGetBoolDecl(LazyResolver *resolver) const {
 FuncDecl *ASTContext::getEqualIntDecl() const {
   if (Impl.EqualIntDecl)
     return Impl.EqualIntDecl;
+
+  if (!getIntDecl() || !getBoolDecl())
+    return nullptr;
 
   auto intType = getIntDecl()->getDeclaredType();
   auto boolType = getBoolDecl()->getDeclaredType();

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1062,8 +1062,12 @@ static ValueDecl *getIntToFPWithOverflowOperation(ASTContext &Context,
 
 static ValueDecl *getUnreachableOperation(ASTContext &Context,
                                           Identifier Id) {
+  auto NeverTy = Context.getNeverType();
+  if (!NeverTy)
+    return nullptr;
+
   // () -> Never
-  return getBuiltinFunction(Id, {}, Context.getNeverType());
+  return getBuiltinFunction(Id, {}, NeverTy);
 }
 
 static ValueDecl *getOnceOperation(ASTContext &Context,
@@ -1295,8 +1299,11 @@ getSwiftFunctionTypeForIntrinsic(unsigned iid, ArrayRef<Type> TypeArgs,
       llvm::Intrinsic::getAttributes(getGlobalLLVMContext(), ID);
   Info = FunctionType::ExtInfo();
   if (attrs.hasAttribute(llvm::AttributeList::FunctionIndex,
-                         llvm::Attribute::NoReturn))
+                         llvm::Attribute::NoReturn)) {
     ResultTy = Context.getNeverType();
+    if (!ResultTy)
+      return false;
+  }
   
   return true;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -855,29 +855,29 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
               return;
             }
           }
+        }
 
-          // Check the generic parameters if our context is a generic type or
-          // extension thereof.
-          GenericParamList *dcGenericParams = nullptr;
-          if (auto nominal = dyn_cast<NominalTypeDecl>(DC))
-            dcGenericParams = nominal->getGenericParams();
-          else if (auto ext = dyn_cast<ExtensionDecl>(DC))
-            dcGenericParams = ext->getGenericParams();
-          else if (auto subscript = dyn_cast<SubscriptDecl>(DC))
-            dcGenericParams = subscript->getGenericParams();
+        // Check the generic parameters if our context is a generic type or
+        // extension thereof.
+        GenericParamList *dcGenericParams = nullptr;
+        if (auto nominal = dyn_cast<NominalTypeDecl>(DC))
+          dcGenericParams = nominal->getGenericParams();
+        else if (auto ext = dyn_cast<ExtensionDecl>(DC))
+          dcGenericParams = ext->getGenericParams();
+        else if (auto subscript = dyn_cast<SubscriptDecl>(DC))
+          dcGenericParams = subscript->getGenericParams();
 
-          while (dcGenericParams) {
-            namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-            localVal.checkGenericParams(dcGenericParams);
+        while (dcGenericParams) {
+          namelookup::FindLocalVal localVal(SM, Loc, Consumer);
+          localVal.checkGenericParams(dcGenericParams);
 
-            if (!Results.empty())
-              return;
+          if (!Results.empty())
+            return;
 
-            if (!isa<ExtensionDecl>(DC))
-              break;
+          if (!isa<ExtensionDecl>(DC))
+            break;
 
-            dcGenericParams = dcGenericParams->getOuterParameters();
-          }
+          dcGenericParams = dcGenericParams->getOuterParameters();
         }
 
         DC = DC->getParentForLookup();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2439,6 +2439,8 @@ namespace {
         ProtocolDecl *protocols[]
           = {cxt.getProtocol(KnownProtocolKind::RawRepresentable),
              cxt.getProtocol(KnownProtocolKind::Equatable)};
+        if (!protocols[0] || !protocols[1])
+          return nullptr;
 
         auto options = getDefaultMakeStructRawValuedOptions();
         options |= MakeStructRawValuedFlags::MakeUnlabeledValueInit;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3792,11 +3792,14 @@ static bool trySequenceSubsequenceConversionFixIts(InFlightDiagnostic &diag,
                                                    ConstraintSystem &CS,
                                                    Type fromType, Type toType,
                                                    Expr *expr) {
-  if (CS.TC.Context.getStdlibModule() == nullptr) {
+  if (CS.TC.Context.getStdlibModule() == nullptr)
     return false;
-  }
+
   auto String = CS.TC.getStringType(CS.DC);
   auto Substring = CS.TC.getSubstringType(CS.DC);
+
+  if (!String || !Substring)
+    return false;
 
   /// FIXME: Remove this flag when void subscripts are implemented.
   /// Make this unconditional and remove the if statement.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4747,13 +4747,17 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
     // matches what the user actually wrote instead of what the typechecker
     // expects.
     SmallVector<TupleTypeElt, 4> elts;
-    for (auto *el : argTuple->getElements()) {
+    for (unsigned i = 0, e = argTuple->getNumElements(); i < e; ++i) {
       ConcreteDeclRef ref = nullptr;
+      auto *el = argTuple->getElement(i);
       auto typeResult =
         TC.getTypeOfExpressionWithoutApplying(el, CS.DC, ref);
       if (!typeResult)
         return false;
-      elts.push_back(typeResult);
+      auto flags = ParameterTypeFlags().withInOut(typeResult->is<InOutType>());
+      elts.push_back(TupleTypeElt(typeResult->getInOutObjectType(),
+                                  argTuple->getElementName(i),
+                                  flags));
     }
 
     argType = TupleType::get(elts, CS.getASTContext());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -164,8 +164,9 @@ public:
         diag.fixItInsert(resultLoc, fix);
       }
 
-      FD->getBodyResultTypeLoc() = TypeLoc::withoutLoc(
-          TC.Context.getNeverType());
+      auto neverType = TC.Context.getNeverType();
+      if (neverType)
+        FD->getBodyResultTypeLoc() = TypeLoc::withoutLoc(neverType);
     }
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2185,8 +2185,15 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       options |= TR_EditorPlaceholder;
     }
 
+    // FIXME: initTy should be the same as resultTy; now that typeCheckExpression()
+    // returns a Type and not bool, we should be able to simplify the listener
+    // implementation here.
+    auto initTy = listener.getInitType();
+    if (initTy->hasDependentMember())
+      return true;
+
     // Apply the solution to the pattern as well.
-    if (coercePatternToType(pattern, DC, listener.getInitType(), options,
+    if (coercePatternToType(pattern, DC, initTy, options,
                             nullptr, TypeLoc(), listener.isInOut())) {
       return true;
     }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1503,7 +1503,9 @@ recur:
     }
 
     EnumElementDecl *elementDecl = Context.getOptionalSomeDecl(optionalKind);
-    assert(elementDecl && "missing optional some decl?!");
+    if (!elementDecl)
+      return true;
+
     OP->setElementDecl(elementDecl);
 
     Pattern *sub = OP->getSubPattern();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5608,6 +5608,8 @@ bool TypeChecker::useObjectiveCBridgeableConformances(DeclContext *dc,
               auto keyType = args[0];
               auto *hashableProto =
                 TC.Context.getProtocol(KnownProtocolKind::Hashable);
+              if (!hashableProto)
+                return Action::Stop;
 
               auto result = TC.conformsToProtocol(
                   keyType, hashableProto, DC, options,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -237,7 +237,9 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
   auto *NTD = ResultType->getAnyNominal();
   if (!NTD)
     return;
-  auto optionSetType = dyn_cast<ProtocolDecl>(Ctx.getOptionSetDecl());
+  auto optionSetType = dyn_cast_or_null<ProtocolDecl>(Ctx.getOptionSetDecl());
+  if (!optionSetType)
+    return;
   SmallVector<ProtocolConformance *, 4> conformances;
   if (!(optionSetType &&
         NTD->lookupConformance(module, optionSetType, conformances)))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -274,8 +274,13 @@ Type TypeChecker::resolveTypeInContext(
 
   assert(foundDC);
 
+  // selfType is the self type of the context, unless the
+  // context is a protocol type, in which case we might have
+  // to use the existential type or superclass bound as a
+  // parent type instead.
   Type selfType;
-  if (isa<NominalTypeDecl>(typeDecl)) {
+  if (isa<NominalTypeDecl>(typeDecl) &&
+      typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
     // When looking up a nominal type declaration inside of a
     // protocol extension, always use the nominal type and
     // not the protocol 'Self' type.
@@ -292,7 +297,8 @@ Type TypeChecker::resolveTypeInContext(
 
     if (selfType->is<GenericTypeParamType>() &&
         typeDecl->getDeclContext()->getAsClassOrClassExtensionContext()) {
-      // We found a member of a class from a protocol extension.
+      // We found a member of a class from a protocol or protocol
+      // extension.
       //
       // Get the superclass of the 'Self' type parameter.
       auto *sig = foundDC->getGenericSignatureOfContext();

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -417,3 +417,15 @@ extension Array where Element == Int {
     // expected-error@-1 {{use of 'min' nearly matches global function 'min' in module 'Swift' rather than instance method 'min()'}}
   }
 }
+
+// Crash in diagnoseImplicitSelfErrors()
+
+struct Aardvark {
+  var snout: Int
+
+  mutating func burrow() {
+    dig(&snout, .y) // expected-error {{type 'Int' has no member 'y'}}
+  }
+
+  func dig(_: inout Int, _: Int) {}
+}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -237,6 +237,8 @@ protocol ConformedProtocol {
 class BaseWithAlias<T> : ConformedProtocol {
   typealias ConcreteAlias = T
 
+  struct NestedNominal {}
+
   func baseMethod(_: T) {}
 }
 
@@ -261,6 +263,8 @@ extension ExtendedProtocol where Self : DerivedWithAlias {
   func f3(x: AbstractConformanceAlias) {
     let _: DerivedWithAlias = x
   }
+
+  func f4(x: NestedNominal) {}
 }
 
 // ----------------------------------------------------------------------------

--- a/validation-test/SIL/crashers/016-swift-typechecker-typecheckfunctionbodyuntil.sil
+++ b/validation-test/SIL/crashers/016-swift-typechecker-typecheckfunctionbodyuntil.sil
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-func n->a{return:}class a

--- a/validation-test/SIL/crashers_fixed/016-swift-typechecker-typecheckfunctionbodyuntil.sil
+++ b/validation-test/SIL/crashers_fixed/016-swift-typechecker-typecheckfunctionbodyuntil.sil
@@ -1,0 +1,2 @@
+// RUN: not %target-sil-opt %s
+func n->a{return:}class a

--- a/validation-test/compiler_crashers_fixed/28821-isa-protocoldecl-nominal-cannot-be-a-protocol.swift
+++ b/validation-test/compiler_crashers_fixed/28821-isa-protocoldecl-nominal-cannot-be-a-protocol.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A{{}protocol A{func a:Self.a}typealias e:A.a

--- a/validation-test/compiler_crashers_fixed/28825-isa-classdecl-nominaldecl-expected-a-class-here.swift
+++ b/validation-test/compiler_crashers_fixed/28825-isa-classdecl-nominaldecl-expected-a-class-here.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol b:a{init(t:a}class a{class a


### PR DESCRIPTION
We had a bunch of internal radars with test cases generated by an unreleased stdlib fuzzer. Most of the original problems have since been fixed, but while verifying I found a few minor crashers. Some of the fixes don't have test cases because they're only possible to trigger in edge case diagnostics from stdlibs that are missing certain common declarations, such as `Int`.