### PR TITLE
[Serialization] Drop extensions whose base type can't be deserialized.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 354; // Last change: special destructor names
+const uint16_t VERSION_MINOR = 355; // Last change: extension dependencies
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -1038,7 +1038,8 @@ namespace decls_block {
     BCFixed<1>,  // implicit flag
     GenericEnvironmentIDField,  // generic environment
     BCVBR<4>,    // # of protocol conformances
-    BCArray<TypeIDField> // inherited types
+    BCVBR<4>,    // number of inherited types
+    BCArray<TypeIDField> // inherited types, followed by TypeID dependencies
     // Trailed by the generic parameter lists, members record, and then
     // conformance info (if any).
   >;

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -318,6 +318,30 @@ public:
   }
 };
 
+class ExtensionError : public llvm::ErrorInfo<ExtensionError> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  std::unique_ptr<ErrorInfoBase> underlyingReason;
+
+public:
+  explicit ExtensionError(std::unique_ptr<ErrorInfoBase> reason)
+      : underlyingReason(std::move(reason)) {}
+
+  void log(raw_ostream &OS) const override {
+    OS << "could not deserialize extension";
+    if (underlyingReason) {
+      OS << ": ";
+      underlyingReason->log(OS);
+    }
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 class PrettyStackTraceModuleFile : public llvm::PrettyStackTraceEntry {
   const char *Action;
   const ModuleFile &MF;


### PR DESCRIPTION
This shows up with `swift_wrapper` typedefs, which get imported into Swift as structs. If someone makes an extension of a `swift_wrapper` type, but the `swift_wrapper` is only applied in Swift 4 mode, that extension will break any Swift 3 clients. Recover by just dropping the extension entirely.

There's still more complexity around extensions—what if a requirement can't be deserialized? what if something's depending on the protocol conformance provided by the extension?—but the missing base type case should be pretty safe. If you can't see the type at all, things that depend on its conformances are already in trouble.

rdar://problem/33636733