### PR TITLE
Re-enable the tsan-inout.swift test

### DIFF
--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -7,8 +7,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime
 
-// REQUIRES: rdar_33757304
-
 // Test ThreadSanitizer execution end-to-end when calling
 // an uninstrumented module with inout parameters
 


### PR DESCRIPTION
The underlaying OS problem should be resolved now, let's re-enable the test.