### PR TITLE
[QoI] Prevent a crash during diagnostics of ternary/if statements

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7172,13 +7172,18 @@ bool FailureDiagnosis::visitBindOptionalExpr(BindOptionalExpr *BOE) {
 }
 
 bool FailureDiagnosis::visitIfExpr(IfExpr *IE) {
+  auto typeCheckClauseExpr = [&](Expr *clause) -> Expr * {
+    return typeCheckChildIndependently(clause, Type(), CTP_Unused, TCCOptions(),
+                                       nullptr, false);
+  };
+
   // Check all of the subexpressions independently.
-  auto condExpr = typeCheckChildIndependently(IE->getCondExpr());
+  auto condExpr = typeCheckClauseExpr(IE->getCondExpr());
   if (!condExpr) return true;
-  auto trueExpr = typeCheckChildIndependently(IE->getThenExpr());
+  auto trueExpr = typeCheckClauseExpr(IE->getThenExpr());
   if (!trueExpr) return true;
 
-  auto falseExpr = typeCheckChildIndependently(IE->getElseExpr());
+  auto falseExpr = typeCheckClauseExpr(IE->getElseExpr());
   if (!falseExpr) return true;
 
   // If the true/false values already match, it must be a contextual problem.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -281,7 +281,7 @@ func r18800223(_ i : Int) {
 
   
   var buttonTextColor: String?
-  _ = (buttonTextColor != nil) ? 42 : {$0}; // expected-error {{result values in '? :' expression have mismatching types 'Int' and '(_) -> _'}}
+  _ = (buttonTextColor != nil) ? 42 : {$0}; // expected-error {{type of expression is ambiguous without more context}}
 }
 
 // <rdar://problem/21883806> Bogus "'_' can only appear in a pattern or on the left side of an assignment" is back
@@ -1090,4 +1090,15 @@ func sr5081() {
   var a = ["1", "2", "3", "4", "5"]
   var b = [String]()
   b = a[2...4] // expected-error {{cannot assign value of type 'ArraySlice<String>' to type '[String]'}}
+}
+
+func rdar17170728() {
+  var i: Int? = 1
+  var j: Int?
+  var k: Int? = 2
+
+  let _ = [i, j, k].reduce(0 as Int?) {
+    $0 && $1 ? $0! + $1! : ($0 ? $0! : ($1 ? $1! : nil))
+    // expected-error@-1 {{type of expression is ambiguous without more context}}
+  }
 }


### PR DESCRIPTION
While trying to diagnose problems with ternary/if statements don't
allow clauses, when type-checked separately, to have unresolved type
variables because that doesn't help to find errors.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
