### PR TITLE
Disable SwiftSyntax tests (for now)

### DIFF
--- a/test/SwiftSyntax/LazyCaching.swift
+++ b/test/SwiftSyntax/LazyCaching.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: rdar33888321
 
 import StdlibUnittest
 import Foundation

--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: rdar33888321
 
 import Foundation
 import StdlibUnittest

--- a/test/SwiftSyntax/SyntaxFactory.swift
+++ b/test/SwiftSyntax/SyntaxFactory.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: rdar33888321
 
 import Foundation
 import StdlibUnittest


### PR DESCRIPTION
Disabling SwiftSyntax tests until we can fix the CMake dependency issues discovered in #11462.