### PR TITLE
SimplifyCFG: fix a bug which causes SimplifyCFG to hang.

### DIFF
--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -3,6 +3,8 @@
 sil_stage canonical
 
 import Builtin
+import Swift
+import SwiftShims
 
 // CHECK-LABEL: sil @test_jump_threading
 // CHECK: bb4(%{{[0-9]+}} : $Builtin.Int64):
@@ -43,3 +45,65 @@ bb5:
 sil @get_int1 : $@convention(thin)  () -> Builtin.Int64
 sil @get_int2 : $@convention(thin)  () -> Builtin.Int64
 sil @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
+
+
+public final class AA {
+}
+public final class BB {
+  @sil_stored internal weak final var n:  BB!
+  @sil_stored internal final var o: AA!
+}
+
+// Test that SimplifyCFG does not hang when compiling an infinite loop with switch_enum.
+// CHECK-LABEL: test_inifite_loop
+sil hidden @test_inifite_loop : $@convention(method) (@owned BB) -> () {
+bb0(%0 : $BB):
+  %31 = enum $Optional<BB>, #Optional.some!enumelt.1, %0 : $BB
+  br bb4(%31 : $Optional<BB>)
+
+bb4(%36 : $Optional<BB>):
+  switch_enum %36 : $Optional<BB>, case #Optional.some!enumelt.1: bb6, default bb5
+
+bb5:
+  br bb7
+
+bb6:
+  %39 = unchecked_enum_data %36 : $Optional<BB>, #Optional.some!enumelt.1
+  %40 = ref_element_addr %39 : $BB, #BB.o
+  %41 = load %40 : $*Optional<AA>
+  release_value %41 : $Optional<AA>
+  br bb7
+
+bb7:
+  switch_enum %36 : $Optional<BB>, case #Optional.none!enumelt: bb8, case #Optional.some!enumelt.1: bb9
+
+bb8:
+  br bb4(%36 : $Optional<BB>)
+
+bb9:
+  %48 = unchecked_enum_data %36 : $Optional<BB>, #Optional.some!enumelt.1
+  %49 = ref_element_addr %48 : $BB, #BB.n
+  %50 = load_weak %49 : $*@sil_weak Optional<BB>
+  release_value %36 : $Optional<BB>
+  switch_enum %50 : $Optional<BB>, case #Optional.some!enumelt.1: bb11, case #Optional.none!enumelt: bb10
+
+bb10:
+  br bb4(%50 : $Optional<BB>)
+
+bb11:
+  %54 = unchecked_enum_data %50 : $Optional<BB>, #Optional.some!enumelt.1
+  %55 = ref_to_raw_pointer %54 : $BB to $Builtin.RawPointer
+  %56 = ref_to_raw_pointer %0 : $BB to $Builtin.RawPointer
+  %57 = builtin "cmp_eq_RawPointer"(%55 : $Builtin.RawPointer, %56 : $Builtin.RawPointer) : $Builtin.Int1
+  cond_br %57, bb13, bb12
+
+bb12:
+  br bb4(%50 : $Optional<BB>)
+
+bb13:
+  release_value %50 : $Optional<BB>
+  strong_release %0 : $BB
+  %65 = tuple ()
+  return %65 : $()
+}
+


### PR DESCRIPTION
Explanation: This could happen for CFGs which contain an infinite loop through a switch_enum in the loop header.

Scope of Issue: This can only happen if the source already contains an infinite loop. But as I have seen before, such situations can implicitly occur if the source contains an assert which is optimized away in the optimized build.

Risk: Minimal. The change just adds an additional bail-out condition. And the limit for the condition is so high that it does not kick in in regular code (tested with stdlib and benchmark compilation). It only fires in the infinite loop case.

Reviewed By: Roman

Testing: There is a regression test for it

Radar: rdar://problem/33762217
