### PR TITLE
Warn if the getter is used, but the setter argument is not used

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3721,10 +3721,12 @@ WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
         (Identifier))
-WARNING(unused_setter_newvalue, none,
+WARNING(unused_setter_parameter, none,
         "setter argument %0 was never used; did you mean to use it "
         "instead of accessing the property's current value?",
         (Identifier))
+NOTE(fixit_for_unused_setter_parameter, none,
+     "do you want to replace %0 with %1?", (Identifier, Identifier))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3721,6 +3721,10 @@ WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
         (Identifier))
+WARNING(unused_implicit_setter_newvalue, none,
+        "implicit setter argument 'newValue' is never used; consider specifying"
+        " a variable name or using the argument `newValue`",
+        ())
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3722,9 +3722,9 @@ WARNING(pbd_never_used_stmtcond, none,
         "with boolean test",
         (Identifier))
 WARNING(unused_setter_newvalue, none,
-        "setter argument %0 was never used, but the getter was accessed; "
-        "consider using %0 or removing %1",
-        (Identifier, Identifier))
+        "setter argument %0 was never used; did you mean to use it "
+        "instead of accessing the property's current value?",
+        (Identifier))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3722,11 +3722,10 @@ WARNING(pbd_never_used_stmtcond, none,
         "with boolean test",
         (Identifier))
 WARNING(unused_setter_parameter, none,
-        "setter argument %0 was never used; did you mean to use it "
-        "instead of accessing the property's current value?",
+        "setter argument %0 was never used, but the property was accessed",
         (Identifier))
 NOTE(fixit_for_unused_setter_parameter, none,
-     "do you want to replace %0 with %1?", (Identifier, Identifier))
+     "did you mean to use %0 instead of accessing the property's current value?", (Identifier))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3721,10 +3721,10 @@ WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
         (Identifier))
-WARNING(unused_implicit_setter_newvalue, none,
-        "implicit setter argument 'newValue' is never used; consider specifying"
-        " a variable name or using the argument `newValue`",
-        ())
+WARNING(unused_setter_newvalue, none,
+        "setter argument %0 was never used, but the getter was accessed; "
+        "consider using %0 or removing %1",
+        (Identifier, Identifier))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2131,7 +2131,7 @@ public:
     // Track a specific VarDecl
     VarDecls[VD] = 0;
   }
-    
+
   void suppressDiagnostics() {
     sawError = true; // set this flag so that no diagnostics will be emitted on delete.
   }
@@ -2346,7 +2346,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
             Diags.diagnose(DRE->getLoc(), diag::unused_setter_parameter,
                            var->getName());
             Diags.diagnose(DRE->getLoc(), diag::fixit_for_unused_setter_parameter,
-                           getter->getName(), var->getName())
+                           var->getName())
               .fixItReplace(DRE->getSourceRange(), var->getName().str());
           }
         }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2342,7 +2342,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         auto getter = dyn_cast<VarDecl>(FD->getAccessorStorageDecl());
         if ((access & RK_Read) == 0 && (VarDecls[getter] & RK_Read) != 0) {
           Diags.diagnose(var->getLoc(), diag::unused_setter_newvalue,
-                         var->getName(), getter->getName());
+                         var->getName());
         }
       }
       continue;

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -93,6 +93,7 @@ func localComputedProperties() {
       return localProperty // expected-warning{{attempting to access 'localProperty' within its own getter}}
     }
     set {
+      _ = newValue
       print(localProperty)
     }
   }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -274,3 +274,23 @@ func sr2421() {
   let x: Int // expected-warning {{immutable value 'x' was never used; consider removing it}}
   x = 42
 }
