### PR TITLE
[code-completion] Fix for-loop sequences containing collection syntax

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1252,8 +1252,10 @@ public:
   ParserResult<Expr> parseExprCallSuffix(ParserResult<Expr> fn,
                                          bool isExprBasic);
   ParserResult<Expr> parseExprCollection(SourceLoc LSquareLoc = SourceLoc());
-  ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc, Expr *FirstExpr);
-  ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc, Expr *FirstKey);
+  ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc,
+                                    ParserResult<Expr> FirstExpr);
+  ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc,
+                                         ParserResult<Expr> FirstKey);
 
   UnresolvedDeclRefExpr *parseExprOperator();
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3056,22 +3056,20 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
   // Parse the first expression.
   ParserResult<Expr> FirstExpr
     = parseExpr(diag::expected_expr_in_collection_literal);
-  if (FirstExpr.isNull() || FirstExpr.hasCodeCompletion()) {
+  if (FirstExpr.isNull()) {
     skipUntil(tok::r_square);
     if (Tok.is(tok::r_square))
       consumeToken();
-    if (FirstExpr.hasCodeCompletion())
-      return makeParserCodeCompletionResult<Expr>();
-    return nullptr;
+    return FirstExpr;
   }
 
   // If we have a ':', this is a dictionary literal.
   if (Tok.is(tok::colon)) {
-    return parseExprDictionary(LSquareLoc, FirstExpr.get());
+    return parseExprDictionary(LSquareLoc, FirstExpr);
   }
 
   // Otherwise, we have an array literal.
-  return parseExprArray(LSquareLoc, FirstExpr.get());
+  return parseExprArray(LSquareLoc, FirstExpr);
 }
 
 /// parseExprArray - Parse an array literal expression.
