### PR TITLE
[Diagnostics] Provide contextual type when diagnosing invalid if-exp

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7200,18 +7200,21 @@ bool FailureDiagnosis::visitBindOptionalExpr(BindOptionalExpr *BOE) {
 }
 
 bool FailureDiagnosis::visitIfExpr(IfExpr *IE) {
-  auto typeCheckClauseExpr = [&](Expr *clause) -> Expr * {
-    return typeCheckChildIndependently(clause, Type(), CTP_Unused, TCCOptions(),
-                                       nullptr, false);
+  auto typeCheckClauseExpr = [&](Expr *clause, Type contextType = Type(),
+                                 ContextualTypePurpose convertPurpose =
+                                     CTP_Unused) -> Expr * {
+    // Provide proper contextual type when type conversion is specified.
+    return typeCheckChildIndependently(clause, contextType, convertPurpose,
+                                       TCCOptions(), nullptr, false);
   };
-
   // Check all of the subexpressions independently.
   auto condExpr = typeCheckClauseExpr(IE->getCondExpr());
   if (!condExpr) return true;
-  auto trueExpr = typeCheckClauseExpr(IE->getThenExpr());
+  auto trueExpr = typeCheckClauseExpr(IE->getThenExpr(), CS.getContextualType(),
+                                      CS.getContextualTypePurpose());
   if (!trueExpr) return true;
-
-  auto falseExpr = typeCheckClauseExpr(IE->getElseExpr());
+  auto falseExpr = typeCheckClauseExpr(
+      IE->getElseExpr(), CS.getContextualType(), CS.getContextualTypePurpose());
   if (!falseExpr) return true;
 
   // If the true/false values already match, it must be a contextual problem.

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -623,7 +623,7 @@ do {
 }
 
 enum Enum {
-  case two(Int, Int) // expected-note 5 {{'two' declared here}}
+  case two(Int, Int) // expected-note 6 {{'two' declared here}}
   case tuple((Int, Int))
   case labeledTuple(x: (Int, Int))
 }
@@ -631,6 +631,7 @@ enum Enum {
 do {
   _ = Enum.two(3, 4)
   _ = Enum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two(3 > 4 ? 3 : 4) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = Enum.tuple(3, 4) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
   _ = Enum.tuple((3, 4))

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -41,7 +41,7 @@ func test1b(_ b : Bool) {
 
 enum MaybeInt {
   case none
-  case some(Int)
+  case some(Int) // expected-note {{did you mean 'some'?}}
 
   init(_ i: Int) { self = MaybeInt.some(i) }
 }
@@ -87,6 +87,7 @@ func test3(_ a: ZeroOneTwoThree) {
   
   var _ : (Int,Int) -> ZeroOneTwoThree = .Two // expected-error{{type '(Int, Int) -> ZeroOneTwoThree' has no member 'Two'}}
   var _ : Int = .Two // expected-error{{type 'Int' has no member 'Two'}}
+  var _ : MaybeInt = 0 > 3 ? .none : .soma(3) // expected-error {{type 'MaybeInt' has no member 'soma'}}
 }
 
 func test3a(_ a: ZeroOneTwoThree) {
@@ -97,7 +98,9 @@ func test3a(_ a: ZeroOneTwoThree) {
 
   // Overload resolution can resolve this to the right constructor.
   var h = ZeroOneTwoThree(1)
-
+  
+  var i = 0 > 3 ? .none : .some(3) // expected-error {{reference to member 'none' cannot be resolved without a contextual type}}
+  
   test3a;  // expected-error {{unused function}}
   .Zero   // expected-error {{reference to member 'Zero' cannot be resolved without a contextual type}}
   test3a   // expected-error {{unused function}}


### PR DESCRIPTION
This pull request now provides better diagnostics (with fixits) when invalid type/member is provided as a return value of a ternary operator.

Resolves [SR-910](https://bugs.swift.org/browse/SR-910).

cc @xedin 