### PR TITLE
IRGen: Fix emission of reflection metadata for @objc enums

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -961,6 +961,14 @@ void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
   if (!IRGen.Opts.EnableReflectionMetadata)
     return;
 
+  // @objc enums never have generic parameters or payloads,
+  // and lower as their raw type.
+  if (auto *ED = dyn_cast<EnumDecl>(Decl))
+    if (ED->isObjC()) {
+      emitOpaqueTypeMetadataRecord(ED);
+      return;
+    }
+
   FieldTypeMetadataBuilder builder(*this, Decl);
   builder.emit();
 }

--- a/test/Reflection/Inputs/TypeLoweringObjectiveC.swift
+++ b/test/Reflection/Inputs/TypeLoweringObjectiveC.swift
@@ -11,3 +11,13 @@ public class HasObjCClasses {
 
 public class NSObjectSubclass : NSObject {}
 
+@objc public enum ObjCEnum : Int {
+  case first
+  case second
+}
+
+public struct HasObjCEnum {
+  let optionalEnum: ObjCEnum?
+  let reference: AnyObject
+}
+

--- a/test/Reflection/typeref_lowering_objc.swift
+++ b/test/Reflection/typeref_lowering_objc.swift
@@ -19,3 +19,13 @@
 // CHECK: (class TypeLowering.NSObjectSubclass)
 // CHECK-NEXT: (reference kind=strong refcounting=unknown)
 
+12TypeLowering11HasObjCEnumV
+// CHECK: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-NEXT:   (field name=optionalEnum offset=0
+// CHECK-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-NEXT:       (field name=some offset=0
+// CHECK-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-NEXT:   (field name=reference offset=16
+// CHECK-NEXT:     (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
+// CHECK-NEXT:       (field name=object offset=0
+// CHECK-NEXT:         (reference kind=strong refcounting=unknown)))))


### PR DESCRIPTION
@objc enums lower as their raw type, so should go through the same
code path as imported enums.

Fixes <https://bugs.swift.org/browse/SR-5625> and
<rdar://problem/33683103>.