### PR TITLE
Refactor some duplication in class and struct layout

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -3084,11 +3084,6 @@ void swift_initStructMetadata_UniversalStrategy(size_t numFields,
                                          size_t *fieldOffsets,
                                          ValueWitnessTable *vwtable);
 
-struct ClassFieldLayout {
-  size_t Size;
-  size_t AlignMask;
-};
-
 /// Initialize the field offset vector for a dependent-layout class, using the
 /// "Universal" layout strategy.
 ///
@@ -3099,7 +3094,7 @@ SWIFT_RUNTIME_EXPORT
 ClassMetadata *
 swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
                                           size_t numFields,
-                                          const ClassFieldLayout *fieldLayouts,
+                                          const TypeLayout * const *fieldTypes,
                                           size_t *fieldOffsets);
 
 /// \brief Fetch a uniqued metadata for a metatype type.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -813,13 +813,13 @@ FUNCTION(GetExistentialMetadata,
 // struct FieldInfo { size_t Size; size_t AlignMask; };
 // Metadata *swift_initClassMetadata_UniversalStrategy(Metadata *self,
 //                                                     size_t numFields,
-//                                                     const FieldInfo *fields,
+//                                                     TypeLayout * const *fieldTypes,
 //                                                     size_t *fieldOffsets);
 FUNCTION(InitClassMetadataUniversal,
          swift_initClassMetadata_UniversalStrategy, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy,
-              SizeTy->getPointerTo(),
+              Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind))
 

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -86,10 +86,6 @@ public:
   void initializeWithTake(IRGenFunction &IGF, Address destAddr,
                           Address srcAddr, SILType T) const override;
 
