### PR TITLE
[SIL] NFC: use inheritance to simplify printing

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -146,8 +146,8 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
     INST(StrongReleaseInst, RefCountingInst, strong_release, MayHaveSideEffects, MayRelease)
     INST(StrongRetainUnownedInst, RefCountingInst, strong_retain_unowned, MayHaveSideEffects,
          DoesNotRelease)
-    INST(StrongPinInst, SILInstruction, strong_pin, MayHaveSideEffects, DoesNotRelease)
-    INST(StrongUnpinInst, SILInstruction, strong_unpin, MayHaveSideEffects, DoesNotRelease)
+    INST(StrongPinInst, RefCountingInst, strong_pin, MayHaveSideEffects, DoesNotRelease)
+    INST(StrongUnpinInst, RefCountingInst, strong_unpin, MayHaveSideEffects, DoesNotRelease)
     INST(UnownedRetainInst, RefCountingInst, unowned_retain, MayHaveSideEffects, DoesNotRelease)
     INST(UnownedReleaseInst, RefCountingInst, unowned_release, MayHaveSideEffects,
          MayRelease)

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1418,26 +1418,6 @@ public:
     *this << getIDAndType(I->getOperand());
   }
 
-  void visitRetainValueInst(RetainValueInst *I) { visitRefCountingInst(I); }
-
-  void visitReleaseValueInst(ReleaseValueInst *I) { visitRefCountingInst(I); }
-
-  void visitRetainValueAddrInst(RetainValueAddrInst *I) {
-    visitRefCountingInst(I);
-  }
-
-  void visitReleaseValueAddrInst(ReleaseValueAddrInst *I) {
-    visitRefCountingInst(I);
-  }
-
-  void visitAutoreleaseValueInst(AutoreleaseValueInst *I) {
-    visitRefCountingInst(I);
-  }
-
-  void visitSetDeallocatingInst(SetDeallocatingInst *I) {
-    visitRefCountingInst(I);
-  }
-
   void visitStructInst(StructInst *SI) {
     *this << SI->getType() << " (";
     interleave(SI->getElements(),
@@ -1656,21 +1636,6 @@ public:
     if (I->isNonAtomic())
       *this << "[nonatomic] ";
     *this << getIDAndType(I->getOperand(0));
-  }
-  void visitStrongRetainInst(StrongRetainInst *RI) { visitRefCountingInst(RI); }
-  void visitStrongReleaseInst(StrongReleaseInst *RI) {
-    visitRefCountingInst(RI);
-  }
-  void visitStrongPinInst(StrongPinInst *PI) { visitRefCountingInst(PI); }
-  void visitStrongUnpinInst(StrongUnpinInst *UI) { visitRefCountingInst(UI); }
-  void visitStrongRetainUnownedInst(StrongRetainUnownedInst *RI) {
-    visitRefCountingInst(RI);
-  }
-  void visitUnownedRetainInst(UnownedRetainInst *RI) {
-    visitRefCountingInst(RI);
-  }
-  void visitUnownedReleaseInst(UnownedReleaseInst *RI) {
-    visitRefCountingInst(RI);
   }
   void visitIsUniqueInst(IsUniqueInst *CUI) {
     *this << getIDAndType(CUI->getOperand());


### PR DESCRIPTION
There is no need for us to manually call the abstract base class. The
visitor pattern will do that for us.

Also, make SILNodes.def and SILInstruction.h agree about the parent type
of the strong pin/unpin instructions.

@swift-ci please smoke test