### PR TITLE
Fix construction during invalidation

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -10,16 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
+#define SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
+
+#include "swift/SIL/Notifications.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
-#include "swift/SIL/Notifications.h"
 #include <vector>
-
-#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
-#define SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
 
 namespace swift {
   class SILModule;

--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -13,12 +13,13 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
 #define SWIFT_SILOPTIMIZER_ANALYSIS_ANALYSIS_H
 
+#include "swift/Basic/NullablePtr.h"
 #include "swift/SIL/Notifications.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
 #include <vector>
 
 namespace swift {
@@ -175,6 +176,17 @@ namespace swift {
     }
 
   public:
+    /// Returns true if we have an analysis for a specific function \p F without
+    /// actually constructing it.
+    bool hasAnalysis(SILFunction *F) const { return Storage.count(F); }
+
+    NullablePtr<AnalysisTy> maybeGet(SILFunction *F) {
+      auto Iter = Storage.find(F);
+      if (Iter == Storage.end())
+        return nullptr;
+      return Iter->second;
+    }
+
     /// Returns an analysis provider for a specific function \p F.
     AnalysisTy *get(SILFunction *F) {
 

--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -281,7 +281,11 @@ public:
     if (F->isExternalDeclaration()) {
       return;
     }
-    get(F)->handleDeleteNotification(V);
+
+    // If we do have an analysis, tell it to handle its delete notifications.
+    if (auto A = maybeGet(F)) {
+      A.get()->handleDeleteNotification(V);
+    }
   }
 
   virtual bool needsNotifications() override { return true; }


### PR DESCRIPTION
This PR fixes an issue where EpilogueARCAnalysis was creating an EpilogueARCFunctionInfo when attempting to delete the function info. Instead if the function info, doesn't exist, we don't have anything to invalidate!