### PR TITLE
Use emitCopy/Destroy value instead of LoweredCopy/Destroy for large types

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -930,10 +930,6 @@ namespace {
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
                                  LoweringStyle style) const override {
-      if (style == LoweringStyle::Shallow) {
-        emitDestroyValue(B, loc, value);
-        return;
-      }
       assert(style != LoweringStyle::Shallow &&
              "This method should never be called when performing a shallow "
              "destroy value.");

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -350,8 +350,12 @@ static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
 
   bool expand = shouldExpand(DAI->getModule(),
                              DAI->getOperand()->getType().getObjectType());
-  TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue,
-                             Lowering::TypeLowering::getLoweringStyle(expand));
+  if (expand) {
+    TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue,
+                               Lowering::TypeLowering::LoweringStyle::Deep);
+  } else {
+    TL.emitDestroyValue(Builder, DAI->getLoc(), NewValue);
+  }
   DAI->eraseFromParent();
 }
 


### PR DESCRIPTION
radar rdar://problem/33942706

Fixes a small code size issue caused by refactoring: we replace a call to `emitCopyValue` with a shallow-copy `emitLoweredCopyValue`. `emitLowered`  is not equivalent: see for example line 780 in type lowering:
```
    SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                  SILValue aggValue,
                                  LoweringStyle style) const override {
      llvm::SmallVector<SILValue, 8> loweredChildValues;
      for (auto &child : getChildren(B.getModule())) {
        auto &childLowering = child.getLowering();
        SILValue childValue = asImpl().emitRValueProject(B, loc, aggValue,
                                                         child.getIndex(),
                                                         childLowering);
        if (!childLowering.isTrivial()) {
          SILValue loweredChildValue = childLowering.emitLoweredCopyChildValue(
```
as can be seen a separate emit lowered copy is done for each child v.s.
```
    SILValue emitCopyValue(SILBuilder &B, SILLocation loc,
                           SILValue value) const override {
      if (B.getFunction().hasQualifiedOwnership())
        return B.createCopyValue(loc, value);
      B.createRetainValue(loc, value, B.getDefaultAtomicity());
      return value;
    }
```
Which is basically a call to retain value (which will get outlined in the later IRGen pass