### PR TITLE
Large loadable types: add support for destroy_value -> destroy_addr

### DIFF
--- a/test/IRGen/big_types_tests.sil
+++ b/test/IRGen/big_types_tests.sil
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
+
+// UNSUPPORTED: resilient_stdlib
+
+// REQUIRES: CPU=x86_64
+
+// REQUIRES: OS=macosx
+
+sil_stage canonical
+import Builtin
+import Swift
+
+public struct BigStruct {
+  var i0 : Int32 = 0
+  var i1 : Int32 = 1
+  var i2 : Int32 = 2
+  var i3 : Int32 = 3
+  var i4 : Int32 = 4
+  var i5 : Int32 = 5
+  var i6 : Int32 = 6
+  var i7 : Int32 = 7
+  var i8 : Int32 = 8
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @testDestroyValue(%T15big_types_tests9BigStructV* noalias nocapture dereferenceable({{.*}}) #0 {
+// CHECK-NEXT: entry
+// CHECK-NEXT: ret void
+sil @testDestroyValue : $@convention(thin) (@owned BigStruct) -> ()  {
+entry(%x : $BigStruct):
+  destroy_value %x : $BigStruct
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
radar rdar://problem/33942706

small optimization added to the large loadable types IRGen pass: support converting `destroy_value` instructions into `destroy_addr` 