### PR TITLE
Enable large loadable types's IRGen pass by default

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -143,7 +143,7 @@ public:
   bool EnableMandatorySemanticARCOpts = false;
 
   /// \brief Enable large loadable types IRGen pass.
-  bool EnableLargeLoadableTypes = false;
+  bool EnableLargeLoadableTypes = true;
 
   /// Enables the "fully fragile" resilience strategy.
   ///

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s --check-prefix=DWARF
 
+// UNSUPPORTED: OS=watchos
+
 protocol P {}
 
 enum Either {

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s --check-prefix=CHECK2
+
+// UNSUPPORTED: OS=watchos
+
 func use<T>(_ t: T) {}
 
 public func f(_ i : Int?)

--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -28,10 +28,10 @@ bb0(%0 : $Builtin.Int32):
 }
 
 // CHECK: define{{( protected)?}} swiftcc void @non_trivial(
-// CHECK: [[GEP1:%.*]] = getelementptr inbounds %T019copy_value_destroy_B03FooV, %T019copy_value_destroy_B03FooV* %0, i32 0, i32 2
-// CHECK: [[VAL1:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP1]], align 8
-// CHECK: [[GEP2:%.*]] = getelementptr inbounds %T019copy_value_destroy_B03FooV, %T019copy_value_destroy_B03FooV* %0, i32 0, i32 5
-// CHECK: [[VAL2:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP2]], align 8
+// CHECK: [[GEP1:%.*]] = getelementptr inbounds %T019copy_value_destroy_B03FooV, %T019copy_value_destroy_B03FooV* %1, i32 0, i32 2
+// CHECK-NEXT: [[VAL1:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP1]], align 8
+// CHECK: [[GEP2:%.*]] = getelementptr inbounds %T019copy_value_destroy_B03FooV, %T019copy_value_destroy_B03FooV* %1, i32 0, i32 5
+// CHECK-NEXT: [[VAL2:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP2]], align 8
 // CHECK: call void @swift_rt_swift_retain(%swift.refcounted* [[VAL1]])
 // CHECK: call void @swift_rt_swift_retain(%swift.refcounted* [[VAL2]])
 // CHECK: call void @swift_rt_swift_release(%swift.refcounted* [[VAL1]])

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -221,10 +221,6 @@ sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK-32: entry:
 entry(%u : $Singleton):
 // CHECK-32:  [[CAST:%.*]] = bitcast %T4enum9SingletonO* %0 to <{ i64, i64 }>*
-// CHECK-32:  [[GEP1:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[CAST]], i32 0, i32 0
-// CHECK-32:  [[ELT1:%.*]] = load i64, i64* [[GEP1]]
-// CHECK-32:  [[GEP2:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[CAST]], i32 0, i32 1
-// CHECK-32:  [[ELT2:%.*]] = load i64, i64* [[GEP2]]
 // CHECK-64:   br label %[[PREDEST:[0-9]+]]
 // CHECK-32:   br label %[[PREDEST:[0-9]+]]
   switch_enum %u : $Singleton, case #Singleton.value!enumelt.1: dest
@@ -232,16 +228,10 @@ entry(%u : $Singleton):
 // CHECK-64: ; <label>:[[PREDEST]]
 // CHECK-64:   br label %[[DEST:[0-9]+]]
 // CHECK-64: ; <label>:[[DEST]]
-// CHECK-32: ; <label>:[[PREDEST]]
-// CHECK-32:   br label %[[DEST:[0-9]+]]
-// CHECK-32: ; <label>:[[DEST]]
 dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
 // CHECK-64:   {{%.*}} = phi i64 [ %0, %[[PREDEST]] ]
 // CHECK-64:   {{%.*}} = phi i64 [ %1, %[[PREDEST]] ]
 // CHECK-64:   ret void
-// CHECK-32:   {{%.*}} = phi i64 [ [[ELT1]], %[[PREDEST]] ]
-// CHECK-32:   {{%.*}} = phi i64 [ [[ELT2]], %[[PREDEST]] ]
-// CHECK-32:   ret void
   %x = tuple ()
   return %x : $()
 }
