### PR TITLE
Carve up ClangImporter::Implementation::loadAllMembers for readability.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8072,11 +8072,9 @@ void ClangImporter::Implementation::collectMembersToAdd(
                                                         SmallVectorImpl<Decl *> &members) {
   for (const clang::Decl *m : objcContainer->decls()) {
     auto nd = dyn_cast<clang::NamedDecl>(m);
-    if (!nd || nd != nd->getCanonicalDecl() ||
-        nd->getDeclContext() != objcContainer) {
-      continue;
-    }
-    insertMembersAndAlternates(nd, members);
+    if (nd && nd == nd->getCanonicalDecl() &&
+        nd->getDeclContext() == objcContainer)
+      insertMembersAndAlternates(nd, members);
   }
 
   SwiftDeclConverter converter(*this, CurrentVersion);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7963,6 +7963,12 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_
     
     forEachDistinctName(decl, [&](ImportedName newName,
                                   ImportNameVersion nameVersion) {
+      addMemberAndAlternatesToExtension(decl, newName, nameVersion, ext);
+    });
+  }
+}
+
+void ClangImporter::Implementation::addMemberAndAlternatesToExtension(clang::NamedDecl *decl, ImportedName newName, ImportNameVersion nameVersion, ExtensionDecl *ext) {
       // Quickly check the context and bail out if it obviously doesn't
       // belong here.
       if (auto *importDC = newName.getEffectiveContext().getAsDeclContext())
@@ -7989,8 +7995,6 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_
         if (alternate->getDeclContext() == ext)
           ext->addMember(alternate);
       }
-    });
-  }
 }
 
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7918,6 +7918,10 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
     loadAllMembersOfObjcContainer(D, objcContainer);
     return;
   }
+  loadAllMembersIntoExtension(D, extra);
+}
+
+void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_t extra) {
   // We have extension.
   auto ext = cast<ExtensionDecl>(D);
   auto nominal = ext->getExtendedType()->getAnyNominal();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7992,9 +7992,7 @@ void ClangImporter::Implementation::addMemberAndAlternatesToExtension(clang::Nam
   if (!member) return;
   
   member = findMemberThatWillLandInAnExtensionContext(member);
-  if (!member) return;
-  
-  if (member->getDeclContext() != ext) return;
+  if (!member  ||  member->getDeclContext() != ext) return;
   ext->addMember(member);
   
   for (auto alternate : getAlternateDecls(member)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7987,8 +7987,12 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
 
     return;
   }
+  loadAllMembersOfObjcContainer(D, objcContainer);
+}
 
 
+void ClangImporter::Implementation::loadAllMembersOfObjcContainer(
+                                                                  Decl *D, const clang::ObjCContainerDecl *objcContainer) {
   clang::PrettyStackTraceDecl trace(objcContainer, clang::SourceLocation(),
                                     Instance->getSourceManager(),
                                     "loading members for");

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7937,13 +7937,8 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_
   auto table = findLookupTable(topLevelModule);
   if (!table) return;
   
-  StringRef traceName;
-  if (topLevelModule)
-    traceName = topLevelModule->getTopLevelModuleName();
-  else
-    traceName = "(bridging header)";
   PrettyStackTraceStringAction trace("loading import-as-members from",
-                                     traceName);
+                                     topLevelModule ? topLevelModule->getTopLevelModuleName() : "(bridging header)");
   PrettyStackTraceDecl trace2("...for", nominal);
   
   // Dig out the effective Clang context for this nominal type.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7969,15 +7969,15 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_
 }
 
 static Decl *findMemberThatWillLandInAnExtensionContext(Decl *member) {
-  // Find the member that will land in an extension context.
-  while (!isa<ExtensionDecl>(member->getDeclContext())) {
-    auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
+  Decl *result = member;
+  while (!isa<ExtensionDecl>(result->getDeclContext())) {
+    auto nominal = dyn_cast<NominalTypeDecl>(result->getDeclContext());
     if (!nominal) return nullptr;
     
-    member = nominal;
-    if (member->hasClangNode()) return nullptr;
+    result = nominal;
+    if (result->hasClangNode()) return nullptr;
   }
-  return member;
+  return result;
 }
 
 void ClangImporter::Implementation::addMemberAndAlternatesToExtension(clang::NamedDecl *decl, ImportedName newName, ImportNameVersion nameVersion, ExtensionDecl *ext) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7914,7 +7914,10 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
     dyn_cast_or_null<clang::ObjCContainerDecl>(D->getClangDecl());
 
   // If not, we're importing globals-as-members into an extension.
-  if (!objcContainer) {
+  if (objcContainer) {
+    loadAllMembersOfObjcContainer(D, objcContainer);
+    return;
+  }
     // We have extension.
     auto ext = cast<ExtensionDecl>(D);
     auto nominal = ext->getExtendedType()->getAnyNominal();
@@ -7984,10 +7987,6 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
         }
       });
     }
