### PR TITLE
Vim: highlight #function macro, improve string interpolation highlighting

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -154,7 +154,7 @@ syn match swiftOperator "\.\.[<.]" skipwhite nextgroup=swiftTypeParameters
 
 syn match swiftChar /'\([^'\\]\|\\\(["'tnr0\\]\|x[0-9a-fA-F]\{2}\|u[0-9a-fA-F]\{4}\|U[0-9a-fA-F]\{8}\)\)'/
 
-syn match swiftPreproc /#\(\<file\>\|\<line\>\)/
+syn match swiftPreproc /#\(\<file\>\|\<line\>\|\<function\>\)/
 syn match swiftPreproc /^\s*#\(\<if\>\|\<else\>\|\<elseif\>\|\<endif\>\)/
 syn region swiftPreprocFalse start="^\s*#\<if\>\s\+\<false\>" end="^\s*#\(\<else\>\|\<elseif\>\|\<endif\>\)"
 

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -139,8 +139,8 @@ syn match swiftTypeDeclaration skipwhite nextgroup=swiftType,swiftInOutKeyword
 syn match swiftTypeDeclaration skipwhite nextgroup=swiftType
       \ /->/
 
-syn region swiftString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=swiftInterpolation
-syn region swiftInterpolation start=/\\(/ end=/)/ contained contains=swiftPreproc
+syn region swiftString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=swiftInterpolationRegion
+syn region swiftInterpolationRegion matchgroup=swiftInterpolation start=/\\(/ end=/)/ contained contains=TOP
 syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftLineComment,swiftTodo
 syn region swiftLineComment start="//" end="$" contains=swiftComment,swiftTodo
 

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -140,7 +140,7 @@ syn match swiftTypeDeclaration skipwhite nextgroup=swiftType
       \ /->/
 
 syn region swiftString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=swiftInterpolation
-syn region swiftInterpolation start=/\\(/ end=/)/ contained
+syn region swiftInterpolation start=/\\(/ end=/)/ contained contains=swiftPreproc
 syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftLineComment,swiftTodo
 syn region swiftLineComment start="//" end="$" contains=swiftComment,swiftTodo
 


### PR DESCRIPTION
This PR changes the vim plugin's syntax highlighting so that #function is also recognized as a preprocessor macro, and so that these macros are highlighted even when they appear in string interpolation. This matches the behavior of Xcode's highlighting and the highlighting provided by GitHub:

```swift
let mango: [Double] = []
#function
#line
"\(#function), \(data)"
"\(#line)"
```

Before this change:

![pasted image at 2017_08_08 04_43 pm](https://user-images.githubusercontent.com/15369640/29096648-cca08922-7c63-11e7-9e6e-4a3acb834c9d.png)

After:

![pasted image at 2017_08_08 04_44 pm](https://user-images.githubusercontent.com/15369640/29096649-cef299cc-7c63-11e7-9e2c-c884aa75d8dc.png)

---

To my knowledge, this doesn't resolve any bugs in the bug tracker.

It's not clear to me if this counts as a trivial check-in, since it doesn't impact any code for Swift or simulators. If I should run the CI tests please let me know.

