### PR TITLE
[swift-api-digester] Update for 'deinit' as a special name.

### DIFF
--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1096,9 +1096,12 @@ static StringRef getEscapedName(DeclBaseName name) {
   switch (name.getKind()) {
   case DeclBaseName::Kind::Subscript:
     return "subscript";
+  case DeclBaseName::Kind::Destructor:
+    return "deinit";
   case DeclBaseName::Kind::Normal:
     return llvm::StringSwitch<StringRef>(name.getIdentifier().str())
         .Case("subscript", "`subscript`")
+        .Case("deinit", "`deinit`")
         .Default(name.getIdentifier().str());
   }
 }


### PR DESCRIPTION
Missed switch case from the #10965 series. Unbreaks the build after -Werror=switch.
