### PR TITLE
[AST] NFC: Add llvm_unreachable() to getOwnership()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4396,9 +4396,12 @@ public:
 
   Type getReferentType() const { return Referent; }
   Ownership getOwnership() const {
-    return (getKind() == TypeKind::WeakStorage    ? Ownership::Weak :
-            getKind() == TypeKind::UnownedStorage ? Ownership::Unowned
-                                                  : Ownership::Unmanaged);
+    switch (getKind()) {
+    case TypeKind::WeakStorage: return Ownership::Weak;
+    case TypeKind::UnownedStorage: return Ownership::Unowned;
+    case TypeKind::UnmanagedStorage: return Ownership::Unmanaged;
+    default: llvm_unreachable("Unhandled reference storage type");
+    }
   }
 
   // Implement isa/cast/dyncast/etc.


### PR DESCRIPTION
If one adds a new reference storage type, then this change is helpful.

@swift-ci please smoke test and merge