### PR TITLE
Guard Any Optional diagnostic against null type

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3354,6 +3354,10 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
             }
           }
 
+          // Bail out if type checking failed on this segment.
+          if (!segment->getType())
+            continue;
+          
           // Bail out if we don't have an optional.
           if (!segment->getType()->getRValueType()->getOptionalObjectType()) {
             continue;

--- a/validation-test/compiler_crashers_2_fixed/0115-rdar33801890.swift
+++ b/validation-test/compiler_crashers_2_fixed/0115-rdar33801890.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+class C { var property: String? }
+func foo(_ cs : [C?]) -> [String?] {
+  return cs.map({ c in
+    let a = c.propertyWithTypo ?? "default"
+    let b = "\(a)"
+    return b
+  })
+}


### PR DESCRIPTION
Spot fix for a setup that can cause string interpolation segments to wind up with null type.

Resolves rdar://33801890 and [SR-5666](https://bugs.swift.org/browse/SR-5666)