### PR TITLE
[semantic-sil] Update 45 SILGen tests for ownership.

### DIFF
--- a/test/SILGen/NSApplicationMain.swift
+++ b/test/SILGen/NSApplicationMain.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s -check-prefix=IR
 
-// RUN: %target-swift-frontend -emit-silgen -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | %FileCheck %s -check-prefix=IR
 
 // REQUIRES: OS=macosx

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-full-demangle -enforce-exclusivity=checked -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-full-demangle -enforce-exclusivity=checked -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 func modify<T>(_ x: inout T) {}
 
@@ -8,7 +8,7 @@ public struct S {
 }
 
 // CHECK-LABEL: sil hidden [noinline] @_T017access_marker_gen5initSAA1SVyXlSgF : $@convention(thin) (@owned Optional<AnyObject>) -> @owned S {
-// CHECK: bb0(%0 : $Optional<AnyObject>):
+// CHECK: bb0(%0 : @owned $Optional<AnyObject>):
 // CHECK: [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
 // CHECK: [[MARKED_BOX:%.*]] = mark_uninitialized [var] [[BOX]] : ${ var S }
 // CHECK: [[ADDR:%.*]] = project_box [[MARKED_BOX]] : ${ var S }, 0

--- a/test/SILGen/accessibility_warnings.swift
+++ b/test/SILGen/accessibility_warnings.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // This file tests that the AST produced after fixing accessibility warnings
 // is valid according to SILGen and the verifiers.

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // Hold a reference to do to magically become non-POD.
 class Reference {}
@@ -26,7 +26,7 @@ func test0(_ ref: A) {
   ref.array[index0()] = ref.array[index1()]
 }
 // CHECK: sil hidden @_T09accessors5test0yAA1ACF : $@convention(thin) (@owned A) -> () {
-// CHECK: bb0([[ARG:%.*]] : $A):
+// CHECK: bb0([[ARG:%.*]] : @owned $A):
 // CHECK-NEXT: debug_value
 //   Formal evaluation of LHS.
 // CHECK-NEXT: [[BORROWED_ARG_LHS:%.*]] = begin_borrow [[ARG]]
