### PR TITLE
[GSB] Form minimal requirement sources by removing redundant subpaths.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1059,6 +1059,17 @@ public:
   /// derived from another constraint but does not require further information.
   const RequirementSource *viaDerived(GenericSignatureBuilder &builder) const;
 
+  /// Form a new requirement source without the subpath [start, end).
+  ///
+  /// Removes a redundant sub-path \c [start, end) from the requirement source,
+  /// creating a new requirement source comprised on \c start followed by
+  /// everything that follows \c end.
+  /// It is the caller's responsibility to ensure that the path up to \c start
+  /// and the path through \c start to \c end produce the same thing.
+  const RequirementSource *withoutRedundantSubpath(
+                                          const RequirementSource *start,
+                                          const RequirementSource *end) const;
+
   /// Retrieve the root requirement source.
   const RequirementSource *getRoot() const;
 

--- a/validation-test/compiler_crashers_2_fixed/0115-sr5601.swift
+++ b/validation-test/compiler_crashers_2_fixed/0115-sr5601.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend %s -typecheck -verify
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+
+// SR-5601
+protocol P1 {
+    associatedtype X: P3 where X.Q == Self, X.R == UInt8
+    associatedtype Y: P3 where Y.Q == Self, Y.R == UInt16
+    // NOTE: Removing either X or Y from P1 (and A) makes the program compile.
+}
+struct A: P1 {
+    typealias X = S<UInt8>
+    typealias Y = S<UInt16>
+}
+protocol P2 { }
+protocol P3 : P2 { // NOTE: Removing ": P2 " here makes the program compile.
+    associatedtype Q: P1
+    associatedtype R
+}
+struct S<E> : P3 {
+    typealias R = E
+    typealias Q = A
+}
+
+


### PR DESCRIPTION
When we detect that a requirement source is self-derived, identify the
redundant subpath and remove it to produce a new, smaller requirement
source that computes the same result. We were doing this form the
limited case where the redundant subpath ended at the end of the
requirement source; generalize that notion.

Fixes SR-5601.
