### PR TITLE
Change the structure of emitted protocol and generic-wtable metadata

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -407,6 +407,36 @@ public:
   }
 };
 
+class ProtocolRequirementFlags {
+public:
+  typedef uint32_t int_type;
+  enum class Kind {
+    BaseProtocol,
+    InstanceMethod,
+    StaticMethod,
+    Init,
+    Getter,
+    Setter,
+    MaterializeForSet,
+    AssociatedTypeAccessFunction,
+    AssociatedConformanceAccessFunction,
+  };
+
+private:
+  enum : int_type {
+    KindMask = 0x1F,                // 32 kinds should be enough for anybody
+  };
+
+  int_type Value;
+
+public:
+  ProtocolRequirementFlags(Kind kind) : Value(unsigned(kind)) {}
+
+  Kind getKind() const { return Kind(Value & KindMask); }
+
+  int_type getIntValue() const { return Value; }
+};
+
 /// Flags in an existential type metadata record.
 class ExistentialTypeFlags {
   typedef size_t int_type;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3385,7 +3385,7 @@ llvm::StructType *IRGenModule::getGenericWitnessTableCacheTy() {
       // Instantiator
       RelativeAddressTy,
       // PrivateData
-      llvm::ArrayType::get(Int8PtrTy, swift::NumGenericMetadataPrivateDataWords)
+      RelativeAddressTy
     }, "swift.generic_witness_table_cache");
   return GenericWitnessTableCacheTy;
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -194,12 +194,18 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     Int8PtrTy,              // objc properties
     Int32Ty,                // size
     Int32Ty,                // flags
-    Int16Ty,                // minimum witness count
-    Int16Ty,                // default witness count
-    Int32Ty                 // padding
+    Int16Ty,                // mandatory requirement count
+    Int16Ty,                // total requirement count
+    Int32Ty                 // requirements array
   });
   
   ProtocolDescriptorPtrTy = ProtocolDescriptorStructTy->getPointerTo();
+
+  ProtocolRequirementStructTy =
+      createStructType(*this, "swift.protocol_requirement", {
+    Int32Ty,                // flags
+    Int32Ty                 // default implementation
+  });
   
   // A tuple type metadata record has a couple extra fields.
   auto tupleElementTy = createStructType(*this, "swift.tuple_element_type", {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -468,6 +468,7 @@ public:
   llvm::PointerType *FullTypeMetadataPtrTy;/// %swift.full_type*
   llvm::StructType *ProtocolDescriptorStructTy; /// %swift.protocol = type { ... }
   llvm::PointerType *ProtocolDescriptorPtrTy; /// %swift.protocol*
+  llvm::StructType *ProtocolRequirementStructTy; /// %swift.protocol_requirement
   union {
     llvm::PointerType *ObjCPtrTy;        /// %objc_object*
     llvm::PointerType *UnknownRefCountedPtrTy;

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -78,7 +78,7 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    i8* bitcast (i8** (%swift.type*, %swift.type*, i8**)* @_T023associated_type_witness8ComputedVyxq_GAA8AssockedAAr0_l5AssocAA1QPWT to i8*)
 // GLOBAL-SAME:  ]
 //   Generic witness table cache for Computed : Assocked.
-// GLOBAL-LABEL: @_T023associated_type_witness8ComputedVyxq_GAA8AssockedAAr0_lWG = internal global %swift.generic_witness_table_cache {
+// GLOBAL-LABEL: @_T023associated_type_witness8ComputedVyxq_GAA8AssockedAAr0_lWG = internal constant %swift.generic_witness_table_cache {
 // GLOBAL-SAME:    i16 3,
 // GLOBAL-SAME:    i16 1,
 //    Relative reference to protocol
@@ -87,8 +87,10 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([3 x i8*]* @_T023associated_type_witness8ComputedVyxq_GAA8AssockedAAr0_lWP to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @_T023associated_type_witness8ComputedVyxq_GAA8AssockedAAr0_lWG, i32 0, i32 3) to i64)) to i32),
 //    No instantiator function
 // GLOBAL-SAME:    i32 0,
-// GLOBAL-SAME:    [16 x i8*] zeroinitializer
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @_T023associated_type_witness8ComputedVyxq_GAA8AssockedAAr0_lWG, i32 0, i32 5) to i64)) to i32)
 // GLOBAL-SAME:  }
+// GLOBAL:       [[PRIVATE]] = internal global [16 x i8*] zeroinitializer
+
 struct Computed<T, U> : Assocked {
   typealias Assoc = Pair<T, U>
 }
