### PR TITLE
Update -sanitize=fuzzer option to take into account new libFuzzer location

### DIFF
--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -53,7 +53,6 @@
 # * clang-resource-dir-symlink -- install a symlink to the Clang resource
 #   directory (which contains builtin headers) under 'lib/swift/clang'.  This is
 #   useful when Clang and Swift are installed side-by-side.
-# * llvm-resource-dir-symlink -- install a symlink to the LLVM resource directory.
 # * stdlib -- the Swift standard library.
 # * stdlib-experimental -- the Swift standard library module for experimental
 #   APIs.
@@ -67,7 +66,7 @@
 # * toolchain-dev-tools -- install development tools useful in a shared toolchain
 # * dev -- headers and libraries required to use Swift compiler as a library.
 set(_SWIFT_DEFINED_COMPONENTS
-  "autolink-driver;compiler;clang-builtin-headers;clang-resource-dir-symlink;llvm-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;stdlib;stdlib-experimental;swift-syntax;sdk-overlay;editor-integration;tools;testsuite-tools;toolchain-dev-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers")
+  "autolink-driver;compiler;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;stdlib;stdlib-experimental;swift-syntax;sdk-overlay;editor-integration;tools;testsuite-tools;toolchain-dev-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers")
 
 macro(swift_configure_components)
   # Set the SWIFT_INSTALL_COMPONENTS variable to the default value if it is not passed in via -D

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -156,12 +156,6 @@ swift_install_symlink_component(clang-resource-dir-symlink
   TARGET ../clang/${CLANG_VERSION}
   DESTINATION "lib/swift")
 
-# Adding link to "llvm" at install time.
-swift_install_symlink_component(llvm-resource-dir-symlink
-  LINK_NAME llvm
-  TARGET ../
-  DESTINATION "lib/swift")
-
 # Possibly install Clang headers under Clang's resource directory in case we
 # need to use a different version of the headers than the installed Clang. This
 # should be used in conjunction with clang-resource-dir-symlink.

--- a/test/Driver/fuzzer.swift
+++ b/test/Driver/fuzzer.swift
@@ -1,6 +1,6 @@
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address %s | %FileCheck -check-prefix=LIBFUZZER %s
 
-// LIBFUZZER: libLLVMFuzzer.a
+// LIBFUZZER: libclang_rt.fuzzer
 @_cdecl("LLVMFuzzerTestOneInput") public func fuzzOneInput(Data: UnsafePointer<CChar>, Size: CLong) -> CInt {
   return 0;
 }


### PR DESCRIPTION
This change will not pass tests yet, as it is dependent on llvm/clang/compiler-rt changes being cherry-picked (and those in turn will fail tests without this change).
Putting this out for code review.