### PR TITLE
[swiftc (53 vs. 5588)] Add crasher in swift::GenericEnvironment::mapTypeOutOfContext

### DIFF
--- a/validation-test/compiler_crashers/28835-type-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers/28835-type-hastypeparameter-already-have-an-interface-type.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{
+class a:RangeReplaceableCollection
+protocol A:RangeReplaceableCollection
+& a.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::mapTypeOutOfContext`.

Current number of unresolved compiler crashers: 53 (5588 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!type->hasTypeParameter() && "already have an interface type"` added on 2016-12-18 by you in commit fb0f372e :-)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 160)`](https://github.com/apple/swift/blob/31d7f741d099ac9316da607d4102603703affed1/lib/AST/GenericEnvironment.cpp#L160):

```
Assertion `!type->hasTypeParameter() && "already have an interface type"' failed.

When executing: static swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::GenericEnvironment *, swift::Type)
```

Assertion context:

```c++
}

Type
GenericEnvironment::mapTypeOutOfContext(GenericEnvironment *env,
                                        Type type) {
  assert(!type->hasTypeParameter() && "already have an interface type");

  if (!env)
    return type.substDependentTypesWithErrorTypes();

  return env->mapTypeOutOfContext(type);
```
Stack trace:

```
0 0x0000000003f25fd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f25fd4)
1 0x0000000003f26316 SignalHandler(int) (/path/to/swift/bin/swift+0x3f26316)
2 0x00007f7a7dfb6390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f7a7c4db428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f7a7c4dd02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f7a7c4d3bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f7a7c4d3c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001615c84 swift::GenericEnvironment::mapTypeOutOfContext(swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0x1615c84)
8 0x0000000001624a0a maybeAddSameTypeRequirementForNestedType(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x1624a0a)
9 0x000000000162be54 swift::GenericSignatureBuilder::updateSuperclass(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*)::$_20::operator()() const (/path/to/swift/bin/swift+0x162be54)
10 0x000000000162bb85 swift::GenericSignatureBuilder::updateSuperclass(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x162bb85)
11 0x000000000162c32c swift::GenericSignatureBuilder::addSuperclassRequirementDirect(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x162c32c)
12 0x000000000162c9d7 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x162c9d7)
13 0x000000000163ddb3 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x163ddb3)
14 0x0000000001637102 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1637102)
15 0x0000000001627f30 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1627f30)
16 0x00000000016281ee swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x16281ee)
17 0x000000000162c625 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x162c625)
18 0x000000000162a05b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x162a05b)
19 0x00000000015f58ac swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x15f58ac)
20 0x0000000001286c98 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1286c98)
21 0x00000000012556c2 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12556c2)
22 0x000000000126632f (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x126632f)
23 0x0000000001253804 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1253804)
24 0x000000000126534b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x126534b)
25 0x00000000012538ee (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12538ee)
26 0x00000000012536f3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12536f3)
27 0x00000000012e3434 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12e3434)
28 0x0000000001013ce7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1013ce7)
29 0x00000000004bc4d7 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bc4d7)
30 0x00000000004bb284 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bb284)
31 0x0000000000473494 main (/path/to/swift/bin/swift+0x473494)
32 0x00007f7a7c4c6830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000470d49 _start (/path/to/swift/bin/swift+0x470d49)
```