### PR TITLE
[silgen] Teach SILGen how to push a +1 rvalue through a scope like we already can do for +1 managed values.

### DIFF
--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_library(swiftSILGen STATIC
   ManagedValue.cpp
   ResultPlan.cpp
   RValue.cpp
+  Scope.cpp
   SwitchCaseFullExpr.cpp
   SILGen.cpp
   SILGenApply.cpp

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -31,7 +31,9 @@ namespace swift {
 namespace Lowering {
 
 class Initialization;
+class Scope;
 class SILGenFunction;
+class TypeLowering;
 
 /// An "exploded" SIL rvalue, in which tuple values are recursively
 /// destructured.
@@ -66,6 +68,8 @@ class SILGenFunction;
 /// *NOTE* In SILGen we don't try to explode structs, because doing so would
 /// require considering resilience, a job we want to delegate to IRGen.
 class RValue {
+  friend class swift::Lowering::Scope;
+
   std::vector<ManagedValue> values;
   CanType type;
   unsigned elementsToBeAdded;
@@ -293,6 +297,12 @@ public:
   void extractElements(SmallVectorImpl<RValue> &elements) &&;
   
   CanType getType() const & { return type; }
+
+  /// Return the lowered type associated with the given CanType's type lowering.
+  SILType getLoweredType(SILGenFunction &SGF) const &;
+
+  /// Return the type lowering of RValue::getType().
+  const Lowering::TypeLowering &getTypeLowering(SILGenFunction &SGF) const &;
 
   /// Rewrite the type of this r-value.
   void rewriteType(CanType newType) & {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -15,6 +15,7 @@
 
 #include "JumpDest.h"
 #include "ManagedValue.h"
+#include "RValue.h"
 #include "swift/SIL/SILBuilder.h"
 
 namespace swift {
@@ -350,15 +351,19 @@ class CleanupCloner {
   SILGenFunction &SGF;
   bool hasCleanup;
   bool isLValue;
-  ValueOwnershipKind ownershipKind;
 
 public:
   CleanupCloner(SILGenFunction &SGF, ManagedValue mv)
-      : SGF(SGF), hasCleanup(mv.hasCleanup()), isLValue(mv.isLValue()),
-        ownershipKind(mv.getOwnershipKind()) {}
+      : SGF(SGF), hasCleanup(mv.hasCleanup()), isLValue(mv.isLValue()) {}
 
   CleanupCloner(SILGenBuilder &builder, ManagedValue mv)
       : CleanupCloner(builder.getSILGenFunction(), mv) {}
+
+  CleanupCloner(SILGenFunction &SGF, const RValue &rv)
+      : SGF(SGF), hasCleanup(rv.isPlusOne(SGF)), isLValue(false) {}
+
+  CleanupCloner(SILGenBuilder &builder, const RValue &rv)
+      : CleanupCloner(builder.getSILGenFunction(), rv) {}
 
   ManagedValue clone(SILValue value) const;
 };

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -1,0 +1,69 @@
+//===--- Scope.cpp --------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "Scope.h"
+
+using namespace swift;
+using namespace Lowering;
+
+ManagedValue Scope::popPreservingValue(ManagedValue mv) {
+  // If we have a value, make sure that it is an object. The reason why is
+  // that we want to make sure that we are not forwarding a cleanup for a
+  // stack location that will be destroyed by this scope.
+  assert(mv && mv.getType().isObject() &&
+         (mv.getType().isTrivial(cleanups.SGF.getModule()) ||
+          mv.getOwnershipKind() == ValueOwnershipKind::Trivial ||
+          mv.hasCleanup()));
+  CleanupCloner cloner(cleanups.SGF, mv);
+  SILValue value = mv.forward(cleanups.SGF);
+  pop();
+  return cloner.clone(value);
+}
+
+RValue Scope::popPreservingValue(RValue &&rv) {
+  assert(rv.isPlusOne(cleanups.SGF) &&
+         "Can only push plus one rvalues through a scope");
+  assert(rv.getTypeLowering(cleanups.SGF).isLoadable() &&
+         "Can only push loadable +1 rvalues through a scope");
+
+  // First gather all of the data that we need to recreate the RValue in the
+  // outer scope.
+  CanType type = rv.type;
+  unsigned numEltsRemaining = rv.elementsToBeAdded;
+  CleanupCloner cloner(cleanups.SGF, rv);
+  llvm::SmallVector<SILValue, 4> values;
+  std::move(rv).forwardAll(cleanups.SGF, values);
+
+  // Then pop the cleanups.
+  pop();
+
+  // Reconstruct the managed values from the underlying sil values in the outer
+  // scope. Since the RValue wants a std::vector value, we use that instead.
+  std::vector<ManagedValue> managedValues;
+  std::transform(
+      values.begin(), values.end(), std::back_inserter(managedValues),
+      [&cloner](SILValue v) -> ManagedValue { return cloner.clone(v); });
+
+  // And then assemble the managed values into a rvalue.
+  return RValue(cleanups.SGF, std::move(managedValues), type, numEltsRemaining);
+}
+
+void Scope::popImpl() {
+  cleanups.stack.checkIterator(depth);
+  cleanups.stack.checkIterator(cleanups.innermostScope);
+  assert(cleanups.innermostScope == depth && "popping scopes out of order");
+
+  cleanups.innermostScope = savedInnermostScope;
+  cleanups.endScope(depth, loc);
+  cleanups.stack.checkIterator(cleanups.innermostScope);
+  cleanups.popTopDeadCleanups(cleanups.innermostScope);
+}


### PR DESCRIPTION
This PR contains two commits.

The first one is:

```
[silgen] Teach SILGen how to push a +1 rvalue through a scope like we already can do for +1 managed values.

rdar://33358110
```

The second commit just removes code that I realized was actually dead. Now we only have 1 struct named EmitBBArguments in SILGen. = p.