### PR TITLE
Add type checker performance tests.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+func memoize<A: Hashable, R>(
+  f: @escaping ((A) -> R, A) -> R
+) -> ((A) -> R) {
+  var memo = Dictionary<A,R>()
+
+  var recur: ((A) -> R)!
+  recur = { (a: A) -> R in
+    if let r = memo[a] { return r }
+    let r = f(recur, a)
+    memo[a] = r
+    return r
+  }
+
+  return recur
+}
+
+let fibonacci = memoize {
+  (fibonacci, n) in
+  n < 2 ? n as Int : fibonacci(n - 1) + fibonacci(n - 2)
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar19029974.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19029974.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+infix operator <*> : AdditionPrecedence
+func <*><A, B>(lhs: ((A) -> B)?, rhs: A?) -> B? {
+  if let lhs1 = lhs, let rhs1 = rhs {
+    return lhs1(rhs1)
+  }
+  return nil
+}
+
+func cons<T, U>(lhs: T) -> (U) -> (T, U) {
+   return { rhs in (lhs, rhs) }
+}
+
+var str: String? = "x"
+if let f = cons <*> str <*> (cons <*> str <*> (cons <*> str <*> (cons <*> str <*> (cons <*> str <*> (cons <*> str <*> (cons <*> str <*> str)))))) {
+   print("\(f)")
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar17024694.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar17024694.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+2...100.reversed().filter({ $0 % 11 == 0 }).map {
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  "\($0) bottles of beer on the wall, \($0) bottles of beer;\n"
+  + "  take eleven down, pass 'em around, \($0-11) bottles of beer on the wall!"
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar17170728.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+let i: Int? = 1
+let j: Int?
+let k: Int? = 2
+
+let _ = [i, j, k].reduce(0 as Int?) {
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  $0 != nil && $1 != nil ? $0! + $1! : ($0 != nil ? $0! : ($1 != nil ? $1! : nil))
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar18360240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18360240.swift.gyb
@@ -1,0 +1,10 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+let empty: [Int] = []
+let _ = empty +
+%for i in range(0, N):
+    empty +
+%end
+    empty

--- a/validation-test/Sema/type_checker_perf/slow/rdar18699199.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18699199.swift.gyb
@@ -1,0 +1,17 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+public enum E
+{
+    case First,
+%for i in range(0, N):
+    C${i},
+%end
+    End
+
+    static let toRawValues = [
+%for i in range(0, N):
+    C${i}: String("hi"),
+%end
+    ]
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar18724501.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18724501.swift
@@ -1,0 +1,12 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+typealias X = (Range<Int>, [Range<Int>])
+
+let samples: ContiguousArray<X> = [
+  (0..<1, [ 1..<1, 2..<3 ]),
+%for i in range(0, N):
+  (0..<1, [ 1..<1, 2..<3 ]),
+%end
+]

--- a/validation-test/Sema/type_checker_perf/slow/rdar18800950.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18800950.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+// Mixed Float and Double arithmetic
+func rdar18800950(v: Float) -> Double {
+  let c1: Float = 1.0
+  let c2 = 2.0
+  let r = v / c1
+  let _ = (c2 * 2 * (3 * (1 - c1 / v) - 4) * r + 5) * (c2 * 2 * (3 * (1 - c1 / v) - 4) * r + 5)
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19181998.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19181998.swift.gyb
@@ -1,0 +1,14 @@
+// RUN: not %scale-test --begin 1 --end 4 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+public func test(_ fn: @escaping () -> Void) {}
+
+test {
+  let _: Set<Set<Int>> = Set([
+      Set([1]),
+%for i in range(0, N):
+      Set([1]),
+%end
+    ])
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19368383.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19368383.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+// Missing force of optional result of dictionary lookup.
+func rdar19368383(d: [String : String]) -> [String] {
+  var r = [String]()
+  r += [ // expected-error {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+    "1" + d["2"] + "3",
+    "1" + d["2"] + "3",
+    "1" + d["2"] + "3",
+    "1" + d["2"] + "3",
+    "1" + d["2"] + "3",
+    "1" + d["2"] + "3",
+  ]
+  return r
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19394804.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19394804.swift.gyb
@@ -1,0 +1,24 @@
+// RUN: not %scale-test --begin 1 --end 4 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+class rdar19394804 {
+  let data = [
+    [
+      "first": [
+        [
+          "key1": "value"
+        ],
+        [
+          "key2": "value"
+        ]
+      ]
+    ],
+%for i in range(0, N):
+    [
+      "key1": "value",
+      "key2": []
+    ],
+%end
+  ]
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+struct Stringly {
+  init(string: String) {}
+  init(format: String, _ args: Any...) {}
+  init(stringly: Stringly) {}
+}
+
+struct rdar19612086 {
+  let i = 0
+  let x = 1.0
+
+  var description : String {
+    return "\(i)" + Stringly(format: "%.2f", x) +
+           "\(i+1)" + Stringly(format: "%.2f", x) +
+           "\(i+2)" + Stringly(format: "%.2f", x)
+    // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  }
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+let a = "a"
+let b = "b"
+let c = 42
+_ = "a=" + a + ";b=" + b + ";c=" + c
+// expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19836070.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+let _: (Character) -> Bool = { c in
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  ("a" <= c && c <= "z") || ("A" <= c && c <= "Z") || c == "_"
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift.gyb
@@ -1,0 +1,8 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+let a = [0]
+let d = a[0] * 1
+%for i in range(0, N):
+  + a[0] * 1
+%end

--- a/validation-test/Sema/type_checker_perf/slow/rdar20233198.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20233198.swift
@@ -1,0 +1,9 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+let _ = (UInt8(0)
+%for i in range(0, N):
+  , UInt8(0)
+%end
+)

--- a/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+struct Stringly {
+  init(string: String) {}
+  init(format: String, _ args: Any...) {}
+  init(stringly: Stringly) {}
+}
+
+[Int](0..<1).map {
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  print(Stringly(format: "%d: ", $0 * 2) + ["a", "b", "c", "d"][$0 * 2] + ",")
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar20959612.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20959612.swift
@@ -1,0 +1,32 @@
+// RUN: not %scale-test --begin 3 --end 7 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+func curry<T0
+%for i in range(1, N+2):
+, T${i}
+%end
+>(
+  _ fn: @escaping (T0
+%for i in range(1, N+1):
+, T${i}
+%end
+  ) -> T${N+1}
+) -> (T0)
+%for i in range(1, N+2):
+  -> (T${i})
+%end
+{
+  return { t0 in
+%for i in range(1, N+1):
+    { t${i} in
+%end
+      fn(t0
+%for i in range(1, N+1):
+	, t${i}
+%end
+      )
+%for i in range(0, N+1):
+    }
+%end
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar21328584.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar21328584.swift.gyb
@@ -1,0 +1,15 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+struct S {
+  var s : String?
+
+  var d: [String : Any]? {
+    return [
+%for i in range(0, N):
+      "test" : s ?? "",
+%end
+    ]
+  }
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar21398466.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar21398466.swift
@@ -1,0 +1,48 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 4
+// REQUIRES: tools-release,no_asserts
+
+// This problem is related to renaming,
+// as soon as `init(truncatingBitPattern:)` is changed
+// to `init(truncatingIfNeeded:)` this example is no longer "too complex"
+func getUInt8(u: UInt) -> [UInt8]
+{
+  let values: [UInt8]
+
+  values = [
+    // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf),
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf),
+  ]
+
+  return values
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar21720888.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar21720888.swift.gyb
@@ -1,0 +1,9 @@
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+_ = [
+%for i in range(0, N):
+  (label: "string"),
+%end
+]

--- a/validation-test/Sema/type_checker_perf/slow/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22022980.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+_ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]
+// expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar22626740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22626740.swift.gyb
@@ -1,0 +1,11 @@
+// RUN: not %scale-test --begin 2 --end 4 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+var a: [UInt32]
+
+a = [
+%for i in range(0, N):
+  UInt32(0),
+%end
+]

--- a/validation-test/Sema/type_checker_perf/slow/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22770433.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+func test(n: Int) -> Int {
+  return n == 0 ? 0 : (0..<n).reduce(0) {
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+    ($0 > 0 && $1 % 2 == 0) ? (($0 + $1) / ($1 - $0)) : $0
+  }
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+let j = 1
+
+_ = "a" + j + "b" + j + "c" + j
+// expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+_ = [0,1,2,3].lazy.map { String($0)+"hi" }.sorted(by: { $0 > $1 })
+// expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}


### PR DESCRIPTION
Add type checker performance tests under
validation-test/Sema/type_checker_perf.

Under ./fast/ we have tests that compile reasonably quickly now but at
one point did not.

Under ./slow/ we have tests that are still very slow to compile.

Some tests use %scale-test and others
-solver-expression-time-threshold to determine if they are scaling
well or compiling fast enough.

I've got several more tests gathered that have not yet been set up to
run in our test system. Those are forthcoming!

Further contributions welcome.

Thanks go to @xedin who helped collect most of the test cases.
