### PR TITLE
Replicate NSAffineTransform logic for rotation to AffineTransform

### DIFF
--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -166,12 +166,19 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
          [    0       0    1 ]
      */
     public mutating func rotate(byRadians angle: CGFloat) {
-        let α = Double(angle)
-        
-        let sine = CGFloat(sin(α))
-        let cosine = CGFloat(cos(α))
-        
-        append(AffineTransform(m11: cosine, m12: sine, m21: -sine, m22: cosine, tX: 0, tY: 0))
+        let t2 = self
+        let t1 = AffineTransform(rotationByRadians: angle)
+
+        var t = AffineTransform.identity
+
+        t.m11 = t1.m11 * t2.m11 + t1.m12 * t2.m21
+        t.m12 = t1.m11 * t2.m12 + t1.m12 * t2.m22
+        t.m21 = t1.m21 * t2.m11 + t1.m22 * t2.m21
+        t.m22 = t1.m21 * t2.m12 + t1.m22 * t2.m22
+        t.tX = t1.tX * t2.m11 + t1.tY * t2.m21 + t2.tX
+        t.tY = t1.tX * t2.m12 + t1.tY * t2.m22 + t2.tY
+
+        self = t
     }
     
     /**

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -372,6 +372,16 @@ class TestAffineTransform : TestAffineTransformSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(AffineTransform(), AffineTransform._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_rotation_compose() {
+        var t = AffineTransform.identity
+        t.translate(x: 1.0, y: 1.0)
+        t.rotate(byDegrees: 90)
+        t.translate(x: -1.0, y: -1.0)
+        let result = t.transform(NSPoint(x: 1.0, y: 2.0))
+        expectEqualWithAccuracy(0.0, Double(result.x), accuracy: accuracyThreshold)
+        expectEqualWithAccuracy(1.0, Double(result.y), accuracy: accuracyThreshold)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -395,6 +405,7 @@ AffineTransformTests.test("test_hashing_values") { TestAffineTransform().test_ha
 AffineTransformTests.test("test_AnyHashableContainingAffineTransform") { TestAffineTransform().test_AnyHashableContainingAffineTransform() }
 AffineTransformTests.test("test_AnyHashableCreatedFromNSAffineTransform") { TestAffineTransform().test_AnyHashableCreatedFromNSAffineTransform() }
 AffineTransformTests.test("test_unconditionallyBridgeFromObjectiveC") { TestAffineTransform().test_unconditionallyBridgeFromObjectiveC() }
+AffineTransformTests.test("test_rotation_compose") { TestAffineTransform().test_rotation_compose() }
 runAllTests()
 #endif
     


### PR DESCRIPTION
AffineTransform was modified previously to alter the rotation logic, this unfortunately did not account for composition of matrices. This change replicates the logic in NSAffineTransform for rotation.

This addresses:
rdar://problem/33510242