### PR TITLE
[QoI] Improve diagnostics for misaligned archetypes with the same name in calls

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -340,6 +340,10 @@ ERROR(cannot_convert_default_arg_value_nil,none,
 ERROR(cannot_convert_argument_value,none,
       "cannot convert value of type %0 to expected argument type %1",
       (Type,Type))
+ERROR(cannot_convert_argument_value_generic,none,
+      "cannot convert value of type %0 (%1) to expected argument type %2 (%3)",
+      (Type, StringRef, Type, StringRef))
+
 ERROR(cannot_convert_argument_value_protocol,none,
       "argument type %0 does not conform to expected type %1", (Type, Type))
 ERROR(cannot_convert_partial_argument_value_protocol,none,
@@ -2547,6 +2551,8 @@ ERROR(generic_type_requires_arguments,none,
       "reference to generic type %0 requires arguments in <...>", (Type))
 NOTE(generic_type_declared_here,none,
      "generic type %0 declared here", (Identifier))
+NOTE(descriptive_generic_type_declared_here,none,
+     "%0 declared here", (StringRef))
 
 WARNING(use_of_void_pointer,none,
 "Unsafe%0Pointer<Void> has been replaced by Unsafe%0RawPointer", (StringRef))

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -480,3 +480,19 @@ public struct S5 {
         g(models: arr)
     }
 }
+
+// rdar://problem/24329052 - QoI: call argument archetypes not lining up leads to ambiguity errors
+
+struct S_24329052<T> { // expected-note {{generic parameter 'T' of generic struct 'S_24329052' declared here}}
+  var foo: (T) -> Void
+  // expected-note@+1 {{generic parameter 'T' of instance method 'bar(_:)' declared here}}
+  func bar<T>(_ v: T) { foo(v) }
+  // expected-error@-1 {{cannot convert value of type 'T' (generic parameter of instance method 'bar(_:)') to expected argument type 'T' (generic parameter of generic struct 'S_24329052')}}
+}
+
+extension Sequence {
+  var rdar24329052: (Element) -> Void { fatalError() }
+  // expected-note@+1 {{generic parameter 'Element' of instance method 'foo24329052(_:)' declared here}}
+  func foo24329052<Element>(_ v: Element) { rdar24329052(v) }
+  // expected-error@-1 {{cannot convert value of type 'Element' (generic parameter of instance method 'foo24329052(_:)') to expected argument type 'Self.Element' (associated type of protocol 'Sequence')}}
+}


### PR DESCRIPTION
Resolves: rdar://problem/24329052.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
