### PR TITLE
[4.0] Fix a memory leak in _cocoaStringSlice

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -69,6 +69,7 @@ _swift_shims_CFIndex _swift_stdlib_CFStringGetLength(
     _swift_shims_CFStringRef _Nonnull theString);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+__attribute__((ns_returns_retained))
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateWithSubstring(
     _swift_shims_CFAllocatorRef _Nullable alloc,
     _swift_shims_CFStringRef _Nonnull str, _swift_shims_CFRange range);


### PR DESCRIPTION
_cocoaStringSlice uses _swift_stdlib_CFStringCreateWithSubstring which returns
its result +1. However, because of a missing annotation we assume @autoreleased.
Add the annotation.

Original fix by John McCall.

rdar://33837897