### PR TITLE
Move the include guard of Analysis.h /above/ the includes.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -10,16 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
+#define SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
+
+#include "swift/SIL/Notifications.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
-#include "swift/SIL/Notifications.h"
 #include <vector>
-
-#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
-#define SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
 
 namespace swift {
   class SILModule;


### PR DESCRIPTION
Move the include guard of Analysis.h /above/ the includes.

Otherwise, every time we include Analysis.h, we will try to include those other
files even if we have already included Analysis.h. This can increase compile
time.

rdar://33841629