### PR TITLE
Filter out 0-length tokens when generating syntax model nodes

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -63,6 +63,9 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
   auto LiteralStartLoc = Optional<SourceLoc>();
   for (unsigned I = 0, E = Tokens.size(); I != E; ++I) {
     auto &Tok = Tokens[I];
+    // Ignore empty string literals between interpolations, e.g. "\(1)\(2)"
+    if (!Tok.getLength())
+        continue;
     SyntaxNodeKind Kind;
     SourceLoc Loc;
     Optional<unsigned> Length;

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -240,6 +240,9 @@ func f(x: Int) -> Int {
   """
       This is a multiline\( "interpolated" )string
    """
+
+  // CHECK: <str>"</str>\<anchor>(</anchor><int>1</int><anchor>)</anchor>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str>"</str>
+  "\(1)\(1)"
 }
 
 // CHECK: <kw>func</kw> bar(x: <type>Int</type>) -> (<type>Int</type>, <type>Float</type>) {


### PR DESCRIPTION

<!-- What's in this pull request? -->
`swift::tokenize()` with `TokenizeInterpolatedString` set to `true` produces an empty string literal token between directly adjacent interpolations, e.g. in `"\(1)\(1)"`. The syntax model relies upon having a string literal token in this position to determine whether the next left paren and preceding right paren are string interpolation anchors or not, but there is no need to to include a corresponding empty `SyntaxNode` in the syntax model. 0-length syntax nodes don't really make sense and may break assumptions in client `SyntaxModelWalker`s.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/33601932.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->