+
+// Tests fix to SR-964
+func sr964() {
+  var noOpSetter: String {
+    get { return "" }
+    set { } // No warning
+  }
+  var suspiciousSetter: String {
+    get { return "" }
+    set { print(suspiciousSetter) } // expected-warning {{setter argument 'newValue' was never used, but the getter was accessed; consider using 'newValue' or removing 'suspiciousSetter'}}
+  }
+  var namedSuspiciousSetter: String {
+    get { return "" }
+    set(parameter) { print(namedSuspiciousSetter) } // expected-warning {{setter argument 'parameter' was never used, but the getter was accessed; consider using 'parameter' or removing 'namedSuspiciousSetter'}}
+  }
+  var okSetter: String {
+    get { return "" }
+    set { print(newValue) } // No warning
+  }
+}

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -284,13 +284,13 @@ func sr964() {
   var suspiciousSetter: String {
     get { return "" }
     set {
-      print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used; did you mean to use it instead of accessing the property's current value?}} expected-note {{do you want to replace 'suspiciousSetter' with 'newValue'?}}
+      print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{13-29=newValue}}
     }
   }
   var namedSuspiciousSetter: String {
     get { return "" }
     set(parameter) {
-      print(namedSuspiciousSetter) // expected-warning {{setter argument 'parameter' was never used; did you mean to use it instead of accessing the property's current value?}} expected-note {{do you want to replace 'namedSuspiciousSetter' with 'parameter'?}}
+      print(namedSuspiciousSetter) // expected-warning {{setter argument 'parameter' was never used, but the property was accessed}} expected-note {{did you mean to use 'parameter' instead of accessing the property's current value?}} {{13-34=parameter}}
     }
   }
   var okSetter: String {
@@ -300,7 +300,7 @@ func sr964() {
   var multiTriggerSetter: String {
     get { return "" }
     set {
-      print(multiTriggerSetter) // expected-warning {{setter argument 'newValue' was never used; did you mean to use it instead of accessing the property's current value?}} expected-note {{do you want to replace 'multiTriggerSetter' with 'newValue'?}}
+      print(multiTriggerSetter) // expected-warning {{setter argument 'newValue' was never used, but the property was accessed}} expected-note {{did you mean to use 'newValue' instead of accessing the property's current value?}} {{13-31=newValue}}
       print(multiTriggerSetter)
     }
   }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -283,11 +283,11 @@ func sr964() {
   }
   var suspiciousSetter: String {
     get { return "" }
-    set { print(suspiciousSetter) } // expected-warning {{setter argument 'newValue' was never used, but the getter was accessed; consider using 'newValue' or removing 'suspiciousSetter'}}
+    set { print(suspiciousSetter) } // expected-warning {{setter argument 'newValue' was never used; did you mean to use it instead of accessing the property's current value?}}
   }
   var namedSuspiciousSetter: String {
     get { return "" }
-    set(parameter) { print(namedSuspiciousSetter) } // expected-warning {{setter argument 'parameter' was never used, but the getter was accessed; consider using 'parameter' or removing 'namedSuspiciousSetter'}}
+    set(parameter) { print(namedSuspiciousSetter) } // expected-warning {{setter argument 'parameter' was never used; did you mean to use it instead of accessing the property's current value?}}
   }
   var okSetter: String {
     get { return "" }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -283,14 +283,25 @@ func sr964() {
   }
   var suspiciousSetter: String {
     get { return "" }
-    set { print(suspiciousSetter) } // expected-warning {{setter argument 'newValue' was never used; did you mean to use it instead of accessing the property's current value?}}
+    set {
+      print(suspiciousSetter) // expected-warning {{setter argument 'newValue' was never used; did you mean to use it instead of accessing the property's current value?}} expected-note {{do you want to replace 'suspiciousSetter' with 'newValue'?}}
+    }
   }
   var namedSuspiciousSetter: String {
     get { return "" }
-    set(parameter) { print(namedSuspiciousSetter) } // expected-warning {{setter argument 'parameter' was never used; did you mean to use it instead of accessing the property's current value?}}
+    set(parameter) {
+      print(namedSuspiciousSetter) // expected-warning {{setter argument 'parameter' was never used; did you mean to use it instead of accessing the property's current value?}} expected-note {{do you want to replace 'namedSuspiciousSetter' with 'parameter'?}}
+    }
   }
   var okSetter: String {
     get { return "" }
     set { print(newValue) } // No warning
+  }
+  var multiTriggerSetter: String {
+    get { return "" }
+    set {
+      print(multiTriggerSetter) // expected-warning {{setter argument 'newValue' was never used; did you mean to use it instead of accessing the property's current value?}} expected-note {{do you want to replace 'multiTriggerSetter' with 'newValue'?}}
+      print(multiTriggerSetter)
+    }
   }
 }


### PR DESCRIPTION
This PR generates a warning if a setters getter is used, but the setter argument is not used. This is a common bug that occurs when a custom setter is implemented, but the getter is accidentally used instead of the setter argument.

This PR also removes some code that added method parameters to the checker. It was only used to warn about var parameters that were not mutated. Since var parameter support was dropped in 3.0, this was just busy work.

This was a rebase off of this [PR](https://github.com/apple/swift/pull/9258) that wasn't cooperating with CI.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-964](https://bugs.swift.org/browse/SR-964).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
