### PR TITLE
[4.0] Fix Quaternions init from vector

### DIFF
--- a/stdlib/public/SDK/simd/Quaternion.swift.gyb
+++ b/stdlib/public/SDK/simd/Quaternion.swift.gyb
@@ -43,13 +43,6 @@ extension ${quat} {
     vector = simd_make_${vec4}(imag, real)
   }
 
-  /// Construct a quaternion from a vector; the imaginary parts are the first
-  /// three components of the vector, and the real part is the last component.
-  @_transparent
-  public init(vector: ${vec4}) {
-    self.vector = vector
-  }
-
   /// A quaternion whose action is a rotation by `angle` radians about `axis`.
   ///
   /// - Parameters:


### PR DESCRIPTION
We already get these inits from the imported (C) struct definition, so having them in the overlay extension merely results in a false ambiguity.

<rdar://problem/33758735> Cannot call simd_quatf(vector: ...) in Swift 4

[for swift-4.0-branch]
**Explanation:** Remove unnecessary inits that cause ambiguity.
**Scope:** Local to the simd overlay
**Radar:** 33758735
**Risk:** Very Low.