### PR TITLE
Store self in Callee as an argument source

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -55,6 +55,7 @@ void ArgumentSource::rewriteType(CanType newType) & {
   case Kind::Tuple:
     llvm_unreachable("cannot rewrite type of tuple");
   case Kind::RValue:
+  case Kind::DelayedBorrowedRValue:
     Storage.get<RValueStorage>(StoredKind).Value.rewriteType(newType);
     return;
   case Kind::Expr:
@@ -70,6 +71,7 @@ bool ArgumentSource::requiresCalleeToEvaluate() const {
   case Kind::Invalid:
     llvm_unreachable("argument source is invalid");
   case Kind::RValue:
+  case Kind::DelayedBorrowedRValue:
   case Kind::LValue:
     return false;
   case Kind::Expr:
@@ -118,8 +120,11 @@ RValue ArgumentSource::getAsRValue(SILGenFunction &SGF, SGFContext C) && {
     llvm_unreachable("argument source is invalid");
   case Kind::LValue:
     llvm_unreachable("cannot get l-value as r-value");
+  case Kind::DelayedBorrowedRValue:
+    return std::move(*this).asKnownRValue(SGF).borrow(SGF,
+                                                      getKnownRValueLocation());
   case Kind::RValue:
-    return std::move(*this).asKnownRValue();
+    return std::move(*this).asKnownRValue(SGF);
   case Kind::Expr:
     return SGF.emitRValue(std::move(*this).asKnownExpr(), C);
   case Kind::Tuple:
@@ -172,13 +177,22 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
     return SGF.emitAddressOfLValue(loc, std::move(*this).asKnownLValue(),
                                    AccessKind::ReadWrite);
   }
+  case Kind::DelayedBorrowedRValue: {
+    assert(!C.getEmitInto() &&
+           "Can not put a delayed borrowed rvalue into an initialization");
+    auto loc = getKnownRValueLocation();
+    return std::move(*this)
+        .asKnownRValue(SGF)
+        .getAsSingleValue(SGF, loc)
+        .borrow(SGF, loc);
+  }
   case Kind::RValue: {
     auto loc = getKnownRValueLocation();
     if (auto init = C.getEmitInto()) {
-      std::move(*this).asKnownRValue().forwardInto(SGF, loc, init);
+      std::move(*this).asKnownRValue(SGF).forwardInto(SGF, loc, init);
       return ManagedValue::forInContext();
     } else {
-      return std::move(*this).asKnownRValue().getAsSingleValue(SGF, loc);
+      return std::move(*this).asKnownRValue(SGF).getAsSingleValue(SGF, loc);
     }
   }
   case Kind::Expr: {
@@ -218,6 +232,9 @@ ManagedValue ArgumentSource::getConverted(SILGenFunction &SGF,
     llvm_unreachable("argument source is invalid");
   case Kind::LValue:
     llvm_unreachable("cannot get converted l-value");
+  case Kind::DelayedBorrowedRValue:
+    // TODO: We probably can, but we would need to introduce a copy.
+    llvm_unreachable("cannot get converted borrowed r-value");
   case Kind::RValue:
   case Kind::Expr:
   case Kind::Tuple:
@@ -235,9 +252,11 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF, Initialization *dest) && {
     llvm_unreachable("argument source is invalid");
   case Kind::LValue:
     llvm_unreachable("cannot forward an l-value");
+  case Kind::DelayedBorrowedRValue:
+    llvm_unreachable("cannot forward a delayed borrowed r-value");
   case Kind::RValue: {
     auto loc = getKnownRValueLocation();
-    std::move(*this).asKnownRValue().forwardInto(SGF, loc, dest);
+    std::move(*this).asKnownRValue(SGF).forwardInto(SGF, loc, dest);
     return;
   }
   case Kind::Expr: {
@@ -262,6 +281,7 @@ ArgumentSource ArgumentSource::borrow(SILGenFunction &SGF) const & {
     llvm_unreachable("argument source is invalid");
   case Kind::LValue:
     llvm_unreachable("cannot borrow an l-value");
+  case Kind::DelayedBorrowedRValue:
   case Kind::RValue: {
     auto loc = getKnownRValueLocation();
     return ArgumentSource(loc, asKnownRValue().borrow(SGF, loc));
@@ -280,7 +300,7 @@ ArgumentSource ArgumentSource::borrow(SILGenFunction &SGF) const & {
 ManagedValue ArgumentSource::materialize(SILGenFunction &SGF) && {
   if (isRValue()) {
     auto loc = getKnownRValueLocation();
-    return std::move(*this).asKnownRValue().materialize(SGF, loc);
+    return std::move(*this).asKnownRValue(SGF).materialize(SGF, loc);
   }
 
   auto loc = getLocation();
@@ -370,6 +390,7 @@ SILType ArgumentSource::getSILSubstType(SILGenFunction &SGF) const & {
 void ArgumentSource::dump() const {
   dump(llvm::errs());
 }
+
 void ArgumentSource::dump(raw_ostream &out, unsigned indent) const {
   out.indent(indent) << "ArgumentSource::";
   switch (StoredKind) {
@@ -391,6 +412,7 @@ void ArgumentSource::dump(raw_ostream &out, unsigned indent) const {
     return;
   }
   case Kind::RValue:
+  case Kind::DelayedBorrowedRValue:
     out << "RValue\n";
     Storage.get<RValueStorage>(StoredKind).Value.dump(out, indent + 2);
     return;

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -256,6 +256,27 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF, Initialization *dest) && {
   llvm_unreachable("bad kind");
 }
 
+ArgumentSource ArgumentSource::borrow(SILGenFunction &SGF) const & {
+  switch (StoredKind) {
+  case Kind::Invalid:
+    llvm_unreachable("argument source is invalid");
+  case Kind::LValue:
+    llvm_unreachable("cannot borrow an l-value");
+  case Kind::RValue: {
+    auto loc = getKnownRValueLocation();
+    return ArgumentSource(loc, asKnownRValue().borrow(SGF, loc));
+  }
+  case Kind::Expr: {
+    llvm_unreachable("cannot borrow an expression");
+  }
+  case Kind::Tuple: {
+    // FIXME: We can if we check the sub argument sources.
+    llvm_unreachable("cannot borrow a tuple");
+  }
+  }
+  llvm_unreachable("bad kind");
+}
+
 ManagedValue ArgumentSource::materialize(SILGenFunction &SGF) && {
   if (isRValue()) {
     auto loc = getKnownRValueLocation();

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -343,6 +343,9 @@ public:
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
 private:
+  /// Private helper constructor for delayed borrowed rvalues.
+  ArgumentSource(SILLocation loc, RValue &&rv, Kind kind);
+
   /// Returns true if this ArgumentSource stores a delayed borrowed RValue.
   ///
   /// This is private since we do not want users to be able to determine if the

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -52,6 +52,8 @@ class ArgumentSource {
   enum class Kind : unsigned char {
     Invalid,
     RValue,
+    // An RValue that will be borrowed when emitted.
+    DelayedBorrowedRValue,
     LValue,
     Expr,
     Tuple,
@@ -88,7 +90,9 @@ class ArgumentSource {
   static StorageMembers::Index getStorageIndexForKind(Kind kind) {
     switch (kind) {
     case Kind::Invalid: return StorageMembers::indexOf<void>();
-    case Kind::RValue: return StorageMembers::indexOf<RValueStorage>();
+    case Kind::RValue:
+    case Kind::DelayedBorrowedRValue:
+      return StorageMembers::indexOf<RValueStorage>();
     case Kind::LValue: return StorageMembers::indexOf<LValueStorage>();
     case Kind::Expr: return StorageMembers::indexOf<Expr*>();
     case Kind::Tuple: return StorageMembers::indexOf<TupleStorage>();
@@ -143,6 +147,7 @@ public:
     case Kind::Invalid:
       return false;
     case Kind::RValue:
+    case Kind::DelayedBorrowedRValue:
       return !asKnownRValue().isNull();
     case Kind::LValue:
       return asKnownLValue().isValid();
@@ -159,6 +164,7 @@ public:
     case Kind::Invalid:
       llvm_unreachable("argument source is invalid");
     case Kind::RValue:
+    case Kind::DelayedBorrowedRValue:
       return asKnownRValue().getType();
     case Kind::LValue:
       return CanInOutType::get(asKnownLValue().getSubstFormalType());
@@ -177,6 +183,7 @@ public:
     case Kind::Invalid:
       llvm_unreachable("argument source is invalid");
     case Kind::RValue:
+    case Kind::DelayedBorrowedRValue:
       return asKnownRValue().getType();
     case Kind::LValue:
       return asKnownLValue().getSubstFormalType();
@@ -193,7 +200,9 @@ public:
   bool hasLValueType() const & {
     switch (StoredKind) {
     case Kind::Invalid: llvm_unreachable("argument source is invalid");
-    case Kind::RValue: return false;
+    case Kind::RValue:
+    case Kind::DelayedBorrowedRValue:
+      return false;
     case Kind::LValue: return true;
     case Kind::Expr: return asKnownExpr()->isSemanticallyInOutExpr();
     case Kind::Tuple: return false;
@@ -206,6 +215,7 @@ public:
     case Kind::Invalid:
       llvm_unreachable("argument source is invalid");
     case Kind::RValue:
+    case Kind::DelayedBorrowedRValue:
       return getKnownRValueLocation();
     case Kind::LValue:
       return getKnownLValueLocation();
@@ -218,15 +228,24 @@ public:
   }
 
   bool isExpr() const & { return StoredKind == Kind::Expr; }
-  bool isRValue() const & { return StoredKind == Kind::RValue; }
+  bool isRValue() const & {
+    return StoredKind == Kind::RValue ||
+           StoredKind == Kind::DelayedBorrowedRValue;
+  }
   bool isLValue() const & { return StoredKind == Kind::LValue; }
   bool isTuple() const & { return StoredKind == Kind::Tuple; }
 
   /// Given that this source is storing an RValue, extract and clear
   /// that value.
-  RValue &&asKnownRValue() && {
+  RValue &&asKnownRValue(SILGenFunction &SGF) && {
+    if (isDelayedBorrowedRValue()) {
+      std::move(Storage.get<RValueStorage>(StoredKind).Value)
+          .borrow(SGF, getKnownRValueLocation());
+    }
+
     return std::move(Storage.get<RValueStorage>(StoredKind).Value);
   }
+
   SILLocation getKnownRValueLocation() const & {
     return Storage.get<RValueStorage>(StoredKind).Loc;
   }
@@ -294,6 +313,15 @@ public:
   /// return the ArgumentSource. Otherwise, assert.
   ArgumentSource borrow(SILGenFunction &SGF) const &;
 
+  /// If we have an rvalue, return an Argument Source that when the RValue is
+  /// retrieved, the RValue is always borrowed first.
+  ///
+  /// This allows us to specify when creating callees that a value must be
+  /// borrowed, but emit the actual borrow once the callee is evaluated later in
+  /// SILGenApply. Ideally, the callee would always eagerly borrow, but since we
+  /// still have uncurrying, we can not do that.
+  ArgumentSource delayedBorrow(SILGenFunction &SGF) const &;
+
   ManagedValue materialize(SILGenFunction &SGF) &&;
 
   /// Emit this value to memory so that it follows the abstraction
@@ -315,6 +343,14 @@ public:
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
 private:
+  /// Returns true if this ArgumentSource stores a delayed borrowed RValue.
+  ///
+  /// This is private since we do not want users to be able to determine if the
+  /// given ArgumentSource is a normal RValue or a delayed borrow rvalue.
+  bool isDelayedBorrowedRValue() const & {
+    return StoredKind == Kind::DelayedBorrowedRValue;
+  }
+
   // Make the non-move accessors private to make it more difficult
   // to accidentally re-emit values.
   const RValue &asKnownRValue() const & {

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -290,6 +290,10 @@ public:
   void forwardInto(SILGenFunction &SGF, AbstractionPattern origFormalType,
                    Initialization *dest, const TypeLowering &destTL) &&;
 
+  /// If we have an rvalue, borrow the rvalue into a new ArgumentSource and
+  /// return the ArgumentSource. Otherwise, assert.
+  ArgumentSource borrow(SILGenFunction &SGF) const &;
+
   ManagedValue materialize(SILGenFunction &SGF) &&;
 
   /// Emit this value to memory so that it follows the abstraction

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -510,6 +510,7 @@ void RValue::addElement(SILGenFunction &SGF, ManagedValue element,
 
 SILValue RValue::forwardAsSingleValue(SILGenFunction &SGF, SILLocation l) && {
   assert(isComplete() && "rvalue is not complete");
+  assert(isPlusOne(SGF) && "Can not forward borrowed RValues");
   SILValue result
     = implodeTupleValues<ImplodeKind::Forward>(values, SGF, type, l);
 
@@ -521,6 +522,7 @@ SILValue RValue::forwardAsSingleStorageValue(SILGenFunction &SGF,
                                              SILType storageType,
                                              SILLocation l) && {
   assert(isComplete() && "rvalue is not complete");
+  assert(isPlusOne(SGF) && "Can not forward borrowed RValues");
   SILValue result = std::move(*this).forwardAsSingleValue(SGF, l);
   return SGF.emitConversionFromSemanticValue(l, result, storageType);
 }
@@ -528,6 +530,7 @@ SILValue RValue::forwardAsSingleStorageValue(SILGenFunction &SGF,
 void RValue::forwardInto(SILGenFunction &SGF, SILLocation loc, 
                          Initialization *I) && {
   assert(isComplete() && "rvalue is not complete");
+  assert(isPlusOne(SGF) && "Can not forward borrowed RValues");
   ArrayRef<ManagedValue> elts = values;
   copyOrInitValuesInto<ImplodeKind::Forward>(I, elts, type, loc, SGF);
 }
@@ -707,6 +710,7 @@ RValue RValue::borrow(SILGenFunction &SGF, SILLocation loc) const & {
 }
 
 ManagedValue RValue::materialize(SILGenFunction &SGF, SILLocation loc) && {
+  assert(isPlusOne(SGF) && "Can not materialize a non-plus one RValue");
   auto &paramTL = SGF.getTypeLowering(getType());
 
   // If we're already materialized, we're done.

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -30,6 +30,7 @@
 namespace swift {
 namespace Lowering {
 
+class ArgumentSource;
 class Initialization;
 class Scope;
 class SILGenFunction;
@@ -69,6 +70,7 @@ class TypeLowering;
 /// require considering resilience, a job we want to delegate to IRGen.
 class RValue {
   friend class swift::Lowering::Scope;
+  friend class swift::Lowering::ArgumentSource;
 
   std::vector<ManagedValue> values;
   CanType type;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2759,7 +2759,7 @@ private:
 
         auto loc = arg.getKnownRValueLocation();
         SmallVector<RValue, 4> elts;
-        std::move(arg).asKnownRValue().extractElements(elts);
+        std::move(arg).asKnownRValue(SGF).extractElements(elts);
         for (auto i : indices(substArgType.getElementTypes())) {
           emit({ loc, std::move(elts[i]) },
                origParamType.getTupleElementType(i));
@@ -2769,7 +2769,7 @@ private:
 
       auto loc = arg.getKnownRValueLocation();
       SmallVector<RValue, 1> elts;
-      std::move(arg).asKnownRValue().extractElements(elts);
+      std::move(arg).asKnownRValue(SGF).extractElements(elts);
       emit({ loc, std::move(elts[0]) },
            origParamType.getTupleElementType(0));
       return;
@@ -2877,8 +2877,8 @@ private:
       // for one.)  The onus is on the caller to ensure that formal
       // access semantics are honored.
       } else if (arg.isRValue()) {
-        auto address = std::move(arg).asKnownRValue()
-          .getAsSingleValue(SGF, arg.getKnownRValueLocation());
+        auto address = std::move(arg).asKnownRValue(SGF).getAsSingleValue(
+            SGF, arg.getKnownRValueLocation());
         assert(address.isLValue());
         auto substObjectType = cast<InOutType>(substType).getObjectType();
         return LValue::forAddress(address, None,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -62,11 +62,13 @@ getIndirectApplyAbstractionPattern(SILGenFunction &SGF,
   llvm_unreachable("bad representation");
 }
 
-static CanType getDynamicMethodSelfType(SILValue proto, ValueDecl *member) {
+static CanType getDynamicMethodSelfType(SILGenFunction &SGF,
+                                        const ArgumentSource &proto,
+                                        ValueDecl *member) {
   if (member->isInstanceMember()) {
     return member->getASTContext().TheUnknownObjectType;
   } else {
-    return proto->getType().getSwiftRValueType();
+    return proto.getSILSubstType(SGF).getSwiftRValueType();
   }
 }
 
@@ -144,20 +146,15 @@ replaceSelfTypeForDynamicLookup(ASTContext &ctx,
 }
 
 /// Retrieve the type to use for a method found via dynamic lookup.
-static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &SGF,
-                                           SILValue proto,
-                                           SILDeclRef methodName,
-                                           CanAnyFunctionType substMemberTy) {
+static CanSILFunctionType
+getDynamicMethodLoweredType(SILGenFunction &SGF, SILValue v,
+                            SILDeclRef methodName,
+                            CanAnyFunctionType substMemberTy) {
   auto &ctx = SGF.getASTContext();
-
-  // Determine the opaque 'self' parameter type.
-  CanType selfTy;
-  if (methodName.getDecl()->isInstanceMember()) {
-    selfTy = proto->getType().getSwiftRValueType();
-    assert(selfTy->is<ArchetypeType>() && "Dynamic lookup needs an archetype");
-  } else {
-    selfTy = proto->getType().getSwiftRValueType();
-  }
+  CanType selfTy = v->getType().getSwiftRValueType();
+  assert((!methodName.getDecl()->isInstanceMember() ||
+          selfTy->is<ArchetypeType>()) &&
+         "Dynamic lookup needs an archetype");
 
   // Replace the 'self' parameter type in the method type with it.
   auto objcFormalTy = substMemberTy.withExtInfo(substMemberTy->getExtInfo()
@@ -214,28 +211,25 @@ static SILValue getOriginalSelfValue(SILValue selfValue) {
   return selfValue;
 }
 
-/// We return the casted value and the borrowed value so we can input the
-/// end_borrow.
-///
-/// TODO: Once end_borrow's 2nd value is eliminated, this should return just a
-/// SILValue.
-static std::pair<SILValue, SILValue> castToOriginalSelfType(SILGenBuilder &builder,
-                                       SILLocation loc,
-                                       SILValue selfValue) {
-  SILValue originalSelfValue = getOriginalSelfValue(selfValue);
-  SILType originalSelfType = originalSelfValue->getType();
+/// Borrow self and then upcast self to its original type. If self is a
+/// metatype, we just return the original metatype since metatypes are trivial.
+static ManagedValue borrowedCastToOriginalSelfType(SILGenFunction &SGF,
+                                                   SILLocation loc,
+                                                   ManagedValue self) {
+  SILValue originalSelf = getOriginalSelfValue(self.getValue());
+  SILType originalSelfType = originalSelf->getType();
 
   // If we have a metatype, then we just return the original self value since
   // metatypes are trivial, so we can avoid ownership concerns.
   if (originalSelfType.getSwiftRValueType()->is<AnyMetatypeType>()) {
-    assert(originalSelfType.isTrivial(builder.getModule()) && "Metatypes should always be trivial");
-    return {originalSelfValue, SILValue()};
+    assert(originalSelfType.isTrivial(SGF.getModule()) &&
+           "Metatypes should always be trivial");
+    return ManagedValue::forUnmanaged(originalSelf);
   }
 
-  // Otherwise, we have a non-metatype. Use an unchecked_ref_cast.
-  SILValue borrowedValue = builder.createBeginBorrow(loc, selfValue);
-  SILValue castValue = builder.createUncheckedRefCast(loc, borrowedValue, originalSelfType);
-  return {castValue, borrowedValue};
+  // Otherwise, we have a non-metatype. Use a borrow+unchecked_ref_cast.
+  return SGF.B.createUncheckedRefCast(loc, self.borrow(SGF, loc),
+                                      originalSelfType);
 }
 
 namespace {
@@ -294,7 +288,7 @@ private:
 
   /// This field is set if we are calling to a SuperMethod or ClassMethod and
   /// thus need to pass self to get the correct implementation.
-  SILValue SelfValue;
+  Optional<ArgumentSource> SelfValue;
 
   /// The abstraction pattern of the callee.
   AbstractionPattern OrigFormalInterfaceType;
@@ -348,22 +342,15 @@ private:
   {
   }
 
-  Callee(Kind methodKind,
-         SILGenFunction &SGF,
-         SILValue selfValue,
-         SILDeclRef methodName,
-         AbstractionPattern origFormalType,
-         CanAnyFunctionType substFormalType,
-         SubstitutionList subs,
-         SILLocation l)
-    : kind(methodKind), Constant(methodName), SelfValue(selfValue),
-      OrigFormalInterfaceType(origFormalType),
-      SubstFormalInterfaceType(getSubstFormalInterfaceType(substFormalType,
-                                                           subs)),
-      Substitutions(subs),
-      Loc(l)
-  {
-  }
+  Callee(Kind methodKind, SILGenFunction &SGF,
+         Optional<ArgumentSource> &&selfValue, SILDeclRef methodName,
+         AbstractionPattern origFormalType, CanAnyFunctionType substFormalType,
+         SubstitutionList subs, SILLocation l)
+      : kind(methodKind), Constant(methodName), SelfValue(std::move(selfValue)),
+        OrigFormalInterfaceType(origFormalType),
+        SubstFormalInterfaceType(
+            getSubstFormalInterfaceType(substFormalType, subs)),
+        Substitutions(subs), Loc(l) {}
 
 public:
 
@@ -384,25 +371,23 @@ public:
                                SILLocation l) {
     assert(isa<EnumElementDecl>(c.getDecl()));
     auto &ci = SGF.getConstantInfo(c);
-    return Callee(Kind::EnumElement, SGF, SILValue(), c,
-                  ci.FormalPattern, ci.FormalType, subs, l);
+    return Callee(Kind::EnumElement, SGF, None, c, ci.FormalPattern,
+                  ci.FormalType, subs, l);
   }
-  static Callee forClassMethod(SILGenFunction &SGF, SILValue selfValue,
-                               SILDeclRef c,
-                               SubstitutionList subs,
+  static Callee forClassMethod(SILGenFunction &SGF, ArgumentSource &&selfValue,
+                               SILDeclRef c, SubstitutionList subs,
                                SILLocation l) {
     auto base = SGF.SGM.Types.getOverriddenVTableEntry(c);
     auto &baseCI = SGF.getConstantInfo(base);
     auto &derivedCI = SGF.getConstantInfo(c);
-    return Callee(Kind::ClassMethod, SGF, selfValue, c,
+    return Callee(Kind::ClassMethod, SGF, std::move(selfValue), c,
                   baseCI.FormalPattern, derivedCI.FormalType, subs, l);
   }
-  static Callee forSuperMethod(SILGenFunction &SGF, SILValue selfValue,
-                               SILDeclRef c,
-                               SubstitutionList subs,
+  static Callee forSuperMethod(SILGenFunction &SGF, ArgumentSource &&selfValue,
+                               SILDeclRef c, SubstitutionList subs,
                                SILLocation l) {
     auto &ci = SGF.getConstantInfo(c);
-    return Callee(Kind::SuperMethod, SGF, selfValue, c,
+    return Callee(Kind::SuperMethod, SGF, std::move(selfValue), c,
                   ci.FormalPattern, ci.FormalType, subs, l);
   }
   static Callee forArchetype(SILGenFunction &SGF,
@@ -414,18 +399,17 @@ public:
     c = c.asForeign(protocol->isObjC());
 
     auto &ci = SGF.getConstantInfo(c);
-    return Callee(Kind::WitnessMethod, SGF, SILValue(), c,
-                  ci.FormalPattern, ci.FormalType, subs, l);
+    return Callee(Kind::WitnessMethod, SGF, None, c, ci.FormalPattern,
+                  ci.FormalType, subs, l);
   }
-  static Callee forDynamic(SILGenFunction &SGF, SILValue proto,
+  static Callee forDynamic(SILGenFunction &SGF, ArgumentSource &&arg,
                            SILDeclRef c, const SubstitutionList &constantSubs,
                            CanAnyFunctionType partialSubstFormalType,
-                           SubstitutionList subs,
-                           SILLocation l) {
+                           SubstitutionList subs, SILLocation l) {
     auto &ci = SGF.getConstantInfo(c);
     AbstractionPattern origFormalType = ci.FormalPattern;
 
-    auto selfType = getDynamicMethodSelfType(proto, c.getDecl());
+    auto selfType = getDynamicMethodSelfType(SGF, arg, c.getDecl());
 
     // Replace the original self type with the partially-applied subst type.
     auto origFormalFnType = cast<AnyFunctionType>(origFormalType.getType());
@@ -450,9 +434,10 @@ public:
                                                 partialSubstFormalType,
                                                 origFormalFnType->getExtInfo());
 
-    return Callee(Kind::DynamicMethod, SGF, proto, c,
-                  origFormalType, substFormalType, subs, l);
+    return Callee(Kind::DynamicMethod, SGF, std::move(arg), c, origFormalType,
+                  substFormalType, subs, l);
   }
+
   Callee(Callee &&) = default;
   Callee &operator=(Callee &&) = default;
 
@@ -500,9 +485,9 @@ public:
     return cast<EnumElementDecl>(Constant.getDecl());
   }
 
-  std::tuple<ManagedValue, CanSILFunctionType,
-             Optional<ForeignErrorConvention>, ImportAsMemberStatus, ApplyOptions>
-  getAtUncurryLevel(SILGenFunction &SGF, unsigned level) const {
+  std::tuple<ManagedValue, CanSILFunctionType, Optional<ForeignErrorConvention>,
+             ImportAsMemberStatus, ApplyOptions>
+  getAtUncurryLevel(SILGenFunction &SGF, unsigned level) const & {
     ManagedValue mv;
     ApplyOptions options = ApplyOptions::None;
     Optional<SILDeclRef> constant = None;
@@ -562,11 +547,13 @@ public:
       }
 
       // Otherwise, do the dynamic dispatch inline.
-      SILValue methodVal = SGF.B.createClassMethod(Loc,
-                                                   SelfValue,
-                                                   *constant,
-                                                   /*volatile*/
-                                                     constant->isForeign);
+      Scope S(SGF, Loc);
+      ManagedValue borrowedSelf =
+          SelfValue.getValue().borrow(SGF).getAsSingleValue(SGF);
+      SILValue methodVal =
+          SGF.B.createClassMethod(Loc, borrowedSelf.getValue(), *constant,
+                                  /*volatile*/
+                                  constant->isForeign);
 
       mv = ManagedValue::forUnmanaged(methodVal);
       break;
@@ -574,20 +561,17 @@ public:
     case Kind::SuperMethod: {
       assert(!constant->isCurried);
 
-      SILValue castValue, borrowedValue;
-      std::tie(castValue, borrowedValue) = castToOriginalSelfType(SGF.B, Loc, SelfValue);
+      Scope S(SGF, Loc);
+      ManagedValue self =
+          SelfValue.getValue().borrow(SGF).getAsSingleValue(SGF);
+      ManagedValue castValue = borrowedCastToOriginalSelfType(SGF, Loc, self);
 
       auto base = SGF.SGM.Types.getOverriddenVTableEntry(*constant);
       auto constantInfo = SGF.SGM.Types.getConstantOverrideInfo(*constant, base);
-      auto methodVal = SGF.B.createSuperMethod(Loc, castValue,
-                                               *constant,
-                                               constantInfo.getSILType(),
-                                               /*volatile*/
-                                                 constant->isForeign);
-      if (borrowedValue) {
-        SGF.B.createEndBorrow(Loc, borrowedValue, SelfValue);
-      }
-      mv = ManagedValue::forUnmanaged(methodVal);
+      mv = SGF.B.createSuperMethod(Loc, castValue, *constant,
+                                   constantInfo.getSILType(),
+                                   /*volatile*/
+                                   constant->isForeign);
       break;
     }
     case Kind::WitnessMethod: {
@@ -626,16 +610,18 @@ public:
       auto fnType = SGF.SGM.M.Types
         .getUncachedSILFunctionTypeForConstant(*constant, objcFormalType);
 
-      auto closureType =
-        replaceSelfTypeForDynamicLookup(SGF.getASTContext(), fnType,
-                                SelfValue->getType().getSwiftRValueType(),
-                                Constant);
+      auto closureType = replaceSelfTypeForDynamicLookup(
+          SGF.getASTContext(), fnType,
+          SelfValue.getValue().getSILSubstType(SGF).getSwiftRValueType(),
+          Constant);
 
-      SILValue fn = SGF.B.createDynamicMethod(Loc,
-                          SelfValue,
-                          *constant,
-                          SILType::getPrimitiveObjectType(closureType),
-                          /*volatile*/ Constant.isForeign);
+      Scope S(SGF, Loc);
+      ManagedValue self =
+          SelfValue.getValue().borrow(SGF).getAsSingleValue(SGF);
+      SILValue fn = SGF.B.createDynamicMethod(
+          Loc, self.getValue(), *constant,
+          SILType::getPrimitiveObjectType(closureType),
+          /*volatile*/ Constant.isForeign);
       mv = ManagedValue::forUnmanaged(fn);
       break;
     }
@@ -984,15 +970,16 @@ public:
                     selfValue);
     }
 
-    auto selfValue = self.peekScalarValue();
-
-    setSelfParam(ArgumentSource(thisCallSite->getArg(), std::move(self)),
-                 thisCallSite);
     auto constant = SILDeclRef(afd, kind.getValue())
                         .asForeign(requiresForeignEntryPoint(afd));
 
+    ArgumentSource selfArgSource(thisCallSite->getArg(), std::move(self));
     auto subs = e->getDeclRef().getSubstitutions();
-    setCallee(Callee::forClassMethod(SGF, selfValue, constant, subs, e));
+    SILLocation loc(thisCallSite->getArg());
+    setCallee(Callee::forClassMethod(SGF, selfArgSource.delayedBorrow(SGF),
+                                     constant, subs, e));
+
+    setSelfParam(std::move(selfArgSource), thisCallSite);
     return true;
   }
 
@@ -1167,18 +1154,19 @@ public:
       llvm_unreachable("invalid super callee");
     }
 
-    // *NOTE* Temporary staging variable for refactoring.
-    SILValue superValue = super.peekScalarValue();
-    setSelfParam(ArgumentSource(arg, std::move(super)), apply);
-
+    assert(super.isComplete() && "At this point super should be a complete "
+                                 "rvalue that is not in any special states");
+    ArgumentSource superArgSource(arg, std::move(super));
     if (!canUseStaticDispatch(SGF, constant)) {
       // ObjC super calls require dynamic dispatch.
-      setCallee(
-          Callee::forSuperMethod(SGF, superValue, constant, substitutions, fn));
+      setCallee(Callee::forSuperMethod(SGF, superArgSource.delayedBorrow(SGF),
+                                       constant, substitutions, fn));
     } else {
       // Native Swift super calls to final methods are direct.
       setCallee(Callee::forDirect(SGF, constant, substitutions, fn));
     }
+
+    setSelfParam(std::move(superArgSource), apply);
   }
 
   /// Walk the given \c selfArg expression that produces the appropriate
@@ -1318,10 +1306,8 @@ public:
       }
     }
 
-    setSelfParam(ArgumentSource(arg, RValue(SGF, expr, selfFormalType, self)),
-                 expr);
-
     auto subs = ctorRef->getDeclRef().getSubstitutions();
+    ArgumentSource selfArgSource(arg, RValue(SGF, expr, selfFormalType, self));
 
     // Determine the callee. For structs and enums, this is the allocating
     // constructor (because there is no initializing constructor). For protocol
@@ -1329,9 +1315,10 @@ public:
     // that's the only thing that's witnessed. For classes,
     // this is the initializing constructor, to which we will dynamically
     // dispatch.
-    if (selfParam.getSubstRValueType()->getRValueInstanceType()
-          ->is<ArchetypeType>()
-        && isa<ProtocolDecl>(ctorRef->getDecl()->getDeclContext())) {
+    if (selfArgSource.getSubstRValueType()
+            ->getRValueInstanceType()
+            ->is<ArchetypeType>() &&
+        isa<ProtocolDecl>(ctorRef->getDecl()->getDeclContext())) {
       // Look up the witness for the constructor.
       auto constant = SILDeclRef(ctorRef->getDecl(),
                              useAllocatingCtor
@@ -1343,16 +1330,14 @@ public:
     } else if (getMethodDispatch(ctorRef->getDecl())
                  == MethodDispatch::Class) {
       // Dynamic dispatch to the initializer.
+      Scope S(SGF, expr);
       setCallee(Callee::forClassMethod(
-                  SGF,
-                  self.getValue(),
-                  SILDeclRef(ctorRef->getDecl(),
-                             useAllocatingCtor
-                               ? SILDeclRef::Kind::Allocator
-                             : SILDeclRef::Kind::Initializer)
-                    .asForeign(requiresForeignEntryPoint(ctorRef->getDecl())),
-                  subs,
-                  fn));
+          SGF, selfArgSource.delayedBorrow(SGF),
+          SILDeclRef(ctorRef->getDecl(),
+                     useAllocatingCtor ? SILDeclRef::Kind::Allocator
+                                       : SILDeclRef::Kind::Initializer)
+              .asForeign(requiresForeignEntryPoint(ctorRef->getDecl())),
+          subs, fn));
     } else {
       // Directly call the peer constructor.
       setCallee(
@@ -1366,6 +1351,8 @@ public:
           subs,
           fn));
     }
+
+    setSelfParam(std::move(selfArgSource), expr);
 
     return true;
   }
@@ -1443,13 +1430,8 @@ public:
     // Local function that actually emits the dynamic member reference.
     auto emitDynamicMemberRef = [&] {
       // We found it. Emit the base.
-      ManagedValue base =
-        SGF.emitRValueAsSingleValue(dynamicMemberRef->getBase());
-
-      setSelfParam(ArgumentSource(dynamicMemberRef->getBase(),
-                                  RValue(SGF, dynamicMemberRef,
-                                    base.getType().getSwiftRValueType(), base)),
-                   dynamicMemberRef);
+      ArgumentSource baseArgSource(dynamicMemberRef->getBase(),
+                                   SGF.emitRValue(dynamicMemberRef->getBase()));
 
       // Determine the type of the method we referenced, by replacing the
       // class type of the 'Self' parameter with Builtin.UnknownObject.
@@ -1458,9 +1440,10 @@ public:
       auto substFormalType =
         cast<FunctionType>(dynamicMemberRef->getType()->getCanonicalType()
                                             .getAnyOptionalObjectType());
-      setCallee(Callee::forDynamic(SGF, base.getValue(), member,
-                                   memberRef.getSubstitutions(),
+      setCallee(Callee::forDynamic(SGF, baseArgSource.delayedBorrow(SGF),
+                                   member, memberRef.getSubstitutions(),
                                    substFormalType, {}, e));
+      setSelfParam(std::move(baseArgSource), dynamicMemberRef);
     };
 
     // When we have an open existential, open it and then emit the
@@ -4261,16 +4244,17 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
   auto loc = uncurriedLoc.getValue();
   auto subs = callee.getSubstitutions();
   auto upcastedSelf = uncurriedArgs.back();
-  SILValue castValue, borrowedValue;
-  std::tie(castValue, borrowedValue) = castToOriginalSelfType(SGF.B, loc, upcastedSelf.getValue());
+
   auto constantInfo = SGF.getConstantInfo(callee.getMethodName());
   auto functionTy = constantInfo.getSILType();
-  SILValue superMethodVal =
-      SGF.B.createSuperMethod(loc, castValue, constant, functionTy,
-                              /*volatile*/
-                              constant.isForeign);
-  if (borrowedValue) {
-    SGF.B.createEndBorrow(loc, borrowedValue, upcastedSelf.getValue());
+  ManagedValue superMethod;
+  {
+    Scope S(SGF, loc);
+    ManagedValue castValue =
+        borrowedCastToOriginalSelfType(SGF, loc, upcastedSelf);
+    superMethod = SGF.B.createSuperMethod(loc, castValue, constant, functionTy,
+                                          /*volatile*/
+                                          constant.isForeign);
   }
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
       constantInfo.getSILType(), 1, SGF.B.getModule(), subs,
@@ -4283,8 +4267,8 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
     partialApplyTy = partialApplyTy.substGenericArgs(module, subs);
 
   SILValue partialApply =
-      SGF.B.createPartialApply(loc, superMethodVal, partialApplyTy, subs,
-                               {upcastedSelf.forward(SGF)}, closureTy);
+      SGF.B.createPartialApply(loc, superMethod.getValue(), partialApplyTy,
+                               subs, {upcastedSelf.forward(SGF)}, closureTy);
   return RValue(SGF, loc, formalApplyType.getResult(),
                 ManagedValue::forUnmanaged(partialApply));
 }
@@ -4586,8 +4570,8 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
   Optional<ForeignErrorConvention> foreignError;
   ImportAsMemberStatus foreignSelf;
   ApplyOptions options;
-  std::tie(mv, substFnType, foreignError, foreignSelf, options)
-    = callee.getAtUncurryLevel(*this, 0);
+  std::tie(mv, substFnType, foreignError, foreignSelf, options) =
+      callee.getAtUncurryLevel(*this, 0);
 
   assert(!foreignError);
   assert(!foreignSelf.isImportAsMember());
@@ -4918,14 +4902,15 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
 
   // Otherwise, if we have a non-final class dispatch to a normal method,
   // perform a dynamic dispatch.
-  auto self = selfValue.forceAndPeekRValue(SGF).peekScalarValue();
   if (!isSuper)
-    return Callee::forClassMethod(SGF, self, constant, subs, loc);
+    return Callee::forClassMethod(SGF, selfValue.delayedBorrow(SGF), constant,
+                                  subs, loc);
 
   // If this is a "super." dispatch, we do a dynamic dispatch for objc methods
   // or non-final native Swift methods.
   if (!canUseStaticDispatch(SGF, constant))
-    return Callee::forSuperMethod(SGF, self, constant, subs, loc);
+    return Callee::forSuperMethod(SGF, selfValue.delayedBorrow(SGF), constant,
+                                  subs, loc);
 
   return Callee::forDirect(SGF, constant, subs, loc);
 }

--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -21,7 +21,8 @@ func test1() {
   // CHECK: [[CTOR:%.*]] = function_ref @_T010assignment1DC{{[_0-9a-zA-Z]*}}fC
   // CHECK: [[T0:%.*]] = metatype $@thick D.Type
   // CHECK: [[D:%.*]] = apply [[CTOR]]([[T0]])
-  // CHECK: [[SETTER:%.*]] = class_method [[D]] : $D,  #D.child!setter.1
+  // CHECK: [[BORROWED_D:%.*]] = begin_borrow [[D]]
+  // CHECK: [[SETTER:%.*]] = class_method [[BORROWED_D]] : $D,  #D.child!setter.1
   // CHECK: [[BORROWED_D:%.*]] = begin_borrow [[D]]
   // CHECK: [[CTOR:%.*]] = function_ref @_T010assignment1CC{{[_0-9a-zA-Z]*}}fC
   // CHECK: [[T0:%.*]] = metatype $@thick C.Type

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -17,7 +17,8 @@ class A {
 // CHECK:   [[PB:%.*]] = project_box [[UNINIT_SELF]]
 // CHECK:   store [[SELF_PARAM]] to [init] [[PB]] : $*A
 // CHECK:   [[SELFP:%[0-9]+]] = load [take] [[PB]] : $*A
-// CHECK:   [[INIT:%[0-9]+]] = class_method [[SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A, $@convention(method) (X, @owned A) -> @owned A
+// CHECK:   [[BORROWED_SELFP:%.*]] = begin_borrow [[SELFP]]
+// CHECK:   [[INIT:%[0-9]+]] = class_method [[BORROWED_SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A, $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
 // CHECK:   [[X:%[0-9]+]] = apply [[X_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -459,7 +459,7 @@ public class Sub : Base {
   // CHECK:     [[BORROWED_CASTED_VALUE_COPY:%.*]] = begin_borrow [[CASTED_VALUE_COPY]]
   // CHECK:     [[DOWNCAST_FOR_SUPERMETHOD:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_VALUE_COPY]]
   // CHECK:     [[SUPER:%.*]] = super_method [volatile] [[DOWNCAST_FOR_SUPERMETHOD]] : $Sub, #Base.x!getter.1.foreign : (Base) -> () -> Bool, $@convention(objc_method) (Base) -> ObjCBool
-  // CHECK:     end_borrow [[BORROWED_CASTED_VALUE_COPY]] from [[CASTED_VALUE_COPY]]
+  // CHECK:     end_borrow [[BORROWED_CASTED_VALUE_COPY]]
   // CHECK:     = apply [[SUPER]]([[CASTED_VALUE_COPY]])
   // CHECK:     destroy_value [[VALUE_COPY]]
   // CHECK:     end_borrow [[BORROWED_VALUE]] from [[VALUE]]

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -27,7 +27,8 @@ func direct_to_class(_ obj: AnyObject) {
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[OPENED_ARG:%[0-9]+]] = open_existential_ref [[BORROWED_ARG]] : $AnyObject to $@opened({{.*}}) AnyObject
   // CHECK: [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
-  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign : (X) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK: [[BORROWED_OPENED_ARG_COPY:%.*]] = begin_borrow [[OPENED_ARG_COPY]]
+  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[BORROWED_OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign : (X) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK: apply [[METHOD]]([[OPENED_ARG_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK: destroy_value [[OPENED_ARG_COPY]]
   // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
@@ -42,7 +43,8 @@ func direct_to_protocol(_ obj: AnyObject) {
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[OPENED_ARG:%[0-9]+]] = open_existential_ref [[BORROWED_ARG]] : $AnyObject to $@opened({{.*}}) AnyObject
   // CHECK:   [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
-  // CHECK:   [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <Self where Self : P> (Self) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK:   [[BORROWED_OPENED_ARG_COPY:%.*]] = begin_borrow [[OPENED_ARG_COPY]]
+  // CHECK:   [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[BORROWED_OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <Self where Self : P> (Self) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK:   apply [[METHOD]]([[OPENED_ARG_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK:   destroy_value [[OPENED_ARG_COPY]]
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]

--- a/test/SILGen/dynamic_lookup_throws.swift
+++ b/test/SILGen/dynamic_lookup_throws.swift
@@ -17,7 +17,8 @@ func testBlub(a: AnyObject) throws {
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ANYOBJECT_REF:%.*]] = open_existential_ref [[BORROWED_ARG]] : $AnyObject to $@opened("[[OPENED:.*]]") AnyObject
   // CHECK:   [[ANYOBJECT_REF_COPY:%.*]] = copy_value [[ANYOBJECT_REF]]
-  // CHECK:   dynamic_method [volatile] [[ANYOBJECT_REF_COPY]] : $@opened("[[OPENED]]") AnyObject, #Blub.blub!1.foreign : (Blub) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @opened("[[OPENED]]") AnyObject) -> ObjCBool
+  // CHECK:   [[BORROWED_ANYOBJECT_REF_COPY:%.*]] = begin_borrow [[ANYOBJECT_REF_COPY]]
+  // CHECK:   dynamic_method [volatile] [[BORROWED_ANYOBJECT_REF_COPY]] : $@opened("[[OPENED]]") AnyObject, #Blub.blub!1.foreign : (Blub) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @opened("[[OPENED]]") AnyObject) -> ObjCBool
   // CHECK:   cond_br {{%.*}}, bb1, bb2
 
   // CHECK: bb1

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -41,8 +41,9 @@ class GY<T> : GX<[T]> { }
 // CHECK: bb0([[Y:%[0-9]+]] : $Y):
 // CHECK:   [[BORROWED_Y:%.*]] = begin_borrow [[Y]]
 // CHECK:   [[Y_COPY:%.*]] = copy_value [[BORROWED_Y]]
-// CHECK:   [[Y_AS_X_COPY:%[0-9]+]] = upcast [[Y_COPY]] : $Y to $X  
-// CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
+// CHECK:   [[Y_AS_X_COPY:%[0-9]+]] = upcast [[Y_COPY]] : $Y to $X
+// CHECK:   [[BORROWED_Y_AS_X_COPY:%.*]] = begin_borrow [[Y_AS_X_COPY]]
+// CHECK:   [[X_F:%[0-9]+]] = class_method [[BORROWED_Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
 // => SEMANTIC SIL TODO: This argument here needs to be borrowed.
 // CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   destroy_value [[Y_AS_X_COPY]]
@@ -60,7 +61,8 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK:   [[BORROWED_GY:%.*]] = begin_borrow [[GY]]
   // CHECK:   [[GY_COPY:%.*]] = copy_value [[BORROWED_GY]]
   // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
-  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   [[BORROWED_GY_AS_GX_COPY:%.*]] = begin_borrow [[GY_AS_GX_COPY]]
+  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[BORROWED_GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   destroy_value [[GY_AS_GX_COPY]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
@@ -133,7 +135,8 @@ func testObjCInit(meta: ObjCInit.Type) {
 // CHECK: bb0([[THICK_META:%[0-9]+]] : $@thick ObjCInit.Type):
 // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[THICK_META]] : $@thick ObjCInit.Type to $@objc_metatype ObjCInit.Type
 // CHECK:   [[OBJ:%[0-9]+]] = alloc_ref_dynamic [objc] [[OBJC_META]] : $@objc_metatype ObjCInit.Type, $ObjCInit
-// CHECK:   [[INIT:%[0-9]+]] = class_method [volatile] [[OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit, $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
+// CHECK:   [[BORROWED_OBJ:%.*]] = begin_borrow [[OBJ]]
+// CHECK:   [[INIT:%[0-9]+]] = class_method [volatile] [[BORROWED_OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit, $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   [[RESULT_OBJ:%[0-9]+]] = apply [[INIT]]([[OBJ]]) : $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
@@ -165,7 +168,9 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK:      [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:      [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
-// CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
+// CHECK:      [[BORROWED_CAST_COPY_ARG:%.*]] = begin_borrow [[CAST_COPY_ARG]]
+// CHECK:      [[T0:%.*]] = class_method [[BORROWED_CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
+// CHECK-NEXT: end_borrow [[BORROWED_CAST_COPY_ARG]] from [[CAST_COPY_ARG]]
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
 // CHECK:      switch_enum [[RES]] : $Optional<OptionalResult>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]]
 // CHECK: [[SOME_BB]]([[T1:%.*]] : $OptionalResult):

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -24,7 +24,8 @@ class D: C {}
 // CHECK: [[SOME_BAR]]:
 // CHECK:   [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<Bar>
 // CHECK:   [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
-// CHECK:   [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
+// CHECK:   [[BORROWED_BAR:%.*]] = begin_borrow [[BAR]]
+// CHECK:   [[METHOD:%.*]] = class_method [[BORROWED_BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
 // CHECK:   [[BORROWED_BAR:%.*]] = begin_borrow [[BAR]]
 // CHECK:   apply [[METHOD]]([[BORROWED_BAR]])
 // CHECK:   end_borrow [[BORROWED_BAR]] from [[BAR]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -151,7 +151,8 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
   // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [[BORROWED_C]] : {{.*}}, #SomeClass.method!1
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
@@ -168,7 +169,8 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
   // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [[BORROWED_C]] : {{.*}}, #SomeClass.method!1
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
@@ -204,7 +206,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
-  // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.someProperty!setter.1 : (SomeClass) -> (Builtin.Int64) -> ()
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[SETTER:%[0-9]+]] = class_method [[BORROWED_C]] : $SomeClass, #SomeClass.someProperty!setter.1 : (SomeClass) -> (Builtin.Int64) -> ()
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: apply [[SETTER]]([[I]], [[BORROWED_C]])
   // CHECK: end_borrow [[BORROWED_C]] from [[C]]
@@ -217,7 +220,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: [[READK:%.*]] = begin_access [read] [unknown] [[KADDR]]
   // CHECK: [[K:%[0-9]+]] = load [trivial] [[READK]]
-  // CHECK: [[GETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64, $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[GETTER:%[0-9]+]] = class_method [[BORROWED_C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64, $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: apply [[GETTER]]([[J]], [[K]], [[BORROWED_C]])
   // CHECK: end_borrow [[BORROWED_C]] from [[C]]
@@ -232,7 +236,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: [[READK:%.*]] = begin_access [read] [unknown] [[KADDR]]
   // CHECK: [[K:%[0-9]+]] = load [trivial] [[READK]]
-  // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> (), $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[SETTER:%[0-9]+]] = class_method [[BORROWED_C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> (), $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[BORROWED_C]])
   // CHECK: end_borrow [[BORROWED_C]] from [[C]]
@@ -283,7 +288,8 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[READG:%.*]] = begin_access [read] [unknown] [[GADDR]]
   // CHECK: [[G:%[0-9]+]] = load [copy] [[READG]]
-  // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.method!1
+  // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
+  // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[BORROWED_G]] : {{.*}}, #SomeGeneric.method!1
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
@@ -294,7 +300,8 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[READG:%.*]] = begin_access [read] [unknown] [[GADDR]]
   // CHECK: [[G:%[0-9]+]] = load [copy] [[READG]]
-  // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.generic!1
+  // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
+  // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[BORROWED_G]] : {{.*}}, #SomeGeneric.generic!1
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
@@ -305,7 +312,8 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
   // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
-  // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.generic!1
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[BORROWED_C]] : {{.*}}, #SomeClass.generic!1
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -525,7 +525,9 @@ class LetFieldClass {
   // CHECK: bb0([[CLS:%.*]] : @guaranteed $LetFieldClass):
   // CHECK: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
-  // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[KRAKEN]]
+  // CHECK-NEXT: [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
+  // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[BORROWED_KRAKEN]]
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
   // CHECK-NEXT: [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[BORROWED_KRAKEN]])
   // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -95,8 +95,8 @@ class C1 {
 
     // CHECK:   store [[ORIG_SELF]] to [init] [[PB]] : $*C1
     // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load [take] [[PB]] : $*C1
-
-    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1, $@convention(method) (X, X, @owned C1) -> @owned C1
+    // CHECK:   [[BORROWED_SELF_FROM_BOX:%.*]] = begin_borrow [[SELF_FROM_BOX]]
+    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[BORROWED_SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1, $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   store [[SELFP]] to [init] [[PB]] : $*C1
     // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[PB]] : $*C1
@@ -119,8 +119,8 @@ class C1 {
     // CHECK:   [[PB_SELF:%.*]] = project_box [[MARKED_SELF_BOX]]
     // CHECK:   store [[ORIG_SELF]] to [init] [[PB_SELF]] : $*C2
     // CHECK:   [[SELF:%[0-9]+]] = load [take] [[PB_SELF]] : $*C2
-
-    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2, $@convention(method) (X, X, @owned C2) -> @owned C2
+    // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[BORROWED_SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2, $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   store [[REPLACE_SELF]] to [init] [[PB_SELF]] : $*C2
     // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[PB_SELF]] : $*C2

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -33,7 +33,7 @@ extension Sub {
     // CHECK: [[BORROWED_SELF_COPY_CAST:%.*]] = begin_borrow [[SELF_COPY_CAST]]
     // CHECK: [[CAST_BACK:%.*]] = unchecked_ref_cast [[BORROWED_SELF_COPY_CAST]] : $Base to $Sub
     // CHECK: [[SUPER_METHOD:%.*]] = super_method [volatile] [[CAST_BACK]] : $Sub, #Base.prop!getter.1.foreign
-    // CHECK: end_borrow [[BORROWED_SELF_COPY_CAST]] from [[SELF_COPY_CAST]]
+    // CHECK: end_borrow [[BORROWED_SELF_COPY_CAST]]
     // CHECK: [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[SELF_COPY_CAST]])
     // CHECK: bb3(
     // CHECK: destroy_value [[SELF_COPY]]
@@ -78,7 +78,7 @@ extension Sub {
     // CHECK:   [[BORROWED_UPCAST_SELF:%.*]] = begin_borrow [[UPCAST_SELF_COPY]] : $Base
     // CHECK:   [[SUPERREF_DOWNCAST:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_SELF]] : $Base to $Sub
     // CHECK:   [[SET_SUPER_METHOD:%.*]] = super_method [volatile] [[SUPERREF_DOWNCAST]] : $Sub, #Base.prop!setter.1.foreign : (Base) -> (String!) -> (), $@convention(objc_method) (Optional<NSString>, Base) -> ()
-    // CHECK:   end_borrow [[BORROWED_UPCAST_SELF]]
+    // CHECK:    end_borrow [[BORROWED_UPCAST_SELF]]
     // CHECK:   [[BORROWED_NEW_VALUE:%.*]] = begin_borrow [[NEW_VALUE]]
     // CHECK:   [[NEW_VALUE_COPY:%.*]] = copy_value [[BORROWED_NEW_VALUE]]
     // CHECK:   switch_enum [[NEW_VALUE_COPY]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -13,7 +13,8 @@ extension Gizmo {
     // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
     // CHECK:   store [[ORIG_SELF]] to [init] [[PB_BOX]] : $*Gizmo
     // CHECK:   [[SELF:%[0-9]+]] = load [take] [[PB_BOX]] : $*Gizmo
-    // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+    // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+    // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[BORROWED_SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF4:%.*]] = load [copy] [[PB_BOX]]
     // CHECK:   destroy_value [[MARKED_SELF_BOX]]

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -94,7 +94,8 @@ func test7(_ g: Gizmo) {
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[GIZMO_BOX_PB]] : $*Gizmo
   // CHECK:   [[G:%.*]] = load [copy] [[READ]]
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[G]] : {{.*}}, #Gizmo.fork!1.foreign
+  // CHECK:   [[BORROWED_G:%.*]] = begin_borrow [[G]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_G]] : {{.*}}, #Gizmo.fork!1.foreign
   // CHECK:   apply [[METHOD]]([[G]])
   // CHECK-NOT:  destroy_value [[G]]
   // CHECK:   destroy_value [[GIZMO_BOX]]
@@ -142,7 +143,9 @@ func test10(_ g: Gizmo) -> AnyClass {
   // CHECK:      [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK:      [[G_COPY:%.*]] = copy_value [[BORROWED_G]]
   // CHECK-NEXT: [[NS_G_COPY:%[0-9]+]] = upcast [[G_COPY]] : $Gizmo to $NSObject
-  // CHECK-NEXT: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.classProp!getter.1.foreign : (NSObject) -> () -> AnyObject.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
+  // CHECK-NEXT: [[BORROWED_NS_G_COPY:%.*]] = begin_borrow [[NS_G_COPY]]
+  // CHECK-NEXT: [[GETTER:%[0-9]+]] = class_method [volatile] [[BORROWED_NS_G_COPY]] : $NSObject, #NSObject.classProp!getter.1.foreign : (NSObject) -> () -> AnyObject.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
+  // CHECK-NEXT: end_borrow [[BORROWED_NS_G_COPY]]
   // CHECK-NEXT: [[OPT_OBJC:%.*]] = apply [[GETTER]]([[NS_G_COPY]]) : $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
   // CHECK-NEXT: switch_enum [[OPT_OBJC]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
   //
@@ -162,7 +165,9 @@ func test11(_ g: Gizmo) -> AnyClass {
   // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK: [[G_COPY:%.*]] = copy_value [[BORROWED_G]]
   // CHECK: [[NS_G_COPY:%[0-9]+]] = upcast [[G_COPY:%[0-9]+]] : $Gizmo to $NSObject
-  // CHECK: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.qualifiedClassProp!getter.1.foreign : (NSObject) -> () -> NSAnsing.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
+  // CHECK: [[BORROWED_NS_G_COPY:%.*]] = begin_borrow [[NS_G_COPY]]
+  // CHECK-NEXT: [[GETTER:%[0-9]+]] = class_method [volatile] [[BORROWED_NS_G_COPY]] : $NSObject, #NSObject.qualifiedClassProp!getter.1.foreign : (NSObject) -> () -> NSAnsing.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
+  // CHECK-NEXT: end_borrow [[BORROWED_NS_G_COPY]]
   // CHECK-NEXT: [[OPT_OBJC:%.*]] = apply [[GETTER]]([[NS_G_COPY]]) : $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
   // CHECK-NEXT: switch_enum [[OPT_OBJC]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
   //

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -783,7 +783,8 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
     // CHECK:   [[SELF_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[SELF_META]] : $@thick Self.Type to $@objc_metatype Self.Type
     // CHECK:   [[SELF_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[SELF_META_OBJC]] : $@objc_metatype Self.Type, $Self
     // CHECK:   [[SELF_ALLOC_C:%[0-9]+]] = upcast [[SELF_ALLOC]] : $Self to $ObjCInitClass
-    // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[SELF_ALLOC_C]] : $ObjCInitClass, #ObjCInitClass.init!initializer.1 : (ObjCInitClass.Type) -> () -> ObjCInitClass, $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
+    // CHECK:   [[BORROWED_SELF_ALLOC_C:%.*]] = begin_borrow [[SELF_ALLOC_C]]
+    // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[BORROWED_SELF_ALLOC_C]] : $ObjCInitClass, #ObjCInitClass.init!initializer.1 : (ObjCInitClass.Type) -> () -> ObjCInitClass, $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
     // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[OBJC_INIT]]([[SELF_ALLOC_C]]) : $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
     // CHECK:   [[SELF_RESULT_AS_SELF:%[0-9]+]] = unchecked_ref_cast [[SELF_RESULT]] : $ObjCInitClass to $Self
     // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[PB_SELF_BOX]] : $*Self

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -126,7 +126,8 @@ func methodCalls(
   // CHECK: [[PAYLOAD:%.*]] = open_existential_ref [[BORROW]] : $Base<Int> & P to $@opened("{{.*}}") Base<Int> & P
   // CHECK: [[REF:%.*]] = copy_value [[PAYLOAD]] : $@opened("{{.*}}") Base<Int> & P
   // CHECK: [[CLASS_REF:%.*]] = upcast [[REF]] : $@opened("{{.*}}") Base<Int> & P to $Base<Int>
-  // CHECK: [[METHOD:%.*]] = class_method [[CLASS_REF]] : $Base<Int>, #Base.classSelfReturn!1 : <T> (Base<T>) -> () -> @dynamic_self Base<T>, $@convention(method) <τ_0_0> (@guaranteed Base<τ_0_0>) -> @owned Base<τ_0_0>
+  // CHECK: [[BORROWED_CLASS_REF:%.*]] = begin_borrow [[CLASS_REF]]
+  // CHECK: [[METHOD:%.*]] = class_method [[BORROWED_CLASS_REF]] : $Base<Int>, #Base.classSelfReturn!1 : <T> (Base<T>) -> () -> @dynamic_self Base<T>, $@convention(method) <τ_0_0> (@guaranteed Base<τ_0_0>) -> @owned Base<τ_0_0>
   // CHECK: [[RESULT_CLASS_REF:%.*]] = apply [[METHOD]]<Int>([[CLASS_REF]]) : $@convention(method) <τ_0_0> (@guaranteed Base<τ_0_0>) -> @owned Base<τ_0_0>
   // CHECK: destroy_value [[CLASS_REF]] : $Base<Int>
   // CHECK: [[RESULT_REF:%.*]] = unchecked_ref_cast [[RESULT_CLASS_REF]] : $Base<Int> to $@opened("{{.*}}") Base<Int> & P
@@ -137,7 +138,7 @@ func methodCalls(
 
   // CHECK: [[BORROW:%.*]] = begin_borrow %0 : $Base<Int> & P
   // CHECK: [[PAYLOAD:%.*]] = open_existential_ref [[BORROW]] : $Base<Int> & P to $@opened("{{.*}}") Base<Int> & P
-  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") Base<Int> & P, #P.protocolSelfReturn!1 : <Self where Self : P> (Self) -> () -> @dynamic_self Self, %16 : $@opened("{{.*}}") Base<Int> & P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") Base<Int> & P, #P.protocolSelfReturn!1 : <Self where Self : P> (Self) -> () -> @dynamic_self Self, [[PAYLOAD]] : $@opened("{{.*}}") Base<Int> & P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   // CHECK: [[RESULT_BOX:%.*]] = alloc_stack $@opened("{{.*}}") Base<Int> & P
   // CHECK: [[SELF_BOX:%.*]] = alloc_stack $@opened("{{.*}}") Base<Int> & P
   // CHECK: store_borrow [[PAYLOAD]] to [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
@@ -162,7 +163,7 @@ func methodCalls(
   // CHECK: [[METATYPE:%.*]] = open_existential_metatype %1 : $@thick (Base<Int> & P).Type to $@thick (@opened("{{.*}}") (Base<Int> & P)).Type
   // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") (Base<Int> & P), #P.protocolSelfReturn!1 : <Self where Self : P> (Self.Type) -> () -> @dynamic_self Self, [[METATYPE]] : $@thick (@opened("{{.*}}") (Base<Int> & P)).Type : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[RESULT:%.*]] = alloc_stack $@opened("{{.*}}") (Base<Int> & P)
-  // CHECK: apply [[METHOD]]<@opened("{{.*}}") (Base<Int> & P)>(%37, %35) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: apply [[METHOD]]<@opened("{{.*}}") (Base<Int> & P)>([[RESULT]], [[METATYPE]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[RESULT_REF:%.*]] = load [take] [[RESULT]] : $*@opened("{{.*}}") (Base<Int> & P)
   // CHECK: [[RESULT_VALUE:%.*]] = init_existential_ref [[RESULT_REF]] : $@opened("{{.*}}") (Base<Int> & P) : $@opened("{{.*}}") (Base<Int> & P), $Base<Int> & P
   // CHECK: destroy_value [[RESULT_VALUE]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -120,7 +120,9 @@ func test_unowned_let_capture(_ aC : C) {
 // CHECK: bb0([[ARG:%.*]] : $@sil_unowned C):
 // CHECK-NEXT:   debug_value %0 : $@sil_unowned C, let, name "bC", argno 1
 // CHECK-NEXT:   [[UNOWNED_ARG:%.*]] = copy_unowned_value [[ARG]] : $@sil_unowned C
-// CHECK-NEXT:   [[FUN:%.*]] = class_method [[UNOWNED_ARG]] : $C, #C.f!1 : (C) -> () -> Int, $@convention(method) (@guaranteed C) -> Int
+// CHECK-NEXT:   [[BORROWED_UNOWNED_ARG:%.*]] = begin_borrow [[UNOWNED_ARG]]
+// CHECK-NEXT:   [[FUN:%.*]] = class_method [[BORROWED_UNOWNED_ARG]] : $C, #C.f!1 : (C) -> () -> Int, $@convention(method) (@guaranteed C) -> Int
+// CHECK-NEXT:   end_borrow [[BORROWED_UNOWNED_ARG]]
 // CHECK-NEXT:   [[RESULT:%.*]] = apply [[FUN]]([[UNOWNED_ARG]]) : $@convention(method) (@guaranteed C) -> Int
 // CHECK-NEXT:   destroy_value [[UNOWNED_ARG]]
 // CHECK-NEXT:   destroy_value [[ARG]] : $@sil_unowned C


### PR DESCRIPTION
This PR contains two infrastructure commits that are then used to implement the 3rd commit that is the actual side-effect having commit. For the purposes of PR context the commit message is:

```
[silgen] Store self as an ArgumentSource in Callee instead of as a SILValue.

This will let me treat self during delegating initialization as an lvalue and
thus be emitted later without a scope. Thus I can simplify delegating
initialization slightly and land my argument scoping work.

rdar://33358110
```