### PR TITLE
(Not for checkin) Fix convenience init to protocol extension init delegation

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2810,14 +2810,18 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
 
   bool isStatic = false;
   bool isMutating = false;
+  bool isDynamicSelf = false;
 
   if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
     isStatic = FD->isStatic();
     isMutating = FD->isMutating();
 
+    // Methods returning 'Self' have a dynamic 'self'.
+    //
+    // FIXME: All methods of non-final classes should have this.
     if (wantDynamicSelf && FD->hasDynamicSelf())
-      selfTy = DynamicSelfType::get(selfTy, Ctx);
-  } else if (isa<ConstructorDecl>(AFD)) {
+      isDynamicSelf = true;
+  } else if (auto *CD = dyn_cast<ConstructorDecl>(AFD)) {
     if (isInitializingCtor) {
       // initializing constructors of value types always have an implicitly
       // inout self.
@@ -2826,10 +2830,20 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
       // allocating constructors have metatype 'self'.
       isStatic = true;
     }
+
+    // Convenience initializers have a dynamic 'self'.
+    if (wantDynamicSelf && CD->isConvenienceInit()) {
+      if (auto *classDecl = selfTy->getClassOrBoundGenericClass())
+        if (!classDecl->isFinal())
+          isDynamicSelf = true;
+    }
   } else if (isa<DestructorDecl>(AFD)) {
     // destructors of value types always have an implicitly inout self.
     isMutating = true;
   }
+
+  if (isDynamicSelf)
+    selfTy = DynamicSelfType::get(selfTy, Ctx);
 
   // 'static' functions have 'self' of type metatype<T>.
   if (isStatic)

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -726,8 +726,7 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
 
   SILDeclRef constant(decl);
 
