### PR TITLE
Cleanup passing around of ImportAsMemberStatus foreignSelf

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4016,7 +4016,6 @@ namespace {
     RValue
     applyEnumElementConstructor(CanFunctionType &formalType,
                                 Optional<ForeignErrorConvention> &foreignError,
-                                ImportAsMemberStatus &foreignSelf,
                                 unsigned uncurryLevel, SGFContext C);
 
     RValue applyNormalCall(CanFunctionType &formalType,
@@ -4068,8 +4067,7 @@ RValue CallEmission::applyFirstLevelCallee(
   }
 
   if (isEnumElementConstructor()) {
-    return applyEnumElementConstructor(formalType,
-                                       foreignError, foreignSelf, uncurryLevel,
+    return applyEnumElementConstructor(formalType, foreignError, uncurryLevel,
                                        C);
   }
 
@@ -4148,9 +4146,8 @@ RValue CallEmission::applyNormalCall(
 }
 
 RValue CallEmission::applyEnumElementConstructor(
-    CanFunctionType &formalType,
-    Optional<ForeignErrorConvention> &foreignError,
-    ImportAsMemberStatus &foreignSelf, unsigned uncurryLevel, SGFContext C) {
+    CanFunctionType &formalType, Optional<ForeignErrorConvention> &foreignError,
+    unsigned uncurryLevel, SGFContext C) {
   assert(!assumedPlusZeroSelf);
   SGFContext uncurriedContext = (extraSites.empty() ? C : SGFContext());
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3997,7 +3997,7 @@ namespace {
         CanFunctionType &formalType, AbstractionPattern &origFormalType,
         CanSILFunctionType substFnType,
         Optional<ForeignErrorConvention> &foreignError,
-        ImportAsMemberStatus &foreignSelf,
+        ImportAsMemberStatus foreignSelf,
         SmallVectorImpl<ManagedValue> &uncurriedArgs,
         Optional<SILLocation> &uncurriedLoc, CanFunctionType &formalApplyType);
 
@@ -4380,7 +4380,7 @@ ApplyOptions CallEmission::emitArgumentsForNormalApply(
     CanFunctionType &formalType, AbstractionPattern &origFormalType,
     CanSILFunctionType substFnType,
     Optional<ForeignErrorConvention> &foreignError,
-    ImportAsMemberStatus &foreignSelf,
+    ImportAsMemberStatus foreignSelf,
     SmallVectorImpl<ManagedValue> &uncurriedArgs,
     Optional<SILLocation> &uncurriedLoc, CanFunctionType &formalApplyType) {
   ApplyOptions options = ApplyOptions::None;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3695,7 +3695,7 @@ namespace {
     ClaimedParamsRef
     claimParams(AbstractionPattern origParamType, CanType substParamType,
                 const Optional<ForeignErrorConvention> &foreignError,
-                const ImportAsMemberStatus &foreignSelf) {
+                ImportAsMemberStatus foreignSelf) {
       unsigned count = getFlattenedValueCount(origParamType, substParamType,
                                               foreignSelf);
       if (foreignError) count++;
@@ -3796,7 +3796,7 @@ namespace {
               ParamLowering &lowering, SmallVectorImpl<ManagedValue> &args,
               SmallVectorImpl<DelayedArgument> &delayedArgs,
               const Optional<ForeignErrorConvention> &foreignError,
-              const ImportAsMemberStatus &foreignSelf) && {
+              ImportAsMemberStatus foreignSelf) && {
       auto params = lowering.claimParams(origParamType, getSubstArgType(),
                                          foreignError, foreignSelf);
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4004,7 +4004,7 @@ namespace {
     RValue
     applySpecializedEmitter(CanFunctionType &formalType,
                             Optional<ForeignErrorConvention> &foreignError,
-                            ImportAsMemberStatus &foreignSelf,
+                            ImportAsMemberStatus foreignSelf,
                             SpecializedEmitter &specializedEmitter,
                             unsigned uncurryLevel, SGFContext C);
 
@@ -4289,9 +4289,8 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
 }
 
 RValue CallEmission::applySpecializedEmitter(
-    CanFunctionType &formalType,
-    Optional<ForeignErrorConvention> &foreignError,
-    ImportAsMemberStatus &foreignSelf, SpecializedEmitter &specializedEmitter,
+    CanFunctionType &formalType, Optional<ForeignErrorConvention> &foreignError,
+    ImportAsMemberStatus foreignSelf, SpecializedEmitter &specializedEmitter,
     unsigned uncurryLevel, SGFContext C) {
 
   // We use the context emit-into initialization only for the

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4011,7 +4011,7 @@ namespace {
     RValue applyPartiallyAppliedSuperMethod(
         CanFunctionType &formalType,
         Optional<ForeignErrorConvention> &foreignError,
-        ImportAsMemberStatus &foreignSelf, unsigned uncurryLevel, SGFContext C);
+        ImportAsMemberStatus foreignSelf, unsigned uncurryLevel, SGFContext C);
 
     RValue
     applyEnumElementConstructor(CanFunctionType &formalType,
@@ -4215,9 +4215,8 @@ RValue CallEmission::applyEnumElementConstructor(
 }
 
 RValue CallEmission::applyPartiallyAppliedSuperMethod(
-    CanFunctionType &formalType,
-    Optional<ForeignErrorConvention> &foreignError,
-    ImportAsMemberStatus &foreignSelf, unsigned uncurryLevel, SGFContext C) {
+    CanFunctionType &formalType, Optional<ForeignErrorConvention> &foreignError,
+    ImportAsMemberStatus foreignSelf, unsigned uncurryLevel, SGFContext C) {
 
   assert(uncurryLevel == 0);
 


### PR DESCRIPTION
This PR cleans up how we pass around ImportAsMemberStatus foreignSelf in CallEmission. Specifically:

1. Places where we were passing ImportAsMemberStatus as a const ref, I changed to passing by value. ImportAsMemberStatus is just an integer.
2. I changed places that were taking ImportAsMemberStatus as a ref but not writing to ImportAsMemberStatus to instead just take ImportAsMemberStatus by value.

The reason why things got this way initially is b/c this was originally conditional spaghetti code that I refactored mechanically by copying conditional code to make the control flow easier to understand. The one place left that takes ImportAsMemberStatus as a reference is applyNormalCall where we actually do modify ImportAsMemberStatus.

rdar://33358110