### PR TITLE
[stdlib-code-size] Do not produce useless partial specializations for the shift operations on integers

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1631,6 +1631,7 @@ ${operatorComment(x.operator, False)}
 % for x in maskingShifts:
   // Heterogeneous non-masking shift in terms of shift-assignment
 ${operatorComment(x.nonMaskingOperator, False)}
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   public static func ${x.nonMaskingOperator}<RHS: BinaryInteger>(
     _ lhs: Self, _ rhs: RHS
   ) -> Self {
@@ -2168,6 +2169,7 @@ extension FixedWidthInteger {
   
   // Homogeneous masking shift
 ${operatorComment(x.operator, False)}
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${x.operator} (lhs: Self, rhs: Self) -> Self {
     var lhs = lhs
@@ -2177,6 +2179,7 @@ ${operatorComment(x.operator, False)}
 
   // Heterogeneous masking shift
 ${operatorComment(x.operator, False)}
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   public static func ${x.operator} <
     Other : BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
@@ -2185,6 +2188,7 @@ ${operatorComment(x.operator, False)}
 
   // Heterogeneous masking shift assignment
 ${assignmentOperatorComment(x.operator, False)}
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${x.operator}= <
     Other : BinaryInteger
@@ -2229,6 +2233,7 @@ extension FixedWidthInteger {
 //===----------------------------------------------------------------------===//
 
 ${operatorComment(x.nonMaskingOperator, True)}
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${x.nonMaskingOperator} <
     Other : BinaryInteger
@@ -2239,6 +2244,7 @@ ${operatorComment(x.nonMaskingOperator, True)}
   }
 
   @_transparent
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   public static func ${x.nonMaskingOperator}= <
     Other : BinaryInteger
   >(lhs: inout Self, rhs: Other) {
@@ -3339,6 +3345,7 @@ ${operatorComment(x.operator, True)}
 
 ${operatorComment(x.operator, True)}
   @available(swift, obsoleted: 4)
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${op.nonMaskingOperator}(
     lhs: ${Self}, rhs: ${Self}
@@ -3350,6 +3357,7 @@ ${operatorComment(x.operator, True)}
 
 ${assignmentOperatorComment(x.operator, True)}
   @available(swift, obsoleted: 4)
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${op.nonMaskingOperator}=(
     lhs: inout ${Self}, rhs: ${Self}
@@ -3474,6 +3482,7 @@ extension FixedWidthInteger {
 %   for op in maskingShifts:
 
   @available(swift, obsoleted: 4)
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${op.nonMaskingOperator}(
     lhs: Self, rhs: Self
@@ -3484,6 +3493,7 @@ extension FixedWidthInteger {
   }
 
   @available(swift, obsoleted: 4)
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func ${op.nonMaskingOperator}=(
     lhs: inout Self, rhs: Self


### PR DESCRIPTION
This reduces the stdlib binary size by 200KB.
