### PR TITLE
Modify the optimization pipeline to better support custom array iterators

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -269,10 +269,11 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   P.addCSE();
   P.addRedundantLoadElimination();
 
-  // Perform retain/release code motion and run the first ARC optimizer.
+  P.addPerformanceConstantPropagation();
   P.addCSE();
   P.addDCE();
 
+  // Perform retain/release code motion and run the first ARC optimizer.
   P.addEarlyCodeMotion();
   P.addReleaseHoisting();
   P.addARCSequenceOpts();
@@ -333,6 +334,10 @@ static void addMidLevelPassPipeline(SILPassPipelinePlan &P) {
   // Specialize partially applied functions with dead arguments as a preparation
   // for CapturePropagation.
   P.addDeadArgSignatureOpt();
+
+  // Run loop unrolling after inlining and constant propagation, because loop
+  // trip counts may have became constant.
+  P.addLoopUnroll();
 }
 
 static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
@@ -402,6 +407,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
 
   // Remove dead code.
   P.addDCE();
+  P.addSILCombine();
   P.addSimplifyCFG();
 
   // Try to hoist all releases, including epilogue releases. This should be


### PR DESCRIPTION
This patch is supposed to recover the performance regressions that would be introduced by yet to be merged PR #9145, which introduces custom, more efficient array iterators.

The crucial part of this patch is running loop unrolling also during the mid-level optimizations phase, because it may catch more loops with constant trip counts. To make trip counts constant, an additional run of constant propagation is helpful.
