### PR TITLE
Sema: Fix type mixup with unbound method references [4.0]

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1281,7 +1281,8 @@ ConstraintSystem::getTypeOfMemberReference(
   } else {
     // For an unbound instance method reference, replace the 'Self'
     // parameter with the base type.
-    type = openedFnType->replaceSelfParameterType(baseObjTy);
+    openedType = openedFnType->replaceSelfParameterType(baseObjTy);
+    type = openedType;
   }
 
   // When accessing protocol members with an existential base, replace

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -167,3 +167,25 @@ struct StructWithStaticVar {
   init() {
   }
 }
+
+// Make sure unbound method references on class hierarchies are
+// properly represented in the AST
+
+class Base {
+  func method1() -> Self { return self }
+  func method2() -> Self { return self }
+}
+
+class Derived : Base {
+  override func method2() -> Self { return self }
+}
+
+func generic<T>(arg: T) { }
+
+func unboundMethodReferences() {
+  generic(arg: Derived.method1)
+  generic(arg: Derived.method2)
+
+  _ = type(of: Derived.method1)
+  _ = type(of: Derived.method2)
+}


### PR DESCRIPTION
* Description: Fixes a crash that's possible with a construct that's mostly useless, but beginners might mistakenly write it expecting it to work.

* Scope of the issue: This was reported by a customer while testing a development toolchain trying to reproduce an unrelated issue.

* Risk: Low.

* Reviewed by: @rudkx

* Radar: <rdar://problem/34048597>