### PR TITLE
[FrontendTool] Make emit-syntax perform parse only

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -583,6 +583,7 @@ static bool performCompile(CompilerInstance &Instance,
 
   if (Action == FrontendOptions::Parse ||
       Action == FrontendOptions::DumpParse ||
+      Action == FrontendOptions::EmitSyntax ||
       Action == FrontendOptions::DumpInterfaceHash ||
       Action == FrontendOptions::EmitImportedModules)
     Instance.performParseOnly();


### PR DESCRIPTION
Previously, `emit-syntax` performed semantic analysis. It should only perform parse.