### PR TITLE
Sema: Fix crash when resolving bound generic type with unbound parent [4.0]

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -665,6 +665,28 @@ Type TypeChecker::applyUnboundGenericArguments(
   // type.
   if (auto parentType = unboundType->getParent()) {
     if (parentType->hasUnboundGenericType()) {
+      // If we're working with a nominal type declaration, just construct
+      // a bound generic type without checking the generic arguments.
+      if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl)) {
+        SmallVector<Type, 2> args;
+        for (auto &genericArg : genericArgs) {
+          // Propagate failure.
+          if (validateType(genericArg, dc, options, resolver,
+                           unsatisfiedDependency))
+            return ErrorType::get(Context);
+
+          auto substTy = genericArg.getType();
+
+          // Unsatisfied dependency case.
+          if (!substTy)
+            return nullptr;
+
+          args.push_back(substTy);
+        }
+
+        return BoundGenericType::get(nominalDecl, parentType, args);
+      }
+
       assert(!resultType->hasTypeParameter());
       return resultType;
     }

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -381,12 +381,28 @@ struct Claws<A: ExpressibleByCatLiteral> {
   struct Fangs<B: ExpressibleByDogLiteral> { }
 }
 
+struct NotADog {}
+
 func pets<T>(fur: T) -> Claws<Kitten>.Fangs<T> {
   return Claws<Kitten>.Fangs<T>()
 }
 
+func something<T>() -> T { // expected-note {{in call to function 'something()'}}
+  while true {}
+}
+
 func test() {
   let _: Claws<Kitten>.Fangs<Puppy> = pets(fur: Puppy())
+
+  // <https://bugs.swift.org/browse/SR-5600>
+  let _: Claws.Fangs<Puppy> = pets(fur: Puppy())
+  let _: Claws.Fangs<Puppy> = Claws<Kitten>.Fangs()
+  let _: Claws.Fangs<Puppy> = Claws.Fangs()
+  // expected-error@-1 {{cannot convert value of type 'Claws<_>.Fangs<_>' to specified type 'Claws.Fangs<Puppy>'}}
+  let _: Claws.Fangs<NotADog> = something()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}} // FIXME: bad diagnostic
+  _ = Claws.Fangs<NotADog>()
+  // expected-error@-1 {{type 'NotADog' does not conform to protocol 'ExpressibleByDogLiteral'}}
 }
 
 // https://bugs.swift.org/browse/SR-4379

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -387,7 +387,7 @@ func pets<T>(fur: T) -> Claws<Kitten>.Fangs<T> {
   return Claws<Kitten>.Fangs<T>()
 }
 
-func something<T>() -> T { // expected-note {{in call to function 'something()'}}
+func something<T>() -> T { // expected-note {{in call to function 'something'}}
   while true {}
 }
 


### PR DESCRIPTION
* Description: Fixes a regression when referencing a nested generic type with arguments provided for the inner type but leaving the parent type unbound, eg `Foo.Bar<Int>`.

* Scope of the issue: Affects anyone using nested generics, with the shorthand to infer generic arguments by omitting them.

* Origination: This used to work in Swift 3.1 and regressed in 4.0 after some other fixes to generic typealiases.

* Risk: Low, this is well tested by the test suite and source compatibility suite.

* Tested: New test added.

* Reviewed by: @DougGregor 

* Radar: <rdar://problem/33655028>