### PR TITLE
Enable more sanitizer tests on Linux.

### DIFF
--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -o %t_asan-binary
 // RUN: not env %env-ASAN_OPTIONS=abort_on_error=0 %target-run %t_asan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
-// REQUIRES: objc_interop
 // REQUIRES: asan_runtime
 
 // Make sure we can handle swifterror. LLVM's address sanitizer pass needs to

--- a/test/Sanitizers/witness_table_lookup.swift
+++ b/test/Sanitizers/witness_table_lookup.swift
@@ -2,7 +2,6 @@
 // RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
-// REQUIRES: objc_interop
 
 // Check that TSan does not report spurious races in witness table lookup.
 


### PR DESCRIPTION
The logic for sanitizer usage was ported to Linux; there's no reason to exclude those tests now.