### PR TITLE
[ConstraintSolver] Fix validation of `DynamicTypeOf` to use left-hand…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -217,8 +217,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       // bound (because 'Bind' requires equal types to
       // succeed), or left is bound to Any which is not an
       // [existential] metatype.
-      if (constraint->getFirstType()->isEqual(typeVar))
-        return {};
+      auto dynamicType = constraint->getFirstType();
+      if (auto *tv = dynamicType->getAs<TypeVariableType>()) {
+        if (tv->getImpl().getRepresentative(nullptr) == typeVar)
+          return {};
+      }
 
       // This is right-hand side, let's continue.
       continue;

--- a/test/Constraints/type_of.swift
+++ b/test/Constraints/type_of.swift
@@ -44,15 +44,37 @@ class C {
    typealias T = Int
 }
 
+// We need at least 4 classes here because type(of:)
+// has 3 declarations in this file, and we need to
+// try and make it so type(of:) picked as first overload.
+
 class D : C {
+   typealias T = Float
+}
+
+class E : D {
+   typealias T = Double
+}
+
+class F : E {
+   typealias T = UInt
+}
+
+class G : F {
    typealias T = Float
 }
 
 func foo(_: Any...) {}
 
-func bar() -> Int { return 42 }    // expected-note {{found this candidate}}
-func bar() -> Float { return 0.0 } // expected-note {{found this candidate}}
+// It's imperative for bar() to have more overloads
+// the that of type(of:) to make sure that latter is
+// picked first.
 
-foo(type(of: D.T.self)) // Ok
-let _: Any = type(of: D.T.self) // Ok
+func bar() -> Int {}    // expected-note {{found this candidate}}
+func bar() -> Float {}  // expected-note {{found this candidate}}
+func bar() -> String {} // expected-note {{found this candidate}}
+func bar() -> UInt {}   // expected-note {{found this candidate}}
+
+foo(type(of: G.T.self)) // Ok
+let _: Any = type(of: G.T.self) // Ok
 foo(type(of: bar())) // expected-error {{ambiguous use of 'bar()'}}


### PR DESCRIPTION
… side's representative

When search for potential bindings for the given type variable
encounters `DynamicTypeOf` constraint, its validation should use
representative type variable of the left-hand side instead of
direct comparison.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
