### PR TITLE
Sema: Fix crash when ternary operator is applied to an lvalue of IUO type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7803,11 +7803,15 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
 
 Expr *
 Solution::convertBooleanTypeToBuiltinI1(Expr *expr, ConstraintLocator *locator) const {
-  // FIXME: Cache name.
   auto &cs = getConstraintSystem();
+
+  // Load lvalues here.
+  expr = cs.coerceToRValue(expr);
+
   auto &tc = cs.getTypeChecker();
   auto &ctx = tc.Context;
-  auto type = cs.getType(expr)->getRValueType();
+
+  auto type = cs.getType(expr);
 
   // Member accesses are permitted to implicitly look through
   // ImplicitlyUnwrappedOptional<T>.

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -50,3 +50,14 @@ func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK:   br [[CONT]]
   return x ? a : b
 }
+
+// <rdar://problem/31595572> - crash when conditional expression is an
+// lvalue of IUO type
+
+// CHECK-LABEL: sil hidden @_T07if_expr18iuo_lvalue_ternarySiSQySbGz1x_tF : $@convention(thin) (@inout Optional<Bool>) -> Int
+// CHECK: [[IUO_BOOL_ADDR:%.*]] = begin_access [read] [unknown] %0 : $*Optional<Bool>
+// CHECK: [[IUO_BOOL:%.*]] = load [trivial] [[IUO_BOOL_ADDR]] : $*Optional<Bool>
+// CHECK: switch_enum [[IUO_BOOL]]
+func iuo_lvalue_ternary(x: inout Bool!) -> Int {
+  return x ? 1 : 0
+}


### PR DESCRIPTION
Note that the bug was in Sema, but I added a SILGen test, since
that's an easy way to ensure the AST is valid.

Unfortunately the AST verifier does not perform many checks when
we emit diagnostics; adding the test case to an existing Sema test
would not catch regressions.

Fixes <rdar://problem/31595572>.