### PR TITLE
[sourcekitd] Remove calls to llvm::Initialize*

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
@@ -17,7 +17,6 @@
 
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Mutex.h"
-#include "llvm/Support/TargetSelect.h"
 #include <chrono>
 #include <xpc/xpc.h>
 #include <dispatch/dispatch.h>
@@ -250,11 +249,6 @@ static void handleInterruptedConnection(xpc_object_t event, xpc_connection_t con
 
 void sourcekitd::initialize() {
   initializeTracing();
-
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
 
   assert(!GlobalConn);
   GlobalConn = xpc_connection_create(SOURCEKIT_XPCSERVICE_IDENTIFIER, nullptr);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -35,7 +35,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/TargetSelect.h"
 #include <mutex>
 
 // FIXME: Portability.
@@ -87,11 +86,6 @@ static void onDocumentUpdateNotification(StringRef DocumentName) {
 static SourceKit::Context *GlobalCtx = nullptr;
 
 void sourcekitd::initialize() {
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
-
   GlobalCtx = new SourceKit::Context(sourcekitd::getRuntimeLibPath(),
                                      SourceKit::createSwiftLangSupport);
   GlobalCtx->getNotificationCenter().addDocumentUpdateNotificationReceiver(


### PR DESCRIPTION
* **Explanation**: We added some calls to llvm::Initialize functions that turned out to be unnecessary. These bloated the binary size of sourcekitd, and in particular our thin client-side library, taking it from ~350 KB to over 20 MB because it required statically linking in most of LLVM.
* **Scope**: Affects binary size of sourcekitd and (theoretically) time to startup.
* **Radar**: rdar://problem/31902757
* **Risk**: Low; removes unnecessary calls.  If they were needed we expect it would have caused test failures in our code-completion PCH tests.
* **Testing**: Existing regression tests pass after removal of code.