### PR TITLE
[SourceKit] Include function return type in function kinds structure (SR-5613)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5219,6 +5219,10 @@ public:
   void setMutating(bool mutating = true) {
     Mutating = mutating;
   }
+
+  TypeLoc getReturnTypeLoc() const {
+    return FnRetType;
+  }
   
   /// \brief Returns the parameter lists(s) for the function definition.
   ///

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -766,6 +766,10 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
                                                      AFD->getBodySourceRange());
       SN.NameRange = charSourceRangeFromSourceRange(SM,
                           AFD->getSignatureSourceRange());
+      if (FD) {
+        SN.TypeRange = charSourceRangeFromSourceRange(SM,
+                                      FD->getReturnTypeLoc().getSourceRange());
+      }
       pushStructureNode(SN, AFD);
     }
   } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
@@ -963,6 +967,8 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
                                                SubscriptD->getBracesRange());
     SN.NameRange = charSourceRangeFromSourceRange(SM,
                                         SubscriptD->getSignatureSourceRange());
+    SN.TypeRange = charSourceRangeFromSourceRange(SM,
+                            SubscriptD->getElementTypeLoc().getSourceRange());
     pushStructureNode(SN, SubscriptD);
   }
 

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -1,15 +1,15 @@
 // RUN: %swift-ide-test -structure -source-filename %s | %FileCheck %s
 
 // CHECK: <class>class <name>MyCls</name> : <inherited><elem-typeref>OtherClass</elem-typeref></inherited> {
-// CHECK:   <property>var <name>bar</name> : Int</property>
-// CHECK:   <property>var <name>anotherBar</name> : Int = 42</property>
-// CHECK:   <cvar>class var <name>cbar</name> : Int = 0</cvar>
+// CHECK:   <property>var <name>bar</name> : <type>Int</type></property>
+// CHECK:   <property>var <name>anotherBar</name> : <type>Int</type> = 42</property>
+// CHECK:   <cvar>class var <name>cbar</name> : <type>Int</type> = 0</cvar>
 class MyCls : OtherClass {
   var bar : Int
   var anotherBar : Int = 42
   class var cbar : Int = 0
 
-  // CHECK:   <ifunc>func <name>foo(<param>_ arg1: Int</param>, <param><name>name</name>: String</param>, <param><name>param</name> par: String</param>)</name> {
+  // CHECK:   <ifunc>func <name>foo(<param>_ arg1: <type>Int</type></param>, <param><name>name</name>: <type>String</type></param>, <param><name>param</name> par: <type>String</type></param>)</name> {
   // CHECK:     <lvar>var <name>abc</name></lvar>
   // CHECK:     <if>if <elem-condexpr>1</elem-condexpr> <brace>{
   // CHECK:       <call><name>foo</name>(<arg>1</arg>, <arg><name>name</name>:"test"</arg>, <arg><name>param</name>:"test2"</arg>)</call>
@@ -22,7 +22,7 @@ class MyCls : OtherClass {
     }
   }
 
-  // CHECK:   <ifunc><name>init (<param><name>x</name>: Int</param>)</name></ifunc>
+  // CHECK:   <ifunc><name>init (<param><name>x</name>: <type>Int</type></param>)</name></ifunc>
   init (x: Int)
 
   // CHECK:   <cfunc>class func <name>cfoo()</name></cfunc>
@@ -32,8 +32,8 @@ class MyCls : OtherClass {
 }
 
 // CHECK: <struct>struct <name>MyStruc</name> {
-// CHECK:   <property>var <name>myVar</name>: Int</property>
-// CHECK:   <svar>static var <name>sbar</name> : Int = 0</svar>
+// CHECK:   <property>var <name>myVar</name>: <type>Int</type></property>
+// CHECK:   <svar>static var <name>sbar</name> : <type>Int</type> = 0</svar>
 // CHECK:   <sfunc>static func <name>cfoo()</name></sfunc>
 // CHECK: }</struct>
 struct MyStruc {
@@ -58,7 +58,7 @@ extension MyStruc {
   }
 }
 
