### PR TITLE
Sema: Fix pre-check expression folding nested types of generic parameters

### DIFF
--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -104,14 +104,13 @@ func takesInner(_: [Outer.Middle.GenericInner<Int>]) {}
 takesInner([Outer.Middle.GenericInner<Int>]())
 takesInner([array.Outer.Middle.GenericInner<Int>]())
 
-// FIXME: We should support this with nested types of generic parameters also
 protocol HasAssocType {
   associatedtype A
 }
 
-func takesAssocType<T : HasAssocType>(_: T, _: [T.A]) {}
+func takesAssocType<T : HasAssocType>(_: T, _: [T.A], _: [T.A?]) {}
 
 func passAssocType<T : HasAssocType>(_ t: T) {
-  takesAssocType(t, [T.A]())
-  // expected-error@-1 {{cannot call value of non-function type '[T.A.Type]'}}
+  takesAssocType(t, [T.A](), [T.A?]())
 }
+

--- a/validation-test/compiler_crashers_fixed/28777-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28777-swift-typebase-getcanonicaltype.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{<a.h=a
-class a<H
+// RUN: not %target-swift-frontend %s -emit-ir
+{
+f
+typealias a:b{}var f=a.a

--- a/validation-test/compiler_crashers_fixed/28811-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28811-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{
-f
-typealias a:b{}var f=a.a
+// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+{<a.h=a
+class a<H


### PR DESCRIPTION
This allows `[Foo.Bar]()`, `[Foo.Bar?]()` etc to type check if Bar is
an associated type of a generic parameter Foo.

Fixes <rdar://problem/27631137>.