### PR TITLE
A couple of small improvements for the resilient builds of the stdlib

### DIFF
--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -183,6 +183,7 @@ extension Comparable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
+  @_inlineable
   public static func > (lhs: Self, rhs: Self) -> Bool {
     return rhs < lhs
   }
@@ -196,6 +197,7 @@ extension Comparable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
+  @_inlineable
   public static func <= (lhs: Self, rhs: Self) -> Bool {
     return !(rhs < lhs)
   }
@@ -211,6 +213,7 @@ extension Comparable {
   ///   - rhs: Another value to compare.
   /// - Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,
   ///   `false`.
+  @_inlineable
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return !(lhs < rhs)
   }

--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -297,6 +297,11 @@ public struct DoubleWidth<Base : FixedWidthInteger> :
     return (result, didCarry || hadPositiveOverflow)
   }
 
+  // Specialize for the most popular types.
+  @_specialize(where Base == Int)
+  @_specialize(where Base == UInt)
+  @_specialize(where Base == Int64)
+  @_specialize(where Base == UInt64)
   public func quotientAndRemainder(dividingBy other: DoubleWidth)
     -> (quotient: DoubleWidth, remainder: DoubleWidth) {
     let isNegative = (self < (0 as DoubleWidth)) != (other < (0 as DoubleWidth))

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1633,6 +1633,7 @@ ${operatorComment(x.operator, False)}
   // Heterogeneous non-masking shift in terms of shift-assignment
 ${operatorComment(x.nonMaskingOperator, False)}
   @_semantics("optimize.sil.specialize.generic.partial.never")
+  @_inlineable
   public static func ${x.nonMaskingOperator}<RHS: BinaryInteger>(
     _ lhs: Self, _ rhs: RHS
   ) -> Self {
@@ -2184,6 +2185,7 @@ ${operatorComment(x.operator, False)}
   // Heterogeneous masking shift
 ${operatorComment(x.operator, False)}
   @_semantics("optimize.sil.specialize.generic.partial.never")
+  @_inlineable
   public static func ${x.operator} <
     Other : BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {


### PR DESCRIPTION
*  Mark more functions as @_inlineable
*  Force popular specializations of a very big function to speed-up the compilation on client side
