### PR TITLE
Refactor ModuleFile::loadAllMembers for legibility for compile-time work

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4507,7 +4507,11 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   members.reserve(rawMemberIDs.size());
   for (DeclID rawID : rawMemberIDs) {
     Expected<Decl *> next = getDeclChecked(rawID);
-    if (!next) {
+    if (next) {
+      assert(next.get() && "unchecked error deserializing next member");
+      members.push_back(next.get());
+    }
+    else {
       if (!getContext().LangOpts.EnableDeserializationRecovery)
         fatal(next.takeError());
 
@@ -4559,8 +4563,6 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
       }
       continue;
     }
-    assert(next.get() && "unchecked error deserializing next member");
-    members.push_back(next.get());
   }
 
   for (auto member : members)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4535,54 +4535,54 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
 }
 
 Decl *handleErrorAndSupplyMissingMember(ASTContext& context, Decl *container, llvm::Error &&error) {
-      Decl *suppliedMissingMember = nullptr;
-      // Drop the member if it had a problem.
-      // FIXME: Handle overridable members in class extensions too, someday.
-      if (auto *containingClass = dyn_cast<ClassDecl>(container)) {
-        auto handleMissingClassMember =
-            [&](const DeclDeserializationError &error) {
-          if (error.isDesignatedInitializer())
-            containingClass->setHasMissingDesignatedInitializers();
-          if (error.needsVTableEntry() || error.needsAllocatingVTableEntry())
-            containingClass->setHasMissingVTableEntries();
-
-          if (error.getName().getBaseName() == context.Id_init) {
-            suppliedMissingMember = MissingMemberDecl::forInitializer(
-                context, containingClass, error.getName(),
-                error.needsVTableEntry(), error.needsAllocatingVTableEntry());
-          } else if (error.needsVTableEntry()) {
-            suppliedMissingMember = MissingMemberDecl::forMethod(
-                context, containingClass, error.getName(),
-                error.needsVTableEntry());
-          }
-          // FIXME: Handle other kinds of missing members: properties,
-          // subscripts, and methods that don't need vtable entries.
-        };
-        llvm::handleAllErrors(std::move(error), handleMissingClassMember);
-      } else if (auto *containingProto = dyn_cast<ProtocolDecl>(container)) {
-        auto handleMissingProtocolMember =
-            [&](const DeclDeserializationError &error) {
-          assert(!error.needsAllocatingVTableEntry());
-          if (error.needsVTableEntry())
-            containingProto->setHasMissingRequirements(true);
-
-          if (error.getName().getBaseName() == context.Id_init) {
-            suppliedMissingMember = MissingMemberDecl::forInitializer(
-                context, containingProto, error.getName(),
-                error.needsVTableEntry(), error.needsAllocatingVTableEntry());
-          } else if (error.needsVTableEntry()) {
-            suppliedMissingMember = MissingMemberDecl::forMethod(
-                context, containingProto, error.getName(),
-                error.needsVTableEntry());
-          }
-          // FIXME: Handle other kinds of missing members: properties,
-          // subscripts, and methods that don't need vtable entries.
-        };
-        llvm::handleAllErrors(std::move(error), handleMissingProtocolMember);
-      } else {
-        llvm::consumeError(std::move(error));
+  Decl *suppliedMissingMember = nullptr;
+  // Drop the member if it had a problem.
+  // FIXME: Handle overridable members in class extensions too, someday.
+  if (auto *containingClass = dyn_cast<ClassDecl>(container)) {
+    auto handleMissingClassMember =
+    [&](const DeclDeserializationError &error) {
+      if (error.isDesignatedInitializer())
+        containingClass->setHasMissingDesignatedInitializers();
+      if (error.needsVTableEntry() || error.needsAllocatingVTableEntry())
+        containingClass->setHasMissingVTableEntries();
+      
+      if (error.getName().getBaseName() == context.Id_init) {
+        suppliedMissingMember = MissingMemberDecl::forInitializer(
+                                                                  context, containingClass, error.getName(),
+                                                                  error.needsVTableEntry(), error.needsAllocatingVTableEntry());
+      } else if (error.needsVTableEntry()) {
+        suppliedMissingMember = MissingMemberDecl::forMethod(
+                                                             context, containingClass, error.getName(),
+                                                             error.needsVTableEntry());
       }
-      return suppliedMissingMember;
+      // FIXME: Handle other kinds of missing members: properties,
+      // subscripts, and methods that don't need vtable entries.
+    };
+    llvm::handleAllErrors(std::move(error), handleMissingClassMember);
+  } else if (auto *containingProto = dyn_cast<ProtocolDecl>(container)) {
+    auto handleMissingProtocolMember =
+    [&](const DeclDeserializationError &error) {
+      assert(!error.needsAllocatingVTableEntry());
+      if (error.needsVTableEntry())
+        containingProto->setHasMissingRequirements(true);
+      
+      if (error.getName().getBaseName() == context.Id_init) {
+        suppliedMissingMember = MissingMemberDecl::forInitializer(
+                                                                  context, containingProto, error.getName(),
+                                                                  error.needsVTableEntry(), error.needsAllocatingVTableEntry());
+      } else if (error.needsVTableEntry()) {
+        suppliedMissingMember = MissingMemberDecl::forMethod(
+                                                             context, containingProto, error.getName(),
+                                                             error.needsVTableEntry());
+      }
+      // FIXME: Handle other kinds of missing members: properties,
+      // subscripts, and methods that don't need vtable entries.
+    };
+    llvm::handleAllErrors(std::move(error), handleMissingProtocolMember);
+  } else {
+    llvm::consumeError(std::move(error));
+  }
+  return suppliedMissingMember;
 }
 
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4543,18 +4543,15 @@ static Decl *handleErrorAndSupplyMissingProtoMember(ASTContext &context,
 static Decl *handleErrorAndSupplyMissingMiscMember(llvm::Error &&error);
 
 Decl *handleErrorAndSupplyMissingMember(ASTContext& context, Decl *container, llvm::Error &&error) {
-  Decl *suppliedMissingMember = nullptr;
   // Drop the member if it had a problem.
   // FIXME: Handle overridable members in class extensions too, someday.
   if (auto *containingClass = dyn_cast<ClassDecl>(container)) {
-    suppliedMissingMember = handleErrorAndSupplyMissingClassMember(context, std::move(error), containingClass);
-  } else if (auto *containingProto = dyn_cast<ProtocolDecl>(container)) {
-    suppliedMissingMember = handleErrorAndSupplyMissingProtoMember(context, std::move(error), containingProto);
+    return handleErrorAndSupplyMissingClassMember(context, std::move(error), containingClass);
   }
-  else {
-    suppliedMissingMember = handleErrorAndSupplyMissingMiscMember(std::move(error));
+  if (auto *containingProto = dyn_cast<ProtocolDecl>(container)) {
+    return handleErrorAndSupplyMissingProtoMember(context, std::move(error), containingProto);
   }
-  return suppliedMissingMember;
+  return handleErrorAndSupplyMissingMiscMember(std::move(error));
 }
 
 Decl *handleErrorAndSupplyMissingClassMember(ASTContext &context,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4513,7 +4513,9 @@ Decl *handleErrorAndSupplyMissingProtoMember(ASTContext &context,
           suppliedMissingMember = MissingMemberDecl::forInitializer(
               context, containingProto, error.getName(),
               error.needsVTableEntry(), error.needsAllocatingVTableEntry());
-        } else if (error.needsVTableEntry()) {
+              return;
+        }
+        if (error.needsVTableEntry()) {
           suppliedMissingMember = MissingMemberDecl::forMethod(
               context, containingProto, error.getName(),
               error.needsVTableEntry());


### PR DESCRIPTION
<!-- What's in this pull request? -->
ModuleFile::loadAllMembers included lots of code to handle errors inline. This PR separates out that code to enhance legibility of the flow. Redone from the previous such PR, which was closed before merging, in order to dice the commits finely for ease of review.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
