### PR TITLE
Fix simplifyCheckedCastAddrBranchInst to properly destroy the value.

### DIFF
--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1984,10 +1984,12 @@ simplifyCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
     // The unconditional_addr_cast can be skipped, if the result of a cast
     // is not used afterwards.
     if (ResultNotUsed) {
+      if (shouldTakeOnSuccess(Inst->getConsumptionKind())) {
+        auto &srcTL = Builder.getModule().getTypeLowering(Src->getType());
+        srcTL.emitDestroyAddress(Builder, Loc, Src);
+      }
       EraseInstAction(Inst);
       Builder.setInsertionPoint(BB);
-      if (shouldTakeOnSuccess(Inst->getConsumptionKind()))
-        Builder.emitDestroyAddr(Loc, Src);
       auto *NewI = Builder.createBranch(Loc, SuccessBB);
       WillSucceedAction();
       return NewI;

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -2914,7 +2914,8 @@ class IsQ : Q {}
 // CHECK-LABEL: sil @test_dead_checked_cast_br : $@convention(thin) (@in IsQ) -> () {
 // CHECK: bb0(%0 : $*IsQ):
 // CHECK:   [[Q:%.*]] = alloc_stack $Q
-// CHECK:   destroy_addr %0 : $*IsQ
+// CHECK:   [[LD:%.*]] = load %0 : $*IsQ
+// CHECK:   strong_release [[LD]] : $IsQ
 // CHECK:   dealloc_stack [[Q]] : $*Q
 // CHECK:   [[R:%.*]] = tuple ()
 // CHECK:   return [[R]] : $()


### PR DESCRIPTION
Fixes a change from earlier today that popped up on ASAN.
The fix also uses a more idiomatic approach to destroying values.
