### PR TITLE
Add index unit tests for Arrays

### DIFF
--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -158,8 +158,7 @@ ArrayTestSuite.test("${Kind}/append") {
 }
 % end
 
-ArrayTestSuite.test("ArraySlice/append") 
-  .xfail(.custom({true}, reason: "<rdar://problem/33997561>")).code {
+ArrayTestSuite.test("ArraySlice/append") {
   do {
     let a: [OpaqueValue<Int>] = [ 42, 2525, 3535, 42 ].map(OpaqueValue.init)
     var s = a[1..<2]

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -138,6 +138,215 @@ ArrayTestSuite.test("${Kind}/popLast") {
 }
 % end
 
+// Check how append affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/append") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
+    let v = OpaqueValue(1)
+    a.append(v)
+    expectEqual(0, a.startIndex)
+    expectEqual(2, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
+    let v = OpaqueValue(1)
+    a.append(v)
+    expectEqual(0, a.startIndex)
+    expectEqual(2, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/append") 
+  .xfail(.custom({true}, reason: "<rdar://problem/33997561>")).code {
+  do {
+    let a: [OpaqueValue<Int>] = [ 42, 2525, 3535, 42 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    let v = OpaqueValue(1515)
+    s.append(v)
+    expectEqual(1, s.startIndex)
+    expectEqual(3, s.endIndex)
+  }
+}
+
+// Check how insert(_:at:) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/insert") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
+    let v = OpaqueValue(1)
+    a.insert(v, at: 0)
+    expectEqual(0, a.startIndex)
+    expectEqual(2, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
+    let v = OpaqueValue(1)
+    a.insert(v, at: 1)
+    expectEqual(0, a.startIndex)
+    expectEqual(2, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/insert") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 42, 2525, 3535, 42 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    let v = OpaqueValue(1515)
+    s.insert(v, at: 1)
+    expectEqual(1, s.startIndex)
+    expectEqual(3, s.endIndex)
+  }
+}
+
+// Check how partition(by:) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/partition") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 10, 2, -33, 44, -5 ].map(OpaqueValue.init))
+    a.partition(by: { $0.value > 0 })
+    expectEqual(0, a.startIndex)
+    expectEqual(5, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 10, 2, -33, 44, -5 ].map(OpaqueValue.init))
+    a.partition(by: { $0.value > 100 })
+    expectEqual(0, a.startIndex)
+    expectEqual(5, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 10, 2, -33, 44, -5 ].map(OpaqueValue.init))
+    a.partition(by: { $0.value > 100 })
+    expectEqual(0, a.startIndex)
+    expectEqual(5, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/partition") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.removeFirst()
+    expectEqual(2, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.removeFirst()
+    expectEqual(2, s.startIndex)
+    expectEqual(3, s.endIndex)
+  }
+}
+
+// Check how removeLast() affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeLast") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
+    a.removeLast()
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.removeLast()
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeLast") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.removeLast()
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.removeLast()
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+}
+
+// Check how remove(at:) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/remove(at:)") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
+    a.remove(at: 0)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.remove(at: 1)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/remove(at:)") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.remove(at: 1)
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.remove(at: 1)
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+}
+
+// Check how removeAll(keepingCapacity:) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeAll(keepingCapacity:)") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3, ].map(OpaqueValue.init))
+    a.removeAll(keepingCapacity: true)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.removeAll(keepingCapacity: false)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeAll(keepingCapacity:)") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.removeAll(keepingCapacity: true)
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.removeAll(keepingCapacity: false)
+    expectEqual(0, s.endIndex)
+    expectEqual(0, s.endIndex)
+  }
+}
+
 // Check how removeFirst() affects indices.
 % for Kind in ['Array', 'ContiguousArray']:
 ArrayTestSuite.test("${Kind}/removeFirst") {
@@ -145,11 +354,13 @@ ArrayTestSuite.test("${Kind}/removeFirst") {
     var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
     a.removeFirst()
     expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
   }
   do {
     var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
     a.removeFirst()
     expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
   }
 }
 % end
