### PR TITLE
Add AssociatedType and AssociatedConformance abstractions; NFC

### DIFF
--- a/include/swift/AST/ProtocolAssociations.h
+++ b/include/swift/AST/ProtocolAssociations.h
@@ -1,0 +1,167 @@
+//===--- ProtocolAssociations.h - Associated types/conformances -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines types for representing types and conformances
+// associated with a protocol.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_PROTOCOLASSOCIATIONS_H
+#define SWIFT_AST_PROTOCOLASSOCIATIONS_H
+
+#include "swift/AST/Decl.h"
+#include "llvm/ADT/DenseMapInfo.h"
+
+namespace swift {
+
+/// A type associated with a protocol.
+///
+/// This struct exists largely so that we can maybe eventually
+/// generalize it to an arbitrary path.
+class AssociatedType {
+  AssociatedTypeDecl *Association;
+  using AssociationInfo = llvm::DenseMapInfo<AssociatedTypeDecl*>;
+
+  struct SpecialValue {};
+  explicit AssociatedType(SpecialValue _, AssociatedTypeDecl *specialValue)
+      : Association(specialValue) {}
+
+public:
+  explicit AssociatedType(AssociatedTypeDecl *association)
+      : Association(association) {
+    assert(association);
+  }
+
+  ProtocolDecl *getSourceProtocol() const {
+    return Association->getProtocol();
+  }
+
+  AssociatedTypeDecl *getAssociation() const {
+    return Association;
+  }
+
+  friend bool operator==(AssociatedType lhs, AssociatedType rhs) {
+    return lhs.Association == rhs.Association;
+  }
+  friend bool operator!=(AssociatedType lhs, AssociatedType rhs) {
+    return !(lhs == rhs);
+  }
+
+  unsigned getHashValue() const {
+    return llvm::hash_value(Association);
+  }
+
+  static AssociatedType getEmptyKey() {
+    return AssociatedType(SpecialValue(), AssociationInfo::getEmptyKey());
+  }
+  static AssociatedType getTombstoneKey() {
+    return AssociatedType(SpecialValue(), AssociationInfo::getTombstoneKey());
+  }
+};
+
+/// A conformance associated with a protocol.
+class AssociatedConformance {
+  ProtocolDecl *Source;
+  CanType Association;
+  ProtocolDecl *Requirement;
+
+  using SourceInfo = llvm::DenseMapInfo<ProtocolDecl*>;
+
+  explicit AssociatedConformance(ProtocolDecl *specialValue)
+      : Source(specialValue), Association(CanType()), Requirement(nullptr) {}
+
+public:
+  explicit AssociatedConformance(ProtocolDecl *source, CanType association,
+                                 ProtocolDecl *requirement)
+      : Source(source), Association(association), Requirement(requirement) {
+    assert(source && association && requirement);
+  }
+
+  ProtocolDecl *getSourceProtocol() const {
+    return Source;
+  }
+
+  CanType getAssociation() const {
+    return Association;
+  }
+
+  ProtocolDecl *getAssociatedRequirement() const {
+    return Requirement;
+  }
+
+  friend bool operator==(const AssociatedConformance &lhs,
+                         const AssociatedConformance &rhs) {
+    return lhs.Source == rhs.Source &&
+           lhs.Association == rhs.Association &&
+           lhs.Requirement == rhs.Requirement;
+  }
+  friend bool operator!=(const AssociatedConformance &lhs,
+                         const AssociatedConformance &rhs) {
+    return !(lhs == rhs);
+  }
+
+  unsigned getHashValue() const {
+    return hash_value(llvm::hash_combine(Source,
+                                         Association.getPointer(),
+                                         Requirement));
+  }
+
+  static AssociatedConformance getEmptyKey() {
+    return AssociatedConformance(SourceInfo::getEmptyKey());
+  }
+  static AssociatedConformance getTombstoneKey() {
+    return AssociatedConformance(SourceInfo::getTombstoneKey());
+  }
+};
+
+} // end namespace swift
+
+namespace llvm {
+  template <> struct DenseMapInfo<swift::AssociatedType> {
+    static inline swift::AssociatedType getEmptyKey() {
+      return swift::AssociatedType::getEmptyKey();
+    }
+
+    static inline swift::AssociatedType getTombstoneKey() {
+      return swift::AssociatedType::getTombstoneKey();
+    }
+
+    static unsigned getHashValue(swift::AssociatedType val) {
+      return val.getHashValue();
+    }
+
+    static bool isEqual(swift::AssociatedType lhs, swift::AssociatedType rhs) {
+      return lhs == rhs;
+    }
+  };
+
+  template <> struct DenseMapInfo<swift::AssociatedConformance> {
+    static inline swift::AssociatedConformance getEmptyKey() {
+      return swift::AssociatedConformance::getEmptyKey();
+    }
+
+    static inline swift::AssociatedConformance getTombstoneKey() {
+      return swift::AssociatedConformance::getTombstoneKey();
+    }
+
+    static unsigned getHashValue(swift::AssociatedConformance val) {
+      return val.getHashValue();
+    }
+
+    static bool isEqual(swift::AssociatedConformance lhs,
+                        swift::AssociatedConformance rhs) {
+      return lhs == rhs;
+    }
+  };
+}
+
+#endif

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -14,6 +14,7 @@
 #define SWIFT_IRGEN_LINKING_H
 
 #include "swift/AST/Decl.h"
