### PR TITLE
Sema: Fix crash when resolving bound generic type with unbound parent

### DIFF
--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -381,12 +381,28 @@ struct Claws<A: ExpressibleByCatLiteral> {
   struct Fangs<B: ExpressibleByDogLiteral> { }
 }
 
+struct NotADog {}
+
 func pets<T>(fur: T) -> Claws<Kitten>.Fangs<T> {
   return Claws<Kitten>.Fangs<T>()
 }
 
+func something<T>() -> T { // expected-note {{in call to function 'something()'}}
+  while true {}
+}
+
 func test() {
   let _: Claws<Kitten>.Fangs<Puppy> = pets(fur: Puppy())
+
+  // <https://bugs.swift.org/browse/SR-5600>
+  let _: Claws.Fangs<Puppy> = pets(fur: Puppy())
+  let _: Claws.Fangs<Puppy> = Claws<Kitten>.Fangs()
+  let _: Claws.Fangs<Puppy> = Claws.Fangs()
+  // expected-error@-1 {{cannot convert value of type 'Claws<_>.Fangs<_>' to specified type 'Claws.Fangs<Puppy>'}}
+  let _: Claws.Fangs<NotADog> = something()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}} // FIXME: bad diagnostic
+  _ = Claws.Fangs<NotADog>()
+  // expected-error@-1 {{type 'NotADog' does not conform to protocol 'ExpressibleByDogLiteral'}}
 }
 
 // https://bugs.swift.org/browse/SR-4379


### PR DESCRIPTION
Eg, if both Foo and Bar are generic, `Foo.Bar<Int>` would crash.

This was introduced when I refactored the code a bit to combine
the code path for nominal types and generic typealiases. I was
a little too eager in merging them, because in fact the
substitution-based approach doesn't work when the parent type
is an unbound generic, which can occur in the nominal type case.

Note that we skip validation of generic parameters when the
parent type is an unbound generic. This is because there may
be requirements relating the generic arguments of the parent
type with the generic arguments of the nested type, and unless
all arguments are known, we cannot check these requirements.

For example:

```
struct Outer<T : Collection> {
  struct Inner<U : Collection> where T.Element == U.Element { }
}
```

When Sema opens the unbound generic type by creating new type
variables for each generic argument, it will also introduce
constraints corresponding to each generic requirement. Therefore
constraint system will eventually fail if the arguments are
wrong.

Fixes <https://bugs.swift.org/browse/SR-5600>,
<rdar://problem/33655028>.