### PR TITLE
Replicate NSAffineTransform logic for rotation to AffineTransform

### DIFF
--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -1,18 +1,23 @@
-//===----------------------------------------------------------------------===//
-//
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-//===----------------------------------------------------------------------===//
 
+#if os(OSX) || os(iOS)
+    import Darwin
+#elseif os(Linux) || CYGWIN
+    import Glibc
+#endif
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
 @_exported import Foundation // Clang module
+#endif
 
-#if os(OSX)
+#if os(OSX) || DEPLOYMENT_RUNTIME_SWIFT
 
 private let ε: CGFloat = 2.22045e-16
 
@@ -23,7 +28,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     
     /**
      Creates an affine transformation.
-    */
+     */
     public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {
         self.m11 = m11
         self.m12 = m12
@@ -51,7 +56,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     /**
      Creates an affine transformation matrix with identity values.
      - seealso: identity
-    */
+     */
     public init() {
         self.init(m11: CGFloat(1.0), m12: CGFloat(0.0),
                   m21: CGFloat(0.0), m22: CGFloat(1.0),
@@ -62,37 +67,37 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      Creates an affine transformation matrix from translation values.
      The matrix takes the following form:
      
-         [ 1  0  0 ]
-         [ 0  1  0 ]
-         [ x  y  1 ]
+     [ 1  0  0 ]
+     [ 0  1  0 ]
+     [ x  y  1 ]
      */
     public init(translationByX x: CGFloat, byY y: CGFloat) {
         self.init(m11: CGFloat(1.0), m12: CGFloat(0.0),
                   m21: CGFloat(0.0), m22: CGFloat(1.0),
-                   tX: x,             tY: y)
+                  tX: x,             tY: y)
     }
     
     /**
      Creates an affine transformation matrix from scaling values.
      The matrix takes the following form:
      
-         [ x  0  0 ]
-         [ 0  y  0 ]
-         [ 0  0  1 ]
+     [ x  0  0 ]
+     [ 0  y  0 ]
+     [ 0  0  1 ]
      */
     public init(scaleByX x: CGFloat, byY y: CGFloat) {
         self.init(m11: x,            m12: CGFloat(0.0),
                   m21: CGFloat(0.0), m22: y,
-                   tX: CGFloat(0.0),  tY: CGFloat(0.0))
+                  tX: CGFloat(0.0),  tY: CGFloat(0.0))
     }
     
     /**
      Creates an affine transformation matrix from scaling a single value.
      The matrix takes the following form:
      
-         [ f  0  0 ]
-         [ 0  f  0 ]
-         [ 0  0  1 ]
+     [ f  0  0 ]
+     [ 0  f  0 ]
+     [ 0  0  1 ]
      */
     public init(scale factor: CGFloat) {
         self.init(scaleByX: factor, byY: factor)
@@ -102,9 +107,9 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      Creates an affine transformation matrix from rotation value (angle in radians).
      The matrix takes the following form:
      
-         [  cos α   sin α  0 ]
-         [ -sin α   cos α  0 ]
-         [    0       0    1 ]
+     [  cos α   sin α  0 ]
+     [ -sin α   cos α  0 ]
+     [    0       0    1 ]
      */
     public init(rotationByRadians angle: CGFloat) {
         let α = Double(angle)
@@ -119,9 +124,9 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      Creates an affine transformation matrix from a rotation value (angle in degrees).
      The matrix takes the following form:
      
-         [  cos α   sin α  0 ]
-         [ -sin α   cos α  0 ]
-         [    0       0    1 ]
+     [  cos α   sin α  0 ]
+     [ -sin α   cos α  0 ]
+     [    0       0    1 ]
      */
     public init(rotationByDegrees angle: CGFloat) {
         let α = angle * .pi / 180.0
@@ -131,9 +136,9 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     /**
      An identity affine transformation matrix
      
-         [ 1  0  0 ]
-         [ 0  1  0 ]
-         [ 0  0  1 ]
+     [ 1  0  0 ]
+     [ 0  1  0 ]
+     [ 0  0  1 ]
      */
     public static let identity = AffineTransform(m11: 1, m12: 0, m21: 0, m22: 1, tX: 0, tY: 0)
     
@@ -148,9 +153,9 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      Mutates an affine transformation matrix from a rotation value (angle α in degrees).
      The matrix takes the following form:
      
-         [  cos α   sin α  0 ]
-         [ -sin α   cos α  0 ]
-         [    0       0    1 ]
+     [  cos α   sin α  0 ]
+     [ -sin α   cos α  0 ]
+     [    0       0    1 ]
      */
     public mutating func rotate(byDegrees angle: CGFloat) {
         let α = angle * .pi / 180.0
@@ -161,17 +166,24 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      Mutates an affine transformation matrix from a rotation value (angle α in radians).
      The matrix takes the following form:
      
-         [  cos α   sin α  0 ]
-         [ -sin α   cos α  0 ]
-         [    0       0    1 ]
+     [  cos α   sin α  0 ]
+     [ -sin α   cos α  0 ]
+     [    0       0    1 ]
      */
     public mutating func rotate(byRadians angle: CGFloat) {
-        let α = Double(angle)
+        let t2 = self
+        let t1 = AffineTransform(rotationByRadians: angle)
         
-        let sine = CGFloat(sin(α))
-        let cosine = CGFloat(cos(α))
+        var t = AffineTransform.identity
         
-        append(AffineTransform(m11: cosine, m12: sine, m21: -sine, m22: cosine, tX: 0, tY: 0))
+        t.m11 = t1.m11 * t2.m11 + t1.m12 * t2.m21
+        t.m12 = t1.m11 * t2.m12 + t1.m12 * t2.m22
+        t.m21 = t1.m21 * t2.m11 + t1.m22 * t2.m21
+        t.m22 = t1.m21 * t2.m12 + t1.m22 * t2.m22
+        t.tX = t1.tX * t2.m11 + t1.tY * t2.m21 + t2.tX
+        t.tY = t1.tX * t2.m12 + t1.tY * t2.m22 + t2.tY
+        
+        self = t
     }
     
     /**
@@ -180,13 +192,13 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      the `transformStruct`'s affine transformation matrix.
      The resulting matrix takes the following form:
      
-                 [ m11_T  m12_T  0 ] [ m11_M  m12_M  0 ]
-         T * M = [ m21_T  m22_T  0 ] [ m21_M  m22_M  0 ]
-                 [  tX_T   tY_T  1 ] [  tX_M   tY_M  1 ]
+     [ m11_T  m12_T  0 ] [ m11_M  m12_M  0 ]
+     T * M = [ m21_T  m22_T  0 ] [ m21_M  m22_M  0 ]
+     [  tX_T   tY_T  1 ] [  tX_M   tY_M  1 ]
      
-                 [    (m11_T*m11_M + m12_T*m21_M)       (m11_T*m12_M + m12_T*m22_M)    0 ]
-               = [    (m21_T*m11_M + m22_T*m21_M)       (m21_T*m12_M + m22_T*m22_M)    0 ]
-                 [ (tX_T*m11_M + tY_T*m21_M + tX_M)  (tX_T*m12_M + tY_T*m22_M + tY_M)  1 ]
+     [    (m11_T*m11_M + m12_T*m21_M)       (m11_T*m12_M + m12_T*m22_M)    0 ]
+     = [    (m21_T*m11_M + m22_T*m21_M)       (m21_T*m12_M + m22_T*m22_M)    0 ]
+     [ (tX_T*m11_M + tY_T*m21_M + tX_M)  (tX_T*m12_M + tY_T*m22_M + tY_M)  1 ]
      */
     private func concatenated(_ other: AffineTransform) -> AffineTransform {
         let (t, m) = (self, other)
@@ -214,7 +226,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     
     /**
      Inverts the transformation matrix if possible. Matrices with a determinant that is less than
-     the smallest valid representation of a double value greater than zero are considered to be 
+     the smallest valid representation of a double value greater than zero are considered to be
      invalid for representing as an inverse. If the input AffineTransform can potentially fall into
      this case then the inverted() method is suggested to be used instead since that will return
      an optional value that will be nil in the case that the matrix cannot be inverted.
@@ -222,7 +234,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
      D = (m11 * m22) - (m12 * m21)
      
      D < ε the inverse is undefined and will be nil
-    */
+     */
     public mutating func invert() {
         guard let inverse = inverted() else {
             fatalError("Transform has no inverse")
@@ -280,16 +292,22 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     public var debugDescription: String {
         return description
     }
-
+    
     public static func ==(lhs: AffineTransform, rhs: AffineTransform) -> Bool {
         return lhs.m11 == rhs.m11 && lhs.m12 == rhs.m12 &&
-               lhs.m21 == rhs.m21 && lhs.m22 == rhs.m22 &&
-               lhs.tX == rhs.tX && lhs.tY == rhs.tY
+            lhs.m21 == rhs.m21 && lhs.m22 == rhs.m22 &&
+            lhs.tX == rhs.tX && lhs.tY == rhs.tY
     }
-
+    
 }
 
-extension AffineTransform : _ObjectiveCBridgeable {
+#if DEPLOYMENT_RUNTIME_SWIFT
+internal typealias AffineTransformBridgeType = _ObjectTypeBridgeable
+#else
+internal typealias AffineTransformBridgeType = _ObjectiveCBridgeable
+#endif
+
+extension AffineTransform : AffineTransformBridgeType {
     public static func _getObjectiveCType() -> Any.Type {
         return NSAffineTransform.self
     }
@@ -309,7 +327,7 @@ extension AffineTransform : _ObjectiveCBridgeable {
         result = AffineTransform(reference: x)
         return true // Can't fail
     }
-
+    
     public static func _unconditionallyBridgeFromObjectiveC(_ x: NSAffineTransform?) -> AffineTransform {
         guard let src = x else { return AffineTransform.identity }
         return AffineTransform(reference: src)
@@ -334,7 +352,7 @@ extension AffineTransform : Codable {
         tX  = try container.decode(CGFloat.self)
         tY  = try container.decode(CGFloat.self)
     }
-
+    
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
         try container.encode(self.m11)
@@ -347,3 +365,4 @@ extension AffineTransform : Codable {
 }
 
 #endif
+

--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -1,11 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
+//===----------------------------------------------------------------------===//
+
 
 #if os(OSX) || os(iOS)
     import Darwin

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -372,6 +372,16 @@ class TestAffineTransform : TestAffineTransformSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(AffineTransform(), AffineTransform._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_rotation_compose() {
+        var t = AffineTransform.identity
+        t.translate(x: 1.0, y: 1.0)
+        t.rotate(byDegrees: 90)
+        t.translate(x: -1.0, y: -1.0)
+        let result = t.transform(NSPoint(x: 1.0, y: 2.0))
+        expectEqualWithAccuracy(0.0, Double(result.x), accuracy: accuracyThreshold)
+        expectEqualWithAccuracy(1.0, Double(result.y), accuracy: accuracyThreshold)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -395,6 +405,7 @@ AffineTransformTests.test("test_hashing_values") { TestAffineTransform().test_ha
 AffineTransformTests.test("test_AnyHashableContainingAffineTransform") { TestAffineTransform().test_AnyHashableContainingAffineTransform() }
 AffineTransformTests.test("test_AnyHashableCreatedFromNSAffineTransform") { TestAffineTransform().test_AnyHashableCreatedFromNSAffineTransform() }
 AffineTransformTests.test("test_unconditionallyBridgeFromObjectiveC") { TestAffineTransform().test_unconditionallyBridgeFromObjectiveC() }
+AffineTransformTests.test("test_rotation_compose") { TestAffineTransform().test_rotation_compose() }
 runAllTests()
 #endif
     


### PR DESCRIPTION
AffineTransform was modified previously to alter the rotation logic, this unfortunately did not account for composition of matrices. This change replicates the logic in NSAffineTransform for rotation.

This addresses:
rdar://problem/33510242