### PR TITLE
[4.0] Emit TBD separately and add -tbd-install_name

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -119,6 +119,9 @@ public:
   /// The path to which we should output a loaded module trace file.
   std::string LoadedModuleTracePath;
 
+  /// The path to which we should output a TBD file.
+  std::string TBDPath;
+
   /// Arguments which should be passed in immediate mode.
   std::vector<std::string> ImmediateArgv;
 
@@ -170,7 +173,6 @@ public:
     /// Parse, type-check, and dump type refinement context hierarchy
     DumpTypeRefinementContexts,
 
-    EmitTBD, ///< Emit a TBD file for this module
     EmitImportedModules, ///< Emit the modules that this one imports
     EmitPCH, ///< Emit PCH of imported bridging header
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -295,6 +295,9 @@ public:
   /// Compare the symbols in the IR against the TBD file we would generate.
   TBDValidationMode ValidateTBDAgainstIR = TBDValidationMode::None;
 
+  /// The install_name to use in the TBD file.
+  std::string TBDInstallName;
+
   /// An enum with different modes for automatically crashing at defined times.
   enum class DebugCrashMode {
     None, ///< Don't automatically crash.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -58,6 +58,13 @@ def emit_fixits_path
   : Separate<["-"], "emit-fixits-path">, MetaVarName<"<path>">,
     HelpText<"Output compiler fixits as source edits to <path>">;
 
+def tbd_install_name
+  : Separate<["-"], "tbd-install_name">, MetaVarName<"<path>">,
+    HelpText<"The install_name to use in an emitted TBD file">;
+
+def tbd_install_name_EQ : Joined<["-"], "tbd-install_name=">,
+  Alias<tbd_install_name>;
+
 def verify : Flag<["-"], "verify">,
   HelpText<"Verify diagnostics against expected-{error|warning|note} "
            "annotations">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -209,6 +209,16 @@ def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-pa
 def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-path=">,
   Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_loaded_module_trace_path>;
 
+def emit_tbd : Flag<["-"], "emit-tbd">,
+  HelpText<"Emit a TBD file">,
+  Flags<[FrontendOption, NoInteractiveOption]>;
+def emit_tbd_path : Separate<["-"], "emit-tbd-path">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Emit the TBD file to <path>">,
+  MetaVarName<"<path>">;
+def emit_tbd_path_EQ : Joined<["-"], "emit-tbd-path=">,
+  Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_tbd_path>;
+
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Serialize diagnostics in a binary format">;
@@ -531,9 +541,6 @@ def emit_sibgen : Flag<["-"], "emit-sibgen">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def emit_imported_modules : Flag<["-"], "emit-imported-modules">,
   HelpText<"Emit a list of the imported modules">, ModeOpt,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
-def emit_tbd : Flag<["-"], "emit-tbd">,
-  HelpText<"Emit a TBD file">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
 def c : Flag<["-"], "c">, Alias<emit_object>,

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -12,14 +12,28 @@
 #ifndef SWIFT_IRGEN_TBDGEN_H
 #define SWIFT_IRGEN_TBDGEN_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace swift {
 class FileUnit;
+class ModuleDecl;
 
 void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,
-                            bool hasMultipleIRGenThreads, bool isWholeModule,
+                            bool hasMultipleIRGenThreads,
                             bool silSerializeWitnessTables);
+void enumeratePublicSymbols(ModuleDecl *module, llvm::StringSet<> &symbols,
+                            bool hasMultipleIRGenThreads,
+                            bool silSerializeWitnessTables);
+
+void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
+                  bool hasMultipleIRGenThreads, bool silSerializeWitnessTables,
+                  llvm::StringRef installName);
+
 } // end namespace swift
 
 #endif

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -231,9 +231,6 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_ImportedModules:
       FrontendModeOption = "-emit-imported-modules";
       break;
-    case types::TY_TBD:
-      FrontendModeOption = "-emit-tbd";
-      break;
 
     // BEGIN APPLE-ONLY OUTPUT TYPES
     case types::TY_IndexData:
@@ -263,6 +260,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_Image:
     case types::TY_SwiftDeps:
     case types::TY_ModuleTrace:
+    case types::TY_TBD:
       llvm_unreachable("Output type can never be primary output.");
     case types::TY_INVALID:
       llvm_unreachable("Invalid type ID");
