### PR TITLE
[ClangImporter] Avoid trying to import enums without definitions.

### DIFF
--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -36,6 +36,9 @@ using namespace importer;
 /// Classify the given Clang enumeration to describe how to import it.
 void EnumInfo::classifyEnum(ASTContext &ctx, const clang::EnumDecl *decl,
                             clang::Preprocessor &pp) {
+  assert(decl);
+  clang::PrettyStackTraceDecl trace(decl, clang::SourceLocation(),
+                                    pp.getSourceManager(), "classifying");
   assert(decl->isThisDeclarationADefinition());
 
   // Anonymous enumerations simply get mapped to constants of the

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1545,10 +1545,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   // "Code" off the end of the name, if it's there, because it's
   // redundant.
   if (auto enumDecl = dyn_cast<clang::EnumDecl>(D)) {
-    auto enumInfo = getEnumInfo(enumDecl);
-    if (enumInfo.isErrorEnum() && baseName.size() > 4 &&
-        camel_case::getLastWord(baseName) == "Code")
-      baseName = baseName.substr(0, baseName.size() - 4);
+    if (enumDecl->isThisDeclarationADefinition()) {
+      auto enumInfo = getEnumInfo(enumDecl);
+      if (enumInfo.isErrorEnum() && baseName.size() > 4 &&
+          camel_case::getLastWord(baseName) == "Code")
+        baseName = baseName.substr(0, baseName.size() - 4);
+    }
   }
 
   // Objective-C protocols may have the suffix "Protocol" appended if

--- a/test/ClangImporter/Inputs/enum-objc.h
+++ b/test/ClangImporter/Inputs/enum-objc.h
@@ -8,3 +8,13 @@ typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnum, "SwiftEnum") {
     ObjCEnumTwo,
     ObjCEnumThree
 };
+
+enum BareForwardEnum;
+enum ForwardEnumWithUnderlyingType : int;
+typedef SWIFT_ENUM_NAMED(NSInteger, ForwardObjCEnum, "ForwardSwiftEnum");
+
+void forwardBarePointer(enum BareForwardEnum * _Nonnull);
+void forwardWithUnderlyingValue(enum ForwardEnumWithUnderlyingType);
+void forwardWithUnderlyingPointer(enum ForwardEnumWithUnderlyingType * _Nonnull);
+void forwardObjCValue(ForwardObjCEnum);
+void forwardObjCPointer(ForwardObjCEnum * _Nonnull);

--- a/test/ClangImporter/enum-objc.swift
+++ b/test/ClangImporter/enum-objc.swift
@@ -9,3 +9,11 @@ func test(_ value: SwiftEnum) {
     case .three: break
     } // no error
 }
+
+let _: Int = forwardBarePointer // expected-error {{cannot convert value of type '(OpaquePointer) -> Void' to specified type 'Int'}}
+let _: Int = forwardWithUnderlyingPointer // expected-error {{cannot convert value of type '(OpaquePointer) -> Void' to specified type 'Int'}}
+let _: Int = forwardObjCPointer // expected-error {{cannot convert value of type '(OpaquePointer) -> Void' to specified type 'Int'}}
+
+// FIXME: It would be nice to import these as unavailable somehow instead.
+let _: Int = forwardWithUnderlyingValue // expected-error {{use of unresolved identifier 'forwardWithUnderlyingValue'}}
+let _: Int = forwardObjCValue // expected-error {{use of unresolved identifier 'forwardObjCValue'}}


### PR DESCRIPTION
This would fail later down the line anyway, meaning this does not change the ultimate behavior of the importer, but since I added an assertion that we're expecting a definition here in #11170, we need to avoid even asking the question.

Also fix up a few other places where we aren't sure we'll have a definition when calling these functions.

rdar://problem/33784466