### PR TITLE
[stdlib] RandomAccessCollection conformance for standard integer Words

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2968,9 +2968,9 @@ ${assignmentOperatorComment(x.operator, True)}
       )._lowWord._value)
   }
 
-% if bits <= word_bits:
-  public typealias Words = CollectionOfOne<UInt>
-% else:  
+  // Keep Words defined the same on 32- and 64-bit platforms.
+% WordsType = 'UInt' if self_type.is_word or bits <= 32 else 'UInt64'
+% if WordsType == Self:
   public struct Words : RandomAccessCollection {
     public typealias Indices = CountableRange<Int>
     public typealias SubSequence = RandomAccessSlice<${Self}.Words>
@@ -2999,6 +2999,8 @@ ${assignmentOperatorComment(x.operator, True)}
       }
     }
   }
+% else:
+  public typealias Words = ${WordsType}.Words
 % end
 
   /// A collection containing the words of this value's binary
@@ -3010,10 +3012,10 @@ ${assignmentOperatorComment(x.operator, True)}
 % end
   @_transparent
   public var words: Words {
-    % if bits <= word_bits:
+    % if WordsType == 'UInt':
     return Words(self._lowWord)
-    % else:
-    return Words(self)
+    % else: # UInt64, Int64
+    return Words(UInt64(_value))
     % end
   }
 

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2968,10 +2968,12 @@ ${assignmentOperatorComment(x.operator, True)}
       )._lowWord._value)
   }
 
-  // FIXME should be RandomAccessCollection
-  public struct Words : BidirectionalCollection {
+% if bits <= word_bits:
+  public typealias Words = CollectionOfOne<UInt>
+% else:  
+  public struct Words : RandomAccessCollection {
     public typealias Indices = CountableRange<Int>
-    public typealias SubSequence = BidirectionalSlice<${Self}.Words>
+    public typealias SubSequence = RandomAccessSlice<${Self}.Words>
 
     var _value: ${Self}
 
@@ -2987,14 +2989,6 @@ ${assignmentOperatorComment(x.operator, True)}
 
     public var endIndex: Int { return count }
 
-    public var indices: Indices { return startIndex ..< endIndex }
-
-    @_transparent
-    public func index(after i: Int) -> Int { return i + 1 }
-
-    @_transparent
-    public func index(before i: Int) -> Int { return i - 1 }
-
     public subscript(position: Int) -> UInt {
       get {
         _precondition(position >= 0, "Negative word index")
@@ -3005,6 +2999,7 @@ ${assignmentOperatorComment(x.operator, True)}
       }
     }
   }
+% end
 
   /// A collection containing the words of this value's binary
   /// representation, in order from the least significant to most significant.
@@ -3015,7 +3010,11 @@ ${assignmentOperatorComment(x.operator, True)}
 % end
   @_transparent
   public var words: Words {
+    % if bits <= word_bits:
+    return Words(self._lowWord)
+    % else:
     return Words(self)
+    % end
   }
 
   @_transparent

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -16,7 +16,8 @@ from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
     sliceTypeName,
-    protocolsForCollectionFeatures
+    protocolsForCollectionFeatures,
+    defaultIndicesForTraversal
 )
 
 def get_slice_doc_comment(Self):
@@ -119,6 +120,7 @@ public struct ${Self}<Base : ${BaseRequirements}>
 
   public typealias Index = Base.Index
   public typealias IndexDistance = Base.IndexDistance
+  public typealias Indices = ${defaultIndicesForTraversal(Traversal)}<${Self}>
 
   public var _startIndex: Index
   public var _endIndex: Index


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR updates the definition of `Words` on all standard integer types (from `Int8` to `UInt64`) to implement `RandomAccessCollection`.

For integer types that fit in a single word, the custom `Words` collection is replaced with `CollectionOfOne<UInt>`. The original collection is still used by `Int64` and `UInt64` on 32-bit platforms, though, but it is updated to implement `RandomAccessCollection`.

Making `Int.Words` (or `UInt.Words`) conform to `RandomAccessCollection` reveals a type inference issue with `RandomAccessSlice.Indices`: it seems that in this case, `Int.Words.SubSequence.Indices` does not default to `DefaultRandomAccessIndices`, but rather `DefaultIndices`, which breaks `RandomAccessCollection` requirements. I worked around this by adding an explicit definition for `Indices` to all slice types, forcing the compiler to always use the correct type.

This PR ~~has negligible impact on~~ **slightly improves** stdlib compilation time.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->