### PR TITLE
[4.0] [Serialization] Make requirement signature conformance loading lazy.

### DIFF
--- a/validation-test/Serialization/Inputs/SR5191-other.swift
+++ b/validation-test/Serialization/Inputs/SR5191-other.swift
@@ -1,0 +1,17 @@
+protocol FooBaseProto {}
+
+protocol FooProto: FooBaseProto {}
+
+protocol BarProto {
+  associatedtype Foo: FooProto
+  init(foo: Foo)
+}
+
+protocol BazProto {
+  associatedtype Bar: BarProto
+  init(bar: Bar)
+}
+
+struct BarImpl: BarProto {
+  init(foo: FooImpl) {}
+}

--- a/validation-test/Serialization/SR5191.swift
+++ b/validation-test/Serialization/SR5191.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name SwiftCrash -emit-module -o %t/SR5191.swiftmodule %s %S/Inputs/SR5191-other.swift
+// RUN: %target-build-swift -module-name SwiftCrash -emit-module -o %t/SR5191_reversed.swiftmodule %S/Inputs/SR5191-other.swift %s
+
+// REQUIRES: objc_interop
+// The module name is significant here; it must be later ASCIIbetically than
+// "Swift". This has to do with the canonical ordering of protocols, including
+// those inherited by extending NSObject.
+
+import Foundation
+
+class FooImpl: NSObject, FooProto, BazProto {
+  required init(bar: BarImpl) {}
+}


### PR DESCRIPTION
- **Explanation**: In certain cases, deserialization of protocol conformances that involved inherited protocols would result in circular dependencies, which meant a compiler crash. By delaying some of the work of deserialization, we avoid those issues.
- **Scope**: Affects non-WMO builds of modules that contain inheriting protocols and a conforming type with a member that references back to one of the protocols.
- **Issue**: [SR-5191](https://bugs.swift.org/browse/SR-5191) / rdar://problem/33804554
- **Reviewed by**: @DougGregor 
- **Risk**: Medium-low. We originally didn't cherry-pick this because delaying deserialization can occasionally have ripple effects, but it's been living in master for a while with no obvious problems, and it clearly *does* fix some issues.
- **Testing**: Added compiler regression test.