### PR TITLE
[ConstraintSolver] Fix computeFavoredTypeForExpr not to impose types …

### DIFF
--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -496,3 +496,11 @@ extension Sequence {
   func foo24329052<Element>(_ v: Element) { rdar24329052(v) }
   // expected-error@-1 {{cannot convert value of type 'Element' (generic parameter of instance method 'foo24329052(_:)') to expected argument type 'Self.Element' (associated type of protocol 'Sequence')}}
 }
+
+func rdar27700622<E: Comparable>(_ input: [E]) -> [E] {
+  let pivot = input.first!
+  let lhs = input.dropFirst().filter { $0 <= pivot }
+  let rhs = input.dropFirst().filter { $0 > pivot }
+
+  return rdar27700622(lhs) + [pivot] + rdar27700622(rhs) // Ok
+}

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -152,3 +152,27 @@ let bar_33759839 = ["A", "B", "C"]
 let _: [E_33759839] = foo_33759839.map { .bar($0) } +
                       bar_33759839.map { .bar($0) } +
                       [E_33759839.foo] // Ok
+
+// rdar://problem/28688585
+
+class B_28688585 {
+  var value: Int
+
+  init(value: Int) {
+    self.value = value
+  }
+
+  func add(_ other: B_28688585) -> B_28688585 {
+    return B_28688585(value: value + other.value)
+  }
+}
+
+class D_28688585 : B_28688585 {
+}
+
+func + (lhs: B_28688585, rhs: B_28688585) -> B_28688585 {
+  return lhs.add(rhs)
+}
+
+let var_28688585 = D_28688585(value: 1)
+_ = var_28688585 + var_28688585 + var_28688585 // Ok

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -138,3 +138,17 @@ func shrinkTooFar(_ : Double, closure : ()->()) {}
 func testShrinkTooFar() {
   shrinkTooFar(0*0*0) {}
 }
+
+// rdar://problem/33759839
+
+enum E_33759839 {
+    case foo
+    case bar(String)
+}
+
+let foo_33759839 = ["a", "b", "c"]
+let bar_33759839 = ["A", "B", "C"]
+
+let _: [E_33759839] = foo_33759839.map { .bar($0) } +
+                      bar_33759839.map { .bar($0) } +
+                      [E_33759839.foo] // Ok


### PR DESCRIPTION
…on the merged binary operators

`LinkedExprAnalyzer` is not always precise in collecting types of expressions,
so let's not try to impose anything upon linked operator expressions, which are
"mergable", except actually merging argument/result types together to help
constraint solver.

Resolves: rdar://problem/27700622

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