@@ -746,19 +736,7 @@ enum AggregateSinglePayload2 {
 // CHECK-32: define{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(%T4enum23AggregateSinglePayload2O* noalias nocapture dereferenceable(16)) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
-// CHECK-32:  [[CAST:%.*]] = bitcast %T4enum23AggregateSinglePayload2O* %0 to { i32, i32, i32, i32 }*
-// CHECK-32:  [[GEP:%.*]] = getelementptr inbounds {{.*}} [[CAST]], i32 0, i32 0
-// CHECK-32:  [[LOAD1:%.*]] = load i32, i32* [[GEP]]
-// CHECK-32:  [[LOAD2:%.*]] = load i32, i32* {{.*}}
-// CHECK-32:  [[LOAD3:%.*]] = load i32, i32* {{.*}}
-// CHECK-32:  [[LOAD4:%.*]] = load i32, i32* {{.*}}
   switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt.1: x_dest, default end
-
-// CHECK-32:   [[TRUNC:%.*]] = trunc [[WORD]] [[LOAD1]] to i21
-// CHECK-32:   phi i21 [ [[TRUNC]]
-// CHECK-32:   phi [[WORD]] [ [[LOAD2]]
-// CHECK-32:   phi [[WORD]] [ [[LOAD3]]
-// CHECK-32:   phi [[WORD]] [ [[LOAD4]]
 
 // CHECK-64:   [[TRUNC:%.*]] = trunc [[WORD]] %0 to i21
 // CHECK-64:   phi i21 [ [[TRUNC]]

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -12,9 +12,9 @@ struct HugeAlignment {
 }
 
 // TODO: could be the context param
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP:%.*]] = alloca
-// CHECK:         call swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) [[TMP]])
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}))
+// CHECK-NOT:     alloca
+// CHECK:         call swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}) %0)
 sil @huge_method : $@convention(method) Huge -> () {
 entry(%x : $Huge):
   %f = function_ref @huge_method : $@convention(method) Huge -> ()
@@ -23,8 +23,8 @@ entry(%x : $Huge):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP:%.*]] = alloca
-// CHECK:         call swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) [[TMP]])
+// CHECK-NOT:         alloca
+// CHECK:         call swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %0)
 sil @huge_param : $@convention(thin) Huge -> () {
 entry(%x : $Huge):
   %f = function_ref @huge_param : $@convention(thin) Huge -> ()
@@ -33,8 +33,8 @@ entry(%x : $Huge):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP:%.*]] = alloca
-// CHECK:         call swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}) [[TMP]])
+// CHECK-NOT:     alloca
+// CHECK:         call swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}) %0)
 sil @huge_alignment_param : $@convention(thin) HugeAlignment -> () {
 entry(%x : $HugeAlignment):
   %f = function_ref @huge_alignment_param : $@convention(thin) HugeAlignment -> ()
@@ -43,9 +43,8 @@ entry(%x : $HugeAlignment):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         [[TMP_RET:%.*]] = alloca
-// CHECK:         call swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret [[TMP_RET]], %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]])
+// CHECK:         call swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret [[TMP_RET]], %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %1)
 sil @huge_param_and_return : $@convention(thin) Huge -> Huge {
 entry(%x : $Huge):
   %f = function_ref @huge_param_and_return : $@convention(thin) Huge -> Huge
@@ -54,8 +53,8 @@ entry(%x : $Huge):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_param_and_indirect_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP_ARG:%.*]] = alloca
-// CHECK:         call swiftcc void @huge_param_and_indirect_return(%T17indirect_argument4HugeV* noalias nocapture sret %0, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]])
+// CHECK-NOT:     alloca
+// CHECK:         call swiftcc void @huge_param_and_indirect_return(%T17indirect_argument4HugeV* noalias nocapture sret %0, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %1)
 sil @huge_param_and_indirect_return : $@convention(thin) (Huge) -> @out Huge {
 entry(%o : $*Huge, %x : $Huge):
   %f = function_ref @huge_param_and_indirect_return : $@convention(thin) (Huge) -> @out Huge
@@ -64,10 +63,10 @@ entry(%o : $*Huge, %x : $Huge):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_partial_application(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP_ARG:%.*]] = alloca
+// CHECK-NOT:     alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %T17indirect_argument4HugeV }>*
-// CHECK:         call swiftcc void @_T024huge_partial_applicationTA(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]], %swift.refcounted* swiftself [[CLOSURE]])
+// CHECK:         call swiftcc void @_T024huge_partial_applicationTA(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %0, %swift.refcounted* swiftself [[CLOSURE]])
 // CHECK:       define internal swiftcc void @_T024huge_partial_applicationTA(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %swift.refcounted* swiftself)
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK-NOT:     tail
@@ -81,11 +80,10 @@ entry(%x : $Huge, %y : $Huge):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_partial_application_stret(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %T17indirect_argument4HugeV }>*
-// CHECK:         call swiftcc void @_T030huge_partial_application_stretTA(%T17indirect_argument4HugeV* noalias nocapture sret [[TMP_RET]], %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]], %swift.refcounted* swiftself [[CLOSURE]])
+// CHECK:         call swiftcc void @_T030huge_partial_application_stretTA(%T17indirect_argument4HugeV* noalias nocapture sret [[TMP_RET]], %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %1, %swift.refcounted* swiftself [[CLOSURE]])
 // CHECK:       define internal swiftcc void @_T030huge_partial_application_stretTA(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %swift.refcounted* swiftself)
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK-NOT:     tail

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -472,26 +472,10 @@ sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> 
 // CHECK-LABEL: define{{.*}} @partial_apply_generic_indirect_return2
 // CHECK: insertvalue {{.*}}_T024generic_indirect_return2TA
 
