### PR TITLE
[4.0] [Type checker] Guard against recursing into non-single-expression closures.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3523,6 +3523,10 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
       if (!E || isa<ErrorExpr>(E) || !E->getType())
         return { false, E };
 
+      if (auto *CE = dyn_cast<AbstractClosureExpr>(E))
+        if (!CE->hasSingleExpressionBody())
+          return { false, E };
+
       if (auto *coercion = dyn_cast<CoerceExpr>(E)) {
         if (E->getType()->isAny() && isa<ErasureExpr>(coercion->getSubExpr()))
           ErasureCoercedToAny.insert(coercion->getSubExpr());

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -555,3 +555,25 @@ extension A_SR_5030 {
     // expected-error@-1 {{cannot convert value of type '(idx: (Int))' to closure result type 'Int'}}
   }
 }
+
+// rdar://problem/33296619
+let u = rdar33296619().element //expected-error {{use of unresolved identifier 'rdar33296619'}}
+
+[1].forEach { _ in
+  _ = "\(u)"
+  _ = 1 + "hi" // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}}
+  // expected-note@-1 {{overloads for '+' exist with these partially matching parameter lists}}
+}
+
+class SR5666 {
+  var property: String?
+}
+
+func testSR5666(cs: [SR5666?]) -> [String?] {
+  return cs.map({ c in
+      let a = c.propertyWithTypo ?? "default"
+      // expected-error@-1 {{value of type 'SR5666?' has no member 'propertyWithTypo'}}
+      let b = "\(a)"
+      return b
+    })
+}


### PR DESCRIPTION
Description: Fixes a very common crasher that happens when there are type-checking problems in multi-statement closures.

Origination: This was introduced when the diagnostics pass to diagnose unintended optional behavior was added.

Risk: Very low.

Reviewed by: @slavapestov 

Radar: rdar://problem/33296619

----------

**Commit details**
In diagnoseUnintendedOptionalBehavior, guard against recursing into
non-single-expression closures. If we recurse into these, we can end
up hitting malformed ASTs that we do not expect. These happen when we
successfully type-check the code outside of the closure, but the
closure body has errors.

There are potentially other similar issues in other miscellaneous
diagnostics walks.

I opened https://bugs.swift.org/browse/SR-5758 to remind us to review
these and ensure they do not have similar issues.

Fixes rdar://problem/33296619 (aka SR-5666).
