### PR TITLE
[stdlib] Deprecate String/Substring.CharacterView

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -57,6 +57,8 @@ extension String {
   ///         print(firstName)
   ///     }
   ///     // Prints "Marie"
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
   public struct CharacterView {
     @_versioned
     internal var _core: _StringCore
@@ -82,6 +84,8 @@ extension String {
   }
 
   /// A view of the string's contents as a collection of characters.
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
   public var characters: CharacterView {
     get {
       return CharacterView(self)

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -386,6 +386,10 @@ extension StringProtocol {
 %   View = ViewPrefix + 'View'
 %   RangeReplaceable = 'RangeReplaceable' if property == 'unicodeScalars' else ''
 extension Substring {
+  % if View == 'CharacterView':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
   public struct ${View} {
     var _slice: ${RangeReplaceable}BidirectionalSlice<String.${View}>
   }
@@ -424,6 +428,10 @@ extension Substring.${View} : BidirectionalCollection {
 }
 
 extension Substring {
+  % if View == 'CharacterView':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
   public var ${property}: ${View} {
     get {
       return ${View}(_wholeString.${property}, _bounds: startIndex..<endIndex)

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -418,7 +418,7 @@ extension Array where Element: Hashable {
     }
 }
 
-func rdar29633747(characters: String.CharacterView) {
+func rdar29633747(characters: String) {
   let _ = Array(characters).trimmed(["("])
 }
 

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -396,7 +396,6 @@ func resyncParserB11() {}
 // rdar://21346928
 func optStr() -> String? { return nil }
 let x = (optStr() ?? "autoclosure").#^TOP_LEVEL_AUTOCLOSURE_1^#
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      unicodeScalars[#String.UnicodeScalarView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
 

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -55,7 +55,6 @@ func giveMeAString() -> Int {
   return "Here's a string".#^LITERAL5^# // try .characters.count here
 }
 
-// LITERAL5-DAG:     Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]{{; name=.+$}}
 // LITERAL5-DAG:     Decl[InstanceVar]/CurrNominal:      endIndex[#String.Index#]{{; name=.+$}}
 // LITERAL5-DAG:     Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: reserveCapacity({#(n): Int#})[#Void#]{{; name=.+$}}
 // LITERAL5-DAG:     Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: append({#(c): Character#})[#Void#]{{; name=.+$}}

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1730,7 +1730,6 @@ func testThrows006() {
 
 // rdar://21346928
 // Just sample some String API to sanity check.
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      unicodeScalars[#String.UnicodeScalarView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
 func testWithAutoClosure1(_ x: String?) {

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1127,7 +1127,7 @@ func test22436880() {
 
 // sr-184
 let x: String? // expected-note 2 {{constant defined here}}
-print(x?.characters.count as Any) // expected-error {{constant 'x' used before being initialized}}
+print(x?.count as Any) // expected-error {{constant 'x' used before being initialized}}
 print(x!) // expected-error {{constant 'x' used before being initialized}}
 
 

--- a/test/stdlib/Renames.swift
+++ b/test/stdlib/Renames.swift
@@ -503,7 +503,7 @@ func _String<S : Sequence>(s: S, sep: String) where S.Iterator.Element == String
   _ = s.joinWithSeparator(sep) // expected-error {{'joinWithSeparator' has been renamed to 'joined(separator:)'}} {{9-26=joined}} {{27-27=separator: }} {{none}}
 }
 
-func _StringCharacterView<S, C>(x: String.CharacterView, s: S, c: C, i: String.CharacterView.Index)
+func _StringCharacterView<S, C>(x: String, s: S, c: C, i: String.Index)
   where S : Sequence, S.Iterator.Element == Character, C : Collection, C.Iterator.Element == Character {
   var x = x
   x.replaceRange(i..<i, with: c) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange'}} {{5-17=replaceSubrange}} {{none}}

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -3,12 +3,20 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // FIXME: deprecate CharacterView. This call currently gets paired with default popFirst from Collection :-(
+  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // ok
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
+
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charSubView)
 }
 

--- a/test/stdlib/StringCompatibilityDiagnostics3.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics3.swift
@@ -3,14 +3,22 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
-    // TODO: ^^^ deprecate the view, and update the warning here
+  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
   _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // ok
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
+
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charSubView)
 }
 
 

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -82,7 +82,7 @@ func testStringCollectionTypes(s: String) {
   acceptsBidirectionalCollection(s.unicodeScalars)
   acceptsRandomAccessCollection(s.unicodeScalars) // expected-error{{argument type 'String.UnicodeScalarView' does not conform to expected type 'RandomAccessCollection'}}
 
-  acceptsCollection(s.characters)
-  acceptsBidirectionalCollection(s.characters)
-  acceptsRandomAccessCollection(s.characters) // expected-error{{argument type 'String.CharacterView' does not conform to expected type 'RandomAccessCollection'}}
+  acceptsCollection(s)
+  acceptsBidirectionalCollection(s)
+  acceptsRandomAccessCollection(s) // expected-error{{argument type 'String' does not conform to expected type 'RandomAccessCollection'}}
 }

--- a/test/stdlib/StringDiagnostics_without_Foundation.swift
+++ b/test/stdlib/StringDiagnostics_without_Foundation.swift
@@ -19,9 +19,9 @@ func testStringCollectionTypes(s: String) {
   acceptsBidirectionalCollection(s.unicodeScalars)
   acceptsRandomAccessCollection(s.unicodeScalars) // expected-error{{argument type 'String.UnicodeScalarView' does not conform to expected type 'RandomAccessCollection'}}
 
-  acceptsCollection(s.characters)
-  acceptsBidirectionalCollection(s.characters)
-  acceptsRandomAccessCollection(s.characters) // expected-error{{argument type 'String.CharacterView' does not conform to expected type 'RandomAccessCollection'}}
+  acceptsCollection(s)
+  acceptsBidirectionalCollection(s)
+  acceptsRandomAccessCollection(s) // expected-error{{argument type 'String' does not conform to expected type 'RandomAccessCollection'}}
 }
 
 struct NotLosslessStringConvertible {}

--- a/test/stdlib/UnavailableStringAPIs.swift.gyb
+++ b/test/stdlib/UnavailableStringAPIs.swift.gyb
@@ -48,7 +48,7 @@ func test_UnicodeScalarView(s: String.UnicodeScalarView, i: String.UnicodeScalar
   _ = s.distance(from: i, to: i) // OK
 }
 
-func test_CharacterView(s: String.CharacterView, i: String.CharacterView.Index, d: Int) {
+func test_CharacterView(s: String, i: String.Index, d: Int) {
   _ = s.index(after: i) // OK
   _ = s.index(before: i) // OK
   _ = s.index(i, offsetBy: d) // OK


### PR DESCRIPTION
CharacterView is now entirely redundant in Swift 4. Deprecate its
use. This also allows us to schedule the unbreaking of
String.CharacterView leakiness without a hard source break.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
