### PR TITLE
[4.0] SimplifyCFG: fix hang caused by infinite loop in CFG

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1090,9 +1090,19 @@ static SILBasicBlock *getTrampolineDest(SILBasicBlock *SBB) {
   if (!BI)
     return nullptr;
 
-  // Disallow infinite loops.
-  if (BI->getDestBB() == SBB)
-    return nullptr;
+  // Disallow infinite loops through SBB.
+  llvm::SmallPtrSet<SILBasicBlock *, 8> VisitedBBs;
+  BranchInst *NextBI = BI;
+  do {
+    SILBasicBlock *NextBB = NextBI->getDestBB();
+    // We don't care about infinite loops after SBB.
+    if (!VisitedBBs.insert(NextBB).second)
+      break;
+    // Only if the infinite loop goes through SBB directly we bail.
+    if (NextBB == SBB)
+      return nullptr;
+    NextBI = dyn_cast<BranchInst>(NextBB->getTerminator());
+  } while (NextBI);
 
   auto BrArgs = BI->getArgs();
   if (BrArgs.size() != SBB->getNumArguments())

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -2859,3 +2859,38 @@ bb5(%e : $MyError):
 bb6(%44 : $Builtin.Int8):
   return %44 : $Builtin.Int8
 }
+
+// CHECK-LABEL: sil @dont_hang
+// CHECK:      bb6:
+// CHECK:        integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:   br bb5
+// CHECK-NEXT: }
+sil @dont_hang : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb4
+
+bb1:
+  %0 = integer_literal $Builtin.Int64, 1
+  cond_br undef, bb2, bb6
+
+bb2:
+  br bb3
+
+bb3:
+  br bb5
+
+bb4:
+  %1 = integer_literal $Builtin.Int64, 1
+  br bb3
+
+bb5:
+  br bb2
+
+bb6:
+  %2 = integer_literal $Builtin.Int64, 1
+  br bb7
+
+bb7:
+  br bb5
+}
+


### PR DESCRIPTION
Explanation: This fixes a compiler hang. It can happen for control flows which contain branches to non-single-cycle empty infinite loops.

Scope of Issue: This can only happen if the source already contains an infinite loop. But as I have seen before, such situations can implicitly occur if the source contains an assert which is optimized away in the optimized build.

Risk: Low. The change just adds an additional bail-out condition which checks for infinite loops in the CFG.

Reviewed By: Roman

Testing: There is a regression test for it

Jira/Radar: SR-5764, rdar://problem/34068905
