### PR TITLE
[SR-5671] Emit diagnostic in place of collection downcast in pattern

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2944,8 +2944,9 @@ WARNING(type_inferred_to_undesirable_type,none,
         "which may be unexpected", (Identifier, Type, bool))
 NOTE(add_explicit_type_annotation_to_silence,none,
      "add an explicit type annotation to silence this warning", ())
-ERROR(isa_pattern_value,none,
-      "downcast pattern value of type %0 cannot be used", (Type))
+ERROR(isa_collection_downcast_pattern_value_unimplemented,none,
+      "collection downcast in cast pattern is not implemented; use an explicit "
+      "downcast to %0 instead", (Type))
 
 WARNING(swift3_ignore_specialized_enum_element_call,none,
         "cannot specialize enum case; ignoring generic argument, "

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -295,7 +295,9 @@ class Derived : Base { }
 
 
 switch [Derived(), Derived(), Base()] {
-case let ds as [Derived]: // expected-error{{downcast pattern value of type '[Derived]' cannot be used}}
+case let ds as [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
+  ()
+case is [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
   ()
 
 default:


### PR DESCRIPTION
For switch statements like the following

```swift
class Animal {}
class Cat : Animal {}
class Dog : Animal {}

func check(_ arry: [Animal]) {
  switch arry {
  case is [Cat]:
    ()
  case let dogs as [Dog]:
    ()
  default:
    ()
  }
}
```

Collection downcasts are not implemented.  SILGen support requires
refactoring SILGenPattern to emit the collection downcast, but
would be better solved by a future rewrite.

At least offer a more informative diagnostic than what was there
before.

Resolves [SR-5671](https://bugs.swift.org/browse/SR-5671) (in an unsatisfactory way).
