### PR TITLE
Remove -swift-version 3 checks for "expression too complex".

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1342,8 +1342,7 @@ ConstraintSystem::solve(Expr *&expr,
   // had found at least one solution before deciding an expression was
   // "too complex". Maintain that behavior, but for Swift > 3 return
   // Unsolved in these cases.
-  auto tooComplex = getExpressionTooComplex(solutions) &&
-    !getASTContext().isSwiftVersion3();
+  auto tooComplex = getExpressionTooComplex(solutions);
   auto unsolved = tooComplex || solutions.empty();
 
   return unsolved ? SolutionKind::Unsolved : SolutionKind::Solved;
@@ -1876,9 +1875,7 @@ bool ConstraintSystem::solveSimplified(
   // not allow our caller to continue as if we have been successful.
   // Maintain the broken behavior under Swift 3 mode though, to avoid
   // breaking code.
-  auto tooComplex = getExpressionTooComplex(solutions) &&
-    !getASTContext().isSwiftVersion3();
-
+  auto tooComplex = getExpressionTooComplex(solutions);
   return tooComplex || !lastSolvedChoice;
 }
 

--- a/test/Misc/expression_too_complex.swift
+++ b/test/Misc/expression_too_complex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-memory-threshold 12000 -propagate-constraints
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 16000 -propagate-constraints
 
 var z = 10 + 10 // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
 


### PR DESCRIPTION
This was initially added to avoid "expression was too complex" in a
case where we were not previously reporting it for -swift-version 3
but should have been. In retrospect this seems misguided since
although we would not like to regress on "too complex" expressions, we
really don't want to silently continue in the cases where we decide an
expression is "too complex", but where we have a solution that we
could use. It's better to fail.
