### PR TITLE
[CMake] [Do Not Merge] Allow building non-stdlib Swift libraries

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -516,6 +516,7 @@ endfunction()
 #     [FILE_DEPENDS target1 ...]
 #     [DONT_EMBED_BITCODE]
 #     [IS_STDLIB]
+#     [MODULE_DIR]
 #     [FORCE_BUILD_OPTIMIZED]
 #     [IS_STDLIB_CORE]
 #     [IS_SDK_OVERLAY]
@@ -580,6 +581,9 @@ endfunction()
 # IS_STDLIB
 #   Install library dylib and swift module files to lib/swift.
 #
+# MODULE_DIR
+#   Directory to install .swiftmodule and .o file in.
+#
 # IS_STDLIB_CORE
 #   Compile as the standard library core.
 #
@@ -597,7 +601,7 @@ endfunction()
 function(_add_swift_library_single target name)
   set(SWIFTLIB_SINGLE_options
       SHARED STATIC OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE IS_SDK_OVERLAY
-      TARGET_LIBRARY FORCE_BUILD_FOR_HOST_SDK
+      TARGET_LIBRARY FORCE_BUILD_FOR_HOST_SDK MODULE_DIR
       API_NOTES_NON_OVERLAY DONT_EMBED_BITCODE FORCE_BUILD_OPTIMIZED)
   cmake_parse_arguments(SWIFTLIB_SINGLE
     "${SWIFTLIB_SINGLE_options}"
@@ -1588,6 +1592,7 @@ function(add_swift_library name)
           PRIVATE_LINK_LIBRARIES ${swiftlib_private_link_libraries_targets}
           INCORPORATE_OBJECT_LIBRARIES ${SWIFTLIB_INCORPORATE_OBJECT_LIBRARIES}
           INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY ${SWIFTLIB_INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY}
+          MODULE_DIR ${SWIFTLIB_MODULE_DIR}
           ${SWIFTLIB_DONT_EMBED_BITCODE_keyword}
           ${SWIFTLIB_API_NOTES_NON_OVERLAY_keyword}
           ${SWIFTLIB_IS_STDLIB_keyword}

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -582,7 +582,7 @@ endfunction()
 #   Install library dylib and swift module files to lib/swift.
 #
 # MODULE_DIR
-#   Directory to install .swiftmodule and .o file in.
+#   Put .swiftmodule, .swiftdoc., and .o into this directory.
 #
 # IS_STDLIB_CORE
 #   Compile as the standard library core.

--- a/tools/SwiftSyntax/CMakeLists.txt
+++ b/tools/SwiftSyntax/CMakeLists.txt
@@ -18,7 +18,8 @@ add_swift_library(swiftSwiftSyntax SHARED
   TokenKind.swift.gyb
   Trivia.swift
 
+  TARGET_LIBRARY
+  HAS_SWIFT_CONTENT
   SWIFT_MODULE_DEPENDS Foundation
   INSTALL_IN_COMPONENT swift-syntax
-  TARGET_SDKS OSX
-  IS_STDLIB)
+  TARGET_SDKS OSX)


### PR DESCRIPTION
The only thing that previously informed the module install directory was
the presence of the IS_STDLIB flag when calling add_swift_library. This
adds a MODULE_DIR directory through the add_swift_library chain such
that a non-stdlib module can be built.

@gottesmm: I can't figure out how to actually compute a `MODULE_DIR` for `swiftSwiftSyntax` because the only way to compute the `LIBRARY_SUBDIR` that `IS_STDLIB` infers requires an SDK and architecture, which isn't known when declaring the library. Should this be _another_ flag like `BUILD_ALONGSIDE_STDLIB` or something?