### PR TITLE
SILGen: Fix bug with local function default arguments

### DIFF
--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -46,3 +46,20 @@ func testInitializable() {
   // CHECK: function_ref @_T025default_arguments_generic7GenericVACyxGxcfcfA_ : $@convention(thin) <τ_0_0 where τ_0_0 : Initializable> () -> @out τ_0_0
   // CHECK: apply [[INIT]]<InitializableImpl>({{%.+}}, {{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : Initializable> (@in τ_0_0, @thin Generic<τ_0_0>.Type) -> Generic<τ_0_0>
 } // CHECK: end sil function '_T025default_arguments_generic17testInitializableyyF'
+
+// Local generic functions with default arguments
+
+// CHECK-LABEL: sil hidden @_T025default_arguments_generic5outeryx1t_tlF : $@convention(thin) <T> (@in T) -> ()
+func outer<T>(t: T) {
+  func inner1(x: Int = 0) {}
+
+  // CHECK: [[ARG_GENERATOR:%.*]] = function_ref @_T025default_arguments_generic5outeryx1t_tlF6inner1L_ySi1x_tlFfA_ : $@convention(thin) () -> Int
+  // CHECK: [[ARG:%.*]] = apply [[ARG_GENERATOR]]() : $@convention(thin) () -> Int
+  _ = inner1()
+
+  func inner2(x: Int = 0) { _ = T.self }
+
+  // CHECK: [[ARG_GENERATOR:%.*]] = function_ref @_T025default_arguments_generic5outeryx1t_tlF6inner2L_ySi1x_tlFfA_ : $@convention(thin) <τ_0_0> () -> Int
+  // CHECK: [[ARG:%.*]] = apply [[ARG_GENERATOR]]<T>() : $@convention(thin) <τ_0_0> () -> Int
+  _ = inner2()
+}


### PR DESCRIPTION
If a local function is in generic context but does not capture
any generic parameters, it has a non-generic lowered type.

However we use substitutions from the AST when forming calls to
generic argument generators. In the AST, such local functions
always have generic types regardless of their captures.

As a result we would crash in this case.

Fixes <rdar://problem/33003280>.