### PR TITLE
[ConstraintSolver] When searching for viable bindings treat `DynamicT…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -204,13 +204,25 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
     case ConstraintKind::BridgingConversion:
     case ConstraintKind::CheckedCast:
-    case ConstraintKind::DynamicTypeOf:
     case ConstraintKind::EscapableFunctionOf:
     case ConstraintKind::OpenedExistentialOf:
     case ConstraintKind::KeyPath:
     case ConstraintKind::KeyPathApplication:
       // Constraints from which we can't do anything.
       continue;
+
+    case ConstraintKind::DynamicTypeOf: {
+      // Direct binding of the left-hand side could result
+      // in `DynamicTypeOf` failure if right-hand side is
+      // bound (because 'Bind' requires equal types to
+      // succeed), or left is bound to Any which is not an
+      // [existential] metatype.
+      if (constraint->getFirstType()->isEqual(typeVar))
+        return {};
+
+      // This is right-hand side, let's continue.
+      continue;
+    }
 
     case ConstraintKind::Defaultable:
       // Do these in a separate pass.

--- a/test/Constraints/type_of.swift
+++ b/test/Constraints/type_of.swift
@@ -36,3 +36,23 @@ let _: Q.Type = Swift.type(of: Q())
 let _: R = Swift.type(of: Q()) // expected-error{{}}
 let _: Q.Type = main.type(of: Q()) // expected-error{{}}
 let _: R = main.type(of: Q()) 
+
+// Let's make sure that binding of the left-hand side
+// of the dynamic-type-of constraint is not attempted.
+
+class C {
+   typealias T = Int
+}
+
+class D : C {
+   typealias T = Float
+}
+
+func foo(_: Any...) {}
+
+func bar() -> Int { return 42 }    // expected-note {{found this candidate}}
+func bar() -> Float { return 0.0 } // expected-note {{found this candidate}}
+
+foo(type(of: D.T.self)) // Ok
+let _: Any = type(of: D.T.self) // Ok
+foo(type(of: bar())) // expected-error {{ambiguous use of 'bar()'}}


### PR DESCRIPTION
…ypeOf` constraint specially

When trying to find bindings let's avoid type variables which
represent left-hand side of the `DynamicTypeOf` constraint,
 because such type variables might be (implicitly) convertible to
[existential] metatype, but at the same time bound to something else
(e.g. Any), which fails when solver tries to simplify `DynamicTypeOf`
constraint itself.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
