### PR TITLE
Instrument NominalTypeDecl::lookupDirect

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -101,6 +101,7 @@ public:
     size_t NumLazyGenericEnvironments;
     size_t NumLazyGenericEnvironmentsLoaded;
     size_t NumLazyIterableDeclContexts;
+    size_t NominalTypeLookupDirectCount;
     size_t NumTypesDeserialized;
     size_t NumTypesValidated;
     size_t NumUnloadedLazyIterableDeclContexts;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "NameLookupImpl.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTScope.h"
@@ -1191,6 +1192,14 @@ void NominalTypeDecl::makeMemberVisible(ValueDecl *member) {
 TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
+  static RecursiveSharedTimer timer("lookupDirect");
+  auto guard = RecursiveSharedTimer::Guard(timer);
+  (void)guard;
+
+  ASTContext &ctx = getASTContext();
+  if (ctx.Stats)
+    ++ctx.Stats->getFrontendCounters().NominalTypeLookupDirectCount;
+  
   (void)getMembers();
 
   // Make sure we have the complete list of members (in this nominal and in all

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -187,6 +187,7 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
     PUBLISH_STAT(C, "Sema", NumLazyGenericEnvironments);
     PUBLISH_STAT(C, "Sema", NumLazyGenericEnvironmentsLoaded);
     PUBLISH_STAT(C, "Sema", NumLazyIterableDeclContexts);
+    PUBLISH_STAT(C, "Sema", NominalTypeLookupDirectCount);
     PUBLISH_STAT(C, "Sema", NumTypesDeserialized);
     PUBLISH_STAT(C, "Sema", NumTypesValidated);
     PUBLISH_STAT(C, "Sema", NumUnloadedLazyIterableDeclContexts);
@@ -277,6 +278,7 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
     PRINT_STAT(OS, delim, C, "Sema", NumLazyGenericEnvironments);
     PRINT_STAT(OS, delim, C, "Sema", NumLazyGenericEnvironmentsLoaded);
     PRINT_STAT(OS, delim, C, "Sema", NumLazyIterableDeclContexts);
+    PRINT_STAT(OS, delim, C, "Sema", NominalTypeLookupDirectCount);
     PRINT_STAT(OS, delim, C, "Sema", NumTypesDeserialized);
     PRINT_STAT(OS, delim, C, "Sema", NumTypesValidated);
     PRINT_STAT(OS, delim, C, "Sema", NumUnloadedLazyIterableDeclContexts);


### PR DESCRIPTION
Also implement RecursiveSharedTimer

<!-- What's in this pull request? -->
Add counter and timer to NominalTypeDecl::lookupDirect. Also implement RecursiveSharedTimer.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
