### PR TITLE
Build -shared libs without -pie (on Linux), add tests

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1597,7 +1597,8 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
 
-  if (getTriple().getOS() == llvm::Triple::Linux && job.getKind() != LinkKind::DynamicLibrary) {
+  if (getTriple().getOS() == llvm::Triple::Linux &&
+      job.getKind() == LinkKind::Executable) {
     Arguments.push_back("-pie");
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1597,7 +1597,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
 
-  if (getTriple().getOS() == llvm::Triple::Linux && !getTriple().isAndroid()) {
+  if (getTriple().getOS() == llvm::Triple::Linux && job.getKind() != LinkKind::DynamicLibrary) {
     Arguments.push_back("-pie");
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1597,7 +1597,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
 
-  if (getTriple().getOS() == llvm::Triple::Linux) {
+  if (getTriple().getOS() == llvm::Triple::Linux && !getTriple().isAndroid()) {
     Arguments.push_back("-pie");
   }
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -33,6 +33,9 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.cygwin.txt
 // RUN: %FileCheck -check-prefix CYGWIN-x86_64 %s < %t.cygwin.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-unknown-linux-gnu %s -Lbar -o dynlib.out 2>&1 > %t.linux.dynlib.txt
+// RUN: %FileCheck -check-prefix LINUX_DYNLIB-x86_64 %s < %t.linux.dynlib.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-apple-macosx10.9.1 %s -sdk %S/../Inputs/clang-importer-sdk -lfoo -framework bar -Lbaz -Fgarply -Fsystem car -F cdr -Xlinker -undefined -Xlinker dynamic_lookup -o sdk.out 2>&1 > %t.complex.txt
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
@@ -235,6 +238,23 @@
 // COMPLEX-DAG: -macosx_version_min 10.9.1
 // COMPLEX: -o sdk.out
 
+// LINUX_DYNLIB-x86_64: swift
+// LINUX_DYNLIB-x86_64: -o [[OBJECTFILE:.*]]
+// LINUX_DYNLIB-x86_64: -o [[AUTOLINKFILE:.*]]
+
+// LINUX_DYNLIB-x86_64: clang++{{"? }}
+// LINUX_DYNLIB-x86_64-DAG: -shared
+// LINUX_DYNLIB-x86_64-DAG: -fuse-ld=gold
+// LINUX_DYNLIB-x86_64-NOT: -pie
+// LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+/lib/swift/linux]]
+// LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]/x86_64/swift_begin.o
+// LINUX_DYNLIB-x86_64-DAG: [[OBJECTFILE]]
+// LINUX_DYNLIB-x86_64-DAG: @[[AUTOLINKFILE]]
+// LINUX_DYNLIB-x86_64-DAG: [[STDLIB_PATH]]
+// LINUX_DYNLIB-x86_64-DAG: -lswiftCore
+// LINUX_DYNLIB-x86_64-DAG: -L bar
+// LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]/x86_64/swift_end.o
+// LINUX_DYNLIB-x86_64: -o dynlib.out
 
 // DEBUG: bin/swift
 // DEBUG-NEXT: bin/swift

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -129,6 +129,7 @@
 // LINUX-x86_64: -o [[OBJECTFILE:.*]]
 
 // LINUX-x86_64: clang++{{"? }}
+// LINUX-x86_64-DAG: -pie
 // LINUX-x86_64-DAG: [[OBJECTFILE]]
 // LINUX-x86_64-DAG: -lswiftCore
 // LINUX-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
@@ -144,6 +145,7 @@
 // LINUX-armv6: -o [[OBJECTFILE:.*]]
 
 // LINUX-armv6: clang++{{"? }}
+// LINUX-armv6-DAG: -pie
 // LINUX-armv6-DAG: [[OBJECTFILE]]
 // LINUX-armv6-DAG: -lswiftCore
 // LINUX-armv6-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
@@ -160,6 +162,7 @@
 // LINUX-armv7: -o [[OBJECTFILE:.*]]
 
 // LINUX-armv7: clang++{{"? }}
+// LINUX-armv7-DAG: -pie
 // LINUX-armv7-DAG: [[OBJECTFILE]]
 // LINUX-armv7-DAG: -lswiftCore
 // LINUX-armv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
@@ -176,6 +179,7 @@
 // LINUX-thumbv7: -o [[OBJECTFILE:.*]]
 
 // LINUX-thumbv7: clang++{{"? }}
+// LINUX-thumbv7-DAG: -pie
 // LINUX-thumbv7-DAG: [[OBJECTFILE]]
 // LINUX-thumbv7-DAG: -lswiftCore
 // LINUX-thumbv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
@@ -192,6 +196,7 @@
 // ANDROID-armv7: -o [[OBJECTFILE:.*]]
 
 // ANDROID-armv7: clang++{{"? }}
+// ANDROID-armv7-DAG: -pie
 // ANDROID-armv7-DAG: [[OBJECTFILE]]
 // ANDROID-armv7-DAG: -lswiftCore
 // ANDROID-armv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch applies -pie flag to executables only. I.e. dynamic libraries will be build without it (-shared implies position independence).

This PR is extended version of https://github.com/apple/swift/pull/11510, taking @johnno1962 fixes as well as adding driver tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5721](https://bugs.swift.org/browse/SR-5721).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->