### PR TITLE
[Parse] [SR-5674] Add fix-it for computed 'let' declaration

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -836,7 +836,8 @@ public:
                        SourceLoc staticLoc, ParsedAccessors &accessors);
   void parseAccessorBodyDelayed(AbstractFunctionDecl *AFD);
   VarDecl *parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
-                              SourceLoc StaticLoc, bool hasInitializer,
+                              SourceLoc StaticLoc, SourceLoc VarLoc,
+                              bool hasInitializer,
                               const DeclAttributes &Attributes,
                               SmallVectorImpl<Decl *> &Decls);
   

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -2,12 +2,12 @@
 
 func markUsed<T>(_ t: T) {}
 
-let bad_property_1: Int {    // expected-error {{'let' declarations cannot be computed properties}}
+let bad_property_1: Int {    // expected-error {{'let' declarations cannot be computed properties}} {{1-4=var}}
   get {
     return 42
   }
 }
-let bad_property_2: Int = 0 { // expected-error {{'let' declarations cannot be computed properties}} expected-error {{variable with getter/setter cannot have an initial value}}
+let bad_property_2: Int = 0 { // expected-error {{'let' declarations cannot be computed properties}} {{1-4=var}} expected-error {{variable with getter/setter cannot have an initial value}}
   get {
     return 42
   }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -448,7 +448,7 @@ struct X4 : P1 { // expected-error{{type 'X4' does not conform to protocol 'P1'}
 
 protocol ShouldntCrash {
   // rdar://16109996
-  let fullName: String { get }  // expected-error {{'let' declarations cannot be computed properties}}
+  let fullName: String { get }  // expected-error {{'let' declarations cannot be computed properties}} {{3-6=var}}
   
   // <rdar://problem/17200672> Let in protocol causes unclear errors and crashes
   let fullName2: String  // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1027,7 +1027,7 @@ struct PropertiesWithOwnershipTypes {
 
 // <rdar://problem/16608609> Assert (and incorrect error message) when defining a constant stored property with observers
 class Test16608609 {
-   let constantStored: Int = 0 {  // expected-error {{'let' declarations cannot be observing properties}}
+   let constantStored: Int = 0 {  // expected-error {{'let' declarations cannot be observing properties}} {{4-7=var}}
       willSet {
       }
       didSet {

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -259,7 +259,7 @@ extension ProtoAdopter : ProtosEvilTwin {}
 public struct Foo { // expected-note {{to match this opening '{'}}}
   public static let S { a // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
     // expected-error@-1{{type annotation missing in pattern}}
-    // expected-error@-2{{'let' declarations cannot be computed properties}}
+    // expected-error@-2{{'let' declarations cannot be computed properties}} {{17-20=var}}
     // expected-error@-3{{use of unresolved identifier 'a'}}
 }
 


### PR DESCRIPTION
This pull request adds a fix-it which replaces `let` with `var`, if `let`was used to declare a computed property, an observing property or a property with addressors.

Resolves [SR-5674](https://bugs.swift.org/browse/SR-5674).