### PR TITLE
[CMake] Make several libs depend on swift-syntax-generated-headers

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -16,6 +16,8 @@ add_swift_library(swiftClangImporter STATIC
   ImportName.cpp
   ImportType.cpp
   SwiftLookupTable.cpp
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftAST
     swiftParse

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -16,7 +16,9 @@ set(swiftDriver_targetDefines)
 
 add_swift_library(swiftDriver STATIC
   ${swiftDriver_sources}
-  DEPENDS SwiftOptions
+  DEPENDS
+    SwiftOptions
+    swift-syntax-generated-headers
   LINK_LIBRARIES swiftAST swiftBasic swiftFrontend swiftOption)
 
 # Generate the static-stdlib-args.lnk file used by -static-stdlib option

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -12,7 +12,9 @@ add_swift_library(swiftFrontend STATIC
   PrintingDiagnosticConsumer.cpp
   SerializedDiagnosticConsumer.cpp
   ${AppleHostVersionDetection}
-  DEPENDS SwiftOptions
+  DEPENDS
+    SwiftOptions
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftSIL
     swiftMigrator

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -44,6 +44,8 @@ add_swift_library(swiftMigrator STATIC
   RewriteBufferEditsReceiver.cpp
   TupleSplatMigratorPass.cpp
   TypeOfMigratorPass.cpp
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES swiftSyntax swiftIDE)
 
 add_dependencies(swiftMigrator

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_swift_library(swiftParseSIL STATIC
   ParseSIL.cpp
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftParse
     swiftSema

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_library(swiftPrintAsObjC STATIC
   PrintAsObjC.cpp
-
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftIDE
     swiftFrontend

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -31,6 +31,8 @@ add_swift_library(swiftSILGen STATIC
   SILGenStmt.cpp
   SILGenThunk.cpp
   SILGenType.cpp
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftSIL
 )

--- a/tools/swift-syntax-test/CMakeLists.txt
+++ b/tools/swift-syntax-test/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_swift_host_tool(swift-syntax-test
   swift-syntax-test.cpp
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftAST
     swiftDriver


### PR DESCRIPTION
`swift/Parse/Lexer.h` is used by these libraries.

Fixes:
```
In file included from /Users/rintaro/swift-oss/swift/lib/SILGen/SILGenProfiling.cpp:18:
In file included from /Users/rintaro/swift-oss/swift/include/swift/Parse/Lexer.h:24:
In file included from /Users/rintaro/swift-oss/swift/include/swift/Syntax/TokenSyntax.h:21:
In file included from /Users/rintaro/swift-oss/swift/include/swift/Syntax/RawTokenSyntax.h:25:
/Users/rintaro/swift-oss/swift/include/swift/Syntax/RawSyntax.h:33:10: fatal error: 'swift/Syntax/SyntaxKind.h' file not found
#include "swift/Syntax/SyntaxKind.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

I don't think this is the ideal fix for this problem, but...

CC/ @harlanhaskins 