### PR TITLE
[swiftc (51 vs. 5588)] Add crasher in swift::TypeChecker::lookupMember

### DIFF
--- a/validation-test/compiler_crashers/28833-foundintype-isexistentialtype.swift
+++ b/validation-test/compiler_crashers/28833-foundintype-isexistentialtype.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:a{}class a:RangeReplaceableCollection
+& a
+func<a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::lookupMember`.

Current number of unresolved compiler crashers: 51 (5588 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `foundInType->isExistentialType()` added on 2017-07-27 by you in commit bfb252ab :-)

Assertion failure in [`lib/Sema/TypeCheckNameLookup.cpp (line 159)`](https://github.com/apple/swift/blob/5456dc60f01e1aff7293658d6b7e0a89fceb393a/lib/Sema/TypeCheckNameLookup.cpp#L159):

```
Assertion `foundInType->isExistentialType()' failed.

When executing: void (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl *, swift::DeclContext *, swift::Type)
```

Assertion context:

```c++
                                                 conformanceOptions);
      if (!conformance) {
        // If there's no conformance, we have an existential
        // and we found a member from one of the protocols, and
        // not a class constraint if any.
        assert(foundInType->isExistentialType());
        addResult(found);
        return;
      }

      if (conformance->isAbstract()) {
```
Stack trace:

```
0 0x0000000003f25fd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f25fd4)
1 0x0000000003f26316 SignalHandler(int) (/path/to/swift/bin/swift+0x3f26316)
2 0x00007fd0f05f6390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fd0eeb1b428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd0eeb1d02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd0eeb13bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fd0eeb13c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001288d45 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::DeclContext*, swift::Type) (/path/to/swift/bin/swift+0x1288d45)
8 0x00000000012892e1 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12892e1)
9 0x0000000001289cbd swift::TypeChecker::lookupConstructors(swift::DeclContext*, swift::Type, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x1289cbd)
10 0x000000000136fb81 diagSyntacticUseRestrictions(swift::TypeChecker&, swift::Expr const*, swift::DeclContext const*, bool)::DiagnoseWalker::checkUseOfMetaTypeName(swift::Expr*) (/path/to/swift/bin/swift+0x136fb81)
11 0x000000000136e8e7 diagSyntacticUseRestrictions(swift::TypeChecker&, swift::Expr const*, swift::DeclContext const*, bool)::DiagnoseWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x136e8e7)
12 0x00000000015cdd0b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x15cdd0b)
13 0x0000000001367cb3 swift::performSyntacticExprDiagnostics(swift::TypeChecker&, swift::Expr const*, swift::DeclContext const*, bool) (/path/to/swift/bin/swift+0x1367cb3)
14 0x000000000123c485 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x123c485)
15 0x00000000012c3db5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x12c3db5)
16 0x00000000012c35d6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x12c35d6)
17 0x00000000012e34a0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12e34a0)
18 0x0000000001013ce7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1013ce7)
19 0x00000000004bc4d7 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bc4d7)
20 0x00000000004bb284 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bb284)
21 0x0000000000473494 main (/path/to/swift/bin/swift+0x473494)
22 0x00007fd0eeb06830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000470d49 _start (/path/to/swift/bin/swift+0x470d49)
```