### PR TITLE
[silgen] Change getAtUncurryLevel to return a ManagedValue and a CalleeTypeInfo

### DIFF
--- a/lib/SILGen/Callee.h
+++ b/lib/SILGen/Callee.h
@@ -23,27 +23,31 @@ namespace Lowering {
 class CalleeTypeInfo {
 public:
   CanSILFunctionType substFnType;
-  AbstractionPattern origResultType;
+  Optional<AbstractionPattern> origResultType;
   CanType substResultType;
   Optional<ForeignErrorConvention> foreignError;
+  ImportAsMemberStatus foreignSelf;
 
 private:
   Optional<SILFunctionTypeRepresentation> overrideRep;
 
 public:
+  CalleeTypeInfo() = default;
+
   CalleeTypeInfo(CanSILFunctionType substFnType,
                  AbstractionPattern origResultType, CanType substResultType,
                  const Optional<ForeignErrorConvention> &foreignError,
+                 ImportAsMemberStatus foreignSelf,
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
       : substFnType(substFnType), origResultType(origResultType),
         substResultType(substResultType), foreignError(foreignError),
-        overrideRep(overrideRep) {}
+        foreignSelf(foreignSelf), overrideRep(overrideRep) {}
 
   CalleeTypeInfo(CanSILFunctionType substFnType,
                  AbstractionPattern origResultType, CanType substResultType,
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
       : substFnType(substFnType), origResultType(origResultType),
-        substResultType(substResultType), foreignError(),
+        substResultType(substResultType), foreignError(), foreignSelf(),
         overrideRep(overrideRep) {}
 
   SILFunctionTypeRepresentation getOverrideRep() const {

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -395,7 +395,7 @@ ResultPlanPtr ResultPlanBuilder::buildTopLevelResult(Initialization *init,
   // build.
   auto foreignError = calleeTypeInfo.foreignError;
   if (!foreignError) {
-    return build(init, calleeTypeInfo.origResultType,
+    return build(init, calleeTypeInfo.origResultType.getValue(),
                  calleeTypeInfo.substResultType);
   }
 
@@ -428,7 +428,7 @@ ResultPlanPtr ResultPlanBuilder::buildTopLevelResult(Initialization *init,
   }
   }
 
-  ResultPlanPtr subPlan = build(init, calleeTypeInfo.origResultType,
+  ResultPlanPtr subPlan = build(init, calleeTypeInfo.origResultType.getValue(),
                                 calleeTypeInfo.substResultType);
   return ResultPlanPtr(new ForeignErrorInitializationPlan(
       SGF, loc, calleeTypeInfo, std::move(subPlan)));

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1692,7 +1692,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     CalleeTypeInfo calleeTypeInfo(
         fnType, AbstractionPattern(nativeFnTy->getGenericSignature(),
                                    bridgedFormalResultType),
-        nativeFormalResultType, foreignError);
+        nativeFormalResultType, foreignError, ImportAsMemberStatus());
 
     auto init = indirectResult
                 ? useBufferAsTemporary(indirectResult,


### PR DESCRIPTION
[silgen] Change getAtUncurryLevel to return a ManagedValue and a CalleeTypeInfo

This is in prepatation for splitting getAtUncurryLevel into one function that
returns the CalleeTypeInfo (which is needed early) and a later one that returns
a ManagedValue, which can occur later.

rdar://33358110
