### PR TITLE
SIL: Record whether vtable entries are inherited or overridden

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -622,6 +622,10 @@ ERROR(sil_vtable_func_not_found,none,
       "sil function not found %0", (Identifier))
 ERROR(sil_vtable_class_not_found,none,
       "sil class not found %0", (Identifier))
+ERROR(sil_vtable_bad_entry_kind,none,
+      "expected 'inherited' or 'override'", ())
+ERROR(sil_vtable_expect_rsquare,none,
+      "expected ']' after vtable entry kind", ())
 
 // SIL Global
 ERROR(sil_global_variable_not_found,none,

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -43,11 +43,27 @@ public:
   // TODO: Entry should include substitutions needed to invoke an overridden
   // generic base class method.
   struct Entry {
+    enum Kind : uint8_t {
+      /// The vtable entry is for a method defined directly in this class.
+      Normal,
+      /// The vtable entry is inherited from the superclass.
+      Inherited,
+      /// The vtable entry is inherited from the superclass, and overridden
+      /// in this class.
+      Override,
+    };
 
-    Entry() : Implementation(nullptr), Linkage(SILLinkage::Private) { }
+    Entry()
+      : Implementation(nullptr),
+        TheKind(Kind::Normal),
+        Linkage(SILLinkage::Private) { }
 
-    Entry(SILDeclRef Method, SILFunction *Implementation, SILLinkage Linkage) :
-      Method(Method), Implementation(Implementation), Linkage(Linkage) { }
+    Entry(SILDeclRef Method, SILFunction *Implementation,
+          Kind TheKind, SILLinkage Linkage)
+      : Method(Method),
+        Implementation(Implementation),
+        TheKind(TheKind),
+        Linkage(Linkage) { }
 
     /// The declaration reference to the least-derived method visible through
     /// the class.
@@ -55,6 +71,9 @@ public:
 
     /// The function which implements the method for the class.
     SILFunction *Implementation;
+
+    /// The entry kind.
+    Kind TheKind;
 
     /// The linkage of the implementing function.
     ///

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 355; // Last change: extension dependencies
+const uint16_t VERSION_MINOR = 356; // Last change: SILVTable::Entry::Kind
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2448,8 +2448,19 @@ void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
         stripExternalFromLinkage(entry.Implementation->getLinkage())) {
       OS << getLinkageString(entry.Linkage);
     }
-    OS << entry.Implementation->getName()
-       << "\t// " << demangleSymbol(entry.Implementation->getName()) << "\n";
+    OS << entry.Implementation->getName();
+    switch (entry.TheKind) {
+    case SILVTable::Entry::Kind::Normal:
+      break;
+    case SILVTable::Entry::Kind::Inherited:
+      OS << " [inherited]";
+      break;
+    case SILVTable::Entry::Kind::Override:
+      OS << " [override]";
+      break;
+    }
+    OS << "\t// " << demangleSymbol(entry.Implementation->getName());
+    OS << "\n";
   }
   OS << "}\n\n";
 }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -173,7 +173,8 @@ public:
   /// Emit a vtable thunk for a derived method if its natural abstraction level
   /// diverges from the overridden base method. If no thunking is needed,
   /// returns a static reference to the derived method.
