### PR TITLE
Fixes a bug in eraseUsesOfInstruction's iterator

### DIFF
--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -225,13 +225,10 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(SILInstruction *I,
 
 void swift::eraseUsesOfInstruction(SILInstruction *Inst,
                                    CallbackTy Callback) {
-  for (auto UI = Inst->use_begin(), E = Inst->use_end(); UI != E;) {
+  while (!Inst->use_empty()) {
+    auto UI = Inst->use_begin();
     auto *User = UI->getUser();
-    UI++;
-    // User have already been deleted by our recursive eraser
-    if (!User) {
-      continue;
-    }
+    assert(User && "User should never be NULL!");
 
     // If the instruction itself has any uses, recursively zap them so that
     // nothing uses this instruction.


### PR DESCRIPTION
radar rdar://problem/34145918

Fixes a bug in the recursive eraser's logic that, in rare occasions, deletes a "user" that is yet to be iterated over in the Instruction’s users loop.

Consider the following example:
```
  %5 = alloc_stack $String.UnicodeScalarView.Iterator // users: %168, %166, %162, %158, %173, %113, %60, %36, %31, %29, %24, %19, %16, %13
  %166 = struct_element_addr %5 : $*String.UnicodeScalarView.Iterator, #String.UnicodeScalarView.Iterator._asciiBase // user: %167
  %167 = load %166 : $*Optional<UnsafeBufferPointerIterator<UInt8>> // user: %170
  %168 = struct_element_addr %5 : $*String.UnicodeScalarView.Iterator, #String.UnicodeScalarView.Iterator._base // user: %169
  %169 = load %168 : $*Optional<UnsafeBufferPointerIterator<UInt16>> // user: %170
  %170 = struct $String.UnicodeScalarView.Iterator (%12 : $Unicode.UTF16, %161 : $Bool, %165 : $Bool, %167 : $Optional<UnsafeBufferPointerIterator<UInt8>>, %169 : $Optional<UnsafeBufferPointerIterator<UInt16>>, %23 : $IndexingIterator<_StringCore>) // user: %172
  retain_value %2 : $Optional<AnyObject>          // id: %171
  release_value %170 : $String.UnicodeScalarView.Iterator // id: %172
```

we start by deleting `%168`, which, at some point in the recursion, will delete `%170`.
`%170` is the only user of `%167` so that gets deleted
`%167` is the only user of `%166` so that gets deleted
going back to `%5`, `%166` has already been deleted -> Invalid iterator.

This PR fixes this problem by making sure we don't use a stale users list