### PR TITLE
Simplify performMemberLookup()

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -127,10 +127,6 @@ ERROR(init_candidate_inaccessible,none,
       "'%select{private|fileprivate|internal|%error|%error}1' protection level",
       (Type, Accessibility))
 
-ERROR(all_candidates_inaccessible,none,
-      "all %0 candidates are inaccessible",
-      (DeclName))
-
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
       "cannot use mutating member on immutable value: %0",
       (StringRef))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -8639,21 +8639,8 @@ bool FailureDiagnosis::diagnoseMemberFailures(
       allInaccessible = false;
   }
 
-  // If no candidates were accessible, say so.
-  if (allInaccessible && !viableCandidatesToReport.empty()) {
-    diagnose(BaseLoc, diag::all_candidates_inaccessible, memberName);
-    for (auto &candidate : result.ViableCandidates) {
-      if (!candidate.isDecl())
-        continue;
-
-      if (auto decl = candidate.getDecl()) {
-        diagnose(decl, diag::note_candidate_inaccessible, decl->getFullName(),
-                 decl->getFormalAccess());
-      }
-    }
-
-    return true;
-  }
+  // diagnoseSimpleErrors() should have diagnosed this scenario.
+  assert(!allInaccessible || viableCandidatesToReport.empty());
 
   if (result.UnviableCandidates.empty() && isInitializer &&
       !baseObjTy->is<AnyMetatypeType>()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3076,115 +3076,23 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
                                           argumentLabels->HasTrailingClosure);
   };
 
-  
-  // Handle initializers, they have their own approach to name lookup.
-  if (memberName.isSimpleName(TC.Context.Id_init)) {
-    // The constructors are only found on the metatype.
-    if (!isMetatype)
-      return result;
-    
-    NameLookupOptions lookupOptions = defaultConstructorLookupOptions;
-    if (isa<AbstractFunctionDecl>(DC))
-      lookupOptions |= NameLookupFlags::KnownPrivate;
-    
-    // If we're doing a lookup for diagnostics, include inaccessible members,
-    // the diagnostics machinery will sort it out.
-    if (includeInaccessibleMembers)
-      lookupOptions |= NameLookupFlags::IgnoreAccessibility;
+  // Look for members within the base.
+  LookupResult &lookup = lookupMember(instanceTy, memberName);
 
-    LookupResult ctors = TC.lookupConstructors(DC, instanceTy, lookupOptions);
-    if (!ctors)
-      return result;    // No result.
-    
-    TypeBase *favoredType = nullptr;
+  TypeBase *favoredType = nullptr;
+  if (memberName.isSimpleName(TC.Context.Id_init)) {
     if (auto anchor = memberLocator->getAnchor()) {
       if (auto applyExpr = dyn_cast<ApplyExpr>(anchor)) {
         auto argExpr = applyExpr->getArg();
         favoredType = getFavoredType(argExpr);
-        
+
         if (!favoredType) {
           optimizeConstraints(argExpr);
           favoredType = getFavoredType(argExpr);
-        }        
-      }
-    }
-    
-    // Introduce a new overload set.
-  retry_ctors_after_fail:
-    bool labelMismatch = false;
-    for (auto entry : ctors) {
-      auto *ctor = entry.getValueDecl();
-
-      // If the constructor is invalid, we fail entirely to avoid error cascade.
-      TC.validateDecl(ctor);
-      if (ctor->isInvalid())
-        return result.markErrorAlreadyDiagnosed();
-
-      // FIXME: Deal with broken recursion
-      if (!ctor->hasInterfaceType())
-        continue;
-
-      // If the argument labels for this result are incompatible with
-      // the call site, skip it.
-      if (!hasCompatibleArgumentLabels(ctor)) {
-        labelMismatch = true;
-        result.addUnviable(ctor, MemberLookupResult::UR_LabelMismatch);
-        continue;
-      }
-
-      // If our base is an existential type, we can't make use of any
-      // constructor whose signature involves associated types.
-      if (isExistential) {
-        if (auto *proto = ctor->getDeclContext()
-                ->getAsProtocolOrProtocolExtensionContext()) {
-          if (!proto->isAvailableInExistential(ctor)) {
-            result.addUnviable(ctor,
-                               MemberLookupResult::UR_UnavailableInExistential);
-            continue;
-          }
         }
       }
-
-      // If the invocation's argument expression has a favored type,
-      // use that information to determine whether a specific overload for
-      // the initializer should be favored.
-      if (favoredType && result.FavoredChoice == ~0U) {
-        // Only try and favor monomorphic initializers.
-        if (auto fnTypeWithSelf =
-            ctor->getInterfaceType()->getAs<FunctionType>()) {
-          
-          if (auto fnType =
-                  fnTypeWithSelf->getResult()->getAs<FunctionType>()) {
-          
-            auto argType = fnType->getInput()->getWithoutParens();
-            argType = ctor->getInnermostDeclContext()
-                ->mapTypeIntoContext(argType);
-            if (argType->isEqual(favoredType))
-              if (!ctor->getAttrs().isUnavailable(getASTContext()))
-                result.FavoredChoice = result.ViableCandidates.size();
-          }
-        }
-      }
-      
-      result.addViable(OverloadChoice(baseTy, ctor, functionRefKind));
     }
-
-
-    // If we rejected some possibilities due to an argument-label
-    // mismatch and ended up with nothing, try again ignoring the
-    // labels. This allows us to perform typo correction on the labels.
-    if (result.ViableCandidates.empty() && labelMismatch &&
-        shouldAttemptFixes()) {
-      argumentLabels.reset();
-      goto retry_ctors_after_fail;
-    }
-
-    // FIXME: Should we look for constructors in bridged types?
-    return result;
   }
-
-  // Look for members within the base.
-  LookupResult &lookup = lookupMember(instanceTy, memberName);
 
   // The set of directly accessible types, which is only used when
   // we're performing dynamic lookup into an existential type.
@@ -3234,6 +3142,26 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
           result.addUnviable(cand,
                              MemberLookupResult::UR_UnavailableInExistential);
           return;
+        }
+      }
+    }
+
+    // If the invocation's argument expression has a favored type,
+    // use that information to determine whether a specific overload for
+    // the candidate should be favored.
+    if (isa<ConstructorDecl>(cand) && favoredType &&
+        result.FavoredChoice == ~0U) {
+      // Only try and favor monomorphic initializers.
+      if (auto fnTypeWithSelf = cand->getInterfaceType()
+                                                      ->getAs<FunctionType>()) {
+        if (auto fnType = fnTypeWithSelf->getResult()
+                                                      ->getAs<FunctionType>()) {
+          auto argType = fnType->getInput()->getWithoutParens();
+          argType = cand->getInnermostDeclContext()
+                                                  ->mapTypeIntoContext(argType);
+          if (argType->isEqual(favoredType))
+            if (!cand->getAttrs().isUnavailable(getASTContext()))
+              result.FavoredChoice = result.ViableCandidates.size();
         }
       }
     }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -188,9 +188,9 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
   _ = pp().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
   _ = pp().bar(2) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
 
