### PR TITLE
[Do Not Merge]: Adding counter and timer to NominalTypeDecl::lookupDirect

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1722,8 +1722,6 @@ public:
 
   void setConformanceLoader(LazyMemberLoader *resolver, uint64_t contextData);
 
-  DeclRange getMembers() const;
-
   /// Determine whether this is a constrained extension, which adds additional
   /// requirements beyond those of the nominal type.
   bool isConstrainedExtension() const;
@@ -2775,7 +2773,6 @@ protected:
 public:
   using GenericTypeDecl::getASTContext;
 
-  DeclRange getMembers() const;
   SourceRange getBraces() const { return Braces; }
   
   void setBraces(SourceRange braces) { Braces = braces; }
@@ -2967,7 +2964,7 @@ public:
 ///
 /// The type of the decl itself is a MetatypeType; use getDeclaredType()
 /// to get the declared type ("Bool" or "Optional" in the above example).
-class EnumDecl : public NominalTypeDecl {
+class EnumDecl final : public NominalTypeDecl {
   SourceLoc EnumLoc;
 
   struct {
@@ -3123,7 +3120,7 @@ public:
 ///
 /// The type of the decl itself is a MetatypeType; use getDeclaredType()
 /// to get the declared type ("Complex" in the above example).
-class StructDecl : public NominalTypeDecl {
+class StructDecl final : public NominalTypeDecl {
   SourceLoc StructLoc;
 
 public:
@@ -3193,7 +3190,7 @@ enum class ObjCClassKind : uint8_t {
 ///
 /// The type of the decl itself is a MetatypeType; use getDeclaredType()
 /// to get the declared type ("Complex" in the above example).
-class ClassDecl : public NominalTypeDecl {
+class ClassDecl final : public NominalTypeDecl {
   class ObjCMethodLookupTable;
 
   SourceLoc ClassLoc;
@@ -3488,7 +3485,7 @@ private:
 ///   protocol Drawable {
 ///     func draw()
 ///   }
-class ProtocolDecl : public NominalTypeDecl {
+class ProtocolDecl final : public NominalTypeDecl {
   SourceLoc ProtocolLoc;
 
   /// The location of the 'class' keyword for class-bound protocols.

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -211,37 +211,27 @@ public:
   ///
   /// The implementation should add the members to D.
   virtual void
-  loadAllMembers(Decl *D, uint64_t contextData) {
-    llvm_unreachable("unimplemented");
-  }
+  loadAllMembers(Decl *D, uint64_t contextData) = 0;
 
   /// Populates the given vector with all conformances for \p D.
   ///
   /// The implementation should \em not call setConformances on \p D.
   virtual void
   loadAllConformances(const Decl *D, uint64_t contextData,
-                      SmallVectorImpl<ProtocolConformance *> &Conformances) {
-    llvm_unreachable("unimplemented");
-  }
+                      SmallVectorImpl<ProtocolConformance *> &Conformances) = 0;
 
   /// Populates the given vector with all conformances for \p D.
   virtual void
   finishNormalConformance(NormalProtocolConformance *conformance,
-                          uint64_t contextData) {
-    llvm_unreachable("unimplemented");
-  }
+                          uint64_t contextData) = 0;
 
   /// Returns the default definition type for \p ATD.
   virtual TypeLoc loadAssociatedTypeDefault(const AssociatedTypeDecl *ATD,
-                                            uint64_t contextData) {
-    llvm_unreachable("unimplemented");
-  }
+                                            uint64_t contextData) = 0;
 
   /// Returns the generic environment.
   virtual GenericEnvironment *loadGenericEnvironment(const DeclContext *decl,
-                                                     uint64_t contextData) {
-    llvm_unreachable("unimplemented");
-  }
+                                                     uint64_t contextData) = 0;
 };
 
 }

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -101,6 +101,7 @@ public:
     size_t NumLazyGenericEnvironments;
     size_t NumLazyGenericEnvironmentsLoaded;
     size_t NumLazyIterableDeclContexts;
+    size_t NominalTypeLookupDirectCount;
     size_t NumTypesDeserialized;
     size_t NumTypesValidated;
     size_t NumUnloadedLazyIterableDeclContexts;

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -45,6 +45,30 @@ namespace swift {
       CompilationTimersEnabled = State::Enabled;
     }
   };
+  
+  // A SharedTimer for recursive routines.
+  // Declare as a static, and call enter and exit.
+  class RecursiveSharedTimer {
+  private:
+    int recursionCount = 0;
+    const StringRef name;
+    SharedTimer *timer;
+  public:
+    RecursiveSharedTimer(StringRef name) : name(name), timer(nullptr) {}
+    
+    void enter() {
+      assert(recursionCount >= 0  &&  "too many exits");
+      if (recursionCount++ == 0)
+        timer = new SharedTimer(name);
+    }
+    void exit() {
+      assert(recursionCount > 0  &&  "too many exits");
+      if (--recursionCount == 0) {
+        delete timer;
+        timer = nullptr;
+      }
+    }
+  };
 } // end namespace swift
 
 #endif // SWIFT_BASIC_TIMER_H

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -807,11 +807,6 @@ ImportDecl::findBestImportKind(ArrayRef<ValueDecl *> Decls) {
   return FirstKind;
 }
 
-DeclRange NominalTypeDecl::getMembers() const {
-  loadAllMembers();
-  return IterableDeclContext::getMembers();
-}
-
 void NominalTypeDecl::setConformanceLoader(LazyMemberLoader *lazyLoader,
                                            uint64_t contextData) {
   assert(!NominalTypeDeclBits.HasLazyConformances &&
@@ -869,11 +864,6 @@ ExtensionDecl *ExtensionDecl::create(ASTContext &ctx, SourceLoc extensionLoc,
     result->setClangNode(clangNode);
 
   return result;
-}
-
-DeclRange ExtensionDecl::getMembers() const {
-  loadAllMembers();
-  return IterableDeclContext::getMembers();
 }
 
 void ExtensionDecl::setConformanceLoader(LazyMemberLoader *lazyLoader,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "NameLookupImpl.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTScope.h"
@@ -1191,6 +1192,12 @@ void NominalTypeDecl::makeMemberVisible(ValueDecl *member) {
 TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
+  static RecursiveSharedTimer timer("lookupDirect");
+  timer.enter();
+  ASTContext &ctx = getASTContext();
+  if (ctx.Stats)
+    ++ctx.Stats->getFrontendCounters().NominalTypeLookupDirectCount;
+  
   (void)getMembers();
 
   // Make sure we have the complete list of members (in this nominal and in all
@@ -1204,6 +1211,8 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
 
   // Look for the declarations with this name.
   auto known = LookupTable.getPointer()->find(name);
+  timer.exit();
+  
   if (known == LookupTable.getPointer()->end())
     return { };
 

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -187,6 +187,7 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
     PUBLISH_STAT(C, "Sema", NumLazyGenericEnvironments);
     PUBLISH_STAT(C, "Sema", NumLazyGenericEnvironmentsLoaded);
     PUBLISH_STAT(C, "Sema", NumLazyIterableDeclContexts);
+    PUBLISH_STAT(C, "Sema", NominalTypeLookupDirectCount);
     PUBLISH_STAT(C, "Sema", NumTypesDeserialized);
     PUBLISH_STAT(C, "Sema", NumTypesValidated);
     PUBLISH_STAT(C, "Sema", NumUnloadedLazyIterableDeclContexts);
@@ -277,6 +278,7 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
     PRINT_STAT(OS, delim, C, "Sema", NumLazyGenericEnvironments);
     PRINT_STAT(OS, delim, C, "Sema", NumLazyGenericEnvironmentsLoaded);
     PRINT_STAT(OS, delim, C, "Sema", NumLazyIterableDeclContexts);
+    PRINT_STAT(OS, delim, C, "Sema", NominalTypeLookupDirectCount);
     PRINT_STAT(OS, delim, C, "Sema", NumTypesDeserialized);
     PRINT_STAT(OS, delim, C, "Sema", NumTypesValidated);
     PRINT_STAT(OS, delim, C, "Sema", NumUnloadedLazyIterableDeclContexts);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1126,6 +1126,18 @@ public:
 
   void finishNormalConformance(NormalProtocolConformance *conformance,
                                uint64_t unused) override;
+  
+  /// Returns the default definition type for \p ATD.
+  TypeLoc loadAssociatedTypeDefault(const AssociatedTypeDecl *ATD,
+                                            uint64_t contextData) override {
+    llvm_unreachable("unimplemented for ClangImporter");
+  }
+  
+  /// Returns the generic environment.
+  virtual GenericEnvironment *loadGenericEnvironment(const DeclContext *decl,
+                                                     uint64_t contextData) override {
+    llvm_unreachable("unimplemented for ClangImporter");
+  }
 
   template <typename DeclTy, typename ...Targs>
   DeclTy *createDeclWithClangNode(ClangNode ClangN, Accessibility access,


### PR DESCRIPTION
<!-- What's in this pull request? -->
Beginning of work to reduce time spent in NominalTypeDecl::lookupDirect. Adds timer "lookupDirect" and counter "NominalTypeLookupDirectCount".

Also remove redundant (NominalType|Extension)Decl::getMembers
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->