### PR TITLE
[sil-ownership] is_nonnull does not take trivial values, it takes classes and functions.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -499,7 +499,6 @@ CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, InitEnumDataAddr)
 CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, InitExistentialAddr)
 CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, InitExistentialMetatype)
 CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, InjectEnumAddr)
-CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, IsNonnull)
 CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, IsUnique)
 CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, IsUniqueOrPinned)
 CONSTANT_OWNERSHIP_INST(Trivial, MustBeLive, Load)
@@ -581,6 +580,7 @@ ACCEPTS_ANY_OWNERSHIP_INST(UncheckedTrivialBitCast)
 ACCEPTS_ANY_OWNERSHIP_INST(ExistentialMetatype)
 ACCEPTS_ANY_OWNERSHIP_INST(ValueMetatype)
 ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
+ACCEPTS_ANY_OWNERSHIP_INST(IsNonnull)
 #undef ACCEPTS_ANY_OWNERSHIP_INST
 
 // Trivial if trivial typed, otherwise must accept owned?

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -387,6 +387,13 @@ bb0(%0 : @owned $SuperKlass):
   return %9999 : $()
 }
 
+sil @test_isnonnull : $@convention(thin) (@owned SuperKlass) -> Builtin.Int1 {
+bb0(%0 : @owned $SuperKlass):
+  %1 = is_nonnull %0 : $SuperKlass
+  destroy_value %0 : $SuperKlass
+  return %1 : $Builtin.Int1
+}
+
 //////////////////////
 // Terminator Tests //
 //////////////////////


### PR DESCRIPTION
[sil-ownership] is_nonnull does not take trivial values, it takes classes and functions.

rdar://33358110