-  _ = pp.init() // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
-  _ = pp.init().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
-  _ = pp.init().bar(3) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
+  _ = pp.init() // expected-error{{protocol type 'P' cannot be instantiated}}
+  _ = pp.init().bar // expected-error{{protocol type 'P' cannot be instantiated}}
+  _ = pp.init().bar(3) // expected-error{{protocol type 'P' cannot be instantiated}}
 
   _ = P() // expected-error{{protocol type 'P' cannot be instantiated}}
   _ = P().bar // expected-error{{protocol type 'P' cannot be instantiated}}

--- a/test/Constraints/super_constructor.swift
+++ b/test/Constraints/super_constructor.swift
@@ -55,12 +55,12 @@ class B {
 
 // SR-2484: Bad diagnostic for incorrectly calling private init
 class SR_2484 {
-  private init() {} // expected-note {{'init()' is inaccessible due to 'private' protection level}}
-  private init(a: Int) {} // expected-note {{'init(a:)' is inaccessible due to 'private' protection level}}
+  private init() {} // expected-note {{'init' declared here}}
+  private init(a: Int) {} // expected-note {{'init' declared here}}
 }
 
 class Impl_2484 : SR_2484 {
   init() {
-    super.init() // expected-error {{all 'init' candidates are inaccessible}}
+    super.init() // expected-error {{'init' is inaccessible due to 'private' protection level}}
   }
 }


### PR DESCRIPTION
Simplify performMemberLookup() by having the normal code path handle both simple and compound named constructors. As a part of the fallout, a redundant diagnostic can also be removed.

This branch continues the favored constructor optimization.

All validation tests pass on my machine.