### PR TITLE
[CMake] Correct creation of LLVM headers symlink.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -407,6 +407,8 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
                                              PotentialArchetype *currentPA,
                                              ProtocolDecl *proto,
                                              bool &derivedViaConcrete) const {
+  derivedViaConcrete = false;
+
   // If it's not a derived requirement, it's not self-derived.
   if (!isDerivedRequirement()) return this;
 
@@ -428,7 +430,6 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
     return nullptr;
   };
 
-  derivedViaConcrete = false;
   bool sawProtocolRequirement = false;
 
   PotentialArchetype *rootPA = nullptr;

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -78,27 +78,34 @@ endif()
 string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" CLANG_VERSION
   "${LLVM_PACKAGE_VERSION}")
 
-if(SWIFT_BUILT_STANDALONE)
-  set(clang_headers_locations
-      "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION}"
+# Function to find LLVM or Clang headers
+function(find_llvm_clang_headers suffix description out_var)
+  set(headers_locations
+      "${LLVM_LIBRARY_DIR}${suffix}"
 
-      # FIXME: if we want to support separate Clang builds and mix different
-      # build configurations of Clang and Swift, this line should be adjusted.
-      "${SWIFT_PATH_TO_CLANG_BUILD}/${CMAKE_CFG_INTDIR}/lib/clang/${CLANG_VERSION}"
-      "${SWIFT_PATH_TO_CLANG_BUILD}/${LLVM_BUILD_TYPE}/lib/clang/${CLANG_VERSION}")
+      "${SWIFT_PATH_TO_CLANG_BUILD}/${CMAKE_CFG_INTDIR}/lib${suffix}"
+      "${SWIFT_PATH_TO_CLANG_BUILD}/${LLVM_BUILD_TYPE}/lib${suffix}")
 
-  set(clang_headers_location)
-  foreach(loc ${clang_headers_locations})
+  set(headers_location)
+  foreach(loc ${headers_locations})
     if(EXISTS "${loc}")
-      set(clang_headers_location "${loc}")
+      set(headers_location "${loc}")
+      set(${out_var} "${loc}" PARENT_SCOPE)
       break()
     endif()
   endforeach()
-  if("${clang_headers_location}" STREQUAL "")
-    message(FATAL_ERROR "Clang headers were not found in any of the following locations: ${clang_headers_locations}")
+  if("${headers_location}" STREQUAL "")
+    message(FATAL_ERROR "${description} headers were not found in any of the following locations: ${headers_locations}")
   endif()
+endfunction()
+
+if(SWIFT_BUILT_STANDALONE)
+  find_llvm_clang_headers("" "LLVM" llvm_headers_location)
+  find_llvm_clang_headers("/clang/${CLANG_VERSION}" "Clang"
+    clang_headers_location)
 else() # NOT SWIFT_BUILT_STANDALONE
   set(clang_headers_location "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION}")
+  set(llvm_headers_location "${LLVM_LIBRARY_DIR}")
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
@@ -125,7 +132,7 @@ add_custom_command_target(unused_var2
       "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTLIB_DIR}"
     COMMAND
       "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
-      "${LLVM_LIBRARY_DIR}"
+      "${llvm_headers_location}"
       "${SWIFTLIB_DIR}/llvm"
 
     CUSTOM_TARGET_NAME "symlink_llvm_headers"


### PR DESCRIPTION
In Xcode project builds where LLVM/Clang are built differentually than
Swift  (e.g., RelWithDebInfo LLVM/Clang + Debug Swift, a Very Useful
Combination), the LLVM headers symlink pointed to nowhere. Follow the
same logic used for the Clang headers to deal with this case.