### PR TITLE
[Parse] Parse incomplete 'for' as ForEachStmt

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1011,11 +1011,11 @@ ERROR(expected_var_decl_for_stmt,PointsToFirstBadToken,
       "expected var declaration in a 'for' statement", ())
 
 // For-each Stmt
-ERROR(expected_foreach_in,none,
+ERROR(expected_foreach_in,PointsToFirstBadToken,
       "expected 'in' after for-each pattern", ())
-ERROR(expected_foreach_container,none,
+ERROR(expected_foreach_container,PointsToFirstBadToken,
       "expected Sequence expression for for-each loop", ())
-ERROR(expected_foreach_lbrace,none,
+ERROR(expected_foreach_lbrace,PointsToFirstBadToken,
       "expected '{' to start the body of for-each loop", ())
 ERROR(expected_foreach_where_expr,PointsToFirstBadToken,
       "expected expression in 'where' guard of 'for/in'", ())

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -573,10 +573,14 @@ std::pair<bool, Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
     SyntaxStructureNode SN;
     SN.Kind = SyntaxStructureKind::ForEachStatement;
     SN.Range = charSourceRangeFromSourceRange(SM, S->getSourceRange());
-    if (ForEachS->getPattern())
-      SN.Elements.emplace_back(SyntaxStructureElementKind::Id,
-                               charSourceRangeFromSourceRange(SM,
-                                     ForEachS->getPattern()->getSourceRange()));
+    if (ForEachS->getPattern()) {
+      auto Pat = ForEachS->getPattern();
+      if (!Pat->isImplicit()) {
+        SourceRange ElemRange = Pat->getSourceRange();
+        SN.Elements.emplace_back(SyntaxStructureElementKind::Id,
+                                 charSourceRangeFromSourceRange(SM, ElemRange));
+      }
+    }
     if (ForEachS->getSequence())
       addExprElem(SyntaxStructureElementKind::Expr, ForEachS->getSequence(),SN);
     pushStructureNode(SN, S);

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -18,7 +18,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COND_DO_WHILE_1 | %FileCheck %s -check-prefix=COND-WITH-RELATION
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COND_DO_WHILE_2 | %FileCheck %s -check-prefix=COND-WITH-RELATION1
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=C_STYLE_FOR_INIT_1 | %FileCheck %s -check-prefix=COND_COMMON
+// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=C_STYLE_FOR_INIT_1 | %FileCheck %s -check-prefix=COND_COMMON
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=C_STYLE_FOR_INIT_2 | %FileCheck %s -check-prefix=COND_COMMON
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=C_STYLE_FOR_INIT_3 | %FileCheck %s -check-prefix=COND_COMMON
 

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -105,7 +105,7 @@ let myArray2 = [1]
 // CHECK: <gvar>let <name>myDict2</name> = <dictionary>[<elem-expr>1</elem-expr>:<elem-expr>1</elem-expr>]</dictionary></gvar>
 let myDict2 = [1:1]
 
-// CHECK: <for>for <brace><brace>{}</brace></brace></for>
+// CHECK: <foreach>for <brace>{}</brace></foreach>
 for {}
 
 // CHECK: <class>class <name><#MyCls#></name> : <inherited><elem-typeref><#OtherClass#></elem-typeref></inherited> {}

--- a/test/Parse/EOF/unfinished-for-at-eof.swift
+++ b/test/Parse/EOF/unfinished-for-at-eof.swift
@@ -1,10 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
 func fuzz() { for var H
-// expected-note@-1 {{to match this opening '{'}}
-// expected-error@-2{{type annotation missing in pattern}}
-// expected-error@-3 2 {{expected ';' in 'for' statement}}
-// expected-error@+4{{expected '{' in 'for' statement}}
-// expected-error@+3{{expected '}' at end of brace statement}}
-// expected-error@+2{{expected condition in 'for' statement}}
-// expected-error@+1{{expected expression}}
+// expected-error@-1{{expected 'in' after for-each pattern}}
+// expected-error@-2{{expected Sequence expression for for-each loop}}
+// expected-error@-3{{expected '{' to start the body of for-each loop}}
+// expected-note@-4 {{to match this opening '{'}}
+// expected-error@+1{{expected '}' at end of brace statement}}

--- a/test/Parse/foreach.swift
+++ b/test/Parse/foreach.swift
@@ -8,7 +8,7 @@ struct IntRange<Int> : Sequence, IteratorProtocol {
   func makeIterator() -> IntRange<Int> { return self }
 }
 
-func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note 2 {{did you mean 'r'?}}
+func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note {{did you mean 'r'?}}
   var sum = 0
 
   // Simple foreach loop, using the variable in the body
@@ -30,7 +30,11 @@ func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note 2 {{did you 
   }
 
   // Parse errors
-  for i r { // expected-error 2{{expected ';' in 'for' statement}} expected-error {{use of unresolved identifier 'i'}} expected-error {{'Range<Int>' is not convertible to 'Bool'}}
-  }
+  // FIXME: Bad diagnostics; should be just 'expected 'in' after for-each patter'.
+  for i r { // expected-error {{found an unexpected second identifier in constant declaration}}
+  }         // expected-note @-1 {{join the identifiers together}}
+            // expected-note @-2 {{join the identifiers together with camel-case}}
+            // expected-error @-3 {{expected 'in' after for-each pattern}}
+            // expected-error @-4 {{expected Sequence expression for for-each loop}}
   for i in CountableRange(r) sum = sum + i; // expected-error{{expected '{' to start the body of for-each loop}}
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -140,18 +140,6 @@ func missingWhileInRepeat() {
 func acceptsClosure<T>(t: T) -> Bool { return true }
 
 func missingControllingExprInFor() {
-  for // expected-error {{expected initialization in a 'for' statement}}
-
-  for { // expected-error {{missing initialization in a 'for' statement}}
-  }
-
-  for // expected-error {{missing initialization in a 'for' statement}}
-  {
-  }
-
-  for var i { // expected-error 2{{expected ';' in 'for' statement}} expected-error {{type annotation missing in pattern}}
-  }
-
   for ; { // expected-error {{expected ';' in 'for' statement}}
   }
 
@@ -164,40 +152,70 @@ func missingControllingExprInFor() {
   }
 
   for var i = 0; true { // expected-error {{expected ';' in 'for' statement}}
+    i += 1
   }
-
- 
-// The #if block is used to provide a scope for the for stmt to force it to end
-// where necessary to provoke the crash.
-#if true  // <rdar://problem/21679557> compiler crashes on "for{{"
-  // expected-error @+2 {{missing initialization in a 'for' statement}}
-  // expected-note @+1 2 {{to match this opening '{'}}
-for{{ // expected-error {{expression resolves to an unused function}}
-#endif  // expected-error 2 {{expected '}' at end of closure}}
-  
-#if true
-  // expected-error @+1 {{missing initialization in a 'for' statement}}
-  for{
-    var x = 42
-  }
-#endif
-
 }
 
 func missingControllingExprInForEach() {
-  for in { // expected-error {{expected pattern}} expected-error {{expected Sequence expression for for-each loop}}
-  }
+  // expected-error @+3 {{expected pattern}}
+  // expected-error @+2 {{expected Sequence expression for for-each loop}}
+  // expected-error @+1 {{expected '{' to start the body of for-each loop}}
+  for
 
-
-  // expected-error @+4 {{expected 'in' after for-each pattern}}
-  // expected-error @+3 {{expected '{' to start the body of for-each loop}}
   // expected-error @+2 {{expected pattern}}
   // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for {
+  }
+
+  // expected-error @+2 {{expected pattern}}
+  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for
+  {
+  }
+
+  // expected-error @+2 {{expected 'in' after for-each pattern}}
+  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for i {
+  }
+
+  // expected-error @+2 {{expected 'in' after for-each pattern}}
+  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for var i {
+  }
+
+  // expected-error @+2 {{expected pattern}}
+  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for in {
+  }
+
+  // expected-error @+1 {{expected pattern}}
+  for 0..<12 {
+  }
+
+  // expected-error @+3 {{expected pattern}}
+  // expected-error @+2 {{expected Sequence expression for for-each loop}}
+  // expected-error @+1 {{expected '{' to start the body of for-each loop}}
   for for in { // expected-error {{expected pattern}} expected-error {{expected Sequence expression for for-each loop}}
   }
 
   for i in { // expected-error {{expected Sequence expression for for-each loop}}
   }
+
+// The #if block is used to provide a scope for the for stmt to force it to end
+// where necessary to provoke the crash.
+#if true  // <rdar://problem/21679557> compiler crashes on "for{{"
+  // expected-error @+2 {{expected pattern}}
+  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for{{ // expected-note 2 {{to match this opening '{'}}
+#endif  // expected-error {{expected '}' at end of closure}} expected-error {{expected '}' at end of brace statement}}
+
+#if true
+  // expected-error @+2 {{expected pattern}}
+  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  for{
+    var x = 42
+  }
+#endif
 }
 
 func missingControllingExprInSwitch() {

--- a/test/Parse/toplevel_library_invalid.swift
+++ b/test/Parse/toplevel_library_invalid.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library
 // RUN: %target-typecheck-verify-swift -parse-as-library -enable-astscope-lookup
 
-let x = 42 // expected-note{{did you mean 'x'?}}
+let x = 42
 x + x; // expected-error {{expressions are not allowed at the top level}} expected-warning {{result of operator '+' is unused}}
 x + x; // expected-error {{expressions are not allowed at the top level}} expected-warning {{result of operator '+' is unused}}
 // Make sure we don't crash on closures at the top level
@@ -10,9 +10,7 @@ x + x; // expected-error {{expressions are not allowed at the top level}} expect
 // expected-warning @-1 {{result of call is unused}}
 
 
-// FIXME: Too many errors for this.
-for i // expected-error 2 {{expected ';' in 'for' statement}} 
-      // expected-error @-1{{use of unresolved identifier 'i'}}
-      // expected-error @+3{{expected '{' in 'for' statement}}
-      // expected-error @+2{{expected condition in 'for' statement}}
-      // expected-error @+1{{expected expression}}
+// expected-error @+3 {{expected 'in' after for-each pattern}}
+// expected-error @+2 {{expected Sequence expression for for-each loop}}
+// expected-error @+1 {{expected '{' to start the body of for-each loop}}
+for i


### PR DESCRIPTION
Not as c-style for statement.

This is just a step forward for making c-style `for` be obsolete.
This slightly improves diagnostics for incomplete `for` statements; e.g.:

```
test.swift:1:12: error: expected ';' in 'for' statement
for 0..<12 {}
           ^
test.swift:1:12: error: expected ';' in 'for' statement
for 0..<12 {}
~~~~~~~~~~~^
test.swift:1:6: warning: result of operator '..<' is unused
for 0..<12 {}
    ~^  ~~
```
becomes:
```
test.swift:1:5: error: expected pattern
for 0..<12 {}
    ^
```