### PR TITLE
[TypeChecker] Return correct type when asked to skip applying solution

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1784,7 +1784,7 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
 
   if (options.contains(TypeCheckExprFlags::SkipApplyingSolution)) {
     cleanup.disable();
-    return cs.getType(expr);
+    return solution.simplifyType(cs.getType(expr));
   }
 
   // Apply the solution to the expression.


### PR DESCRIPTION
When type-checker is asked to skip applying deduced solution to expression,
it still needs to use type information for it to return correct result type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
