### PR TITLE
[WIP] Failure analysis based on the constraint solver information

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -9542,10 +9542,12 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
   // eliminated.
   viable.clear();
 
+  DiagnosticListener diagnostics(*this);
   {
     // Set up solver state.
     SolverState state(*this);
     state.recordFixes = true;
+    state.Diagnostics = &diagnostics;
 
     // Solve the system.
     solveRec(viable, FreeTypeVariableBinding::Disallow);
@@ -9596,8 +9598,15 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     return true;
   }
 
+  if (diagnoseFailure(diagnostics))
+    return true;
+
   // If all else fails, diagnose the failure by looking through the system's
   // constraints.
   diagnoseFailureForExpr(expr);
   return true;
+}
+
+bool ConstraintSystem::diagnoseFailure(DiagnosticListener &capturedInfo) {
+  return false;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1598,8 +1598,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // but we still have an lvalue, fail.
         if (!typeVar1->getImpl().canBindToLValue() && type2->hasLValueType()) {
           if (solverState)
-            solverState->recordFailure(typeVar1, type2,
-                                       getConstraintLocator(locator));
+            solverState->recordFailure(typeVar1, type2, locator);
           return SolutionKind::Error;
         }
 
@@ -1610,8 +1609,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         if (typeVar1->getImpl().mustBeMaterializable()) {
           if (!type2->isMaterializable()) {
             if (solverState)
-              solverState->recordFailure(typeVar1, type2,
-                                         getConstraintLocator(locator));
+              solverState->recordFailure(typeVar1, type2, locator);
             return SolutionKind::Error;
           }
 
@@ -1654,8 +1652,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (!typeVar2->getImpl().canBindToLValue() &&
           type1->hasLValueType()) {
         if (solverState)
-          solverState->recordFailure(type1, typeVar2,
-                                     getConstraintLocator(locator));
+          solverState->recordFailure(type1, typeVar2, locator);
         return SolutionKind::Error;
         
         // Okay. Bind below.
@@ -1802,8 +1799,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (isa<ParenType>(type1.getPointer()) !=
           isa<ParenType>(type2.getPointer())) {
         if (solverState)
-          solverState->recordFailure(type1, type2,
-                                     getConstraintLocator(locator));
+          solverState->recordFailure(type1, type2, locator);
         return SolutionKind::Error;
       }
     }
@@ -1968,8 +1964,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (kind == ConstraintKind::BindParam ||
           kind >= ConstraintKind::OperatorArgumentConversion) {
         if (solverState)
-          solverState->recordFailure(desugar1, desugar2,
-                                     getConstraintLocator(locator));
+          solverState->recordFailure(desugar1, desugar2, locator);
         return SolutionKind::Error;
       }
 
@@ -2432,7 +2427,7 @@ commit_to_conversions:
       return formUnsolvedResult();
 
     if (solverState)
-      solverState->recordFailure(type1, type2, getConstraintLocator(locator));
+      solverState->recordFailure(type1, type2, locator);
     return SolutionKind::Error;
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -428,9 +428,6 @@ ConstraintSystem::SolverState::~SolverState() {
          "Expected constraint system to have this solver state!");
   CS.solverState = nullptr;
 
-  if (CS.TC.getLangOpts().DebugConstraintSolver)
-    Path.print(CS, CS.getASTContext().TypeCheckerDebug->getStream());
-
   // Restore debugging state.
   LangOptions &langOpts = CS.getTypeChecker().Context.LangOpts;
   langOpts.DebugConstraintSolver = OldDebugConstraintSolver;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1620,6 +1620,15 @@ private:
         ConstraintSystemFlags::ReturnAllDiscoveredSolutions);
   }
 
+  /// \brief Select the best disjunction in current conditions to attempt
+  /// to solve next.
+  ///
+  /// \param disjunctions The list of currently available disjunctions.
+  ///
+  /// \returns the disjunction to solve next, or nullptr.
+  Constraint *
+  selectDisjunction(SmallVectorImpl<Constraint *> &disjunctions) const;
+
   /// \brief Finalize this constraint system; we're done attempting to solve
   /// it.
   ///


### PR DESCRIPTION
This is an alternative approach to current status quo, where we try to type-check
each sub-expressions to try and locate the error. Instead of doing that, this
patch tracks constraint solver failures and each path taken, and based on that tries
to produce diagnostics according to most common failure locations.

This makes it very easy to locate and diagnose failures related to structure of parameters,
shadowing, contextual conversions and generic requirements among many others.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
