### PR TITLE
Try to ensure we try to bind the elements of BindParam constraints le…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -188,9 +188,16 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       continue;
 
     switch (constraint->getKind()) {
+    case ConstraintKind::BindParam:
+      if (simplifyType(constraint->getSecondType())
+              ->getAs<TypeVariableType>() == typeVar) {
+        result.IsRHSOfBindParam = true;
+      }
+
+      LLVM_FALLTHROUGH;
+
     case ConstraintKind::Bind:
     case ConstraintKind::Equal:
-    case ConstraintKind::BindParam:
     case ConstraintKind::BindToPointerType:
     case ConstraintKind::Subtype:
     case ConstraintKind::Conversion:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2532,6 +2532,9 @@ private:
     /// The number of defaultable bindings.
     unsigned NumDefaultableBindings = 0;
 
+    /// Is this type variable on the RHS of a BindParam constraint?
+    bool IsRHSOfBindParam = false;
+
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
 
@@ -2544,12 +2547,14 @@ private:
     /// \c x is a better set of bindings that \c y.
     friend bool operator<(const PotentialBindings &x,
                           const PotentialBindings &y) {
-      return std::make_tuple(!x.hasNonDefaultableBindings(), x.FullyBound,
+      return std::make_tuple(!x.hasNonDefaultableBindings(),
+                             x.FullyBound, x.IsRHSOfBindParam,
                              x.SubtypeOfExistentialType,
                              static_cast<unsigned char>(x.LiteralBinding),
                              x.InvolvesTypeVariables,
                              -(x.Bindings.size() - x.NumDefaultableBindings)) <
-             std::make_tuple(!y.hasNonDefaultableBindings(), y.FullyBound,
+             std::make_tuple(!y.hasNonDefaultableBindings(),
+                             y.FullyBound, y.IsRHSOfBindParam,
                              y.SubtypeOfExistentialType,
                              static_cast<unsigned char>(y.LiteralBinding),
                              y.InvolvesTypeVariables,

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -597,3 +597,6 @@ func testSR5666(cs: [SR5666?]) -> [String?] {
       return b
     })
 }
+
+// Ensure that we still do the appropriate pointer conversion here.
+_ = "".withCString { UnsafeMutableRawPointer(mutating: $0) }


### PR DESCRIPTION
…ft-to-right.

If we allow the right-hand type to be bound first, it can artificially
limit the options for the left-hand side, so attempt to delay binding of
the right-hand side types until after we've chosen something for the
left-hand side.

The test here will not fail without this change, but will fail without
this change if the ConstraintGraph.cpp changes from @xedin's edge
contraction patch (https://github.com/apple/swift/pull/11118) are
applied.
