### PR TITLE
[silgen] Provide a convenience borrow API for RValue ArgumentSources

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -256,6 +256,27 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF, Initialization *dest) && {
   llvm_unreachable("bad kind");
 }
 
+ArgumentSource ArgumentSource::borrow(SILGenFunction &SGF) const & {
+  switch (StoredKind) {
+  case Kind::Invalid:
+    llvm_unreachable("argument source is invalid");
+  case Kind::LValue:
+    llvm_unreachable("cannot borrow an l-value");
+  case Kind::RValue: {
+    auto loc = getKnownRValueLocation();
+    return ArgumentSource(loc, asKnownRValue().borrow(SGF, loc));
+  }
+  case Kind::Expr: {
+    llvm_unreachable("cannot borrow an expression");
+  }
+  case Kind::Tuple: {
+    // FIXME: We can if we check the sub argument sources.
+    llvm_unreachable("cannot borrow a tuple");
+  }
+  }
+  llvm_unreachable("bad kind");
+}
+
 ManagedValue ArgumentSource::materialize(SILGenFunction &SGF) && {
   if (isRValue()) {
     auto loc = getKnownRValueLocation();

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -290,6 +290,10 @@ public:
   void forwardInto(SILGenFunction &SGF, AbstractionPattern origFormalType,
                    Initialization *dest, const TypeLowering &destTL) &&;
 
+  /// If we have an rvalue, borrow the rvalue into a new ArgumentSource and
+  /// return the ArgumentSource. Otherwise, assert.
+  ArgumentSource borrow(SILGenFunction &SGF) const &;
+
   ManagedValue materialize(SILGenFunction &SGF) &&;
 
   /// Emit this value to memory so that it follows the abstraction


### PR DESCRIPTION
[silgen] Provide a convenience borrow API for RValue ArgumentSources

If the argument source is not an RValue, we assert.

rdar://33358110