### PR TITLE
Unify the capitalization across all user-visible error messages 

### DIFF
--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -30,17 +30,17 @@ public func withOverriddenLocaleCurrentLocale<Result>(
   guard let oldMethod = class_getClassMethod(
     NSLocale.self, #selector(getter: NSLocale.current)) as Optional
   else {
-    _preconditionFailure("could not find +[Locale currentLocale]")
+    _preconditionFailure("Could not find +[Locale currentLocale]")
   }
 
   guard let newMethod = class_getClassMethod(
     NSLocale.self, #selector(NSLocale._swiftUnittest_currentLocale)) as Optional
   else {
-    _preconditionFailure("could not find +[Locale _swiftUnittest_currentLocale]")
+    _preconditionFailure("Could not find +[Locale _swiftUnittest_currentLocale]")
   }
 
   precondition(_temporaryLocaleCurrentLocale == nil,
-    "nested calls to withOverriddenLocaleCurrentLocale are not supported")
+    "Nested calls to withOverriddenLocaleCurrentLocale are not supported")
 
   _temporaryLocaleCurrentLocale = temporaryLocale
   method_exchangeImplementations(oldMethod, newMethod)
@@ -57,7 +57,7 @@ public func withOverriddenLocaleCurrentLocale<Result>(
 ) -> Result {
   precondition(
     NSLocale.availableLocaleIdentifiers.contains(temporaryLocaleIdentifier),
-    "requested locale \(temporaryLocaleIdentifier) is not available")
+    "Requested locale \(temporaryLocaleIdentifier) is not available")
 
   return withOverriddenLocaleCurrentLocale(
     NSLocale(localeIdentifier: temporaryLocaleIdentifier), body)

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1137,7 +1137,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         @inline(__always)
         set {
-            precondition(count >= 0, "count must be positive")
+            precondition(count >= 0, "Count must be positive")
             if !isKnownUniquelyReferenced(&_backing) {
                 _backing = _backing.mutableCopy(_sliceRange)
             }
@@ -1181,7 +1181,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - warning: This method does not verify that the contents at pointer have enough space to hold `count` bytes.
     @inline(__always)
     public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, count: Int) {
-        precondition(count >= 0, "count of bytes to copy must be positive")
+        precondition(count >= 0, "Count of bytes to copy must be positive")
         if count == 0 { return }
         memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: _sliceRange.lowerBound), Swift.min(count, _sliceRange.count))
     }
@@ -1302,7 +1302,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     @inline(__always)
     public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
