### PR TITLE
AST: Fix bogus diagnostic with bad conformance requirements in generic signature [4.0]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1668,11 +1668,12 @@ ERROR(protocol_composition_one_class,none,
       "contains class %1", (Type, Type))
 
 ERROR(requires_conformance_nonprotocol,none,
-      "type %0 constrained to non-protocol type %1", (TypeLoc, TypeLoc))
+      "type %0 constrained to non-protocol, non-class type %1",
+      (TypeLoc, TypeLoc))
 ERROR(requires_not_suitable_archetype,none,
-      "%select{|first |second }0type %1 in %select{conformance|same-type}2 "
-      "requirement does not refer to a generic parameter or associated type",
-      (int, TypeLoc, int))
+      "type %0 in conformance requirement does not refer to a "
+      "generic parameter or associated type",
+      (TypeLoc))
 ERROR(requires_no_same_type_archetype,none,
       "neither type in same-type refers to a generic parameter or "
       "associated type",

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2834,7 +2834,7 @@ ConstraintResult GenericSignatureBuilder::addLayoutRequirement(
     // complain.
     if (source.isExplicit() && source.getLoc().isValid()) {
       Diags.diagnose(source.getLoc(), diag::requires_not_suitable_archetype,
-                     0, TypeLoc::withoutLoc(resolvedSubject->getType()), 0);
+                     TypeLoc::withoutLoc(resolvedSubject->getType()));
       return ConstraintResult::Concrete;
     }
 
@@ -2956,20 +2956,14 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
   }
 
   // The right-hand side needs to be concrete.
+  Type constraintType;
   if (auto constraintPA = resolvedConstraint->getPotentialArchetype()) {
-    // The constraint type isn't a statically-known constraint.
-    if (source.getLoc().isValid()) {
-      auto constraintType = constraintPA->getDependentType(Impl->GenericParams);
-      Diags.diagnose(source.getLoc(), diag::requires_not_suitable_archetype,
-                     1, TypeLoc::withoutLoc(constraintType), 0);
-    }
-
-    return ConstraintResult::Concrete;
+    constraintType = constraintPA->getDependentType(Impl->GenericParams);
+  } else {
+    constraintType = resolvedConstraint->getType();
   }
 
   // Check whether we have a reasonable constraint type at all.
