### PR TITLE
[silgen] Verify that all ManagedValues in all RValues that are loadable are actual loaded (i.e. have object type).

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -79,6 +79,16 @@ public:
   }
 
   void visitType(CanType formalType, ManagedValue v) {
+    // If we have a loadable type that has not been loaded, actually load it.
+    if (v.getType().isLoadable(SGF.getModule()) &&
+        !v.getType().isObject()) {
+      if (v.hasCleanup()) {
+        v = SGF.B.createLoadTake(loc, v);
+      } else {
+        v = SGF.B.createLoadBorrow(loc, v);
+      }
+    }
+
     values.push_back(v);
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1537,7 +1537,7 @@ static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
     TupleTypeElt TypeElts[] = {Elts[0].getType().getSwiftRValueType()};
     CanType ty =
         TupleType::get(TypeElts, SGF.getASTContext())->getCanonicalType();
-    return RValue::withPreExplodedElements(Elts, ty);
+    return RValue(SGF, Elts, ty);
   }
 
   // The string literal provides the data.
@@ -1582,7 +1582,7 @@ static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
 
   CanType ty =
     TupleType::get(TypeElts, SGF.getASTContext())->getCanonicalType();
-  return RValue::withPreExplodedElements(Elts, ty);
+  return RValue(SGF, Elts, ty);
 }
 
 /// Emit a raw apply operation, performing no additional lowering of
@@ -5271,7 +5271,7 @@ emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
 
   // (buffer, callbackStorage)  or (buffer, callbackStorage, indices) ->
   // Note that this "RValue" stores a mixed LValue/RValue tuple.
-  RValue args = [&] {
+  RValue args = [&] () -> RValue {
     SmallVector<ManagedValue, 4> elts;
 
     auto bufferPtr =
@@ -5284,7 +5284,7 @@ emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
     if (!subscripts.isNull()) {
       std::move(subscripts).getAll(elts);
     }
-    return RValue::withPreExplodedElements(elts, accessType.getInput());
+    return RValue(*this, elts, accessType.getInput());
   }();
   emission.addCallSite(loc, ArgumentSource(loc, std::move(args)), accessType);
   // (buffer, optionalCallback)

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -265,8 +265,7 @@ static ManagedValue emitBuiltinAssign(SILGenFunction &gen,
                                                /*isInvariant*/ false);
   
   // Build the value to be assigned, reconstructing tuples if needed.
-  auto src = RValue::withPreExplodedElements(args.slice(0, args.size() - 1),
-                                             assignFormalType);
+  auto src = RValue(gen, args.slice(0, args.size() - 1), assignFormalType);
   
   std::move(src).assignInto(gen, loc, addr);
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4558,8 +4558,7 @@ public:
         loc, loadedBase.getUnmanagedValue(), unownedType);
 
     // A reference type should never be exploded.
-    return RValue::withPreExplodedElements(ManagedValue::forUnmanaged(unowned),
-                                           refType);
+    return RValue(gen, ManagedValue::forUnmanaged(unowned), refType);
   }
 
   /// Compare 'this' lvalue and the 'rhs' lvalue (which is guaranteed to have

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1206,8 +1206,8 @@ namespace {
           CanType type = subscripts.getType();
           SmallVector<ManagedValue, 4> values;
           std::move(subscripts).getAll(values);
-          subscripts = RValue::withPreExplodedElements(values, type);
-          borrowedSubscripts = RValue::withPreExplodedElements(values, type);
+          subscripts = RValue(SGF, values, type);
+          borrowedSubscripts = RValue(SGF, values, type);
           optSubscripts = &borrowedSubscripts;
         }
         return new GetterSetterComponent(decl, IsSuper, IsDirectAccessorUse,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -319,7 +319,7 @@ RValue Transform::transform(RValue &&input,
     return RValue::forInContext();
   }
 
-  return RValue::withPreExplodedElements(outputExpansion, outputTupleType);
+  return RValue(SGF, outputExpansion, outputTupleType);
 }
 
 // Single @objc protocol value metatypes can be converted to the ObjC

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -117,8 +117,10 @@ public func foo(_ x: Double) {
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
+  // CHECK: [[ZVAL_2:%.*]] = load [trivial] [[ZTMP]]
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetRadius : $@convention(c) (@in Struct1) -> Double
-  // CHECK: apply [[GET]]([[ZTMP]])
+  // CHECK: store [[ZVAL_2]] to [trivial] [[ZTMP_2:%.*]] :
+  // CHECK: apply [[GET]]([[ZTMP_2]])
   _ = z.radius
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]


### PR DESCRIPTION
[silgen] Verify that all ManagedValues in all RValues that are loadable are actual loaded (i.e. have object type).

This is already an RValue invariant that used to be enforced upon RValue
construction. We put in a hack to work around a bug where that was not occuring
and changed RValue constructors to instead load stored objects when they needed
to. But the problem is that since then we have added more constructors that
provide other manners to create such an invalid RValue.

I added verification to many parts of RValue and exposed an additional verify
method that we can invoke at the end of emitRValue() eventually to verify our
invariants. This will give me the comfort to make that assumption in other parts
of SILGen without worry.

rdar://33358110