### PR TITLE
[master-next] Update test to match llvm.dbg.value change

### DIFF
--- a/test/DebugInfo/liverange-extension-vector.swift
+++ b/test/DebugInfo/liverange-extension-vector.swift
@@ -9,7 +9,7 @@ func getInt32() -> Int32 { return -1 }
 public func rangeExtension(x: Int32, y: Int32) {
   let p = int2(x, y)
   // CHECK: define {{.*}}rangeExtension
-  // CHECK: llvm.dbg.value(metadata <2 x i32> %[[P:.*]], metadata
+  // CHECK: llvm.dbg.value(metadata <2 x i32> %[[P:.*]], metadata {{.*}}, metadata
   use(p)
   // CHECK: asm sideeffect "", "r"{{.*}}[[P]]
 }


### PR DESCRIPTION
The filecheck pattern in DebugInfo/liverange-extension-vector.swift
was failing because llvm.dbg.value now has two metadata arguments. The
"[[P]]" pattern was matching "%4, metadata !60" instead of only the "%4".