-
-    return;
-  }
-  loadAllMembersOfObjcContainer(D, objcContainer);
 }
 
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7974,19 +7974,19 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
         auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
         if (!nominal) return;
         
-          member = nominal;
-          if (member->hasClangNode()) return;
-        }
-
-        if (member->getDeclContext() != ext) return;
-        ext->addMember(member);
-        
-        for (auto alternate : getAlternateDecls(member)) {
-          if (alternate->getDeclContext() == ext)
-            ext->addMember(alternate);
-        }
-      });
-    }
+        member = nominal;
+        if (member->hasClangNode()) return;
+      }
+      
+      if (member->getDeclContext() != ext) return;
+      ext->addMember(member);
+      
+      for (auto alternate : getAlternateDecls(member)) {
+        if (alternate->getDeclContext() == ext)
+          ext->addMember(alternate);
+      }
+    });
+  }
 }
 
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7968,7 +7968,17 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_
   }
 }
 
-static Decl *findMemberThatWillLandInAnExtensionContext(Decl *member);
+static Decl *findMemberThatWillLandInAnExtensionContext(Decl *member) {
+  // Find the member that will land in an extension context.
+  while (!isa<ExtensionDecl>(member->getDeclContext())) {
+    auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
+    if (!nominal) return nullptr;
+    
+    member = nominal;
+    if (member->hasClangNode()) return nullptr;
+  }
+  return member;
+}
 
 void ClangImporter::Implementation::addMemberAndAlternatesToExtension(clang::NamedDecl *decl, ImportedName newName, ImportNameVersion nameVersion, ExtensionDecl *ext) {
   // Quickly check the context and bail out if it obviously doesn't
@@ -7991,18 +8001,6 @@ void ClangImporter::Implementation::addMemberAndAlternatesToExtension(clang::Nam
     if (alternate->getDeclContext() == ext)
       ext->addMember(alternate);
   }
-}
-
-static Decl *findMemberThatWillLandInAnExtensionContext(Decl *member) {
-  // Find the member that will land in an extension context.
-  while (!isa<ExtensionDecl>(member->getDeclContext())) {
-    auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
-    if (!nominal) return nullptr;
-    
-    member = nominal;
-    if (member->hasClangNode()) return nullptr;
-  }
-  return member;
 }
 
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7969,32 +7969,32 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(Decl *D, uint64_
 }
 
 void ClangImporter::Implementation::addMemberAndAlternatesToExtension(clang::NamedDecl *decl, ImportedName newName, ImportNameVersion nameVersion, ExtensionDecl *ext) {
-      // Quickly check the context and bail out if it obviously doesn't
-      // belong here.
-      if (auto *importDC = newName.getEffectiveContext().getAsDeclContext())
-        if (importDC->isTranslationUnit())
-          return;
-      
-      // Then try to import the decl under the specified name.
-      auto *member = importDecl(decl, nameVersion);
-      if (!member) return;
-      
-      // Find the member that will land in an extension context.
-      while (!isa<ExtensionDecl>(member->getDeclContext())) {
-        auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
-        if (!nominal) return;
-        
-        member = nominal;
-        if (member->hasClangNode()) return;
-      }
-      
-      if (member->getDeclContext() != ext) return;
-      ext->addMember(member);
-      
-      for (auto alternate : getAlternateDecls(member)) {
-        if (alternate->getDeclContext() == ext)
-          ext->addMember(alternate);
-      }
+  // Quickly check the context and bail out if it obviously doesn't
+  // belong here.
+  if (auto *importDC = newName.getEffectiveContext().getAsDeclContext())
+    if (importDC->isTranslationUnit())
+      return;
+  
+  // Then try to import the decl under the specified name.
+  auto *member = importDecl(decl, nameVersion);
+  if (!member) return;
+  
+  // Find the member that will land in an extension context.
+  while (!isa<ExtensionDecl>(member->getDeclContext())) {
+    auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
+    if (!nominal) return;
+    
+    member = nominal;
+    if (member->hasClangNode()) return;
+  }
+  
+  if (member->getDeclContext() != ext) return;
+  ext->addMember(member);
+  
+  for (auto alternate : getAlternateDecls(member)) {
+    if (alternate->getDeclContext() == ext)
+      ext->addMember(alternate);
+  }
 }
 
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1125,8 +1125,10 @@ private:
   void collectMembersToAdd(const clang::ObjCContainerDecl *objcContainer,
                            Decl *D, DeclContext *DC,
                            SmallVectorImpl<Decl *> &members);