-  std::pair<llvm::Value*, llvm::Value*>
-  getSizeAndAlignmentMask(IRGenFunction &IGF, SILType T) const override;
-  std::tuple<llvm::Value*,llvm::Value*,llvm::Value*>
-  getSizeAndAlignmentMaskAndStride(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getSize(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getAlignmentMask(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getStride(IRGenFunction &IGF, SILType T) const override;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1831,10 +1831,8 @@ namespace {
         return visit(singletonFieldTy.getSwiftRValueType());
 
       // If the type is fixed-layout, emit a copy of its layout.
-      if (auto fixed = dyn_cast<FixedTypeInfo>(&ti)) {
-
+      if (auto fixed = dyn_cast<FixedTypeInfo>(&ti))
         return IGF.IGM.emitFixedTypeLayout(t, *fixed);
-      }
 
       return emitFromTypeMetadata(t);
     }

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -252,7 +252,14 @@ namespace irgen {
                              NominalTypeDecl *type,
                              llvm::Function *fn,
                              ArrayRef<FieldTypeInfo> fieldTypes);
-  
+
+  /// \brief Initialize the field offset vector within the given class or struct
+  /// metadata.
+  llvm::Value *emitInitializeFieldOffsetVector(IRGenFunction &IGF,
+                                               SILType T,
+                                               llvm::Value *metadata,
+                                               llvm::Value *vwtable);
+
   /// Adjustment indices for the address points of various metadata.
   /// Size is in words.
   namespace MetadataAdjustmentIndex {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -183,21 +183,6 @@ static llvm::Constant *asSizeConstant(IRGenModule &IGM, Size size) {
   return llvm::ConstantInt::get(IGM.SizeTy, size.getValue());
 }
 
-/// Return the size and alignment of this type.
-std::pair<llvm::Value*,llvm::Value*>
-FixedTypeInfo::getSizeAndAlignmentMask(IRGenFunction &IGF,
-                                       SILType T) const {
-  return {FixedTypeInfo::getSize(IGF, T),
-          FixedTypeInfo::getAlignmentMask(IGF, T)};
-}
-std::tuple<llvm::Value*,llvm::Value*,llvm::Value*>
-FixedTypeInfo::getSizeAndAlignmentMaskAndStride(IRGenFunction &IGF,
-                                                SILType T) const {
-  return std::make_tuple(FixedTypeInfo::getSize(IGF, T),
-                         FixedTypeInfo::getAlignmentMask(IGF, T),
-                         FixedTypeInfo::getStride(IGF, T));
-}
-
 llvm::Value *FixedTypeInfo::getSize(IRGenFunction &IGF, SILType T) const {
   return FixedTypeInfo::getStaticSize(IGF.IGM);
 }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1753,6 +1753,11 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
         || structDecl->hasClangNode())
       return SILType();
 
+    // A single-field struct with custom alignment has different layout from its
+    // field.
+    if (structDecl->getAttrs().hasAttribute<AlignmentAttr>())
+      return SILType();
+
     // If there's only one stored property, we have the layout of its field.
     auto allFields = structDecl->getStoredProperties();
     

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -41,90 +41,90 @@ namespace {
 
 template <class Impl, template <class> class Base>
 class LayoutScanner : public Base<Impl> {
-	Optional<Size> AddressPoint;
+  Optional<Size> AddressPoint;
 
 protected:
-	template <class... As>
-	LayoutScanner(As &&... args) : Base<Impl>(std::forward<As>(args)...) {}
+  template <class... As>
+  LayoutScanner(As &&... args) : Base<Impl>(std::forward<As>(args)...) {}
 
 public:
-	using StoredOffset = MetadataLayout::StoredOffset;
+  using StoredOffset = MetadataLayout::StoredOffset;
 
-	void noteAddressPoint() { AddressPoint = this->NextOffset; }
-	StoredOffset getNextOffset() {
-		return StoredOffset(this->NextOffset - AddressPoint.getValue());
-	}
+  void noteAddressPoint() { AddressPoint = this->NextOffset; }
+  StoredOffset getNextOffset() {
+    return StoredOffset(this->NextOffset - AddressPoint.getValue());
+  }
 };
 
 }
 
 ClassMetadataLayout &IRGenModule::getMetadataLayout(ClassDecl *decl) {
-	return cast<ClassMetadataLayout>(
-								        getMetadataLayout(static_cast<NominalTypeDecl*>(decl)));
+  return cast<ClassMetadataLayout>(
+                        getMetadataLayout(static_cast<NominalTypeDecl*>(decl)));
 }
 
 EnumMetadataLayout &IRGenModule::getMetadataLayout(EnumDecl *decl) {
-	return cast<EnumMetadataLayout>(
-								        getMetadataLayout(static_cast<NominalTypeDecl*>(decl)));
+  return cast<EnumMetadataLayout>(
+                        getMetadataLayout(static_cast<NominalTypeDecl*>(decl)));
 }
 
 StructMetadataLayout &IRGenModule::getMetadataLayout(StructDecl *decl) {
-	return cast<StructMetadataLayout>(
-								        getMetadataLayout(static_cast<NominalTypeDecl*>(decl)));
+  return cast<StructMetadataLayout>(
+                        getMetadataLayout(static_cast<NominalTypeDecl*>(decl)));
 }
 
 NominalMetadataLayout &IRGenModule::getMetadataLayout(NominalTypeDecl *decl) {
-	auto &entry = MetadataLayouts[decl];
-	if (!entry) {
-		if (auto theClass = dyn_cast<ClassDecl>(decl)) {
-			entry = new ClassMetadataLayout(*this, theClass);			
-		} else if (auto theEnum = dyn_cast<EnumDecl>(decl)) {
-			entry = new EnumMetadataLayout(*this, theEnum);			
-		} else if (auto theStruct = dyn_cast<StructDecl>(decl)) {
-			entry = new StructMetadataLayout(*this, theStruct);
-		} else {
-			llvm_unreachable("bad nominal type!");
-		}
-	}
-	return *cast<NominalMetadataLayout>(entry);
+  auto &entry = MetadataLayouts[decl];
+  if (!entry) {
+    if (auto theClass = dyn_cast<ClassDecl>(decl)) {
+      entry = new ClassMetadataLayout(*this, theClass);
+    } else if (auto theEnum = dyn_cast<EnumDecl>(decl)) {
+      entry = new EnumMetadataLayout(*this, theEnum);
+    } else if (auto theStruct = dyn_cast<StructDecl>(decl)) {
+      entry = new StructMetadataLayout(*this, theStruct);
+    } else {
+      llvm_unreachable("bad nominal type!");
+    }
+  }
+  return *cast<NominalMetadataLayout>(entry);
 }
 
 void IRGenModule::destroyMetadataLayoutMap() {
-	for (auto &entry : MetadataLayouts) {
-		entry.second->destroy();
-	}
+  for (auto &entry : MetadataLayouts) {
+    entry.second->destroy();
+  }
 }
 
 void MetadataLayout::destroy() const {
-	switch (getKind()) {
-	case Kind::Class:
-		delete cast<ClassMetadataLayout>(this);
-		return;
+  switch (getKind()) {
+  case Kind::Class:
+    delete cast<ClassMetadataLayout>(this);
+    return;
 
-	case Kind::Struct:
-		delete cast<StructMetadataLayout>(this);
-		return;
+  case Kind::Struct:
+    delete cast<StructMetadataLayout>(this);
+    return;
 
-	case Kind::Enum:
-		delete cast<EnumMetadataLayout>(this);
-		return;
-	}
-	llvm_unreachable("bad kind");
+  case Kind::Enum:
+    delete cast<EnumMetadataLayout>(this);
+    return;
+  }
+  llvm_unreachable("bad kind");
 }
 
 /******************************* NOMINAL TYPES ********************************/
 
 Offset NominalMetadataLayout::getParentOffset(IRGenFunction &IGF) const {
-	assert(Parent.isValid());
-	assert(Parent.isStatic() && "resilient metadata layout unsupported!");
-	return Offset(Parent.getStaticOffset());
+  assert(Parent.isValid());
+  assert(Parent.isStatic() && "resilient metadata layout unsupported!");
+  return Offset(Parent.getStaticOffset());
 }
 
 Offset
 NominalMetadataLayout::getGenericRequirementsOffset(IRGenFunction &IGF) const {
-	assert(GenericRequirements.isValid());
-	assert(GenericRequirements.isStatic() && "resilient metadata layout unsupported!");
-	return Offset(GenericRequirements.getStaticOffset());
+  assert(GenericRequirements.isValid());
+  assert(GenericRequirements.isStatic() && "resilient metadata layout unsupported!");
+  return Offset(GenericRequirements.getStaticOffset());
 }
 
 /// Given a reference to some metadata, derive a reference to the
@@ -189,18 +189,18 @@ llvm::Value *irgen::emitArgumentWitnessTableRef(IRGenFunction &IGF,
 /********************************** CLASSES ***********************************/
 
 ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
-		: NominalMetadataLayout(Kind::Class) {
+    : NominalMetadataLayout(Kind::Class) {
 
-	struct Scanner : LayoutScanner<Scanner, ClassMetadataScanner> {
-		using super = LayoutScanner;
+  struct Scanner : LayoutScanner<Scanner, ClassMetadataScanner> {
+    using super = LayoutScanner;
 
-		ClassMetadataLayout &Layout;
-		Scanner(IRGenModule &IGM, ClassDecl *decl, ClassMetadataLayout &layout)
-			: super(IGM, decl), Layout(layout) {}
+    ClassMetadataLayout &Layout;
+    Scanner(IRGenModule &IGM, ClassDecl *decl, ClassMetadataLayout &layout)
+      : super(IGM, decl), Layout(layout) {}
 
     void addParentMetadataRef(ClassDecl *forClass, Type classType) {
       if (forClass == Target)
-      	Layout.Parent = getNextOffset();
+        Layout.Parent = getNextOffset();
       super::addParentMetadataRef(forClass, classType);
     }
 
@@ -212,65 +212,65 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
 
     void addMethod(SILDeclRef fn) {
       if (fn.getDecl()->getDeclContext() == Target)
-      	Layout.MethodInfos.try_emplace(fn, getNextOffset());
+        Layout.MethodInfos.try_emplace(fn, getNextOffset());
       super::addMethod(fn);
     }
 
     void noteStartOfFieldOffsets(ClassDecl *forClass) {
-    	if (forClass == Target)
-    		Layout.FieldOffsetVector = getNextOffset();
-    	super::noteStartOfFieldOffsets(forClass);
+      if (forClass == Target)
+        Layout.FieldOffsetVector = getNextOffset();
+      super::noteStartOfFieldOffsets(forClass);
     }
 
     void addFieldOffset(VarDecl *field) {
-    	if (field->getDeclContext() == Target)
-    		Layout.FieldOffsets.try_emplace(field, getNextOffset());
-    	super::addFieldOffset(field);
+      if (field->getDeclContext() == Target)
+        Layout.FieldOffsets.try_emplace(field, getNextOffset());
+      super::addFieldOffset(field);
     }
-	};
+  };
 
-	Scanner(IGM, decl, *this).layout();
+  Scanner(IGM, decl, *this).layout();
 }
 
 ClassMetadataLayout::MethodInfo
 ClassMetadataLayout::getMethodInfo(IRGenFunction &IGF, SILDeclRef method) const{
-	auto &stored = getStoredMethodInfo(method);
+  auto &stored = getStoredMethodInfo(method);
 
-	assert(stored.TheOffset.isStatic() &&
-				 "resilient class metadata layout unsupported!");
-	auto offset = Offset(stored.TheOffset.getStaticOffset());
+  assert(stored.TheOffset.isStatic() &&
+         "resilient class metadata layout unsupported!");
+  auto offset = Offset(stored.TheOffset.getStaticOffset());
 
-	return MethodInfo(offset);
+  return MethodInfo(offset);
 }
 
 Size ClassMetadataLayout::getStaticMethodOffset(SILDeclRef method) const{
-	auto &stored = getStoredMethodInfo(method);
+  auto &stored = getStoredMethodInfo(method);
 
-	assert(stored.TheOffset.isStatic() &&
-				 "resilient class metadata layout unsupported!");
-	return stored.TheOffset.getStaticOffset();
+  assert(stored.TheOffset.isStatic() &&
+         "resilient class metadata layout unsupported!");
+  return stored.TheOffset.getStaticOffset();
 }
 
 Offset ClassMetadataLayout::getFieldOffset(IRGenFunction &IGF,
-																					 VarDecl *field) const {
-	// TODO: implement resilient metadata layout
-	return Offset(getStaticFieldOffset(field));
+                                           VarDecl *field) const {
+  // TODO: implement resilient metadata layout
+  return Offset(getStaticFieldOffset(field));
 }
 Size ClassMetadataLayout::getStaticFieldOffset(VarDecl *field) const {
-	auto &stored = getStoredFieldOffset(field);
-	assert(stored.isStatic() && "resilient class metadata layout unsupported!");
-	return stored.getStaticOffset();
+  auto &stored = getStoredFieldOffset(field);
+  assert(stored.isStatic() && "resilient class metadata layout unsupported!");
+  return stored.getStaticOffset();
 }
 
 Offset
 ClassMetadataLayout::getFieldOffsetVectorOffset(IRGenFunction &IGF) const {
-	// TODO: implement resilient metadata layout
-	assert(FieldOffsetVector.isStatic());
-	return Offset(FieldOffsetVector.getStaticOffset());
+  // TODO: implement resilient metadata layout
+  assert(FieldOffsetVector.isStatic());
+  return Offset(FieldOffsetVector.getStaticOffset());
 }
 
 Size irgen::getClassFieldOffsetOffset(IRGenModule &IGM, ClassDecl *theClass,
-                                			VarDecl *field) {
+                                      VarDecl *field) {
   return IGM.getMetadataLayout(theClass).getStaticFieldOffset(field);
 }
 
@@ -281,25 +281,25 @@ llvm::Value *irgen::emitClassFieldOffset(IRGenFunction &IGF,
                                          ClassDecl *theClass,
                                          VarDecl *field,
                                          llvm::Value *metadata) {
-	auto slot = emitAddressOfClassFieldOffset(IGF, metadata, theClass, field);
+  auto slot = emitAddressOfClassFieldOffset(IGF, metadata, theClass, field);
   return IGF.emitInvariantLoad(slot);
 }
 
 Address irgen::emitAddressOfClassFieldOffset(IRGenFunction &IGF,
-																						 llvm::Value *metadata,
-                                         		 ClassDecl *theClass,
-                                         		 VarDecl *field) {
-	auto offset = IGF.IGM.getMetadataLayout(theClass).getFieldOffset(IGF, field);
-	auto slot = IGF.emitAddressAtOffset(metadata, offset, IGF.IGM.SizeTy,
-																			IGF.IGM.getPointerAlignment());
-	return slot;
+                                             llvm::Value *metadata,
+                                              ClassDecl *theClass,
+                                              VarDecl *field) {
+  auto offset = IGF.IGM.getMetadataLayout(theClass).getFieldOffset(IGF, field);
+  auto slot = IGF.emitAddressAtOffset(metadata, offset, IGF.IGM.SizeTy,
+                                      IGF.IGM.getPointerAlignment());
+  return slot;
 }
 
 Address irgen::emitAddressOfFieldOffsetVector(IRGenFunction &IGF,
-																							llvm::Value *metadata,
+                                              llvm::Value *metadata,
                                               ClassDecl *theClass) {
-	auto offset =
-		IGF.IGM.getMetadataLayout(theClass).getFieldOffsetVectorOffset(IGF);
+  auto offset =
+    IGF.IGM.getMetadataLayout(theClass).getFieldOffsetVectorOffset(IGF);
  
   return IGF.emitAddressAtOffset(metadata, offset, IGF.IGM.SizeTy,
                                  IGF.IGM.getPointerAlignment());
@@ -308,14 +308,14 @@ Address irgen::emitAddressOfFieldOffsetVector(IRGenFunction &IGF,
 /*********************************** ENUMS ************************************/
 
 EnumMetadataLayout::EnumMetadataLayout(IRGenModule &IGM, EnumDecl *decl)
-		: NominalMetadataLayout(Kind::Enum) {
+    : NominalMetadataLayout(Kind::Enum) {
 
-	struct Scanner : LayoutScanner<Scanner, EnumMetadataScanner> {
-		using super = LayoutScanner;
+  struct Scanner : LayoutScanner<Scanner, EnumMetadataScanner> {
+    using super = LayoutScanner;
 
-		EnumMetadataLayout &Layout;
-		Scanner(IRGenModule &IGM, EnumDecl *decl, EnumMetadataLayout &layout)
-			: super(IGM, decl), Layout(layout) {}
+    EnumMetadataLayout &Layout;
+    Scanner(IRGenModule &IGM, EnumDecl *decl, EnumMetadataLayout &layout)
+      : super(IGM, decl), Layout(layout) {}
 
     void addParentMetadataRef() {
       Layout.Parent = getNextOffset();
@@ -326,22 +326,22 @@ EnumMetadataLayout::EnumMetadataLayout(IRGenModule &IGM, EnumDecl *decl)
       Layout.GenericRequirements = getNextOffset();
       super::noteStartOfGenericRequirements();
     }
-	};
+  };
 
-	Scanner(IGM, decl, *this).layout();
+  Scanner(IGM, decl, *this).layout();
 }
 
 /********************************** STRUCTS ***********************************/
 
 StructMetadataLayout::StructMetadataLayout(IRGenModule &IGM, StructDecl *decl)
-		: NominalMetadataLayout(Kind::Struct) {
+    : NominalMetadataLayout(Kind::Struct) {
 
-	struct Scanner : LayoutScanner<Scanner, StructMetadataScanner> {
-		using super = LayoutScanner;
+  struct Scanner : LayoutScanner<Scanner, StructMetadataScanner> {
+    using super = LayoutScanner;
 
-		StructMetadataLayout &Layout;
-		Scanner(IRGenModule &IGM, StructDecl *decl, StructMetadataLayout &layout)
-			: super(IGM, decl), Layout(layout) {}
+    StructMetadataLayout &Layout;
+    Scanner(IRGenModule &IGM, StructDecl *decl, StructMetadataLayout &layout)
+      : super(IGM, decl), Layout(layout) {}
 
     void addParentMetadataRef() {
       Layout.Parent = getNextOffset();
@@ -357,18 +357,18 @@ StructMetadataLayout::StructMetadataLayout(IRGenModule &IGM, StructDecl *decl)
       Layout.FieldOffsets.try_emplace(field, getNextOffset());
       super::addFieldOffset(field);
     }
-	};
+  };
 
-	Scanner(IGM, decl, *this).layout();
+  Scanner(IGM, decl, *this).layout();
 }
 
 Offset StructMetadataLayout::getFieldOffset(IRGenFunction &IGF,
-																						VarDecl *field) const {
-	// TODO: implement resilient metadata layout
-	return Offset(getStaticFieldOffset(field));
+                                            VarDecl *field) const {
+  // TODO: implement resilient metadata layout
+  return Offset(getStaticFieldOffset(field));
 }
 Size StructMetadataLayout::getStaticFieldOffset(VarDecl *field) const {
-	auto &stored = getStoredFieldOffset(field);
-	assert(stored.isStatic() && "resilient struct metadata layout unsupported!");
-	return stored.getStaticOffset();
+  auto &stored = getStoredFieldOffset(field);
+  assert(stored.isStatic() && "resilient struct metadata layout unsupported!");
+  return stored.getStaticOffset();
 }

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -204,6 +204,9 @@ public:
 class StructMetadataLayout : public NominalMetadataLayout {
   llvm::DenseMap<VarDecl*, StoredOffset> FieldOffsets;
 
+  /// The start of the field-offset vector.
+  StoredOffset FieldOffsetVector;
+
   const StoredOffset &getStoredFieldOffset(VarDecl *field) const {
     auto it = FieldOffsets.find(field);
     assert(it != FieldOffsets.end());
@@ -223,6 +226,8 @@ public:
   /// DEPRECATED: callers should be updated to handle this in a
   /// more arbitrary fashion.
   Size getStaticFieldOffset(VarDecl *field) const;
+
+  Offset getFieldOffsetVectorOffset() const;
 
   static bool classof(const MetadataLayout *layout) {
     return layout->getKind() == Kind::Struct;
@@ -248,10 +253,11 @@ Size getClassFieldOffsetOffset(IRGenModule &IGM,
                                ClassDecl *theClass,
                                VarDecl *field);
 
-/// Emit the address of the field-offset vector in the given class metadata.
+/// Emit the address of the field-offset vector in the given class or struct
+/// metadata.
 Address emitAddressOfFieldOffsetVector(IRGenFunction &IGF,
                                        llvm::Value *metadata,
-                                       ClassDecl *theClass);
+                                       NominalTypeDecl *theDecl);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -88,21 +88,6 @@ public:
     return IGF.emitValueWitnessTableRef(T);
   }
 
-  std::pair<llvm::Value*,llvm::Value*>
-  getSizeAndAlignmentMask(IRGenFunction &IGF, SILType T) const override {
-    auto size = emitLoadOfSize(IGF, T);
-    auto align = emitLoadOfAlignmentMask(IGF, T);
-    return { size, align };
-  }
-
-  std::tuple<llvm::Value*,llvm::Value*,llvm::Value*>
-  getSizeAndAlignmentMaskAndStride(IRGenFunction &IGF, SILType T) const override {
-    auto size = emitLoadOfSize(IGF, T);
-    auto align = emitLoadOfAlignmentMask(IGF, T);
-    auto stride = emitLoadOfStride(IGF, T);
-    return std::make_tuple(size, align, stride);
-  }
-
   llvm::Value *getSize(IRGenFunction &IGF, SILType T) const override {
     return emitLoadOfSize(IGF, T);
   }

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -231,10 +231,6 @@ public:
   Address getUndefAddress() const;
     
   /// Return the size and alignment of this type.
-  virtual std::pair<llvm::Value*,llvm::Value*>
-    getSizeAndAlignmentMask(IRGenFunction &IGF, SILType T) const = 0;
-  virtual std::tuple<llvm::Value*,llvm::Value*,llvm::Value*>
-    getSizeAndAlignmentMaskAndStride(IRGenFunction &IGF, SILType T) const = 0;
   virtual llvm::Value *getSize(IRGenFunction &IGF, SILType T) const = 0;
   virtual llvm::Value *getAlignmentMask(IRGenFunction &IGF, SILType T) const = 0;
   virtual llvm::Value *getStride(IRGenFunction &IGF, SILType T) const = 0;

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -301,11 +301,11 @@ entry(%c : $RootGeneric<Int32>):
 
 // CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_RootGeneric(%swift.type_pattern*, i8**) {{.*}} {
 // -- initialize the dependent field offsets
-// CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* {{%.*}}, i64 3, i64* {{%.*}}, i64* {{%.*}})
+// CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* {{%.*}}, i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
 // CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_RootGenericFixedLayout(%swift.type_pattern*, i8**) {{.*}} {
-// CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* {{%.*}}, i64 3, i64* {{%.*}}, i64* {{%.*}})
+// CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* {{%.*}}, i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
 // CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_GenericInheritsGeneric(%swift.type_pattern*, i8**) {{.*}} {
@@ -349,20 +349,13 @@ entry(%c : $RootGeneric<Int32>):
 //   Initialize our own dependent field offsets.
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
 // CHECK:   [[OFFSETS:%.*]] = getelementptr inbounds i64, i64* [[METADATA_ARRAY]], i64 23
+// CHECK:   [[FIELDS_ADDR:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %classFields, i32 0, i32 0
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %B to i8***
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], i64 -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[T1]], align 8
 // CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 11
-// CHECK:   [[T1:%.*]] = load i8*, i8** [[T0]], align 8
-// CHECK:   [[SIZE:%.*]] = ptrtoint i8* [[T1]] to i64
-// CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 12
-// CHECK:   [[T1:%.*]] = load i8*, i8** [[T0]], align 8
-// CHECK:   [[T2:%.*]] = ptrtoint i8* [[T1]] to i64
-// CHECK:   [[ALIGN:%.*]] = and i64 [[T2]], 65535
-// CHECK:   [[SIZE_ADDR:%.*]] = getelementptr inbounds [2 x i64], [2 x i64]* [[TYPES:%.*]], i32 0, i32 0
-// CHECK:   store i64 [[SIZE]], i64* [[SIZE_ADDR]], align 8
-// CHECK:   [[ALIGN_ADDR:%.*]] = getelementptr inbounds [2 x i64], [2 x i64]* [[TYPES]], i32 0, i32 1
-// CHECK:   store i64 [[ALIGN]], i64* [[ALIGN_ADDR]], align 8
-// CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* [[METADATA]], i64 1, i64* [[SIZE_ADDR]], i64* [[OFFSETS]])
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[FIELDS_ADDR]], i32 0
+// CHECK:   store i8** [[T0]], i8*** [[T1]], align 8
+// CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* [[METADATA]], i64 1, i8*** [[FIELDS_ADDR]], i64* [[OFFSETS]])
 // CHECK:   ret %swift.type* [[METADATA]]
 // CHECK: }

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -134,7 +134,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   %a = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.a2
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i32 3
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 3
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 2
   // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
@@ -143,7 +143,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   %b = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.b
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i32 3
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 3
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 3
   // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
@@ -153,7 +153,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   %c = struct_element_addr %5 : $*SingleDynamic<B>, #SingleDynamic.x
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i32 3
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 3
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 4
   // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
@@ -214,7 +214,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // CHECK:   store i8* [[VWTABLE_VAL]], i8** [[VWTABLE_SLOT_ADDR]], align 8
 //   Lay out fields.
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
-// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i32 3
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 3
 // CHECK:   [[T2:%.*]] = getelementptr inbounds i8**, i8*** [[TYPES:%.*]], i32 0
 // CHECK:   call void @swift_initStructMetadata_UniversalStrategy(i64 1, i8*** [[TYPES]], i64* [[T1]], i8** [[VWTABLE_ADDR]])
 // CHECK:   ret %swift.type* [[METADATA]]

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -59,7 +59,7 @@ public func functionWithResilientTypes(_ r: Rectangle) {
 
 // CHECK: [[METADATA:%.*]] = call %swift.type* @_T016resilient_struct9RectangleVMa()
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
-// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], i32 3
+// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 3
 // CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[FIELD_OFFSET_VECTOR]], i32 2
 // CHECK-NEXT: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
 // CHECK-NEXT: [[STRUCT_ADDR:%.*]] = bitcast %T16resilient_struct9RectangleV* %0 to i8*
@@ -116,7 +116,7 @@ public struct StructWithResilientStorage {
 // CHECK-LABEL: define{{( protected)?}} swiftcc {{i32|i64}} @_T017struct_resilience26StructWithResilientStorageV1nSifg(%T17struct_resilience26StructWithResilientStorageV* {{.*}})
 // CHECK: [[METADATA:%.*]] = call %swift.type* @_T017struct_resilience26StructWithResilientStorageVMa()
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
-// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], i32 3
+// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 3
 // CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[FIELD_OFFSET_VECTOR]], i32 2
 // CHECK-NEXT: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
 // CHECK-NEXT: [[STRUCT_ADDR:%.*]] = bitcast %T17struct_resilience26StructWithResilientStorageV* %0 to i8*

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -16,6 +16,11 @@ enum EMult { case X(Int64), Y(Int64) }
 @_alignment(4)
 struct CommonLayout { var x,y,z,w: Int8 }
 
+struct FourInts { var x,y,z,w: Int32 }
+
+@_alignment(16)
+struct AlignedFourInts { var x: FourInts }
+
 // CHECK:       @_T011type_layout14TypeLayoutTestVMP = internal global {{.*}} @create_generic_metadata_TypeLayoutTest
 // CHECK:       define private %swift.type* @create_generic_metadata_TypeLayoutTest
 struct TypeLayoutTest<T> {
@@ -62,4 +67,7 @@ struct TypeLayoutTest<T> {
   // -- Common layout, reuse common value witness table layout
   // CHECK:       store i8** getelementptr (i8*, i8** @_T0Bi32_WV, i32 11)
   var k: CommonLayout
+  // -- Single-field aggregate with alignment
+  // CHECK:       store i8** getelementptr (i8*, i8** @_T0Bi128_WV, i32 11)
+  var l: AlignedFourInts
 }

--- a/test/stdlib/simd.swift.gyb
+++ b/test/stdlib/simd.swift.gyb
@@ -90,6 +90,18 @@ simdTestSuite.test("sizes") {
   expectEqual(128, MemoryLayout<double4x4>.size)
 }
 
+simdTestSuite.test("alignment") {
+  struct GenericLayout<T> {
+    let t: T = 0 as! T
+    let v: int4 = [1,2,3,4]
+  }
+
+  let g = GenericLayout<Int>()
+  expectEqual(0, g.t)
+  expectEqual([1,2,3,4], g.v)
+}
+
+
 simdTestSuite.test("vector init") {
 % for type in scalar_types:
 %   for size in [2,3,4]:


### PR DESCRIPTION
Both classes and structs can contain fields of generic type and therefore require runtime layout. The runtime exposed two different entry points for this. The struct entry point took an array of TypeLayout objects, whereas the class entry point took an array of size/alignment pairs. The code for initializing the field offset vector was duplicated and slightly different in IRGen.

Refactor classes to use TypeLayouts and converge the two code paths.

While testing the refactoring, I discovered that IRGen was incorrectly emitting TypeLayouts for SIMD types. Before the change, this was only exposed by generic structs with SIMD fields. After the change, generic classes with SIMD fields also broke, and we had a test case that covered that.

Now that the code duplication is gone, the same fix applies to both cases.