### PR TITLE
[IRGen] fix const inferred return type in lambda

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1176,7 +1176,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
   // Derive the callee function pointer.
   auto fnTy = origSig.getType()->getPointerTo();
-  FunctionPointer fnPtr = [&] {
+  FunctionPointer fnPtr = [&]() -> FunctionPointer {
     // If we found a function pointer statically, great.
     if (staticFnPtr) {
       assert(staticFnPtr->getPointer()->getType() == fnTy &&


### PR DESCRIPTION
Fixes compile error with clang

`
/home/zbowling/swift-source/swift/lib/IRGen/GenFunc.cpp:1196:5: error: return type 'swift::irgen::FunctionPointer' must match previous return type 'const swift::irgen::FunctionPointer' when lambda expression has unspecified explicit return type
    return FunctionPointer(fnPtr, origSig);
    ^
`

