### PR TITLE
Add NumSourceLines{,PerSecond} counters, fix SourceFile counters for WMO mode

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -74,6 +74,8 @@ public:
   struct AlwaysOnFrontendCounters
   {
     size_t NumSourceBuffers;
+    size_t NumSourceLines;
+    size_t NumSourceLinesPerSecond;
     size_t NumLinkLibraries;
     size_t NumLoadedModules;
     size_t NumImportedExternalDefinitions;
@@ -132,6 +134,7 @@ public:
 
 private:
   SmallString<128> Filename;
+  llvm::TimeRecord StartedTime;
   std::unique_ptr<llvm::NamedRegionTimer> Timer;
 
   std::unique_ptr<AlwaysOnDriverCounters> DriverCounters;

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -123,6 +123,7 @@ UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
                                            StringRef AuxName,
                                            StringRef Directory)
   : Filename(Directory),
+    StartedTime(llvm::TimeRecord::getCurrentTime()),
     Timer(make_unique<NamedRegionTimer>(AuxName,
                                         "Building Target",
                                         ProgramName, "Running Program"))
@@ -160,6 +161,8 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
     auto &C = getFrontendCounters();
 
     PUBLISH_STAT(C, "AST", NumSourceBuffers);
+    PUBLISH_STAT(C, "AST", NumSourceLines);
+    PUBLISH_STAT(C, "AST", NumSourceLinesPerSecond);
     PUBLISH_STAT(C, "AST", NumLinkLibraries);
     PUBLISH_STAT(C, "AST", NumLoadedModules);
     PUBLISH_STAT(C, "AST", NumImportedExternalDefinitions);
@@ -250,6 +253,8 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
     auto &C = getFrontendCounters();
 
     PRINT_STAT(OS, delim, C, "AST", NumSourceBuffers);
+    PRINT_STAT(OS, delim, C, "AST", NumSourceLines);
+    PRINT_STAT(OS, delim, C, "AST", NumSourceLinesPerSecond);
     PRINT_STAT(OS, delim, C, "AST", NumLinkLibraries);
     PRINT_STAT(OS, delim, C, "AST", NumLoadedModules);
     PRINT_STAT(OS, delim, C, "AST", NumImportedExternalDefinitions);
@@ -338,9 +343,22 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
   // we're repurposing a bit here.
   Timer.reset();
 
+  // We currently do this by manual TimeRecord keeping because LLVM has decided
+  // not to allow access to the Timers inside NamedRegionTimers.
+  auto ElapsedTime = llvm::TimeRecord::getCurrentTime();
+  ElapsedTime -= StartedTime;
+
   if (DriverCounters) {
     auto &C = getDriverCounters();
     C.ChildrenMaxRSS = getChildrenMaxResidentSetSize();
+  }
+
+  if (FrontendCounters) {
+    auto &C = getFrontendCounters();
+    // Convenience calculation for crude top-level "absolute speed".
+    if (C.NumSourceLines != 0 && ElapsedTime.getProcessTime() != 0.0)
+      C.NumSourceLinesPerSecond = (size_t) (((double)C.NumSourceLines) /
+                                            ElapsedTime.getProcessTime());
   }
 
   std::error_code EC;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -429,6 +429,27 @@ static bool emitIndexData(SourceFile *PrimarySourceFile,
       const CompilerInvocation &Invocation,
       CompilerInstance &Instance);
 
+static void countStatsOfSourceFile(UnifiedStatsReporter &Stats,
+                                   CompilerInstance &Instance,
+                                   SourceFile *SF) {
+  auto &C = Stats.getFrontendCounters();
+  auto &SM = Instance.getSourceMgr();
+  C.NumDecls += SF->Decls.size();
+  C.NumLocalTypeDecls += SF->LocalTypeDecls.size();
+  C.NumObjCMethods += SF->ObjCMethods.size();
+  C.NumInfixOperators += SF->InfixOperators.size();
+  C.NumPostfixOperators += SF->PostfixOperators.size();
+  C.NumPrefixOperators += SF->PrefixOperators.size();
+  C.NumPrecedenceGroups += SF->PrecedenceGroups.size();
+  C.NumUsedConformances += SF->getUsedConformances().size();
+
+  auto bufID = SF->getBufferID();
+  if (bufID.hasValue()) {
+    C.NumSourceLines +=
+      SM.getEntireTextForBuffer(bufID.getValue()).count('\n');
+  }
+}
+
 static void countStatsPostSema(UnifiedStatsReporter &Stats,
                                CompilerInstance& Instance) {
   auto &C = Stats.getFrontendCounters();
@@ -452,19 +473,13 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
   }
 
   if (auto *SF = Instance.getPrimarySourceFile()) {
-    C.NumDecls = SF->Decls.size();
-    C.NumLocalTypeDecls = SF->LocalTypeDecls.size();
-    C.NumObjCMethods = SF->ObjCMethods.size();
-    C.NumInfixOperators = SF->InfixOperators.size();
-    C.NumPostfixOperators = SF->PostfixOperators.size();
-    C.NumPrefixOperators = SF->PrefixOperators.size();
-    C.NumPrecedenceGroups = SF->PrecedenceGroups.size();
-    C.NumUsedConformances = SF->getUsedConformances().size();
-
-    auto bufID = SF->getBufferID();
-    if (bufID.hasValue()) {
-      C.NumSourceLines =
-        SM.getEntireTextForBuffer(bufID.getValue()).count('\n');
+    countStatsOfSourceFile(Stats, Instance, SF);
+  } else if (auto *M = Instance.getMainModule()) {
+    // No primary source file, but a main module; this is WMO-mode
+    for (auto *F : M->getFiles()) {
+      if (auto *SF = dyn_cast<SourceFile>(F)) {
+        countStatsOfSourceFile(Stats, Instance, SF);
+      }
     }
   }
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -432,7 +432,8 @@ static bool emitIndexData(SourceFile *PrimarySourceFile,
 static void countStatsPostSema(UnifiedStatsReporter &Stats,
                                CompilerInstance& Instance) {
   auto &C = Stats.getFrontendCounters();
-  C.NumSourceBuffers = Instance.getSourceMgr().getLLVMSourceMgr().getNumBuffers();
+  auto &SM = Instance.getSourceMgr();
+  C.NumSourceBuffers = SM.getLLVMSourceMgr().getNumBuffers();
   C.NumLinkLibraries = Instance.getLinkLibraries().size();
 
   auto const &AST = Instance.getASTContext();
@@ -459,6 +460,12 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
     C.NumPrefixOperators = SF->PrefixOperators.size();
     C.NumPrecedenceGroups = SF->PrecedenceGroups.size();
     C.NumUsedConformances = SF->getUsedConformances().size();
+
+    auto bufID = SF->getBufferID();
+    if (bufID.hasValue()) {
+      C.NumSourceLines =
+        SM.getEntireTextForBuffer(bufID.getValue()).count('\n');
+    }
   }
 }
 

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -15,6 +15,7 @@
 // RUN: %FileCheck -input-file %t/driver.csv %s
 // RUN: %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
 
+// CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}
 // CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
 // CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
 


### PR DESCRIPTION
This adds a new pair of counters to UnifiedStatsReporter's frontend counters that gives us a count of source lines (against-which to normalize other counters in downstream reporting) as well as a pre-normalized (greppable), very crude top-level absolute-speed value in terms of "lines compiled per second" to eyeball, track over time, and compare between codebases (don't take it any more seriously than, say, within an order of magnitude).

Also contains a change to fix per-SourceFile counters to work in WMO mode, not just primary-file mode.