@@ -3083,13 +3081,13 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
 ///     '[' expr (',' expr)* ','? ']'
 ///     '[' ']'
 ParserResult<Expr> Parser::parseExprArray(SourceLoc LSquareLoc,
-                                          Expr *FirstExpr) {
+                                          ParserResult<Expr> FirstExpr) {
   SmallVector<Expr *, 8> SubExprs;
   SmallVector<SourceLoc, 8> CommaLocs;
-  SubExprs.push_back(FirstExpr);
+  SubExprs.push_back(FirstExpr.get());
 
   SourceLoc CommaLoc, RSquareLoc;
-  ParserStatus Status;
+  ParserStatus Status(FirstExpr);
 
   if (Tok.isNot(tok::r_square) && !consumeIf(tok::comma, CommaLoc)) {
     diagnose(Tok, diag::expected_separator, ",")
@@ -3115,9 +3113,6 @@ ParserResult<Expr> Parser::parseExprArray(SourceLoc LSquareLoc,
     return Element;
   });
 
-  if (Status.hasCodeCompletion())
-    return makeParserCodeCompletionResult<Expr>();
-
   assert(SubExprs.size() >= 1);
   return makeParserResult(Status,
           ArrayExpr::create(Context, LSquareLoc, SubExprs, CommaLocs,
@@ -3133,7 +3128,7 @@ ParserResult<Expr> Parser::parseExprArray(SourceLoc LSquareLoc,
 ///     '[' expr ':' expr (',' expr ':' expr)* ','? ']'
 ///     '[' ':' ']'
 ParserResult<Expr> Parser::parseExprDictionary(SourceLoc LSquareLoc,
-                                               Expr *FirstKey) {
+                                               ParserResult<Expr> FirstKey) {
   assert(Tok.is(tok::colon));
 
   // Each subexpression is a (key, value) tuple.
@@ -3149,48 +3144,44 @@ ParserResult<Expr> Parser::parseExprDictionary(SourceLoc LSquareLoc,
 
   bool FirstPair = true;
 
-  ParserStatus Status =
+  ParserStatus Status(FirstKey);
+  Status |=
       parseList(tok::r_square, LSquareLoc, RSquareLoc,
                 /*AllowSepAfterLast=*/true,
                 diag::expected_rsquare_array_expr, [&]() -> ParserStatus {
     // Parse the next key.
     ParserResult<Expr> Key;
     if (FirstPair) {
-      Key = makeParserResult(FirstKey);
+      Key = makeParserResult(FirstKey.get());
       FirstPair = false;
     } else {
       Key = parseExpr(diag::expected_key_in_dictionary_literal);
-      if (Key.isNull() || Key.hasCodeCompletion())
+      if (Key.isNull())
         return Key;
     }
 
     // Parse the ':'.
     if (Tok.isNot(tok::colon)) {
       diagnose(Tok, diag::expected_colon_in_dictionary_literal);
-      return makeParserError();
+      return ParserStatus(Key) | makeParserError();
     }
     consumeToken();
 
     // Parse the next value.
     ParserResult<Expr> Value =
         parseExpr(diag::expected_value_in_dictionary_literal);
-    if (Value.hasCodeCompletion())
-      return Value;
 
     if (Value.isNull())
       Value = makeParserResult(Value, new (Context) ErrorExpr(PreviousLoc));
 
     // Add this key/value pair.
     addKeyValuePair(Key.get(), Value.get());
-    return Value;
+    return ParserStatus(Key) | ParserStatus(Value);
   });
 
-  if (Status.hasCodeCompletion())
-    return makeParserCodeCompletionResult<Expr>();
-
   assert(SubExprs.size() >= 1);
-  return makeParserResult(DictionaryExpr::create(Context, LSquareLoc, SubExprs,
-                                                 RSquareLoc));
+  return makeParserResult(Status, DictionaryExpr::create(Context, LSquareLoc,
+                                                         SubExprs, RSquareLoc));
 }
 
 void Parser::addPatternVariablesToScope(ArrayRef<Pattern *> Patterns) {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1857,13 +1857,16 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
     consumeToken(tok::code_complete);
   } else {
     Container = parseExprBasic(diag::expected_foreach_container);
+    llvm::errs() << "container:\n";
+    if (!Container.isNull()) {
+      Container.get()->dump();
+    }
+    Status |= Container;
     if (Container.isNull())
       Container = makeParserErrorResult(new (Context) ErrorExpr(Tok.getLoc()));
     if (Container.isParseError())
       // Recover.
       skipUntilDeclStmtRBrace(tok::l_brace, tok::kw_where);
-
-    Status |= Container;
   }
 
   // Introduce a new scope and place the variables in the pattern into that

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -123,6 +123,31 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRING_INTERP_3 | %FileCheck %s -check-prefix=STRING_INTERP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRING_INTERP_4 | %FileCheck %s -check-prefix=STRING_INTERP
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_1 > %t.for_collection1
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection1
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_2 > %t.for_collection2
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection2
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_3 > %t.for_collection3
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection3
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_4 > %t.for_collection4
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection4
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_5 > %t.for_collection5
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection5
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection5
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_6 > %t.for_collection6
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection6
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_7 > %t.for_collection7
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection7
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection7
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOR_COLLECTION_8 > %t.for_collection8
+// RUN: %FileCheck %s -check-prefix=PLAIN_TOP_LEVEL < %t.for_collection8
+// RUN: %FileCheck %s -check-prefix=FOR_COLLECTION < %t.for_collection8
+
 // Test code completion in top-level code.
 //
 // This test is not meant to test that we can correctly form all kinds of
@@ -436,6 +461,16 @@ _ = "" + "\(#^STRING_INTERP_4^#)" + ""
 // STRING_INTERP-DAG: Decl[GlobalVar]/Local: fooObject[#FooStruct#];
 // STRING_INTERP: End completions
 func resyncParserC1() {}
+
+// FOR_COLLECTION-NOT: forIndex
+for forIndex in [#^FOR_COLLECTION_1^#] {}
+for forIndex in [1,#^FOR_COLLECTION_2^#] {}
+for forIndex in [1:#^FOR_COLLECTION_3^#] {}
+for forIndex in [#^FOR_COLLECTION_4^#:] {}
+for forIndex in [#^FOR_COLLECTION_5^#:2] {}
+for forIndex in [1:2, #^FOR_COLLECTION_6^#] {}
+for forIndex in [1:2, #^FOR_COLLECTION_7^#:] {}
+for forIndex in [1:2, #^FOR_COLLECTION_8^#:2] {}
 
 
 //

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -61,6 +61,14 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_2 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_3 | %FileCheck %s -check-prefix=IN_FOR_EACH_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_4 | %FileCheck %s -check-prefix=IN_FOR_EACH_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_5 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_6 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_7 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_8 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_9 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_10 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_11 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_12 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPRECATED_1 | %FileCheck %s -check-prefix=DEPRECATED_1
 
@@ -455,6 +463,47 @@ func testInForEach4(arg: Int) {
   for index in 1 ... 2 {
     #^IN_FOR_EACH_4^#
   }
+  let after = 4
+}
+
+func testInForEach5(arg: Int) {
+  let local = 2
+  for index in [#^IN_FOR_EACH_5^#] {}
+  let after = 4
+}
+func testInForEach6(arg: Int) {
+  let local = 2
+  for index in [1,#^IN_FOR_EACH_6^#] {}
+  let after = 4
+}
+func testInForEach7(arg: Int) {
+  let local = 2
+  for index in [1:#^IN_FOR_EACH_7^#] {}
+  let after = 4
+}
+func testInForEach8(arg: Int) {
+  let local = 2
+  for index in [#^IN_FOR_EACH_8^#:] {}
+  let after = 4
+}
+func testInForEach9(arg: Int) {
+  let local = 2
+  for index in [#^IN_FOR_EACH_9^#:2] {}
+  let after = 4
+}
+func testInForEach10(arg: Int) {
+  let local = 2
+  for index in [1:2, #^IN_FOR_EACH_10^#] {}
+  let after = 4
+}
+func testInForEach11(arg: Int) {
+  let local = 2
+  for index in [1:2, #^IN_FOR_EACH_11^#:] {}
+  let after = 4
+}
+func testInForEach12(arg: Int) {
+  let local = 2
+  for index in [1:2, #^IN_FOR_EACH_12^#:2] {}
   let after = 4
 }
 


### PR DESCRIPTION
This fixes various issues with getting no code-completion in top-level
code containing array/dictionary sugar, such as:
```
for x in [<HERE>] {}
for x in [1: 2, <HERE>] {}
```

And also removes the index variable from completions inside the sequence
(it was coming through as a local variable with <<error type>>).

rdar://problem/33884082