### PR TITLE
Disable ArraySlice.append index test

### DIFF
--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -226,13 +226,14 @@ let indexTests: [ArrayIndexTest<[Int]>] = [
     expectedEnd: 1,
     operation: .append(1)
   ),
-  ArrayIndexTest(
-    data: [ 42, 2525, 3535, 42 ],
-    expectedStart: 1,
-    expectedEnd: 3,
-    operation: .append(1),
-    range: 1..<2
-  ),
+  // TODO: re-enable when rdar://problem/33358110 is addressed
+  // ArrayIndexTest(
+  //   data: [ 42, 2525, 3535, 42 ],
+  //   expectedStart: 1,
+  //   expectedEnd: 3,
+  //   operation: .append(1),
+  //   range: 1..<2
+  // ),
   // Check how insert(_:at:) affects indices.
   ArrayIndexTest(
     data: [ 2 ],


### PR DESCRIPTION
This test is failing for debug builds. Disable it for now.