@@ -433,6 +431,13 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (!LoadedModuleTracePath.empty()) {
     Arguments.push_back("-emit-loaded-module-trace-path");
     Arguments.push_back(LoadedModuleTracePath.c_str());
+  }
+
+  const std::string &TBDPath =
+      context.Output.getAdditionalOutputForType(types::TY_TBD);
+  if (!TBDPath.empty()) {
+    Arguments.push_back("-emit-tbd-path");
+    Arguments.push_back(TBDPath.c_str());
   }
 
   if (context.Args.hasArg(options::OPT_migrate_keep_objc_visibility)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -310,8 +310,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::EmitPCH;
     } else if (Opt.matches(OPT_emit_imported_modules)) {
       Action = FrontendOptions::EmitImportedModules;
-    } else if (Opt.matches(OPT_emit_tbd)) {
-      Action = FrontendOptions::EmitTBD;
     } else if (Opt.matches(OPT_parse)) {
       Action = FrontendOptions::Parse;
     } else if (Opt.matches(OPT_typecheck)) {
@@ -597,13 +595,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       else
         Suffix = "importedmodules";
       break;
-
-    case FrontendOptions::EmitTBD:
-      if (Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
-      else
-        Suffix = "tbd";
-      break;
     }
 
     if (!Suffix.empty()) {
@@ -713,6 +704,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
                           OPT_emit_loaded_module_trace_path,
                           "trace.json", false);
 
+  determineOutputFilename(Opts.TBDPath, OPT_emit_tbd, OPT_emit_tbd_path, "tbd",
+                          false);
+
   if (const Arg *A = Args.getLastArg(OPT_emit_fixits_path)) {
     Opts.FixitsOutputPath = A->getValue();
   }
@@ -763,7 +757,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }
@@ -794,7 +787,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }
@@ -826,7 +818,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }
@@ -861,7 +852,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
     case FrontendOptions::EmitImportedModules:
