### PR TITLE
Temporarily disable linux-fatal-backtrace.swift.

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
+// REQUIRES: rdar33718631
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.


### PR DESCRIPTION
This test is failing and blocking PR testing for Linux. I am disabling it
while we sort out the problem.

rdar://problem/33718631