### PR TITLE
[4.0] Fix ambiguity between overlay inits and default inits for BNNS structs.

### DIFF
--- a/stdlib/public/SDK/Accelerate/BNNS.swift.gyb
+++ b/stdlib/public/SDK/Accelerate/BNNS.swift.gyb
@@ -89,9 +89,7 @@ extension BNNSImageStackDescriptor {
               channels: Int,
               row_stride: Int,
               image_stride: Int,
-              data_type: BNNSDataType,
-              data_scale: Float = 1,
-              data_bias: Float = 0) {
+              data_type: BNNSDataType) {
 
     _precondition(data_type != .indexed8,
                   "Image stacks cannot use the indexed8 data type.")
@@ -102,25 +100,23 @@ extension BNNSImageStackDescriptor {
     self.row_stride = row_stride
     self.image_stride = image_stride
     self.data_type = data_type
-    self.data_scale = data_scale
-    self.data_bias = data_bias
+    self.data_scale = 1
+    self.data_bias = 0
   }
 }
 
 extension BNNSVectorDescriptor {
   ${available(bnns2016)}
   public init(size: Int,
-              data_type: BNNSDataType,
-              data_scale: Float = 1,
-              data_bias: Float = 0) {
+              data_type: BNNSDataType) {
 
     _precondition(data_type != .indexed8,
                   "Vectors cannot use the indexed8 data type.")
 
     self.size = size
     self.data_type = data_type
-    self.data_scale = data_scale
-    self.data_bias = data_bias
+    self.data_scale = 1
+    self.data_bias = 0
   }
 }
 
@@ -129,24 +125,33 @@ extension BNNSLayerData {
   public init(data: UnsafeRawPointer?,
               data_type: BNNSDataType,
               data_scale: Float = 1,
-              data_bias: Float = 0,
-              data_table: UnsafePointer<Float>? = nil) {
+              data_bias: Float = 0) {
 
-    if data_type == .indexed8 {
-      _precondition(data_table != nil,
-                    "data_table cannot be nil if data_type is .indexed8.")
-    }
+    _precondition(data_type != .indexed8,
+                  "This initializer cannot be used with the indexed8 data type; use BNNSLayerData.indexed8 instead.")
 
     self.data = data
     self.data_type = data_type
     self.data_scale = data_scale
     self.data_bias = data_bias
-    self.data_table = data_table
+    self.data_table = nil
   }
 
   ${available(bnns2016)}
   public static var zero: BNNSLayerData {
     return BNNSLayerData()
+  }
+
+  /// A BNNSLayerData object with the indexed8 data type.
+  ${available(bnns2016)}
+  public static func indexed8(data: UnsafePointer<Int8>?,
+                              data_table: UnsafePointer<Float>)
+                              -> BNNSLayerData {
+    return BNNSLayerData(data: data,
+                         data_type: .indexed8,
+                         data_scale: 1, // unused
+                         data_bias: 0, // unused
+                         data_table: data_table)
   }
 }
 
@@ -231,9 +236,7 @@ extension BNNSConvolutionLayerParameters {
               k_height: Int,
               in_channels: Int,
               out_channels: Int,
-              weights: BNNSLayerData,
-              bias: BNNSLayerData = .zero,
-              activation: BNNSActivation = .identity) {
+              weights: BNNSLayerData) {
     self.x_stride = x_stride
     self.y_stride = y_stride
     self.x_padding = x_padding
@@ -243,8 +246,8 @@ extension BNNSConvolutionLayerParameters {
     self.in_channels = in_channels
     self.out_channels = out_channels
     self.weights = weights
-    self.bias = bias
-    self.activation = activation
+    self.bias = .zero
+    self.activation = .identity
   }
 }
 
@@ -258,9 +261,7 @@ extension BNNSPoolingLayerParameters {
               k_height: Int,
               in_channels: Int,
               out_channels: Int,
-              pooling_function: BNNSPoolingFunction,
-              bias: BNNSLayerData = .zero,
-              activation: BNNSActivation = .identity) {
+              pooling_function: BNNSPoolingFunction) {
     self.x_stride = x_stride
     self.y_stride = y_stride
     self.x_padding = x_padding
@@ -270,8 +271,8 @@ extension BNNSPoolingLayerParameters {
     self.in_channels = in_channels
     self.out_channels = out_channels
     self.pooling_function = pooling_function
-    self.bias = bias
-    self.activation = activation
+    self.bias = .zero
+    self.activation = .identity
   }
 }
 