-  if (decl->getImplicitSelfDecl()->getType()->getInOutObjectType()
-        ->getClassOrBoundGenericClass()) {
+  if (decl->getDeclContext()->getAsClassOrClassExtensionContext()) {
     // Class constructors have separate entry points for allocation and
     // initialization.
     emitOrDelayFunction(*this, constant, [this,constant,decl](SILFunction *f){

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4715,10 +4715,7 @@ static RValue emitApplyAllocatingInitializer(SILGenFunction &SGF,
     ManagedValue v = std::move(result).getAsSingleValue(SGF, loc);
     CanType canOverriddenSelfType = overriddenSelfType->getCanonicalType();
     SILType loweredResultTy = SGF.getLoweredType(canOverriddenSelfType);
-    v = ManagedValue(SGF.B.createUncheckedRefCast(loc,
-                                                  v.getValue(),
-                                                  loweredResultTy),
-                     v.getCleanup());
+    v = SGF.B.createUncheckedRefCast(loc, v, loweredResultTy);
     result = RValue(SGF, loc, canOverriddenSelfType, v);
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1950,6 +1950,11 @@ RValue RValueEmitter::visitCovariantReturnConversionExpr(
   ManagedValue original = SGF.emitRValueAsSingleValue(e->getSubExpr());
   SILType resultType = SGF.getLoweredType(e->getType());
 
+  // DynamicSelfType lowers as its self type, so no SIL-level conversion
+  // is required in this case.
+  if (resultType == original.getType())
+    return RValue(SGF, e, original);
+
   ManagedValue result = SGF.B.createUncheckedRefCast(e, original, resultType);
 
   return RValue(SGF, e, result);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -470,10 +470,7 @@ ManagedValue Transform::transform(ManagedValue v,
     // CF <-> Objective-C via toll-free bridging.
     if ((class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType) ^
         (class2->getForeignClassKind() == ClassDecl::ForeignKind::CFType)) {
-       return ManagedValue(SGF.B.createUncheckedRefCast(Loc,
-                                                        v.getValue(),
-                                                        loweredResultTy),
-                           v.getCleanup());
+      return SGF.B.createUncheckedRefCast(Loc, v, loweredResultTy);
     }
 
     if (outputSubstType->isExactSuperclassOf(inputSubstType)) {
@@ -486,8 +483,7 @@ ManagedValue Transform::transform(ManagedValue v,
       // Unchecked-downcast to a covariant return type.
       assert(inputSubstType->isExactSuperclassOf(outputSubstType)
              && "should be inheritance relationship between input and output");
-      return SGF.emitManagedRValueWithCleanup(
-        SGF.B.createUncheckedRefCast(Loc, v.forward(SGF), loweredResultTy));      
+      return SGF.B.createUncheckedRefCast(Loc, v, loweredResultTy);
     }
   }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1540,8 +1540,8 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     auto decl = declRefExpr->getDecl();
     candidates.push_back({ decl, getCalleeLevel(decl) });
     
-    if (auto fTy = decl->getInterfaceType()->getAs<AnyFunctionType>())
-      declName = fTy->getInput()->getRValueInstanceType()->getString()+".init";
+    if (auto selfTy = decl->getDeclContext()->getSelfInterfaceType())
+      declName = selfTy.getString() + ".init";
     else
       declName = "init";
     return;
@@ -1657,7 +1657,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     if (UDE->getName().getBaseName() == CS.TC.Context.Id_init) {
       auto selfTy = CS.getType(UDE->getBase())->getWithoutSpecifierType();
       if (!selfTy->hasTypeVariable())
-        declName = selfTy.getString() + "." + declName;
+        declName = selfTy->eraseDynamicSelfType().getString() + "." + declName;
     }
 
     // Otherwise, look for a disjunction constraint explaining what the set is.

--- a/test/Interpreter/protocol_initializers.swift
+++ b/test/Interpreter/protocol_initializers.swift
@@ -35,6 +35,10 @@ extension TriviallyConstructible {
     }
     self.init(inner: x)
   }
+
+  init(assignToSelf x: LifetimeTracked) {
+    self = Self(inner: x)
+  }
 }
 
 class TrivialClass : TriviallyConstructible {
@@ -51,6 +55,10 @@ class TrivialClass : TriviallyConstructible {
     try self.init(throwingMiddle: x, shouldThrow: shouldThrow)
   }
 
+  convenience init(delegates x: LifetimeTracked) {
+    self.init(assignToSelf: x)
+  }
+
   required init(inner tracker: LifetimeTracked) {
     self.tracker = tracker
   }
@@ -60,6 +68,7 @@ class TrivialClass : TriviallyConstructible {
 
 ProtocolInitTestSuite.test("ProtocolInit_Trivial") {
   _ = TrivialClass(outer: LifetimeTracked(0))
+  _ = TrivialClass(delegates: LifetimeTracked(0))
 }
 
 ProtocolInitTestSuite.test("ProtocolInit_Failable") {
@@ -84,6 +93,17 @@ ProtocolInitTestSuite.test("ProtocolInit_Throwing") {
     let result = try TrivialClass(throwingOuter: LifetimeTracked(5), shouldThrow: true)
     preconditionFailure("Expected error")
   } catch {}
+}
+
+class TrivialSubclass : TrivialClass {}
+
+func makeSubclass() -> TrivialClass {
+  return TrivialSubclass(delegates: LifetimeTracked(0))
+}
+
+ProtocolInitTestSuite.test("ProtocolInit_Subclass") {
+  let t = makeSubclass()
+  assert(t is TrivialSubclass)
 }
 
 runAllTests()

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -167,10 +167,8 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
 // CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
-// CHECK:      switch_enum [[RES]] : $Optional<OptionalResult>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]]
-// CHECK: [[SOME_BB]]([[T1:%.*]] : $OptionalResult):
-// CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[T1]] : $OptionalResult to $OptionalResultInheritor
-// CHECK-NEXT: enum $Optional<OptionalResultInheritor>, #Optional.some!enumelt.1, [[T4]]
+// CHECK-NEXT: destroy_value [[CAST_COPY_ARG]]
+// CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[RES]] : $Optional<OptionalResult> to $Optional<OptionalResultInheritor>
 
 func id<T>(_ t: T) -> T { return t }
 

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -30,11 +30,11 @@ class TrivialClass : TriviallyConstructible {
   // CHECK-NEXT:  [[SELF_BOX:%.*]] = alloc_stack $TrivialClass
   // CHECK-NEXT:  debug_value
   // CHECK-NEXT:  store [[OLD_SELF]] to [[SELF_BOX]]
-  // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1
+  // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick @dynamic_self TrivialClass.Type, %1
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $TrivialClass
-  // CHECK-NEXT:  apply [[FN]]<TrivialClass>([[RESULT]], %0, [[METATYPE]])
+  // CHECK-NEXT:  apply [[FN]]<@dynamic_self TrivialClass>([[RESULT]], %0, [[METATYPE]])
   // CHECK-NEXT:  [[NEW_SELF:%.*]] = load [[RESULT]]
   // CHECK-NEXT:  store [[NEW_SELF]] to [[SELF_BOX]]
   // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -330,3 +330,61 @@ class Runce : Runcible {
     return self
   }
 }
+
+// ----------------------------------------------------------------------------
+// Forming a type with 'Self' in invariant position
+
+struct Generic<T> { init(_: T) {} }
+
+class InvariantSelf {
+  func me() -> Self {
+    let a = Generic(self)
+    let _: Generic<InvariantSelf> = a
+    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to specified type 'Generic<InvariantSelf>'}}
+
+    return self
+  }
+}
+
+// FIXME: This should be allowed
+
+final class FinalInvariantSelf {
+  func me() -> Self {
+    let a = Generic(self)
+    let _: Generic<FinalInvariantSelf> = a
+    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to specified type 'Generic<FinalInvariantSelf>'}}
+
+    return self
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Semi-bogus factory init pattern
+
+protocol FactoryPattern {
+  init(factory: @autoclosure () -> Self)
+}
+
+extension  FactoryPattern {
+  init(factory: @autoclosure () -> Self) { self = factory() }
+}
+
+class Factory : FactoryPattern {
+  init(_string: String) {}
+
+  convenience init(string: String) {
+    self.init(factory: Factory(_string: string))
+    // expected-error@-1 {{incorrect argument label in call (have 'factory:', expected '_string:')}}
+    // FIXME: Bogus diagnostic
+  }
+}
+
+// Final classes are OK
+
+final class FinalFactory : FactoryPattern {
+  init(_string: String) {}
+
+  convenience init(string: String) {
+    self.init(factory: FinalFactory(_string: string))
+  }
+}


### PR DESCRIPTION
Consider a class initializer that delegates to a protocol extension initializer, for example

```
protocol P {}
extension P {
  init() { ... }
}

class C : P {
  convenience init(foo: Int) { self.init() }
}
```

The `self.init()` inside the class initializer must pass a substitution for the Self type parameter to the protocol extension method. It was passing the static type, not the dynamic type. This is wrong because convenience initializers can be inherited, so calling an inherited initializer would use the wrong 'Self' type. This was a problem if the protocol extension method either had 'Self' in contravariant position (in which case we might type check invalid code) or if it constructed a new instance of 'Self' and returned it (in which case we would do the wrong thing at runtime).

Fix the problem and add tests for both cases.

Also clean up some related code I looked at along the way.