### PR TITLE
Reject member lookups that require bridging metatypes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3263,7 +3263,7 @@ retry_after_fail:
 
   // If the instance type is a bridged to an Objective-C type, perform
   // a lookup into that Objective-C type.
-  if (bridgedType) {
+  if (bridgedType && !isMetatype) {
     LookupResult &bridgedLookup = lookupMember(bridgedClass, memberName);
     ModuleDecl *foundationModule = nullptr;
     for (auto result : bridgedLookup) {

--- a/test/ClangImporter/objc_bridge_categories.swift
+++ b/test/ClangImporter/objc_bridge_categories.swift
@@ -9,7 +9,7 @@ import AppKit
 
 func testStringBridge(_ str: String) {
   var str2 = str.nsStringMethod()!
-  var int = String.nsStringClassMethod()
+  var int = NSString.nsStringClassMethod()
   var str3 = str.nsStringProperty!
 
   // Make sure the types worked out as expected

--- a/test/Constraints/Inputs/invalid_metatype_bridging_header.h
+++ b/test/Constraints/Inputs/invalid_metatype_bridging_header.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+// rdar://problem/33830526: Constraint system should not add static methods
+// to the overload search space if it would require bridging unrelated metatypes.
+@interface NSString (Extension)
++ (void) meth;
+@end

--- a/test/Constraints/invalid_metatype_bridging_header.swift
+++ b/test/Constraints/invalid_metatype_bridging_header.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -import-objc-header %S/Inputs/invalid_metatype_bridging_header.h %s -verify
+
+// REQUIRES: objc_interop
+
+// rdar://problem/33830526: Constraint system should not add static methods
+// to the overload search space if it would require bridging unrelated metatypes.
+class Crasher {
+  static func called(argument: String) {}
+}
+
+Crasher.called(argument: .meth) // expected-error {{type 'String' has no member 'meth'}}
+Crasher.called(argument: String.meth) // expected-error {{type 'String' has no member 'meth'}}


### PR DESCRIPTION
We can only coerce metatypes covariantly but bridging
always requires an unrelated metatype cast.  When
performing member lookup, especially unqualified member
lookup, disregard static members from bridged types entirely.

Resolves [SR-5670](https://bugs.swift.org/browse/SR-5670) and rdar://problem/33830526.

<strike>I have a hunch this might break things, stand by.</strike>