### PR TITLE
[master-next] fix flake8 complaints about test/swift_test.py

### DIFF
--- a/test/swift_test.py
+++ b/test/swift_test.py
@@ -32,13 +32,15 @@ class SwiftTest(lit.formats.ShTest, object):
 
     def before_test(self, test, litConfig):
         _, tmp_base = lit.TestRunner.getTempPaths(test)
-        
-        # Apparently despite the docs, tmpDir is not actually unique for each test, but
-        # tmpBase is.  Remove it here and add a tmpBase substitution in before_test.
-        # Speculative fix for rdar://32928464.
+
+        # Apparently despite the docs, tmpDir is not actually unique for each
+        # test, but tmpBase is. Remove it here and add a tmpBase substitution
+        # in before_test. Speculative fix for rdar://32928464.
         try:
-            percentT_index = [x[0] for x in test.config.substitutions].index('%T')
-        except ValueError: pass
+            percentT_index = \
+                [x[0] for x in test.config.substitutions].index('%T')
+        except ValueError:
+            pass
         else:
             test.config.substitutions.pop(percentT_index)
 


### PR DESCRIPTION
The python-lint test was failing with:
./test/swift_test.py:35:1: W293 blank line contains whitespace
./test/swift_test.py:36:80: E501 line too long (87 > 79 characters)
./test/swift_test.py:37:80: E501 line too long (84 > 79 characters)
./test/swift_test.py:40:80: E501 line too long (82 > 79 characters)
./test/swift_test.py:41:26: E701 multiple statements on one line (colon)