-// CHECK: <gvar>var <name>gvar</name> : Int = 0</gvar>
+// CHECK: <gvar>var <name>gvar</name> : <type>Int</type> = 0</gvar>
 var gvar : Int = 0
 
 // CHECK: <ffunc>func <name>ffoo()</name> {}</ffunc>
@@ -149,7 +149,7 @@ enum Rawness : Int {
   case Two = 2, Three = 3
 }
 
-// CHECK: <ffunc>func <name>rethrowFunc(<param>_ f: () throws -> ()</param>)</name> rethrows {}</ffunc>
+// CHECK: <ffunc>func <name>rethrowFunc(<param>_ f: <type>() throws -> ()</type></param>)</name> rethrows {}</ffunc>
 func rethrowFunc(_ f: () throws -> ()) rethrows {}
 
 class NestedPoundIf{
@@ -189,7 +189,7 @@ class SubscriptTest {
   subscript(index: Int) -> Int {
     return 0
   }
-  // CHECK: <subscript><name>subscript(<param>index: Int</param>)</name> -> Int {
+  // CHECK: <subscript><name>subscript(<param>index: <type>Int</type></param>)</name> -> <type>Int</type> {
   // CHECK:  return 0
   // CHECK: }</subscript>
 
@@ -201,11 +201,24 @@ class SubscriptTest {
       print(value)
     }
   }
-  // CHECK: <subscript><name>subscript(<param>string: String</param>)</name> -> Int {
+  // CHECK: <subscript><name>subscript(<param>string: <type>String</type></param>)</name> -> <type>Int</type> {
   // CHECK: get {
   // CHECK:   return 0
   // CHECK: }
   // CHECK: set(<param>value</param>) {
   // CHECK:   <call><name>print</name>(value)</call>
   // CHECK: }</subscript>
+}
+
+class ReturnType {
+  func foo() -> Int { return 0 }
+  // CHECK:  <ifunc>func <name>foo()</name> -> <type>Int</type> {
+  // CHECK:  return 0
+  // CHECK: }</ifunc>
+  
+  func foo2<T>() -> T {}
+  // CHECK:  <ifunc>func <name>foo2<T>()</name> -> <type>T</type> {}</ifunc>
+  
+  func foo3() -> () -> Int {}
+  // CHECK:  <ifunc>func <name>foo3()</name> -> <type>() -> Int</type> {}</ifunc>
 }

