### PR TITLE
[dead-store-elimination] Add support for handling stores to stack promoted objects

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -117,6 +117,20 @@ findDeallocStackInst(AllocStackInst *ASI) {
   return DSIs;
 }
 
+/// Return the deallocate ref instructions corresponding to the given
+/// AllocRefInst.
+static llvm::SmallVector<SILInstruction *, 1>
+findDeallocRefInst(AllocRefInst *ARI) {
+  llvm::SmallVector<SILInstruction *, 1> DSIs;
+  for (auto UI = ARI->use_begin(), E = ARI->use_end(); UI != E; ++UI) {
+    if (auto *D = dyn_cast<DeallocRefInst>(UI->getUser())) {
+      if (D->isDeallocatingStack())
+        DSIs.push_back(D);
+    }
+  }
+  return DSIs;
+}
+
 static inline bool isComputeMaxStoreSet(DSEKind Kind) {
   return Kind == DSEKind::ComputeMaxStoreSet;
 }
@@ -138,6 +152,7 @@ static bool isDeadStoreInertInstruction(SILInstruction *Inst) {
   case ValueKind::UnownedRetainInst:
   case ValueKind::RetainValueInst:
   case ValueKind::DeallocStackInst:
+  case ValueKind::DeallocRefInst:
   case ValueKind::CondFailInst:
   case ValueKind::FixLifetimeInst:
     return true;
@@ -647,6 +662,16 @@ void BlockState::initStoreSetAtEndOfBlock(DSEContext &Ctx) {
     // Turn on the store bit at the block which the stack slot is deallocated.
     if (auto *ASI = dyn_cast<AllocStackInst>(LocationVault[i].getBase())) {
       for (auto X : findDeallocStackInst(ASI)) {
+        SILBasicBlock *DSIBB = X->getParent();
+        if (DSIBB != BB)
+          continue;
+        startTrackingLocation(BBDeallocateLocation, i);
+      }
+    }
+    if (auto *ARI = dyn_cast<AllocRefInst>(LocationVault[i].getBase())) {
+      if (!ARI->isAllocatingStack())
+        continue;
+      for (auto X : findDeallocRefInst(ARI)) {
         SILBasicBlock *DSIBB = X->getParent();
         if (DSIBB != BB)
           continue;

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -172,6 +172,47 @@ bb0:
   return %4 : $()
 }
 
+// We should be able to remove the local store into alloc_ref [stack] locations
+// that is not read.
+//
+// CHECK-LABEL: trivial_local_dead_store_into_alloc_ref
+// CHECK: bb0
+// CHECK-NOT: {{ store}}
+// CHECK: tuple
+// CHECK: return
+sil hidden @trivial_local_dead_store_into_alloc_ref_stack : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] $foo
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = struct $Int (%1 : $Builtin.Int64)
+  %3 = ref_element_addr %0 : $foo, #foo.a
+  store %2 to %3 : $*Int
+  %4 = tuple ()
+  dealloc_ref [stack] %0 : $foo
+  return %4 : $()
+}
+
+// We cannot remove the local store that is potentially read by the deinit of foo.
+//
+// CHECK-LABEL: sil hidden @blocking_read_on_local_store_into_alloc_ref_stack
+// CHECK: bb0
+// CHECK: alloc_ref
+// CHECK: store
+// CHECK: dealloc_ref
+// CHECK: return
+sil hidden @blocking_read_on_local_store_into_alloc_ref_stack : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] $foo
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = struct $Int (%1 : $Builtin.Int64)
+  %3 = ref_element_addr %0 : $foo, #foo.a
+  store %2 to %3 : $*Int
+  %4 = tuple ()
+  strong_release %0 : $foo
+  dealloc_ref [stack] %0 : $foo
+  return %4 : $()
+}
+
 // We cannot remove the local store that is read.
 //
 // CHECK-LABEL: blocking_read_on_local_store


### PR DESCRIPTION
Essentially, treat `alloc_ref [stack]` allocated objects in the same way as we treat `alloc_stack` allocated objects.
