### PR TITLE
Fixup __shared propagation

### DIFF
--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -134,7 +134,5 @@ func owned_to_shared_conversion(_ f : (Int, ValueAggregate, RefAggregate) -> Voi
   return owned_to_shared_conversion { (trivial : __shared Int, val : __shared ValueAggregate, ref : __shared RefAggregate) in }
 }
 
-// TODO: Investigate a different lowering scheme than @owned.  Perhaps '@guaranteed $@callee_guaranteed'?
-
-// CHECK-LABEL: sil hidden @_T06shared0A17_closure_loweringyySi_AA14ValueAggregateVAA03RefE0CtcF : $@convention(thin) (@owned @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+// CHECK-LABEL: sil hidden @_T06shared0A17_closure_loweringyySi_AA14ValueAggregateVAA03RefE0CtcF : $@convention(thin) (@guaranteed @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
 func shared_closure_lowering(_ f : __shared (Int, ValueAggregate, RefAggregate) -> Void) {}


### PR DESCRIPTION
Two minor fixes that affect propagation of the __shared bit

* Type canonicalization now preserves __shared.  This could
manifest as invalid references to SILDeclRefs with the
wrong signature.

* Function type lowering dispatches __shared tuples that are
not valid substitution targets through the @owned path in all
cases.

This has the added benefit of lowering __shared closures `@guaranteed @callee_owned`.