@@ -279,13 +280,11 @@ extension BNNSFullyConnectedLayerParameters {
   ${available(bnns2016)}
   public init(in_size: Int,
               out_size: Int,
-              weights: BNNSLayerData,
-              bias: BNNSLayerData = .zero,
-              activation: BNNSActivation = .identity) {
+              weights: BNNSLayerData) {
     self.in_size = in_size
     self.out_size = out_size
     self.weights = weights
-    self.bias = bias
-    self.activation = activation
+    self.bias = .zero
+    self.activation = .identity
   }
 }

--- a/test/stdlib/Accelerate.swift
+++ b/test/stdlib/Accelerate.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// UNSUPPORTED: OS=watchos
 // XFAIL: linux
 
 import StdlibUnittest

--- a/test/stdlib/Accelerate.swift
+++ b/test/stdlib/Accelerate.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// UNSUPPORTED: OS=watchos
 // XFAIL: linux
 
 import StdlibUnittest
@@ -9,14 +8,20 @@ import Accelerate
 
 var AccelerateTests = TestSuite("Accelerate")
 
-if #available(iOS 10.0, OSX 10.12, tvOS 10.0, *) {
+if #available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 4.0, *) {
   
   AccelerateTests.test("BNNS/ImageStackDescriptor") {
-    let succeed = BNNSImageStackDescriptor(width: 0, height: 0, channels: 0,
+    var succeed = BNNSImageStackDescriptor(width: 0, height: 0, channels: 0,
                                            row_stride: 0, image_stride: 0,
                                            data_type: .int8)
     expectEqual(succeed.data_scale, 1)
     expectEqual(succeed.data_bias, 0)
+    succeed = BNNSImageStackDescriptor(width: 0, height: 0, channels: 0,
+                                       row_stride: 0, image_stride: 0,
+                                       data_type: .int16,
+                                       data_scale: 0.5, data_bias: 0.5)
+    expectEqual(succeed.data_scale, 0.5)
+    expectEqual(succeed.data_bias, 0.5)
     expectCrashLater()
     //  indexed8 is not allowed as an imageStack data type.
     let _ = BNNSImageStackDescriptor(width: 0, height: 0, channels: 0,
@@ -25,9 +30,13 @@ if #available(iOS 10.0, OSX 10.12, tvOS 10.0, *) {
   }
   
   AccelerateTests.test("BNNS/VectorDescriptor") {
-    let succeed = BNNSVectorDescriptor(size: 0, data_type: .int8)
+    var succeed = BNNSVectorDescriptor(size: 0, data_type: .int8)
     expectEqual(succeed.data_scale, 1)
     expectEqual(succeed.data_bias, 0)
+    succeed = BNNSVectorDescriptor(size: 0, data_type: .int8,
+                                   data_scale: 0.5, data_bias: 0.5)
+    expectEqual(succeed.data_scale, 0.5)
+    expectEqual(succeed.data_bias, 0.5)
     expectCrashLater()
     //  indexed8 is not allowed as a vector data type.
     let _ = BNNSVectorDescriptor(size: 0, data_type: .indexed8)
@@ -39,8 +48,12 @@ if #available(iOS 10.0, OSX 10.12, tvOS 10.0, *) {
     var succeed = BNNSLayerData(data: nil, data_type: .int8)
     expectEqual(succeed.data_scale, 1)
     expectEqual(succeed.data_bias, 0)
+    succeed = BNNSLayerData(data: nil, data_type: .int8, data_scale: 0.5,
+                            data_bias: 0.5, data_table: nil)
+    expectEqual(succeed.data_scale, 0.5)
+    expectEqual(succeed.data_bias, 0.5)
     var table: [Float] = [1.0]
-    succeed = BNNSLayerData(data: nil, data_type: .indexed8, data_table: &table)
+    succeed = BNNSLayerData.indexed8(data: nil, data_table: &table)
     expectCrashLater()
     // indexed8 requires a non-nil data table.
     let _ = BNNSLayerData(data: nil, data_type: .indexed8)


### PR DESCRIPTION
Most of these are resolvable by simply switching over to inits without the previously-defaulted arguments, because the default args are all-or-nothing. In one case that doesn't make sense, so instead I've provided a dedicated static func to construct one class of object, and an init that doesn't match the importer-created one for the more common case.

resolves rdar://problem/33880553

[for swift-4.0-branch]
**Explanation:** Some inits in the BNNS overlay are not available due to ambiguity with the importer-created inits.
**Scope:** Local to the Accelerate/vecLib/BNNS module.
**Radar:** 33880553
**Risk:** Low. Only effects BNNS functions, and only really makes functionality available that is currently entirely broken.