### PR TITLE
[swiftc (54 vs. 5588)] Add crasher in swift::TypeChecker::configureInterfaceType

### DIFF
--- a/validation-test/compiler_crashers/28836-functy-hasarchetype.swift
+++ b/validation-test/compiler_crashers/28836-functy-hasarchetype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{protocol P{}func a{protocol P{class a:a{func a:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::configureInterfaceType`.

Current number of unresolved compiler crashers: 54 (5588 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!funcTy->hasArchetype()` added on 2016-07-24 by you in commit c55e0eec :-)

Assertion failure in [`lib/Sema/TypeCheckGeneric.cpp (line 883)`](https://github.com/apple/swift/blob/6726f2491f45678b66003688b719559026013871/lib/Sema/TypeCheckGeneric.cpp#L883):

```
Assertion `!funcTy->hasArchetype()' failed.

When executing: void swift::TypeChecker::configureInterfaceType(swift::AbstractFunctionDecl *, swift::GenericSignature *)
```

Assertion context:

```c++
      info = info.withThrows();

    assert(std::all_of(argTy.begin(), argTy.end(), [](const AnyFunctionType::Param &aty){
      return !aty.getType()->hasArchetype();
    }));
    assert(!funcTy->hasArchetype());
    if (initFuncTy)
      assert(!initFuncTy->hasArchetype());

    if (sig && i == e-1) {
      funcTy = GenericFunctionType::get(sig, argTy, funcTy, info);
```
Stack trace:

```
0 0x0000000003f25fd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f25fd4)
1 0x0000000003f26316 SignalHandler(int) (/path/to/swift/bin/swift+0x3f26316)
2 0x00007ff1f9cea390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007ff1f820f428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff1f821102a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007ff1f8207bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007ff1f8207c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001285257 swift::TypeChecker::configureInterfaceType(swift::AbstractFunctionDecl*, swift::GenericSignature*) (/path/to/swift/bin/swift+0x1285257)
8 0x0000000001283bbe swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1283bbe)
9 0x0000000001268a77 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1268a77)
10 0x0000000001253824 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1253824)
11 0x000000000126534b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x126534b)
12 0x00000000012538ee (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12538ee)
13 0x000000000126664b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x126664b)
14 0x0000000001253804 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1253804)
15 0x00000000012536f3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12536f3)
16 0x00000000012c3d55 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x12c3d55)
17 0x00000000012c205c swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x12c205c)
18 0x00000000012c1eb5 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x12c1eb5)
19 0x00000000012c2c2d swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x12c2c2d)
20 0x00000000012e2638 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x12e2638)
21 0x00000000012e352a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12e352a)
22 0x0000000001013ce7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1013ce7)
23 0x00000000004bc4d7 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bc4d7)
24 0x00000000004bb284 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bb284)
25 0x0000000000473494 main (/path/to/swift/bin/swift+0x473494)
26 0x00007ff1f81fa830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x0000000000470d49 _start (/path/to/swift/bin/swift+0x470d49)
```