### PR TITLE
Follow up for: Introduce a special DeclBaseName for "deinit" 

### DIFF
--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1096,6 +1096,8 @@ static StringRef getEscapedName(DeclBaseName name) {
   switch (name.getKind()) {
   case DeclBaseName::Kind::Subscript:
     return "subscript";
+  case DeclBaseName::Kind::Destructor:
+    return "deinit";
   case DeclBaseName::Kind::Normal:
     return llvm::StringSwitch<StringRef>(name.getIdentifier().str())
         .Case("subscript", "`subscript`")


### PR DESCRIPTION
This is a follow-up of #10965, adding a switch case for `DeclBaseName::Kind::Destructor` in `swift-api-digester.cpp`, which I had forgotten.

I don't usually build everything during development and only just realised the warning issued by the missing case. 
Looks like dc1d0943b2 has already changed the compiler options to catch mistakes like these as an error in the future.