### PR TITLE
Don't throw out AST for if/guard bindings during code-completion

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1269,7 +1269,7 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
               diag::expected_expr_conditional;
         auto BoolExpr = parseExprBasic(diagID);
         Status |= BoolExpr;
-        if (BoolExpr.isNull() || BoolExpr.hasCodeCompletion())
+        if (BoolExpr.isNull())
           return Status;
         result.push_back(BoolExpr.get());
         BindingKindStr = StringRef();
@@ -1353,7 +1353,7 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
       ParserResult<Expr> InitExpr
         = parseExprBasic(diag::expected_expr_conditional_var);
       Status |= InitExpr;
-      if (InitExpr.isNull() || InitExpr.hasCodeCompletion())
+      if (InitExpr.isNull())
         return Status;
       Init = InitExpr.get();
       

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -132,6 +132,15 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_GUARD_6 | %FileCheck %s -check-prefix=UNRESOLVED_B
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_GUARD_7 | %FileCheck %s -check-prefix=UNRESOLVED_B
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IF_LET_BIND_1 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IF_LET_BIND_2 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IF_LET_BIND_3 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GUARD_LET_BIND_1 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GUARD_LET_BIND_2 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GUARD_LET_BIND_3 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GUARD_LET_BIND_4 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GUARD_LET_BIND_5 | %FileCheck %s -check-prefix=FOOSTRUCT_DOT
+
 
 struct FooStruct {
   var instanceVar : Int
@@ -572,3 +581,34 @@ func testUnresolvedGuard6(x: BB) {
 func testUnresolvedGuard7(x: BB) {
   guard let x.takeEnum(.#^UNRESOLVED_GUARD_7^#) else {}
 }
+
+func testIfLetBinding1(x: FooStruct?) {
+  if let y = x, y.#^IF_LET_BIND_1^# {}
+}
+func testIfLetBinding2(x: FooStruct?) {
+  if let y = x, y.#^IF_LET_BIND_2^#
+}
+func testIfLetBinding3(x: FooStruct?) {
+  if let y = x, let z = y.#^IF_LET_BIND_3^# {}
+}
+func testGuardLetBinding1(x: FooStruct?) {
+  guard let y = x, y.#^GUARD_LET_BIND_1^# else {}
+}
+func testGuardLetBinding2(x: FooStruct?) {
+  guard let y = x, y.#^GUARD_LET_BIND_2^#
+}
+func testGuardLetBinding3(x: FooStruct?) {
+  guard let y = x, y.#^GUARD_LET_BIND_3^# else
+}
+func testGuardLetBinding4(x: FooStruct?) {
+  guard let y = x, y.#^GUARD_LET_BIND_4^# {}
+}
+func testGuardLetBinding5(x: FooStruct?) {
+  guard let y = x, let z = y.#^GUARD_LET_BIND_5^# else {}
+}
+
+// FOOSTRUCT_DOT: Begin completions
+// FOOSTRUCT_DOT-DAG: Decl[InstanceVar]/CurrNominal:      instanceVar[#Int#];
+// FOOSTRUCT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   boolGen()[#Bool#];
+// FOOSTRUCT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   intGen()[#Int#];
+// FOOSTRUCT_DOT: End completions


### PR DESCRIPTION
* Explanation: Code-completion did not work inside an `if let` condition when the base expression was itself bound in a previous condition of the same `if let`.
* Scope: Affects code-completion of variables bound in an `if let` condition in subsequent conditions.
* Radar: rdar://problem/32818340
* Risk: Low; only affects parsing during code-completion.
* Testing: Regression tests added.
