### PR TITLE
[4.0] [QoI] Fix crash while trying to compute default parameters

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -780,10 +780,10 @@ swift::decomposeParamType(Type type, const ValueDecl *paramOwner,
   case TypeKind::Tuple: {
     auto tupleTy = cast<TupleType>(type.getPointer());
 
-    // FIXME: In the weird case where we have a tuple type that should
-    // be wrapped in a ParenType but isn't, just... forget it happened.
-    if (paramList && tupleTy->getNumElements() != paramList->size() &&
-        paramList->size() == 1)
+    // Arguments and parameters are not guaranteed to always line-up
+    // perfectly, e.g. failure diagnostics tries to match argument type
+    // to different "candidate" parameters.
+    if (paramList && tupleTy->getNumElements() != paramList->size())
       paramList = nullptr;
 
     for (auto i : range(0, tupleTy->getNumElements())) {
@@ -804,7 +804,8 @@ swift::decomposeParamType(Type type, const ValueDecl *paramOwner,
     CallArgParam argParam;
     argParam.Ty = cast<ParenType>(type.getPointer())->getUnderlyingType();
     argParam.HasDefaultArgument =
-        paramList && paramList->get(0)->isDefaultArgument();
+        paramList && paramList->size() == 1 &&
+        paramList->get(0)->isDefaultArgument();
     result.push_back(argParam);
     break;
   }

--- a/validation-test/compiler_crashers_2_fixed/0117-rdar33433087.swift
+++ b/validation-test/compiler_crashers_2_fixed/0117-rdar33433087.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+class C {
+  private init() {} // expected-error {{declared here}}
+  init(n: Int) {}
+}
+
+_ = C()
+// expected-error@-1 {{'C' initializer is inaccessible due to 'private' protection level}}


### PR DESCRIPTION
* Description: Arguments and parameters are not guaranteed to line-up perfectly,
because failure diagnostics sometimes has to match one argument
to different "candidate" parameters to see which one is closer,
so let's teach `computeDefaultMap` to respect that.

* Origination: One of the code completion crashers.

* Risk: Low.

* Tested: Added new tests, Swift CI.

* Reviewed by: Doug Gregor, Ben Langmuir.

* Resolves: rdar://problem/33433087.
(cherry picked from commit 2d49d1202cd432188619776f07a7eef3c5c49034)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
