### PR TITLE
Refactor ModuleFile::loadAllMembers into shorter functions for readab…

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -697,6 +697,9 @@ public:
 
   virtual void loadAllMembers(Decl *D,
                               uint64_t contextData) override;
+private:
+  Decl* getOrFudgeOneMember(Decl *container, serialization::DeclID rawID);
+public:
 
   virtual void
   loadAllConformances(const Decl *D, uint64_t contextData,


### PR DESCRIPTION
…ility.

<!-- What's in this pull request? -->
ModuleFile::loadAllMembers included a 50-line for-loop body, almost all of which was error handling.
This PR pulls that out in to a few, separate smaller functions, intended to help readability.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
