### PR TITLE
Sema: Track ReferenceWritableKeyPath applications as reads of their base.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2561,6 +2561,9 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
     if (KPA->getKeyPath()->getType()->getAnyNominal()
           == C.getWritableKeyPathDecl())
       markStoredOrInOutExpr(KPA->getBase(), RK_Written|RK_Read);
+    if (KPA->getKeyPath()->getType()->getAnyNominal()
+          == C.getReferenceWritableKeyPathDecl())
+      markStoredOrInOutExpr(KPA->getBase(), RK_Read);
     return;
   }
   

--- a/test/expr/unary/keypath/keypath-mutation.swift
+++ b/test/expr/unary/keypath/keypath-mutation.swift
@@ -18,5 +18,18 @@ func referenceSetting<Root, Value>(_ kp: ReferenceWritableKeyPath<Root, Value>, 
   // expected-warning@+1 {{was never mutated}}
   var copy = root
   copy[keyPath: kp] = value
+  
+  // Should not warn about lack of use of `immCopy`
+  let immCopy = root
+  immCopy[keyPath: kp] = value
+  return copy
+}
+
+func referenceUsage<Root, Value>(_ kp: ReferenceWritableKeyPath<Root, Value>, _ root: Root, _ value: Value) -> Root {
+  // Should warn about lack of mutation, since a RefKeyPath doesn't modify its
+  // base.
+  // expected-warning@+1 {{was never mutated}}
+  var copy = root
+  copy[keyPath: kp] = value
   return copy
 }


### PR DESCRIPTION
Fixes SR-5673 | rdar://problem/33881533.