### PR TITLE
Sema: Fix crash when ternary operator is applied to an lvalue of IUO type [4.0]

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7898,11 +7898,15 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
 
 Expr *
 Solution::convertBooleanTypeToBuiltinI1(Expr *expr, ConstraintLocator *locator) const {
-  // FIXME: Cache name.
   auto &cs = getConstraintSystem();
+
+  // Load lvalues here.
+  expr = cs.coerceToRValue(expr);
+
   auto &tc = cs.getTypeChecker();
   auto &ctx = tc.Context;
-  auto type = cs.getType(expr)->getRValueType();
+
+  auto type = cs.getType(expr);
 
   // Member accesses are permitted to implicitly look through
   // ImplicitlyUnwrappedOptional<T>.

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -50,3 +50,14 @@ func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK:   br [[CONT]]
   return x ? a : b
 }
+
+// <rdar://problem/31595572> - crash when conditional expression is an
+// lvalue of IUO type
+
+// CHECK-LABEL: sil hidden @_T07if_expr18iuo_lvalue_ternarySiSQySbGz1x_tF : $@convention(thin) (@inout Optional<Bool>) -> Int
+// CHECK: [[IUO_BOOL_ADDR:%.*]] = begin_access [read] [unknown] %0 : $*Optional<Bool>
+// CHECK: [[IUO_BOOL:%.*]] = load [trivial] [[IUO_BOOL_ADDR]] : $*Optional<Bool>
+// CHECK: switch_enum [[IUO_BOOL]]
+func iuo_lvalue_ternary(x: inout Bool!) -> Int {
+  return x ? 1 : 0
+}


### PR DESCRIPTION
* Description: Fixes a crash when applying the ternary operator to certain expressions involving mutable properties.

* Scope of the issue: Reported externally several times over the last few months.

* Origination: Probably has been there for a long time.

* Risk: Very low.

* Radar: <rdar://problem/34048306>

* Reviewed by: @rudkx 