### PR TITLE
[4.0] [Driver] Obey -emit-module-path in -wmo that only does -emit-module.

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2093,8 +2093,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
   }
 
   // Choose the swiftmodule output path.
-  if (OI.ShouldGenerateModule && isa<CompileJobAction>(JA) &&
-      Output->getPrimaryOutputType() != types::TY_SwiftModuleFile) {
+  if (OI.ShouldGenerateModule && isa<CompileJobAction>(JA)) {
     StringRef OFMModuleOutputPath;
     if (OutputMap) {
       auto iter = OutputMap->find(types::TY_SwiftModuleFile);

--- a/test/Frontend/emit-module-path-wmo.swift
+++ b/test/Frontend/emit-module-path-wmo.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// Default output:
+// RUN: cd %t; %target-swift-frontend -emit-module -module-name foo -whole-module-optimization %s
+// RUN: test -f %t/foo.swiftmodule
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name foo -emit-module-path %t/bar.swiftmodule -whole-module-optimization %s
+// RUN: test -f %t/bar.swiftmodule
+// RUN: not test -f %t/foo.swiftmodule


### PR DESCRIPTION
Radar (and possibly SR Issue): rdar://problem/33737532
Explanation: If a compile job used -whole-module-optimization and only did -emit-module (i.e. not -emit-library or -c, etc.), then the -o argument is used instead of -emit-module-path and the latter is completely, and silently ignored.
Scope of Issue:  This shouldn't affect anyone, since it's rare to compile with only `-emit-module`, and, furthermore, the -o argument is still obeyed so existing compiles will still work.
Origination: Someone was wanting to compile with `-emit-module -emit-module-path ... -emit-tbd`, and `-emit-tbd` (currently) requires `-wmo`. The problem surfaced in this case because `-emit-tbd` isn't a "full" output like `-emit-library` or `-c`.
Risk: Low.
Reviewed By: Doug Gregor
Testing: CI with test specifically for this case.
Directions for QE: N/A