### PR TITLE
Turn on circularity checks for ProtocolCompositions

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2927,7 +2927,7 @@ Type TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
   };
 
   for (auto tyR : repr->getTypes()) {
-    Type ty = TC.resolveType(tyR, DC, withoutContext(options), Resolver);
+    Type ty = resolveType(tyR, withoutContext(options));
     if (!ty || ty->hasError()) return ty;
 
     auto nominalDecl = ty->getAnyNominal();

--- a/validation-test/compiler_crashers_fixed/28810-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28810-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class A:a:a{}typealias a:A.a
 & Ms


### PR DESCRIPTION
When resolving protocol composition types, using the old type checker to resolve the type manually instead of the iterative type checker winds up submitting a recursive-but-satisfiable request to the ITC anyway.  This way we directly resolve through TypeCheckType and can catch the circularity before it takes down the compiler.
