### PR TITLE
Make SourceKitSupport depend on swift-syntax-generated-headers

### DIFF
--- a/tools/SourceKit/lib/Support/CMakeLists.txt
+++ b/tools/SourceKit/lib/Support/CMakeLists.txt
@@ -15,5 +15,6 @@ endif()
 
 add_sourcekit_library(SourceKitSupport
   ${SourceKitSupport_sources}
+  TARGET_DEPENDS swift-syntax-generated-headers
   DEPENDS ${SOURCEKIT_SUPPORT_DEPEND}
 )


### PR DESCRIPTION
This should unblock the bots but probably introduce a conflict with #11228.

rdar://33647571