+#include "swift/AST/ProtocolAssociations.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
 #include "swift/IRGen/ValueWitness.h"
@@ -509,21 +510,22 @@ public:
 
   static LinkEntity
   forAssociatedTypeMetadataAccessFunction(const ProtocolConformance *C,
-                                          AssociatedTypeDecl *associate) {
+                                          AssociatedType association) {
     LinkEntity entity;
     entity.setForProtocolConformanceAndAssociatedType(
-                     Kind::AssociatedTypeMetadataAccessFunction, C, associate);
+                     Kind::AssociatedTypeMetadataAccessFunction, C,
+                     association.getAssociation());
     return entity;
   }
 
   static LinkEntity
   forAssociatedTypeWitnessTableAccessFunction(const ProtocolConformance *C,
-                                              CanType associatedType,
-                                              ProtocolDecl *associatedProtocol){
+                                     const AssociatedConformance &association) {
     LinkEntity entity;
     entity.setForProtocolConformanceAndAssociatedConformance(
                      Kind::AssociatedTypeWitnessTableAccessFunction, C,
-                     associatedType, associatedProtocol);
+                     association.getAssociation(),
+                     association.getAssociatedRequirement());
     return entity;
   }
 

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -21,6 +21,7 @@
 
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ProtocolAssociations.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/SmallVector.h"
@@ -59,7 +60,7 @@ public:
       for (Decl *member : protocol->getMembers()) {
         if (auto associatedType = dyn_cast<AssociatedTypeDecl>(member)) {
           // TODO: only add associated types when they're new?
-          asDerived().addAssociatedType(associatedType);
+          asDerived().addAssociatedType(AssociatedType(associatedType));
         }
       }
     };
@@ -100,7 +101,8 @@ public:
         addAssociatedTypes();
 
         // Otherwise, add an associated requirement.
-        asDerived().addAssociatedConformance(type, requirement);
+        AssociatedConformance assocConf(protocol, type, requirement);
+        asDerived().addAssociatedConformance(assocConf);
         continue;
       }
       }

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -64,8 +64,8 @@ llvm::Value *irgen::emitArchetypeTypeMetadataRef(IRGenFunction &IGF,
            "type metadata for primary archetype was not bound in context");
 
     CanArchetypeType parent(archetype->getParent());
-    metadata = emitAssociatedTypeMetadataRef(IGF, parent,
-                                             archetype->getAssocType());
+    AssociatedType association(archetype->getAssocType());
+    metadata = emitAssociatedTypeMetadataRef(IGF, parent, association);
 
     setTypeMetadataName(IGF.IGM, metadata, archetype);
 
@@ -242,8 +242,8 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
 
     // Otherwise, it's an associated conformance requirement.
     } else {
-      WitnessIndex index =
-        lastPI.getAssociatedConformanceIndex(depType, requirement);
+      AssociatedConformance association(lastProtocol, depType, requirement);
+      WitnessIndex index = lastPI.getAssociatedConformanceIndex(association);
       path.addAssociatedConformanceComponent(index);
     }
 
@@ -263,15 +263,16 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
 
 llvm::Value *irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                                   CanArchetypeType origin,
-                                               AssociatedTypeDecl *associate) {
+                                                  AssociatedType association) {
   // Find the conformance of the origin to the associated type's protocol.
   llvm::Value *wtable = emitArchetypeWitnessTableRef(IGF, origin,
-                                                     associate->getProtocol());
+                                               association.getSourceProtocol());
 
   // Find the origin's type metadata.
   llvm::Value *originMetadata = emitArchetypeTypeMetadataRef(IGF, origin);
 
