### PR TITLE
Set _swift_reportFatalErrorsToDebugger to true by default and remove all the staging parts (frontend flag, irgen changes)

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -189,9 +189,6 @@ namespace swift {
     /// accesses.
     bool DisableTsanInoutInstrumentation = false;
 
-    /// \brief Staging flag for reporting runtime issues to the debugger.
-    bool ReportErrorsToDebugger = false;
-
     /// \brief Staging flag for class resilience, which we do not want to enable
     /// fully until more code is in place, to allow the standard library to be
     /// tested with value type resilience only.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -302,9 +302,6 @@ def disable_tsan_inout_instrumentation : Flag<["-"],
   "disable-tsan-inout-instrumentation">,
   HelpText<"Disable treatment of inout parameters as Thread Sanitizer accesses">;
 
-def report_errors_to_debugger : Flag<["-"], "report-errors-to-debugger">,
-  HelpText<"Invoke the debugger hook on fatalError calls">;
-
 def enable_infer_import_as_member :
   Flag<["-"], "enable-infer-import-as-member">,
   HelpText<"Infer when a global could be imported as a member">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -979,9 +979,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableTsanInoutInstrumentation |=
       Args.hasArg(OPT_disable_tsan_inout_instrumentation);
 
-  Opts.ReportErrorsToDebugger |=
-      Args.hasArg(OPT_report_errors_to_debugger);
-
   if (FrontendOpts.InputKind == InputFileKind::IFK_SIL)
     Opts.DisableAvailabilityChecking = true;
   

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -44,7 +44,6 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MD5.h"
-#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include "GenEnum.h"
 #include "GenType.h"
@@ -1041,31 +1040,6 @@ void IRGenModule::emitAutolinkInfo() {
   }
 }
 
-void IRGenModule::emitEnableReportErrorsToDebugger() {
-  if (!Context.LangOpts.ReportErrorsToDebugger)
-    return;
-
-  if (!getSwiftModule()->hasEntryPoint())
-    return;
-
-  llvm::Function *NewFn = llvm::Function::Create(
-      llvm::FunctionType::get(VoidTy, false), llvm::GlobalValue::PrivateLinkage,
-      "_swift_enable_report_errors_to_debugger");
-  IRGenFunction NewIGF(*this, NewFn);
-  NewFn->setAttributes(constructInitialAttributes());
-  Module.getFunctionList().push_back(NewFn);
-  NewFn->setCallingConv(DefaultCC);
-
-  llvm::Value *addr =
-      Module.getOrInsertGlobal("_swift_reportFatalErrorsToDebugger", Int1Ty);
-  llvm::Value *one = llvm::ConstantInt::get(Int1Ty, 1);
-
-  NewIGF.Builder.CreateStore(one, addr, Alignment(1));
-  NewIGF.Builder.CreateRetVoid();
-
-  llvm::appendToGlobalCtors(Module, NewFn, 0, nullptr);
-}
-
 void IRGenModule::cleanupClangCodeGenMetadata() {
   // Remove llvm.ident that ClangCodeGen might have left in the module.
   auto *LLVMIdent = Module.getNamedMetadata("llvm.ident");
@@ -1134,7 +1108,6 @@ bool IRGenModule::finalize() {
     return false;
 
   emitAutolinkInfo();
-  emitEnableReportErrorsToDebugger();
   emitGlobalLists();
   if (DebugInfo)
     DebugInfo->finalize();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -799,7 +799,6 @@ private:
 
   void emitGlobalLists();
   void emitAutolinkInfo();
-  void emitEnableReportErrorsToDebugger();
   void cleanupClangCodeGenMetadata();
 
 //--- Remote reflection metadata --------------------------------------------

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -21,7 +21,7 @@
 
 using namespace swift;
 
-bool swift::_swift_reportFatalErrorsToDebugger = false;
+bool swift::_swift_reportFatalErrorsToDebugger = true;
 
 static int swift_asprintf(char **strp, const char *fmt, ...) {
   va_list args;


### PR DESCRIPTION
Set _swift_reportFatalErrorsToDebugger to true by default and remove all the staging parts (frontend flag, irgen changes).