--- a/test/IDE/structure_object_literals.swift
+++ b/test/IDE/structure_object_literals.swift
@@ -4,14 +4,14 @@ struct S: _ExpressibleByColorLiteral {
   init(_colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
 }
 
-// CHECK: <gvar>let <name>y</name>: S = <object-literal-expression>#<name>colorLiteral</name>(<arg><name>red</name>: 1</arg>, <arg><name>green</name>: 0</arg>, <arg><name>blue</name>: 0</arg>, <arg><name>alpha</name>: 1</arg>)</object-literal-expression></gvar>
+// CHECK: <gvar>let <name>y</name>: <type>S</type> = <object-literal-expression>#<name>colorLiteral</name>(<arg><name>red</name>: 1</arg>, <arg><name>green</name>: 0</arg>, <arg><name>blue</name>: 0</arg>, <arg><name>alpha</name>: 1</arg>)</object-literal-expression></gvar>
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
 
 struct I: _ExpressibleByImageLiteral {
   init?(imageLiteralResourceName: String) {}
 }
 
-// CHECK: <gvar>let <name>z</name>: I? = <object-literal-expression>#<name>imageLiteral</name>(<arg><name>resourceName</name>: "hello.png"</arg>)</object-literal-expression></gvar>
+// CHECK: <gvar>let <name>z</name>: <type>I?</type> = <object-literal-expression>#<name>imageLiteral</name>(<arg><name>resourceName</name>: "hello.png"</arg>)</object-literal-expression></gvar>
 let z: I? = #imageLiteral(resourceName: "hello.png")
 
 func before() {}

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -411,6 +411,7 @@
           key.name: "test(arg1:)",
           key.offset: 732,
           key.length: 156,
+          key.typename: "Int",
           key.nameoffset: 737,
           key.namelength: 16,
           key.bodyoffset: 762,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
@@ -59,6 +59,7 @@ public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
     key.name: "fooHelperExplicitFrameworkFunc1(_:)",
     key.offset: 8,
     key.length: 57,
+    key.typename: "Int32",
     key.nameoffset: 13,
     key.namelength: 43,
     key.substructure: [

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -177,6 +177,7 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.name: "fooHelperFunc1(_:)",
     key.offset: 74,
     key.length: 40,
+    key.typename: "Int32",
     key.nameoffset: 79,
     key.namelength: 26,
     key.substructure: [

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -4978,6 +4978,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.name: "fooFunc1(_:)",
     key.offset: 2119,
     key.length: 34,
+    key.typename: "Int32",
     key.nameoffset: 2124,
     key.namelength: 20,
     key.docoffset: 2086,
@@ -5000,6 +5001,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.name: "fooFunc1AnonymousParam(_:)",
     key.offset: 2162,
     key.length: 46,
+    key.typename: "Int32",
     key.nameoffset: 2167,
     key.namelength: 32,
     key.substructure: [
@@ -5019,6 +5021,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.name: "fooFunc3(_:_:_:_:)",
     key.offset: 2216,
     key.length: 94,
+    key.typename: "Int32",
     key.nameoffset: 2221,
     key.namelength: 80,
     key.substructure: [
@@ -5106,6 +5109,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.name: "fooFuncNoreturn1()",
     key.offset: 2508,
     key.length: 32,
+    key.typename: "Never",
     key.nameoffset: 2513,
     key.namelength: 18
   },
@@ -5115,6 +5119,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.name: "fooFuncNoreturn2()",
     key.offset: 2548,
     key.length: 32,
+    key.typename: "Never",
     key.nameoffset: 2553,
     key.namelength: 18
   },
@@ -5177,6 +5182,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
     key.offset: 3092,
     key.length: 58,
+    key.typename: "Int32",
     key.nameoffset: 3097,
     key.namelength: 44,
     key.docoffset: 3035,
@@ -5340,6 +5346,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "fooBaseInstanceFunc1(_:)",
         key.offset: 3898,
         key.length: 60,
+        key.typename: "FooClassBase!",
         key.nameoffset: 3903,
         key.namelength: 38,
         key.substructure: [
@@ -5836,6 +5843,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "_internalMeth1()",
         key.offset: 5658,
         key.length: 29,
+        key.typename: "Any!",
         key.nameoffset: 5663,
         key.namelength: 16
       }
@@ -5857,6 +5865,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "_internalMeth2()",
         key.offset: 5771,
         key.length: 29,
+        key.typename: "Any!",
         key.nameoffset: 5776,
         key.namelength: 16
       },
@@ -5866,6 +5875,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "nonInternalMeth()",
         key.offset: 5811,
         key.length: 30,
+        key.typename: "Any!",
         key.nameoffset: 5816,
         key.namelength: 17
       }
@@ -5887,6 +5897,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "_internalMeth3()",
         key.offset: 5880,
         key.length: 29,
+        key.typename: "Any!",
         key.nameoffset: 5885,
         key.namelength: 16
       }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -332,6 +332,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooSubFunc1(_:)",
     key.offset: 62,
     key.length: 37,
+    key.typename: "Int32",
     key.nameoffset: 67,
     key.namelength: 23,
     key.substructure: [

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1034,6 +1034,8 @@ private:
     for (auto &Elem : Node.Elements) {
       tagRange(Elem.Range, getTagName(Elem.Kind), Node);
     }
+    if (Node.TypeRange.isValid() && Node.Range.contains(Node.TypeRange))
+      tagRange(Node.TypeRange, "type", Node);
 
     return true;
   }


### PR DESCRIPTION
Reopened from https://github.com/apple/swift/pull/11447 to see if @swift-ci wakes up.

----
Adds `key.typename` to function and subscripts structures.

Resolves [SR-5613](https://bugs.swift.org/browse/SR-5613).

// cc @nkcsgexi 