@@ -64,7 +64,7 @@ func test0(_ ref: A) {
 // CHECK-NEXT: apply [[SETTER]]([[VALUE]], [[INDEX0]], [[ADDR]])
 // CHECK-NEXT: switch_enum [[OPT_CALLBACK]] : $Optional<Builtin.RawPointer>, case #Optional.some!enumelt.1: [[WRITEBACK:bb[0-9]+]], case #Optional.none!enumelt: [[CONT:bb[0-9]+]]
 
-// CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
+// CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : @trivial $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout A, @thick A.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $A
 // SEMANTIC SIL TODO: This is an issue caused by the callback for materializeForSet in the class case taking the value as @inout when it should really take it as @guaranteed.
@@ -100,7 +100,7 @@ func test1(_ ref: B) {
   ref.array[index0()] = ref.array[index1()]
 }
 // CHECK-LABEL: sil hidden @_T09accessors5test1yAA1BCF : $@convention(thin) (@owned B) -> () {
-// CHECK:    bb0([[ARG:%.*]] : $B):
+// CHECK:    bb0([[ARG:%.*]] : @owned $B):
 // CHECK-NEXT: debug_value
 //   Formal evaluation of LHS.
 // CHECK-NEXT: [[BORROWED_ARG_LHS:%.*]] = begin_borrow [[ARG]]
@@ -127,7 +127,7 @@ func test1(_ ref: B) {
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[T0]]([[INDEX1]], [[ADDR]])
 // CHECK-NEXT: switch_enum [[OPT_CALLBACK]] : $Optional<Builtin.RawPointer>, case #Optional.some!enumelt.1: [[WRITEBACK:bb[0-9]+]], case #Optional.none!enumelt: [[CONT:bb[0-9]+]]
 //
-// CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
+// CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : @trivial $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout B, @thick B.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $B
 // CHECK-NEXT: store_borrow [[BORROWED_ARG_RHS]] to [[TEMP2]] : $*B
@@ -153,7 +153,7 @@ func test1(_ ref: B) {
 // CHECK-NEXT: apply [[SETTER]]([[VALUE]], [[INDEX0]], [[ADDR]])
 // CHECK-NEXT: switch_enum [[OPT_CALLBACK]] : $Optional<Builtin.RawPointer>, case #Optional.some!enumelt.1: [[WRITEBACK:bb[0-9]+]], case #Optional.none!enumelt: [[CONT:bb[0-9]+]]
 //
-// CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
+// CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : @trivial $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout B, @thick B.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $B
 // CHECK-NEXT: store_borrow [[BORROWED_ARG_LHS]] to [[TEMP2]] : $*B

--- a/test/SILGen/apply_abstraction_nested.swift
+++ b/test/SILGen/apply_abstraction_nested.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen %s | %FileCheck %s
 
 infix operator ~> { precedence 255 associativity left }
 

--- a/test/SILGen/argument_labels.swift
+++ b/test/SILGen/argument_labels.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 public struct X { }
 public struct Y { }
@@ -9,7 +9,7 @@ public class Foo {
 }
 
 // CHECK-LABEL: sil hidden @_T015argument_labels7testFoo{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[ARG0:%.*]] : $Foo,
+// CHECK: bb0([[ARG0:%.*]] : @owned $Foo,
 func testFoo(foo: Foo, x: X, y: Y) {
   // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
   // CHECK: class_method [[BORROWED_ARG0]] : $Foo, #Foo.doSomething!1 : (Foo) -> (X, Y) -> ()

--- a/test/SILGen/argument_shuffle.swift
+++ b/test/SILGen/argument_shuffle.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s
 
 struct Horse<T> {
   func walk(_: (String, Int), reverse: Bool) {}

--- a/test/SILGen/argument_shuffle_swift3.swift
+++ b/test/SILGen/argument_shuffle_swift3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -swift-version 3 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s -swift-version 3 | %FileCheck %s
 
 func fn(_: Any) {}
 

--- a/test/SILGen/arguments_as_tuple_overloads.swift
+++ b/test/SILGen/arguments_as_tuple_overloads.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -module-name=test -emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -module-name=test -emit-silgen -enable-sil-ownership -primary-file %s | %FileCheck %s
 
 // Check if we mangle the following constructors, functions, and
 // subscripts correctly.

--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enforce-exclusivity=checked %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -enforce-exclusivity=checked %s | %FileCheck %s
 
 class C {}
 
@@ -7,8 +7,10 @@ struct B { var owner: C }
 
 var a = A()
 
+// CHECK-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 // CHECK: assign {{%.*}} to {{%.*}} : $*A
 // CHECK: destroy_value {{%.*}} : $B
+// CHECK: } // end sil function 'main'
 (a, _) = (A(), B(owner: C()))
 
 class D { var child: C = C() }
@@ -20,10 +22,13 @@ func test1() {
   // CHECK: [[T0:%.*]] = metatype $@thick D.Type
   // CHECK: [[D:%.*]] = apply [[CTOR]]([[T0]])
   // CHECK: [[SETTER:%.*]] = class_method [[D]] : $D,  #D.child!setter.1
+  // CHECK: [[BORROWED_D:%.*]] = begin_borrow [[D]]
   // CHECK: [[CTOR:%.*]] = function_ref @_T010assignment1CC{{[_0-9a-zA-Z]*}}fC
   // CHECK: [[T0:%.*]] = metatype $@thick C.Type
-  // CHECK: [[C:%.*]] = apply [[CTOR]]([[T0]])
-  // CHECK: apply [[SETTER]]([[C]], [[D]])
+  // CHECK: [[C:%.*]] = apply [[CTOR]]([[T0]]) : $@convention(method) (@thick C.Type) -> @owned C
+  // CHECK: apply [[SETTER]]([[C]], [[BORROWED_D]])
+  // CHECK: end_borrow [[BORROWED_D]] from [[D]]
+  // CHECK: destroy_value [[D]]
   D().child = C()
 }
 
@@ -37,7 +42,7 @@ protocol P {
 // RHS is formally evaluated.
 // CHECK-LABEL: sil hidden @_T010assignment15copyRightToLeftyAA1P_pz1p_tF : $@convention(thin) (@inout P) -> () {
 func copyRightToLeft(p: inout P) {
-  // CHECK: bb0(%0 : $*P):
+  // CHECK: bb0(%0 : @trivial $*P):
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] %0 : $*P
   // CHECK:   [[READ_OPEN:%.*]] = open_existential_addr immutable_access [[READ]]
   // CHECK:   end_access [[READ]] : $*P

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-debuginfo -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // Test that we emit a call to super.init at the end of the initializer, when none has been previously added.
 

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s -target x86_64-apple-macosx10.50 -verify
-// RUN: %target-swift-frontend -emit-silgen %s -target x86_64-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s -target x86_64-apple-macosx10.50 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s --check-prefix=GUARANTEED
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-sil-ownership -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-sil-ownership -emit-silgen %s | %FileCheck %s --check-prefix=GUARANTEED
 
 func test_type_lowering(_ x: Error) { }
 // CHECK-LABEL: sil hidden @_T018boxed_existentials18test_type_loweringys5Error_pF : $@convention(thin) (@owned Error) -> () {
@@ -18,7 +18,7 @@ func test_concrete_erasure(_ x: ClericalError) -> Error {
   return x
 }
 // CHECK-LABEL: sil hidden @_T018boxed_existentials21test_concrete_erasures5Error_pAA08ClericalF0OF
-// CHECK:       bb0([[ARG:%.*]] : $ClericalError):
+// CHECK:       bb0([[ARG:%.*]] : @owned $ClericalError):
 // CHECK:         [[EXISTENTIAL:%.*]] = alloc_existential_box $Error, $ClericalError
 // CHECK:         [[ADDR:%.*]] = project_existential_box $ClericalError in [[EXISTENTIAL]] : $Error
 // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -58,7 +58,7 @@ func test_property(_ x: Error) -> String {
   return x._domain
 }
 // CHECK-LABEL: sil hidden @_T018boxed_existentials13test_propertySSs5Error_pF
-// CHECK: bb0([[ARG:%.*]] : $Error):
+// CHECK: bb0([[ARG:%.*]] : @owned $Error):
 // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:         [[VALUE:%.*]] = open_existential_box [[BORROWED_ARG]] : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]
 // FIXME: Extraneous copy here
@@ -78,7 +78,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
 }
 
 // CHECK-LABEL: sil hidden @_T018boxed_existentials23test_property_of_lvalueSSs5Error_pF :
-// CHECK:       bb0([[ARG:%.*]] : $Error):
+// CHECK:       bb0([[ARG:%.*]] : @owned $Error):
 // CHECK:         [[VAR:%.*]] = alloc_box ${ var Error }
 // CHECK:         [[PVAR:%.*]] = project_box [[VAR]]
 // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -104,7 +104,7 @@ extension Error {
 
 // CHECK-LABEL: sil hidden @_T018boxed_existentials21test_extension_methodys5Error_pF
 func test_extension_method(_ error: Error) {
-  // CHECK: bb0([[ARG:%.*]] : $Error):
+  // CHECK: bb0([[ARG:%.*]] : @owned $Error):
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[VALUE:%.*]] = open_existential_box [[BORROWED_ARG]]
   // CHECK: [[METHOD:%.*]] = function_ref
@@ -122,8 +122,8 @@ func plusOneError() -> Error { }
 
 // CHECK-LABEL: sil hidden @_T018boxed_existentials31test_open_existential_semanticsys5Error_p_sAC_ptF
 // GUARANTEED-LABEL: sil hidden @_T018boxed_existentials31test_open_existential_semanticsys5Error_p_sAC_ptF
-// CHECK: bb0([[ARG0:%.*]]: $Error,
-// GUARANTEED: bb0([[ARG0:%.*]]: $Error,
+// CHECK: bb0([[ARG0:%.*]]: @owned $Error,
+// GUARANTEED: bb0([[ARG0:%.*]]: @owned $Error,
 func test_open_existential_semantics(_ guaranteed: Error,
                                      _ immediate: Error) {
   var immediate = immediate
@@ -193,7 +193,7 @@ func test_open_existential_semantics(_ guaranteed: Error,
 }
 
 // CHECK-LABEL: sil hidden @_T018boxed_existentials14erasure_to_anyyps5Error_p_sAC_ptF
-// CHECK:       bb0([[OUT:%.*]] : $*Any, [[GUAR:%.*]] : $Error,
+// CHECK:       bb0([[OUT:%.*]] : @trivial $*Any, [[GUAR:%.*]] : @owned $Error,
 func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
   var immediate = immediate
   // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -1,10 +1,10 @@
-// RUN: %target-swift-frontend -emit-silgen -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -verify %s | %FileCheck %s
 
 func values(_ arg: @escaping @convention(c) (Int) -> Int) -> @convention(c) (Int) -> Int {
   return arg
 }
 // CHECK-LABEL: sil hidden @_T019c_function_pointers6valuesS2iXCS2iXCF
-// CHECK:       bb0(%0 : $@convention(c) (Int) -> Int):
+// CHECK:       bb0(%0 : @trivial $@convention(c) (Int) -> Int):
 // CHECK:         return %0 : $@convention(c) (Int) -> Int
 
 @discardableResult
@@ -12,7 +12,7 @@ func calls(_ arg: @convention(c) (Int) -> Int, _ x: Int) -> Int {
   return arg(x)
 }
 // CHECK-LABEL: sil hidden @_T019c_function_pointers5callsS3iXC_SitF
-// CHECK:       bb0(%0 : $@convention(c) (Int) -> Int, %1 : $Int):
+// CHECK:       bb0(%0 : @trivial $@convention(c) (Int) -> Int, %1 : @trivial $Int):
 // CHECK:         [[RESULT:%.*]] = apply %0(%1)
 // CHECK:         return [[RESULT]]
 
@@ -27,7 +27,7 @@ func no_args() -> Int { return 42 }
 
 // CHECK-LABEL: sil hidden @_T019c_function_pointers0B19_to_swift_functionsySiF
 func pointers_to_swift_functions(_ x: Int) {
-// CHECK: bb0([[X:%.*]] : $Int):
+// CHECK: bb0([[X:%.*]] : @trivial $Int):
 
   func local(_ y: Int) -> Int { return y }
 

--- a/test/SILGen/c_materializeForSet_linkage.swift
+++ b/test/SILGen/c_materializeForSet_linkage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -enable-sil-ownership | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/call_chain_reabstraction.swift
+++ b/test/SILGen/call_chain_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 struct A {
         func g<U>(_ recur: (A, U) -> U) -> (A, U) -> U {

--- a/test/SILGen/capture-canonicalization.swift
+++ b/test/SILGen/capture-canonicalization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 struct Foo<T> {}
 struct Bar {}

--- a/test/SILGen/capture_list.swift
+++ b/test/SILGen/capture_list.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s
 
 // Capture list with weak capture vs noescape closure
 func transform<T>(fn: () -> T) -> T {

--- a/test/SILGen/capture_typed_boxes.swift
+++ b/test/SILGen/capture_typed_boxes.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 func foo(_ x: Int) -> () -> Int {
   var x = x
   return { x }
 }
 // CHECK-LABEL: sil private @_T019capture_typed_boxes3fooSiycSiFSiycfU_ : $@convention(thin) (@owned { var Int }) -> Int {
-// CHECK:       bb0(%0 : ${ var Int }):
+// CHECK:       bb0(%0 : @owned ${ var Int }):
 
 func closure(_ f: @escaping (Int) -> Int) -> Int {
   var f = f
@@ -16,7 +16,7 @@ func closure(_ f: @escaping (Int) -> Int) -> Int {
   return bar(0)
 }
 // CHECK-LABEL: sil private @_T019capture_typed_boxes7closureS3icF3barL_S2iF : $@convention(thin) (Int, @owned { var @callee_owned (Int) -> Int }) -> Int {
-// CHECK:       bb0(%0 : $Int, %1 : ${ var @callee_owned (Int) -> Int }):
+// CHECK:       bb0(%0 : @trivial $Int, %1 : @owned ${ var @callee_owned (Int) -> Int }):
 
 func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
   var f = f
@@ -27,5 +27,5 @@ func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
   return bar(x)
 }
 // CHECK-LABEL: sil private @_T019capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>) -> @out T {
-// CHECK-LABEL: bb0(%0 : $*T, %1 : $*T, %2 : $<τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>):
+// CHECK-LABEL: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @owned $<τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>):
 

--- a/test/SILGen/cdecl.swift
+++ b/test/SILGen/cdecl.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden [thunk] @pear : $@convention(c)
 // CHECK:         function_ref @_T05cdecl5apple{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -I %S/../IDE/Inputs/custom-modules %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -I %S/../IDE/Inputs/custom-modules %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 
@@ -16,7 +16,7 @@ public func importAsUnaryInit() {
 
 // CHECK-LABEL: sil @_T010cf_members3foo{{[_0-9a-zA-Z]*}}F
 public func foo(_ x: Double) {
-// CHECK: bb0([[X:%.*]] : $Double):
+// CHECK: bb0([[X:%.*]] : @trivial $Double):
   // CHECK: [[GLOBALVAR:%.*]] = global_addr @IAMStruct1GlobalVar
   // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBALVAR]] : $*Double
   // CHECK: [[ZZ:%.*]] = load [trivial] [[READ]]
@@ -220,37 +220,37 @@ public func foo(_ x: Double) {
 // CHECK: } // end sil function '_T010cf_members3foo{{[_0-9a-zA-Z]*}}F'
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1VABSd5value_tcfCTO
-// CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $@thin Struct1.Type):
+// CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1CreateSimple
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[X]])
 // CHECK:         return [[RET]]
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V9translateABSd7radians_tFTO
-// CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
+// CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         store [[SELF]] to [trivial] [[TMP:%.*]] :
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Rotate
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[TMP]], [[X]])
 // CHECK:         return [[RET]]
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V5scaleABSdFTO
-// CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
+// CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Scale
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[SELF]], [[X]])
 // CHECK:         return [[RET]]
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V12staticMethods5Int32VyFZTO
-// CHECK:       bb0([[SELF:%.*]] : $@thin Struct1.Type):
+// CHECK:       bb0([[SELF:%.*]] : @trivial $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1StaticMethod
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]()
 // CHECK:         return [[RET]]
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V13selfComesLastySd1x_tFTO
-// CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
+// CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesLast
 // CHECK:         apply [[CFUNC]]([[X]], [[SELF]])
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V14selfComesThirdys5Int32V1a_Sf1bSd1xtFTO
-// CHECK:       bb0([[X:%.*]] : $Int32, [[Y:%.*]] : $Float, [[Z:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
+// CHECK:       bb0([[X:%.*]] : @trivial $Int32, [[Y:%.*]] : @trivial $Float, [[Z:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesThird
 // CHECK:         apply [[CFUNC]]([[X]], [[Y]], [[SELF]], [[Z]])
 

--- a/test/SILGen/class_resilience.swift
+++ b/test/SILGen/class_resilience.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -I %t -emit-silgen -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-sil-ownership -enable-resilience %s | %FileCheck %s
 
 import resilient_class
 
@@ -23,7 +23,7 @@ public class MyResilientClass {
 // directly
 
 // CHECK-LABEL: sil @_T016class_resilience19finalPropertyOfMineyAA16MyResilientClassCF
-// CHECK: bb0([[ARG:%.*]] : $MyResilientClass):
+// CHECK: bb0([[ARG:%.*]] : @owned $MyResilientClass):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   ref_element_addr [[BORROWED_ARG]] : $MyResilientClass, #MyResilientClass.finalProperty
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]

--- a/test/SILGen/closure_inline_initializer.swift
+++ b/test/SILGen/closure_inline_initializer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // CHECK-LABEL: sil private @_T026closure_inline_initializer3FooV3fooSivfiSiycfU_
 

--- a/test/SILGen/closure_script_global_escape.swift
+++ b/test/SILGen/closure_script_global_escape.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -module-name foo -emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name foo -emit-sil -verify %s
+// RUN: %target-swift-frontend -module-name foo -enable-sil-ownership -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name foo -enable-sil-ownership -emit-sil -verify %s
 
 // CHECK-LABEL: sil @main
 

--- a/test/SILGen/closure_self_recursion.swift
+++ b/test/SILGen/closure_self_recursion.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -module-name foo -emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name foo -emit-sil -verify %s
+// RUN: %target-swift-frontend -module-name foo -enable-sil-ownership -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name foo -enable-sil-ownership -emit-sil -verify %s
 
 // CHECK-LABEL: sil @main
 

--- a/test/SILGen/collection_subtype_downcast.swift
+++ b/test/SILGen/collection_subtype_downcast.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend -emit-silgen -sdk %S/Inputs %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sdk %S/Inputs %s | %FileCheck %s
 
 struct S { var x, y: Int }
 
 // CHECK-LABEL: sil hidden @_T027collection_subtype_downcast06array_C0SayAA1SVGSgSayypG0D0_tF :
-// CHECK:    bb0([[ARG:%.*]] : $Array<Any>):
+// CHECK:    bb0([[ARG:%.*]] : @owned $Array<Any>):
 // CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -28,7 +28,7 @@ func ==(lhs: S, rhs: S) -> Bool {
 
 // FIXME: This entrypoint name should not be bridging-specific
 // CHECK-LABEL:      sil hidden @_T027collection_subtype_downcast05dict_C0s10DictionaryVyAA1SVSiGSgADyAFypG0D0_tF :
-// CHECK:    bb0([[ARG:%.*]] : $Dictionary<S, Any>):
+// CHECK:    bb0([[ARG:%.*]] : @owned $Dictionary<S, Any>):
 // CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]

--- a/test/SILGen/collection_subtype_upcast.swift
+++ b/test/SILGen/collection_subtype_upcast.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend -emit-silgen -sdk %S/Inputs %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sdk %S/Inputs %s | %FileCheck %s
 
 struct S { var x, y: Int }
 
 // CHECK-LABEL: sil hidden @_T025collection_subtype_upcast06array_C0SayypGSayAA1SVG0D0_tF :
-// CHECK:    bb0([[ARG:%.*]] : $Array<S>):
+// CHECK:    bb0([[ARG:%.*]] : @owned $Array<S>):
 // CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -28,7 +28,7 @@ func ==(lhs: S, rhs: S) -> Bool {
 
 // FIXME: This entrypoint name should not be bridging-specific
 // CHECK-LABEL:      sil hidden @_T025collection_subtype_upcast05dict_C0s10DictionaryVyAA1SVypGADyAFSiG0D0_tF :
-// CHECK:    bb0([[ARG:%.*]] : $Dictionary<S, Int>):
+// CHECK:    bb0([[ARG:%.*]] : @owned $Dictionary<S, Int>):
 // CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -1,17 +1,17 @@
-// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-silgen -enable-sil-ownership | %FileCheck %s
 
 struct X { }
 
 class A {
 // CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thick A.Type) -> @owned A
-// CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick A.Type):
+// CHECK: bb0([[SELF_META:%[0-9]+]] : @trivial $@thick A.Type):
 // CHECK:   [[SELF:%[0-9]+]] = alloc_ref_dynamic [[SELF_META]] : $@thick A.Type, $A
 // CHECK:   [[OTHER_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
 // CHECK:   [[RESULT:%[0-9]+]] = apply [[OTHER_INIT]]([[SELF]]) : $@convention(method) (@owned A) -> @owned A
 // CHECK:   return [[RESULT]] : $A
 
 // CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
-// CHECK: bb0([[SELF_PARAM:%[0-9]+]] : $A):
+// CHECK: bb0([[SELF_PARAM:%[0-9]+]] : @owned $A):
 // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var A }
 // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var A }
 // CHECK:   [[PB:%.*]] = project_box [[UNINIT_SELF]]

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -primary-file %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil -O -primary-file %s > /dev/null
 // RUN: %target-swift-frontend -emit-ir -primary-file %s > /dev/null
 

--- a/test/SILGen/crashers_silgen.swift
+++ b/test/SILGen/crashers_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -o /dev/null %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -o /dev/null %s
 
 // <rdar://22000564> Crash on Subscript taking a tuple argument list
 class r22000564 {

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -parse-as-library -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @_T05decls11void_returnyyF
 // CHECK: = tuple
@@ -86,7 +86,7 @@ func tuple_patterns() {
 }
 
 // CHECK-LABEL: sil hidden @_T05decls16simple_arguments{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0(%0 : $Int, %1 : $Int):
+// CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $Int):
 // CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: store %0 to [trivial] [[PBX]]
@@ -100,14 +100,14 @@ func simple_arguments(x: Int, y: Int) -> Int {
 }
 
 // CHECK-LABEL: sil hidden @_T05decls14tuple_argument{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0(%0 : $Int, %1 : $Float):
+// CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $Float):
 // CHECK: [[UNIT:%[0-9]+]] = tuple ()
 // CHECK: [[TUPLE:%[0-9]+]] = tuple (%0 : $Int, %1 : $Float, [[UNIT]] : $())
 func tuple_argument(x: (Int, Float, ())) {
 }
 
 // CHECK-LABEL: sil hidden @_T05decls14inout_argument{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0(%0 : $*Int, %1 : $Int):
+// CHECK: bb0(%0 : @trivial $*Int, %1 : @trivial $Int):
 // CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box ${ var Int }
 // CHECK: [[PBX:%.*]] = project_box [[X_LOCAL]]
 func inout_argument(x: inout Int, y: Int) {

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s --check-prefix=NEGATIVE
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-sil-ownership -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-sil-ownership -emit-silgen %s | %FileCheck %s --check-prefix=NEGATIVE
 
 // __FUNCTION__ used as top-level parameter produces the module name.
 // CHECK-LABEL: sil @main
@@ -180,7 +180,7 @@ func takeDefaultArgUnnamed(_ x: Int = 5) { }
 
 // CHECK-LABEL: sil hidden @_T017default_arguments25testTakeDefaultArgUnnamed{{[_0-9a-zA-Z]*}}F
 func testTakeDefaultArgUnnamed(_ i: Int) {
-  // CHECK: bb0([[I:%[0-9]+]] : $Int):
+  // CHECK: bb0([[I:%[0-9]+]] : @trivial $Int):
   // CHECK:   [[FN:%[0-9]+]] = function_ref @_T017default_arguments21takeDefaultArgUnnamedySiF : $@convention(thin) (Int) -> ()
   // CHECK:   apply [[FN]]([[I]]) : $@convention(thin) (Int) -> ()
   takeDefaultArgUnnamed(i)

--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen -swift-version 3 %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen -swift-version 4 %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -swift-version 3 %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -swift-version 4 %s | %FileCheck %s
 
 func foo<T: ExpressibleByIntegerLiteral>(_: T.Type, x: T = 0) { }
 

--- a/test/SILGen/default_arguments_imported.swift
+++ b/test/SILGen/default_arguments_imported.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -enable-sil-ownership | %FileCheck %s
 
 // Test SIL generation for imported default arguments.
 

--- a/test/SILGen/default_arguments_inherited.swift
+++ b/test/SILGen/default_arguments_inherited.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // When we synthesize an inherited designated initializer, the default
 // arguments are still conceptually rooted on the base declaration.

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -enable-sil-ownership -primary-file %s | %FileCheck %s
 
 struct B {
   var i : Int, j : Float
@@ -53,7 +53,7 @@ class E {
 // XCHECK-NEXT: return [[VALUE]] : $Int64
 
 // CHECK-LABEL: sil hidden @_T019default_constructor1EC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned E) -> @owned E
-// CHECK: bb0([[SELFIN:%[0-9]+]] : $E)
+// CHECK: bb0([[SELFIN:%[0-9]+]] : @owned $E)
 // CHECK: [[SELF:%[0-9]+]] = mark_uninitialized
 // CHECK: [[INIT:%[0-9]+]] = function_ref @_T019default_constructor1EC1is5Int64Vvfi : $@convention(thin) () -> Int64
 // CHECK-NEXT: [[VALUE:%[0-9]+]] = apply [[INIT]]() : $@convention(thin) () -> Int64
@@ -70,7 +70,7 @@ class E {
 class F : E { }
 
 // CHECK-LABEL: sil hidden @_T019default_constructor1FCACycfc : $@convention(method) (@owned F) -> @owned F
-// CHECK: bb0([[ORIGSELF:%[0-9]+]] : $F)
+// CHECK: bb0([[ORIGSELF:%[0-9]+]] : @owned $F)
 // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var F }
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
 // CHECK-NEXT: [[PB:%.*]] = project_box [[SELF]]

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 protocol P {
   associatedtype A
@@ -10,12 +10,12 @@ struct Foo<T>: P {
 
   func f(_ t: T.Type) {}
   // CHECK-LABEL: sil private [transparent] [thunk] @_T025dependent_member_lowering3FooVyxGAA1PAAlAaEP1fy1AQzFTW : $@convention(witness_method) <τ_0_0> (@in @thick τ_0_0.Type, @in_guaranteed Foo<τ_0_0>) -> ()
-  // CHECK:       bb0(%0 : $*@thick τ_0_0.Type, %1 : $*Foo<τ_0_0>):
+  // CHECK:       bb0(%0 : @trivial $*@thick τ_0_0.Type, %1 : @trivial $*Foo<τ_0_0>):
 }
 struct Bar<T>: P {
   typealias A = (Int) -> T
 
   func f(_ t: @escaping (Int) -> T) {}
   // CHECK-LABEL: sil private [transparent] [thunk] @_T025dependent_member_lowering3BarVyxGAA1PAAlAaEP1fy1AQzFTW : $@convention(witness_method) <τ_0_0> (@in @callee_owned (@in Int) -> @out τ_0_0, @in_guaranteed Bar<τ_0_0>) -> ()
-  // CHECK:       bb0(%0 : $*@callee_owned (@in Int) -> @out τ_0_0, %1 : $*Bar<τ_0_0>):
+  // CHECK:       bb0(%0 : @trivial $*@callee_owned (@in Int) -> @out τ_0_0, %1 : @trivial $*Bar<τ_0_0>):
 }

--- a/test/SILGen/downcast_reabstraction.swift
+++ b/test/SILGen/downcast_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @_T022downcast_reabstraction19condFunctionFromAnyyypF 
 // CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_owned (@in ()) -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]

--- a/test/SILGen/downgrade_exhaustivity_swift3.swift
+++ b/test/SILGen/downgrade_exhaustivity_swift3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 3 -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 3 -enable-sil-ownership -emit-silgen %s | %FileCheck %s
 
 enum Downgradable {
   case spoon
@@ -17,7 +17,7 @@ func testDowngradableOmittedPatternIsUnreachable(pat : Downgradable?) {
   // CHECK: [[CASE2]]:
   case .hat:
     break
-  // CHECK: [[DEFAULT_CASE]]:
+  // CHECK: [[DEFAULT_CASE]]({{%.*}} : @trivial $Downgradable):
   // CHECK-NEXT:   unreachable
   }
   
@@ -32,15 +32,15 @@ func testDowngradableOmittedPatternIsUnreachable(pat : Downgradable?) {
     break
   case (.hat, .hat):
     break
-  // CHECK: [[TUPLE_DEFAULT_CASE_2]]:
+  // CHECK: [[TUPLE_DEFAULT_CASE_2]]({{%.*}} : @trivial $Downgradable):
   // CHECK-NEXT:   unreachable
     
   // CHECK: switch_enum [[Y]] : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_3:bb[0-9]+]]
     
-  // CHECK: [[TUPLE_DEFAULT_CASE_3]]:
+  // CHECK: [[TUPLE_DEFAULT_CASE_3]]({{%.*}} : @trivial $Downgradable):
   // CHECK-NEXT:   unreachable
     
-  // CHECK: [[TUPLE_DEFAULT_CASE_1]]:
+  // CHECK: [[TUPLE_DEFAULT_CASE_1]]({{%.*}} : @trivial $Downgradable):
   // CHECK-NEXT:   unreachable
   }
   

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-sil-ownership -emit-silgen %s | %FileCheck %s
 
 // CHECK: sil_global [[DSO:@__dso_handle]] : $Builtin.RawPointer
 

--- a/test/SILGen/dynamic_init.swift
+++ b/test/SILGen/dynamic_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 class C {
   required init() { }
@@ -6,7 +6,7 @@ class C {
 
 // CHECK-LABEL: sil hidden @_T012dynamic_init15testDynamicInit{{[_0-9a-zA-Z]*}}F
 func testDynamicInit(cm: C.Type) {
-  // CHECK: bb0([[CM:%[0-9]+]] : $@thick C.Type):
+  // CHECK: bb0([[CM:%[0-9]+]] : @trivial $@thick C.Type):
   // CHECK:   [[METHOD:%[0-9]+]] = class_method [[CM]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   [[C_OBJ:%[0-9]+]] = apply [[METHOD]]([[CM]]) : $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   destroy_value [[C_OBJ]] : $C

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 func fizzbuzz(i: Int) -> String {
   return i % 3 == 0
@@ -31,7 +31,7 @@ func consumeAddressOnly(_: AddressOnly) {}
 
 // CHECK: sil hidden @_T07if_expr19addr_only_ternary_1{{[_0-9a-zA-Z]*}}F
 func addr_only_ternary_1(x: Bool) -> AddressOnly {
-  // CHECK: bb0([[RET:%.*]] : $*AddressOnly, {{.*}}):
+  // CHECK: bb0([[RET:%.*]] : @trivial $*AddressOnly, {{.*}}):
   // CHECK: [[a:%[0-9]+]] = alloc_box ${ var AddressOnly }, var, name "a"
   // CHECK: [[PBa:%.*]] = project_box [[a]]
   var a : AddressOnly = A()

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 class C {
   func f() -> Int { return 42 }
@@ -13,7 +13,7 @@ struct A {
 // CHECK:    sil hidden @_T04weak5test0yAA1CC1c_tF : $@convention(thin) (@owned C) -> () {
 func test0(c c: C) {
   var c = c
-// CHECK:    bb0(%0 : $C):
+// CHECK:    bb0(%0 : @owned $C):
 // CHECK:      [[C:%.*]] = alloc_box ${ var C }
 // CHECK-NEXT: [[PBC:%.*]] = project_box [[C]]
 
@@ -52,7 +52,7 @@ func test0(c c: C) {
 // <rdar://problem/16871284> silgen crashes on weak capture
 // CHECK: closure #1 () -> Swift.Int in weak.testClosureOverWeak() -> ()
 // CHECK-LABEL: sil private @_T04weak19testClosureOverWeakyyFSiycfU_ : $@convention(thin) (@owned { var @sil_weak Optional<C> }) -> Int {
-// CHECK: bb0(%0 : ${ var @sil_weak Optional<C> }):
+// CHECK: bb0(%0 : @owned ${ var @sil_weak Optional<C> }):
 // CHECK-NEXT:  %1 = project_box %0
 // CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1
 // CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] %1
@@ -68,7 +68,7 @@ class CC {
   weak var x: CC?
 
   // CHECK-LABEL: sil hidden @_T04weak2CCC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned CC) -> @owned CC {
-  // CHECK:  bb0([[SELF:%.*]] : $CC):
+  // CHECK:  bb0([[SELF:%.*]] : @owned $CC):
   // CHECK:    [[UNINIT_SELF:%.*]] = mark_uninitialized [rootself] [[SELF]] : $CC
   // CHECK:    [[FOO:%.*]] = alloc_box ${ var Optional<CC> }, var, name "foo"
   // CHECK:    [[PB:%.*]] = project_box [[FOO]]


### PR DESCRIPTION
Very roughly this increases the total coverage of SILGen tests with ownership
enabled to ~20%. This handles most of the tests with characters in between a-d.

rdar://33358110