@@ -158,16 +369,223 @@ ArrayTestSuite.test("ArraySlice/removeFirst") {
   do {
     let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
     var s = a[1..<2]
-    expectEqual(1, s.startIndex)
     s.removeFirst()
     expectEqual(2, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.removeFirst()
+    expectEqual(2, s.startIndex)
+    expectEqual(3, s.endIndex)
+  }
+}
+
+// Check how removeFirst(_:) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeFirst(_:)") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.removeFirst(2)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3, 4 ].map(OpaqueValue.init))
+    a.removeFirst(2)
+    expectEqual(0, a.startIndex)
+    expectEqual(2, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeFirst(_:)") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1...2]
+    s.removeFirst(2)
+    expectEqual(3, s.startIndex)
+    expectEqual(3, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1...3]
+    s.removeFirst(2)
+    expectEqual(3, s.startIndex)
+    expectEqual(4, s.endIndex)
+  }
+}
+
+// Check how removeLast() affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeLast") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
+    a.removeLast()
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.removeLast()
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeLast") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.removeLast()
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
   }
   do {
     let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
     var s = a[1..<2]
+    s.removeLast()
     expectEqual(1, s.startIndex)
-    s.removeFirst()
-    expectEqual(2, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+}
+
+// Check how removeSubrange(_:ClosedRange) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeSubrange(_:ClosedRange)") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
+    a.removeSubrange(0..<1)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
+    a.removeSubrange(0..<2)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
+    a.removeSubrange(1..<3)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeSubrange(_:ClosedRange)") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<2]
+    s.removeSubrange(1..<2)
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.removeLast()
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+}
+
+// Check how removeSubrange(_:Range) affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeSubrange(_:Range)") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.removeSubrange(0...1)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
+    a.removeSubrange(0...1)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
+    a.removeSubrange(1...2)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeSubrange(_:Range)") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.removeSubrange(1...2)
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
+    var s = a[1..<4]
+    s.removeSubrange(2...3)
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
+    var s = a[1..<4]
+    s.removeSubrange(1...2)
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+}
+
+// Check how filter() affects indices.
+% for Kind in ['Array', 'ContiguousArray']:
+ArrayTestSuite.test("${Kind}/removeSubrange(_:Range)") {
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
+    a.removeSubrange(0...1)
+    expectEqual(0, a.startIndex)
+    expectEqual(0, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
+    a.removeSubrange(0...1)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+  do {
+    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
+    a.removeSubrange(1...2)
+    expectEqual(0, a.startIndex)
+    expectEqual(1, a.endIndex)
+  }
+}
+% end
+
+ArrayTestSuite.test("ArraySlice/removeSubrange(_:Range)") {
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
+    var s = a[1..<3]
+    s.removeSubrange(1...2)
+    expectEqual(1, s.startIndex)
+    expectEqual(1, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
+    var s = a[1..<4]
+    s.removeSubrange(2...3)
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
+  }
+  do {
+    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
+    var s = a[1..<4]
+    s.removeSubrange(1...2)
+    expectEqual(1, s.startIndex)
+    expectEqual(2, s.endIndex)
   }
 }
 

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -215,12 +215,6 @@ ArrayTestSuite.test("${Kind}/partition") {
     expectEqual(0, a.startIndex)
     expectEqual(5, a.endIndex)
   }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 10, 2, -33, 44, -5 ].map(OpaqueValue.init))
-    a.partition(by: { $0.value > 100 })
-    expectEqual(0, a.startIndex)
-    expectEqual(5, a.endIndex)
-  }
 }
 % end
 

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -173,7 +173,7 @@ public struct ArrayIndexTest<T: Collection> {
     self.expectedEnd = expectedEnd
     self.operation = operation
     self.range = range
-    self.loc = SourceLoc(file, line, comment: "dropFirst() test data")
+    self.loc = SourceLoc(file, line, comment: "Array index test data")
   }
 }
 

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -138,449 +138,409 @@ ArrayTestSuite.test("${Kind}/popLast") {
 }
 % end
 
