### PR TITLE
[Diagnostics] Resolves: SR-5324 Improved diagnostic when instance member of outer type is referenced from nested type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -107,6 +107,9 @@ ERROR(could_not_use_type_member_on_protocol_metatype,none,
 ERROR(could_not_use_instance_member_on_type,none,
       "instance member %1 cannot be used on type %0",
       (Type, DeclName))
+ERROR(could_not_use_instance_member_of_outer_type_on_nested_type,none,
+      "instance member %1 of type %0 cannot be used on instance of nested type %2",
+      (Type, DeclName, Type))
 ERROR(could_not_use_member_on_existential,none,
       "member %1 cannot be used on value of protocol type %0; use a generic"
       " constraint instead",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -105,11 +105,10 @@ ERROR(could_not_use_type_member_on_protocol_metatype,none,
       "static member %1 cannot be used on protocol metatype %0",
       (Type, DeclName))
 ERROR(could_not_use_instance_member_on_type,none,
-      "instance member %1 cannot be used on type %0",
-      (Type, DeclName))
-ERROR(could_not_use_instance_member_of_outer_type_on_nested_type,none,
-      "instance member %1 of type %0 cannot be used on instance of nested type %2",
-      (Type, DeclName, Type))
+      "instance member %1"
+      "%select{| of type %2}3 cannot be used on"
+      "%select{| instance of nested}3 type %0",
+      (Type, DeclName, Type, bool))
 ERROR(could_not_use_member_on_existential,none,
       "member %1 cannot be used on value of protocol type %0; use a generic"
       " constraint instead",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2749,14 +2749,21 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
       // provide more specialized message.
       auto memberTypeContext = member->getDeclContext()->getInnermostTypeContext();
       auto currentTypeContext = CS.DC->getInnermostTypeContext();
-      auto IsMemberOnOuterScope = memberTypeContext->getSemanticDepth() <
-        currentTypeContext->getSemanticDepth();
-
-      diagnose(loc, diag::could_not_use_instance_member_on_type,
-               currentTypeContext->getDeclaredInterfaceType(), memberName,
-               memberTypeContext->getDeclaredTypeOfContext(),
-               IsMemberOnOuterScope)
-        .highlight(baseRange).highlight(nameLoc.getSourceRange());
+      if (memberTypeContext && currentTypeContext &&
+          memberTypeContext->getSemanticDepth() <
+          currentTypeContext->getSemanticDepth()) {
+        diagnose(loc, diag::could_not_use_instance_member_on_type,
+                 currentTypeContext->getDeclaredInterfaceType(), memberName,
+                 memberTypeContext->getDeclaredTypeOfContext(),
+                 true)
+          .highlight(baseRange).highlight(nameLoc.getSourceRange());
+      } else {
+        diagnose(loc, diag::could_not_use_instance_member_on_type,
+                 instanceTy, memberName,
+                 instanceTy,
+                 false)
+         .highlight(baseRange).highlight(nameLoc.getSourceRange());
+      }
       return;
     }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2749,17 +2749,18 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
       // provide more specialized message
       auto memberTypeContext = member->getDeclContext()->getInnermostTypeContext();
       auto currentTypeContext = CS.DC->getInnermostTypeContext();
-      if (memberTypeContext->getSyntacticDepth() < currentTypeContext->getSyntacticDepth()) {
+      if (memberTypeContext->getSemanticDepth() <
+          currentTypeContext->getSemanticDepth()) {
         diagnose(loc, diag::could_not_use_instance_member_of_outer_type_on_nested_type,
                  memberTypeContext->getDeclaredTypeOfContext(), memberName,
-                 currentTypeContext->getDeclaredTypeOfContext()
-         ).highlight(baseRange).highlight(nameLoc.getSourceRange());
+                 currentTypeContext->getDeclaredTypeOfContext())
+          .highlight(baseRange).highlight(nameLoc.getSourceRange());
         return;
       }
 
       diagnose(loc, diag::could_not_use_instance_member_on_type,
                instanceTy, memberName)
-      .highlight(baseRange).highlight(nameLoc.getSourceRange());
+        .highlight(baseRange).highlight(nameLoc.getSourceRange());
       return;
     }
 

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -450,6 +450,8 @@ func rdar33914444() {
   // expected-error@-1 {{type 'A.R<A.S.E>' has no member 'e1'}}
 }
 
+// SR-5324: Better diagnostic when instance member of outer type is referenced from nested type
+
 struct Outer {
   var outer: Int
 

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -460,7 +460,7 @@ struct Outer {
 
     func sum() -> Int {
       return inner + outer
-      // expected-error{{instance member 'outer' of type 'Outer' cannot be used on instance of nested type 'Outer.Inner'}}
+      // expected-error@-1 {{instance member 'outer' of type 'Outer' cannot be used on instance of nested type 'Outer.Inner'}}
     }
   }
 }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -449,3 +449,16 @@ func rdar33914444() {
   _ = A.S(e: .e1)
   // expected-error@-1 {{type 'A.R<A.S.E>' has no member 'e1'}}
 }
+
+struct Outer {
+  var outer: Int
+
+  struct Inner {
+    var inner: Int
+
+    func sum() -> Int {
+      return inner + outer
+      // expected-error{{instance member 'outer' of type 'Outer' cannot be used on instance of nested type 'Outer.Inner'}}
+    }
+  }
+}


### PR DESCRIPTION
The intended behavior is described in JIRA issue.
Resolves [SR-5324](https://bugs.swift.org/browse/SR-5324).

It's my first touch to the Swift compiler and I'm not sure whether it's the right approach. I'm looking for your feedback :) 
Could you take a look @xedin ?

Thanks!