+  void insertMembersAndAlternates(const clang::NamedDecl *nd,
+                                  SmallVectorImpl<Decl *> &members);
+  
 public:
-
   void
   loadAllConformances(
     const Decl *D, uint64_t contextData,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1128,6 +1128,7 @@ private:
   void insertMembersAndAlternates(const clang::NamedDecl *nd,
                                   SmallVectorImpl<Decl *> &members);
   void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
+  void addMemberAndAlternatesToExtension(clang::NamedDecl *decl,importer::ImportedName newName, importer::ImportNameVersion nameVersion, ExtensionDecl *ext);
   
 public:
   void

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1118,6 +1118,11 @@ public:
 
   virtual void
   loadAllMembers(Decl *D, uint64_t unused) override;
+private:
+  void
+  loadAllMembersOfObjcContainer(Decl *D,
+                                const clang::ObjCContainerDecl *objcContainer);
+public:
 
   void
   loadAllConformances(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1118,6 +1118,7 @@ public:
 
   virtual void
   loadAllMembers(Decl *D, uint64_t unused) override;
+
 private:
   void
   loadAllMembersOfObjcContainer(Decl *D,
@@ -1128,8 +1129,10 @@ private:
   void insertMembersAndAlternates(const clang::NamedDecl *nd,
                                   SmallVectorImpl<Decl *> &members);
   void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
-  void addMemberAndAlternatesToExtension(clang::NamedDecl *decl,importer::ImportedName newName, importer::ImportNameVersion nameVersion, ExtensionDecl *ext);
-  
+  void addMemberAndAlternatesToExtension(
+      clang::NamedDecl *decl, importer::ImportedName newName,
+      importer::ImportNameVersion nameVersion, ExtensionDecl *ext);
+
 public:
   void
   loadAllConformances(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1122,6 +1122,9 @@ private:
   void
   loadAllMembersOfObjcContainer(Decl *D,
                                 const clang::ObjCContainerDecl *objcContainer);
+  void collectMembersToAdd(const clang::ObjCContainerDecl *objcContainer,
+                           Decl *D, DeclContext *DC,
+                           SmallVectorImpl<Decl *> &members);
 public:
 
   void

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1127,6 +1127,7 @@ private:
                            SmallVectorImpl<Decl *> &members);
   void insertMembersAndAlternates(const clang::NamedDecl *nd,
                                   SmallVectorImpl<Decl *> &members);
+  void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
   
 public:
   void


### PR DESCRIPTION
<!-- What's in this pull request? -->
ClangImporter::Implementation::loadAllMembers is broken up into smaller pieces.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
