### PR TITLE
[silgen] Move CleanupCloner from SILGenBuilder.{h,cpp} => Cleanup.{h,cpp}

### DIFF
--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -29,8 +29,10 @@ class SILValue;
 
 namespace Lowering {
 
+class RValue;
 class JumpDest;
 class SILGenFunction;
+class SILGenBuilder;
 class ManagedValue;
 class SharedBorrowFormalAccess;
 class FormalEvaluationScope;
@@ -238,6 +240,20 @@ public:
 
 private:
   void popImpl();
+};
+
+class CleanupCloner {
+  SILGenFunction &SGF;
+  bool hasCleanup;
+  bool isLValue;
+
+public:
+  CleanupCloner(SILGenFunction &SGF, const ManagedValue &mv);
+  CleanupCloner(SILGenBuilder &builder, const ManagedValue &mv);
+  CleanupCloner(SILGenFunction &SGF, const RValue &rv);
+  CleanupCloner(SILGenBuilder &builder, const RValue &rv);
+
+  ManagedValue clone(SILValue value) const;
 };
 
 } // end namespace Lowering

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -22,26 +22,6 @@ using namespace swift;
 using namespace Lowering;
 
 //===----------------------------------------------------------------------===//
-//                               CleanupCloner
-//===----------------------------------------------------------------------===//
-
-ManagedValue CleanupCloner::clone(SILValue value) const {
-  if (isLValue) {
-    return ManagedValue::forLValue(value);
-  }
-
-  if (!hasCleanup) {
-    return ManagedValue::forUnmanaged(value);
-  }
-
-  if (value->getType().isAddress()) {
-    return SGF.emitManagedBufferWithCleanup(value);
-  }
-
-  return SGF.emitManagedRValueWithCleanup(value);
-}
-
-//===----------------------------------------------------------------------===//
 //                              Utility Methods
 //===----------------------------------------------------------------------===//
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -22,6 +22,7 @@
 #ifndef SWIFT_SILGEN_SILGENBUILDER_H
 #define SWIFT_SILGEN_SILGENBUILDER_H
 
+#include "Cleanup.h"
 #include "JumpDest.h"
 #include "ManagedValue.h"
 #include "RValue.h"
@@ -353,27 +354,6 @@ public:
 
 private:
   SILGenFunction &getSGF() const { return builder.getSILGenFunction(); }
-};
-
-class CleanupCloner {
-  SILGenFunction &SGF;
-  bool hasCleanup;
-  bool isLValue;
-
-public:
-  CleanupCloner(SILGenFunction &SGF, ManagedValue mv)
-      : SGF(SGF), hasCleanup(mv.hasCleanup()), isLValue(mv.isLValue()) {}
-
-  CleanupCloner(SILGenBuilder &builder, ManagedValue mv)
-      : CleanupCloner(builder.getSILGenFunction(), mv) {}
-
-  CleanupCloner(SILGenFunction &SGF, const RValue &rv)
-      : SGF(SGF), hasCleanup(rv.isPlusOne(SGF)), isLValue(false) {}
-
-  CleanupCloner(SILGenBuilder &builder, const RValue &rv)
-      : CleanupCloner(builder.getSILGenFunction(), rv) {}
-
-  ManagedValue clone(SILValue value) const;
 };
 
 } // namespace Lowering


### PR DESCRIPTION
[silgen] Move CleanupCloner from SILGenBuilder.{h,cpp} => Cleanup.{h,cpp}

CleanupCloner never seemed like it should be in SILGenBuilder.{h,cpp}.
