### PR TITLE
Make swiftFrontendTool depend on Syntax headers

### DIFF
--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -3,7 +3,8 @@ add_swift_library(swiftFrontendTool STATIC
   ImportedModules.cpp
   ReferenceDependencies.cpp
   TBD.cpp
-  DEPENDS SwiftOptions
+  DEPENDS
+    swift-syntax-generated-headers SwiftOptions
   LINK_LIBRARIES
     swiftIndex
     swiftIDE


### PR DESCRIPTION
Should unblock the build bots. Hopefully this is the last time this needs to happen.