### PR TITLE
[swiftc (50 vs. 5588)] Add crasher in swift::IterativeTypeChecker::processTypeCheckSuperclass

### DIFF
--- a/validation-test/compiler_crashers/28832-superclass-superclass-hasarchetype-superclass-must-be-interface-type.swift
+++ b/validation-test/compiler_crashers/28832-superclass-superclass-hasarchetype-superclass-must-be-interface-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension CountableRange{{}class a:a&a.a{func a


### PR DESCRIPTION
Add test case for crash triggered in `swift::IterativeTypeChecker::processTypeCheckSuperclass`.

Current number of unresolved compiler crashers: 50 (5588 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"` added on 2016-06-25 by you in commit 680688cb :-)

Assertion failure in [`lib/AST/Decl.cpp (line 5399)`](https://github.com/apple/swift/blob/1f136dba524725f1c5bd6f89e5c3e51fbe093e91/lib/AST/Decl.cpp#L5399):

```
Assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"' failed.

When executing: void swift::ClassDecl::setSuperclass(swift::Type)
```

Assertion context:

```c++
  return nullptr;
}

void ClassDecl::setSuperclass(Type superclass) {
  assert((!superclass || !superclass->hasArchetype())
         && "superclass must be interface type");
  LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);
}
```
Stack trace:

```
0 0x0000000003f25fd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f25fd4)
1 0x0000000003f26316 SignalHandler(int) (/path/to/swift/bin/swift+0x3f26316)
2 0x00007efe46964390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007efe44e89428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007efe44e8b02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007efe44e81bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007efe44e81c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015fcb7d (/path/to/swift/bin/swift+0x15fcb7d)
8 0x000000000139a40d swift::IterativeTypeChecker::processTypeCheckSuperclass(swift::ClassDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x139a40d)
9 0x0000000001363626 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1363626)
10 0x00000000013636eb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x13636eb)
11 0x00000000013636eb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x13636eb)
12 0x000000000124b929 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x124b929)
13 0x00000000016983bc swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0x16983bc)
14 0x0000000001697d4f swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0x1697d4f)
15 0x0000000001697c75 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0x1697c75)
16 0x000000000169bd7e swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x169bd7e)
17 0x0000000001671976 swift::NominalTypeDecl::getAllProtocols() const (/path/to/swift/bin/swift+0x1671976)
18 0x0000000001299a61 swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) (/path/to/swift/bin/swift+0x1299a61)
19 0x0000000001259c63 shouldMarkAsObjC(swift::TypeChecker&, swift::ValueDecl const*, bool) (/path/to/swift/bin/swift+0x1259c63)
20 0x0000000001268e97 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1268e97)
21 0x0000000001253824 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1253824)
22 0x0000000001255951 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1255951)
23 0x00000000016642ab swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0x16642ab)
24 0x00000000012892ae swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12892ae)
25 0x00000000012db5b0 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x12db5b0)
26 0x00000000012d51b0 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x12d51b0)
27 0x00000000012d47ca swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x12d47ca)
28 0x00000000012d5597 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x12d5597)
29 0x00000000012d549c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x12d549c)
30 0x00000000012d3cd0 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x12d3cd0)
31 0x000000000124c86c swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x124c86c)
32 0x0000000001255271 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1255271)
33 0x000000000126524c (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x126524c)
34 0x00000000012538ee (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12538ee)
35 0x0000000001264bab (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x1264bab)
36 0x00000000012537f4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12537f4)
37 0x00000000012536f3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12536f3)
38 0x00000000012e3434 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12e3434)
39 0x0000000001013ce7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1013ce7)
40 0x00000000004bc4d7 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bc4d7)
41 0x00000000004bb284 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bb284)
42 0x0000000000473494 main (/path/to/swift/bin/swift+0x473494)
43 0x00007efe44e74830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
44 0x0000000000470d49 _start (/path/to/swift/bin/swift+0x470d49)
```