### PR TITLE
Osize: Only skip inlining for class methods

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -183,9 +183,13 @@ bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,
     if (AI.getFunction()->isThunk())
       return false;
 
-    // Don't inline methods.
-    if (Callee->getRepresentation() == SILFunctionTypeRepresentation::Method)
-      return false;
+    // Don't inline class methods.
+    if (Callee->hasSelfParam()) {
+      auto SelfTy = Callee->getLoweredFunctionType()->getSelfInstanceType();
+      if (SelfTy->mayHaveSuperclass() &&
+          Callee->getRepresentation() == SILFunctionTypeRepresentation::Method)
+        return false;
+    }
 
     BaseBenefit = BaseBenefit / 2;
   }


### PR DESCRIPTION
This addresses most of the regressions (when comparing O to Osize) from the compat suite and some size saving gains.
