### PR TITLE
Staging for __consuming

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -174,6 +174,8 @@ SIMPLE_DECL_ATTR(objcMembers, ObjCMembers, OnClass, 34)
 
 // Non-serialized attributes.
 
+SIMPLE_DECL_ATTR(__consuming, Consuming, OnFunc | DeclModifier | NotSerialized,
+                 /* Not serialized */ 40)
 SIMPLE_DECL_ATTR(mutating, Mutating, OnFunc | DeclModifier | NotSerialized,
                  /* Not serialized */ 41)
 SIMPLE_DECL_ATTR(nonmutating, NonMutating, OnFunc | DeclModifier | NotSerialized,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1006,12 +1006,17 @@ ERROR(attribute_requires_single_argument,none,
       "'%0' requires a function with one argument", (StringRef))
 
 ERROR(mutating_invalid_global_scope,none,
-      "'mutating' is only valid on methods", ())
+      "'%select{nonmutating|mutating|__consuming}0' is only valid on methods",
+      (unsigned))
 ERROR(mutating_invalid_classes,none,
-      "'%select{|non}0mutating' isn't valid on methods in classes or class-bound protocols",
-      (bool))
+      "'%select{nonmutating|mutating|__consuming}0' isn't valid on methods in "
+      "classes or class-bound protocols", (bool))
+
 ERROR(functions_mutating_and_not,none,
-      "method may not be declared both mutating and nonmutating", ())
+      "method may not be declared both "
+      "%select{nonmutating|mutating|__consuming}0 and "
+      "%select{nonmutating|mutating|__consuming}1",
+      (unsigned, unsigned))
 ERROR(static_functions_not_mutating,none,
       "static functions may not be declared mutating", ())
 
@@ -1572,8 +1577,9 @@ NOTE(protocol_witness_static_conflict,none,
 NOTE(protocol_witness_prefix_postfix_conflict,none,
      "candidate is %select{|prefix, |postfix, }1not "
      "%select{prefix|postfix}0 as required", (bool, unsigned))
-NOTE(protocol_witness_mutating_conflict,none,
-     "candidate is marked 'mutating' but protocol does not allow it", ())
+NOTE(protocol_witness_mutation_modifier_conflict,none,
+     "candidate is marked '%select{nonmutating|mutating|__consuming}0' but "
+     "protocol does not allow it", (unsigned))
 NOTE(protocol_witness_settable_conflict,none,
      "candidate is not settable, but protocol requires it", ())
 NOTE(protocol_witness_rethrows_conflict,none,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 359; // Last change: object, global_value
+const uint16_t VERSION_MINOR = 360; // Last change: '__consuming'
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -237,6 +237,15 @@ enum class AddressorKind : uint8_t {
   NotAddressor, Unsafe, Owning, NativeOwning, NativePinning
 };
 using AddressorKindField = BCFixed<3>;
+ 
+// These IDs must \em not be renumbered or reordered without incrementing
+// VERSION_MAJOR.
+enum class SelfAccessKind : uint8_t {
+  NonMutating = 0,
+  Mutating,
+  __Consuming,
+};
+using SelfAccessKindField = BCFixed<2>;
   
 /// Translates an operator DeclKind to a Serialization fixity, whose values are
 /// guaranteed to be stable.
@@ -933,7 +942,7 @@ namespace decls_block {
     BCFixed<1>,   // is 'static' or 'class'?
     StaticSpellingKindField, // spelling of 'static' or 'class'
     BCFixed<1>,   // explicitly objc?
-    BCFixed<1>,   // mutating?
+    SelfAccessKindField,   // self access kind
     BCFixed<1>,   // has dynamic self?
     BCFixed<1>,   // throws?
     BCVBR<5>,     // number of parameter patterns

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2526,6 +2526,9 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         if (decl->isMutating() && !decl->getAttrs().hasAttribute<MutatingAttr>()) {
           Printer.printKeyword("mutating");
           Printer << " ";
+        } else if (decl->isConsuming() && !decl->getAttrs().hasAttribute<ConsumingAttr>()) {
+          Printer.printKeyword("__consuming");
+          Printer << " ";
         }
         Printer << tok::kw_func << " ";
       }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -619,7 +619,8 @@ static FuncDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
   setterDecl->setInterfaceType(type);
 
   setterDecl->setAccessibility(Accessibility::Public);
-  setterDecl->setMutating();
+  setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+
 
   return setterDecl;
 }
@@ -5377,7 +5378,7 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(
 
   result->setAccessibility(Accessibility::Public);
   if (selfIsInOut)
-    result->setMutating();
+    result->setSelfAccessKind(SelfAccessKind::Mutating);
   if (selfIdx) {
     result->setSelfIndex(selfIdx.getValue());
   } else {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2291,6 +2291,10 @@ Parser::parseDecl(ParseDeclOptions Flags,
         parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_NonMutating);
         continue;
       }
+      if (Tok.isContextualKeyword("__consuming")) {
+        parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
+        continue;
+      }
       if (Tok.isContextualKeyword("convenience")) {
         parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Convenience);
         continue;
@@ -3489,7 +3493,7 @@ static FuncDecl *createAccessorFunc(SourceLoc DeclLoc, ParameterList *param,
   case AccessorKind::IsWillSet:
   case AccessorKind::IsDidSet:
     if (D->isInstanceMember())
-      D->setMutating();
+      D->setSelfAccessKind(SelfAccessKind::Mutating);
     break;
 
   case AccessorKind::IsMaterializeForSet:
@@ -3738,6 +3742,8 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
         parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Mutating);
       } else if (Tok.isContextualKeyword("nonmutating")) {
         parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_NonMutating);
+      } else if (Tok.isContextualKeyword("__consuming")) {
+        parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
       }
 
       AccessorKind Kind;
