### PR TITLE
[swiftc (48 vs. 5588)] Add crasher in swift::TypeChecker::validateExtension(...)

### DIFF
--- a/validation-test/compiler_crashers/28830-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
+++ b/validation-test/compiler_crashers/28830-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{protocol a:P}extension P.a.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateExtension(...)`.

Current number of unresolved compiler crashers: 48 (5588 resolved)

Stack trace:

```
0 0x0000000003f81e94 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f81e94)
1 0x0000000003f821d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3f821d6)
2 0x00007f72592e4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000125ca20 formExtensionInterfaceType(swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x125ca20)
4 0x000000000125ca29 formExtensionInterfaceType(swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x125ca29)
5 0x000000000123ee82 checkExtensionGenericParams(swift::TypeChecker&, swift::ExtensionDecl*, swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x123ee82)
6 0x000000000123229f swift::TypeChecker::validateExtension(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x123229f)
7 0x00000000012492eb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12492eb)
8 0x0000000001238194 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1238194)
9 0x0000000001238093 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1238093)
10 0x00000000012c7e94 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12c7e94)
11 0x0000000000ffa5d7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xffa5d7)
12 0x00000000004bc0e0 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bc0e0)
13 0x00000000004ba654 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4ba654)
14 0x00000000004732b4 main (/path/to/swift/bin/swift+0x4732b4)
15 0x00007f72577f4830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
16 0x0000000000470b69 _start (/path/to/swift/bin/swift+0x470b69)
```