-  auto constraintType = resolvedConstraint->getType();
-  assert(constraintType && "Missing constraint type?");
   if (!constraintType->isExistentialType() &&
       !constraintType->getClassOrBoundGenericClass()) {
     if (source.getLoc().isValid() && !constraintType->hasError()) {
@@ -3004,7 +2998,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
     if (source.isExplicit()) {
       if (source.getLoc().isValid()) {
         Diags.diagnose(source.getLoc(), diag::requires_not_suitable_archetype,
-                       0, TypeLoc::withoutLoc(resolvedSubject->getType()), 0);
+                       TypeLoc::withoutLoc(resolvedSubject->getType()));
       }
 
       return ConstraintResult::Concrete;

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -284,7 +284,7 @@ func beginsWith3<S0: P2, S1: P2>(_ seq1: S0, _ seq2: S1) -> Bool
 // Bogus requirements
 //===----------------------------------------------------------------------===//
 func nonTypeReq<T>(_: T) where T : Wibble {} // expected-error{{use of undeclared type 'Wibble'}}
-func badProtocolReq<T>(_: T) where T : Int {} // expected-error{{type 'T' constrained to non-protocol type 'Int'}}
+func badProtocolReq<T>(_: T) where T : Int {} // expected-error{{type 'T' constrained to non-protocol, non-class type 'Int'}}
 
 func nonTypeSameType<T>(_: T) where T == Wibble {} // expected-error{{use of undeclared type 'Wibble'}}
 func nonTypeSameType2<T>(_: T) where Wibble == T {} // expected-error{{use of undeclared type 'Wibble'}}

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -101,3 +101,12 @@ protocol P1 {
   associatedtype C where ThisTypeDoesNotExist == ThisTypeDoesNotExist
   // expected-error@-1 2{{use of undeclared type 'ThisTypeDoesNotExist'}}
 }
+
+// Diagnostic referred to the wrong type - <rdar://problem/33604221>
+
+protocol E { associatedtype XYZ }
+
+class P<N> {
+  func q<A>(b:A) where A:E, N : A.XYZ { return }
+  // expected-error@-1 {{type 'N' constrained to non-protocol, non-class type 'A.XYZ'}}
+}

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -45,7 +45,7 @@ var TopLevelVar: TopLevelVar? { return nil } // expected-error 2 {{use of undecl
 
 // FIXME: The first error is redundant, isn't correct in what it states, and
 // also should be emitted on the inheritance clause.
-protocol AProtocol { // expected-error {{first type 'Self.e' in conformance requirement does not refer to a generic parameter or associated type}}
+protocol AProtocol { // expected-error {{type 'Self.e' constrained to non-protocol, non-class type 'Self.e'}}
   associatedtype e : e // expected-error {{inheritance from non-protocol, non-class type 'Self.e'}}
 }
 

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -151,10 +151,10 @@ public func anotherFuncWithTwoGenericParameters<X: P, Y>(x: X, y: Y) {
 
 @_specialize(where T: P) // expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
 @_specialize(where T: Int) // expected-error{{Only conformances to protocol types are supported by '_specialize' attribute}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
-// expected-error@-1{{type 'T' constrained to non-protocol type 'Int'}}
+// expected-error@-1{{type 'T' constrained to non-protocol, non-class type 'Int'}}
 
 @_specialize(where T: S1) // expected-error{{Only conformances to protocol types are supported by '_specialize' attribute}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
-// expected-error@-1{{type 'T' constrained to non-protocol type 'S1'}}
+// expected-error@-1{{type 'T' constrained to non-protocol, non-class type 'S1'}}
 @_specialize(where T: C1) // expected-error{{Only conformances to protocol types are supported by '_specialize' attribute}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
 @_specialize(where Int: P) // expected-error{{type 'Int' in conformance requirement does not refer to a generic parameter or associated type}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 0, but expected 1)}} expected-error{{Missing constraint for 'T' in '_specialize' attribute}}
 func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -40,7 +40,7 @@ func test1() {
 
 protocol Bogus : Int {}
 // expected-error@-1{{inheritance from non-protocol type 'Int'}}
-// expected-error@-2{{type 'Self' constrained to non-protocol type 'Int'}}
+// expected-error@-2{{type 'Self' constrained to non-protocol, non-class type 'Int'}}
 
 // Explicit conformance checks (successful).
 

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -40,11 +40,11 @@ protocol Base {
 // FIXME: This used to /not/ error in Swift 3. It didn't impose any statically-
 // enforced requirements, but the compiler crashed if you used anything but the
 // same type.
-protocol Sub1: Base { // expected-error {{first type 'Self.Assoc' in conformance requirement does not refer to a generic parameter or associated type}}
+protocol Sub1: Base { // expected-error {{type 'Self.SubAssoc' constrained to non-protocol, non-class type 'Self.Assoc'}}
   associatedtype SubAssoc: Assoc // expected-error {{inheritance from non-protocol, non-class type 'Self.Assoc'}}
 }
 // FIXME: This error is incorrect in what it states and should be emitted on
 // the where-clause.
-protocol Sub2: Base { // expected-error {{first type 'Self.Assoc' in conformance requirement does not refer to a generic parameter or associated type}}
+protocol Sub2: Base { // expected-error {{type 'Self.SubAssoc' constrained to non-protocol, non-class type 'Self.Assoc'}}
   associatedtype SubAssoc where SubAssoc: Assoc
 }


### PR DESCRIPTION
* Description: Fix misleading diagnostic emitted with invalid code.

* Scope of the issue: Affects people using generics.

* Risk: Very low.

* Reviewed by: @DougGregor

* Radar: <rdar://problem/34048495>.
