### PR TITLE
[sil-ownership] Reify the lifetime constraint of a use from a bool in to UseLifetimeConstraint.

### DIFF
--- a/lib/SIL/UseOwnershipRequirement.h
+++ b/lib/SIL/UseOwnershipRequirement.h
@@ -1,0 +1,54 @@
+//===--- UseOwnershipRequirement.h ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file contains declarations that enable clients to compute the ownership
+/// requirements that a use puts on an SSA value. This is used in coordination
+/// with the OwnershipChecker in SILOwnershipVerifier.cpp and the SILValue
+/// ValueOwnershipKind visitor in ValueOwnershipKindClassifier.cpp to perform
+/// SIL level ownership verification.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_USEOWNERSHIPREQUIREMENT_H
+#define SWIFT_SIL_USEOWNERSHIPREQUIREMENT_H
+
+namespace swift {
+
+/// What constraint does the given use of an SSA value put on the lifetime of
+/// the given SSA value.
+///
+/// There are two possible constraints: MustBeLive and
+/// MustBeInvalidated. MustBeLive means that the SSA value must be able to be
+/// used in a valid way at the given use point. MustBeInvalidated means that any
+/// use of given SSA value after this instruction on any path through this
+/// instruction.
+enum class UseLifetimeConstraint {
+  /// This use requires the SSA value to be live after the given instruction's
+  /// execution.
+  MustBeLive,
+
+  /// This use invalidates the given SSA value.
+  ///
+  /// This means that the given SSA value can not have any uses that are
+  /// reachable from this instruction. When a value has owned semantics this
+  /// means the SSA value is destroyed at this point. When a value has
+  /// guaranteed (i.e. shared borrow) semantics this means that the program
+  /// has left the scope of the borrowed SSA value and said value can not be
+  /// used.
+  MustBeInvalidated,
+};
+
+} // end namespace swift
+
+#endif

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -936,3 +936,41 @@ bb0(%0 : @owned $SwiftKlassP):
   %9999 = tuple()
   return %9999 : $()
 }
+
+/////////////////
+// Undef Tests //
+/////////////////
+
+sil @class_method_undef_test : $@convention(thin) () -> () {
+bb0:
+  %0 = unchecked_ref_cast undef : $Builtin.NativeObject to $SuperKlass
+  %1 = class_method %0 : $SuperKlass, #SuperKlass.d!1 : (SuperKlass) -> () -> (), $@convention(method) (@guaranteed SuperKlass) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @forwarding_instruction_undef_test : $@convention(thin) () -> () {
+bb0:
+  %0 = unchecked_ref_cast undef : $Builtin.NativeObject to $SuperKlass
+  %1 = unchecked_ref_cast %0 : $SuperKlass to $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @transforming_terminator_undef_test : $@convention(thin) () -> () {
+bb0:
+  %0 = unchecked_ref_cast undef : $Builtin.NativeObject to $Builtin.NativeObject
+  checked_cast_br %0 : $Builtin.NativeObject to $SuperKlass, bb1, bb2
+
+bb1(%1 : @owned $SuperKlass):
+  destroy_value %1 : $SuperKlass
+  br bb3
+
+bb2(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
[sil-ownership] Reify the lifetime constraint of a use from a bool in to UseLifetimeConstraint.

This is the first in a series of commits that cleans up the SILOwnershipVerifier
based off of discussions/feedback with other people who are now using it. The
next step is to split the checker from the declarative computation of what I
call the UseOwnershipRequirement.

rdar://33358110