### PR TITLE
[ConstraintSolver] Skip performance hacks in presence of unavailable …

### DIFF
--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -49,3 +49,9 @@ class R<K: Hashable, V> {
     dict.forEach(body)
   }
 }
+
+// Make sure that solver doesn't try to form solutions with available overloads when better generic choices are present.
+infix operator +=+ : AdditionPrecedence
+func +=+(_ lhs: Int, _ rhs: Int) -> Bool { return lhs == rhs }
+func +=+<T: BinaryInteger>(_ lhs: T, _ rhs: Int) -> Bool { return lhs == rhs }
+let _ = DoubleWidth<Int>(Int.min) - 1 +=+ Int.min // Ok


### PR DESCRIPTION
…overloads

Limit the scope of the performance hacks which currently exist in the
solver even further by not allowing it to skip generic overlaods or stop
solver in case when previous solutions involve unavailable overloads,
which otherwise might lead to producing incorrect overall solutions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
