### PR TITLE
[master-next] Disable the failing part of availability_host_os.swift.

### DIFF
--- a/test/Interpreter/availability_host_os.swift
+++ b/test/Interpreter/availability_host_os.swift
@@ -1,7 +1,11 @@
 // Note: This deliberately uses the script interpreter rather than build/run.
 // RUN: %swift_driver -import-objc-header %S/Inputs/availability_host_os.h -DFAIL -Xfrontend -verify %s
 // RUN: %swift_driver -import-objc-header %S/Inputs/availability_host_os.h %s | %FileCheck %s
-// RUN: not %swift -typecheck -import-objc-header %S/Inputs/availability_host_os.h %s 2>&1 | %FileCheck -check-prefix=CHECK-NOT-INFERRED %s
+
+// This check is disabled for now because LLVM has started inferring the current
+// OS for the default target triple all the time. rdar://problem/29948658 tracks
+// deciding whether that's the right behavior.
+// RUN-DISABLED: not %swift -typecheck -import-objc-header %S/Inputs/availability_host_os.h %s 2>&1 | %FileCheck -check-prefix=CHECK-NOT-INFERRED %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test


### PR DESCRIPTION
LLVM r307372 makes it so that the current running macOS version is always chosen as the default target. It's unclear whether that's the behavior we want or not; deciding that is tracked by rdar://problem/29948658. For now, just disable that part of the test.