### PR TITLE
[Lexer] Forward declare RawTokenSyntax in 'Lexer.h'

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -21,11 +21,17 @@
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Token.h"
-#include "swift/Syntax/TokenSyntax.h"
+#include "swift/Syntax/References.h"
+#include "swift/Syntax/Trivia.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/SaveAndRestore.h"
 
 namespace swift {
+
+namespace syntax {
+  struct RawTokenSyntax;
+}
+
   /// Given a pointer to the starting byte of a UTF8 character, validate it and
   /// advance the lexer past it.  This returns the encoded character or ~0U if
   /// the encoding is invalid.


### PR DESCRIPTION
Avoids generated `Syntax` header dependencies.

Supersedes #11289 

