### PR TITLE
Add an option to optimize for size -Osize

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -97,6 +97,9 @@ public:
   /// Whether or not to run optimization passes.
   unsigned Optimize : 1;
 
+  /// Whether or not to optimize for code size.
+  unsigned OptimizeForSize : 1;
+
   /// Which sanitizer is turned on.
   OptionSet<SanitizerKind> Sanitizers;
 
@@ -173,7 +176,8 @@ public:
 
   IRGenOptions()
       : DWARFVersion(2), OutputKind(IRGenOutputKind::LLVMAssembly),
-        Verify(true), Optimize(false), Sanitizers(OptionSet<SanitizerKind>()),
+        Verify(true), Optimize(false), OptimizeForSize(false),
+        Sanitizers(OptionSet<SanitizerKind>()),
         DebugInfoKind(IRGenDebugInfoKind::None), UseJIT(false),
         DisableLLVMOptzns(false), DisableLLVMARCOpts(false),
         DisableLLVMSLPVectorizer(false), DisableFPElim(true), Playground(false),
@@ -197,6 +201,7 @@ public:
   unsigned getLLVMCodeGenOptionsHash() {
     unsigned Hash = 0;
     Hash = (Hash << 1) | Optimize;
+    Hash = (Hash << 1) | OptimizeForSize;
     Hash = (Hash << 1) | DisableLLVMOptzns;
     Hash = (Hash << 1) | DisableLLVMARCOpts;
     return Hash;

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -52,6 +52,7 @@ public:
     None,
     Debug,
     Optimize,
+    OptimizeForSize,
     OptimizeUnchecked
   };
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -374,6 +374,8 @@ def Onone : Flag<["-"], "Onone">, Group<O_Group>, Flags<[FrontendOption]>,
   HelpText<"Compile without any optimization">;
 def O : Flag<["-"], "O">, Group<O_Group>, Flags<[FrontendOption]>,
   HelpText<"Compile with optimizations">;
+def Osize : Flag<["-"], "Osize">, Group<O_Group>, Flags<[FrontendOption]>,
+  HelpText<"Compile with optimizations and target small code size">;
 def Ounchecked : Flag<["-"], "Ounchecked">, Group<O_Group>,
   Flags<[FrontendOption]>,
   HelpText<"Compile with optimizations and remove runtime safety checks">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1380,6 +1380,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // Parse the optimization level.
   // Default to Onone settings if no option is passed.
   IRGenOpts.Optimize = false;
