### PR TITLE
[test] Add a test for the tricky circularity in SR-5191

### DIFF
--- a/validation-test/Serialization/Inputs/SR5191-other.swift
+++ b/validation-test/Serialization/Inputs/SR5191-other.swift
@@ -1,0 +1,17 @@
+protocol FooBaseProto {}
+
+protocol FooProto: FooBaseProto {}
+
+protocol BarProto {
+  associatedtype Foo: FooProto
+  init(foo: Foo)
+}
+
+protocol BazProto {
+  associatedtype Bar: BarProto
+  init(bar: Bar)
+}
+
+struct BarImpl: BarProto {
+  init(foo: FooImpl) {}
+}

--- a/validation-test/Serialization/SR5191.swift
+++ b/validation-test/Serialization/SR5191.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name SwiftCrash -emit-module -o %t/SR5191.swiftmodule %s %S/Inputs/SR5191-other.swift
+// RUN: %target-build-swift -module-name SwiftCrash -emit-module -o %t/SR5191_reversed.swiftmodule %S/Inputs/SR5191-other.swift %s
+
+// REQUIRES: objc_interop
+// The module name is significant here; it must be later ASCIIbetically than
+// "Swift". This has to do with the canonical ordering of protocols, including
+// those inherited by extending NSObject.
+
+import Foundation
+
+class FooImpl: NSObject, FooProto, BazProto {
+  required init(bar: BarImpl) {}
+}


### PR DESCRIPTION
This was fixed by 897effe in #10707, which I had originally thought would be a no-functionality-change commit because it just made things lazier. Turns out requirement signature deserialization can result in circularity with sufficiently cross-referential conformances.

This isn't exactly a reduced test case because it still depends on subclassing NSObject, which probably means there are hidden dependencies on conforming to standard library protocols. But it's better than nothing.

[SR-5191](https://bugs.swift.org/browse/SR-5191)