### PR TITLE
[Diagnostics QoI] Walk into the closure of a CaptureListExpr

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2259,6 +2259,7 @@ private:
   bool visitCoerceExpr(CoerceExpr *CE);
   bool visitIfExpr(IfExpr *IE);
   bool visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E);
+  bool visitCaptureListExpr(CaptureListExpr *CLE);
   bool visitClosureExpr(ClosureExpr *CE);
   bool visitKeyPathExpr(KeyPathExpr *KPE);
 };
@@ -7243,6 +7244,11 @@ visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E) {
   // Don't walk the children for this node, it leads to multiple diagnostics
   // because of how sema injects this node into the type checker.
   return false;
+}
+
+bool FailureDiagnosis::visitCaptureListExpr(CaptureListExpr *CLE) {
+  // Always walk into the closure of a capture list expression.
+  return visitClosureExpr(CLE->getClosureBody());
 }
 
 static bool isInvalidClosureResultType(Type resultType) {

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -10,6 +10,7 @@ _ = myMap(intArray, { x -> String in String(x) } )
 // Closures with too few parameters.
 func foo(_ x: (Int, Int) -> Int) {}
 foo({$0}) // expected-error{{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 1 was used in closure body}}
+foo({ [intArray] in $0}) // expected-error{{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 1 was used in closure body}}
 
 struct X {}
 func mySort(_ array: [String], _ predicate: (String, String) -> Bool) -> [String] {}


### PR DESCRIPTION
Previously, the failure diagnosis visitor would default to the generic expr walk here which would wind
up type checking the closure body then call it a day. Walk into the closure of a capture list expression to emit better diagnostics.

Resolves [SR-5747](https://bugs.swift.org/browse/SR-5747).