+  IRGenOpts.OptimizeForSize = false;
   Opts.Optimization = SILOptions::SILOptMode::None;
   if (const Arg *A = Args.getLastArg(OPT_O_Group)) {
     if (A->getOption().matches(OPT_Onone)) {
@@ -1387,6 +1388,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     } else if (A->getOption().matches(OPT_Ounchecked)) {
       // Turn on optimizations and remove all runtime checks.
       IRGenOpts.Optimize = true;
+      IRGenOpts.OptimizeForSize = false;
       Opts.Optimization = SILOptions::SILOptMode::OptimizeUnchecked;
       // Removal of cond_fail (overflow on binary operations).
       Opts.RemoveRuntimeAsserts = true;
@@ -1394,9 +1396,15 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     } else if (A->getOption().matches(OPT_Oplayground)) {
       // For now -Oplayground is equivalent to -Onone.
       IRGenOpts.Optimize = false;
+      IRGenOpts.OptimizeForSize = false;
       Opts.Optimization = SILOptions::SILOptMode::None;
+    } else if (A->getOption().matches(OPT_Osize)) {
+      IRGenOpts.Optimize = true;
+      IRGenOpts.OptimizeForSize = true;
+      Opts.Optimization = SILOptions::SILOptMode::OptimizeForSize;
     } else {
       assert(A->getOption().matches(OPT_O));
+      IRGenOpts.OptimizeForSize = false;
       IRGenOpts.Optimize = true;
       Opts.Optimization = SILOptions::SILOptMode::Optimize;
     }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1066,6 +1066,7 @@ static bool emitIndexData(SourceFile *PrimarySourceFile,
       isDebugCompilation = true;
       break;
     case SILOptions::SILOptMode::Optimize:
+    case SILOptions::SILOptMode::OptimizeForSize:
     case SILOptions::SILOptMode::OptimizeUnchecked:
       isDebugCompilation = false;
       break;
@@ -1165,6 +1166,8 @@ silOptModeArgStr(SILOptions::SILOptMode mode) {
    return "O";
  case SILOptions::SILOptMode::OptimizeUnchecked:
    return "Ounchecked";
+ case SILOptions::SILOptMode::OptimizeForSize:
+   return "Osize";
  default:
    return "Onone";
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1369,6 +1369,9 @@ static llvm::Function *getTypeMetadataAccessFunction(IRGenModule &IGM,
   if (!isTypeMetadataAccessTrivial(IGM, type)) {
     cacheVariable = cast<llvm::GlobalVariable>(
         IGM.getAddrOfTypeMetadataLazyCacheVariable(type, ForDefinition));
+
+    if (IGM.getOptions().OptimizeForSize)
+      accessor->addFnAttr(llvm::Attribute::NoInline);
   }
 
   emitLazyCacheAccessFunction(IGM, accessor, cacheVariable,
@@ -1410,6 +1413,9 @@ static llvm::Function *getGenericTypeMetadataAccessFunction(IRGenModule &IGM,
   // have defined it, just return the pointer.
   if (!shouldDefine || !accessor->empty())
     return accessor;
+
+  if (IGM.getOptions().OptimizeForSize)
+    accessor->addFnAttr(llvm::Attribute::NoInline);
 
   emitLazyCacheAccessFunction(IGM, accessor, /*cacheVariable=*/nullptr,
                               [&](IRGenFunction &IGF) -> llvm::Value* {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -986,6 +986,9 @@ getWitnessTableLazyAccessFunction(IRGenModule &IGM,
   if (!accessor->empty())
     return accessor;
 
+  if (IGM.getOptions().OptimizeForSize)
+    accessor->addFnAttr(llvm::Attribute::NoInline);
+
   // Okay, define the accessor.
   auto cacheVariable = cast<llvm::GlobalVariable>(
     IGM.getAddrOfWitnessTableLazyCacheVariable(conformance, conformingType,
@@ -1312,6 +1315,8 @@ getAssociatedTypeMetadataAccessFunction(AssociatedType requirement,
   llvm::Function *accessor =
     IGM.getAddrOfAssociatedTypeMetadataAccessFunction(&Conformance,
                                                       requirement);
+  if (IGM.getOptions().OptimizeForSize)
+    accessor->addFnAttr(llvm::Attribute::NoInline);
 
   IRGenFunction IGF(IGM, accessor);
   if (IGM.DebugInfo)
@@ -1419,6 +1424,9 @@ getAssociatedTypeWitnessTableAccessFunction(AssociatedConformance requirement,
   IRGenFunction IGF(IGM, accessor);
   if (IGM.DebugInfo)
     IGM.DebugInfo->emitArtificialFunction(IGF, accessor);
+
+  if (IGM.getOptions().OptimizeForSize)
+    accessor->addFnAttr(llvm::Attribute::NoInline);
 
   Explosion parameters = IGF.collectParameters();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -805,6 +805,8 @@ void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs) {
     });
     Attrs.addAttribute("target-features", allFeatures);
   }
+  if (IRGen.Opts.OptimizeForSize)
+    Attrs.addAttribute(llvm::Attribute::OptimizeForSize);
 }
 
 llvm::AttributeList IRGenModule::constructInitialAttributes() {

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -2292,9 +2292,16 @@ class SwiftArrayOptPass : public SILFunctionTransform {
     if (!ShouldSpecializeArrayProps)
       return;
 
+    auto *Fn = getFunction();
+
+    // Don't hoist array property calls at Osize.
+    auto OptMode = Fn->getModule().getOptions().Optimization;
+    if (OptMode == SILOptions::SILOptMode::OptimizeForSize)
+      return;
+
     DominanceAnalysis *DA = PM->getAnalysis<DominanceAnalysis>();
     SILLoopAnalysis *LA = PM->getAnalysis<SILLoopAnalysis>();
-    SILLoopInfo *LI = LA->get(getFunction());
+    SILLoopInfo *LI = LA->get(Fn);
 
     bool HasChanged = false;
 

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -1140,6 +1140,11 @@ public:
   void run() override {
     auto *F = getFunction();
 
+    // Don't run function signature optimizations at -Os.
+    if (F->getModule().getOptions().Optimization ==
+        SILOptions::SILOptMode::OptimizeForSize)
+      return;
+
     // Don't optimize callees that should not be optimized.
     if (!F->shouldOptimize())
       return;

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -556,6 +556,13 @@ namespace {
     ~SpeculativeDevirtualization() override {}
 
     void run() override {
+
+      auto &CurFn = *getFunction();
+      // Don't perform speculative devirtualization at -Os.
+      if (CurFn.getModule().getOptions().Optimization ==
+          SILOptions::SILOptMode::OptimizeForSize)
+        return;
+
       ClassHierarchyAnalysis *CHA = PM->getAnalysis<ClassHierarchyAnalysis>();
 
       bool Changed = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,7 +135,7 @@ set(profdata_merge_worker
     "${CMAKE_CURRENT_SOURCE_DIR}/../utils/profdata_merge/main.py")
 
 set(TEST_MODES
-    optimize_none optimize optimize_unchecked
+    optimize_none optimize optimize_unchecked optimize_size
     only_executable only_non_executable
 )
 set(TEST_SUBSETS

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=OSIZE
 
 // REQUIRES: CPU=x86_64
 
@@ -365,3 +366,6 @@ entry(%c : $RootGeneric<Int32>):
 // CHECK:   call %swift.type* @swift_initClassMetadata_UniversalStrategy(%swift.type* [[METADATA]], i64 1, i8*** [[FIELDS_ADDR]], i64* [[OFFSETS]])
 // CHECK:   ret %swift.type* [[METADATA]]
 // CHECK: }
+
+// OSIZE: define hidden %swift.type* @_T015generic_classes11RootGenericCMa(%swift.type*) [[ATTRS:#[0-9]+]] {
+// OSIZE: [[ATTRS]] = {{{.*}}noinline

--- a/test/IRGen/optimize_for_size.sil
+++ b/test/IRGen/optimize_for_size.sil
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=O
+sil_stage canonical
+
+import Builtin
+
+// CHECK-LABEL: define{{.*}} swiftcc void @optimize_for_size_attribute({{.*}}) #0 {
+// O-LABEL: define{{.*}} swiftcc void @optimize_for_size_attribute({{.*}}) #0 {
+sil @optimize_for_size_attribute : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : $Builtin.Int32):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// O-NOT: attributes #0 = {{{.*}}optsize
+// CHECK: attributes #0 = {{{.*}}optsize

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=OSIZE
 
 // <rdar://problem/21665983> IRGen crash with protocol extension involving same-type constraint to X<T>
 public struct DefaultFoo<T> {
@@ -58,3 +59,6 @@ where Self : CodingType,
       Self.ValueType.Coder == Self {
   print(Self.ValueType.self)
 }
+
+// OSIZE: define internal i8** @_T021same_type_constraints12GenericKlazzCyxq_GAA1EAA4DataQy_RszAaER_r0_lAfA0F4TypePWT(%swift.type* %"GenericKlazz<T, R>.Data", %swift.type* nocapture readonly %"GenericKlazz<T, R>", i8** nocapture readnone %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
+// OSIZE: [[ATTRS]] = {{{.*}}noinline

--- a/test/IRGen/typemetadata.sil
+++ b/test/IRGen/typemetadata.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=OSIZE
 
 // REQUIRES: CPU=x86_64
 // XFAIL: linux
@@ -46,4 +47,8 @@ bb0:
 // CHECK-NEXT: br label
 // CHECK:      [[RES:%.*]] = phi
 // CHECK-NEXT: ret %swift.type* [[RES]]
+
+
+// OSIZE: define hidden %swift.type* @_T012typemetadata1CCMa() [[ATTR:#[0-9]+]] {
+// OSIZE: [[ATTR]] = {{{.*}}noinline
 

--- a/test/Interpreter/SDK/protocol_lookup_foreign.swift
+++ b/test/Interpreter/SDK/protocol_lookup_foreign.swift
@@ -6,6 +6,7 @@
 
 // rdar://20990451 is tracking the fix for compiling this test optimized.
 // XFAIL: swift_test_mode_optimize
+// XFAIL: swift_test_mode_optimize_size
 // XFAIL: swift_test_mode_optimize_unchecked
 
 import Foundation

--- a/test/SILOptimizer/devirt_speculate.swift
+++ b/test/SILOptimizer/devirt_speculate.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -parse-as-library -O -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -parse-as-library -Osize -emit-sil | %FileCheck %s --check-prefix=OSIZE
 //
 // Test speculative devirtualization.
 
@@ -40,6 +41,10 @@ class Sub7 : Base {
 // CHECK-NOT: checked_cast_br
 // CHECK: %[[CM:[0-9]+]] = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK: apply %[[CM]](%0) : $@convention(method) (@guaranteed Base) -> ()
+
+// OSIZE: @_T016devirt_speculate28testMaxNumSpeculativeTargetsyAA4BaseCF
+// OSIZE-NOT: checked_cast_br [exact] %0 : $Base to $Base
+// OSIZE-NOT: checked_cast_br [exact] %0 : $Base to $Sub
 public func testMaxNumSpeculativeTargets(_ b: Base) {
   b.foo()
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -458,6 +458,14 @@ elif swift_test_mode == 'optimize':
     # optimize mode for a cpu.
     config.available_features.add("swift_test_mode_optimize_" + run_cpu)
     swift_execution_tests_extra_flags = '-O'
+elif swift_test_mode == 'optimize_size':
+    config.available_features.add("executable_test")
+    config.limit_to_features.add("executable_test")
+    config.available_features.add("swift_test_mode_optimize_size")
+    # Add the cpu as a feature so we can selectively disable tests in an
+    # optimize mode for a cpu.
+    config.available_features.add("swift_test_mode_optimize_" + run_cpu)
+    swift_execution_tests_extra_flags = '-Osize'
 elif swift_test_mode == 'optimize_unchecked':
     config.available_features.add("executable_test")
     config.limit_to_features.add("executable_test")


### PR DESCRIPTION
This adds an size optimization mode ("Osize") which intends to enable some
optimization but targets mainly reduced code size compared to the regular
optimized mode ("O").

And some early changes under this mode.

Code size savings (positive is a text+data size reduction) for the source compat suite:
```
Project/platform                           :        Old        New   Percent
AMScrollingNavbar/iphoneos                 :     118060     115052    2.55
Alamofire/iphoneos                         :    1007735     852567   15.40
Alamofire/iphoneos                         :    1007735     852567   15.40
iOS Example/iphoneos                       :     126008     134552   -6.78
Chatto/iphoneos                            :     522959     505057    3.42
Chatto/iphoneos                            :     522959     505057    3.42
ChattoAdditions/iphoneos                   :    1157599    1036917   10.43
ChattoAdditions/iphoneos                   :    1157599    1036917   10.43
ChattoApp/iphoneos                         :     322215     310099    3.76
CleanroomLogger/watchos                    :     149162     135950    8.86
Dollar/macos                               :     192598     164200   14.74
Dwifft/iphoneos                            :     168940     145868   13.66
Example/iphoneos                           :      57231      54863    4.14
IBAnimatable/iphoneos                      :    3283576    2584044   21.30
IBAnimatableApp/iphoneos                   :     375702     372418    0.87
JSQDataSourcesKit/iphoneos                 :     191065     186289    2.50
KeychainAccess/watchos                     :     163960     151556    7.57
Kingfisher/watchos                         :     208324     193820    6.96
Kommander/watchos                          :      53448      41228   22.86
LaunchScreenSnapshot/iphoneos              :      85932      82064    4.50
ObjectMapper/watchos                       :     173358     148802   14.16
PanelKit/iphoneos                          :     257496     245936    4.49
Prelude/appletvos                          :      96856      87152   10.02
Prelude_UIKit/appletvos                    :     252361     253405   -0.41
PromiseKit/appletvos                       :     271600     238801   12.08
ReLax/appletvos                            :     173035     180327   -4.21
ReSwift/watchos                            :      40534      38254    5.62
ReactiveCocoa/watchos                      :      71840      71626    0.30
ReactiveExtensions/appletvos               :     159359     142367   10.66
ReactiveSwift/appletvos                    :     819507     749878    8.50
ReactiveSwift/watchos                      :     526163     476415    9.45
Realm/watchos                              :    3118785    3118785    0.00
Result/appletvos                           :      62529      61342    1.90
Result/watchos                             :      37353      35561    4.80
RxCocoa/iphoneos                           :     937394     884526    5.64
RxSwift/appletvos                          :    1109376    1046540    5.66
RxSwift/iphoneos                           :    1562946    1488650    4.75
RxTest/appletvos                           :      87468      78152   10.65
Siesta/macos                               :     632922     562350   11.15
SiestaUI/macos                             :         48         48    0.00
Socket/iphoneos                            :     190418     173610    8.83
Starscream/appletvos                       :     132204     125067    5.40
SwiftDate/watchos                          :     405367     368865    9.00
SwifterSwift/watchos                       :     311135     290335    6.69
```

