### PR TITLE
Increase the max number of possible @_specialize attributes for a SILFunction

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 357; // Last change: UnconditionalCheckedCastAddr.
+const uint16_t VERSION_MINOR = 358; // Last change: Increase the max number of possible @_specialize attribiutes.
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -268,7 +268,7 @@ namespace sil_block {
                      BCFixed<1>,  // global_init
                      BCFixed<2>,  // inlineStrategy
                      BCFixed<2>,  // side effect info.
-                     BCFixed<2>,  // number of specialize attributes
+                     BCFixed<16>,  // number of specialize attributes
                      BCFixed<1>,  // has qualified ownership
                      TypeIDField, // SILFunctionType
                      GenericEnvironmentIDField,


### PR DESCRIPTION
The number was limited to 3 attributes for some reason. Now a SILFunction may have up to 2^16 such attributes, which should be enough for a while ;-)

Fixes rdar://problem/34026325
