### PR TITLE
[Clang importer] Add correct path for shims

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -214,12 +214,6 @@ function(_compile_swift_files
   compute_library_subdir(library_subdir
       "${SWIFTFILE_SDK}" "${SWIFTFILE_ARCHITECTURE}")
 
-  # Allow import of other Swift modules we just built.
-  list(APPEND swift_flags
-      "-I" "${SWIFTLIB_DIR}/${library_subdir}")
-  # FIXME: should we use '-resource-dir' here?  Seems like it has no advantage
-  # over '-I' in this case.
-
   # If we have a custom module cache path, use it.
   if (SWIFT_MODULE_CACHE_PATH)
     list(APPEND swift_flags "-module-cache-path" "${SWIFT_MODULE_CACHE_PATH}")

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -445,6 +445,9 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
   // Construct the invocation arguments for the current target.
   // Add target-independent options first.
+  SmallString<128> shimsPath;
+  shimsPath = searchPathOpts.RuntimeResourcePath;
+  llvm::sys::path::append(shimsPath, "shims");
   invocationArgStrs.insert(
       invocationArgStrs.end(),
       {
@@ -464,7 +467,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
           "-fretain-comments-from-system-headers",
 
-          SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
+          SHIMS_INCLUDE_FLAG, shimsPath.str(),
       });
 
   // Set C language options.


### PR DESCRIPTION
The shims are installed into the directory "shims" underneath the
resource directory, not the resource directory itself.

Fixes the Xcode project build.
