### PR TITLE
In case of Android, give warning only and return the empty sectionInfo.

### DIFF
--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -27,6 +27,10 @@
 #include <link.h>
 #include <string.h>
 
+#if defined(__ANDROID__)
+#include "llvm/ADT/StringRef.h"
+#endif
+
 using namespace swift;
 
 /// The symbol name in the image that identifies the beginning of the
@@ -68,6 +72,13 @@ static SectionInfo getSectionInfo(const char *imageName,
   SectionInfo sectionInfo = { 0, nullptr };
   void *handle = dlopen(imageName, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
+#ifdef __ANDROID__
+    llvm::StringRef imagePath = llvm::StringRef(imageName);
+    if (imagePath.startswith("/system/lib") ||
+        (imageName && !imagePath.endswith(".so"))) {
+      return sectionInfo;
+    }
+#endif
     fatalError(/* flags = */ 0, "dlopen() failed on `%s': %s", imageName,
                dlerror());
   }


### PR DESCRIPTION
This will avoid unnecessary crashes in Android

<!-- What's in this pull request? -->
Fix for https://bugs.swift.org/browse/SR-5757

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5757](https://bugs.swift.org/browse/SR-5757).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
