### PR TITLE
[Constraint system] Allow the solver to bind collection literal types…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1786,12 +1786,15 @@ bool ConstraintSystem::solveSimplified(
   PotentialBindings bestBindings;
   std::tie(bestBindings, bestTypeVar) = determineBestBindings();
 
-  // If we have a binding that does not involve type variables, or we have
-  // no other option, go ahead and try the bindings for this type variable.
+  // If we have a binding that does not involve type variables, and is
+  // not fully bound, and is either not a literal or is a collection
+  // literal, or we have no disjunction to attempt instead, go ahead
+  // and try the bindings for this type variable.
   if (bestBindings &&
       (!disjunction ||
        (!bestBindings.InvolvesTypeVariables && !bestBindings.FullyBound &&
-        bestBindings.LiteralBinding == LiteralBindingKind::None))) {
+        (bestBindings.LiteralBinding == LiteralBindingKind::None ||
+         bestBindings.LiteralBinding == LiteralBindingKind::Collection)))) {
     return tryTypeVariableBindings(solverState->depth, bestTypeVar,
                                    bestBindings.Bindings, solutions,
                                    allowFreeTypeVariables);

--- a/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: not %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: not %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
@@ -2,4 +2,3 @@
 // REQUIRES: tools-release,no_asserts
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]
-// expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}

--- a/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: not %scale-test --begin 2 --end 7 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: not %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
… earlier.

When this kicks in it can result in substantially speeding up type
inference for collection literals.
