### PR TITLE
[silgen] Add a "fake" destroy in objc destructors.

### DIFF
--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -49,6 +49,7 @@ class SwiftGizmo : Gizmo {
     // CHECK:   [[SUPER_DEALLOC:%[0-9]+]] = super_method [[SELF]] : $SwiftGizmo, #Gizmo.deinit!deallocator.foreign : (Gizmo) -> () -> (), $@convention(objc_method) (Gizmo) -> ()
     // CHECK:   [[SUPER:%[0-9]+]] = upcast [[SELF]] : $SwiftGizmo to $Gizmo
     // CHECK:   [[SUPER_DEALLOC_RESULT:%[0-9]+]] = apply [[SUPER_DEALLOC]]([[SUPER]]) : $@convention(objc_method) (Gizmo) -> ()
+    // CHECK:   end_lifetime [[SUPER]]
     // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
     // CHECK:   return [[RESULT]] : $()
   }


### PR DESCRIPTION
[silgen] Add a "fake" destroy in objc destructors.

In this case, we get in an `@owned` value but pass it off to the objc destroyer
that takes the `@owned` value as `@unowned`. To appease the verifier, this commit
puts in an "end_lifetime" instruction that acts as the implicit -1 associated
with the `@owned` value.

rdar://33358110