@@ -132,7 +134,7 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 //   Generic witness table pattern for GenericComputed : DerivedFromSimpleAssoc.
 // GLOBAL-LABEL: @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWP = hidden constant [1 x i8*] zeroinitializer
 //   Generic witness table cache for GenericComputed : DerivedFromSimpleAssoc.
-// GLOBAL-LABEL: @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG = internal global %swift.generic_witness_table_cache {
+// GLOBAL-LABEL: @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG = internal constant %swift.generic_witness_table_cache {
 // GLOBAL-SAME:    i16 1,
 // GLOBAL-SAME:    i16 0,
 //   Relative reference to protocol
@@ -141,7 +143,7 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([1 x i8*]* @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWP to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG, i32 0, i32 3) to i64)) to i32),
 //   Relative reference to instantiator function
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWI to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG, i32 0, i32 4) to i64)) to i32),
-// GLOBAL-SAME:    [16 x i8*] zeroinitializer
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* {{@.*}} to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @_T023associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG, i32 0, i32 5) to i64)) to i32)
 // GLOBAL-SAME:  }
 struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
   typealias Assoc = PBox<T>

--- a/test/IRGen/generic_wt_linkage.sil
+++ b/test/IRGen/generic_wt_linkage.sil
@@ -44,7 +44,7 @@ sil_default_witness_table hidden DerivedFromSimpleAssoc {
   no_default
 }
 
-// CHECK: @_T04test15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG = internal global
+// CHECK: @_T04test15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWG = internal constant
 // CHECK: define internal void @_T04test15GenericComputedVyxGAA22DerivedFromSimpleAssocA2A1PRzlWI
 
 

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -21,20 +21,23 @@ protocol ABO : A, B, O { func abo() }
 // CHECK: @_T017protocol_metadata1AMp = hidden constant %swift.protocol {
 // -- size 72
 // -- flags: 1 = Swift | 2 = Not Class-Constrained | 4 = Needs Witness Table
-// CHECK:   i32 72, i32 7,
-// CHECK:   i16 0, i16 0
-// CHECK: }
+// CHECK-SAME:   i32 72, i32 7,
+// CHECK-SAME:   i16 1, i16 1,
+// CHECK-SAME:   i32 trunc (i64 sub (i64 ptrtoint ([1 x %swift.protocol_requirement]* [[A_REQTS:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @_T017protocol_metadata1AMp, i32 0, i32 12) to i64)) to i32)
+// CHECK-SAME: }
 
 // CHECK: @_T017protocol_metadata1BMp = hidden constant %swift.protocol {
-// CHECK:   i32 72, i32 7,
-// CHECK:   i16 0, i16 0
+// CHECK-SAME:   i32 72, i32 7,
+// CHECK-SAME:   i16 1, i16 1,
+// CHECK-SAME:   i32 trunc (i64 sub (i64 ptrtoint ([1 x %swift.protocol_requirement]* [[B_REQTS:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @_T017protocol_metadata1BMp, i32 0, i32 12) to i64)) to i32)
 // CHECK: }
 
 // CHECK: @_T017protocol_metadata1CMp = hidden constant %swift.protocol {
 // -- flags: 1 = Swift | 4 = Needs Witness Table
-// CHECK:   i32 72, i32 5,
-// CHECK:   i16 0, i16 0
-// CHECK: }
+// CHECK-SAME:   i32 72, i32 5,
+// CHECK-SAME:   i16 1, i16 1,
+// CHECK-SAME:   i32 trunc (i64 sub (i64 ptrtoint ([1 x %swift.protocol_requirement]* [[C_REQTS:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @_T017protocol_metadata1CMp, i32 0, i32 12) to i64)) to i32)
+// CHECK-SAME: }
 
 // -- @objc protocol O uses ObjC symbol mangling and layout
 // CHECK: @_PROTOCOL__TtP17protocol_metadata1O_ = private constant { {{.*}} i32, [1 x i8*]*, i8*, i8* } {
@@ -43,6 +46,10 @@ protocol ABO : A, B, O { func abo() }
 // CHECK-SAME:   i32 96, i32 1
 // CHECK-SAME: @_PROTOCOL_METHOD_TYPES__TtP17protocol_metadata1O_
 // CHECK-SAME: }
+
+// CHECK: [[A_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 1, i32 0 }]
+// CHECK: [[B_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 1, i32 0 }]
+// CHECK: [[C_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 1, i32 0 }]
 
 // -- @objc protocol OPT uses ObjC symbol mangling and layout
 // CHECK: @_PROTOCOL__TtP17protocol_metadata3OPT_ = private constant { {{.*}} i32, [4 x i8*]*, i8*, i8* } {