-// Check how append affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/append") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
-    let v = OpaqueValue(1)
-    a.append(v)
-    expectEqual(0, a.startIndex)
-    expectEqual(2, a.endIndex)
+public struct ArrayIndexTest<T: Collection> {
+  public enum RangeBox {
+    case closed(ClosedRange<Int>)
+    case halfClosed(Range<Int>)
   }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
-    let v = OpaqueValue(1)
-    a.append(v)
-    expectEqual(0, a.startIndex)
-    expectEqual(2, a.endIndex)
+  
+  public enum Operation {
+    case append(Int)
+    case insert(Int, at: Int)
+    case partition(by: (OpaqueValue<Int>) throws -> Bool)
+    case removeFirst
+    case removeFirstN(Int)
+    case removeLast
+    case removeLastN(Int)
+    case removeAt(Int)
+    case removeAll(Bool)
+    case removeClosedSubrange(ClosedRange<Int>)
+    case removeHalfClosedSubrange(Range<Int>)
+  }
+  
+  public let data: T
+  public let expectedStart: Int
+  public let expectedEnd: Int
+  public let range: Range<Int>?
+  public let operation: Operation
+  public let loc: SourceLoc
+
+  public init(data: T, expectedStart: Int, expectedEnd: Int, 
+        operation: Operation, range: Range<Int>? = nil,
+        file: String = #file, line: UInt = #line) {
+    self.data = data
+    self.expectedStart = expectedStart
+    self.expectedEnd = expectedEnd
+    self.operation = operation
+    self.range = range
+    self.loc = SourceLoc(file, line, comment: "dropFirst() test data")
+  }
+}
+
+let indexTests: [ArrayIndexTest<[Int]>] = [
+  // Check how partition() affects indices.
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .partition(by: { $0.value > 100 } ),
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 3,
+    operation: .partition(by: { $0.value > 0} ),
+    range: 1..<3
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 3,
+    operation: .partition(by: { $0.value > 3000 }),
+    range: 1..<3
+  ),
+  // Check how partition(by:) affects indices. 
+  ArrayIndexTest(
+    data: [ 10, 2, -33, 44, -5 ],
+    expectedStart: 0,
+    expectedEnd: 5,
+    operation: .partition(by: { $0.value > 0 })
+  ),
+  ArrayIndexTest(
+    data: [ 10, 2, -33, 44, -5 ],
+    expectedStart: 0,
+    expectedEnd: 5,
+    operation: .partition(by: { $0.value > 100 })
+  ),
+  // Check how append affects indices.
+  ArrayIndexTest(
+    data: [ 2 ],
+    expectedStart: 0,
+    expectedEnd: 2,
+    operation: .append(1)
+  ),
+  ArrayIndexTest(
+    data: [],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .append(1)
+  ),
+  ArrayIndexTest(
+    data: [ 42, 2525, 3535, 42 ],
+    expectedStart: 1,
+    expectedEnd: 3,
+    operation: .append(1),
+    range: 1..<2
+  ),
+  // Check how insert(_:at:) affects indices.
+  ArrayIndexTest(
+    data: [ 2 ],
+    expectedStart: 0,
+    expectedEnd: 2,
+    operation: .insert(2, at: 0)
+  ),
+  ArrayIndexTest(
+    data: [ 2 ],
+    expectedStart: 0,
+    expectedEnd: 2,
+    operation: .insert(2, at: 1)
+  ),
+  ArrayIndexTest(
+    data: [ 42, 2525, 3535, 42 ],
+    expectedStart: 1,
+    expectedEnd: 3,
+    operation: .insert(2, at: 1),
+    range: 1..<2
+  ),
+  // Check how removeLast() affects indices.
+  ArrayIndexTest(
+    data: [ 1 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeLast
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeLast
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeLast,
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .removeLast,
+    range: 1..<3
+  ),
+  // Check how remove(at:) affects indices.
+  ArrayIndexTest(
+    data: [ 1 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeAt(0)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeAt(1)
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeAt(1),
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .removeAt(1),
+    range: 1..<3
+  ),
+  // Check how removeAll(keepingCapacity:) affects indices.
+  ArrayIndexTest(
+    data: [ 1, 2, 3 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeAll(true)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeAll(false)
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeAll(true),
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeAll(false),
+    range: 1..<2
+  ),
+  // Check how removeFirst() affects indices.
+  ArrayIndexTest(
+    data: [ 1 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeFirst
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeFirst
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 2,
+    expectedEnd: 2,
+    operation: .removeFirst,
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 2,
+    expectedEnd: 3,
+    operation: .removeFirst,
+    range: 1..<3
+  ),
+  // Check how removeFirst(_:) affects indices.
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeFirstN(2)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2, 3, 4 ],
+    expectedStart: 0,
+    expectedEnd: 2,
+    operation: .removeFirstN(2)
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 3,
+    expectedEnd: 3,
+    operation: .removeFirstN(2),
+    range: 1..<3
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 3,
+    expectedEnd: 4,
+    operation: .removeFirstN(2),
+    range: 1..<4
+  ),
+  // Check how removeLast() affects indices.
+  ArrayIndexTest(
+    data: [ 1 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeLast
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeLast
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeLast,
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeLast,
+    range: 1..<2
+  ),
+  // Check how removeSubrange(_:ClosedRange) affects indices.
+  ArrayIndexTest(
+    data: [ 1 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeHalfClosedSubrange(0..<1)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2, 3 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeHalfClosedSubrange(0..<2)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2, 3 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeHalfClosedSubrange(0..<3)
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeHalfClosedSubrange(1..<2),
+    range: 1..<2
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .removeHalfClosedSubrange(1..<2),
+    range: 1..<3
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .removeHalfClosedSubrange(2..<4),
+    range: 1..<4
+  ),
+  // Check how removeSubrange(_:Range) affects indices.
+  ArrayIndexTest(
+    data: [ 1, 2 ],
+    expectedStart: 0,
+    expectedEnd: 0,
+    operation: .removeClosedSubrange(0...1)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2, 3 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeClosedSubrange(0...1)
+  ),
+  ArrayIndexTest(
+    data: [ 1, 2, 3 ],
+    expectedStart: 0,
+    expectedEnd: 1,
+    operation: .removeClosedSubrange(0...2)
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 99 ],
+    expectedStart: 1,
+    expectedEnd: 1,
+    operation: .removeClosedSubrange(1...2),
+    range: 1..<3
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99, 44 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .removeClosedSubrange(2...3),
+    range: 1..<4
+  ),
+  ArrayIndexTest(
+    data: [ 99, 1010, 2020, 99, 44 ],
+    expectedStart: 1,
+    expectedEnd: 2,
+    operation: .removeClosedSubrange(1...2),
+    range: 1..<4
+  )
+]
+
+% for Kind in ['Array', 'ContiguousArray', 'ArraySlice']:
+ArrayTestSuite.test("ArrayIndexTests") {
+  for test in indexTests {
+    let testData = test.data.map(OpaqueValue.init)
+% if Kind == 'ArraySlice':
+    guard let range = test.range else { continue }
+    var a = testData[range]
+% else:
+    if test.range != nil { continue }
+    var a = ${Kind}(testData)
+% end
+
+    switch test.operation {
+    case let .append(v):
+      a.append(OpaqueValue(v))
+    case let .insert(v, index):
+      a.insert(OpaqueValue(v), at: index)
+    case let .partition(c):
+      expectDoesNotThrow({ 
+        _ = try a.partition(by: c) 
+      })
+    case .removeFirst:
+      a.removeFirst()
+    case let .removeFirstN(n):
+      a.removeFirst(n)
+    case .removeLast:
+      a.removeLast()
+    case let .removeLastN(n):
+      a.removeLast(n)
+    case let .removeAt(index):
+      a.remove(at: index)
+    case let .removeAll(keepCapacity):
+      a.removeAll(keepingCapacity: keepCapacity)
+    case let .removeHalfClosedSubrange(range):
+        a.removeSubrange(range)
+    case let .removeClosedSubrange(range):
+        a.removeSubrange(range)
+    }
+    
+    expectEqual(test.expectedStart, a.startIndex, stackTrace: SourceLocStack().with(test.loc))
+    expectEqual(test.expectedEnd, a.endIndex, stackTrace: SourceLocStack().with(test.loc))
   }
 }
 % end
-
-ArrayTestSuite.test("ArraySlice/append") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 42, 2525, 3535, 42 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    let v = OpaqueValue(1515)
-    s.append(v)
-    expectEqual(1, s.startIndex)
-    expectEqual(3, s.endIndex)
-  }
-}
-
-// Check how insert(_:at:) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/insert") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
-    let v = OpaqueValue(1)
-    a.insert(v, at: 0)
-    expectEqual(0, a.startIndex)
-    expectEqual(2, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 2 ].map(OpaqueValue.init))
-    let v = OpaqueValue(1)
-    a.insert(v, at: 1)
-    expectEqual(0, a.startIndex)
-    expectEqual(2, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/insert") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 42, 2525, 3535, 42 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    let v = OpaqueValue(1515)
-    s.insert(v, at: 1)
-    expectEqual(1, s.startIndex)
-    expectEqual(3, s.endIndex)
-  }
-}
-
-// Check how partition(by:) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/partition") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 10, 2, -33, 44, -5 ].map(OpaqueValue.init))
-    a.partition(by: { $0.value > 0 })
-    expectEqual(0, a.startIndex)
-    expectEqual(5, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 10, 2, -33, 44, -5 ].map(OpaqueValue.init))
-    a.partition(by: { $0.value > 100 })
-    expectEqual(0, a.startIndex)
-    expectEqual(5, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/partition") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeFirst()
-    expectEqual(2, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.removeFirst()
-    expectEqual(2, s.startIndex)
-    expectEqual(3, s.endIndex)
-  }
-}
-
-// Check how removeLast() affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeLast") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
-    a.removeLast()
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeLast()
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeLast") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeLast()
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.removeLast()
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-}
-
-// Check how remove(at:) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/remove(at:)") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
-    a.remove(at: 0)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.remove(at: 1)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/remove(at:)") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.remove(at: 1)
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.remove(at: 1)
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-}
-
-// Check how removeAll(keepingCapacity:) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeAll(keepingCapacity:)") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3, ].map(OpaqueValue.init))
-    a.removeAll(keepingCapacity: true)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeAll(keepingCapacity: false)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeAll(keepingCapacity:)") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeAll(keepingCapacity: true)
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeAll(keepingCapacity: false)
-    expectEqual(0, s.endIndex)
-    expectEqual(0, s.endIndex)
-  }
-}
-
-// Check how removeFirst() affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeFirst") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
-    a.removeFirst()
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeFirst()
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeFirst") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeFirst()
-    expectEqual(2, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.removeFirst()
-    expectEqual(2, s.startIndex)
-    expectEqual(3, s.endIndex)
-  }
-}
-
-// Check how removeFirst(_:) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeFirst(_:)") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeFirst(2)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3, 4 ].map(OpaqueValue.init))
-    a.removeFirst(2)
-    expectEqual(0, a.startIndex)
-    expectEqual(2, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeFirst(_:)") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1...2]
-    s.removeFirst(2)
-    expectEqual(3, s.startIndex)
-    expectEqual(3, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1...3]
-    s.removeFirst(2)
-    expectEqual(3, s.startIndex)
-    expectEqual(4, s.endIndex)
-  }
-}
-
-// Check how removeLast() affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeLast") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
-    a.removeLast()
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeLast()
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeLast") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeLast()
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeLast()
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-}
-
-// Check how removeSubrange(_:ClosedRange) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeSubrange(_:ClosedRange)") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1 ].map(OpaqueValue.init))
-    a.removeSubrange(0..<1)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
-    a.removeSubrange(0..<2)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
-    a.removeSubrange(1..<3)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeSubrange(_:ClosedRange)") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<2]
-    s.removeSubrange(1..<2)
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.removeLast()
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-}
-
-// Check how removeSubrange(_:Range) affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeSubrange(_:Range)") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeSubrange(0...1)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
-    a.removeSubrange(0...1)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
-    a.removeSubrange(1...2)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeSubrange(_:Range)") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.removeSubrange(1...2)
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
-    var s = a[1..<4]
-    s.removeSubrange(2...3)
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
-    var s = a[1..<4]
-    s.removeSubrange(1...2)
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-}
-
-// Check how filter() affects indices.
-% for Kind in ['Array', 'ContiguousArray']:
-ArrayTestSuite.test("${Kind}/removeSubrange(_:Range)") {
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2 ].map(OpaqueValue.init))
-    a.removeSubrange(0...1)
-    expectEqual(0, a.startIndex)
-    expectEqual(0, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
-    a.removeSubrange(0...1)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-  do {
-    var a: ${Kind}<OpaqueValue<Int>> = ${Kind}([ 1, 2, 3 ].map(OpaqueValue.init))
-    a.removeSubrange(1...2)
-    expectEqual(0, a.startIndex)
-    expectEqual(1, a.endIndex)
-  }
-}
-% end
-
-ArrayTestSuite.test("ArraySlice/removeSubrange(_:Range)") {
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 99 ].map(OpaqueValue.init)
-    var s = a[1..<3]
-    s.removeSubrange(1...2)
-    expectEqual(1, s.startIndex)
-    expectEqual(1, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
-    var s = a[1..<4]
-    s.removeSubrange(2...3)
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-  do {
-    let a: [OpaqueValue<Int>] = [ 99, 1010, 2020, 99, 44 ].map(OpaqueValue.init)
-    var s = a[1..<4]
-    s.removeSubrange(1...2)
-    expectEqual(1, s.startIndex)
-    expectEqual(2, s.endIndex)
-  }
-}
 
 //===----------------------------------------------------------------------===//
 // Array and EvilCollection that changes its size while we are not looking


### PR DESCRIPTION
Add unit tests to do a sanity check on startIndex and endIndex for all mutating methods on Array, ArraySlice and ContiguousArray.
