### PR TITLE
[Docs] Note that commit access is required to trigger CI

### DIFF
--- a/docs/ContinuousIntegration.md
+++ b/docs/ContinuousIntegration.md
@@ -23,7 +23,7 @@ In order for the Swift project to be able to advance quickly, it is important th
 
 ### @swift-ci
 
-swift-ci pull request testing is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The current test types are:
+Users with [commit access](https://swift.org/contributing/#commit-access) can trigger pull request testing by writing a comment on a PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment used. The current test types are:
 
 1. Smoke Testing
 2. Validation Testing


### PR DESCRIPTION
<!-- What's in this pull request? -->
When reading about how to contribute to Swift, the documentation eventually brought me to ContinuousIntegration.md. It says that passing smoke tests are required, but it doesn't make it clear that Commit Access is required to trigger the tests. I think the only way to find out is to either try it or ask somebody, so I believe that it makes sense to call that out here.