### PR TITLE
Revert "Simplify performMemberLookup()"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -127,6 +127,10 @@ ERROR(init_candidate_inaccessible,none,
       "'%select{private|fileprivate|internal|%error|%error}1' protection level",
       (Type, Accessibility))
 
+ERROR(all_candidates_inaccessible,none,
+      "all %0 candidates are inaccessible",
+      (DeclName))
+
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
       "cannot use mutating member on immutable value: %0",
       (StringRef))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2464,10 +2464,6 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
       Diag.emplace(diagnose(loc,
                             diag::assoc_type_outside_of_protocol,
                             ATD->getName()));
-    } else if (auto CD = dyn_cast<ConstructorDecl>(member)) {
-      Diag.emplace(diagnose(loc,
-                            diag::construct_protocol_by_name,
-                            metatypeTy->getInstanceType()));
     } else {
       Diag.emplace(diagnose(loc,
                             diag::could_not_use_type_member_on_protocol_metatype,
@@ -5609,9 +5605,8 @@ bool FailureDiagnosis::diagnoseParameterErrors(CalleeCandidateInfo &CCI,
       // is malformed.
       SourceRange initExprRange(fnExpr->getSourceRange().Start,
                                 argExpr->getSourceRange().End);
-      CS.TC.diagnose(fnExpr->getLoc(), instTy->isExistentialType() ?
-                     diag::construct_protocol_by_name :
-                     diag::non_nominal_no_initializers, instTy)
+      CS.TC
+          .diagnose(fnExpr->getLoc(), diag::non_nominal_no_initializers, instTy)
           .highlight(initExprRange);
       return true;
     }
@@ -6602,11 +6597,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     
     auto arg = callExpr->getArg();
 
-    if (fnType->is<ExistentialMetatypeType>()) {
-      auto diag = diagnose(arg->getStartLoc(),
-                           diag::missing_init_on_metatype_initialization);
-      diag.highlight(fnExpr->getSourceRange());
-    } else {
+    {
       auto diag = diagnose(arg->getStartLoc(),
                            diag::cannot_call_non_function_value, fnType);
       diag.highlight(fnExpr->getSourceRange());
@@ -6959,13 +6950,6 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     }
     
     return true;
-  }
-
-  if (auto MTT = fnType->getAs<MetatypeType>()) {
-    if (MTT->getInstanceType()->isExistentialType()) {
-      diagnose(fnExpr->getLoc(), diag::construct_protocol_value, fnType);
-      return true;
-    }
   }
   
   // If we have an argument list (i.e., a scalar, or a non-zero-element tuple)
@@ -8639,8 +8623,21 @@ bool FailureDiagnosis::diagnoseMemberFailures(
       allInaccessible = false;
   }
 
-  // diagnoseSimpleErrors() should have diagnosed this scenario.
-  assert(!allInaccessible || viableCandidatesToReport.empty());
+  // If no candidates were accessible, say so.
+  if (allInaccessible && !viableCandidatesToReport.empty()) {
+    diagnose(BaseLoc, diag::all_candidates_inaccessible, memberName);
+    for (auto &candidate : result.ViableCandidates) {
+      if (!candidate.isDecl())
+        continue;
+
+      if (auto decl = candidate.getDecl()) {
+        diagnose(decl, diag::note_candidate_inaccessible, decl->getFullName(),
+                 decl->getFormalAccess());
+      }
+    }
+
+    return true;
+  }
 
   if (result.UnviableCandidates.empty() && isInitializer &&
       !baseObjTy->is<AnyMetatypeType>()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3076,6 +3076,113 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
                                           argumentLabels->HasTrailingClosure);
   };
 
+  
+  // Handle initializers, they have their own approach to name lookup.
+  if (memberName.isSimpleName(TC.Context.Id_init)) {
+    // The constructors are only found on the metatype.
+    if (!isMetatype)
+      return result;
+    
+    NameLookupOptions lookupOptions = defaultConstructorLookupOptions;
+    if (isa<AbstractFunctionDecl>(DC))
+      lookupOptions |= NameLookupFlags::KnownPrivate;
+    
+    // If we're doing a lookup for diagnostics, include inaccessible members,
+    // the diagnostics machinery will sort it out.
+    if (includeInaccessibleMembers)
+      lookupOptions |= NameLookupFlags::IgnoreAccessibility;
+
+    LookupResult ctors = TC.lookupConstructors(DC, instanceTy, lookupOptions);
+    if (!ctors)
+      return result;    // No result.
+    
+    TypeBase *favoredType = nullptr;
+    if (auto anchor = memberLocator->getAnchor()) {
+      if (auto applyExpr = dyn_cast<ApplyExpr>(anchor)) {
+        auto argExpr = applyExpr->getArg();
+        favoredType = getFavoredType(argExpr);
+        
+        if (!favoredType) {
+          optimizeConstraints(argExpr);
+          favoredType = getFavoredType(argExpr);
+        }        
+      }
+    }
+    
+    // Introduce a new overload set.
+  retry_ctors_after_fail:
+    bool labelMismatch = false;
+    for (auto entry : ctors) {
+      auto *ctor = entry.getValueDecl();
+
+      // If the constructor is invalid, we fail entirely to avoid error cascade.
+      TC.validateDecl(ctor);
+      if (ctor->isInvalid())
+        return result.markErrorAlreadyDiagnosed();
+
+      // FIXME: Deal with broken recursion
+      if (!ctor->hasInterfaceType())
+        continue;
+
+      // If the argument labels for this result are incompatible with
+      // the call site, skip it.
+      if (!hasCompatibleArgumentLabels(ctor)) {
+        labelMismatch = true;
+        result.addUnviable(ctor, MemberLookupResult::UR_LabelMismatch);
+        continue;
+      }
+
+      // If our base is an existential type, we can't make use of any
+      // constructor whose signature involves associated types.
+      if (isExistential) {
+        if (auto *proto = ctor->getDeclContext()
+                ->getAsProtocolOrProtocolExtensionContext()) {
+          if (!proto->isAvailableInExistential(ctor)) {
+            result.addUnviable(ctor,
+                               MemberLookupResult::UR_UnavailableInExistential);
+            continue;
+          }
+        }
+      }
+
+      // If the invocation's argument expression has a favored type,
+      // use that information to determine whether a specific overload for
+      // the initializer should be favored.
+      if (favoredType && result.FavoredChoice == ~0U) {
+        // Only try and favor monomorphic initializers.
+        if (auto fnTypeWithSelf =
+            ctor->getInterfaceType()->getAs<FunctionType>()) {
+          
+          if (auto fnType =
+                  fnTypeWithSelf->getResult()->getAs<FunctionType>()) {
+          
+            auto argType = fnType->getInput()->getWithoutParens();
+            argType = ctor->getInnermostDeclContext()
+                ->mapTypeIntoContext(argType);
+            if (argType->isEqual(favoredType))
+              if (!ctor->getAttrs().isUnavailable(getASTContext()))
+                result.FavoredChoice = result.ViableCandidates.size();
+          }
+        }
+      }
+      
+      result.addViable(OverloadChoice(baseTy, ctor, functionRefKind));
+    }
+
+
+    // If we rejected some possibilities due to an argument-label
+    // mismatch and ended up with nothing, try again ignoring the
+    // labels. This allows us to perform typo correction on the labels.
+    if (result.ViableCandidates.empty() && labelMismatch &&
+        shouldAttemptFixes()) {
+      argumentLabels.reset();
+      goto retry_ctors_after_fail;
+    }
+
+    // FIXME: Should we look for constructors in bridged types?
+    return result;
+  }
+
   // Look for members within the base.
   LookupResult &lookup = lookupMember(instanceTy, memberName);
 

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -188,9 +188,9 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
   _ = pp().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
   _ = pp().bar(2) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
 
-  _ = pp.init() // expected-error{{protocol type 'P' cannot be instantiated}}
-  _ = pp.init().bar // expected-error{{protocol type 'P' cannot be instantiated}}
-  _ = pp.init().bar(3) // expected-error{{protocol type 'P' cannot be instantiated}}
+  _ = pp.init() // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
+  _ = pp.init().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
+  _ = pp.init().bar(3) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
 
   _ = P() // expected-error{{protocol type 'P' cannot be instantiated}}
   _ = P().bar // expected-error{{protocol type 'P' cannot be instantiated}}

--- a/test/Constraints/super_constructor.swift
+++ b/test/Constraints/super_constructor.swift
@@ -55,12 +55,12 @@ class B {
 
 // SR-2484: Bad diagnostic for incorrectly calling private init
 class SR_2484 {
-  private init() {} // expected-note {{'init' declared here}}
-  private init(a: Int) {} // expected-note {{'init' declared here}}
+  private init() {} // expected-note {{'init()' is inaccessible due to 'private' protection level}}
+  private init(a: Int) {} // expected-note {{'init(a:)' is inaccessible due to 'private' protection level}}
 }
 
 class Impl_2484 : SR_2484 {
   init() {
-    super.init() // expected-error {{'init' is inaccessible due to 'private' protection level}}
+    super.init() // expected-error {{all 'init' candidates are inaccessible}}
   }
 }


### PR DESCRIPTION
The commit broke the following code to now return expression to complex.

class P {
    var x : Int = 0
    var y : Int = 1
}

let dist : (P, P) -> Double = {
  (p : P, s : P)  -> Double in
    sqrt(Double((p.x-s.x)*(p.x-s.x) + (p.y-s.y)*(p.y-s.y)))
}

Reverts apple/swift#11397