### PR TITLE
[runtime] Implement sidetable path for isUniquelyReferenced

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -961,7 +961,7 @@ class RefCounts {
   bool isUniquelyReferenced() const {
     auto bits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
     if (bits.hasSideTable())
-      return false;  // FIXME: implement side table path if useful
+      return bits.getSideTable()->isUniquelyReferenced();
     
     assert(!bits.getIsDeiniting());
     return bits.isUniquelyReferenced();
@@ -1382,6 +1382,10 @@ class HeapObjectSideTableEntry {
   // Note that this is not equal to the number of outstanding weak pointers.
   uint32_t getCount() const {
     return refCounts.getCount();
+  }
+
+  bool isUniquelyReferenced() const {
+    return refCounts.isUniquelyReferenced();
   }
 
   bool isUniquelyReferencedOrPinned() const {

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -36,6 +36,31 @@ tests.test("_isUnique/NativeObject") {
   expectFalse(_isUnique_native(&b))
 }
 
+tests.test("_isUnique/NativeObjectWithPreviousStrongRef") {
+  var a: Builtin.NativeObject = Builtin.castToNativeObject(X())
+  expectTrue(_isUnique_native(&a))
+  var b: Builtin.NativeObject? = a
+  expectFalse(_isUnique_native(&a))
+  b = nil
+  expectTrue(_isUnique_native(&a))
+}
+
+tests.test("_isUnique/NativeObjectWithWeakRef") {
+  var a: Builtin.NativeObject = Builtin.castToNativeObject(X())
+  expectTrue(_isUnique_native(&a))
+  weak var b = a
+  expectTrue(_isUnique_native(&a))
+  expectFalse(_isUnique_native(&b))
+}
+
+tests.test("_isUnique/NativeObjectWithUnownedRef") {
+  var a: Builtin.NativeObject = Builtin.castToNativeObject(X())
+  expectTrue(_isUnique_native(&a))
+  unowned var b = a
+  expectTrue(_isUnique_native(&a))
+  expectFalse(_isUnique_native(&b))
+}
+
 tests.test("_isUniquelyReferenced/OptionalNativeObject") {
   var a: Builtin.NativeObject? = Builtin.castToNativeObject(X())
   StdlibUnittest.expectTrue(_getBool(Builtin.isUnique(&a)))


### PR DESCRIPTION

<!-- What's in this pull request? -->
The stdlib function `isKnownUniquelyReferenced(_:)` currently returns false for any object that 
has (or has ever had) a weak reference to it. This is a regression from Swift 3.1 (and before), where the function ignored any weak references.

The regression is caused by an unimplemented path in the Swift runtime's implementation of `isKnownUniquelyReferenced(_:)`. This PR implements the missing codepath, resolving the issue.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5633](https://bugs.swift.org/browse/SR-5633).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
