### PR TITLE
Sema: Fix crash when we try to generate constraints for invalid code

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3043,11 +3043,19 @@ namespace {
 
       // Don't visit CoerceExpr with an empty sub expression. They may occur
       // if the body of a closure was not visited while pre-checking because
-      // of an error in the closure's signature
+      // of an error in the closure's signature.
       if (auto coerceExpr = dyn_cast<CoerceExpr>(expr)) {
         if (!coerceExpr->getSubExpr()) {
           return { false, expr };
         }
+      }
+
+      // Don't visit IfExpr with empty sub expressions. They may occur
+      // if the body of a closure was not visited while pre-checking because
+      // of an error in the closure's signature.
+      if (auto ifExpr = dyn_cast<IfExpr>(expr)) {
+        if (!ifExpr->getThenExpr() || !ifExpr->getElseExpr())
+          return { false, expr };
       }
 
       return { true, expr };

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -600,3 +600,9 @@ func testSR5666(cs: [SR5666?]) -> [String?] {
 
 // Ensure that we still do the appropriate pointer conversion here.
 _ = "".withCString { UnsafeMutableRawPointer(mutating: $0) }
+
+// rdar://problem/34077439 - Crash when pre-checking bails out and
+// leaves us with unfolded SequenceExprs inside closure body.
+_ = { (offset) -> T in // expected-error {{use of undeclared type 'T'}}
+  return offset ? 0 : 0
+}


### PR DESCRIPTION
Perhaps we shouldn't visit AST nodes for which pre-checking failed
at all, but that would be a bigger change.

Fixes <rdar://problem/34077439>.