### PR TITLE
[silgen] Rename getUncurriedOrigFormalType to getUncurriedOrigFormalResultType and simplify slightly.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4023,17 +4023,21 @@ namespace {
                             ImportAsMemberStatus foreignSelf,
                             Optional<ForeignErrorConvention> foreignError,
                             SGFContext C);
-
-    AbstractionPattern
-    getUncurriedOrigFormalType(AbstractionPattern origFormalType) {
-      for (unsigned i = 0, e = uncurriedSites.size(); i < e; ++i) {
-        claimNextParamClause(origFormalType);
-      }
-
-      return origFormalType;
-    }
   };
 } // end anonymous namespace
+
+/// This function claims param clauses from the passed in formal type until the
+/// type is completely uncurried. This will be the final result type for a
+/// normal call.
+static AbstractionPattern
+getUncurriedOrigFormalResultType(AbstractionPattern origFormalType,
+                                 unsigned numUncurriedSites) {
+  for (unsigned i = 0, e = numUncurriedSites; i < e; ++i) {
+    claimNextParamClause(origFormalType);
+  }
+
+  return origFormalType;
+}
 
 RValue CallEmission::applyFirstLevelCallee(
     CanFunctionType &formalType,
@@ -4095,7 +4099,8 @@ RValue CallEmission::applyNormalCall(
   }
 
   CalleeTypeInfo calleeTypeInfo(
-      substFnType, getUncurriedOrigFormalType(origFormalType),
+      substFnType,
+      getUncurriedOrigFormalResultType(origFormalType, uncurriedSites.size()),
       uncurriedSites.back().getSubstResultType(), foreignError);
   ResultPlanPtr resultPlan = ResultPlanBuilder::computeResultPlan(
       SGF, calleeTypeInfo, uncurriedSites.back().Loc, uncurriedContext);
@@ -4372,9 +4377,9 @@ void CallEmission::emitArgumentsForNormalApply(
     Optional<SILLocation> &uncurriedLoc, CanFunctionType &formalApplyType) {
   SmallVector<SmallVector<ManagedValue, 4>, 2> args;
   SmallVector<DelayedArgument, 2> delayedArgs;
-  auto expectedUncurriedOrigFormalType =
-      getUncurriedOrigFormalType(origFormalType);
-  (void)expectedUncurriedOrigFormalType;
+  auto expectedUncurriedOrigResultFormalType =
+      getUncurriedOrigFormalResultType(origFormalType, uncurriedSites.size());
+  (void)expectedUncurriedOrigResultFormalType;
 
   args.reserve(uncurriedSites.size());
   {
@@ -4418,9 +4423,9 @@ void CallEmission::emitArgumentsForNormalApply(
   assert(uncurriedLoc);
   assert(formalApplyType);
   assert(origFormalType.getType() ==
-             expectedUncurriedOrigFormalType.getType() &&
-         "getUncurriedOrigFormalType and emitArgumentsForNormalCall are out of "
-         "sync");
+             expectedUncurriedOrigResultFormalType.getType() &&
+         "expectedUncurriedOrigResultFormalType and emitArgumentsForNormalCall "
+         "are out of sync");
 
   // Emit any delayed arguments: formal accesses to inout arguments, etc.
   if (!delayedArgs.empty()) {


### PR DESCRIPTION
[silgen] Rename getUncurriedOrigFormalType to getUncurriedOrigFormalResultType and simplify slightly.

When I was originally refactoring this code, I was confused about what this code
was actually supposed to do so I performed a simple manual transformation that
preserved correctness. After some thought, I have realized that this really is
about stripping off parameters from the origFormalType until we get what we call
on the calee origFormalResultType.

The slight simplification that I spoke of in the main title of the commit is
that I changed the routine to take an unsigned for the number of call sites,
rather than implicitly using the size parameter of the passed in uncurriedSites
list. There is no reason to tie this type to said API. And it will allow me to
make further refactorings as well!

rdar://33358110