-    case FrontendOptions::EmitTBD:
       break;
     }
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -211,6 +211,10 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     }
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_tbd_install_name)) {
+    Opts.TBDInstallName = A->getValue();
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_warn_long_function_bodies)) {
     unsigned attempt;
     if (StringRef(A->getValue()).getAsInteger(10, attempt)) {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -43,7 +43,6 @@ bool FrontendOptions::actionHasOutput() const {
   case EmitBC:
   case EmitObject:
   case EmitImportedModules:
-  case EmitTBD:
     return true;
   }
   llvm_unreachable("Unknown ActionType");
@@ -75,7 +74,6 @@ bool FrontendOptions::actionIsImmediate() const {
   case EmitBC:
   case EmitObject:
   case EmitImportedModules:
-  case EmitTBD:
     return false;
   }
   llvm_unreachable("Unknown ActionType");

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -684,8 +684,12 @@ static bool performCompile(CompilerInstance &Instance,
   if (!opts.TBDPath.empty()) {
     const auto &silOpts = Invocation.getSILOptions();
     auto hasMultipleIRGenThreads = silOpts.NumThreads > 1;
+    auto installName = opts.TBDInstallName.empty()
+                           ? "lib" + Invocation.getModuleName().str() + ".dylib"
+                           : opts.TBDInstallName;
+
     if (writeTBD(Instance.getMainModule(), hasMultipleIRGenThreads,
-                 silOpts.SILSerializeWitnessTables, opts.TBDPath))
+                 silOpts.SILSerializeWitnessTables, opts.TBDPath, installName))
       return true;
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -681,12 +681,12 @@ static bool performCompile(CompilerInstance &Instance,
     return Context.hadError();
   }
 
-  if (Action == FrontendOptions::EmitTBD) {
+  if (!opts.TBDPath.empty()) {
     const auto &silOpts = Invocation.getSILOptions();
     auto hasMultipleIRGenThreads = silOpts.NumThreads > 1;
-    return writeTBD(Instance.getMainModule(), hasMultipleIRGenThreads,
-                    silOpts.SILSerializeWitnessTables,
-                    opts.getSingleOutputFilename());
+    if (writeTBD(Instance.getMainModule(), hasMultipleIRGenThreads,
+                 silOpts.SILSerializeWitnessTables, opts.TBDPath))
+      return true;
   }
 
   assert(Action >= FrontendOptions::EmitSILGen &&

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -25,7 +25,8 @@ class FileUnit;
 class FrontendOptions;
 
 bool writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
-              bool silSerializeWitnessTables, llvm::StringRef OutputFilename);
+              bool silSerializeWitnessTables, llvm::StringRef OutputFilename,
+              llvm::StringRef installName);
 bool inputFileKindCanHaveTBDValidated(InputFileKind kind);
 bool validateTBD(ModuleDecl *M, llvm::Module &IRModule,
                  bool hasMultipleIRGenThreads, bool silSerializeWitnessTables,

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -28,100 +28,16 @@
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/StringSet.h"
 
+#include "TBDGenVisitor.h"
+
 using namespace swift;
 using namespace swift::irgen;
+using namespace swift::tbdgen;
 using StringSet = llvm::StringSet<>;
 
 static bool isPrivateDecl(ValueDecl *VD) {
   return getDeclLinkage(VD) != FormalLinkage::PublicUnique;
 }
-
-namespace {
-class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
-  StringSet &Symbols;
-  const UniversalLinkageInfo &UniversalLinkInfo;
-  ModuleDecl *SwiftModule;
-  bool FileHasEntryPoint;
-  bool SILSerializeWitnessTables;
-
-  bool InsideAbstractStorageDecl = false;
-
-  void addSymbol(StringRef name) {
-    auto isNewValue = Symbols.insert(name).second;
-    (void)isNewValue;
-    assert(isNewValue && "already inserted");
-  }
-
-  void addSymbol(SILDeclRef declRef);
-
-  void addSymbol(LinkEntity entity) {
-    auto linkage =
-        LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
-
-    auto externallyVisible =
-        llvm::GlobalValue::isExternalLinkage(linkage.getLinkage()) &&
-        linkage.getVisibility() != llvm::GlobalValue::HiddenVisibility;
-
-    if (externallyVisible)
-      addSymbol(linkage.getName());
-  }
-
-  void addConformances(DeclContext *DC);
-
-public:
-  TBDGenVisitor(StringSet &symbols,
-                const UniversalLinkageInfo &universalLinkInfo,
-                ModuleDecl *swiftModule, bool fileHasEntryPoint,
-                bool silSerializeWitnessTables)
-      : Symbols(symbols), UniversalLinkInfo(universalLinkInfo),
-        SwiftModule(swiftModule), FileHasEntryPoint(fileHasEntryPoint),
-        SILSerializeWitnessTables(silSerializeWitnessTables) {}
-
-  void visitMembers(Decl *D) {
-    SmallVector<Decl *, 4> members;
-    auto addMembers = [&](DeclRange range) {
-      for (auto member : range)
-        members.push_back(member);
-    };
-    if (auto ED = dyn_cast<ExtensionDecl>(D))
-      addMembers(ED->getMembers());
-    else if (auto NTD = dyn_cast<NominalTypeDecl>(D))
-      addMembers(NTD->getMembers());
-    else if (auto ASD = dyn_cast<AbstractStorageDecl>(D))
-      ASD->getAllAccessorFunctions(members);
-
-    for (auto member : members) {
-      ASTVisitor::visit(member);
-    }
-  }
-
-  void visitPatternBindingDecl(PatternBindingDecl *PBD);
-
-  void visitValueDecl(ValueDecl *VD);
-
-  void visitAbstractFunctionDecl(AbstractFunctionDecl *AFD);
-
-  void visitTypeAliasDecl(TypeAliasDecl *TAD) {
-    // any information here is encoded elsewhere
-  }
-
-  void visitNominalTypeDecl(NominalTypeDecl *NTD);
-
-  void visitClassDecl(ClassDecl *CD);
-
-  void visitConstructorDecl(ConstructorDecl *CD);
-
-  void visitExtensionDecl(ExtensionDecl *ED);
-
-  void visitProtocolDecl(ProtocolDecl *PD);
-
-  void visitAbstractStorageDecl(AbstractStorageDecl *ASD);
-
-  void visitVarDecl(VarDecl *VD);
-
-  void visitDecl(Decl *D) { visitMembers(D); }
-};
-} // end anonymous namespace
 
 static bool isGlobalOrStaticVar(VarDecl *VD) {
   return VD->isStatic() || VD->getDeclContext()->isModuleScopeContext();

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -41,6 +41,7 @@ public:
   const llvm::Triple &Triple;
   const UniversalLinkageInfo &UniversalLinkInfo;
   ModuleDecl *SwiftModule;
+  StringRef InstallName;
 
 private:
   bool FileHasEntryPoint = false;
@@ -73,9 +74,10 @@ private:
 public:
   TBDGenVisitor(StringSet &symbols, const llvm::Triple &triple,
                 const UniversalLinkageInfo &universalLinkInfo,
-                ModuleDecl *swiftModule, bool silSerializeWitnessTables)
+                ModuleDecl *swiftModule, bool silSerializeWitnessTables,
+                StringRef installName)
       : Symbols(symbols), Triple(triple), UniversalLinkInfo(universalLinkInfo),
-        SwiftModule(swiftModule),
+        SwiftModule(swiftModule), InstallName(installName),
         SILSerializeWitnessTables(silSerializeWitnessTables) {}
 
   void setFileHasEntryPoint(bool hasEntryPoint) {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -1,0 +1,135 @@
+//===--- TBDGenVisitor.h - AST Visitor for TBD generation -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the visitor that finds all symbols in a swift AST.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_TBDGEN_TBDGENVISITOR_H
+#define SWIFT_TBDGEN_TBDGENVISITOR_H
+
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTVisitor.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/IRGen/Linking.h"
+#include "swift/SIL/FormalLinkage.h"
+#include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/SILWitnessTable.h"
+#include "swift/SIL/TypeLowering.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/Triple.h"
+
+using namespace swift::irgen;
+using StringSet = llvm::StringSet<>;
+
+namespace swift {
+namespace tbdgen {
+
+class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
+public:
+  StringSet &Symbols;
+  const llvm::Triple &Triple;
+  const UniversalLinkageInfo &UniversalLinkInfo;
+  ModuleDecl *SwiftModule;
+
+private:
+  bool FileHasEntryPoint = false;
+  bool SILSerializeWitnessTables;
+
+  bool InsideAbstractStorageDecl = false;
+
+  void addSymbol(StringRef name) {
+    auto isNewValue = Symbols.insert(name).second;
+    (void)isNewValue;
+    assert(isNewValue && "already inserted");
+  }
+
+  void addSymbol(SILDeclRef declRef);
+
+  void addSymbol(LinkEntity entity) {
+    auto linkage =
+        LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
+
+    auto externallyVisible =
+        llvm::GlobalValue::isExternalLinkage(linkage.getLinkage()) &&
+        linkage.getVisibility() != llvm::GlobalValue::HiddenVisibility;
+
+    if (externallyVisible)
+      addSymbol(linkage.getName());
+  }
+
+  void addConformances(DeclContext *DC);
+
+public:
+  TBDGenVisitor(StringSet &symbols, const llvm::Triple &triple,
+                const UniversalLinkageInfo &universalLinkInfo,
+                ModuleDecl *swiftModule, bool silSerializeWitnessTables)
+      : Symbols(symbols), Triple(triple), UniversalLinkInfo(universalLinkInfo),
+        SwiftModule(swiftModule),
+        SILSerializeWitnessTables(silSerializeWitnessTables) {}
+
+  void setFileHasEntryPoint(bool hasEntryPoint) {
+    FileHasEntryPoint = hasEntryPoint;
+
+    if (hasEntryPoint)
+      addSymbol("main");
+  }
+
+  void visitMembers(Decl *D) {
+    SmallVector<Decl *, 4> members;
+    auto addMembers = [&](DeclRange range) {
+      for (auto member : range)
+        members.push_back(member);
+    };
+    if (auto ED = dyn_cast<ExtensionDecl>(D))
+      addMembers(ED->getMembers());
+    else if (auto NTD = dyn_cast<NominalTypeDecl>(D))
+      addMembers(NTD->getMembers());
+    else if (auto ASD = dyn_cast<AbstractStorageDecl>(D))
+      ASD->getAllAccessorFunctions(members);
+
+    for (auto member : members) {
+      ASTVisitor::visit(member);
+    }
+  }
+
+  void visitPatternBindingDecl(PatternBindingDecl *PBD);
+
+  void visitValueDecl(ValueDecl *VD);
+
+  void visitAbstractFunctionDecl(AbstractFunctionDecl *AFD);
+
+  void visitTypeAliasDecl(TypeAliasDecl *TAD) {
+    // any information here is encoded elsewhere
+  }
+
+  void visitNominalTypeDecl(NominalTypeDecl *NTD);
+
+  void visitClassDecl(ClassDecl *CD);
+
+  void visitConstructorDecl(ConstructorDecl *CD);
+
+  void visitExtensionDecl(ExtensionDecl *ED);
+
+  void visitProtocolDecl(ProtocolDecl *PD);
+
+  void visitAbstractStorageDecl(AbstractStorageDecl *ASD);
+
+  void visitVarDecl(VarDecl *VD);
+
+  void visitDecl(Decl *D) { visitMembers(D); }
+};
+} // end namespace tbdgen
+} // end namespace swift
+
+#endif

--- a/test/reproducible-builds/swiftc-emit-tbd.swift
+++ b/test/reproducible-builds/swiftc-emit-tbd.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -O -g -module-name foo -emit-tbd %s -o %t/run-1.tbd
-// RUN: %target-build-swift -O -g -module-name foo -emit-tbd %s -o %t/run-2.tbd
+// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-1.tbd -force-single-frontend-invocation
+// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-2.tbd -force-single-frontend-invocation
 // RUN: diff -u %t/run-1.tbd %t/run-2.tbd
 print("foo")


### PR DESCRIPTION
#11219 #11305 

Train: swift-4.0-branch
Radar: rdar://problem/33556002
Explanation: TBD files have a specific format, we were initially working with a simple MVP format, but this needs to be changed for the linker to actually be able to read it.
Scope of Issue: This is critical for InstallAPI, and shouldn't affect anyone negatively because it only makes major changes to code that executes with the -emit-tbd flag.
Origination: Part of the TBD work.
Risk: Low: the only major changes are to code that executes with the -emit-tbd flag, with the minor addition of the -tbd-install_name flag to the frontend.
Reviewed By: Slava Pestov
Testing: CI including new test testing that the linker can understand and link the emitted TBD files.
Directions for QE: N/A