### PR TITLE
IRGen: Fix emission of reflection metadata for @objc enums [4.0]

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -961,6 +961,14 @@ void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
   if (!IRGen.Opts.EnableReflectionMetadata)
     return;
 
+  // @objc enums never have generic parameters or payloads,
+  // and lower as their raw type.
+  if (auto *ED = dyn_cast<EnumDecl>(Decl))
+    if (ED->isObjC()) {
+      emitOpaqueTypeMetadataRecord(ED);
+      return;
+    }
+
   FieldTypeMetadataBuilder builder(*this, Decl);
   builder.emit();
 }

--- a/test/Reflection/Inputs/TypeLoweringObjectiveC.swift
+++ b/test/Reflection/Inputs/TypeLoweringObjectiveC.swift
@@ -11,3 +11,13 @@ public class HasObjCClasses {
 
 public class NSObjectSubclass : NSObject {}
 
+@objc public enum ObjCEnum : Int {
+  case first
+  case second
+}
+
+public struct HasObjCEnum {
+  let optionalEnum: ObjCEnum?
+  let reference: AnyObject
+}
+

--- a/test/Reflection/typeref_lowering_objc.swift
+++ b/test/Reflection/typeref_lowering_objc.swift
@@ -19,3 +19,13 @@
 // CHECK: (class TypeLowering.NSObjectSubclass)
 // CHECK-NEXT: (reference kind=strong refcounting=unknown)
 
+12TypeLowering11HasObjCEnumV
+// CHECK: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-NEXT:   (field name=optionalEnum offset=0
+// CHECK-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-NEXT:       (field name=some offset=0
+// CHECK-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-NEXT:   (field name=reference offset=16
+// CHECK-NEXT:     (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
+// CHECK-NEXT:       (field name=object offset=0
+// CHECK-NEXT:         (reference kind=strong refcounting=unknown)))))


### PR DESCRIPTION
- Description: Fix IRGen's remote reflection metadata emission to support @objc enums.

- Scope of the issue: Causes Instruments to report false memory leaks for aggregates containing @objc enums.

- Origination: I think this bug has been there since remote reflection was first introduced.

- Tested: New test case added.

- Risk: Low, the new code only runs for @objc enums, if there's a bug in the change reflection metadata emission can be disabled, and the old behavior was completely wrong.

- Reviewed by: @bitjammer 

- Radar: rdar://problem/33683103