### PR TITLE
Build position independent Linux binaries.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1562,6 +1562,10 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
 
+  if (getTriple().getOS() == llvm::Triple::Linux) {
+    Arguments.push_back("-pie");
+  }
+
   std::string Target = getTargetForLinker();
   if (!Target.empty()) {
     Arguments.push_back("-target");

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -58,13 +58,10 @@ def create_lldb_target(binary, memmap):
     lldb_target = lldb_debugger.CreateTargetWithFileAndArch(
         binary, lldb.LLDB_ARCH_DEFAULT)
     module = lldb_target.GetModuleAtIndex(0)
-    # lldb seems to treat main binary differently, slide offset must be zero
-    lldb_target.SetModuleLoadAddress(module, 0)
     for dynlib_path in memmap:
-        if binary not in dynlib_path:
-            module = lldb_target.AddModule(
-                dynlib_path, lldb.LLDB_ARCH_DEFAULT, None, None)
-            lldb_target.SetModuleLoadAddress(module, memmap[dynlib_path])
+        module = lldb_target.AddModule(
+            dynlib_path, lldb.LLDB_ARCH_DEFAULT, None, None)
+        lldb_target.SetModuleLoadAddress(module, memmap[dynlib_path])
     return lldb_target
 
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes Linux executable to be position independent. It does so by adding `-pie` flag to `clang++` linker invocation.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5405](https://bugs.swift.org/browse/SR-5405).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->