### PR TITLE
Formatting: when aligning siblings in indentation, we should respect use tab setting. rdar://32611247

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -113,7 +113,7 @@ public:
     // Calculating space length
     for (auto C: Range.str()) {
       if (C == '\t')
-        TabLength += FmtOptions.TabWidth;
+        SpaceLength += FmtOptions.TabWidth;
       else
         SpaceLength += 1;
     }

--- a/test/SourceKit/CodeFormat/indent-with-tab.swift
+++ b/test/SourceKit/CodeFormat/indent-with-tab.swift
@@ -8,6 +8,9 @@ var test : Int
 
 }
 
+func bar(a: Int,
+b: Int) {}
+
 // RUN: %sourcekitd-test -req=format -line=1 -length=1 -req-opts=usetabs=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=2 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 -req-opts=usetabs=1 %s >>%t.response
@@ -17,6 +20,7 @@ var test : Int
 // RUN: %sourcekitd-test -req=format -line=7 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=8 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=9 -length=1 -req-opts=usetabs=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=12 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "class Foo {"
@@ -28,3 +32,4 @@ var test : Int
 // CHECK: key.sourcetext: "\t}"
 // CHECK: key.sourcetext: "\t"
 // CHECK: key.sourcetext: "}"
+// CHECK: key.sourcetext: "\t\t b: Int) {}"


### PR DESCRIPTION
We use white spaces for the remaining that cannot be filled with tabs.