### PR TITLE
Move a test that was a bit flaky into the slow tests.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar33476240.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33476240.swift
@@ -1,9 +1,0 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
-
-// Mixed Int/Double slow to emit diagnostics
-func rdar33476240(col: Int, row: Int, maxCol: Int, maxRow: Int) {
-  let _ = (-(maxCol - 1) + (col * 2)) * 0.1
-  // expected-error@-1 {{binary operator '*' cannot be applied to operands of type 'Int' and 'Double'}}
-  // expected-note@-2 {{overloads for '*' exist with these partially matching parameter lists: (Double, Double), (Int, Int)}}
-}

--- a/validation-test/Sema/type_checker_perf/slow/rdar33476240.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar33476240.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+// Mixed Int/Double slow to emit diagnostics
+func rdar33476240(col: Int, row: Int, maxCol: Int, maxRow: Int) {
+  let _ = (-(maxCol - 1) + (col * 2)) * 0.1 * 0.2 * 0.3
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+}


### PR DESCRIPTION
This failed once locally because it was relatively close to 1s for type
checking time, so make it a bit more complex so that it is almost
certain to fail with the current compiler compiled with
release/no-asserts.
