### PR TITLE
[code-completion] Partly fix completion of associatedtypes in where clauses

### DIFF
--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -109,8 +109,12 @@ protocol P2 {
 
 // P2: Begin completions
 // P2-DAG: Decl[GenericTypeParam]/CurrNominal: Self[#Self#];
-// FIXME: Should complete T.
+// P2-DAG: Decl[AssociatedType]/CurrNominal:   T;
+// P2-DAG: Decl[AssociatedType]/CurrNominal:   U;
 // P2: End completions
 
+// U_DOT: Begin completions
 // FIXME: Should complete Q from Assoc.
-// U_DOT-NOT: Begin completions
+// U_DOT-DAG: Keyword/None:                       Type[#Self.U.Type#];
+// U_DOT-DAG: Keyword/CurrNominal:                self[#Self.U#];
+// U_DOT: End completions


### PR DESCRIPTION
This gets us to the point where we will complete 'T' here:
```
    associatedtype T where #^A^#
```
And when completing here, we now at least find the correct declaration:
```
    associatedtype T: P where T.#^A^#
```
There is a remaining issue that in the second example we will not find
members of `P`; we seem to be missing the conformance from the archetype
we get for `T`.

rdar://problem/20582394