### PR TITLE
[sil-ownership] objc_protocol returns an unowned value, not a trivial value.

### DIFF
--- a/lib/SIL/ValueOwnershipKindClassifier.cpp
+++ b/lib/SIL/ValueOwnershipKindClassifier.cpp
@@ -82,7 +82,6 @@ CONSTANT_OWNERSHIP_INST(Trivial, IsUniqueOrPinned)
 CONSTANT_OWNERSHIP_INST(Trivial, MarkFunctionEscape)
 CONSTANT_OWNERSHIP_INST(Trivial, MarkUninitializedBehavior)
 CONSTANT_OWNERSHIP_INST(Trivial, Metatype)
-CONSTANT_OWNERSHIP_INST(Trivial, ObjCProtocol) // Is this right?
 CONSTANT_OWNERSHIP_INST(Trivial, ObjCToThickMetatype)
 CONSTANT_OWNERSHIP_INST(Trivial, OpenExistentialAddr)
 CONSTANT_OWNERSHIP_INST(Trivial, OpenExistentialBox)
@@ -120,6 +119,7 @@ CONSTANT_OWNERSHIP_INST(Unowned, RawPointerToRef)
 CONSTANT_OWNERSHIP_INST(Unowned, RefToUnowned)
 CONSTANT_OWNERSHIP_INST(Unowned, UnmanagedToRef)
 CONSTANT_OWNERSHIP_INST(Unowned, UnownedToRef)
+CONSTANT_OWNERSHIP_INST(Unowned, ObjCProtocol)
 #undef CONSTANT_OWNERSHIP_INST
 
 #define CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(OWNERSHIP, INST)                    \

--- a/test/SIL/ownership-verifier/objc_use_verifier.sil
+++ b/test/SIL/ownership-verifier/objc_use_verifier.sil
@@ -1,0 +1,15 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 -module-name ObjectiveC -o /dev/null 2>&1  %s
+// REQUIRES: asserts
+// REQUIRES: objc_interop
+
+@objc protocol NSBurrito : class {}
+
+class Protocol : NSBurrito {}
+
+sil @test_objc_protocol : $@convention(thin) () -> @owned Protocol {
+bb0:
+  %0 = objc_protocol #NSBurrito : $Protocol
+  %1 = copy_value %0 : $Protocol
+  return %1 : $Protocol
+}
+


### PR DESCRIPTION
[sil-ownership] objc_protocol returns an unowned value, not a trivial value.

rdar://33358110