### PR TITLE
Fix convenience init to protocol extension init delegation

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -862,9 +862,18 @@ public:
   /// Retrieve a generic signature with a single unconstrained type parameter,
   /// like `<T>`.
   CanGenericSignature getSingleGenericParameterSignature() const;
-  
-  /// Whether our effective Swift version is in the Swift 3 family
+
+  /// Whether our effective Swift version is in the Swift 3 family.
   bool isSwiftVersion3() const { return LangOpts.isSwiftVersion3(); }
+
+  /// Whether our effective Swift version is at least 'major'.
+  ///
+  /// This is usually the check you want; for example, when introducing
+  /// a new language feature which is only visible in Swift 5, you would
+  /// check for isSwiftVersionAtLeast(5).
+  bool isSwiftVersionAtLeast(unsigned major) const {
+    return LangOpts.isSwiftVersionAtLeast(major);
+  }
 
 private:
   friend Decl;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -311,6 +311,15 @@ namespace swift {
       return EffectiveLanguageVersion.isVersion3();
     }
 
+    /// Whether our effective Swift version is at least 'major'.
+    ///
+    /// This is usually the check you want; for example, when introducing
+    /// a new language feature which is only visible in Swift 5, you would
+    /// check for isSwiftVersionAtLeast(5).
+    bool isSwiftVersionAtLeast(unsigned major) const {
+      return EffectiveLanguageVersion.isVersionAtLeast(major);
+    }
+
     /// Returns true if the given platform condition argument represents
     /// a supported target operating system.
     ///

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -110,6 +110,12 @@ public:
   /// Whether this version is in the Swift 3 family
   bool isVersion3() const { return !empty() && Components[0] == 3; }
 
+  /// Whether this version is greater than or equal to the given major version
+  /// number.
+  bool isVersionAtLeast(unsigned major) const {
+    return !empty() && Components[0] >= major;
+  }
+
   /// Return this Version struct with minor and sub-minor components stripped
   Version asMajorVersion() const;
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -726,8 +726,7 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
 
   SILDeclRef constant(decl);
 
