### PR TITLE
Escape all keywords when printing DeclBaseNames

### DIFF
--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -189,3 +189,9 @@ func unboundMethodReferences() {
   _ = type(of: Derived.method1)
   _ = type(of: Derived.method2)
 }
+
+// CHECK-LABEL: sil_vtable EscapeKeywordsInDottedPaths
+class EscapeKeywordsInDottedPaths {
+  // CHECK: #EscapeKeywordsInDottedPaths.`switch`!getter.1
+  var `switch`: String = ""
+}


### PR DESCRIPTION
As per https://github.com/apple/swift/pull/10965#discussion_r127492555, escape all keywords when printing `DeclBaseName`s for SIL dotted paths or the api-digester and not only "subscript" and "deinit".