@@ -3835,6 +3841,8 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
       parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Mutating);
     } else if (Tok.isContextualKeyword("nonmutating")) {
       parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_NonMutating);
+    } else if (Tok.isContextualKeyword("__consuming")) {
+      parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
     }
     
     bool isImplicitGet = false;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5066,14 +5066,16 @@ public:
     // Validate the mutating attribute if present, and install it into the bit
     // on funcdecl (instead of just being a DeclAttribute).
     if (FD->getAttrs().hasAttribute<MutatingAttr>())
-      FD->setMutating(true);
+      FD->setSelfAccessKind(SelfAccessKind::Mutating);
     else if (FD->getAttrs().hasAttribute<NonMutatingAttr>())
-      FD->setMutating(false);
+      FD->setSelfAccessKind(SelfAccessKind::NonMutating);
+    else if (FD->getAttrs().hasAttribute<ConsumingAttr>())
+      FD->setSelfAccessKind(SelfAccessKind::__Consuming);
 
     if (FD->isMutating()) {
       Type contextTy = FD->getDeclContext()->getDeclaredInterfaceType();
       if (contextTy->hasReferenceSemantics())
-        FD->setMutating(false);
+        FD->setSelfAccessKind(SelfAccessKind::NonMutating);
     }
 
     // Check whether the return type is dynamic 'Self'.
@@ -6124,6 +6126,7 @@ public:
     UNINTERESTING_ATTR(Accessibility)
     UNINTERESTING_ATTR(Alignment)
     UNINTERESTING_ATTR(CDecl)
+    UNINTERESTING_ATTR(Consuming)
     UNINTERESTING_ATTR(SILGenName)
     UNINTERESTING_ATTR(Exported)
     UNINTERESTING_ATTR(GKInspectable)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1923,6 +1923,20 @@ static uint8_t getRawStableAccessibility(Accessibility access) {
   llvm_unreachable("Unhandled AccessibilityKind in switch.");
 }
 