-  if (decl->getImplicitSelfDecl()->getType()->getInOutObjectType()
-        ->getClassOrBoundGenericClass()) {
+  if (decl->getDeclContext()->getAsClassOrClassExtensionContext()) {
     // Class constructors have separate entry points for allocation and
     // initialization.
     emitOrDelayFunction(*this, constant, [this,constant,decl](SILFunction *f){

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4715,10 +4715,7 @@ static RValue emitApplyAllocatingInitializer(SILGenFunction &SGF,
     ManagedValue v = std::move(result).getAsSingleValue(SGF, loc);
     CanType canOverriddenSelfType = overriddenSelfType->getCanonicalType();
     SILType loweredResultTy = SGF.getLoweredType(canOverriddenSelfType);
-    v = ManagedValue(SGF.B.createUncheckedRefCast(loc,
-                                                  v.getValue(),
-                                                  loweredResultTy),
-                     v.getCleanup());
+    v = SGF.B.createUncheckedRefCast(loc, v, loweredResultTy);
     result = RValue(SGF, loc, canOverriddenSelfType, v);
   }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -629,6 +629,15 @@ ManagedValue SILGenBuilder::createUncheckedRefCast(SILLocation loc,
   return cloner.clone(cast);
 }
 
+ManagedValue SILGenBuilder::createUncheckedBitCast(SILLocation loc,
+                                                   ManagedValue value,
+                                                   SILType type) {
+  CleanupCloner cloner(*this, value);
+  SILValue cast =
+      SILBuilder::createUncheckedBitCast(loc, value.forward(SGF), type);
+  return cloner.clone(cast);
+}
+
 ManagedValue SILGenBuilder::createOpenExistentialRef(SILLocation loc,
                                                      ManagedValue original,
                                                      SILType type) {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -267,6 +267,10 @@ public:
   ManagedValue createUncheckedRefCast(SILLocation loc, ManagedValue original,
                                       SILType type);
 
+  using SILBuilder::createUncheckedBitCast;
+  ManagedValue createUncheckedBitCast(SILLocation loc, ManagedValue original,
+                                      SILType type);
+
   using SILBuilder::createOpenExistentialRef;
   ManagedValue createOpenExistentialRef(SILLocation loc, ManagedValue arg,
                                         SILType openedType);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1950,6 +1950,11 @@ RValue RValueEmitter::visitCovariantReturnConversionExpr(
   ManagedValue original = SGF.emitRValueAsSingleValue(e->getSubExpr());
   SILType resultType = SGF.getLoweredType(e->getType());
 
+  // DynamicSelfType lowers as its self type, so no SIL-level conversion
+  // is required in this case.
+  if (resultType == original.getType())
+    return RValue(SGF, e, original);
+
   ManagedValue result = SGF.B.createUncheckedRefCast(e, original, resultType);
 
   return RValue(SGF, e, result);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3682,10 +3682,8 @@ RValue RValueEmitter::visitInjectIntoOptionalExpr(InjectIntoOptionalExpr *E,
   if (mayLieAboutNonOptionalReturn(SGF.SGM.M, E->getSubExpr())) {
     auto result = SGF.emitRValueAsSingleValue(E->getSubExpr());
     auto optType = SGF.getLoweredLoadableType(E->getType());
-    SILValue bitcast = SGF.B.createUncheckedBitCast(E, result.getValue(),
-                                                    optType);
-    ManagedValue bitcastMV = ManagedValue(bitcast, result.getCleanup());
-    return RValue(SGF, E, bitcastMV);
+    ManagedValue bitcast = SGF.B.createUncheckedBitCast(E, result, optType);
+    return RValue(SGF, E, bitcast);
   }
 
   // Try the bridging peephole.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -475,10 +475,7 @@ ManagedValue Transform::transform(ManagedValue v,
 
     if (outputSubstType->isExactSuperclassOf(inputSubstType)) {
       // Upcast to a superclass.
-      return ManagedValue(SGF.B.createUpcast(Loc,
-                                             v.getValue(),
-                                             loweredResultTy),
-                          v.getCleanup());
+      return SGF.B.createUpcast(Loc, v, loweredResultTy);
     } else {
       // Unchecked-downcast to a covariant return type.
       assert(inputSubstType->isExactSuperclassOf(outputSubstType)
@@ -493,10 +490,7 @@ ManagedValue Transform::transform(ManagedValue v,
       if (archetypeType->getSuperclass()) {
         // Replace the cleanup with a new one on the superclass value so we
         // always use concrete retain/release operations.
-        return ManagedValue(SGF.B.createUpcast(Loc,
-                                               v.getValue(),
-                                               loweredResultTy),
-                            v.getCleanup());
+        return SGF.B.createUpcast(Loc, v, loweredResultTy);
       }
     }
   }
@@ -1090,9 +1084,7 @@ namespace {
                                        outputOrigType, outputTupleType,
                                        loweredTy);
 
-        auto optional = SGF.B.createEnum(Loc, payload.getValue(),
-                                         someDecl, optionalTy);
-        return ManagedValue(optional, payload.getCleanup());
+        return SGF.B.createEnum(Loc, payload, someDecl, optionalTy);
       } else {
         auto optionalBuf = SGF.emitTemporaryAllocation(Loc, optionalTy);
         auto tupleBuf = SGF.B.createInitEnumDataAddr(Loc, optionalBuf, someDecl,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -470,10 +470,7 @@ ManagedValue Transform::transform(ManagedValue v,
     // CF <-> Objective-C via toll-free bridging.
     if ((class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType) ^
         (class2->getForeignClassKind() == ClassDecl::ForeignKind::CFType)) {
-       return ManagedValue(SGF.B.createUncheckedRefCast(Loc,
-                                                        v.getValue(),
-                                                        loweredResultTy),
-                           v.getCleanup());
+      return SGF.B.createUncheckedRefCast(Loc, v, loweredResultTy);
     }
 
     if (outputSubstType->isExactSuperclassOf(inputSubstType)) {
@@ -486,8 +483,7 @@ ManagedValue Transform::transform(ManagedValue v,
       // Unchecked-downcast to a covariant return type.
       assert(inputSubstType->isExactSuperclassOf(outputSubstType)
              && "should be inheritance relationship between input and output");
-      return SGF.emitManagedRValueWithCleanup(
-        SGF.B.createUncheckedRefCast(Loc, v.forward(SGF), loweredResultTy));      
+      return SGF.B.createUncheckedRefCast(Loc, v, loweredResultTy);
     }
   }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1540,8 +1540,8 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     auto decl = declRefExpr->getDecl();
     candidates.push_back({ decl, getCalleeLevel(decl) });
     
-    if (auto fTy = decl->getInterfaceType()->getAs<AnyFunctionType>())
-      declName = fTy->getInput()->getRValueInstanceType()->getString()+".init";
+    if (auto selfTy = decl->getDeclContext()->getSelfInterfaceType())
+      declName = selfTy.getString() + ".init";
     else
       declName = "init";
     return;
@@ -1657,7 +1657,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     if (UDE->getName().getBaseName() == CS.TC.Context.Id_init) {
       auto selfTy = CS.getType(UDE->getBase())->getWithoutSpecifierType();
       if (!selfTy->hasTypeVariable())
-        declName = selfTy.getString() + "." + declName;
+        declName = selfTy->eraseDynamicSelfType().getString() + "." + declName;
     }
 
     // Otherwise, look for a disjunction constraint explaining what the set is.

--- a/test/Compatibility/dynamic_self_swift4.swift
+++ b/test/Compatibility/dynamic_self_swift4.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// ----------------------------------------------------------------------------
+// Semi-bogus factory init pattern -- Swift 4 permitted this for non-final
+// classes, which is unsound, but swift-corelibs-foundation made use of
+// this, so possibly there are other usages in the wild.
+//
+// See test/decl/func/dynamic_self.swift for the Swift 5 test case.
+
+protocol FactoryPattern {
+  init(factory: @autoclosure () -> Self)
+}
+
+extension  FactoryPattern {
+  init(factory: @autoclosure () -> Self) { self = factory() }
+}
+
+class Factory : FactoryPattern {
+  init(_string: String) {}
+
+  convenience init(string: String) {
+    self.init(factory: Factory(_string: string))
+  }
+}

--- a/test/Interpreter/protocol_initializers.swift
+++ b/test/Interpreter/protocol_initializers.swift
@@ -1,4 +1,8 @@
-// RUN: %target-run-simple-swift -swift-version 5
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift -swift-version 5 %s -o %t/a.out
+//
+// RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -167,10 +167,8 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
 // CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
-// CHECK:      switch_enum [[RES]] : $Optional<OptionalResult>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]]
-// CHECK: [[SOME_BB]]([[T1:%.*]] : $OptionalResult):
-// CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[T1]] : $OptionalResult to $OptionalResultInheritor
-// CHECK-NEXT: enum $Optional<OptionalResultInheritor>, #Optional.some!enumelt.1, [[T4]]
+// CHECK-NEXT: destroy_value [[CAST_COPY_ARG]]
+// CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[RES]] : $Optional<OptionalResult> to $Optional<OptionalResultInheritor>
 
 func id<T>(_ t: T) -> T { return t }
 

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -473,7 +473,7 @@ class PropertyRequirementWitnessFromBase : PropertyRequirementBase, PropertyRequ
   // CHECK-NEXT: [[CADR:%.*]] = tuple_extract [[RES]] : $({{.*}}), 1
   // CHECK-NEXT: [[TUPLE:%.*]] = tuple ([[CAR]] : {{.*}}, [[CADR]] : {{.*}})
   // CHECK-NEXT: end_borrow [[BORROWED_CAST_ARG2_LOADED]] from [[CAST_ARG2_LOADED]]
-  // CHECK-NEXT: destroy_value [[ARG2_LOADED]]
+  // CHECK-NEXT: destroy_value [[CAST_ARG2_LOADED]]
   // CHECK-NEXT: return [[TUPLE]]
 
   // CHECK-LABEL: sil private [transparent] [thunk] @_T09witnesses34PropertyRequirementWitnessFromBaseCAA0bC0A2aDP6heightSifmZTW : {{.*}} {
@@ -518,7 +518,7 @@ class CrashableBase {
 // CHECK-NEXT: apply [[FN]]([[BORROWED_BASE]]) : $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: end_borrow [[BORROWED_BASE]] from [[BASE]]
-// CHECK-NEXT: destroy_value [[SELF]] : $GenericCrashable<τ_0_0>
+// CHECK-NEXT: destroy_value [[BASE]] : $CrashableBase
 // CHECK-NEXT: dealloc_stack [[BOX]] : $*GenericCrashable<τ_0_0>
 // CHECK-NEXT: return [[RESULT]] : $()
 

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s -swift-version 5 | %FileCheck %s
 
 // Ensure that convenience initializers on concrete types can
 // delegate to factory initializers defined in protocol
@@ -30,11 +30,11 @@ class TrivialClass : TriviallyConstructible {
   // CHECK-NEXT:  [[SELF_BOX:%.*]] = alloc_stack $TrivialClass
   // CHECK-NEXT:  debug_value
   // CHECK-NEXT:  store [[OLD_SELF]] to [[SELF_BOX]]
-  // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1
+  // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick @dynamic_self TrivialClass.Type, %1
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $TrivialClass
-  // CHECK-NEXT:  apply [[FN]]<TrivialClass>([[RESULT]], %0, [[METATYPE]])
+  // CHECK-NEXT:  apply [[FN]]<@dynamic_self TrivialClass>([[RESULT]], %0, [[METATYPE]])
   // CHECK-NEXT:  [[NEW_SELF:%.*]] = load [[RESULT]]
   // CHECK-NEXT:  store [[NEW_SELF]] to [[SELF_BOX]]
   // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1


### PR DESCRIPTION
Consider a class initializer that delegates to a protocol extension initializer, for example

```
protocol P {}
extension P {
  init() { ... }
}

class C : P {
  convenience init(foo: Int) { self.init() }
}
```

The `self.init()` inside the class initializer must pass a substitution for the Self type parameter to the protocol extension method. It was passing the static type, not the dynamic type. This is wrong because convenience initializers can be inherited, so calling an inherited initializer would use the wrong 'Self' type. This was a problem if the protocol extension method either had 'Self' in contravariant position (in which case we might type check invalid code) or if it constructed a new instance of 'Self' and returned it (in which case we would do the wrong thing at runtime).

Fix the problem and add tests for both cases.

Also clean up some related code I looked at along the way.

This is a source-breaking change, so make it conditional on `-swift-version 5`.