-  return emitAssociatedTypeMetadataRef(IGF, originMetadata, wtable, associate);
+  return emitAssociatedTypeMetadataRef(IGF, originMetadata, wtable,
+                                       association);
 }
 
 const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {

--- a/lib/IRGen/GenArchetype.h
+++ b/lib/IRGen/GenArchetype.h
@@ -25,6 +25,7 @@ namespace llvm {
 }
 
 namespace swift {
+  class AssociatedType;
   class ProtocolDecl;
   class SILType;
 
@@ -47,7 +48,7 @@ namespace irgen {
   /// Emit a metadata reference for an associated type of an archetype.
   llvm::Value *emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                              CanArchetypeType origin,
-                                             AssociatedTypeDecl *associate);
+                                             AssociatedType association);
 
   /// Emit a dynamic metatype lookup for the given archetype.
   llvm::Value *emitDynamicTypeOfOpaqueArchetype(IRGenFunction &IGF,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3439,11 +3439,12 @@ IRGenModule::getAddrOfWitnessTable(const NormalProtocolConformance *conf,
 llvm::Function *
 IRGenModule::getAddrOfAssociatedTypeMetadataAccessFunction(
                                   const NormalProtocolConformance *conformance,
-                                  AssociatedTypeDecl *associate) {
+                                  AssociatedType association) {
   auto forDefinition = ForDefinition;
 
   LinkEntity entity =
-    LinkEntity::forAssociatedTypeMetadataAccessFunction(conformance, associate);
+    LinkEntity::forAssociatedTypeMetadataAccessFunction(conformance,
+                                                        association);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
     if (forDefinition) updateLinkageForDefinition(*this, entry, entity);
@@ -3459,14 +3460,12 @@ IRGenModule::getAddrOfAssociatedTypeMetadataAccessFunction(
 llvm::Function *
 IRGenModule::getAddrOfAssociatedTypeWitnessTableAccessFunction(
                                   const NormalProtocolConformance *conformance,
-                                  CanType associatedType,
-                                  ProtocolDecl *associatedProtocol) {
+                                  const AssociatedConformance &association) {
   auto forDefinition = ForDefinition;
 
   LinkEntity entity =
     LinkEntity::forAssociatedTypeWitnessTableAccessFunction(conformance,
-                                                            associatedType,
-                                                            associatedProtocol);
+                                                            association);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
     if (forDefinition) updateLinkageForDefinition(*this, entry, entity);

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -27,6 +27,8 @@ namespace llvm {
 }
 
 namespace swift {
+  class AssociatedConformance;
+  class AssociatedType;
   class CanType;
   class FuncDecl;
   class ProtocolConformanceRef;
@@ -69,7 +71,7 @@ namespace irgen {
   llvm::Value *emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                              llvm::Value *parentMetadata,
                                              llvm::Value *wtable,
-                                           AssociatedTypeDecl *associatedType);
+                                             AssociatedType associatedType);
 
   /// Add the witness parameters necessary for calling a function with
   /// the given generics clause.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -75,6 +75,8 @@ namespace clang {
 
 namespace swift {
   class GenericSignatureBuilder;
+  class AssociatedConformance;
+  class AssociatedType;
   class ASTContext;
   class BraceStmt;
   class CanType;
@@ -1012,11 +1014,10 @@ public:
                                     const NormalProtocolConformance *C);
   llvm::Function *getAddrOfAssociatedTypeMetadataAccessFunction(
                                            const NormalProtocolConformance *C,
-                                           AssociatedTypeDecl *associatedType);
+                                           AssociatedType association);
   llvm::Function *getAddrOfAssociatedTypeWitnessTableAccessFunction(
-                                           const NormalProtocolConformance *C,
-                                           CanType depAssociatedType,
-                                           ProtocolDecl *requiredProtocol);
+                                     const NormalProtocolConformance *C,
+                                     const AssociatedConformance &association);
 
   Address getAddrOfObjCISAMask();
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -442,8 +442,9 @@ public:
                     SILWitnessTable::MethodWitness{requirementRef, witnessFn});
   }
 
-  void addAssociatedType(AssociatedTypeDecl *td) {
+  void addAssociatedType(AssociatedType requirement) {
     // Find the substitution info for the witness type.
+    auto td = requirement.getAssociation();
     Type witness = Conformance->getTypeWitness(td, /*resolver=*/nullptr);
 
     // Emit the record for the type itself.
@@ -451,14 +452,16 @@ public:
                                                 witness->getCanonicalType()});
   }
 
-  void addAssociatedConformance(CanType dependentType, ProtocolDecl *protocol) {
+  void addAssociatedConformance(AssociatedConformance req) {
     auto assocConformance =
-      Conformance->getAssociatedConformance(dependentType, protocol);
+      Conformance->getAssociatedConformance(req.getAssociation(),
+                                            req.getAssociatedRequirement());
 
     SGM.useConformance(assocConformance);
 
     Entries.push_back(SILWitnessTable::AssociatedTypeProtocolWitness{
-        dependentType, protocol, assocConformance});
+        req.getAssociation(), req.getAssociatedRequirement(),
+        assocConformance});
   }
 
   void visitAbstractStorageDecl(AbstractStorageDecl *d) {
@@ -745,12 +748,12 @@ public:
     DefaultWitnesses.push_back(entry);
   }
 
-  void addAssociatedType(AssociatedTypeDecl *ty) {
+  void addAssociatedType(AssociatedType req) {
     // Add a dummy entry for the metatype itself.
     addMissingDefault();
   }
 
-  void addAssociatedConformance(CanType type, ProtocolDecl *requirement) {
+  void addAssociatedConformance(const AssociatedConformance &req) {
     addMissingDefault();
   }
 


### PR DESCRIPTION
Add an AST-level abstraction for representing an abstract associated type or conformance requirement.  NFC.