### PR TITLE
Fix LongRefcounting.cpp to update test expectations after the error message capitalization

### DIFF
--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -279,7 +279,7 @@ TEST(LongRefcountingTest, unowned_retain_overflow_DeathTest) {
   EXPECT_EQ(0u, deinited);
   EXPECT_ALLOCATED(object);
   ASSERT_DEATH(swift_unownedRetain(object),
-               "object's unowned reference was retained too many times");
+               "Object's unowned reference was retained too many times");
 }
 
 TEST(LongRefcountingTest, nonatomic_unowned_retain_max) {
@@ -326,7 +326,7 @@ TEST(LongRefcountingTest, nonatomic_unowned_retain_overflow_DeathTest) {
   EXPECT_EQ(0u, deinited);
   EXPECT_ALLOCATED(object);
   ASSERT_DEATH(swift_nonatomic_unownedRetain(object),
-               "object's unowned reference was retained too many times");
+               "Object's unowned reference was retained too many times");
 }
 
 


### PR DESCRIPTION
Fix LongRefcounting.cpp to update test expectations after the error message capitalization.