### PR TITLE
[silgen] Add a convenience constructor that constructs an RValue from a single ManagedValue.

### DIFF
--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -159,6 +159,12 @@ public:
   /// will be exploded.
   RValue(SILGenFunction &SGF, SILLocation l, CanType type, ManagedValue v);
 
+  /// Create an RValue from a single value. If the value is of tuple type, it
+  /// will be exploded. Use the CanType from the ManagedValue as the underlying
+  /// type of the RValue.
+  RValue(SILGenFunction &SGF, SILLocation l, ManagedValue v)
+      : RValue(SGF, l, v.getType().getSwiftRValueType(), v) {}
+
   /// Create a complete RValue from a pre-exploded set of elements.
   ///
   /// Since the RValue is assumed to be complete, no further values can be


### PR DESCRIPTION
[silgen] Add a convenience constructor that constructs an RValue from a single ManagedValue.

We already have a constructor similar to this, but it requires you to pass in
the CanType of the ManagedValue. This convenience constructor in contrast just
uses the ManagedValues swift rvalue type, so the caller doesn't have to do
anything.

I am going to use this when changing self in SILGenApply to use an
ArgumentSource (so I can in certain cases treat self as an lvalue).

rdar://33358110
