### PR TITLE
[SourceKit] Add associatedtype to doc structure (SR-5700)

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -95,6 +95,7 @@ enum class SyntaxStructureKind : uint8_t {
   EnumElement,
   TypeAlias,
   Subscript,
+  AssociatedType,
 
   ForEachStatement,
   WhileStatement,

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -970,6 +970,15 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     SN.TypeRange = charSourceRangeFromSourceRange(SM,
                             SubscriptD->getElementTypeLoc().getSourceRange());
     pushStructureNode(SN, SubscriptD);
+  } else if (auto *AssociatedTypeD = dyn_cast<AssociatedTypeDecl>(D)) {
+    SyntaxStructureNode SN;
+    setDecl(SN, D);
+    SN.Kind = SyntaxStructureKind::AssociatedType;
+    SN.Range = charSourceRangeFromSourceRange(SM,
+                                            AssociatedTypeD->getSourceRange());
+    SN.NameRange = CharSourceRange(AssociatedTypeD->getNameLoc(),
+                                   AssociatedTypeD->getName().getLength());
+    pushStructureNode(SN, AssociatedTypeD);
   }
 
   return true;

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -222,3 +222,10 @@ class ReturnType {
   func foo3() -> () -> Int {}
   // CHECK:  <ifunc>func <name>foo3()</name> -> <type>() -> Int</type> {}</ifunc>
 }
+
+protocol FooProtocol {
+  associatedtype Bar
+  // CHECK:  <associatedtype>associatedtype <name>Bar</name></associatedtype>
+  associatedtype Baz: Equatable
+  // CHECK:  <associatedtype>associatedtype <name>Baz</name>: Equatable</associatedtype>
+}

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -99,3 +99,8 @@ class ClassObjcAttr2 : NSObject {
     @objc(Foo)
     func m() {}
 }
+
+protocol FooProtocol {
+    associatedtype Bar
+    associatedtype Baz: Equatable
+}

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 1553,
+  key.length: 1636,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1011,6 +1011,38 @@
               key.attribute: source.decl.attribute.objc.name
             }
           ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "FooProtocol",
+      key.offset: 1554,
+      key.length: 81,
+      key.runtime_name: "_TtP13StructureTest11FooProtocol_",
+      key.nameoffset: 1563,
+      key.namelength: 11,
+      key.bodyoffset: 1576,
+      key.bodylength: 58,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.associatedtype,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "Bar",
+          key.offset: 1581,
+          key.length: 18,
+          key.nameoffset: 1596,
+          key.namelength: 3
+        },
+        {
+          key.kind: source.lang.swift.decl.associatedtype,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "Baz",
+          key.offset: 1604,
+          key.length: 29,
+          key.nameoffset: 1619,
+          key.namelength: 3
         }
       ]
     }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -381,6 +381,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclTypeAlias;
     case SyntaxStructureKind::Subscript:
       return KindDeclSubscript;
+    case SyntaxStructureKind::AssociatedType:
+      return KindDeclAssociatedType;
     case SyntaxStructureKind::Parameter:
       return KindDeclVarParam;
     case SyntaxStructureKind::ForEachStatement:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1074,6 +1074,7 @@ private:
       case SyntaxStructureKind::EnumElement: return "enum-elem";
       case SyntaxStructureKind::TypeAlias: return "typealias";
       case SyntaxStructureKind::Subscript: return "subscript";
+      case SyntaxStructureKind::AssociatedType: return "associatedtype";
       case SyntaxStructureKind::Parameter: return "param";
       case SyntaxStructureKind::ForEachStatement: return "foreach";
       case SyntaxStructureKind::WhileStatement: return "while";


### PR DESCRIPTION
Add associatedtype declarations to document structure in SourceKit.

Resolves [SR-5700](https://bugs.swift.org/browse/SR-5700).

// cc @nkcsgexi 