-// CHECK-LABEL: define internal swiftcc { i64, i64, i64, i8 } @_T024generic_indirect_return2TA(%swift.refcounted* swiftself) #0 {
-// CHECK:  [[TMP:%.*]] = alloca %T13partial_apply12GenericEnum2OySiG
-// CHECK:  [[CASTED_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* [[TMP]] to %T13partial_apply12GenericEnum2O*
+// CHECK-LABEL: define internal swiftcc void @_T024generic_indirect_return2TA(%T13partial_apply12GenericEnum2OySiG* noalias nocapture sret, %swift.refcounted* swiftself) #0 {
+// CHECK:  [[CASTED_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* %0 to %T13partial_apply12GenericEnum2O*
 // CHECK: call swiftcc void @generic_indirect_return2(%T13partial_apply12GenericEnum2O* noalias nocapture sret [[CASTED_ADDR]]
-// CHECK:  [[SUBST_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* [[TMP]] to { i64, i64, i64 }*
-// CHECK:  [[ELT_ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[SUBST_ADDR]], i32 0, i32 0
-// CHECK:  [[ELT:%.*]] = load i64, i64* [[ELT_ADDR]]
-// CHECK:  [[ELT_ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[SUBST_ADDR]], i32 0, i32 1
-// CHECK:  [[ELT2:%.*]] = load i64, i64* [[ELT_ADDR]]
-// CHECK:  [[ELT_ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[SUBST_ADDR]], i32 0, i32 2
-// CHECK:  [[ELT3:%.*]] = load i64, i64* [[ELT_ADDR]]
-// CHECK:  [[ENUMTAGADDR:%.*]] = getelementptr inbounds %T13partial_apply12GenericEnum2OySiG, %T13partial_apply12GenericEnum2OySiG* [[TMP]], i32 0, i32 1
-// CHECK:  [[ENUMTAGBITADDR:%.*]] = bitcast [1 x i8]* [[ENUMTAGADDR]] to i1*
-// CHECK:  [[TAGBIT:%.*]] = load i1, i1* [[ENUMTAGBITADDR]]
-// CHECK:  [[ELT4:%.*]] = zext i1 [[TAGBIT]] to i8
-// CHECK:  [[TMP:%.*]] = insertvalue { i64, i64, i64, i8 } undef, i64 [[ELT]], 0
-// CHECK:  [[TMP2:%.*]] = insertvalue { i64, i64, i64, i8 } [[TMP]], i64 [[ELT2]], 1
-// CHECK:  [[TMP3:%.*]] = insertvalue { i64, i64, i64, i8 } [[TMP2]], i64 [[ELT3]], 2
-// CHECK:  [[TMP4:%.*]] = insertvalue { i64, i64, i64, i8 } [[TMP3]], i8 [[ELT4]], 3
-// CHECK:  ret { i64, i64, i64, i8 } [[TMP4]]
+// CHECK:  ret void
 sil @partial_apply_generic_indirect_return2 : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum2<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return2 :$@convention(thin) <T> (Int) -> @owned GenericEnum2<T>

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -58,34 +58,13 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
 }
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @alloc_big([24 x i8]* nocapture dereferenceable({{.*}}), %T13value_buffers9BigStructV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
-// CHECK: [[SLOT0:%.*]] = load i64
-// CHECK: [[SLOT1:%.*]] = load i64
-// CHECK: [[SLOT2:%.*]] = load i64
-// CHECK: [[SLOT3:%.*]] = load i64
-// CHECK: [[SLOT4:%.*]] = load i64
-// CHECK: [[SLOT5:%.*]] = load i64
 // CHECK-NEXT: [[T0:%.*]] = call noalias i8* @swift_rt_swift_slowAlloc(i64 48, i64 7)
 // CHECK-NEXT: [[T1:%.*]] = bitcast [24 x i8]* %0 to i8**
 // CHECK-NEXT: store i8* [[T0]], i8** [[T1]], align 8
 // CHECK-NEXT: [[ADDR:%.*]] = bitcast i8* [[T0]] to %T13value_buffers9BigStructV*
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 0
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT0]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 1
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT1]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 2
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT2]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 3
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT3]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 4
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT4]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 5
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT5]], i64* [[T1]], align 8
+// CHECK-NEXT: [[PARAM1:%.*]] = bitcast %T13value_buffers9BigStructV* [[ADDR]] to i8*
+// CHECK-NEXT: [[PARAM2:%.*]] = bitcast %T13value_buffers9BigStructV* %1 to i8*
+// CHECK-NEXT: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[PARAM1]], i8* [[PARAM2]], i64 48, i32 8, i1 false)
 // CHECK-NEXT: ret void
 
 sil @project_big : $(@inout Builtin.UnsafeValueBuffer, BigStruct) -> () {
@@ -97,32 +76,11 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
 }
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @project_big([24 x i8]* nocapture dereferenceable({{.*}}), %T13value_buffers9BigStructV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
-// CHECK: [[SLOT0:%.*]] = load i64
-// CHECK: [[SLOT1:%.*]] = load i64
-// CHECK: [[SLOT2:%.*]] = load i64
-// CHECK: [[SLOT3:%.*]] = load i64
-// CHECK: [[SLOT4:%.*]] = load i64
-// CHECK: [[SLOT5:%.*]] = load i64
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to %T13value_buffers9BigStructV**
 // CHECK-NEXT: [[ADDR:%.*]] = load %T13value_buffers9BigStructV*, %T13value_buffers9BigStructV** [[T0]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 0
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT0]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 1
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT1]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 2
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT2]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 3
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT3]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 4
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT4]], i64* [[T1]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T13value_buffers9BigStructV, %T13value_buffers9BigStructV* [[ADDR]], i32 0, i32 5
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
-// CHECK-NEXT: store i64 [[SLOT5]], i64* [[T1]], align 8
+// CHECK-NEXT: [[PARAM1:%.*]] = bitcast %T13value_buffers9BigStructV* [[ADDR]] to i8*
+// CHECK-NEXT: [[PARAM2:%.*]] = bitcast %T13value_buffers9BigStructV* %1 to i8*
+// CHECK-NEXT: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[PARAM1]], i8* [[PARAM2]], i64 48, i32 8, i1 false)
 // CHECK-NEXT: ret void
 
 sil @dealloc_big : $(@inout Builtin.UnsafeValueBuffer) -> () {

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -6,9 +6,9 @@
 // CHECK: [[TYPE:%swift.type]] = type
 // CHECK: [[OPAQUE:%swift.opaque]] = type opaque
 // CHECK: [[C:%T4weak1CC]] = type <{ [[REF:%swift.refcounted]] }>
+// CHECK: [[UNKNOWN:%objc_object]] = type opaque
 // CHECK: [[A:%T4weak1AV]] = type <{ [[WEAK:%swift.weak]] }>
 // CHECK: [[WEAK]] = type
-// CHECK: [[UNKNOWN:%objc_object]] = type opaque
 // CHECK: [[B:%T4weak1BV]] = type <{ { [[WEAK]], i8** } }>
 
 sil_stage canonical


### PR DESCRIPTION
radar rdar://problem/28680453

re-enable the new calling conventions by default.

The new improved module pass adds support for return types and `init()`s 

There might be room for further optimizations in the future:
* outline `strong_retain` just like we transform `retain_value` to its new address variant 
* similarly, outline `strong_release` 
..etc

However, these optimizations should not affect the ABI and can be done, if found necessary, at a later date.