### PR TITLE
[QoI] Better mutation attribute diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1012,8 +1012,8 @@ ERROR(attribute_requires_single_argument,none,
 ERROR(mutating_invalid_global_scope,none,
       "'mutating' is only valid on methods", ())
 ERROR(mutating_invalid_classes,none,
-      "'mutating' isn't valid on methods in classes or class-bound protocols",
-      ())
+      "'%select{|non}0mutating' isn't valid on methods in classes or class-bound protocols",
+      (bool))
 ERROR(functions_mutating_and_not,none,
       "method may not be declared both mutating and nonmutating", ())
 ERROR(static_functions_not_mutating,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -284,20 +284,21 @@ void AttributeEarlyChecker::visitTransparentAttr(TransparentAttr *attr) {
 void AttributeEarlyChecker::visitMutationAttr(DeclAttribute *attr) {
   FuncDecl *FD = cast<FuncDecl>(D);
 
+  // Verify we don't have both mutating and nonmutating.
+  if (FD->getAttrs().hasAttribute<MutatingAttr>() &&
+      FD->getAttrs().getAttribute<NonMutatingAttr>()) {
+    TC.diagnose(attr->getLocation(), diag::functions_mutating_and_not);
+    attr->setInvalid();
+  }
+
   auto contextTy = FD->getDeclContext()->getDeclaredInterfaceType();
   if (!contextTy)
     return diagnoseAndRemoveAttr(attr, diag::mutating_invalid_global_scope);
 
   if (contextTy->hasReferenceSemantics())
-    return diagnoseAndRemoveAttr(attr, diag::mutating_invalid_classes);
-  
-  // Verify we don't have both mutating and nonmutating.
-  if (FD->getAttrs().hasAttribute<MutatingAttr>())
-    if (auto *NMA = FD->getAttrs().getAttribute<NonMutatingAttr>()) {
-      diagnoseAndRemoveAttr(NMA, diag::functions_mutating_and_not);
-      if (NMA == attr) return;
-    }
-  
+    return diagnoseAndRemoveAttr(attr, diag::mutating_invalid_classes,
+                                 isa<NonMutatingAttr>(attr));
+
   // Verify that we don't have a static function.
   if (FD->isStatic())
     return diagnoseAndRemoveAttr(attr, diag::static_functions_not_mutating);

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -61,6 +61,12 @@ class FooClass {
   mutating            // expected-error {{'mutating' isn't valid on methods in classes or class-bound protocols}} {{3-12=}}
   func baz() {}
 
+  nonmutating         // expected-error {{'nonmutating' isn't valid on methods in classes or class-bound protocols}} {{3-15=}}
+  func bay() {}
+
+  mutating nonmutating // expected-error {{method may not be declared both mutating and nonmutating}} expected-error {{'mutating' isn't valid on methods in classes or class-bound protocols}} expected-error {{'nonmutating' isn't valid on methods in classes or class-bound protocols}}
+  func bax() {}
+
   var x : Int {
     get {
       return 32
@@ -459,7 +465,7 @@ struct F { // expected-note 1 {{in declaration of 'F'}}
   mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{expected declaration}}
   }
   
-  mutating nonmutating func g() {  // expected-error {{method may not be declared both mutating and nonmutating}} {{12-24=}}
+  mutating nonmutating func g() {  // expected-error {{method may not be declared both mutating and nonmutating}}
   }
 }
 


### PR DESCRIPTION
1) Move the "both" check up and don't prematurely return because there
   may be more errors.
2) Remove fix-it when both attributes exist. We simply don't know which
   attribute the programmer wants to keep.
3) Correctly diagnose 'nonmutating'.

This is the same as pull request #11359, which swift-ci was weirdly ignoring.