### PR TITLE
Split emitRValue into plusone pluszero variants

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -284,7 +284,7 @@ static SILValue implodeTupleValues(ArrayRef<ManagedValue> values,
 
   // To implode an address-only tuple, we need to create a buffer to hold the
   // result tuple.
-  if (loweredType.isAddressOnly(SGF.F.getModule()) &&
+  if (loweredType.isAddressOnly(SGF.getModule()) &&
       SGF.silConv.useLoweredAddresses()) {
     assert(KIND != ImplodeKind::Unmanaged &&
            "address-only values are always managed!");
@@ -796,4 +796,12 @@ const TypeLowering &RValue::getTypeLowering(SILGenFunction &SGF) const & {
 
 SILType RValue::getLoweredType(SILGenFunction &SGF) const & {
   return getTypeLowering(SGF).getLoweredType();
+}
+
+SILType RValue::getLoweredImplodedTupleType(SILGenFunction &SGF) const & {
+  SILType loweredType = getLoweredType(SGF);
+  if (loweredType.isAddressOnly(SGF.getModule()) &&
+      SGF.silConv.useLoweredAddresses())
+    return loweredType.getAddressType();
+  return loweredType.getObjectType();
 }

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -304,6 +304,14 @@ public:
   /// Return the type lowering of RValue::getType().
   const Lowering::TypeLowering &getTypeLowering(SILGenFunction &SGF) const &;
 
+  /// Return the lowered SILType that would be used to implode the given RValue
+  /// into 1 tuple value.
+  ///
+  /// This means that if any sub-objects are address only, an address type will
+  /// be returned. Otherwise, an object will be returned. So this is a
+  /// convenient way to determine if an RValue needs an address.
+  SILType getLoweredImplodedTupleType(SILGenFunction &SGF) const &;
+
   /// Rewrite the type of this r-value.
   void rewriteType(CanType newType) & {
 #ifndef NDEBUG

--- a/lib/SILGen/SGFContext.h
+++ b/lib/SILGen/SGFContext.h
@@ -156,6 +156,17 @@ public:
     result.state.setInt(state.getInt());
     return result;
   }
+
+  /// Get a context for a sub-expression where we plan to evaluate arbitrary
+  /// side-effects. This means we propagate down the initialization, but
+  /// eliminates the +0/+1-ness.
+  SGFContext withSubExprSideEffects() const {
+    if (auto *init = getEmitInto()) {
+      return SGFContext(init);
+    }
+
+    return SGFContext();
+  }
 };
 
 using ValueProducerRef =

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4829,6 +4829,24 @@ RValue SILGenFunction::emitRValue(Expr *E, SGFContext C) {
   return RValueEmitter(*this).visit(E, C);
 }
 
+RValue SILGenFunction::emitPlusOneRValue(Expr *E, SGFContext C) {
+  Scope S(*this, SILLocation(E));
+  assert(!E->getType()->hasLValueType() &&
+         "l-values must be emitted with emitLValue");
+  return S.popPreservingValue(
+      RValueEmitter(*this).visit(E, C.withSubExprSideEffects()));
+}
+
+RValue SILGenFunction::emitPlusZeroRValue(Expr *E) {
+  // Check if E is a case that we know how to emit at plus zero. If so, handle
+  // it here.
+  //
+  // TODO: Fill this in.
+
+  // Otherwise, we go through the +1 path and borrow the result.
+  return emitPlusOneRValue(E).borrow(*this, SILLocation(E));
+}
+
 // Evaluate the expression as an lvalue or rvalue, discarding the result.
 void SILGenFunction::emitIgnoredExpr(Expr *E) {
   // If this is a tuple expression, recursively ignore its elements.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -940,6 +940,21 @@ public:
   /// Emit the given expression as an r-value.
   RValue emitRValue(Expr *E, SGFContext C = SGFContext());
 
+  /// Emit the given expression as a +1 r-value.
+  ///
+  /// *NOTE* This creates the +1 r-value and then pushes that +1 r-value through
+  /// a scope. So all temporaries resulting will be cleaned up.
+  ///
+  /// *NOTE* +0 vs +1 is ignored by this function. The only reason to use the
+  /// SGFContext argument is to pass in an initialization.
+  RValue emitPlusOneRValue(Expr *E, SGFContext C = SGFContext());
+
+  /// Emit the given expression as a +0 r-value.
+  ///
+  /// *NOTE* This does not scope the creation of the +0 r-value. The reason why
+  /// this is done is that +0 r-values can not be pushed through scopes.
+  RValue emitPlusZeroRValue(Expr *E);
+
   /// Emit the given expression as an r-value with the given conversion
   /// context.  This may be more efficient --- and, in some cases,
   /// semantically different --- than emitting the expression and then


### PR DESCRIPTION
[silgen] Begin splitting emitRValue into two different APIs: SILGenFunction::emitPlus{One,Zero}RValue(...).

Today, SILGenFunction::emitRValue assumes the caller will create any cleanup
scopes that are needed to cleanup side-effects relating to the rvalue
evaluation.  The API also provides the ability for the caller to specify that a
+0 rvalues is an "ok" result. The API then tries to produce a +0 rvalue and
returns a +1 rvalue otherwise. These two properties create conflicting
requirements on the caller since the caller does not know whether or not it
should create a scope (if a +1 rvalue will be returned) or not (if a +0 rvalue
would be returned).

The key issue here is the optionality of returning a +0 rvalue. This change
begins to resolve this difference by creating two separate APIs that guarantee
to the caller whether or not a +0 or a +1 rvalue is returned and also creates
local scopes for the caller as appropriate. So by using these APIs, the caller
knows that the +0 or +1 rvalue that is returned has properly been put into the
caller scope. So the caller no longer needs to create its own scopes anymore.

emitPlusOneRValue is emitRValue except that it scopes the rvalue emission and
then *pushes* the produced rvalue through the scope. emitPlusZeroRValue is
currently a stub implementation that just calls emitPlusOneRValue and then
borrows the resulting +1 RValue in the outer scope, creating the +0 RValue that
was requested by the caller.

rdar://33358110
