### PR TITLE
master-next: temporarily disable failing dead_code_elimination.sil test

### DIFF
--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -dce %s | %FileCheck %s
 
+// REQUIRES: rdar34013900
+
 sil_stage canonical
 
 import Builtin


### PR DESCRIPTION
This test has started failing, probably related to LLVM r310940, which now
includes infinite loops in PostDominatorTree. The failing test has an
infinite loop and is checking that the dead code in the body of the loop
is not removed.