### PR TITLE
Implement SE-0075: CanImport

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -262,6 +262,9 @@ private:
   llvm::DenseMap<const Pattern *, DeclContext *>
     DelayedPatternContexts;
 
+  /// Cache of module names that fail the 'canImport' test in this context.
+  llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
+  
 public:
   /// \brief Retrieve the allocator for the given arena.
   llvm::BumpPtrAllocator &

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -43,8 +43,9 @@ namespace swift {
     Endianness,
     /// Runtime support (_ObjC or _Native)
     Runtime,
+    /// Conditional import of module
+    CanImport,
   };
-  enum { NumPlatformConditionKind = 4 };
 
   /// Describes which Swift 3 Objective-C inference warnings should be
   /// emitted.
@@ -341,8 +342,7 @@ namespace swift {
     }
 
   private:
-    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>,
-                      NumPlatformConditionKind>
+    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 4>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
   };

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -426,7 +426,9 @@ public:
 
   /// Parses the input file but does no type-checking or module imports.
   /// Note that this only supports parsing an invocation with a single file.
-  void performParseOnly();
+  ///
+  ///
+  void performParseOnly(bool EvaluateConditionals = false);
 
   /// Frees up the ASTContext and SILModule objects that this instance is
   /// holding on.

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -98,7 +98,9 @@ public:
   };
 
   bool InPoundLineEnvironment = false;
-
+  // FIXME: When condition evaluation moves to a later phase, remove this bit
+  // and adjust the client call 'performParseOnly'.
+  bool PerformConditionEvaluation = true;
 private:
   ScopeInfo ScopeInfo;
   typedef llvm::DenseMap<AbstractFunctionDecl *,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1458,12 +1458,18 @@ bool ASTContext::canImportModule(std::pair<Identifier, SourceLoc> ModulePath) {
   if (getLoadedModule(ModulePath) != nullptr)
     return true;
 
+  // If we've failed loading this module before, don't look for it again.
+  if (FailedModuleImportNames.count(ModulePath.first))
+    return false;
+
   // Otherwise, ask the module loaders.
   for (auto &importer : Impl.ModuleLoaders) {
     if (importer->canImportModule(ModulePath)) {
       return true;
     }
   }
+
+  FailedModuleImportNames.insert(ModulePath.first);
   return false;
 }
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -98,6 +98,10 @@ checkPlatformConditionSupported(PlatformConditionKind Kind, StringRef Value,
   case PlatformConditionKind::Runtime:
     return contains(SupportedConditionalCompilationRuntimes, Value,
                     suggestions);
+  case PlatformConditionKind::CanImport:
+    // All importable names are valid.
+    // FIXME: Perform some kind of validation of the string?
+    return true;
   }
   llvm_unreachable("Unhandled enum value");
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -581,7 +581,7 @@ void CompilerInstance::performSema() {
         finishTypeChecking(*SF);
 }
 
-void CompilerInstance::performParseOnly() {
+void CompilerInstance::performParseOnly(bool EvaluateConditionals) {
   const InputFileKind Kind = Invocation.getInputKind();
   ModuleDecl *MainModule = getMainModule();
   Context->LoadedModules[MainModule->getName()] = MainModule;
@@ -608,6 +608,7 @@ void CompilerInstance::performParseOnly() {
   }
 
   PersistentParserState PersistentState;
+  PersistentState.PerformConditionEvaluation = EvaluateConditionals;
   // Parse all the library files.
   for (auto BufferID : BufferIDs) {
     if (BufferID == MainBufferID)

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -13,7 +13,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
 
 // REQUIRES: objc_interop
-// REQUIRES: can_import
 
 // Test that 'canImport(Foo)' directives do not open symbols from 'Foo' into the
 // current module.  Only an 'import Foo' statement should do this.

--- a/test/ClangImporter/can_import_missing_requirement.swift
+++ b/test/ClangImporter/can_import_missing_requirement.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/missing-requirement %s -verify
 
 // REQUIRES: objc_interop
-// REQUIRES: can_import
 
 class Unique {}
 

--- a/test/IDE/print_ast_non_typechecked.swift
+++ b/test/IDE/print_ast_non_typechecked.swift
@@ -23,5 +23,3 @@ func qux() {}
 // CHECK1: {{^}}  func qux() {
 // CHECK1: {{^}}  }
 // CHECK1: {{^}}#endif
-// CHECK1: {{^}}func qux() {
-// CHECK1: {{^}}}

--- a/test/Parse/ConditionalCompilation/can_import.swift
+++ b/test/Parse/ConditionalCompilation/can_import.swift
@@ -1,8 +1,6 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library
 // RUN: %target-typecheck-verify-swift -D WITH_PERFORM -primary-file %s %S/Inputs/can_import_nonprimary_file.swift
 
-// REQUIRES: can_import
-
 public struct LibraryDependentBool : ExpressibleByBooleanLiteral {
 #if canImport(Swift)
   var _description: String

--- a/test/Parse/ConditionalCompilation/can_import_idempotent.swift
+++ b/test/Parse/ConditionalCompilation/can_import_idempotent.swift
@@ -4,8 +4,6 @@
 // RUN: echo "public var dummyVar = Int()" | %target-swift-frontend -module-name DummyModule -emit-module -o %t -
 // RUN: %target-swift-frontend -typecheck -verify -I %t %s
 
-// REQUIRES: can_import
-
 #if canImport(DummyModule)
 print(DummyModule.dummyVar) // expected-error {{use of unresolved identifier 'DummyModule'}}
 print(dummyVar) // expected-error {{use of unresolved identifier 'dummyVar'}}

--- a/test/Parse/ConditionalCompilation/can_import_sdk.swift
+++ b/test/Parse/ConditionalCompilation/can_import_sdk.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
 
 // REQUIRES: objc_interop
-// REQUIRES: can_import
 
 class Unique {} 
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1366,7 +1366,7 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     Error = "Compiler invocation set up failed";
     return nullptr;
   }
-  ParseCI.performParseOnly();
+  ParseCI.performParseOnly(/*EvaluateConditionals*/true);
 
   SourceFile *SF = nullptr;
   unsigned BufferID = ParseCI.getInputBufferIDs().back();

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
   switch (options::Action) {
     case RefactoringKind::GlobalRename:
     case RefactoringKind::FindGlobalRenameRanges:
-      CI.performParseOnly();
+      CI.performParseOnly(/*EvaluateConditionals*/true);
       break;
     default:
       CI.performSema();


### PR DESCRIPTION
This implementation required a compromise between parser
performance and AST structuring.  On the one hand, Parse
must be fast in order to keep things in the IDE zippy, on
the other we must hit the disk to properly resolve 'canImport'
conditions and inject members of the active clause into the AST.
Additionally, a Parse-only pass may not provide platform-specific
information to the compiler invocation and so may mistakenly
activate or de-activate branches in the if-configuration decl.

The compromise is to perform condition evaluation only when
continuing on to semantic analysis.  This keeps the parser quick
and avoids the odd unpacking that parse does for active conditions
while still retaining the ability to see through to an active
condition when we know we're moving on to a more expensive phase like
semantic analysis anyways.

Resolves [SR-1560](https://bugs.swift.org/browse/SR-1560) and any associated shadowing oddities from the first go around.