### PR TITLE
SILGen: swift_newtypes should be returned autoreleased from ObjC entry points.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1704,7 +1704,8 @@ namespace {
       }
 
       auto type = tl.getLoweredType().getSwiftRValueType();
-      if (type->hasRetainablePointerRepresentation())
+      if (type->hasRetainablePointerRepresentation()
+          || (type->getSwiftNewtypeUnderlyingType() && !tl.isTrivial()))
         return ResultConvention::Autoreleased;
 
       return ResultConvention::Unowned;

--- a/test/SILGen/Inputs/swift_newtype_result_convention.h
+++ b/test/SILGen/Inputs/swift_newtype_result_convention.h
@@ -1,0 +1,3 @@
+@import Foundation;
+
+typedef NSString *NSThing __attribute__((swift_newtype(struct)));

--- a/test/SILGen/swift_newtype_result_convention.swift
+++ b/test/SILGen/swift_newtype_result_convention.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -import-objc-header %S/Inputs/swift_newtype_result_convention.h %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class ThingHolder: NSObject {
+  // CHECK: sil hidden [thunk] @_T{{.*}}5thing{{.*}}To : $@convention(objc_method) (ThingHolder) -> @autoreleased NSThing
+  @objc let thing: NSThing = NSThing("")
+}


### PR DESCRIPTION
Fixes rdar://problem/33908867.