### PR TITLE
Sema: Lazy property setters should not be transparent

### DIFF
--- a/test/Inputs/resilient_class.swift
+++ b/test/Inputs/resilient_class.swift
@@ -34,6 +34,8 @@ open class OutsideParentWithResilientProperty {
   public let s: Size
   public let color: Int32
 
+  public final lazy var laziestNumber = 0
+
   public init(p: Point, s: Size, color: Int32) {
     self.p = p
     self.s = s

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
-// RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift -emit-module-path %t/resilient_class.swiftmodule -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -I %t/ -L %t/ -lresilient_struct -module-name resilient_class -emit-library -o %t/libresilient_class.%target-dylib-extension
+// RUN: %target-build-swift %s -lresilient_struct -lresilient_class -I %t -L %t -o %t/main
+// RUN: %target-run %t/main
 
-// RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_class.swift -I %t/ -o %t/resilient_class.o
-// RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_class.swift -I %t/ -o %t/resilient_class.o
-
-// RUN: %target-build-swift %s -Xlinker %t/resilient_struct.o -Xlinker %t/resilient_class.o -I %t -L %t -o %t/main
-
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
+// RUN: %target-build-swift -emit-module-path %t/resilient_class.swiftmodule -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -I %t/ -L %t/ -lresilient_struct -module-name resilient_class -emit-library -o %t/libresilient_class.%target-dylib-extension -whole-module-optimization
+// RUN: %target-build-swift %s -lresilient_struct -lresilient_class -I %t -L %t -o %t/main
 // RUN: %target-run %t/main
 
 // REQUIRES: executable_test
@@ -57,6 +57,23 @@ ResilientClassTestSuite.test("ClassWithResilientProperty") {
   // Make sure the conformance works
   expectEqual(getS(c).w, 30)
   expectEqual(getS(c).h, 40)
+}
+
+ResilientClassTestSuite.test("OutsideClassWithResilientProperty") {
+  let c = OutsideParentWithResilientProperty(
+      p: Point(x: 10, y: 20),
+      s: Size(w: 30, h: 40),
+      color: 50)
+
+  expectEqual(c.p.x, 10)
+  expectEqual(c.p.y, 20)
+  expectEqual(c.s.w, 30)
+  expectEqual(c.s.h, 40)
+  expectEqual(c.color, 50)
+
+  expectEqual(0, c.laziestNumber)
+  c.laziestNumber = 1
+  expectEqual(1, c.laziestNumber)
 }
 
 

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -2,12 +2,12 @@
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
 // RUN: %target-build-swift -emit-module-path %t/resilient_class.swiftmodule -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -I %t/ -L %t/ -lresilient_struct -module-name resilient_class -emit-library -o %t/libresilient_class.%target-dylib-extension
-// RUN: %target-build-swift %s -lresilient_struct -lresilient_class -I %t -L %t -o %t/main
+// RUN: %target-build-swift %s -lresilient_struct -lresilient_class -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
 // RUN: %target-build-swift -emit-module-path %t/resilient_class.swiftmodule -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -I %t/ -L %t/ -lresilient_struct -module-name resilient_class -emit-library -o %t/libresilient_class.%target-dylib-extension -whole-module-optimization
-// RUN: %target-build-swift %s -lresilient_struct -lresilient_class -I %t -L %t -o %t/main
+// RUN: %target-build-swift %s -lresilient_struct -lresilient_class -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // REQUIRES: executable_test

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -1,12 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
-// RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -emit-library -o %t/libresilient_enum.%target-dylib-extension -I %t -L %t -lresilient_struct
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main
+// RUN: %target-run %t/main
 
-// RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_enum.swift -I %t/ -o %t/resilient_enum.o
-// RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_enum.swift -I %t/ -o %t/resilient_enum.o
-
-// RUN: %target-build-swift %s -Xlinker %t/resilient_struct.o -Xlinker %t/resilient_enum.o -I %t -L %t -o %t/main
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -emit-library -o %t/libresilient_enum.%target-dylib-extension -I %t -L %t -lresilient_struct -whole-module-optimization
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main
 // RUN: %target-run %t/main
 
 // REQUIRES: executable_test

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -2,12 +2,12 @@
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -emit-library -o %t/libresilient_enum.%target-dylib-extension -I %t -L %t -lresilient_struct
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -emit-library -o %t/libresilient_enum.%target-dylib-extension -I %t -L %t -lresilient_struct -whole-module-optimization
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // REQUIRES: executable_test

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -2,12 +2,12 @@
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -emit-library -o %t/libresilient_global.%target-dylib-extension
-// RUN: %target-build-swift %s -lresilient_global -lresilient_struct -I %t -L %t -o %t/main
+// RUN: %target-build-swift %s -lresilient_global -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -emit-library -o %t/libresilient_global.%target-dylib-extension -whole-module-optimization
-// RUN: %target-build-swift %s -lresilient_global -lresilient_struct -I %t -L %t -o %t/main
+// RUN: %target-build-swift %s -lresilient_global -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // REQUIRES: executable_test

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -1,10 +1,15 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_global.swift -o %t/resilient_global.o
-// RUN: %target-build-swift -emit-module -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_global.swift -o %t/resilient_global.o
-// RUN: %target-build-swift -emit-library -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
-// RUN: %target-build-swift -emit-module -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
-// RUN: %target-build-swift %s -Xlinker %t/resilient_global.o -Xlinker %t/resilient_struct.o -I %t -L %t -o %t/main
+
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -emit-library -o %t/libresilient_global.%target-dylib-extension
+// RUN: %target-build-swift %s -lresilient_global -lresilient_struct -I %t -L %t -o %t/main
 // RUN: %target-run %t/main
+
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -emit-library -o %t/libresilient_global.%target-dylib-extension -whole-module-optimization
+// RUN: %target-build-swift %s -lresilient_global -lresilient_struct -I %t -L %t -o %t/main
+// RUN: %target-run %t/main
+
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -1,8 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
-// RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
-// RUN: %target-build-swift %s -Xlinker %t/resilient_struct.o -I %t -L %t -o %t/main
+
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main
 // RUN: %target-run %t/main
+
+// RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
+// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main
+// RUN: %target-run %t/main
+
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension
-// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main
+// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // RUN: %target-build-swift -emit-module -parse-as-library -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -emit-library -o %t/libresilient_struct.%target-dylib-extension -whole-module-optimization
-// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main
+// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/main
 
 // REQUIRES: executable_test

--- a/test/SILGen/lazy_properties.swift
+++ b/test/SILGen/lazy_properties.swift
@@ -1,8 +1,15 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -enable-sil-ownership -primary-file %s | %FileCheck %s
 
 // <rdar://problem/17405715> lazy property crashes silgen of implicit memberwise initializer
-// CHECK-LABEL: // lazy_properties.StructWithLazyField.init
-// CHECK-NEXT: sil hidden @_T015lazy_properties19StructWithLazyFieldVACSiSg4once_tcfC : $@convention(method) (Optional<Int>, @thin StructWithLazyField.Type) -> @owned StructWithLazyField {
+
+// CHECK-LABEL: sil hidden @_T015lazy_properties19StructWithLazyFieldV4onceSifg : $@convention(method) (@inout StructWithLazyField) -> Int
+
+// CHECK-LABEL: sil hidden @_T015lazy_properties19StructWithLazyFieldV4onceSifs : $@convention(method) (Int, @inout StructWithLazyField) -> ()
+
+// CHECK-LABEL: sil hidden [transparent] @_T015lazy_properties19StructWithLazyFieldV4onceSifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout StructWithLazyField) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+
+// CHECK-LABEL: sil hidden @_T015lazy_properties19StructWithLazyFieldVACSiSg4once_tcfC : $@convention(method) (Optional<Int>, @thin StructWithLazyField.Type) -> @owned StructWithLazyField
+
 struct StructWithLazyField {
   lazy var once : Int = 42
   let someProp = "Some value"
@@ -17,7 +24,12 @@ func test21057425() {
 // Anonymous closure parameters in lazy initializer crash SILGen
 
 // CHECK-LABEL: sil hidden @_T015lazy_properties22HasAnonymousParametersV1xSifg : $@convention(method) (@inout HasAnonymousParameters) -> Int
+
 // CHECK-LABEL: sil private @_T015lazy_properties22HasAnonymousParametersV1xSifgS2icfU_ : $@convention(thin) (Int) -> Int
+
+// CHECK-LABEL: sil hidden @_T015lazy_properties22HasAnonymousParametersV1xSifs : $@convention(method) (Int, @inout HasAnonymousParameters) -> ()
+
+// CHECK-LABEL: sil hidden [transparent] @_T015lazy_properties22HasAnonymousParametersV1xSifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout HasAnonymousParameters) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
 
 struct HasAnonymousParameters {
   lazy var x = { $0 }(0)


### PR DESCRIPTION
A lazy property setter stores a value to the underlying storage
of the lazy property. The underlying storage is private, and it
is not proper for a public transparent function body to reference
a private member.

In practice, this only failed if the private member had a
non-constant offset, which only occurs with subclasses of @objc
classes, and resilient classes.

For @objc classes we already had a workaround where no accessors
for stored properties are ever transparent. I put this in to fix
this very issue with lazy properties, but now I realize it was
the wrong workaround, because we still had this problem with
resilient classes.

Note that I'm keeping the logic which made @objc accessors
non-transparent in place, because there's a good chance we will
decide that field offset globals should always be private.

Also, to make this issue reproducible in the test, I changed the
resilience execution tests to build the resilient library as a
dylib and link against that instead of just linking .o files
together. This is because .o files can see each other's internal
symbols, so I was not able to reproduce the original failure
this way. I went ahead and updated the other resilient tests to
do this as well. Also, each test now builds in WMO and non-WMO
mode, to exercise different SIL linking behavior. Again, the
WMO variant was needed to reproduce the issue fixed by this
commit, because without WMO we currently discard serialized SIL,
so no cross-module inlining of the lazy property setter was
taking place.