### PR TITLE
Enable Foundation to build against a new libicu

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2406,6 +2406,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     LIBDISPATCH_BUILD_ARGS="-DLIBDISPATCH_SOURCE_DIR=${LIBDISPATCH_SOURCE_DIR} -DLIBDISPATCH_BUILD_DIR=${LIBDISPATCH_BUILD_DIR}"
                 fi
 
+                # Opt-in for building with icu
+                if [[ ! "${SKIP_BUILD_LIBICU}" ]] ; then
+                    LIBICU_BUILD_DIR=$(build_directory ${host} libicu)
+                    ICU_TMPINSTALL=$LIBICU_BUILD_DIR/tmp_install
+                    LIBICU_BUILD_ARGS="-DLIBICU_SOURCE_DIR=${LIBICU_SOURCE_DIR} -DLIBICU_BUILD_DIR=${LIBICU_BUILD_DIR} -DICU_TMPINSTALL=${ICU_TMPINSTALL}"
+                fi
+
                 if [[ "${USE_GOLD_LINKER}" ]]; then
                     SWIFT_USE_LINKER="-fuse-ld=gold"
                 fi
@@ -2430,7 +2437,7 @@ for host in "${ALL_HOSTS[@]}"; do
     
                 with_pushd "${FOUNDATION_SOURCE_DIR}" \
                     call env SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
-                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="$(get_host_install_destdir ${host})" PREFIX="$(get_host_install_prefix ${host})" ./configure "${FOUNDATION_BUILD_TYPE}" ${FOUNDATION_BUILD_ARGS[@]} -DXCTEST_BUILD_DIR=${XCTEST_BUILD_DIR} $LIBDISPATCH_BUILD_ARGS
+                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="$(get_host_install_destdir ${host})" PREFIX="$(get_host_install_prefix ${host})" ./configure "${FOUNDATION_BUILD_TYPE}" ${FOUNDATION_BUILD_ARGS[@]} -DXCTEST_BUILD_DIR=${XCTEST_BUILD_DIR} $LIBDISPATCH_BUILD_ARGS $LIBICU_BUILD_ARGS
                 with_pushd "${FOUNDATION_SOURCE_DIR}" \
                     call ${NINJA_BIN}
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This enables Foundation to build against a newly built ICU library, such as when the `--libicu` parameter to `build-script` is used.  

It may be desirable to be able to do this on Linux in order to match the version of ICU used on the OSX platform, for two reasons:
- Equivalence of behavior across platforms: differences in the implementation of ICU on OSX versus Linux can otherwise lead to different results from Foundation (see: https://bugs.swift.org/browse/SR-5591)
- Performance: the level of ICU that ships on earlier distros such as Ubuntu 14.04 performs poorly when comparing ASCII strings (see apple/swift#7339).

The corresponding Foundation change is in: https://github.com/apple/swift-corelibs-foundation/pull/1144

This PR would enable `libicu=true` and `install-libicu` to be added, for example, to the `buildbot_linux` build preset in the future - however I imagine that those changes, and a method of obtaining a particular version of ICU, probably belong in a separate PR.

I have tested this locally on Ubuntu 14.04 and 16.04, having first downloaded [ICU 57.1](http://site.icu-project.org/download/57#TOC-ICU4C-Download) and unpacked it at the same level as `swift/`, `swift-corelibs-foundation/`, etc.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