+static serialization::SelfAccessKind
+getStableSelfAccessKind(swift::SelfAccessKind MM) {
+  switch (MM) {
+  case swift::SelfAccessKind::NonMutating:
+    return serialization::SelfAccessKind::NonMutating;
+  case swift::SelfAccessKind::Mutating:
+    return serialization::SelfAccessKind::Mutating;
+  case swift::SelfAccessKind::__Consuming:
+    return serialization::SelfAccessKind::__Consuming;
+  }
+
+  llvm_unreachable("Unhandled StaticSpellingKind in switch.");
+}
+
 #ifndef NDEBUG
 #define DEF_VERIFY_ATTR(DECL)\
 static void verifyAttrSerializable(const DECL ## Decl *D) {\
@@ -2954,7 +2968,8 @@ void Serializer::writeDecl(const Decl *D) {
                            uint8_t(
                              getStableStaticSpelling(fn->getStaticSpelling())),
                            fn->isObjC(),
-                           fn->isMutating(),
+                           uint8_t(
+                             getStableSelfAccessKind(fn->getSelfAccessKind())),
                            fn->hasDynamicSelf(),
                            fn->hasThrows(),
                            fn->getParameterLists().size(),

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -64,7 +64,7 @@ class FooClass {
   nonmutating         // expected-error {{'nonmutating' isn't valid on methods in classes or class-bound protocols}} {{3-15=}}
   func bay() {}
 
-  mutating nonmutating // expected-error {{method may not be declared both mutating and nonmutating}} expected-error {{'mutating' isn't valid on methods in classes or class-bound protocols}} expected-error {{'nonmutating' isn't valid on methods in classes or class-bound protocols}}
+  mutating nonmutating // expected-error {{'mutating' isn't valid on methods in classes or class-bound protocols}} expected-error {{'nonmutating' isn't valid on methods in classes or class-bound protocols}}
   func bax() {}
 
   var x : Int {
@@ -204,6 +204,7 @@ struct TestMutableStruct {
 
   @mutating func mutating_attr() {}  // expected-error {{'mutating' is a declaration modifier, not an attribute}} {{3-4=}}
   @nonmutating func nonmutating_attr() {}  // expected-error {{'nonmutating' is a declaration modifier, not an attribute}} {{3-4=}}
+  @__consuming func consuming_attr() {}  // expected-error {{'__consuming' is a declaration modifier, not an attribute}} {{3-4=}}
 }
 
 func test_mutability() {
@@ -245,23 +246,29 @@ protocol MutatingTestProto {
   mutating
   func mutatingfunc()
   
-  func nonmutatingfunc()  // expected-note {{protocol requires}}
+  func nonmutatingfunc()  // expected-note 2 {{protocol requires}}
+  __consuming
+  func consuming_nonmutating_func()  // expected-note 2 {{protocol requires}}
 }
 
 class TestClass : MutatingTestProto {
   func mutatingfunc() {}  // Ok, doesn't need to be mutating.
   func nonmutatingfunc() {}
+  __consuming // OK, but doesn't make much sense.
+  func consuming_nonmutating_func() {}
 }
 
 struct TestStruct1 : MutatingTestProto {
   func mutatingfunc() {}  // Ok, doesn't need to be mutating.
   func nonmutatingfunc() {}
+  __consuming func consuming_nonmutating_func() {}
 }
 
 struct TestStruct2 : MutatingTestProto {
   mutating
   func mutatingfunc() {}  // Ok, can be mutating.
   func nonmutatingfunc() {}
+  __consuming func consuming_nonmutating_func() {}
 }
 
 struct TestStruct3 : MutatingTestProto {   // expected-error {{type 'TestStruct3' does not conform to protocol 'MutatingTestProto'}}
@@ -269,9 +276,25 @@ struct TestStruct3 : MutatingTestProto {   // expected-error {{type 'TestStruct3
 
   // This is not ok, "nonmutatingfunc" doesn't allow mutating functions.
   mutating
-  func nonmutatingfunc() {}          // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
+  func nonmutatingfunc() {} // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
+  mutating
+  func consuming_nonmutating_func() {} // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
 }
 
+struct TestStruct4 : MutatingTestProto { // expected-error {{type 'TestStruct4' does not conform to protocol 'MutatingTestProto'}}
+  mutating
+  func mutatingfunc() {}  // Ok, can be mutating.
+  func nonmutatingfunc() {}
+  nonmutating func consuming_nonmutating_func() {}  // expected-note {{candidate is marked 'nonmutating' but protocol does not allow it}}
+}
+
+struct TestStruct5 : MutatingTestProto { // expected-error {{type 'TestStruct5' does not conform to protocol 'MutatingTestProto'}}
+  mutating
+  func mutatingfunc() {}  // Ok, can be mutating.
+  __consuming
+  func nonmutatingfunc() {} // expected-note {{candidate is marked '__consuming' but protocol does not allow it}}
+  __consuming func consuming_nonmutating_func() {}
+}
 
 // <rdar://problem/16722603> invalid conformance of mutating setter
 protocol NonMutatingSubscriptable {
@@ -465,8 +488,11 @@ struct F { // expected-note 1 {{in declaration of 'F'}}
   mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{expected declaration}}
   }
   
-  mutating nonmutating func g() {  // expected-error {{method may not be declared both mutating and nonmutating}}
-  }
+  mutating nonmutating func g() {}  // expected-error {{method may not be declared both mutating and nonmutating}}
+  __consuming nonmutating func h() {}  // expected-error {{method may not be declared both __consuming and nonmutating}}
+  __consuming mutating func i() {}  // expected-error {{method may not be declared both __consuming and mutating}}
+  nonmutating mutating func j() {}  // expected-error {{method may not be declared both nonmutating and mutating}}
+  __consuming nonmutating mutating func k() {}  // expected-error {{method may not be declared both __consuming and mutating}} expected-error {{method may not be declared both nonmutating and mutating}}
 }
 
 protocol SingleIntProperty {


### PR DESCRIPTION
Pushes __consuming through the frontend and extends existing
attribute-based diagnsotics to cover it.  Unlike `nonmutating`,
__consuming is allowed in class methods, though it makes little
sense to put it there.

`@owned`  semantics will come in a later patch.