@@ -60,11 +67,13 @@ protocol ABO : A, B, O { func abo() }
 // CHECK:   %swift.protocol* @_T017protocol_metadata1AMp,
 // CHECK:   %swift.protocol* @_T017protocol_metadata1BMp
 // CHECK: }
+// CHECK: [[AB_REQTS:@.*]] = internal unnamed_addr constant [3 x %swift.protocol_requirement] [%swift.protocol_requirement zeroinitializer, %swift.protocol_requirement zeroinitializer, %swift.protocol_requirement { i32 1, i32 0 }]
 // CHECK: @_T017protocol_metadata2ABMp = hidden constant %swift.protocol { 
-// CHECK:   [[AB_INHERITED]]
-// CHECK:   i32 72, i32 7,
-// CHECK:   i16 0, i16 0
-// CHECK: }
+// CHECK-SAME:   [[AB_INHERITED]]
+// CHECK-SAME:   i32 72, i32 7,
+// CHECK-SAME:   i16 3, i16 3,
+// CHECK-SAME:   i32 trunc (i64 sub (i64 ptrtoint ([3 x %swift.protocol_requirement]* [[AB_REQTS]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @_T017protocol_metadata2ABMp, i32 0, i32 12) to i64)) to i32)
+// CHECK-SAME: }
 
 // CHECK: [[ABO_INHERITED:@.*]] = private constant { {{.*}}* } {
 // CHECK:   i64 3,

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -14,12 +14,20 @@ import resilient_protocol
 
 // Protocol is public -- needs resilient witness table
 
-// CHECK: @_T019protocol_resilience17ResilientProtocolMp = {{(protected )?}}constant { {{.*}} } {
+// CHECK: [[RP_REQTS:@.*]] = internal unnamed_addr constant [8 x %swift.protocol_requirement]
+// CHECK-SAME:  [%swift.protocol_requirement { i32 7, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 8, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultC to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 4, i32 1) to {{i32|i64}})){{ | to i32\) }}},
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultD to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 5, i32 1) to {{i32|i64}})){{ | to i32\) }}},
+// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultE to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 6, i32 1) to {{i32|i64}})){{ | to i32\) }}},
+// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultF to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 7, i32 1) to {{i32|i64}})){{ | to i32\) }}}]
+
+// CHECK: @_T019protocol_resilience17ResilientProtocolMp = {{(protected )?}}constant %swift.protocol {
 // CHECK-SAME:   i32 1031,
 // CHECK-SAME:   i16 4,
-// CHECK-SAME:   i16 4,
-// CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultC
-// CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultD
+// CHECK-SAME:   i16 8,
+// CHECK-SAME:   i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint ([8 x %swift.protocol_requirement]* [[RP_REQTS]] to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @_T019protocol_resilience17ResilientProtocolMp, i32 0, i32 12) to {{i32|i64}})){{ | to i32\) }}
 // CHECK-SAME: }
 
 
@@ -39,9 +47,9 @@ public protocol ResilientProtocol {
 
 // CHECK: @_T019protocol_resilience16InternalProtocolMp = hidden constant %swift.protocol {
 // CHECK-SAME:   i32 7,
-// CHECK-SAME:   i16 0,
-// CHECK-SAME:   i16 0,
-// CHECK-SAME:   i32 0
+// CHECK-SAME:   i16 1,
+// CHECK-SAME:   i16 1,
+// CHECK-SAME:   i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint ([1 x %swift.protocol_requirement]* [[IP_REQTS:@.*]] to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @_T019protocol_resilience16InternalProtocolMp, i32 0, i32 12) to {{i32|i64}})){{ | to i32\) }}
 // CHECK-SAME: }
 
 protocol InternalProtocol {


### PR DESCRIPTION
Change the structure of emitted protocol and generic-wtable metadata:

- Always include an array of requirement descriptors in the protocol
  descriptor.  For now, this doesn't contain anything except a general
  requirement kind and an optional default implementation, but eventually
  this can be augmented with type / name metadata.  This array is always
  emitted as constant.

- Guarantee the value of the extent fields in a protocol descriptor and
  slightly tweak their meaning.

- Move the private-data field out of line in a generic witness table
  descriptor so that the main descriptor can be emitted as constant.

- Rely on IRGen's notion of the witness-table layout instead of assuming
  that SILWitnessTable and SILDefaultWitnessTable match the actual
  physical layout.