### PR TITLE
[4.0] SILGen: swift_newtypes should be returned autoreleased from ObjC entry points.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1546,7 +1546,8 @@ namespace {
       }
 
       auto type = tl.getLoweredType().getSwiftRValueType();
-      if (type->hasRetainablePointerRepresentation())
+      if (type->hasRetainablePointerRepresentation()
+          || (type->getSwiftNewtypeUnderlyingType() && !tl.isTrivial()))
         return ResultConvention::Autoreleased;
 
       return ResultConvention::Unowned;

--- a/test/SILGen/Inputs/swift_newtype_result_convention.h
+++ b/test/SILGen/Inputs/swift_newtype_result_convention.h
@@ -1,0 +1,3 @@
+@import Foundation;
+
+typedef NSString *NSThing __attribute__((swift_newtype(struct)));

--- a/test/SILGen/swift_newtype_result_convention.swift
+++ b/test/SILGen/swift_newtype_result_convention.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -import-objc-header %S/Inputs/swift_newtype_result_convention.h %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class ThingHolder: NSObject {
+  // CHECK: sil hidden [thunk] @_T{{.*}}5thing{{.*}}To : $@convention(objc_method) (ThingHolder) -> @autoreleased NSThing
+  @objc let thing: NSThing = NSThing("")
+}


### PR DESCRIPTION
Explanation: The accessor for a property returning a `swift_newtype` enum would leak memory when called from ObjC.

Scope: Memory leak, impacting Apple frameworks

Issue: rdar://problem/33908867.

Risk: Low, small targeted bug fix

Testing: Swift CI