### PR TITLE
Revert "Disable one more test that is failing on bots on armv7"

### DIFF
--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// rdar://33761334
-// UNSUPPORTED: CPU=armv7
-
 // FIXME(id-as-any): make Swift errors boxed in NSError eagerly bridged.
 
 // FIXME(id-as-any): add tests for unboxing.


### PR DESCRIPTION
This reverts commit 6c6230728175c77f5e812120481c6843164c6661.

The cause of the failure in LLVM should be fixed.

rdar://33761334