-  SILVTable::Entry emitVTableMethod(SILDeclRef derived,
+  SILVTable::Entry emitVTableMethod(ClassDecl *theClass,
+                                    SILDeclRef derived,
                                     SILDeclRef base);
 
   /// True if a function has been emitted for a given SILDeclRef.

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -47,6 +47,13 @@ enum SILLinkageEncoding : uint8_t {
 };
 using SILLinkageField = BCFixed<3>;
 
+enum SILVTableEntryKindEncoding : uint8_t {
+  SIL_VTABLE_ENTRY_NORMAL,
+  SIL_VTABLE_ENTRY_INHERITED,
+  SIL_VTABLE_ENTRY_OVERRIDE,
+};
+using SILVTableEntryKindField = BCFixed<2>;
+
 enum CheckedCastKindEncoding : uint8_t {
   SIL_CHECKED_CAST_ARCHETYPE_TO_ARCHETYPE,
   SIL_CHECKED_CAST_ARCHETYPE_TO_CONCRETE,
@@ -185,6 +192,7 @@ namespace sil_block {
   using VTableEntryLayout = BCRecordLayout<
     SIL_VTABLE_ENTRY,
     DeclIDField,  // SILFunction name
+    SILVTableEntryKindField,  // Kind
     SILLinkageField,      // Linkage
     BCArray<ValueIDField> // SILDeclRef
   >;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -74,6 +74,15 @@ static unsigned toStableSILLinkage(SILLinkage linkage) {
   llvm_unreachable("bad linkage");
 }
 
+static unsigned toStableVTableEntryKind(SILVTable::Entry::Kind kind) {
+  switch (kind) {
+  case SILVTable::Entry::Kind::Normal: return SIL_VTABLE_ENTRY_NORMAL;
+  case SILVTable::Entry::Kind::Inherited: return SIL_VTABLE_ENTRY_INHERITED;
+  case SILVTable::Entry::Kind::Override: return SIL_VTABLE_ENTRY_OVERRIDE;
+  }
+  llvm_unreachable("bad vtable entry kind");
+}
+
 static unsigned toStableCastConsumptionKind(CastConsumptionKind kind) {
   switch (kind) {
   case CastConsumptionKind::TakeAlways:
@@ -2029,6 +2038,7 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
         SILAbbrCodes[VTableEntryLayout::Code],
         // SILFunction name
         S.addDeclBaseNameRef(Ctx.getIdentifier(entry.Implementation->getName())),
+        toStableVTableEntryKind(entry.TheKind),
         toStableSILLinkage(entry.Linkage),
         ListOfValues);
   }

--- a/test/SIL/Serialization/vtable.sil
+++ b/test/SIL/Serialization/vtable.sil
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-sil -emit-sib -parse-as-library -parse-stdlib -module-name vtable -o %t/vtable.sib %s
+// RUN: %target-sil-opt %t/vtable.sib -o - -emit-sorted-sil | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+class Base {
+  func m1()
+  func m2()
+}
+
+class Derived : Base {
+  override func m2()
+  func m3()
+}
+
+sil hidden_external @_T01x4BaseC2m1yyF : $@convention(method) (@guaranteed Base) -> ()
+
+sil hidden_external @_T01x4BaseC2m2yyF : $@convention(method) (@guaranteed Base) -> ()
+
+sil hidden_external @_T01x4BaseCfd : $@convention(method) (@guaranteed Base) -> @owned Builtin.NativeObject
+
+sil hidden_external @_T01x4BaseCfD : $@convention(method) (@owned Base) -> ()
+
+sil hidden_external @_T01x4BaseCACycfC : $@convention(method) (@thick Base.Type) -> @owned Base
+
+sil hidden_external @_T01x4BaseCACycfc : $@convention(method) (@owned Base) -> @owned Base
+
+sil hidden_external @_T01x7DerivedC2m2yyF : $@convention(method) (@guaranteed Derived) -> ()
+
+sil hidden_external @_T01x7DerivedC2m3yyF : $@convention(method) (@guaranteed Derived) -> ()
+
+sil hidden_external @_T01x7DerivedCfd : $@convention(method) (@guaranteed Derived) -> @owned Builtin.NativeObject
+
+sil hidden_external @_T01x7DerivedCfD : $@convention(method) (@owned Derived) -> ()
+
+sil hidden_external @_T01x7DerivedCACycfC : $@convention(method) (@thick Derived.Type) -> @owned Derived
+
+sil hidden_external @_T01x7DerivedCACycfc : $@convention(method) (@owned Derived) -> @owned Derived
+
+sil_vtable Base {
+  #Base.m1!1: (Base) -> () -> () : _T01x4BaseC2m1yyF
+  #Base.m2!1: (Base) -> () -> () : _T01x4BaseC2m2yyF
+  #Base.init!initializer.1: (Base.Type) -> () -> Base : _T01x4BaseCACycfc
+  #Base.deinit!deallocator: _T01x4BaseCfD
+}
+
+// CHECK-LABEL: sil_vtable Base {
+// CHECK-NEXT:  #Base.m1!1: (Base) -> () -> () : _T01x4BaseC2m1yyF
+// CHECK-NEXT:  #Base.m2!1: (Base) -> () -> () : _T01x4BaseC2m2yyF
+// CHECK-NEXT:  #Base.init!initializer.1: (Base.Type) -> () -> Base : _T01x4BaseCACycfc
+// CHECK-NEXT:  #Base.deinit!deallocator: _T01x4BaseCfD
+// CHECK-NEXT: }
+
+sil_vtable Derived {
+  #Base.m1!1: (Base) -> () -> () : _T01x4BaseC2m1yyF [inherited]
+  #Base.m2!1: (Base) -> () -> () : _T01x7DerivedC2m2yyF [override]
+  #Base.init!initializer.1: (Base.Type) -> () -> Base : _T01x7DerivedCACycfc [override]
+  #Derived.m3!1: (Derived) -> () -> () : _T01x7DerivedC2m3yyF
+  #Derived.deinit!deallocator: _T01x7DerivedCfD
+}
+
+// CHECK-LABEL: sil_vtable Derived {
+// CHECK-NEXT:  #Base.m1!1: (Base) -> () -> () : _T01x4BaseC2m1yyF [inherited]
+// CHECK-NEXT:  #Base.m2!1: (Base) -> () -> () : _T01x7DerivedC2m2yyF [override]
+// CHECK-NEXT:  #Base.init!initializer.1: (Base.Type) -> () -> Base : _T01x7DerivedCACycfc [override]
+// CHECK-NEXT:  #Derived.m3!1: (Derived) -> () -> () : _T01x7DerivedC2m3yyF
+// CHECK-NEXT:  #Derived.deinit!deallocator: _T01x7DerivedCfD
+// CHECK-NEXT: }

--- a/test/SILGen/accessibility_vtables.swift
+++ b/test/SILGen/accessibility_vtables.swift
@@ -17,11 +17,11 @@ class Sub : Base {
 // CHECK:         function_ref @_T0s25_unimplementedInitializers5NeverOs12StaticStringV9className_AE04initG0AE4fileSu4lineSu6columntF
 
 // CHECK-LABEL: sil_vtable Sub {
-// CHECK-NEXT:  #Base.internalMethod!1: {{.*}} : _T028accessibility_vtables_helper4BaseC14internalMethodyyF
-// CHECK-NEXT:  #Base.prop!getter.1: {{.*}} : _T021accessibility_vtables3SubC4propSifg  // accessibility_vtables.Sub.prop.getter : Swift.Int
-// CHECK-NEXT:  #Base.prop!setter.1: {{.*}} : _T028accessibility_vtables_helper4BaseC4propSifs  // accessibility_vtables_helper.Base.prop.setter : Swift.Int
-// CHECK-NEXT:  #Base.prop!materializeForSet.1: {{.*}} : _T028accessibility_vtables_helper4BaseC4propSifm  // accessibility_vtables_helper.Base.prop.materializeForSet : Swift.Int
-// CHECK-NEXT:  #Base.init!initializer.1: {{.*}} : _T021accessibility_vtables3SubCACycfc  // accessibility_vtables.Sub.init() -> accessibility_vtables.Sub
+// CHECK-NEXT:  #Base.internalMethod!1: {{.*}} : _T028accessibility_vtables_helper4BaseC14internalMethodyyF [inherited]
+// CHECK-NEXT:  #Base.prop!getter.1: {{.*}} : _T021accessibility_vtables3SubC4propSifg [override]  // accessibility_vtables.Sub.prop.getter : Swift.Int
+// CHECK-NEXT:  #Base.prop!setter.1: {{.*}} : _T028accessibility_vtables_helper4BaseC4propSifs [inherited]  // accessibility_vtables_helper.Base.prop.setter : Swift.Int
+// CHECK-NEXT:  #Base.prop!materializeForSet.1: {{.*}} : _T028accessibility_vtables_helper4BaseC4propSifm [inherited]  // accessibility_vtables_helper.Base.prop.materializeForSet : Swift.Int
+// CHECK-NEXT:  #Base.init!initializer.1: {{.*}} : _T021accessibility_vtables3SubCACycfc [override]  // accessibility_vtables.Sub.init() -> accessibility_vtables.Sub
 // CHECK-NEXT: #Sub.internalMethod!1: {{.*}} : _T021accessibility_vtables3SubC14internalMethodyyF
 // CHECK-NEXT: #Sub.prop!setter.1: {{.*}} : _T021accessibility_vtables3SubC4propSifs   // accessibility_vtables.Sub.prop.setter : Swift.Int
 // CHECK-NEXT: #Sub.prop!materializeForSet.1: {{.*}} : _T021accessibility_vtables3SubC4propSifm  // accessibility_vtables.Sub.prop.materializeForSet : Swift.Int
@@ -37,11 +37,11 @@ class InternalSub : InternalBase {
 }
 
 // CHECK-LABEL: sil_vtable InternalSub {
-// CHECK-NEXT:  #InternalBase.method!1: {{.*}} : _T021accessibility_vtables12InternalBaseC6method{{[0-9]+}}[[DISCRIMINATOR:_.+]]
-// CHECK-NEXT:  #InternalBase.prop!getter.1: {{.*}} : _T021accessibility_vtables11InternalSubC4propSifg // accessibility_vtables.InternalSub.prop.getter : Swift.Int
-// CHECK-NEXT:  #InternalBase.prop!setter.1: {{.*}} : _T021accessibility_vtables12InternalBaseC4propSifs        // accessibility_vtables.InternalBase.prop.setter : Swift.Int
-// CHECK-NEXT:  #InternalBase.prop!materializeForSet.1: {{.*}} : _T021accessibility_vtables12InternalBaseC4propSifm // accessibility_vtables.InternalBase.prop.materializeForSet : Swift.Int
-// CHECK-NEXT:  #InternalBase.init!initializer.1: {{.*}} : _T021accessibility_vtables11InternalSubCACycfc
+// CHECK-NEXT:  #InternalBase.method!1: {{.*}} : _T021accessibility_vtables12InternalBaseC6method{{[0-9]+}}[[DISCRIMINATOR:_.+]] [inherited]
+// CHECK-NEXT:  #InternalBase.prop!getter.1: {{.*}} : _T021accessibility_vtables11InternalSubC4propSifg [override] // accessibility_vtables.InternalSub.prop.getter : Swift.Int
+// CHECK-NEXT:  #InternalBase.prop!setter.1: {{.*}} : _T021accessibility_vtables12InternalBaseC4propSifs [inherited]        // accessibility_vtables.InternalBase.prop.setter : Swift.Int
+// CHECK-NEXT:  #InternalBase.prop!materializeForSet.1: {{.*}} : _T021accessibility_vtables12InternalBaseC4propSifm [inherited] // accessibility_vtables.InternalBase.prop.materializeForSet : Swift.Int
+// CHECK-NEXT:  #InternalBase.init!initializer.1: {{.*}} : _T021accessibility_vtables11InternalSubCACycfc [override]
 // CHECK-NEXT:  #InternalSub.method!1: {{.*}} : _T021accessibility_vtables11InternalSubC6methodyyF
 // CHECK-NEXT:  #InternalSub.prop!setter.1: {{.*}} : _T021accessibility_vtables11InternalSubC4propSifs  // accessibility_vtables.InternalSub.prop.setter : Swift.Int
 // CHECK-NEXT:  #InternalSub.prop!materializeForSet.1: {{.*}} : _T021accessibility_vtables11InternalSubC4propSifm // accessibility_vtables.InternalSub.prop.materializeForSet : Swift.Int

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -549,13 +549,13 @@ public class ConcreteDerived : GenericBase<Int> {
 
 // No vtable entry for override of @objc extension property
 // CHECK-LABEL: sil_vtable SubExt {
-// CHECK-NEXT: #BaseExt.init!initializer.1: (BaseExt.Type) -> () -> BaseExt : _T07dynamic6SubExtCACycfc // dynamic.SubExt.init() -> dynamic.SubExt
+// CHECK-NEXT: #BaseExt.init!initializer.1: (BaseExt.Type) -> () -> BaseExt : _T07dynamic6SubExtCACycfc [override] // dynamic.SubExt.init() -> dynamic.SubExt
 // CHECK-NEXT: #SubExt.deinit!deallocator: _T07dynamic6SubExtCfD // dynamic.SubExt.__deallocating_deinit
 // CHECK-NEXT: }
 
 // Dynamic thunk + vtable re-abstraction
 // CHECK-LABEL: sil_vtable ConcreteDerived {
-// CHECK-NEXT: #GenericBase.method!1: <T> (GenericBase<T>) -> (T) -> () : public _T07dynamic15ConcreteDerivedC6methodySiFAA11GenericBaseCADyxFTV     // vtable thunk for dynamic.GenericBase.method(A) -> () dispatching to dynamic.ConcreteDerived.method(Swift.Int) -> ()
-// CHECK-NEXT: #GenericBase.init!initializer.1: <T> (GenericBase<T>.Type) -> () -> GenericBase<T> : _T07dynamic15ConcreteDerivedCACycfc      // dynamic.ConcreteDerived.init() -> dynamic.ConcreteDerived
+// CHECK-NEXT: #GenericBase.method!1: <T> (GenericBase<T>) -> (T) -> () : public _T07dynamic15ConcreteDerivedC6methodySiFAA11GenericBaseCADyxFTV [override]     // vtable thunk for dynamic.GenericBase.method(A) -> () dispatching to dynamic.ConcreteDerived.method(Swift.Int) -> ()
+// CHECK-NEXT: #GenericBase.init!initializer.1: <T> (GenericBase<T>.Type) -> () -> GenericBase<T> : _T07dynamic15ConcreteDerivedCACycfc [override]      // dynamic.ConcreteDerived.init() -> dynamic.ConcreteDerived
 // CHECK-NEXT: #ConcreteDerived.deinit!deallocator: _T07dynamic15ConcreteDerivedCfD  // dynamic.ConcreteDerived.__deallocating_deinit
 // CHECK-NEXT: }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -969,6 +969,6 @@ class SomeErrorClass : Error { }
 class OtherErrorSub : OtherError { }
 
 // CHECK-LABEL: sil_vtable OtherErrorSub {
-// CHECK-NEXT:  #OtherError.init!initializer.1: {{.*}} : _T06errors13OtherErrorSubCACycfc     // OtherErrorSub.init()
+// CHECK-NEXT:  #OtherError.init!initializer.1: {{.*}} : _T06errors13OtherErrorSubCACycfc [override]     // OtherErrorSub.init()
 // CHECK-NEXT:  #OtherErrorSub.deinit!deallocator: _T06errors13OtherErrorSubCfD        // OtherErrorSub.__deallocating_deinit
 // CHECK-NEXT:}

--- a/test/SILGen/objc_dynamic_init.swift
+++ b/test/SILGen/objc_dynamic_init.swift
@@ -39,7 +39,7 @@ final class Bobamathing: Thingamabob {
 // CHECK:         class_method {{%.*}} : $@thick Gadget.Type, #Gadget.init!allocator.1 :
 
 // CHECK-LABEL: sil_vtable Gadget {
-// CHECK:         #Gadget.init!allocator.1: (Gadget.Type) -> () -> Gadget : _T{{.*}}GadgetC{{.*}}C {{ *}}//
+// CHECK:         #Gadget.init!allocator.1: (Gadget.Type) -> () -> Gadget : _T{{.*}}GadgetC{{.*}}C //
 
 // CHECK-LABEL: sil_vtable Gizmo {
-// CHECK:         #Gadget.init!allocator.1: (Gadget.Type) -> () -> Gadget : _T{{.*}}GizmoC{{.*}}C {{ *}}//
+// CHECK:         #Gadget.init!allocator.1: (Gadget.Type) -> () -> Gadget : _T{{.*}}GizmoC{{.*}}C [override] //

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -181,16 +181,16 @@ class StillOpaque<T>: Opaque<T> {
 }
 
 // CHECK-LABEL: sil_vtable StillOpaque {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC8inAndOutxx1x_tF	// Opaque.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : _T027vtable_thunks_reabstraction6OpaqueC18variantOptionalityxSgx1x_tF	// Opaque.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction11StillOpaqueC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tFAA0E0CAdEx_xm_xxcttAF_tFTV	// vtable thunk for Opaque.variantOptionalityTuples(x:) dispatching to StillOpaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction11StillOpaqueCACyxGycfc	// StillOpaque.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC8inAndOutxx1x_tF	[inherited] // Opaque.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : _T027vtable_thunks_reabstraction6OpaqueC18variantOptionalityxSgx1x_tF [inherited]	// Opaque.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction11StillOpaqueC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tFAA0E0CAdEx_xm_xxcttAF_tFTV [override]	// vtable thunk for Opaque.variantOptionalityTuples(x:) dispatching to StillOpaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction11StillOpaqueCACyxGycfc [override]	// StillOpaque.init()
 
 // Tuple becomes more optional -- needs new vtable entry
 
@@ -212,16 +212,16 @@ class ConcreteValue: Opaque<S> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteValue {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteValueC8inAndOutAA1SVAF1x_tFAA6OpaqueCADxxAG_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteValue.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : hidden _T027vtable_thunks_reabstraction13ConcreteValueC15inAndOutGenericxAA1SV1x_x1ytlFAA6OpaqueCADqd__xAG_qd__AHtlFTV	// vtable thunk for Opaque.inAndOutGeneric<A>(x:y:) dispatching to ConcreteValue.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : hidden _T027vtable_thunks_reabstraction13ConcreteValueC17inAndOutMetatypesAA1SVmAFm1x_tFAA6OpaqueCADxmxmAG_tFTV	// vtable thunk for Opaque.inAndOutMetatypes(x:) dispatching to ConcreteValue.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteValueC17inAndOutFunctionsAA1SVAFcA2Fc1x_tFAA6OpaqueCADxxcxxcAG_tFTV	// vtable thunk for Opaque.inAndOutFunctions(x:) dispatching to ConcreteValue.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : hidden _T027vtable_thunks_reabstraction13ConcreteValueC14inAndOutTuplesAA1SV_AFm_A2FcttAF_AFm_A2Fctt1x_tFAA6OpaqueCADx_xm_xxcttx_xm_xxcttAG_tFTV	// vtable thunk for Opaque.inAndOutTuples(x:) dispatching to ConcreteValue.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC18variantOptionalityAA1SVAFSg1x_tFAA6OpaqueCADxSgxAH_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteValue.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityMetatypesAA1SVmAFmSg1x_tFAA6OpaqueCADxmSgxmAH_tFTV	// vtable thunk for Opaque.variantOptionalityMetatypes(x:) dispatching to ConcreteValue.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityFunctionsAA1SVAFcA2FcSg1x_tFAA6OpaqueCADxxcSgxxcAH_tFTV	// vtable thunk for Opaque.variantOptionalityFunctions(x:) dispatching to ConcreteValue.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC24variantOptionalityTuplesAA1SV_AFm_A2FcttAF_AFm_A2FcttSg1x_tFAA6OpaqueCADx_xm_xxcttSgx_xm_xxcttAH_tFTV	// vtable thunk for Opaque.variantOptionalityTuples(x:) dispatching to ConcreteValue.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteValueCACycfc	// ConcreteValue.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteValueC8inAndOutAA1SVAF1x_tFAA6OpaqueCADxxAG_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteValue.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : hidden _T027vtable_thunks_reabstraction13ConcreteValueC15inAndOutGenericxAA1SV1x_x1ytlFAA6OpaqueCADqd__xAG_qd__AHtlFTV [override]	// vtable thunk for Opaque.inAndOutGeneric<A>(x:y:) dispatching to ConcreteValue.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : hidden _T027vtable_thunks_reabstraction13ConcreteValueC17inAndOutMetatypesAA1SVmAFm1x_tFAA6OpaqueCADxmxmAG_tFTV [override]	// vtable thunk for Opaque.inAndOutMetatypes(x:) dispatching to ConcreteValue.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteValueC17inAndOutFunctionsAA1SVAFcA2Fc1x_tFAA6OpaqueCADxxcxxcAG_tFTV [override]	// vtable thunk for Opaque.inAndOutFunctions(x:) dispatching to ConcreteValue.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : hidden _T027vtable_thunks_reabstraction13ConcreteValueC14inAndOutTuplesAA1SV_AFm_A2FcttAF_AFm_A2Fctt1x_tFAA6OpaqueCADx_xm_xxcttx_xm_xxcttAG_tFTV [override]	// vtable thunk for Opaque.inAndOutTuples(x:) dispatching to ConcreteValue.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC18variantOptionalityAA1SVAFSg1x_tFAA6OpaqueCADxSgxAH_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteValue.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityMetatypesAA1SVmAFmSg1x_tFAA6OpaqueCADxmSgxmAH_tFTV [override]	// vtable thunk for Opaque.variantOptionalityMetatypes(x:) dispatching to ConcreteValue.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityFunctionsAA1SVAFcA2FcSg1x_tFAA6OpaqueCADxxcSgxxcAH_tFTV [override]	// vtable thunk for Opaque.variantOptionalityFunctions(x:) dispatching to ConcreteValue.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC24variantOptionalityTuplesAA1SV_AFm_A2FcttAF_AFm_A2FcttSg1x_tFAA6OpaqueCADx_xm_xxcttSgx_xm_xxcttAH_tFTV [override]	// vtable thunk for Opaque.variantOptionalityTuples(x:) dispatching to ConcreteValue.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteValueCACycfc [override]	// ConcreteValue.init()
 
 // Value types becoming more optional -- needs new vtable entry
 
@@ -245,16 +245,16 @@ class ConcreteClass: Opaque<C> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteClass {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteClassC8inAndOutAA1CCAF1x_tFAA6OpaqueCADxxAG_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteClass.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction13ConcreteClassC17inAndOutMetatypesAA1CCmAFm1x_tF	// ConcreteClass.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteClassC17inAndOutFunctionsAA1CCAFcA2Fc1x_tFAA6OpaqueCADxxcxxcAG_tFTV	// vtable thunk for Opaque.inAndOutFunctions(x:) dispatching to ConcreteClass.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : hidden _T027vtable_thunks_reabstraction13ConcreteClassC14inAndOutTuplesAA1CC_AFm_A2FcttAF_AFm_A2Fctt1x_tFAA6OpaqueCADx_xm_xxcttx_xm_xxcttAG_tFTV	// vtable thunk for Opaque.inAndOutTuples(x:) dispatching to ConcreteClass.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC18variantOptionalityAA1CCAFSg1x_tFAA6OpaqueCADxSgxAH_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteClass.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction13ConcreteClassC27variantOptionalityMetatypesAA1CCmAFmSg1x_tF	// ConcreteClass.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC27variantOptionalityFunctionsAA1CCAFcA2FcSg1x_tFAA6OpaqueCADxxcSgxxcAH_tFTV	// vtable thunk for Opaque.variantOptionalityFunctions(x:) dispatching to ConcreteClass.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC24variantOptionalityTuplesAA1CC_AFm_A2FcttAF_AFm_A2FcttSg1x_tFAA6OpaqueCADx_xm_xxcttSgx_xm_xxcttAH_tFTV	// vtable thunk for Opaque.variantOptionalityTuples(x:) dispatching to ConcreteClass.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteClassCACycfc	// ConcreteClass.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteClassC8inAndOutAA1CCAF1x_tFAA6OpaqueCADxxAG_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteClass.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction13ConcreteClassC17inAndOutMetatypesAA1CCmAFm1x_tF [override]	// ConcreteClass.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteClassC17inAndOutFunctionsAA1CCAFcA2Fc1x_tFAA6OpaqueCADxxcxxcAG_tFTV [override]	// vtable thunk for Opaque.inAndOutFunctions(x:) dispatching to ConcreteClass.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : hidden _T027vtable_thunks_reabstraction13ConcreteClassC14inAndOutTuplesAA1CC_AFm_A2FcttAF_AFm_A2Fctt1x_tFAA6OpaqueCADx_xm_xxcttx_xm_xxcttAG_tFTV [override]	// vtable thunk for Opaque.inAndOutTuples(x:) dispatching to ConcreteClass.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC18variantOptionalityAA1CCAFSg1x_tFAA6OpaqueCADxSgxAH_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteClass.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction13ConcreteClassC27variantOptionalityMetatypesAA1CCmAFmSg1x_tF [override]	// ConcreteClass.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC27variantOptionalityFunctionsAA1CCAFcA2FcSg1x_tFAA6OpaqueCADxxcSgxxcAH_tFTV [override]	// vtable thunk for Opaque.variantOptionalityFunctions(x:) dispatching to ConcreteClass.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC24variantOptionalityTuplesAA1CC_AFm_A2FcttAF_AFm_A2FcttSg1x_tFAA6OpaqueCADx_xm_xxcttSgx_xm_xxcttAH_tFTV [override]	// vtable thunk for Opaque.variantOptionalityTuples(x:) dispatching to ConcreteClass.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteClassCACycfc [override]	// ConcreteClass.init()
 
 // Class references are ABI-compatible with optional class references, and
 // similarly for class metatypes.
@@ -274,16 +274,16 @@ class ConcreteClassVariance: Opaque<C> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteClassVariance {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction21ConcreteClassVarianceC8inAndOutAA1DCAA1BC1x_tFAA6OpaqueCADxxAI_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteClassVariance.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction21ConcreteClassVarianceC18variantOptionalityAA1DCAA1BCSg1x_tFAA6OpaqueCADxSgxAJ_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteClassVariance.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteClassVarianceCACycfc	// ConcreteClassVariance.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction21ConcreteClassVarianceC8inAndOutAA1DCAA1BC1x_tFAA6OpaqueCADxxAI_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteClassVariance.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction21ConcreteClassVarianceC18variantOptionalityAA1DCAA1BCSg1x_tFAA6OpaqueCADxSgxAJ_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteClassVariance.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteClassVarianceCACycfc [override]	// ConcreteClassVariance.init()
 
 // No new vtable entries -- class references are ABI compatible with
 // optional class references.
@@ -297,16 +297,16 @@ class OpaqueTuple<U>: Opaque<(U, U)> {
 }
 
 // CHECK-LABEL: sil_vtable OpaqueTuple {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction11OpaqueTupleC8inAndOutx_xtx_xt1x_tFAA0D0CADxxAE_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to OpaqueTuple.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction11OpaqueTupleC18variantOptionalityx_xtx_xtSg1x_tFAA0D0CADxSgxAF_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to OpaqueTuple.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction11OpaqueTupleCACyxGycfc	// OpaqueTuple.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction11OpaqueTupleC8inAndOutx_xtx_xt1x_tFAA0D0CADxxAE_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to OpaqueTuple.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction11OpaqueTupleC18variantOptionalityx_xtx_xtSg1x_tFAA0D0CADxSgxAF_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to OpaqueTuple.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction11OpaqueTupleCACyxGycfc [override]	// OpaqueTuple.init()
 
 // Optionality change of tuple.
 
@@ -321,16 +321,16 @@ class ConcreteTuple: Opaque<(S, S)> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteTuple {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteTupleC8inAndOutAA1SV_AFtAF_AFt1x_tFAA6OpaqueCADxxAG_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteTuple.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction13ConcreteTupleC18variantOptionalityAA1SV_AFtAF_AFtSg1x_tFAA6OpaqueCADxSgxAH_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteTuple.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteTupleCACycfc	// ConcreteTuple.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction13ConcreteTupleC8inAndOutAA1SV_AFtAF_AFt1x_tFAA6OpaqueCADxxAG_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteTuple.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction13ConcreteTupleC18variantOptionalityAA1SV_AFtAF_AFtSg1x_tFAA6OpaqueCADxSgxAH_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteTuple.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteTupleCACycfc [override]	// ConcreteTuple.init()
 
 // Optionality change of tuple.
 
@@ -345,16 +345,16 @@ class OpaqueFunction<U, V>: Opaque<(U) -> V> {
 }
 
 // CHECK-LABEL: sil_vtable OpaqueFunction {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction14OpaqueFunctionC8inAndOutq_xcq_xc1x_tFAA0D0CADxxAE_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to OpaqueFunction.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction14OpaqueFunctionC18variantOptionalityq_xcq_xcSg1x_tFAA0D0CADxSgxAF_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to OpaqueFunction.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction14OpaqueFunctionCACyxq_Gycfc	// OpaqueFunction.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction14OpaqueFunctionC8inAndOutq_xcq_xc1x_tFAA0D0CADxxAE_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to OpaqueFunction.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction14OpaqueFunctionC18variantOptionalityq_xcq_xcSg1x_tFAA0D0CADxSgxAF_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to OpaqueFunction.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction14OpaqueFunctionCACyxq_Gycfc [override]	// OpaqueFunction.init()
 
 // Optionality change of function.
 
@@ -369,16 +369,16 @@ class ConcreteFunction: Opaque<(S) -> S> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteFunction {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction16ConcreteFunctionC8inAndOutAA1SVAFcA2Fc1x_tFAA6OpaqueCADxxAG_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteFunction.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction16ConcreteFunctionC18variantOptionalityAA1SVAFcA2FcSg1x_tFAA6OpaqueCADxSgxAH_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteFunction.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction16ConcreteFunctionCACycfc	// ConcreteFunction.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction16ConcreteFunctionC8inAndOutAA1SVAFcA2Fc1x_tFAA6OpaqueCADxxAG_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteFunction.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction16ConcreteFunctionC18variantOptionalityAA1SVAFcA2FcSg1x_tFAA6OpaqueCADxSgxAH_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteFunction.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction16ConcreteFunctionCACycfc [override]	// ConcreteFunction.init()
 
 // Optionality change of function.
 
@@ -393,16 +393,16 @@ class OpaqueMetatype<U>: Opaque<U.Type> {
 }
 
 // CHECK-LABEL: sil_vtable OpaqueMetatype {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction14OpaqueMetatypeC8inAndOutxmxm1x_tFAA0D0CADxxAE_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to OpaqueMetatype.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction14OpaqueMetatypeC18variantOptionalityxmxmSg1x_tFAA0D0CADxSgxAF_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to OpaqueMetatype.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction14OpaqueMetatypeCACyxGycfc	// OpaqueMetatype.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction14OpaqueMetatypeC8inAndOutxmxm1x_tFAA0D0CADxxAE_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to OpaqueMetatype.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction14OpaqueMetatypeC18variantOptionalityxmxmSg1x_tFAA0D0CADxSgxAF_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to OpaqueMetatype.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction14OpaqueMetatypeCACyxGycfc [override]	// OpaqueMetatype.init()
 
 // Optionality change of metatype.
 
@@ -417,16 +417,16 @@ class ConcreteValueMetatype: Opaque<S.Type> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteValueMetatype {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction21ConcreteValueMetatypeC8inAndOutAA1SVmAFm1x_tFAA6OpaqueCADxxAG_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteValueMetatype.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction21ConcreteValueMetatypeC18variantOptionalityAA1SVmAFmSg1x_tFAA6OpaqueCADxSgxAH_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteValueMetatype.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteValueMetatypeCACycfc	// ConcreteValueMetatype.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction21ConcreteValueMetatypeC8inAndOutAA1SVmAFm1x_tFAA6OpaqueCADxxAG_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteValueMetatype.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction21ConcreteValueMetatypeC18variantOptionalityAA1SVmAFmSg1x_tFAA6OpaqueCADxSgxAH_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteValueMetatype.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteValueMetatypeCACycfc [override]	// ConcreteValueMetatype.init()
 
 // Optionality change of metatype.
 
@@ -441,16 +441,16 @@ class ConcreteClassMetatype: Opaque<C.Type> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteClassMetatype {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction21ConcreteClassMetatypeC8inAndOutAA1CCmAFm1x_tFAA6OpaqueCADxxAG_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteClassMetatype.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction21ConcreteClassMetatypeC18variantOptionalityAA1CCmAFmSg1x_tFAA6OpaqueCADxSgxAH_tFTV	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteClassMetatype.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteClassMetatypeCACycfc	// ConcreteClassMetatype.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction21ConcreteClassMetatypeC8inAndOutAA1CCmAFm1x_tFAA6OpaqueCADxxAG_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteClassMetatype.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : hidden _T027vtable_thunks_reabstraction21ConcreteClassMetatypeC18variantOptionalityAA1CCmAFmSg1x_tFAA6OpaqueCADxSgxAH_tFTV [override]	// vtable thunk for Opaque.variantOptionality(x:) dispatching to ConcreteClassMetatype.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteClassMetatypeCACycfc [override]	// ConcreteClassMetatype.init()
 
 // Class metatypes are ABI compatible with optional class metatypes.
 
@@ -465,16 +465,16 @@ class ConcreteOptional: Opaque<S?> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteOptional {
-// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction16ConcreteOptionalC8inAndOutAA1SVSgAG1x_tFAA6OpaqueCADxxAH_tFTV	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteOptional.inAndOut(x:)
-// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF	// Opaque.inAndOutGeneric<A>(x:y:)
-// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF	// Opaque.inAndOutMetatypes(x:)
-// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF	// Opaque.inAndOutFunctions(x:)
-// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF	// Opaque.inAndOutTuples(x:)
-// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : _T027vtable_thunks_reabstraction6OpaqueC18variantOptionalityxSgx1x_tF	// Opaque.variantOptionality(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF	// Opaque.variantOptionalityMetatypes(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x:)
-// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x:)
-// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction16ConcreteOptionalCACycfc	// ConcreteOptional.init()
+// CHECK-NEXT:   #Opaque.inAndOut!1: <T> (Opaque<T>) -> (T) -> T : hidden _T027vtable_thunks_reabstraction16ConcreteOptionalC8inAndOutAA1SVSgAG1x_tFAA6OpaqueCADxxAH_tFTV [override]	// vtable thunk for Opaque.inAndOut(x:) dispatching to ConcreteOptional.inAndOut(x:)
+// CHECK-NEXT:   #Opaque.inAndOutGeneric!1: <T><U> (Opaque<T>) -> (T, U) -> U : _T027vtable_thunks_reabstraction6OpaqueC15inAndOutGenericqd__x1x_qd__1ytlF [inherited]	// Opaque.inAndOutGeneric<A>(x:y:)
+// CHECK-NEXT:   #Opaque.inAndOutMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutMetatypesxmxm1x_tF [inherited]	// Opaque.inAndOutMetatypes(x:)
+// CHECK-NEXT:   #Opaque.inAndOutFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> (T) -> T : _T027vtable_thunks_reabstraction6OpaqueC17inAndOutFunctionsxxcxxc1x_tF [inherited]	// Opaque.inAndOutFunctions(x:)
+// CHECK-NEXT:   #Opaque.inAndOutTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction6OpaqueC14inAndOutTuplesx_xm_xxcttx_xm_xxctt1x_tF [inherited]	// Opaque.inAndOutTuples(x:)
+// CHECK-NEXT:   #Opaque.variantOptionality!1: <T> (Opaque<T>) -> (T) -> T? : _T027vtable_thunks_reabstraction6OpaqueC18variantOptionalityxSgx1x_tF [inherited]	// Opaque.variantOptionality(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityMetatypes!1: <T> (Opaque<T>) -> (T.Type) -> T.Type? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityMetatypesxmSgxm1x_tF [inherited]	// Opaque.variantOptionalityMetatypes(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF [inherited]	// Opaque.variantOptionalityFunctions(x:)
+// CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF [inherited]	// Opaque.variantOptionalityTuples(x:)
+// CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction16ConcreteOptionalCACycfc [override]	// ConcreteOptional.init()
 // CHECK-NEXT:   #ConcreteOptional.deinit!deallocator: _T027vtable_thunks_reabstraction16ConcreteOptionalCfD	// ConcreteOptional.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -501,8 +501,8 @@ class ConcreteSub : GenericBase<Int> {
 }
 
 // CHECK-LABEL: sil_vtable ConcreteSub {
-// CHECK-NEXT:   #GenericBase.doStuff!1: <T><U> (GenericBase<T>) -> (T, U) -> () : hidden _T027vtable_thunks_reabstraction11ConcreteSubC7doStuffySi1t_x1utlFAA11GenericBaseCADyxAE_qd__AFtlFTV	// vtable thunk for GenericBase.doStuff<A>(t:u:) dispatching to ConcreteSub.doStuff<A>(t:u:)
-// CHECK-NEXT:   #GenericBase.init!initializer.1: <T><U> (GenericBase<T>.Type) -> (T, U) -> GenericBase<T> : hidden _T027vtable_thunks_reabstraction11ConcreteSubCACSi1t_x1utclufcAA11GenericBaseCAGyxGxAD_qd__AEtclufcTV	// vtable thunk for GenericBase.init<A>(t:u:) dispatching to ConcreteSub.init<A>(t:u:)
+// CHECK-NEXT:   #GenericBase.doStuff!1: <T><U> (GenericBase<T>) -> (T, U) -> () : hidden _T027vtable_thunks_reabstraction11ConcreteSubC7doStuffySi1t_x1utlFAA11GenericBaseCADyxAE_qd__AFtlFTV [override]	// vtable thunk for GenericBase.doStuff<A>(t:u:) dispatching to ConcreteSub.doStuff<A>(t:u:)
+// CHECK-NEXT:   #GenericBase.init!initializer.1: <T><U> (GenericBase<T>.Type) -> (T, U) -> GenericBase<T> : hidden _T027vtable_thunks_reabstraction11ConcreteSubCACSi1t_x1utclufcAA11GenericBaseCAGyxGxAD_qd__AEtclufcTV [override]	// vtable thunk for GenericBase.init<A>(t:u:) dispatching to ConcreteSub.init<A>(t:u:)
 // CHECK-NEXT:   #ConcreteSub.deinit!deallocator: _T027vtable_thunks_reabstraction11ConcreteSubCfD	// ConcreteSub.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -527,8 +527,8 @@ class GenericSub<T> : ConcreteBase {
 }
 
 // CHECK-LABEL: sil_vtable GenericSub {
-// CHECK-NEXT:   #ConcreteBase.init!initializer.1: <U> (ConcreteBase.Type) -> (Int, U) -> ConcreteBase : _T027vtable_thunks_reabstraction10GenericSubCACyxGSi1t_qd__1utclufc	// GenericSub.init<A>(t:u:)
-// CHECK-NEXT:   #ConcreteBase.doStuff!1: <U> (ConcreteBase) -> (Int, U) -> () : _T027vtable_thunks_reabstraction10GenericSubC7doStuffySi1t_qd__1utlF	// GenericSub.doStuff<A>(t:u:)
+// CHECK-NEXT:   #ConcreteBase.init!initializer.1: <U> (ConcreteBase.Type) -> (Int, U) -> ConcreteBase : _T027vtable_thunks_reabstraction10GenericSubCACyxGSi1t_qd__1utclufc [override]	// GenericSub.init<A>(t:u:)
+// CHECK-NEXT:   #ConcreteBase.doStuff!1: <U> (ConcreteBase) -> (Int, U) -> () : _T027vtable_thunks_reabstraction10GenericSubC7doStuffySi1t_qd__1utlF [override]	// GenericSub.doStuff<A>(t:u:)
 // CHECK-NEXT:   #GenericSub.deinit!deallocator: _T027vtable_thunks_reabstraction10GenericSubCfD	// GenericSub.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -540,8 +540,8 @@ class MoreGenericSub1<T, TT> : GenericBase<T> {
 }
 
 // CHECK-LABEL: sil_vtable MoreGenericSub1 {
-// CHECK-NEXT:   #GenericBase.doStuff!1: <T><U> (GenericBase<T>) -> (T, U) -> () : _T027vtable_thunks_reabstraction15MoreGenericSub1C7doStuffyx1t_qd__1utlF	// MoreGenericSub1.doStuff<A>(t:u:)
-// CHECK-NEXT:   #GenericBase.init!initializer.1: <T><U> (GenericBase<T>.Type) -> (T, U) -> GenericBase<T> : _T027vtable_thunks_reabstraction11GenericBaseCACyxGx1t_qd__1utclufc	// GenericBase.init<A>(t:u:)
+// CHECK-NEXT:   #GenericBase.doStuff!1: <T><U> (GenericBase<T>) -> (T, U) -> () : _T027vtable_thunks_reabstraction15MoreGenericSub1C7doStuffyx1t_qd__1utlF [override]	// MoreGenericSub1.doStuff<A>(t:u:)
+// CHECK-NEXT:   #GenericBase.init!initializer.1: <T><U> (GenericBase<T>.Type) -> (T, U) -> GenericBase<T> : _T027vtable_thunks_reabstraction11GenericBaseCACyxGx1t_qd__1utclufc [inherited]	// GenericBase.init<A>(t:u:)
 // CHECK-NEXT:   #MoreGenericSub1.deinit!deallocator: _T027vtable_thunks_reabstraction15MoreGenericSub1CfD	// MoreGenericSub1.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -552,7 +552,7 @@ class MoreGenericSub2<TT, T> : GenericBase<T> {
 }
 
 // CHECK-LABEL: sil_vtable MoreGenericSub2 {
-// CHECK-NEXT:   #GenericBase.doStuff!1: <T><U> (GenericBase<T>) -> (T, U) -> () : _T027vtable_thunks_reabstraction15MoreGenericSub2C7doStuffyq_1t_qd__1utlF	// MoreGenericSub2.doStuff<A>(t:u:)
-// CHECK-NEXT:   #GenericBase.init!initializer.1: <T><U> (GenericBase<T>.Type) -> (T, U) -> GenericBase<T> : _T027vtable_thunks_reabstraction11GenericBaseCACyxGx1t_qd__1utclufc	// GenericBase.init<A>(t:u:)
+// CHECK-NEXT:   #GenericBase.doStuff!1: <T><U> (GenericBase<T>) -> (T, U) -> () : _T027vtable_thunks_reabstraction15MoreGenericSub2C7doStuffyq_1t_qd__1utlF [override]	// MoreGenericSub2.doStuff<A>(t:u:)
+// CHECK-NEXT:   #GenericBase.init!initializer.1: <T><U> (GenericBase<T>.Type) -> (T, U) -> GenericBase<T> : _T027vtable_thunks_reabstraction11GenericBaseCACyxGx1t_qd__1utclufc [inherited]	// GenericBase.init<A>(t:u:)
 // CHECK-NEXT:   #MoreGenericSub2.deinit!deallocator: _T027vtable_thunks_reabstraction15MoreGenericSub2CfD	// MoreGenericSub2.__deallocating_deinit
 // CHECK-NEXT: }

--- a/test/SILOptimizer/alive_method_with_thunk.swift
+++ b/test/SILOptimizer/alive_method_with_thunk.swift
@@ -19,6 +19,6 @@ public class DerivedClass: BaseClass<Double> {
 // CHECK: }
 
 // CHECK: sil_vtable DerivedClass {
-// CHECK:  #BaseClass.doSomething!1: <T> (BaseClass<T>) -> (T) -> Int : public _T023alive_method_with_thunk12DerivedClassC11doSomethingSiSdFAA04BaseF0CADSixFTV  // vtable thunk for BaseClass.doSomething(_:) dispatching to DerivedClass.doSomething(_:)
+// CHECK:  #BaseClass.doSomething!1: <T> (BaseClass<T>) -> (T) -> Int : public _T023alive_method_with_thunk12DerivedClassC11doSomethingSiSdFAA04BaseF0CADSixFTV [override]  // vtable thunk for BaseClass.doSomething(_:) dispatching to DerivedClass.doSomething(_:)
 // CHECK: }
 


### PR DESCRIPTION
Consider a class hierarchy like the following:

```
class Base {
  func m1() {}
  func m2() {}
}

class Derived : Base {
  override func m2() {}
  func m3() {}
}
```

The SIL vtable for 'Derived' now records that the entry for m1
is inherited, the entry for m2 is an override, and the entry
for m3 is a new entry:

```
sil_vtable Derived {
  #Base.m1!1: (Base) -> () -> () : _T01a4BaseC2m1yyF [inherited]
  #Base.m2!1: (Base) -> () -> () : _T01a7DerivedC2m2yyF [override]
  #Derived.m3!1: (Derived) -> () -> () : _T01a7DerivedC2m3yyF
}
```

This additional information will allow IRGen to emit the vtable
for Derived resiliently, without referencing the symbol for
the inherited method m1() directly.