### PR TITLE
[silgen][gardening] Standardize more parts of SILGen on using SGF instead of gen for the SILGenFunction.

### DIFF
--- a/lib/SILGen/Varargs.h
+++ b/lib/SILGen/Varargs.h
@@ -62,12 +62,12 @@ public:
 };
 
 /// Begin a varargs emission sequence.
-VarargsInfo emitBeginVarargs(SILGenFunction &gen, SILLocation loc,
+VarargsInfo emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
                              CanType baseTy, CanType arrayTy,
                              unsigned numElements);
 
 /// Successfully end a varargs emission sequence.
-ManagedValue emitEndVarargs(SILGenFunction &gen, SILLocation loc,
+ManagedValue emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
                             VarargsInfo &&varargs); 
 
 } // end namespace Lowering


### PR DESCRIPTION
[silgen][gardening] Standardize more parts of SILGen on using SGF instead of gen for the SILGenFunction.

This adds consistency and makes it easier to work in SILGen in the debugger
since using SGF or gen is not context dependent. You can just use gen.
