### PR TITLE
Android: adding swift suffix to icu generated libs to resolve conflict

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -355,7 +355,7 @@ function(_add_variant_link_flags)
     endif()
   elseif("${LFLAGS_SDK}" STREQUAL "ANDROID")
     list(APPEND result
-        "-ldl" "-llog" "-latomic" "-licudata" "-licui18n" "-licuuc"
+        "-ldl" "-llog" "-latomic" "-licudataswift" "-licui18nswift" "-licuucswift"
         "${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so")
     list(APPEND library_search_directories
         "${SWIFT_ANDROID_PREBUILT_PATH}/arm-linux-androideabi/lib/armv7-a"

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -67,9 +67,125 @@ The steps are as follows:
 3. From the command-line, run `which ndk-build`. Confirm that the path to
    the `ndk-build` executable in the Android NDK you downloaded is displayed.
    If not, you may need to add the Android NDK directory to your `PATH`.
-4. Enter the `libiconv-libicu-android` directory on the command line, then
-   run `build.sh`.
-5. Confirm that the build script created `armeabi-v7a/icu/source/i18n` and
+
+#### Adding `swift` suffix to icu libraries
+
+Android OS has its own icu libraries which are different from the ones we are generating and conflicts with ours. In order to resolve this conflict when linking Swift stdlib dependencies in Android devices, we need to change our icu libraries names by adding `swift` suffix at the end. To do that, enter the `libiconv-libicu-android` directory on the command line, then do the following steps:
+
+Create `armeabi-v7a` directory and generate `icu` directory by uncompressing `icu4c-55_1-src.tgz` file, as following:
+ 
+```
+$ mkdir armeabi-v7a
+$ cd armeabi-v7a
+$ tar xvf ../icu4c-55_1-src.tgz
+```
+
+**Edit icu configure file**
+
+In order to prevent icu configuration from adding `swift` suffix to internal symbols as well, edit `icu/source/configure` file and change:
+
+```
+if test "$ICULIBSUFFIX" != ""
+then
+    U_HAVE_LIB_SUFFIX=1
+    ICULIBSUFFIXCNAME=`echo _$ICULIBSUFFIX | sed 's/^A-Za-z0-9_/_/g'`
+    UCONFIG_CPPFLAGS="${UCONFIG_CPPFLAGS} -DU_HAVE_LIB_SUFFIX=1 -DU_LIB_SUFFIX_C_NAME=${ICULIBSUFFIXCNAME} "
+else
+    U_HAVE_LIB_SUFFIX=0
+fi
+```
+
+To:
+ 
+```
+#if test "$ICULIBSUFFIX" != ""
+#then
+#    U_HAVE_LIB_SUFFIX=1
+#    ICULIBSUFFIXCNAME=`echo _$ICULIBSUFFIX | sed 's/^A-Za-z0-9_/_/g'`
+#    UCONFIG_CPPFLAGS="${UCONFIG_CPPFLAGS} -DU_HAVE_LIB_SUFFIX=1 -DU_LIB_SUFFIX_C_NAME=${ICULIBSUFFIXCNAME} "
+#else
+    U_HAVE_LIB_SUFFIX=0
+#fi
+```
+
+**Edit build.sh file**
+
+Now go back to the `libiconv-libicu-android` root directory:
+
+```
+$ cd ..
+```
+
+In order to prevent `build.sh` from regenerating the icu directory and override the `configure` file we just edited, edit `build.sh` and change:
+
+```
+[ -e ../icu4c-55_1-src.tgz ] || exit 1
+tar xvf ../icu4c-55_1-src.tgz
+```
+
+To:
+
+```
+#[ -e ../icu4c-55_1-src.tgz ] || exit 1
+#tar xvf ../icu4c-55_1-src.tgz
+```
+
+In order to check the existence of `libicuucswift.so` file instead of `libicuuc.so`, change:
+
+```
+[ -e libicuuc.so ] || {
+```
+
+To:
+
+```
+[ -e libicuucswift.so ] || {
+```
+
+Then add the `swift` suffix to the call of `configure` file, by changing:
+
+```
+./configure \
+--host=arm-linux-androideabi \
+--prefix=`pwd`/../../ \
+--with-cross-build=`pwd`/cross \
+--enable-static --enable-shared \
+|| exit 1
+```
+To:
+
+```
+./configure \
+--host=arm-linux-androideabi \
+--prefix=`pwd`/../../ \
+--with-library-suffix=swift \
+--with-cross-build=`pwd`/cross \
+--enable-static --enable-shared \
+|| exit 1
+```
+
+Now change the libraries file names on the last step of th build, by adding `swift` at the end of each one, by changing:
+
+```
+for f in libicudata libicutest libicui18n libicuio libicule libiculx libicutu libicuuc; do
+```
+
+To:
+
+```
+for f in libicudataswift libicutestswift libicui18nswift libicuioswift libiculeswift libiculxswift libicutuswift libicuucswift; do
+```
+
+
+**Run build.sh**
+
+Now we are finally ready to run the `build.sh` file
+
+```
+$ ./build.sh
+```
+
+Confirm that the build script created `armeabi-v7a/icu/source/i18n` and
    `armeabi-v7a/icu/source/common` directories within your
    `libiconv-libicu-android` directory.
 
@@ -88,7 +204,7 @@ $ utils/build-script \
     --android-icu-uc /path/to/libicu-android/armeabi-v7a \
     --android-icu-uc-include /path/to/libicu-android/armeabi-v7a/icu/source/common \
     --android-icu-i18n /path/to/libicu-android/armeabi-v7a \
-    --android-icu-i18n-include /path/to/libicu-android/armeabi-v7a/icu/source/i18n/
+    --android-icu-i18n-include /path/to/libicu-android/armeabi-v7a/icu/source/i18n
 ```
 
 ### 3. Compiling `hello.swift` to run on an Android device
@@ -159,9 +275,9 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswi
 You will also need to push the icu libraries:
 
 ```
-adb push /path/to/libicu-android/armeabi-v7a/libicudata.so /data/local/tmp
-adb push /path/to/libicu-android/armeabi-v7a/libicui18n.so /data/local/tmp
-adb push /path/to/libicu-android/armeabi-v7a/libicuuc.so /data/local/tmp
+adb push /path/to/libicu-android/armeabi-v7a/libicudataswift.so /data/local/tmp
+adb push /path/to/libicu-android/armeabi-v7a/libicui18nswift.so /data/local/tmp
+adb push /path/to/libicu-android/armeabi-v7a/libicuucswift.so /data/local/tmp
 ```
 
 In addition, you'll also need to copy the Android NDK's libc++:


### PR DESCRIPTION
Android: adding swift suffix to icu generated libs to resolve conflit with Android's internal icu libs

<!-- What's in this pull request? -->
https://bugs.swift.org/browse/SR-5672

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5672](https://bugs.swift.org/browse/SR-5672).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
