### PR TITLE
Avoid adding -pie on Android apps which are -shared

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1597,7 +1597,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
 
-  if (getTriple().getOS() == llvm::Triple::Linux && !getTriple().isAndroid()) {
+  if (getTriple().getOS() == llvm::Triple::Linux && job.getKind() != LinkKind::DynamicLibrary) {
     Arguments.push_back("-pie");
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1597,7 +1597,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
 
-  if (getTriple().getOS() == llvm::Triple::Linux) {
+  if (getTriple().getOS() == llvm::Triple::Linux && !getTriple().isAndroid()) {
     Arguments.push_back("-pie");
   }
 


### PR DESCRIPTION
@CodaFi as discussed. The driver automatically adding -pie for Linux apps breaks "swift build" when you are building a shared library for use in an Android application as it is also Linux and -shared and -pie cannot be specified at the same time. This will fix Android but leaves switfc unable to build shared Swift libraries for Linux.

Thanks!