### PR TITLE
IRGen/Runtime: Use relative pointers in default witness table entries

### DIFF
--- a/apinotes/README.md
+++ b/apinotes/README.md
@@ -66,7 +66,7 @@ xcrun swift -apinotes -yaml-to-binary -target i386-apple-ios7.0 -o $SWIFT_EXEC/l
 
 ### iOS Simulator (64-bit)
 ```
-xcrun swift -apinotes -yaml-to-binary -target x64_64-apple-ios7.0 -o $SWIFT_EXEC/lib/swift/iphonesimulator/$MODULE.apinotesc $MODULE.apinotes
+xcrun swift -apinotes -yaml-to-binary -target x86_64-apple-ios7.0 -o $SWIFT_EXEC/lib/swift/iphonesimulator/$MODULE.apinotesc $MODULE.apinotes
 ```
 
 To add API notes for a system module `$MODULE` that does not have them yet,

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1094,6 +1094,12 @@ struct GenericParameterDescriptor {
   // TODO: add meaningful descriptions of the generic requirements.
 };
 
+template <typename Runtime>
+struct TargetMethodDescriptor {
+  /// The method implementation.
+  TargetRelativeDirectPointer<Runtime, void *> Impl;
+};
+
 /// Header for a class vtable descriptor. This is a variable-sized
 /// structure that describes how to find and parse a vtable
 /// within the type metadata for a class.
@@ -1227,7 +1233,7 @@ struct TargetNominalTypeDescriptor {
   ///
   /// Not all type metadata have access functions.
   TargetRelativeDirectPointer<Runtime, NonGenericMetadataAccessFunction,
-                              /*nullable*/ true> AccessFunction;
+                              /*Nullable*/ true> AccessFunction;
 
   /// A pointer to the generic metadata pattern that is used to instantiate
   /// instances of this type. Zero if the type is not generic.
@@ -1959,7 +1965,7 @@ struct TargetLiteralProtocolDescriptorList
   {}
 };
 using LiteralProtocolDescriptorList = TargetProtocolDescriptorList<InProcess>;
-  
+
 /// A protocol descriptor. This is not type metadata, but is referenced by
 /// existential type metadata records to describe a protocol constraint.
 /// Its layout is compatible with the Objective-C runtime's 'protocol_t' record
