### PR TITLE
[swift-4.0-branch][overlay] Public extensions on external protocol are not in fact public

### DIFF
--- a/stdlib/public/SDK/AVFoundation/AVCaptureDevice.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCaptureDevice.swift
@@ -16,7 +16,7 @@ import Foundation
 
 #if os(iOS)
 
-internal protocol _AVCaptureDeviceFormatSupportedColorSpaces {
+public protocol _AVCaptureDeviceFormatSupportedColorSpaces {
   @available(iOS, introduced: 10.0)
   var __supportedColorSpaces: [NSNumber] { get }
 }

--- a/stdlib/public/SDK/AVFoundation/AVCapturePhotoOutput.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCapturePhotoOutput.swift
@@ -16,7 +16,7 @@ import Foundation
 
 #if os(iOS)
 
-internal protocol _AVCapturePhotoOutputSwiftNativeTypes {
+public protocol _AVCapturePhotoOutputSwiftNativeTypes {
   var __supportedFlashModes: [NSNumber] { get }
   var __availablePhotoPixelFormatTypes: [NSNumber] { get }
   var __availableRawPhotoPixelFormatTypes: [NSNumber] { get }
@@ -71,7 +71,7 @@ extension AVCapturePhotoOutput : _AVCapturePhotoOutputSwiftNativeTypes {
 }
 
 
-internal protocol _AVCapturePhotoSettingsSwiftNativeTypes {
+public protocol _AVCapturePhotoSettingsSwiftNativeTypes {
   var __availablePreviewPhotoPixelFormatTypes: [NSNumber] { get }
 }
 

--- a/stdlib/public/SDK/Intents/INRideOption.swift
+++ b/stdlib/public/SDK/Intents/INRideOption.swift
@@ -19,7 +19,7 @@ import Foundation
 // <rdar://problem/29447066>
 // Compiler incorrectly handles combinations of availability declarations on
 // independent axes.
-internal protocol _INRideOptionMeteredFare {
+public protocol _INRideOptionMeteredFare {
   var __usesMeteredFare: NSNumber? { get set }
 }
 

--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t && mkdir %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // REQUIRES: executable_test


### PR DESCRIPTION
* Explanation: Makes the whole API surface available from Swift (parts were accidentally marked as internal and thus invisible for users)
* Scope of Issue: Makes a few internal protocols public, so that their extensions are available on conforming types.
* Risk: Minimal
* Reviewed By: Max Moiseev
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/33850527>