### PR TITLE
SILOptimizer: fix performance problem in EpilogueARCAnalysis

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -240,7 +240,7 @@ public:
   llvm::SmallSetVector<SILInstruction *, 1>
   computeEpilogueARCInstructions(EpilogueARCContext::EpilogueARCKind Kind,
                                  SILValue Arg) {
-    auto ARCCache = Kind == EpilogueARCContext::EpilogueARCKind::Retain ?
+    auto &ARCCache = Kind == EpilogueARCContext::EpilogueARCKind::Retain ?
                  EpilogueRetainInstCache :
                  EpilogueReleaseInstCache;
     auto Iter = ARCCache.find(Arg);


### PR DESCRIPTION
The cache for analysis result was never set. This resulted in a pretty bad quadratic behavior.

rdar://problem/33760501