### PR TITLE
[QoI] Fix crash while trying to compute default parameters

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -786,21 +786,23 @@ void swift::computeDefaultMap(Type type, const ValueDecl *paramOwner,
   switch (type->getKind()) {
   case TypeKind::Tuple: {
     auto tupleTy = cast<TupleType>(type.getPointer());
-    
-    // FIXME: In the weird case where we have a tuple type that should
-    // be wrapped in a ParenType but isn't, just... forget it happened.
-    if (paramList && tupleTy->getNumElements() != paramList->size() &&
-        paramList->size() == 1)
+
+    // Arguments and parameters are not guaranteed to always line-up
+    // perfectly, e.g. failure diagnostics tries to match argument type
+    // to different "candidate" parameters.
+    if (paramList && tupleTy->getNumElements() != paramList->size())
       paramList = nullptr;
-    
+
     for (auto i : range(0, tupleTy->getNumElements())) {
-      outDefaultMap.push_back(paramList && paramList->get(i)->isDefaultArgument());
+      outDefaultMap.push_back(paramList &&
+                              paramList->get(i)->isDefaultArgument());
     }
     break;
   }
       
   case TypeKind::Paren: {
-    outDefaultMap.push_back(paramList && paramList->get(0)->isDefaultArgument());
+    outDefaultMap.push_back(paramList && paramList->size() == 1 &&
+                            paramList->get(0)->isDefaultArgument());
     break;
   }
       

--- a/validation-test/compiler_crashers_2_fixed/0117-rdar33433087.swift
+++ b/validation-test/compiler_crashers_2_fixed/0117-rdar33433087.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+class C {
+  private init() {} // expected-error {{declared here}}
+  init(n: Int) {}
+}
+
+_ = C()
+// expected-error@-1 {{'C' initializer is inaccessible due to 'private' protection level}}


### PR DESCRIPTION
Arguments and parameters are not guaranteed to line-up perfectly,
because failure diagnostics sometimes has to much one argument
to different "candidate" parameters to see which one is closer,
so let's teach `computeDefaultMap` to respect that.

Resolves: rdar://problem/33433087.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
