### PR TITLE
Sema: Fix crash with invalid 'let' property in protocol

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3901,7 +3901,11 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
     if (!CD) return false;
     
     auto *CDC = CD->getDeclContext();
-      
+
+    // 'let' properties are not valid inside protocols.
+    if (CDC->getAsProtocolExtensionContext())
+      return false;
+
     // If this init is defined inside of the same type (or in an extension
     // thereof) as the let property, then it is mutable.
     if (!CDC->isTypeContext() ||

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -492,3 +492,15 @@ protocol P4 {
 class C4 : P4 { // expected-error {{type 'C4' does not conform to protocol 'P4'}}
   associatedtype T = Int  // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}} {{3-17=typealias}}
 }
+
+// <rdar://problem/25185722> Crash with invalid 'let' property in protocol
+protocol LetThereBeCrash {
+  let x: Int
+  // expected-error@-1 {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+  // expected-note@-2 {{change 'let' to 'var' to make it mutable}}
+}
+
+extension LetThereBeCrash {
+  init() { x = 1 }
+  // expected-error@-1 {{cannot assign to property: 'x' is a 'let' constant}}
+}


### PR DESCRIPTION
Fixes <rdar://problem/25185722>.