@@ -2000,20 +2006,23 @@ struct TargetProtocolDescriptor {
   /// Only meaningful if ProtocolDescriptorFlags::IsResilient is set.
   uint16_t MinimumWitnessTableSizeInWords;
 
-  /// The maximum amount to copy from the default requirements in words.
-  /// If any requirements beyond MinimumWitnessTableSizeInWords are present
+  /// The maximum amount to copy from the default requirements in units of
+  /// 4 bytes.
+  ///
+  /// If any requirements beyond NumDefaultWitnessTableEntries are present
   /// in the witness table template, they will be not be overwritten with
   /// defaults.
   ///
   /// Only meaningful if ProtocolDescriptorFlags::IsResilient is set.
-  uint16_t DefaultWitnessTableSizeInWords;
+  uint16_t NumDefaultWitnessTableEntries;
 
-  /// Reserved. Really just here to zero-pad the structure on 64-bit.
-  uint32_t Reserved;
+  using MethodDescriptor = TargetMethodDescriptor<Runtime>;
+
+  MethodDescriptor DefaultWitnessTable[];
 
   /// Default requirements are tail-allocated here.
-  void **getDefaultWitnesses() const {
-    return (void **) (this + 1);
+  void *getDefaultWitness(unsigned index) const {
+    return DefaultWitnessTable[index].Impl.get();
   }
 
   constexpr TargetProtocolDescriptor<Runtime>(const char *Name,
@@ -2027,7 +2036,7 @@ struct TargetProtocolDescriptor {
       DescriptorSize(sizeof(TargetProtocolDescriptor<Runtime>)),
       Flags(Flags),
       MinimumWitnessTableSizeInWords(0),
-      DefaultWitnessTableSizeInWords(0)
+      NumDefaultWitnessTableEntries(0)
   {}
 };
 using ProtocolDescriptor = TargetProtocolDescriptor<InProcess>;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5265,11 +5265,10 @@ namespace {
         B.addInt16(DefaultWitnesses->getMinimumWitnessTableSize());
         B.addInt16(DefaultWitnesses->getDefaultWitnessTableSize());
 
-        // Unused padding
-        B.addInt32(0);
-
         for (auto entry : DefaultWitnesses->getResilientDefaultEntries()) {
-          B.add(IGM.getAddrOfSILFunction(entry.getWitness(), NotForDefinition));
+          auto *witness = IGM.getAddrOfSILFunction(entry.getWitness(),
+                                                   NotForDefinition);
+          B.addRelativeAddress(witness);
         }
       } else {
         B.addInt16(0);

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -enable-resilience -enable-source-import -I %S/../Inputs | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -num-threads 8 -enable-resilience -enable-source-import -I %S/../Inputs | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-resilience -enable-source-import -I %S/../Inputs | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -num-threads 8 -enable-resilience -enable-source-import -I %S/../Inputs | %FileCheck %s
 
 import resilient_struct
 
@@ -11,74 +11,74 @@ public protocol Runcible {
 
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
-// CHECK:           [[RUNCIBLE:%swift.protocol\* @_T028protocol_conformance_records8RuncibleMp]]
+// CHECK-SAME:           [[RUNCIBLE:@_T028protocol_conformance_records8RuncibleMp]]
 // -- type metadata
-// CHECK:           @_T028protocol_conformance_records15NativeValueTypeVMf
+// CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVMf
 // -- witness table
-// CHECK:           @_T028protocol_conformance_records15NativeValueTypeVAA8RuncibleAAWP
+// CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVAA8RuncibleAAWP
 // -- flags 0x01: unique direct metadata
-// CHECK:           i32 1
-// CHECK:         },
+// CHECK-SAME:           i32 1
+// CHECK-SAME:         },
 public struct NativeValueType: Runcible {
   public func runce() {}
 }
 
 // -- TODO class refs should be indirected through their ref variable
-// CHECK:         %swift.protocol_conformance {
+// CHECK-SAME:         %swift.protocol_conformance {
 // -- protocol descriptor
-// CHECK:           [[RUNCIBLE]]
+// CHECK-SAME:           [[RUNCIBLE]]
 // -- class object (TODO should be class ref variable)
-// CHECK:           @_T028protocol_conformance_records15NativeClassTypeCMf
+// CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCMf
 // -- witness table
-// CHECK:           @_T028protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP
+// CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP
 // -- flags 0x01: unique direct metadata (TODO should be 0x03 indirect class)
-// CHECK:           i32 1
-// CHECK:         },
+// CHECK-SAME:           i32 1
+// CHECK-SAME:         },
 public class NativeClassType: Runcible {
   public func runce() {}
 }
 
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
-// CHECK:           [[RUNCIBLE]]
+// CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
-// CHECK:           @_T028protocol_conformance_records17NativeGenericTypeVMn
+// CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVMn
 // -- witness table
-// CHECK:           @_T028protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAlWP
+// CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAlWP
 // -- flags 0x04: unique nominal type descriptor
-// CHECK:           i32 4
-// CHECK:         },
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         },
 public struct NativeGenericType<T>: Runcible {
   public func runce() {}
 }
 
-// CHECK:         %swift.protocol_conformance {
+// CHECK-SAME:         %swift.protocol_conformance {
 // -- protocol descriptor
-// CHECK:           [[RUNCIBLE]]
+// CHECK-SAME:           [[RUNCIBLE]]
 // -- type metadata
-// CHECK:           @got._T0SiN
+// CHECK-SAME:           @got._T0SiN
 // -- witness table
-// CHECK:           @_T0Si28protocol_conformance_records8RuncibleAAWP
+// CHECK-SAME:           @_T0Si28protocol_conformance_records8RuncibleAAWP
 // -- flags 0x01: unique direct metadata
-// CHECK:           i32 1
-// CHECK:         }
+// CHECK-SAME:           i32 1
+// CHECK-SAME:         }
 extension Int: Runcible {
   public func runce() {}
 }
 
 // For a resilient struct, reference the NominalTypeDescriptor
 
-// CHECK:         %swift.protocol_conformance {
+// CHECK-SAME:         %swift.protocol_conformance {
 // -- protocol descriptor
-// CHECK:           [[RUNCIBLE]]
+// CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
-// CHECK:           @got._T016resilient_struct4SizeVN
+// CHECK-SAME:           @got._T016resilient_struct4SizeVN
 // -- witness table
-// CHECK:           @_T028protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAlWP
+// CHECK-SAME:           @_T016resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP
 // -- flags 0x04: unique direct metadata
-// CHECK:           i32 1
-// CHECK:         }
-// CHECK:       ]
+// CHECK-SAME:           i32 1
+// CHECK-SAME:         }
+// CHECK-SAME:       ]
 
 extension Size: Runcible {
   public func runce() {}

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -18,8 +18,7 @@ import resilient_protocol
 // CHECK-SAME:   i32 1031,
 // CHECK-SAME:   i16 4,
 // CHECK-SAME:   i16 4,
-// CHECK-SAME:   i32 0,
-// CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultC,
+// CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultC
 // CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultD
 // CHECK-SAME: }
 


### PR DESCRIPTION
Just a small cleanup I've wanted to do for a while.