### PR TITLE
Fix for SR-5615

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1080,6 +1080,8 @@ ERROR(cdecl_throws,none,
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))
+NOTE(access_control_in_protocol_detailed_info,none,
+      "protocol requirements implicitly have the same access as the protocol", ())
 ERROR(access_control_in_protocol,none,
       "%0 modifier cannot be used in protocols", (DeclAttribute))
 ERROR(access_control_setter,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -654,6 +654,7 @@ bool AttributeEarlyChecker::visitAbstractAccessibilityAttr(
 
   // Or within protocols.
   if (isa<ProtocolDecl>(D->getDeclContext())) {
+    diagnoseAndRemoveAttr(attr, diag::access_control_in_protocol_detailed_info);
     diagnoseAndRemoveAttr(attr, diag::access_control_in_protocol, attr);
     return true;
   }


### PR DESCRIPTION
Change to an error text from **'public' modifier cannot be used in protocols**  to **protocol requirements implicitly have the same access as the protocol**

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5615](https://bugs.swift.org/browse/SR-5615).