-        precondition(count >= 0, "count must be positive")
+        precondition(count >= 0, "Count must be positive")
         if count == 0 { return }
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -207,13 +207,13 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             get {
                 switch self {
                 case .empty:
-                    fatalError("index \(index) out of bounds of count 0")
+                    fatalError("Index \(index) out of bounds of count 0")
                     break
                 case .single(let first):
-                    precondition(index == 0, "index \(index) out of bounds of count 1")
+                    precondition(index == 0, "Index \(index) out of bounds of count 1")
                     return first
                 case .pair(let first, let second):
-                    precondition(index >= 0 && index < 2, "index \(index) out of bounds of count 2")
+                    precondition(index >= 0 && index < 2, "Index \(index) out of bounds of count 2")
                     return index == 0 ? first : second
                 case .array(let indexes):
                     return indexes[index]
@@ -222,14 +222,14 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             set {
                 switch self {
                 case .empty:
-                    fatalError("index \(index) out of bounds of count 0")
+                    fatalError("Index \(index) out of bounds of count 0")
                     break
                 case .single(_):
-                    precondition(index == 0, "index \(index) out of bounds of count 1")
+                    precondition(index == 0, "Index \(index) out of bounds of count 1")
                     self = .single(newValue)
                     break
                 case .pair(let first, let second):
-                    precondition(index >= 0 && index < 2, "index \(index) out of bounds of count 2")
+                    precondition(index >= 0 && index < 2, "Index \(index) out of bounds of count 2")
                     if index == 0 {
                         self = .pair(newValue, second)
                     } else {
@@ -253,7 +253,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     case (0, 0):
                         return .empty
                     default:
-                        fatalError("range \(range) is out of bounds of count 0")
+                        fatalError("Range \(range) is out of bounds of count 0")
                     }
                 case .single(let index):
                     switch (range.lowerBound, range.upperBound) {
@@ -263,7 +263,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     case (0, 1):
                         return .single(index)
                     default:
-                        fatalError("range \(range) is out of bounds of count 1")
+                        fatalError("Range \(range) is out of bounds of count 1")
                     }
                     return self
                 case .pair(let first, let second):
@@ -282,7 +282,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     case (0, 2):
                         return self
                     default:
-                        fatalError("range \(range) is out of bounds of count 2")
+                        fatalError("Range \(range) is out of bounds of count 2")
                     }
                 case .array(let indexes):
                     let slice = indexes[range]
@@ -301,7 +301,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             set {
                 switch self {
                 case .empty:
-                    precondition(range.lowerBound == 0 && range.upperBound == 0, "range \(range) is out of bounds of count 0")
+                    precondition(range.lowerBound == 0 && range.upperBound == 0, "Range \(range) is out of bounds of count 0")
                     self = newValue
                     break
                 case .single(let index):
@@ -337,7 +337,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                         self = .array([index] + other)
                         break
                     default:
-                        fatalError("range \(range) is out of bounds of count 1")
+                        fatalError("Range \(range) is out of bounds of count 1")
                     }
                 case .pair(let first, let second):
                     switch (range.lowerBound, range.upperBound) {
@@ -405,7 +405,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                         }
                         break
                     default:
-                        fatalError("range \(range) is out of bounds of count 2")
+                        fatalError("Range \(range) is out of bounds of count 2")
                     }
                 case .array(let indexes):
                     var newIndexes = indexes

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -782,7 +782,7 @@ public func XCTAssertEqual<T : FloatingPoint>(_ expression1: @autoclosure () thr
       
     default:
       // unknown type, fail with prejudice
-      _preconditionFailure("unsupported floating-point type passed to XCTAssertEqual")
+      _preconditionFailure("Unsupported floating-point type passed to XCTAssertEqual")
     }
     
     if !equalWithAccuracy {
@@ -858,7 +858,7 @@ public func XCTAssertNotEqual<T : FloatingPoint>(_ expression1: @autoclosure () 
       
     default:
       // unknown type, fail with prejudice
-      _preconditionFailure("unsupported floating-point type passed to XCTAssertNotEqual")
+      _preconditionFailure("Unsupported floating-point type passed to XCTAssertNotEqual")
     }
     
     if !notEqualWithAccuracy {

--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -111,16 +111,16 @@ public struct ${vectype} {
   public subscript(index: Int) -> ${scalar} {
     @_transparent
     get {
-      _precondition(index >= 0, "vector index out of range")
-      _precondition(index < ${count}, "vector index out of range")
+      _precondition(index >= 0, "Vector index out of range")
+      _precondition(index < ${count}, "Vector index out of range")
       let elt = Builtin.${extractelement}(_vector,
         Int32(index)._value)
       return ${scalar}(_bits: elt)
     }
     @_transparent
     set(value) {
-      _precondition(index >= 0, "vector index out of range")
-      _precondition(index < ${count}, "vector index out of range")
+      _precondition(index >= 0, "Vector index out of range")
+      _precondition(index < ${count}, "Vector index out of range")
       _vector = Builtin.${insertelement}(_vector,
         value._value,
         Int32(index)._value)
@@ -279,55 +279,55 @@ extension ${vectype} {
   @available(*, unavailable, renamed: "&+",
              message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
   public static func +(x: ${vectype}, y: ${vectype}) -> ${vectype} {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable, renamed: "&-",
              message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
   public static func -(x: ${vectype}, y: ${vectype}) -> ${vectype} {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable, renamed: "&*",
              message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
   public static func *(x: ${vectype}, y: ${vectype}) -> ${vectype} {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable, renamed: "&*",
              message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
   public static func *(x: ${vectype}, y: ${scalar}) -> ${vectype} {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable, renamed: "&*",
              message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
   public static func *(x: ${scalar}, y: ${vectype}) -> ${vectype} {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable,
              message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &+ y' instead")
   public static func +=(x: inout ${vectype}, y: ${vectype}) {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable,
              message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &- y' instead")
   public static func -=(x: inout ${vectype}, y: ${vectype}) {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable,
              message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &* y' instead")
   public static func *=(x: inout ${vectype}, y: ${vectype}) {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 
   @available(*, unavailable,
              message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &* y' instead")
   public static func *=(x: inout ${vectype}, y: ${scalar}) {
-    fatalError("unavailable function cannot be called")
+    fatalError("Unavailable function cannot be called")
   }
 %  end
 }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1489,7 +1489,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// - Returns: The element that was removed.
   @_inlineable
   public mutating func _customRemoveLast() -> Element? {
-    _precondition(count > 0, "can't removeLast from an empty ${Self}")
+    _precondition(count > 0, "Can't removeLast from an empty ${Self}")
     // FIXME(performance): if `self` is uniquely referenced, we should remove
     // the element as shown below (this will deallocate the element and
     // decrease memory use).  If `self` is not uniquely referenced, the code

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -46,7 +46,7 @@ public func assert(
   // Only assert in debug mode.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _assertionFailure("assertion failed", message(), file: file, line: line,
+      _assertionFailure("Assertion failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
     }
   }
@@ -88,7 +88,7 @@ public func precondition(
   // Only check in debug and release mode.  In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _assertionFailure("precondition failed", message(), file: file, line: line,
+      _assertionFailure("Precondition failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
     }
   } else if _isReleaseAssertConfiguration() {
@@ -128,7 +128,7 @@ public func assertionFailure(
   file: StaticString = #file, line: UInt = #line
 ) {
   if _isDebugAssertConfiguration() {
-    _assertionFailure("fatal error", message(), file: file, line: line,
+    _assertionFailure("Fatal error", message(), file: file, line: line,
       flags: _fatalErrorFlags())
   }
   else if _isFastAssertConfiguration() {
@@ -167,7 +167,7 @@ public func preconditionFailure(
 ) -> Never {
   // Only check in debug and release mode.  In release mode just trap.
   if _isDebugAssertConfiguration() {
-    _assertionFailure("fatal error", message(), file: file, line: line,
+    _assertionFailure("Fatal error", message(), file: file, line: line,
       flags: _fatalErrorFlags())
   } else if _isReleaseAssertConfiguration() {
     Builtin.int_trap()
@@ -188,7 +188,7 @@ public func fatalError(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) -> Never {
-  _assertionFailure("fatal error", message(), file: file, line: line,
+  _assertionFailure("Fatal error", message(), file: file, line: line,
     flags: _fatalErrorFlags())
 }
 
@@ -206,7 +206,7 @@ public func _precondition(
   // Only check in debug and release mode. In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _fatalErrorMessage("fatal error", message, file: file, line: line,
+      _fatalErrorMessage("Fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
     }
   } else if _isReleaseAssertConfiguration() {
@@ -235,7 +235,7 @@ public func _overflowChecked<T>(
   let (result, error) = args
   if _isDebugAssertConfiguration() {
     if _branchHint(error, expected: false) {
-      _fatalErrorMessage("fatal error", "Overflow/underflow", 
+      _fatalErrorMessage("Fatal error", "Overflow/underflow", 
         file: file, line: line, flags: _fatalErrorFlags())
     }
   } else {
@@ -260,7 +260,7 @@ public func _debugPrecondition(
   // Only check in debug mode.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _fatalErrorMessage("fatal error", message, file: file, line: line,
+      _fatalErrorMessage("Fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
     }
   }
@@ -290,7 +290,7 @@ public func _sanityCheck(
 ) {
 #if INTERNAL_CHECKS_ENABLED
   if !_branchHint(condition(), expected: true) {
-    _fatalErrorMessage("fatal error", message, file: file, line: line,
+    _fatalErrorMessage("Fatal error", message, file: file, line: line,
       flags: _fatalErrorFlags())
   }
 #endif

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -232,5 +232,5 @@ func _undefined<T>(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) -> T {
-  _assertionFailure("fatal error", message(), file: file, line: line, flags: 0)
+  _assertionFailure("Fatal error", message(), file: file, line: line, flags: 0)
 }

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -265,9 +265,9 @@ extension BidirectionalCollection where SubSequence == Self {
   ///   of the collection.
   public mutating func removeLast(_ n: Int) {
     if n == 0 { return }
-    _precondition(n >= 0, "number of elements to remove should be non-negative")
+    _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
-      "can't remove more items from a collection than it contains")
+      "Can't remove more items from a collection than it contains")
     self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
   }
 }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -110,7 +110,7 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 @_transparent
 public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   _precondition(MemoryLayout<T>.size == MemoryLayout<U>.size,
-    "can't unsafeBitCast between types of different sizes")
+    "Can't unsafeBitCast between types of different sizes")
   return Builtin.reinterpretCast(x)
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1010,10 +1010,10 @@ extension _Indexable {
     // FIXME: swift-3-indexing-model: tests.
     _precondition(
       bounds.lowerBound <= index,
-      "out of bounds: index < startIndex")
+      "Out of bounds: index < startIndex")
     _precondition(
       index < bounds.upperBound,
-      "out of bounds: index >= endIndex")
+      "Out of bounds: index >= endIndex")
   }
 
   @_inlineable
@@ -1021,10 +1021,10 @@ extension _Indexable {
     // FIXME: swift-3-indexing-model: tests.
     _precondition(
       bounds.lowerBound <= index,
-      "out of bounds: index < startIndex")
+      "Out of bounds: index < startIndex")
     _precondition(
       index <= bounds.upperBound,
-      "out of bounds: index > endIndex")
+      "Out of bounds: index > endIndex")
   }
 
   @_inlineable
@@ -1032,16 +1032,16 @@ extension _Indexable {
     // FIXME: swift-3-indexing-model: tests.
     _precondition(
       bounds.lowerBound <= range.lowerBound,
-      "out of bounds: range begins before startIndex")
+      "Out of bounds: range begins before startIndex")
     _precondition(
       range.lowerBound <= bounds.upperBound,
-      "out of bounds: range ends after endIndex")
+      "Out of bounds: range ends after endIndex")
     _precondition(
       bounds.lowerBound <= range.upperBound,
-      "out of bounds: range ends before bounds.lowerBound")
+      "Out of bounds: range ends before bounds.lowerBound")
     _precondition(
       range.upperBound <= bounds.upperBound,
-      "out of bounds: range begins after bounds.upperBound")
+      "Out of bounds: range begins after bounds.upperBound")
   }
 
   /// Returns an index that is the specified distance from the given index.
@@ -1870,7 +1870,7 @@ extension Collection where SubSequence == Self {
   @discardableResult
   public mutating func removeFirst() -> Element {
     // TODO: swift-3-indexing-model - review the following
-    _precondition(!isEmpty, "can't remove items from an empty collection")
+    _precondition(!isEmpty, "Can't remove items from an empty collection")
     let element = first!
     self = self[index(after: startIndex)..<endIndex]
     return element
@@ -1888,9 +1888,9 @@ extension Collection where SubSequence == Self {
   @_inlineable
   public mutating func removeFirst(_ n: Int) {
     if n == 0 { return }
-    _precondition(n >= 0, "number of elements to remove should be non-negative")
+    _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
-      "can't remove more items from a collection than it contains")
+      "Can't remove more items from a collection than it contains")
     self = self[index(startIndex, offsetBy: numericCast(n))..<endIndex]
   }
 }

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -151,14 +151,14 @@ public struct ${Self}<
   }
 
   public func index(after i: Index) -> Index {
-    _precondition(i.base < _base.endIndex, "can't advance past endIndex")
+    _precondition(i.base < _base.endIndex, "Can't advance past endIndex")
     return LazyDropWhileIndex(base: _base.index(after: i.base))
   }
 
 %   if Traversal == 'Bidirectional':
 
   public func index(before i: Index) -> Index {
-    _precondition(i > startIndex, "can't move before startIndex")
+    _precondition(i > startIndex, "Can't move before startIndex")
     return LazyDropWhileIndex(base: _base.index(before: i.base))
   }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -971,7 +971,7 @@ extension AnyIndex : Comparable {
   ///   - rhs: Another index to compare.
   @_inlineable
   public static func == (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-    _precondition(lhs._typeID == rhs._typeID, "base index types differ")
+    _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isEqual(to: rhs._box)
   }
 
@@ -985,7 +985,7 @@ extension AnyIndex : Comparable {
   ///   - rhs: Another index to compare.
   @_inlineable
   public static func < (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-    _precondition(lhs._typeID == rhs._typeID, "base index types differ")
+    _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isLess(than: rhs._box)
   }
 }

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -175,7 +175,7 @@ public struct ${Self}<
   public func formIndex(after i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
     var index = i
-    _precondition(index != _base.endIndex, "can't advance past endIndex")
+    _precondition(index != _base.endIndex, "Can't advance past endIndex")
     repeat {
       _base.formIndex(after: &index)
     } while index != _base.endIndex && !_predicate(_base[index])
@@ -192,7 +192,7 @@ public struct ${Self}<
   public func formIndex(before i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
     var index = i
-    _precondition(index != _base.startIndex, "can't retreat before startIndex")
+    _precondition(index != _base.startIndex, "Can't retreat before startIndex")
     repeat {
       _base.formIndex(before: &index)
     } while !_predicate(_base[index])

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -659,7 +659,7 @@ public struct Set<Element : Hashable> :
   /// - Returns: A member of the set.
   @discardableResult
   public mutating func removeFirst() -> Element {
-    _precondition(!isEmpty, "can't removeFirst from an empty Set")
+    _precondition(!isEmpty, "Can't removeFirst from an empty Set")
     return remove(at: startIndex)
   }
 
@@ -2869,7 +2869,7 @@ public func _dictionaryBridgeFromObjectiveC<
 ) -> Dictionary<SwiftKey, SwiftValue> {
   let result: Dictionary<SwiftKey, SwiftValue>? =
     _dictionaryBridgeFromObjectiveCConditional(source)
-  _precondition(result != nil, "dictionary cannot be bridged from Objective-C")
+  _precondition(result != nil, "Dictionary cannot be bridged from Objective-C")
   return result!
 }
 
@@ -3618,7 +3618,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _precondition(i.offset >= 0 && i.offset < capacity)
     _precondition(
       isInitializedEntry(at: i.offset),
-      "attempting to access ${Self} elements using an invalid Index")
+      "Attempting to access ${Self} elements using an invalid Index")
     let key = self.key(at: i.offset)
 %if Self == 'Set':
     return key
@@ -3802,7 +3802,7 @@ extension _Native${Self}Buffer
 
   internal func assertingGet(_ key: Key) -> Value {
     let (i, found) = _find(key, startBucket: _bucket(key))
-    _precondition(found, "key not found")
+    _precondition(found, "Key not found")
 %if Self == 'Set':
     return self.key(at: i.offset)
 %elif Self == 'Dictionary':
@@ -4341,14 +4341,14 @@ internal struct _Cocoa${Self}Buffer : _HashBuffer {
       }
     }
     _sanityCheck(keyIndex >= 0,
-        "key was found in fast path, but not found later?")
+        "Key was found in fast path, but not found later?")
     return Index(cocoa${Self}, allKeys, keyIndex)
   }
 
   internal func assertingGet(_ i: Index) -> SequenceElement {
 %if Self == 'Set':
     let value: Value? = i.allKeys[i.currentKeyIndex]
-    _sanityCheck(value != nil, "item not found in underlying NS${Self}")
+    _sanityCheck(value != nil, "Item not found in underlying NS${Self}")
     return value!
 %elif Self == 'Dictionary':
     let key: Key = i.allKeys[i.currentKeyIndex]
@@ -4361,11 +4361,11 @@ internal struct _Cocoa${Self}Buffer : _HashBuffer {
   internal func assertingGet(_ key: Key) -> Value {
 %if Self == 'Set':
     let value: Value? = cocoa${Self}.member(key)
-    _precondition(value != nil, "member not found in underlying NS${Self}")
+    _precondition(value != nil, "Member not found in underlying NS${Self}")
     return value!
 %elif Self == 'Dictionary':
     let value: Value? = cocoa${Self}.objectFor(key)
-    _precondition(value != nil, "key not found in underlying NS${Self}")
+    _precondition(value != nil, "Key not found in underlying NS${Self}")
     return value!
 %end
   }
@@ -5371,7 +5371,7 @@ internal struct _Cocoa${Self}Index : Comparable {
   internal func successor() -> _Cocoa${Self}Index {
     // FIXME: swift-3-indexing-model: remove this method.
     _precondition(
-      currentKeyIndex < allKeys.value, "cannot increment endIndex")
+      currentKeyIndex < allKeys.value, "Cannot increment endIndex")
     return _Cocoa${Self}Index(cocoa${Self}, allKeys, currentKeyIndex + 1)
   }
 }
@@ -5507,7 +5507,7 @@ extension ${Self}.Index {
     case (._cocoa(let lhsCocoa), ._cocoa(let rhsCocoa)):
       return lhsCocoa == rhsCocoa
     default:
-      _preconditionFailure("comparing indexes from different sets")
+      _preconditionFailure("Comparing indexes from different sets")
   #endif
     }
   }
@@ -5527,7 +5527,7 @@ extension ${Self}.Index {
     case (._cocoa(let lhsCocoa), ._cocoa(let rhsCocoa)):
       return lhsCocoa < rhsCocoa
     default:
-      _preconditionFailure("comparing indexes from different sets")
+      _preconditionFailure("Comparing indexes from different sets")
   #endif
     }
   }
@@ -5792,9 +5792,9 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
 
   public mutating func take() -> ${Self}<${TypeParameters}> {
     _precondition(_actualCount >= 0,
-      "cannot take the result twice")
+      "Cannot take the result twice")
     _precondition(_actualCount == _requestedCount,
-      "the number of members added does not match the promised count")
+      "The number of members added does not match the promised count")
 
     // Finish building the `${Self}`.
     _nativeBuffer.count = _requestedCount

--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -76,7 +76,7 @@ extension ImplicitlyUnwrappedOptional : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> AnyObject {
     switch self {
     case .none:
-      _preconditionFailure("attempt to bridge an implicitly unwrapped optional containing nil")
+      _preconditionFailure("Attempt to bridge an implicitly unwrapped optional containing nil")
 
     case .some(let x):
       return Swift._bridgeAnythingToObjectiveC(x)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2414,7 +2414,7 @@ ${unsafeOperationComment(x.operator)}
 
     if overflow {
       if (_isDebugAssertConfiguration()) {
-        _preconditionFailure("overflow in unsafe${capitalize(x.name)}")
+        _preconditionFailure("Overflow in unsafe${capitalize(x.name)}")
       }
       else {
         Builtin.conditionallyUnreachable()

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1200,7 +1200,7 @@ internal struct KeyPathBuffer {
 
     func validateReservedBits() {
       _precondition(_value & Header.reservedMask == 0,
-                    "reserved bits set to an unexpected bit pattern")
+                    "Reserved bits set to an unexpected bit pattern")
     }
   }
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -301,7 +301,7 @@ func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
                                     _filenameIsASCII: Builtin.Int1,
                                     _line: Builtin.Word) {
   _preconditionFailure(
-    "unexpectedly found nil while unwrapping an Optional value",
+    "Unexpectedly found nil while unwrapping an Optional value",
     file: StaticString(_start: _filenameStart,
                        utf8CodeUnitCount: _filenameLength,
                        isASCII: _filenameIsASCII),

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -175,9 +175,9 @@ public struct ${Self}<
   }
 
   public func index(after i: Index) -> Index {
-    _precondition(i != endIndex, "can't advance past endIndex")
+    _precondition(i != endIndex, "Can't advance past endIndex")
     guard case .index(let i) = i._value else {
-      _preconditionFailure("invalid index passed to index(after:)")
+      _preconditionFailure("Invalid index passed to index(after:)")
     }
     let nextIndex = _base.index(after: i)
     guard nextIndex != _base.endIndex && _predicate(_base[nextIndex]) else {
@@ -191,7 +191,7 @@ public struct ${Self}<
   public func index(before i: Index) -> Index {
     switch i._value {
     case .index(let i):
-      _precondition(i != _base.startIndex, "can't move before startIndex")
+      _precondition(i != _base.startIndex, "Can't move before startIndex")
       return LazyPrefixWhileIndex(_base.index(before: i))
     case .pastEnd:
       // Look for the position of the last element in a non-empty

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -691,7 +691,7 @@ extension RangeReplaceableCollection {
   @_inlineable
   @discardableResult
   public mutating func remove(at position: Index) -> Element {
-    _precondition(!isEmpty, "can't remove from an empty collection")
+    _precondition(!isEmpty, "Can't remove from an empty collection")
     let result: Element = self[position]
     replaceSubrange(position..<index(after: position), with: EmptyCollection())
     return result
@@ -739,9 +739,9 @@ extension RangeReplaceableCollection {
   @_inlineable
   public mutating func removeFirst(_ n: Int) {
     if n == 0 { return }
-    _precondition(n >= 0, "number of elements to remove should be non-negative")
+    _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
-      "can't remove more items from a collection than it has")
+      "Can't remove more items from a collection than it has")
     let end = index(startIndex, offsetBy: numericCast(n))
     removeSubrange(startIndex..<end)
   }
@@ -765,7 +765,7 @@ extension RangeReplaceableCollection {
   @discardableResult
   public mutating func removeFirst() -> Element {
     _precondition(!isEmpty,
-      "can't remove first element from an empty collection")
+      "Can't remove first element from an empty collection")
     let firstElement = first!
     removeFirst(1)
     return firstElement
@@ -859,7 +859,7 @@ extension RangeReplaceableCollection where SubSequence == Self {
   @_inlineable
   @discardableResult
   public mutating func removeFirst() -> Element {
-    _precondition(!isEmpty, "can't remove items from an empty collection")
+    _precondition(!isEmpty, "Can't remove items from an empty collection")
     let element = first!
     self = self[index(after: startIndex)..<endIndex]
     return element
@@ -883,9 +883,9 @@ extension RangeReplaceableCollection where SubSequence == Self {
   @_inlineable
   public mutating func removeFirst(_ n: Int) {
     if n == 0 { return }
-    _precondition(n >= 0, "number of elements to remove should be non-negative")
+    _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
-      "can't remove more items from a collection than it contains")
+      "Can't remove more items from a collection than it contains")
     self = self[index(startIndex, offsetBy: numericCast(n))..<endIndex]
   }
 }
@@ -1007,7 +1007,7 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   @_inlineable
   @discardableResult
   public mutating func removeLast() -> Element {
-    _precondition(!isEmpty, "can't remove last element from an empty collection")
+    _precondition(!isEmpty, "Can't remove last element from an empty collection")
     if let result = _customRemoveLast() {
       return result
     }
@@ -1032,9 +1032,9 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   @_inlineable
   public mutating func removeLast(_ n: Int) {
     if n == 0 { return }
-    _precondition(n >= 0, "number of elements to remove should be non-negative")
+    _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
-      "can't remove more items from a collection than it contains")
+      "Can't remove more items from a collection than it contains")
     if _customRemoveLast(n) {
       return
     }
@@ -1064,7 +1064,7 @@ extension RangeReplaceableCollection
   @_inlineable
   @discardableResult
   public mutating func removeLast() -> Element {
-    _precondition(!isEmpty, "can't remove last element from an empty collection")
+    _precondition(!isEmpty, "Can't remove last element from an empty collection")
     if let result = _customRemoveLast() {
       return result
     }
@@ -1089,9 +1089,9 @@ extension RangeReplaceableCollection
   @_inlineable
   public mutating func removeLast(_ n: Int) {
     if n == 0 { return }
-    _precondition(n >= 0, "number of elements to remove should be non-negative")
+    _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
-      "can't remove more items from a collection than it contains")
+      "Can't remove more items from a collection than it contains")
     if _customRemoveLast(n) {
       return
     }

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -206,7 +206,7 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
   @_inlineable
   @_versioned
   internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "stride size must not be zero")
+    _precondition(stride != 0, "Stride size must not be zero")
     // At start, striding away from end is allowed; it just makes for an
     // already-empty Sequence.
     self._start = _start
@@ -305,7 +305,7 @@ public struct StrideThrough<
   @_inlineable
   @_versioned
   internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "stride size must not be zero")
+    _precondition(stride != 0, "Stride size must not be zero")
     self._start = _start
     self._end = end
     self._stride = stride

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -191,7 +191,7 @@ extension String {
       // Ensure j's cache is utf8
       if _slowPath(j._cache.utf8 == nil) {
         j = _index(atEncodedOffset: j.encodedOffset)
-        precondition(j != endIndex, "index out of bounds")
+        precondition(j != endIndex, "Index out of bounds")
       }
       
       let buffer = j._cache.utf8._unsafelyUnwrappedUnchecked
@@ -255,7 +255,7 @@ extension String {
       case .error:
         u8 = Unicode.UTF8.encodedReplacementCharacter
       case .emptyInput:
-        _preconditionFailure("index out of bounds")
+        _preconditionFailure("Index out of bounds")
       }
       return Index(
         encodedOffset: i.encodedOffset &- (u8.count < 4 ? 1 : 2),
@@ -299,7 +299,7 @@ extension String {
       @inline(__always)
       get {
         if _fastPath(_core.asciiBuffer != nil), let ascii = _core.asciiBuffer {
-          _precondition(position < endIndex, "index out of bounds")
+          _precondition(position < endIndex, "Index out of bounds")
           return ascii[position.encodedOffset]
         }
         var j = position
@@ -310,7 +310,7 @@ extension String {
               buffer.index(buffer.startIndex, offsetBy: j._transcodedOffset)]
           }
           j = _index(atEncodedOffset: j.encodedOffset)
-          precondition(j < endIndex, "index out of bounds")
+          precondition(j < endIndex, "Index out of bounds")
         }
       }
     }

--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -93,7 +93,7 @@ internal struct _ThreadLocalStorage {
     var err = __swift_stdlib_U_ZERO_ERROR
     __swift_stdlib_ubrk_setText(
       brkIter, bufPtr.baseAddress!, Int32(bufPtr.count), &err)
-    _precondition(err.isSuccess, "unexpected ubrk_setUText failure")
+    _precondition(err.isSuccess, "Unexpected ubrk_setUText failure")
 
     return brkIter
   }
@@ -137,7 +137,7 @@ internal func _initializeThreadLocalStorage()
   let newUBreakIterator = __swift_stdlib_ubrk_open(
       /*type:*/ __swift_stdlib_UBRK_CHARACTER, /*locale:*/ nil,
       /*text:*/ nil, /*textLength:*/ 0, /*status:*/ &err)
-  _precondition(err.isSuccess, "unexpected ubrk_open failure")
+  _precondition(err.isSuccess, "Unexpected ubrk_open failure")
 
   let tlsPtr: UnsafeMutablePointer<_ThreadLocalStorage>
     = UnsafeMutablePointer<_ThreadLocalStorage>.allocate(

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -328,7 +328,7 @@ LLVM_ATTRIBUTE_NORETURN
 void
 swift_deletedMethodError() {
   swift::fatalError(/* flags = */ 0,
-                    "fatal error: call of deleted method\n");
+                    "Fatal error: Call of deleted method\n");
 }
 
 
@@ -336,14 +336,14 @@ swift_deletedMethodError() {
 // FIXME: can't pass the object's address from InlineRefCounts without hacks
 void swift::swift_abortRetainOverflow() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                    "fatal error: object was retained too many times");
+                    "Fatal error: Object was retained too many times");
 }
 
 // Crash due to an unowned retain count overflow.
 // FIXME: can't pass the object's address from InlineRefCounts without hacks
 void swift::swift_abortUnownedRetainOverflow() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                    "fatal error: object's unowned reference was retained too many times");
+                    "Fatal error: Object's unowned reference was retained too many times");
 }
 
 // Crash due to retain of a dead unowned reference.
@@ -351,11 +351,11 @@ void swift::swift_abortUnownedRetainOverflow() {
 void swift::swift_abortRetainUnowned(const void *object) {
   if (object) {
     swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                      "fatal error: attempted to read an unowned reference but "
+                      "Fatal error: Attempted to read an unowned reference but "
                       "object %p was already deallocated", object);
   } else {
     swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                      "fatal error: attempted to read an unowned reference but "
+                      "Fatal error: Attempted to read an unowned reference but "
                       "the object was already deallocated");
   }
 }

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -128,15 +128,15 @@ void
 swift::swift_verifyEndOfLifetime(HeapObject *object) {
   if (object->refCounts.getCount() != 0)
     swift::fatalError(/* flags = */ 0,
-                      "fatal error: stack object escaped\n");
+                      "Fatal error: Stack object escaped\n");
   
   if (object->refCounts.getUnownedCount() != 1)
     swift::fatalError(/* flags = */ 0,
-                      "fatal error: unowned reference to stack object\n");
+                      "Fatal error: Unowned reference to stack object\n");
   
   if (object->refCounts.getWeakCount() != 0)
     swift::fatalError(/* flags = */ 0,
-                      "fatal error: weak reference to stack object\n");
+                      "Fatal error: Weak reference to stack object\n");
 }
 
 /// \brief Allocate a reference-counted object on the heap that

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -118,7 +118,7 @@ void swift::_swift_stdlib_reportUnimplementedInitializerInFile(
   char *log;
   swift_asprintf(
       &log,
-      "%.*s: %" PRIu32 ": %" PRIu32 ": fatal error: use of unimplemented "
+      "%.*s: %" PRIu32 ": %" PRIu32 ": Fatal error: Use of unimplemented "
       "initializer '%.*s' for class '%.*s'\n",
       fileLength, file,
       line, column,
@@ -137,7 +137,7 @@ void swift::_swift_stdlib_reportUnimplementedInitializer(
   char *log;
   swift_asprintf(
       &log,
-      "fatal error: use of unimplemented "
+      "Fatal error: Use of unimplemented "
       "initializer '%.*s' for class '%.*s'\n",
       initNameLength, initName,
       classNameLength, className);

--- a/stdlib/public/stubs/CommandLine.cpp
+++ b/stdlib/public/stubs/CommandLine.cpp
@@ -70,7 +70,7 @@ char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   FILE *cmdline = fopen("/proc/self/cmdline", "rb");
   if (!cmdline) {
     swift::fatalError(0,
-            "fatal error: Unable to open interface to '/proc/self/cmdline'.\n");
+            "Fatal error: Unable to open interface to '/proc/self/cmdline'.\n");
   }
   char *arg = nullptr;
   size_t size = 0;
@@ -137,7 +137,7 @@ char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
     }
   }
   if (!argPtr)
-    swift::fatalError(0, "fatal error: could not retrieve commandline "
+    swift::fatalError(0, "Fatal error: Could not retrieve commandline "
                          "arguments: sysctl: %s.\n", strerror(errno));
 
   char *curPtr = argPtr;
@@ -164,7 +164,7 @@ char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   }
   
   swift::fatalError(0,
-      "fatal error: Command line arguments not supported on this platform.\n");
+      "Fatal error: Command line arguments not supported on this platform.\n");
 }
 #endif
 

--- a/test/Frontend/OptimizationOptions-with-stdlib-checks.swift
+++ b/test/Frontend/OptimizationOptions-with-stdlib-checks.swift
@@ -19,25 +19,25 @@ func test_fatal(x: Int, y: Int) -> Int {
 }
 
 func test_precondition_check(x: Int, y: Int) -> Int {
-  _precondition(x > y, "test precondition check")
+  _precondition(x > y, "Test precondition check")
   return x + y
 }
 
 func test_partial_safety_check(x: Int, y: Int) -> Int {
-  _debugPrecondition(x > y, "test partial safety check")
+  _debugPrecondition(x > y, "Test partial safety check")
   return x + y
 }
 
 // In debug mode keep user asserts and runtime checks.
 // DEBUG-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // DEBUG-DAG: string_literal utf8 "x smaller than y"
-// DEBUG-DAG: string_literal utf8 "assertion failed"
+// DEBUG-DAG: string_literal utf8 "Assertion failed"
 // DEBUG-DAG: cond_fail
 // DEBUG: return
 
 // In playground mode keep user asserts and runtime checks.
 // PLAYGROUND-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// PLAYGROUND-DAG: "assertion failed"
+// PLAYGROUND-DAG: "Assertion failed"
 // PLAYGROUND-DAG: "x smaller than y"
 // PLAYGROUND-DAG: cond_fail
 // PLAYGROUND: return
@@ -45,14 +45,14 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 // In release mode remove user asserts and keep runtime checks.
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // RELEASE-NOT: "x smaller than y"
-// RELEASE-NOT: "assertion failed"
+// RELEASE-NOT: "Assertion failed"
 // RELEASE: cond_fail
 // RELEASE: return
 
 // In fast mode remove user asserts and runtime checks.
 // FAST-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // FAST-NOT: "x smaller than y"
-// FAST-NOT: "assertion failed"
+// FAST-NOT: "Assertion failed"
 // FAST-NOT: cond_fail
 
 
@@ -73,21 +73,21 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 // In release mode keep succinct fatal errors (trap).
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions10test_fatalS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // RELEASE-NOT: "Human nature ..."
-// RELEASE-NOT: "fatal error"
+// RELEASE-NOT: "Fatal error"
 // RELEASE: cond_fail
 // RELEASE: return
 
 // In fast mode remove fatal errors.
 // FAST-LABEL: sil hidden @_T019OptimizationOptions10test_fatalS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // FAST-NOT: "Human nature ..."
-// FAST-NOT: "fatal error"
+// FAST-NOT: "Fatal error"
 // FAST-NOT: int_trap
 
 // Precondition safety checks.
 
 // In debug mode keep verbose library precondition checks.
 // DEBUG-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// DEBUG-DAG: "fatal error"
+// DEBUG-DAG: "Fatal error"
 // DEBUG-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // DEBUG: apply %[[FATAL_ERROR]]{{.*}}
 // DEBUG: unreachable
@@ -95,7 +95,7 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 
 // In playground mode keep verbose library precondition checks.
 // PLAYGROUND-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// PLAYGROUND-DAG: "fatal error"
+// PLAYGROUND-DAG: "Fatal error"
 // PLAYGROUND-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // PLAYGROUND: apply %[[FATAL_ERROR]]{{.*}}
 // PLAYGROUND: unreachable
@@ -103,14 +103,14 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 
 // In release mode keep succinct library precondition checks (trap).
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// RELEASE-NOT:  "fatal error"
+// RELEASE-NOT:  "Fatal error"
 // RELEASE:  %[[V2:.+]] = builtin "xor_Int1"(%{{.+}}, %{{.+}})
 // RELEASE:  cond_fail %[[V2]]
 // RELEASE:  return
 
 // In unchecked mode remove library precondition checks.
 // UNCHECKED-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// UNCHECKED-NOT:  "fatal error"
+// UNCHECKED-NOT:  "Fatal error"
 // UNCHECKED-NOT:  builtin "int_trap"
 // UNCHECKED-NOT:  unreachable
 // UNCHECKED:  return
@@ -119,28 +119,28 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 
 // In debug mode keep verbose partial safety checks.
 // DEBUG-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// DEBUG-DAG: "fatal error"
+// DEBUG-DAG: "Fatal error"
 // DEBUG-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // DEBUG: apply %[[FATAL_ERROR]]{{.*}}
 // DEBUG: unreachable
 
 // In playground mode keep verbose partial safety checks.
 // PLAYGROUND-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// PLAYGROUND-DAG: "fatal error"
+// PLAYGROUND-DAG: "Fatal error"
 // PLAYGROUND-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // PLAYGROUND: apply %[[FATAL_ERROR]]{{.*}}
 // PLAYGROUND: unreachable
 
 // In release mode remove partial safety checks.
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// RELEASE-NOT:  "fatal error"
+// RELEASE-NOT:  "Fatal error"
 // RELEASE-NOT:  builtin "int_trap"
 // RELEASE-NOT:  unreachable
 // RELEASE: return
 
 // In fast mode remove partial safety checks.
 // FAST-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// FAST-NOT:  "fatal error"
+// FAST-NOT:  "Fatal error"
 // FAST-NOT:  builtin "int_trap"
 // FAST-NOT:  unreachable
 // FAST: return

--- a/test/Frontend/OptimizationOptions-without-stdlib-checks.swift
+++ b/test/Frontend/OptimizationOptions-without-stdlib-checks.swift
@@ -19,38 +19,38 @@ func test_fatal(x: Int, y: Int) -> Int {
 }
 
 func test_precondition_check(x: Int, y: Int) -> Int {
-  _precondition(x > y, "test precondition check")
+  _precondition(x > y, "Test precondition check")
   return x + y
 }
 
 func test_partial_safety_check(x: Int, y: Int) -> Int {
-  _debugPrecondition(x > y, "test partial safety check")
+  _debugPrecondition(x > y, "Test partial safety check")
   return x + y
 }
 
 // In debug mode keep user asserts and runtime checks.
 // DEBUG-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // DEBUG: "x smaller than y"
-// DEBUG: "assertion failed"
+// DEBUG: "Assertion failed"
 // DEBUG: cond_fail
 // DEBUG: return
 
 // In playground mode keep user asserts and runtime checks.
 // PLAYGROUND-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // PLAYGROUND: "x smaller than y"
-// PLAYGROUND: "assertion failed"
+// PLAYGROUND: "Assertion failed"
 // PLAYGROUND: cond_fail
 
 // In release mode remove user asserts and keep runtime checks.
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // RELEASE-NOT: "x smaller than y"
-// RELEASE-NOT: "assertion failed"
+// RELEASE-NOT: "Assertion failed"
 // RELEASE: cond_fail
 
 // In fast mode remove user asserts and runtime checks.
 // FAST-LABEL: sil hidden @_T019OptimizationOptions11test_assertS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // FAST-NOT: "x smaller than y"
-// FAST-NOT: "assertion failed"
+// FAST-NOT: "Assertion failed"
 // FAST-NOT: cond_fail
 
 
@@ -71,21 +71,21 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 // In release mode keep succinct fatal errors (trap).
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions10test_fatalS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // RELEASE-NOT: "Human nature ..."
-// RELEASE-NOT: "fatal error"
+// RELEASE-NOT: "Fatal error"
 // RELEASE: cond_fail
 // RELEASE: return
 
 // In fast mode remove fatal errors.
 // FAST-LABEL: sil hidden @_T019OptimizationOptions10test_fatalS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
 // FAST-NOT: "Human nature ..."
-// FAST-NOT: "fatal error"
+// FAST-NOT: "Fatal error"
 // FAST-NOT: int_trap
 
 // Precondition safety checks.
 
 // In debug mode keep verbose library precondition checks.
 // DEBUG-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// DEBUG-DAG: "fatal error"
+// DEBUG-DAG: "Fatal error"
 // DEBUG-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // DEBUG: apply %[[FATAL_ERROR]]({{.*}})
 // DEBUG: unreachable
@@ -93,7 +93,7 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 
 // In playground mode keep verbose library precondition checks.
 // PLAYGROUND-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// PLAYGROUND-DAG: "fatal error"
+// PLAYGROUND-DAG: "Fatal error"
 // PLAYGROUND-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // PLAYGROUND: apply %[[FATAL_ERROR]]({{.*}})
 // PLAYGROUND: unreachable
@@ -101,14 +101,14 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 
 // In release mode keep succinct library precondition checks (trap).
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// RELEASE-NOT:  "fatal error"
+// RELEASE-NOT:  "Fatal error"
 // RELEASE:  %[[V2:.+]] = builtin "xor_Int1"(%{{.+}}, %{{.+}})
 // RELEASE:  cond_fail %[[V2]]
 // RELEASE:  return
 
 // In unchecked mode remove library precondition checks.
 // UNCHECKED-LABEL: sil hidden @_T019OptimizationOptions23test_precondition_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// UNCHECKED-NOT:  "fatal error"
+// UNCHECKED-NOT:  "Fatal error"
 // UNCHECKED-NOT:  builtin "int_trap"
 // UNCHECKED-NOT:  unreachable
 // UNCHECKED:  return
@@ -117,28 +117,28 @@ func test_partial_safety_check(x: Int, y: Int) -> Int {
 
 // In debug mode keep verbose partial safety checks.
 // DEBUG-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// DEBUG-DAG: "fatal error"
+// DEBUG-DAG: "Fatal error"
 // DEBUG-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // DEBUG: apply %[[FATAL_ERROR]]({{.*}})
 // DEBUG: unreachable
 
 // In playground mode keep verbose partial safety checks.
 // PLAYGROUND-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// PLAYGROUND-DAG: "fatal error"
+// PLAYGROUND-DAG: "Fatal error"
 // PLAYGROUND-DAG: %[[FATAL_ERROR:.+]] = function_ref @[[FATAL_ERROR_FUNC]]
 // PLAYGROUND: apply %[[FATAL_ERROR]]({{.*}})
 // PLAYGROUND: unreachable
 
 // In release mode remove partial safety checks.
 // RELEASE-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// RELEASE-NOT:  "fatal error"
+// RELEASE-NOT:  "Fatal error"
 // RELEASE-NOT:  builtin "int_trap"
 // RELEASE-NOT:  unreachable
 // RELEASE: return
 
 // In fast mode remove partial safety checks.
 // FAST-LABEL: sil hidden @_T019OptimizationOptions25test_partial_safety_checkS2i1x_Si1ytF : $@convention(thin) (Int, Int) -> Int {
-// FAST-NOT:  "fatal error"
+// FAST-NOT:  "Fatal error"
 // FAST-NOT:  builtin "int_trap"
 // FAST-NOT:  unreachable
 // FAST: return

--- a/test/IRGen/report_dead_method_call.swift
+++ b/test/IRGen/report_dead_method_call.swift
@@ -6,7 +6,7 @@
 
 // The private, unused methods are optimized away. The test calls these
 // methods anyway (since it has overridden the access control), so we
-// expect them to produce "fatal error: call of deleted method" when run.
+// expect them to produce "Fatal error: Call of deleted method" when run.
 // RUN: %target-run %t/report_dead_method_call
 // REQUIRES: executable_test
 

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -1580,7 +1580,7 @@ bb4:
 
 bb5:
   %39 = function_ref @fatalError : $@convention(thin) (StaticString, StaticString, StaticString) -> Never
-  %40 = string_literal utf8 "fatal error"
+  %40 = string_literal utf8 "Fatal error"
   %41 = integer_literal $Builtin.Word, 11
   %42 = integer_literal $Builtin.Int8, 11
   %43 = struct $StaticString (%40 : $Builtin.RawPointer, %41 : $Builtin.Word, %42 : $Builtin.Int8)

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -63,7 +63,7 @@ SetTraps.test("RemoveFirstFromEmpty")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "can't removeFirst from an empty Set" : "")
+    "Can't removeFirst from an empty Set" : "")
   .code {
   var s = Set<Int>()
   expectCrashLater()

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -162,7 +162,7 @@ indirect enum RawSyntax: Codable {
   ///   - newChild: The new child that should occupy that index in the node.
   func replacingChild(_ index: Int,
                       with newChild: RawSyntax) -> RawSyntax {
-    precondition(index < layout.count, "cursor \(index) reached past layout")
+    precondition(index < layout.count, "Cursor \(index) reached past layout")
     var newLayout = layout
     newLayout[index] = newChild
     return replacingLayout(newLayout)

--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -63,7 +63,7 @@ static SWIFT_CC(swift) void deinitTestObject(SWIFT_CONTEXT HeapObject *_object) 
     // URC increment OK
     // URC decrement OK
     ASSERT_DEATH(swift_unownedCheck(object),
-                 "attempted to read an unowned reference");
+                 "Attempted to read an unowned reference");
     swift_unownedRetain(object);
     swift_unownedRetain(object);
     swift_unownedRelease(object);
@@ -162,7 +162,7 @@ TEST(LongRefcountingTest, retain_overflow_DeathTest) {
   retainALot<true>(object, deallocated, maxRC - 1);
   EXPECT_EQ(0u, deallocated);
   ASSERT_DEATH(swift_retain(object),
-               "object was retained too many times");
+               "Object was retained too many times");
 }
 
 TEST(LongRefcountingTest, nonatomic_retain_max) {
@@ -186,7 +186,7 @@ TEST(LongRefcountingTest, nonatomic_retain_overflow_DeathTest) {
   retainALot<false>(object, deallocated, maxRC - 1);
   EXPECT_EQ(0u, deallocated);
   ASSERT_DEATH(swift_nonatomic_retain(object),
-               "object was retained too many times");
+               "Object was retained too many times");
 }
 
 
@@ -310,7 +310,7 @@ TEST(LongRefcountingTest, lifecycle_live_deiniting_deinited_no_side_DeathTest) {
   // URC increment can't happen
   // URC decrement OK
   ASSERT_DEATH(swift_unownedCheck(object),
-               "attempted to read an unowned reference");
+               "Attempted to read an unowned reference");
   swift_unownedRelease(object);
   EXPECT_ALLOCATED(object);
 
@@ -519,7 +519,7 @@ TEST(LongRefcountingTest, lifecycle_live_deiniting_deinited_with_side_DeathTest)
   // URC increment can't happen
   // URC decrement OK
   ASSERT_DEATH(swift_unownedCheck(object),
-               "attempted to read an unowned reference");
+               "Attempted to read an unowned reference");
   swift_unownedRelease(object);
   EXPECT_ALLOCATED(object);
   EXPECT_ALLOCATED(side);
@@ -759,7 +759,7 @@ TEST(LongRefcountingTest, lifecycle_live_deiniting_deinited_freed_with_side_Deat
   // URC increment can't happen
   // URC decrement OK
   ASSERT_DEATH(swift_unownedCheck(object),
-               "attempted to read an unowned reference");
+               "Attempted to read an unowned reference");
   swift_unownedRelease(object);
   EXPECT_ALLOCATED(object);
   EXPECT_ALLOCATED(side);

--- a/unittests/runtime/weak.mm
+++ b/unittests/runtime/weak.mm
@@ -877,7 +877,7 @@ TEST(WeakTest, objc_unowned_isEqual_DeathTest) {
   // Deinit the assigned objects, invalidating ref1 and ref2
   swift_release(swift1);
   ASSERT_DEATH(swift_unownedCheck(swift1),
-               "attempted to read an unowned reference");
+               "Attempted to read an unowned reference");
   ASSERT_EQ(0U, DestroyedObjCCount);
   swift_unknownRelease(objc1);
   ASSERT_EQ(1U, DestroyedObjCCount);
@@ -886,10 +886,10 @@ TEST(WeakTest, objc_unowned_isEqual_DeathTest) {
   // Equal but invalidated does abort (Swift)
   // Formerly equal but now invalidated returns unequal (ObjC)
   ASSERT_DEATH(swift_unownedIsEqual(&ref1, swift1),
-               "attempted to read an unowned reference");
+               "Attempted to read an unowned reference");
   ASSERT_EQ(false, swift_unownedIsEqual(&ref1, swift2));
   ASSERT_DEATH(swift_unknownUnownedIsEqual(&ref1, swift1),
-               "attempted to read an unowned reference");
+               "Attempted to read an unowned reference");
   ASSERT_EQ(false, swift_unknownUnownedIsEqual(&ref1, swift2));
   ASSERT_EQ(false, swift_unknownUnownedIsEqual(&ref1, objc1));
   ASSERT_EQ(false, swift_unknownUnownedIsEqual(&ref1, objc2));

--- a/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildCrashesDuringShutdown.swift
+++ b/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildCrashesDuringShutdown.swift
@@ -21,14 +21,14 @@ var TestSuiteChildCrashes = TestSuite("TestSuiteChildCrashes")
 
 TestSuiteChildCrashes.test("passes") {
   atexit {
-    fatalError("crash at exit")
+    fatalError("Crash at exit")
   }
 }
 
 // CHECK: [ RUN      ] TestSuiteChildCrashes.passes
 // CHECK: [       OK ] TestSuiteChildCrashes.passes
 // CHECK: TestSuiteChildCrashes: All tests passed
-// CHECK: stderr>>> fatal error: crash at exit:
+// CHECK: stderr>>> Fatal error: Crash at exit:
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: The child process failed during shutdown, aborting.
 // CHECK: abort()

--- a/validation-test/StdlibUnittest/CrashingTests.swift
+++ b/validation-test/StdlibUnittest/CrashingTests.swift
@@ -17,10 +17,10 @@ var TestSuiteCrashes = TestSuite("TestSuiteCrashes")
 
 TestSuiteCrashes.test("crashesUnexpectedly1") {
   print("crashesUnexpectedly1")
-  fatalError("this should crash")
+  fatalError("This should crash")
 }
 // CHECK: stdout>>> crashesUnexpectedly1
-// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly1
 
@@ -41,10 +41,10 @@ TestSuiteCrashes.test("fails1") {
 
 TestSuiteCrashes.test("crashesUnexpectedly2") {
   print("crashesUnexpectedly2")
-  fatalError("this should crash")
+  fatalError("This should crash")
 }
 // CHECK: stdout>>> crashesUnexpectedly2
-// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly2
 
@@ -66,10 +66,10 @@ TestSuiteCrashes.test("fails2") {
 TestSuiteCrashes.test("crashesAsExpected1") {
   print("crashesAsExpected1")
   expectCrashLater()
-  fatalError("this should crash")
+  fatalError("This should crash")
 }
 // CHECK: stdout>>> crashesAsExpected1
-// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesAsExpected1
 
@@ -91,10 +91,10 @@ TestSuiteCrashes.test("fails3") {
 TestSuiteCrashes.test("crashesUnexpectedlyXfail")
   .xfail(.osxBugFix(10, 9, 3, reason: "")).code {
   print("crashesUnexpectedlyXfail")
-  fatalError("this should crash")
+  fatalError("This should crash")
 }
 // CHECK: stdout>>> crashesUnexpectedlyXfail
-// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [    XFAIL ] TestSuiteCrashes.crashesUnexpectedlyXfail
 
@@ -102,64 +102,64 @@ TestSuiteCrashes.test("crashesAsExpectedXfail")
   .xfail(.osxBugFix(10, 9, 3, reason: "")).code {
   print("crashesAsExpectedXfail")
   expectCrashLater()
-  fatalError("this should crash")
+  fatalError("This should crash")
 }
 // CHECK: stdout>>> crashesAsExpectedXfail
-// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [   UXPASS ] TestSuiteCrashes.crashesAsExpectedXfail
 
 TestSuiteCrashes.test("crashesWithMessagePasses")
-  .crashOutputMatches("this should crash").code {
+  .crashOutputMatches("This should crash").code {
   print("abcd")
   expectCrashLater()
-  fatalError("this should crash")
+  fatalError("This should crash")
 }
 // CHECK: stdout>>> abcd
-// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesWithMessagePasses
 
 TestSuiteCrashes.test("crashesWithMessageFails")
-  .crashOutputMatches("this should crash").code {
-  print("this should crash")
+  .crashOutputMatches("This should crash").code {
+  print("This should crash")
   expectCrashLater()
   fatalError("unexpected message")
 }
-// CHECK: stdout>>> this should crash
-// CHECK: stderr>>> fatal error: unexpected message:
+// CHECK: stdout>>> This should crash
+// CHECK: stderr>>> Fatal error: unexpected message:
 // CHECK: stderr>>> OK: saw expected "crashed: sig
-// CHECK: did not find expected string after crash: "this should crash"
+// CHECK: did not find expected string after crash: "This should crash"
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesWithMessageFails
 
 TestSuiteCrashes.test("crashesWithMultipleMessagesPasses")
   .crashOutputMatches("little dog")
-  .crashOutputMatches("this should crash")
+  .crashOutputMatches("This should crash")
   .crashOutputMatches("too")
   .code {
   print("abcd")
   expectCrashLater()
-  fatalError("this should crash and your little dog too")
+  fatalError("This should crash and your little dog too")
 }
 // CHECK: stdout>>> abcd
-// CHECK: stderr>>> fatal error: this should crash and your little dog too:
+// CHECK: stderr>>> Fatal error: This should crash and your little dog too:
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesWithMultipleMessagesPasses
 
 TestSuiteCrashes.test("crashesWithMultipleMessagesFails")
   .crashOutputMatches("unexpected message")
-  .crashOutputMatches("this should crash")
+  .crashOutputMatches("This should crash")
   .crashOutputMatches("big dog")
   .crashOutputMatches("and your little dog too")
 .code {
-  print("this should crash")
+  print("This should crash")
   expectCrashLater()
   fatalError("unexpected message and your little dog too")
 }
-// CHECK: stdout>>> this should crash
-// CHECK: stderr>>> fatal error: unexpected message and your little dog too:
+// CHECK: stdout>>> This should crash
+// CHECK: stderr>>> Fatal error: unexpected message and your little dog too:
 // CHECK: stderr>>> OK: saw expected "crashed: sig
-// CHECK: did not find expected string after crash: "this should crash"
+// CHECK: did not find expected string after crash: "This should crash"
 // CHECK: did not find expected string after crash: "big dog"
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesWithMultipleMessagesFails
 

--- a/validation-test/stdlib/ArrayTraps.swift.gyb
+++ b/validation-test/stdlib/ArrayTraps.swift.gyb
@@ -127,7 +127,7 @@ ${ArrayTy}Traps.test("sliceBounds3/${io}")
 
 ${ArrayTy}Traps.test("PopFromEmpty")
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "can't remove last element from an empty collection" : "")
+    "Can't remove last element from an empty collection" : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   expectCrashLater()

--- a/validation-test/stdlib/ArrayTrapsObjC.swift.gyb
+++ b/validation-test/stdlib/ArrayTrapsObjC.swift.gyb
@@ -79,7 +79,7 @@ ArrayTraps.test("bounds_with_downcast")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "fatal error: Index out of range" : "")
+    "Fatal error: Index out of range" : "")
   .code {
   let ba: [Base] = [ Derived(), Base() ]
   let da = ba as! [Derived]
@@ -136,7 +136,7 @@ ArraySemanticOptzns.test("inout_rule_violated_isNativeBuffer")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "fatal error: inout rules were violated: the array was overwritten" : "")
+    "Fatal error: inout rules were violated: the array was overwritten" : "")
   .code {
   let v = ViolateInoutSafetySwitchToObjcBuffer()
   expectCrashLater()
@@ -179,7 +179,7 @@ ArraySemanticOptzns.test("inout_rule_violated_needsElementTypeCheck")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "fatal error: inout rules were violated: the array was overwritten" : "")
+    "Fatal error: inout rules were violated: the array was overwritten" : "")
   .code {
   let v = ViolateInoutSafetyNeedElementTypeCheck()
   expectCrashLater()


### PR DESCRIPTION
Unify the capitalization across all user-visible error messages (fatal errors, assertion failures, precondition failures) produced by the runtime, standard library and the compiler.

The current state of runtime error messages is really inconsistent.  It seems that most messages start with a capital letter, so let's change all the user-visible messages to be capitalized this way.  I'm focusing on user-visible messages, so I didn't modify the cases where a preconditionFailure was used purely as an internal sanity check and would never be displayed to the user.

Here's a few "before"s:

```
fatal error: unexpectedly found nil while unwrapping an Optional value
fatal error: Can't take a suffix of negative length from a collection
fatal error: can't remove last element from an empty collection
```

And "after"s:

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value
Fatal error: Can't take a suffix of negative length from a collection
Fatal error: Can't remove last element from an empty collection
```
