### PR TITLE
[4.0] Formatting: Respect tab/space setting when aligning siblings

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -102,13 +102,30 @@ public:
       LineText.startswith("return") || LineText.startswith("fallthrough");
   }
 
-  void padToSiblingColumn(StringBuilder &Builder) {
+  void padToSiblingColumn(StringBuilder &Builder,
+                          const CodeFormatOptions &FmtOptions) {
     assert(SiblingInfo.Loc.isValid() && "No sibling to align with.");
     CharSourceRange Range(SM, Lexer::getLocForStartOfLine(SM, SiblingInfo.Loc),
                           SiblingInfo.Loc);
-    for (auto C : Range.str()) {
-      Builder.append(1, C == '\t' ? C : ' ');
+    unsigned SpaceLength = 0;
+    unsigned TabLength = 0;
+
+    // Calculating space length
+    for (auto C: Range.str()) {
+      if (C == '\t')
+        SpaceLength += FmtOptions.TabWidth;
+      else
+        SpaceLength += 1;
     }
+
+    // If we are using tabs, calculating the number of tabs and spaces we need
+    // to insert.
+    if (FmtOptions.UseTabs) {
+      TabLength = SpaceLength / FmtOptions.TabWidth;
+      SpaceLength = SpaceLength % FmtOptions.TabWidth;
+    }
+    Builder.append(TabLength, '\t');
+    Builder.append(SpaceLength, ' ');
   }
 
   bool HasSibling() {
@@ -801,7 +818,7 @@ public:
     if (FC.HasSibling()) {
       StringRef Line = swift::ide::getTextForLine(LineIndex, Text, /*Trim*/true);
       StringBuilder Builder;
-      FC.padToSiblingColumn(Builder);
+      FC.padToSiblingColumn(Builder, FmtOptions);
       if (FC.needExtraIndentationForSibling()) {
         if (FmtOptions.UseTabs)
           Builder.append(1, '\t');

--- a/test/SourceKit/CodeFormat/indent-with-tab.swift
+++ b/test/SourceKit/CodeFormat/indent-with-tab.swift
@@ -8,6 +8,9 @@ var test : Int
 
 }
 
+func bar(a: Int,
+b: Int) {}
+
 // RUN: %sourcekitd-test -req=format -line=1 -length=1 -req-opts=usetabs=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=2 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 -req-opts=usetabs=1 %s >>%t.response
@@ -17,6 +20,7 @@ var test : Int
 // RUN: %sourcekitd-test -req=format -line=7 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=8 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=9 -length=1 -req-opts=usetabs=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=12 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "class Foo {"
@@ -28,3 +32,4 @@ var test : Int
 // CHECK: key.sourcetext: "\t}"
 // CHECK: key.sourcetext: "\t"
 // CHECK: key.sourcetext: "}"
+// CHECK: key.sourcetext: "\t\t b: Int) {}"


### PR DESCRIPTION
### CCC Info
* **Explanation**: When a function call is split over multiple lines, subsequent lines are aligned to the open paren using spaces, regardless of whether the user specified tab spacing as their preference. With this change, if a user prefers tabs, spaces will only be used to make up the remainder when the indentation doesn't fall on a tab boundary. 

* **Scope of Issue**: The change is limited to the formatting request in sourcekitd.
* **Radar**: rdar://problem/32611247
* **Risk**: Low
* **Reviewed By**: Nathan Hawes
* **Testing**: Added regression test for this case.

**PR for master**: https://github.com/apple/swift/pull/11334
**PR for swift-4.0-branch**: https://github.com/apple/swift/pull/11600