### PR TITLE
[swiftc (52 vs. 5588)] Add crasher in swift::TypeChecker::typeCheckExprPattern

### DIFF
--- a/validation-test/compiler_crashers/28834-t-isnull-t-is-inouttype.swift
+++ b/validation-test/compiler_crashers/28834-t-isnull-t-is-inouttype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+switch
+&_{case.o


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckExprPattern`.

Current number of unresolved compiler crashers: 52 (5588 resolved)

/cc @CodaFi - just wanted to let you know that this crasher caused an assertion failure for the assertion `t.isNull() || !t->is<InOutType>()` added on 2017-07-11 by you in commit 8cdddef2 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 3865)`](https://github.com/apple/swift/blob/f82016efd21faeeaa70a7c858d264ca046a0c63b/lib/AST/Decl.cpp#L3865):

```
Assertion `t.isNull() || !t->is<InOutType>()' failed.

When executing: void swift::VarDecl::setType(swift::Type)
```

Assertion context:

```c++
  if (isInOut()) return InOutType::get(typeInContext);
  return typeInContext;
}

void VarDecl::setType(Type t) {
  assert(t.isNull() || !t->is<InOutType>());
  typeInContext = t;
  if (t && t->hasError())
    setInvalid();
}

```
Stack trace:

```
0 0x0000000003f25fd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f25fd4)
1 0x0000000003f26316 SignalHandler(int) (/path/to/swift/bin/swift+0x3f26316)
2 0x00007f07070ff390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f0705624428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f070562602a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f070561cbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f070561cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015f88ac (/path/to/swift/bin/swift+0x15f88ac)
8 0x00000000012418ae swift::TypeChecker::typeCheckExprPattern(swift::ExprPattern*, swift::DeclContext*, swift::Type) (/path/to/swift/bin/swift+0x12418ae)
9 0x000000000128d8ad swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc, bool) (/path/to/swift/bin/swift+0x128d8ad)
10 0x00000000012c4b1d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x12c4b1d)
11 0x00000000012c3ce5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x12c3ce5)
12 0x00000000012c35d6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x12c35d6)
13 0x00000000012e34a0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12e34a0)
14 0x0000000001013ce7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1013ce7)
15 0x00000000004bc4d7 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bc4d7)
16 0x00000000004bb284 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bb284)
17 0x0000000000473494 main (/path/to/swift/bin/swift+0x473494)
18 0x00007f070560f830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x0000000000470d49 _start (/path/to/swift/bin/swift+0x470d49)
```