### PR TITLE
[silgen] Eliminate an unnecessary static function emitArrayToPointer.

### DIFF
--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -74,8 +74,13 @@ class RValue {
   CanType type;
   unsigned elementsToBeAdded;
   
-  /// Flag value used to mark an rvalue as invalid, because it was
-  /// consumed or it was default-initialized.
+  /// \brief Flag value used to mark an rvalue as invalid.
+  ///
+  /// The reasons why this can be true is:
+  ///
+  /// 1. The RValue was consumed.
+  /// 2. The RValue was default-initialized.
+  /// 3. The RValue was emitted into an SGFContext initialization.
   enum : unsigned {
     Null = ~0U,
     Used = Null - 1,

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -9,6 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file defines SILGenBuilder, a subclass of SILBuilder that provides APIs
+/// that traffic in ManagedValue. The intention is that if one is using a
+/// SILGenBuilder, the SILGenBuilder will handle preserving ownership invariants
+/// (or assert upon failure) freeing the implementor of such concerns.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SILGEN_SILGENBUILDER_H
 #define SWIFT_SILGEN_SILGENBUILDER_H


### PR DESCRIPTION
[silgen] Eliminate an unnecessary static function emitArrayToPointer.

We already have a method on SILGenFunction with the exact signature that just
calls this private function. All other uses can be re-routed to the method on
SILGenFunction, allowing us to simplify the code.
