### PR TITLE
master-next: Update comment style in inline asm to match clang r311325.

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -50,7 +50,7 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
 
   // arm64 requires marker assembly for objc_retainAutoreleasedReturnValue.
   target.ObjCRetainAutoreleasedReturnValueMarker =
-    "mov\tfp, fp\t\t# marker for objc_retainAutoreleaseReturnValue";
+    "mov\tfp, fp\t\t// marker for objc_retainAutoreleaseReturnValue";
 
   // arm64 requires ISA-masking.
   target.ObjCUseISAMask = true;
@@ -97,7 +97,7 @@ static void configureARM(IRGenModule &IGM, const llvm::Triple &triple,
                          SwiftTargetInfo &target) {
   // ARM requires marker assembly for objc_retainAutoreleasedReturnValue.
   target.ObjCRetainAutoreleasedReturnValueMarker =
-    "mov\tr7, r7\t\t@ marker for objc_retainAutoreleaseReturnValue";
+    "mov\tr7, r7\t\t// marker for objc_retainAutoreleaseReturnValue";
 
   // armv7k has opaque ISAs which must go through the ObjC runtime.
   if (triple.getSubArch() == llvm::Triple::SubArchType::ARMSubArch_v7k)


### PR DESCRIPTION
LLVM no longer accepts hash markers for comments.