### PR TITLE
Vim plugin: expand highlighting coverage

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: swift
 " Maintainer: Joe Groff <jgroff@apple.com>
-" Last Change: 2013 Feb 2
+" Last Change: 2017 Aug 12
 
 if exists("b:current_syntax")
     finish

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -82,8 +82,10 @@ syn keyword swiftTypeDefinition skipwhite nextgroup=swiftTypeName
       \ protocol
       \ struct
       \ typealias
-syn match swiftMultiwordTypeDefinition nextgroup=swiftTypeName
+
+syn match swiftMultiwordTypeDefinition skipwhite nextgroup=swiftTypeName
       \ "indirect enum"
+      \ "indirect case"
 
 syn keyword swiftVarDefinition skipwhite nextgroup=swiftVarName
       \ let

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -109,7 +109,7 @@ syn match swiftImportModule contained nextgroup=swiftImportComponent
 syn match swiftImportComponent contained nextgroup=swiftImportComponent
       \ /\.\<[A-Za-z_][A-Za-z_0-9]*\>/
 
-syn match swiftTypeName contained nextgroup=swiftTypeParameters
+syn match swiftTypeName contained skipwhite nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>/
 syn match swiftVarName contained skipwhite nextgroup=swiftTypeDeclaration
       \ /\<[A-Za-z_][A-Za-z_0-9]*\>/
@@ -117,12 +117,12 @@ syn match swiftImplicitVarName
       \ /\$\<[A-Za-z_0-9]\+\>/
 
 " TypeName[Optionality]?
-syn match swiftType contained nextgroup=swiftTypeParameters
+syn match swiftType contained skipwhite nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
 syn region swiftType contained contains=swiftTypePair,swiftType
       \ matchgroup=Delimiter start=/\[/ end=/\]/
-syn match swiftTypePair contained nextgroup=swiftTypeParameters,swiftTypeDeclaration
+syn match swiftTypePair contained skipwhite nextgroup=swiftTypeParameters,swiftTypeDeclaration
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " (Type[, Type]) (tuple)
 " FIXME: we should be able to use skip="," and drop swiftParamDelim

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -85,7 +85,6 @@ syn keyword swiftTypeDefinition skipwhite nextgroup=swiftTypeName
 
 syn match swiftMultiwordTypeDefinition skipwhite nextgroup=swiftTypeName
       \ "indirect enum"
-      \ "indirect case"
 
 syn keyword swiftVarDefinition skipwhite nextgroup=swiftVarName
       \ let


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR adds coverage for some cases where highlighting doesn't happen, but should.

- highlight `indirect enum` when followed by whitespace (which it always is, I think?)
- allow whitespace before the `swiftTypeParameters` group, which makes highlighting work for notations like `Type <Param>`.

Not sure if I should add `skipempty`/`skipnl` as well; it isn't used in this syntax file but I think it would be a little more robust to use it.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This doesn't resolve any bug tracker issues that I'm aware of.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
@swift-ci Please smoke test
