### PR TITLE
Excise the terms "blacklist" and "whitelist" from Swift source

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -887,7 +887,7 @@ public:
     return getClangNodeImpl().getAsMacro();
   }
 
-  bool isPrivateStdlibDecl(bool whitelistProtocols=true) const;
+  bool isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic = true) const;
 
   /// Whether this declaration is weak-imported.
   bool isWeakImported(ModuleDecl *fromModule) const;

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -328,7 +328,7 @@ public:
   /// Replace references to substitutable types with error types.
   Type substDependentTypesWithErrorTypes() const;
 
-  bool isPrivateStdlibType(bool whitelistProtocols=true) const;
+  bool isPrivateStdlibType(bool treatNonBuiltinProtocolsAsPublic = true) const;
 
   void dump() const;
   void dump(raw_ostream &os, unsigned indent = 0) const;

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -141,7 +141,7 @@ public:
   /// SWIFT_VERSION_MINOR.
   static Version getCurrentLanguageVersion();
 
-  // Whitelist of backward-compatibility versions that we permit passing as
+  // List of backward-compatibility versions that we permit passing as
   // -swift-version <vers>
   static std::array<StringRef, 3> getValidEffectiveVersions() {
     return {{"3", "4", "5"}};

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -296,9 +296,9 @@ public:
 // Prespecialized symbol lookup.
 // =============================================================================
 
-/// Checks if a given mangled name could be a name of a whitelisted
-/// specialization.
-bool isWhitelistedSpecialization(StringRef SpecName);
+/// Checks if a given mangled name could be a name of a known
+/// prespecialization for -Onone support.
+bool isKnownPrespecialization(StringRef SpecName);
 
 /// Create a new apply based on an old one, but with a different
 /// function being applied.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1272,8 +1272,7 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D, PrintOptions &Options) {
   }
 
   if (Options.SkipPrivateStdlibDecls &&
-      D->isPrivateStdlibDecl(
-                /*whitelistProtocols=*/!Options.SkipUnderscoredStdlibProtocols))
+      D->isPrivateStdlibDecl(!Options.SkipUnderscoredStdlibProtocols))
     return false;
 
   if (Options.SkipEmptyExtensionDecls && isa<ExtensionDecl>(D)) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -393,10 +393,12 @@ bool AbstractFunctionDecl::isTransparent() const {
   return false;
 }
 
-bool Decl::isPrivateStdlibDecl(bool whitelistProtocols) const {
+bool Decl::isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic) const {
   const Decl *D = this;
-  if (auto ExtD = dyn_cast<ExtensionDecl>(D))
-    return ExtD->getExtendedType().isPrivateStdlibType(whitelistProtocols);
+  if (auto ExtD = dyn_cast<ExtensionDecl>(D)) {
+    Type extTy = ExtD->getExtendedType();
+    return extTy.isPrivateStdlibType(treatNonBuiltinProtocolsAsPublic);
+  }
 
   DeclContext *DC = D->getDeclContext()->getModuleScopeContext();
   if (DC->getParentModule()->isBuiltinModule() ||
@@ -449,7 +451,7 @@ bool Decl::isPrivateStdlibDecl(bool whitelistProtocols) const {
       return true;
     if (NameStr.startswith("_ExpressibleBy"))
       return true;
-    if (whitelistProtocols)
+    if (treatNonBuiltinProtocolsAsPublic)
       return false;
   }
 

--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -20,12 +20,14 @@
 using namespace swift;
 using namespace importer;
 
-/// The maximum length of any particular string in the whitelist.
-const size_t MaxCFWhitelistStringLength = 38;
+/// The maximum length of any particular string in the list of known CF types.
+const size_t MaxCFTypeNameLength = 38;
 namespace {
-  struct CFWhitelistEntry {
+  // FIXME: This is only needed because llvm::StringRef doesn't have a constexpr
+  // constructor.
+  struct CFTypeListEntry {
     unsigned char Length;
-    char Data[MaxCFWhitelistStringLength + 1];
+    char Data[MaxCFTypeNameLength + 1];
 
     operator StringRef() const { return StringRef(Data, Length); }
   };
@@ -33,7 +35,7 @@ namespace {
   // Quasi-lexicographic order: string length first, then string data.
   // Since we don't care about the actual length, we can use this, which
   // lets us ignore the string data a larger proportion of the time.
-  struct CFWhitelistComparator {
+  struct SortByLengthComparator {
     bool operator()(StringRef lhs, StringRef rhs) const {
       return (lhs.size() < rhs.size() ||
               (lhs.size() == rhs.size() && lhs < rhs));
@@ -46,20 +48,20 @@ static constexpr size_t string_lengthof(const char (&data)[Len]) {
   return Len - 1;
 }
 
-/// The CF whitelist.  We use 'constexpr' to verify that this is
+/// The list of known CF types.  We use 'constexpr' to verify that this is
 /// emitted as a constant.  Note that this is expected to be sorted in
 /// quasi-lexicographic order.
-static constexpr const CFWhitelistEntry CFWhitelist[] = {
+static constexpr const CFTypeListEntry KnownCFTypes[] = {
 #define CF_TYPE(NAME) { string_lengthof(#NAME), #NAME },
 #define NON_CF_TYPE(NAME)
 #include "SortedCFDatabase.def"
 };
-const size_t NumCFWhitelistEntries = sizeof(CFWhitelist) / sizeof(*CFWhitelist);
+const size_t NumKnownCFTypes = sizeof(KnownCFTypes) / sizeof(*KnownCFTypes);
 
-/// Maintain a set of whitelisted CF types.
-static bool isWhitelistedCFTypeName(StringRef name) {
-  return std::binary_search(CFWhitelist, CFWhitelist + NumCFWhitelistEntries,
-                            name, CFWhitelistComparator());
+/// Maintain a set of known CF types.
+static bool isKnownCFTypeName(StringRef name) {
+  return std::binary_search(KnownCFTypes, KnownCFTypes + NumKnownCFTypes,
+                            name, SortByLengthComparator());
 }
 
 /// Classify a potential CF typedef.
@@ -86,12 +88,12 @@ CFPointeeInfo::classifyTypedef(const clang::TypedefNameDecl *typedefDecl) {
         if (recordDecl->hasAttr<clang::ObjCBridgeAttr>() ||
             recordDecl->hasAttr<clang::ObjCBridgeMutableAttr>() ||
             recordDecl->hasAttr<clang::ObjCBridgeRelatedAttr>() ||
-            isWhitelistedCFTypeName(typedefDecl->getName())) {
+            isKnownCFTypeName(typedefDecl->getName())) {
           return forRecord(isConst, record->getDecl());
         }
       } else if (pointee->isVoidType()) {
         if (typedefDecl->hasAttr<clang::ObjCBridgeAttr>() ||
-            isWhitelistedCFTypeName(typedefDecl->getName())) {
+            isKnownCFTypeName(typedefDecl->getName())) {
           return isConst ? forConstVoid() : forVoid();
         }
       }

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -424,8 +424,8 @@ retrieveNewTypeAttr(const clang::TypedefNameDecl *decl) {
   if (!attr)
     return nullptr;
 
-  // Blacklist types that temporarily lose their
-  // swift_wrapper/swift_newtype attributes in Foundation.
+  // FIXME: CFErrorDomain is marked as CF_EXTENSIBLE_STRING_ENUM, but it turned
+  // out to be more disruptive than not to leave it that way.
   auto name = decl->getName();
   if (name == "CFErrorDomain")
     return nullptr;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2066,13 +2066,12 @@ public:
   }
 };
 
-/// A hack to blacklist particular types in the Darwin module on
-/// Apple platforms.
-class DarwinBlacklistDeclConsumer : public swift::VisibleDeclConsumer {
+/// A hack to hide particular types in the "Darwin" module on Apple platforms.
+class DarwinLegacyFilterDeclConsumer : public swift::VisibleDeclConsumer {
   swift::VisibleDeclConsumer &NextConsumer;
   clang::ASTContext &ClangASTContext;
 
-  bool isBlacklisted(ValueDecl *VD) {
+  bool shouldDiscard(ValueDecl *VD) {
     if (!VD->hasClangNode())
       return false;
 
@@ -2104,7 +2103,7 @@ class DarwinBlacklistDeclConsumer : public swift::VisibleDeclConsumer {
 
     if (clangModule->Parent &&
         clangModule->Parent->Name == "OSServices") {
-      // Note that this is a blacklist rather than a whitelist.
+      // Note that this is a list of things to /drop/ rather than to /keep/.
       // We're more likely to see new, modern headers added to OSServices.
       return llvm::StringSwitch<bool>(clangModule->Name)
           .Cases("IconStorage", "KeychainCore", "Power", true)
@@ -2117,17 +2116,17 @@ class DarwinBlacklistDeclConsumer : public swift::VisibleDeclConsumer {
   }
 
 public:
-  DarwinBlacklistDeclConsumer(swift::VisibleDeclConsumer &consumer,
-                              clang::ASTContext &clangASTContext)
+  DarwinLegacyFilterDeclConsumer(swift::VisibleDeclConsumer &consumer,
+                                 clang::ASTContext &clangASTContext)
       : NextConsumer(consumer), ClangASTContext(clangASTContext) {}
 
-  static bool needsBlacklist(const clang::Module *topLevelModule) {
+  static bool needsFiltering(const clang::Module *topLevelModule) {
     return topLevelModule && (topLevelModule->Name == "Darwin" ||
                               topLevelModule->Name == "CoreServices");
   }
 
   void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
-    if (!isBlacklisted(VD))
+    if (!shouldDiscard(VD))
       NextConsumer.foundDecl(VD, Reason);
   }
 };
@@ -2280,13 +2279,13 @@ void ClangModuleUnit::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
   // FIXME: Respect the access path.
   FilteringVisibleDeclConsumer filterConsumer(consumer, this);
 
-  DarwinBlacklistDeclConsumer darwinBlacklistConsumer(filterConsumer,
+  DarwinLegacyFilterDeclConsumer darwinFilterConsumer(filterConsumer,
                                                       getClangASTContext());
 
   swift::VisibleDeclConsumer *actualConsumer = &filterConsumer;
   if (lookupKind == NLKind::UnqualifiedLookup &&
-      DarwinBlacklistDeclConsumer::needsBlacklist(clangModule)) {
-    actualConsumer = &darwinBlacklistConsumer;
+      DarwinLegacyFilterDeclConsumer::needsFiltering(clangModule)) {
+    actualConsumer = &darwinFilterConsumer;
   }
 
   // Find the corresponding lookup table.
@@ -2312,15 +2311,15 @@ public:
 void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
   VectorDeclPtrConsumer consumer(results);
   FilteringDeclaredDeclConsumer filterConsumer(consumer, this);
-  DarwinBlacklistDeclConsumer blacklistConsumer(filterConsumer,
-                                                getClangASTContext());
+  DarwinLegacyFilterDeclConsumer darwinFilterConsumer(filterConsumer,
+                                                      getClangASTContext());
 
   const clang::Module *topLevelModule =
     clangModule ? clangModule->getTopLevelModule() : nullptr;
 
   swift::VisibleDeclConsumer *actualConsumer = &filterConsumer;
-  if (DarwinBlacklistDeclConsumer::needsBlacklist(topLevelModule))
-    actualConsumer = &blacklistConsumer;
+  if (DarwinLegacyFilterDeclConsumer::needsFiltering(topLevelModule))
+    actualConsumer = &darwinFilterConsumer;
 
   // Find the corresponding lookup table.
   if (auto lookupTable = owner.findLookupTable(topLevelModule)) {
@@ -2424,13 +2423,13 @@ void ClangModuleUnit::lookupValue(ModuleDecl::AccessPathTy accessPath,
   VectorDeclConsumer vectorWriter(results);
   FilteringVisibleDeclConsumer filteringConsumer(vectorWriter, this);
 
-  DarwinBlacklistDeclConsumer darwinBlacklistConsumer(filteringConsumer,
+  DarwinLegacyFilterDeclConsumer darwinFilterConsumer(filteringConsumer,
                                                       getClangASTContext());
 
   swift::VisibleDeclConsumer *consumer = &filteringConsumer;
   if (lookupKind == NLKind::UnqualifiedLookup &&
-      DarwinBlacklistDeclConsumer::needsBlacklist(clangModule)) {
-    consumer = &darwinBlacklistConsumer;
+      DarwinLegacyFilterDeclConsumer::needsFiltering(clangModule)) {
+    consumer = &darwinFilterConsumer;
   }
 
   // Find the corresponding lookup table.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2208,7 +2208,7 @@ namespace {
 
         // Import 'typedef struct __Blah *BlahRef;' and
         // 'typedef const void *FooRef;' as CF types if they have the
-        // right attributes or match our name whitelist.
+        // right attributes or match our list of known types.
         if (!SwiftType) {
           auto DC = Impl.importDeclContextOf(
               Decl, importedName.getEffectiveContext());

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -631,7 +631,7 @@ importer::findSwiftNameAttr(const clang::Decl *decl,
   // used for naming in Swift 2.
   if (attr->isImplicit()) return nullptr;
 
-  // Whitelist certain explicitly-written Swift names that were
+  // Hardcode certain kinds of explicitly-written Swift names that were
   // permitted and used in Swift 2. All others are ignored, so that we are
   // assuming a more direct translation from the Objective-C APIs into Swift.
 
@@ -1684,7 +1684,7 @@ static bool shouldIgnoreMacro(StringRef name, const clang::MacroInfo *macro) {
   if (macro->isFunctionLike())
     return true;
 
-  // Consult the blacklist of macros to suppress.
+  // Consult the list of macros to suppress.
   auto suppressMacro = llvm::StringSwitch<bool>(name)
 #define SUPPRESS_MACRO(NAME) .Case(#NAME, true)
 #include "MacroTable.def"

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1591,7 +1591,7 @@ Type ClangImporter::Implementation::importFunctionReturnType(
      clangDecl->hasAttr<clang::CFReturnsRetainedAttr>() ||
      clangDecl->hasAttr<clang::CFReturnsNotRetainedAttr>());
 
-  // Check if we know more about the type from our whitelists.
+  // Fix up optionality.
   OptionalTypeKind OptionalityOfReturn;
   if (clangDecl->hasAttr<clang::ReturnsNonNullAttr>()) {
     OptionalityOfReturn = OTK_None;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -617,7 +617,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     llvm_unreachable("invalid mode for backend job");
   }
 
-  // Only white-listed flags below are allowed to be embedded.
+  // -embed-bitcode only supports a restricted set of flags.
   Arguments.push_back("-target");
   Arguments.push_back(context.Args.MakeArgString(getTriple().str()));
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -284,7 +284,7 @@ void getSwiftDocKeyword(const Decl* D, CommandWordsPairs &Words) {
 
 static bool shouldHideDeclFromCompletionResults(const ValueDecl *D) {
   // Hide private stdlib declarations.
-  if (D->isPrivateStdlibDecl(/*whitelistProtocols*/false) ||
+  if (D->isPrivateStdlibDecl(/*treatNonBuiltinProtocolsAsPublic*/false) ||
       // ShowInInterfaceAttr is for decls to show in interface as exception but
       // they are not intended to be used directly.
       D->getAttrs().hasAttribute<ShowInInterfaceAttr>())

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -769,14 +769,15 @@ public:
   ExtractCheckResult(ArrayRef<CannotExtractReason> AllReasons):
     KnownFailure(false), AllReasons(AllReasons.begin(), AllReasons.end()) {}
   bool success() { return success({}); }
-  bool success(llvm::ArrayRef<CannotExtractReason> WhiteList) {
+  bool success(llvm::ArrayRef<CannotExtractReason> ExpectedReasons) {
     if (KnownFailure)
       return false;
     bool Result = true;
 
-    // Check if any reasons are out of the white list provided by the client.
+    // Check if any reasons aren't covered by the list of expected reasons
+    // provided by the client.
     for (auto R: AllReasons) {
-      Result &= llvm::is_contained(WhiteList, R);
+      Result &= llvm::is_contained(ExpectedReasons, R);
     }
     return Result;
   }
@@ -1739,8 +1740,8 @@ static bool rangeStartMayNeedRename(ResolvedRangeInfo Info) {
           return true;
 
         // When callling an instance method inside another instance method,
-        // we have a dot sytnax call whose dot and base are both implicit. We
-        // need to whitelist the specific case here.
+        // we have a dot syntax call whose dot and base are both implicit. We
+        // need to explicitly allow the specific case here.
         if (auto *DSC = dyn_cast<DotSyntaxCallExpr>(CE->getFn())) {
           if (DSC->getBase()->isImplicit() &&
               DSC->getFn()->getStartLoc() == Info.TokensInRange.front().getLoc())

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1101,8 +1101,8 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM,
                   f->getDebugScope(), f->getLocation()),
     CurSILFn(f) {
   // Apply sanitizer attributes to the function.
-  // TODO: Check if the function is ASan black listed either in the external
-  // file or via annotations.
+  // TODO: Check if the function is supposed to be excluded from ASan either by
+  // being in the external file or via annotations.
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address)
     CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -108,8 +108,9 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
       // begin access markers. Ignore these for now. But we really should
       // add SIL verification to ensure all loads and stores have associated
       // access markers. Once SIL verification is implemented, enable the
-      // following assert to verify that the whitelist above is comprehensive,
-      // which guarnatees that exclusivity enforcement is complete.
+      // following assert to verify that the cases handled above are
+      // comprehensive, which guarantees that exclusivity enforcement is
+      // complete.
       //   assert(false && "Unrecognized argument use");
       break;
     }

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -1418,7 +1418,7 @@ collectLoads(SILInstruction *user, SILInstruction *address,
   // destroy the source. This way, we know that the destroy_addr instructions
   // that we recorded cover all the temporary's lifetime termination points.
   //
-  // Currently we whitelist address projections and loads.
+  // Currently this includes address projections and loads.
   //
   // TODO: handle non-destructive projections of enums
   // (unchecked_take_enum_data_addr of Optional is nondestructive.)

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2867,7 +2867,7 @@ bool SimplifyCFG::run() {
 
 /// Is an argument from this terminator considered mandatory?
 static bool hasMandatoryArgument(TermInst *term) {
-  // It's more maintainable to just white-list the instructions that
+  // It's more maintainable to just explicitly list the instructions that
   // *do* have mandatory arguments.
   return (!isa<BranchInst>(term) && !isa<CondBranchInst>(term));
 }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2320,7 +2320,7 @@ void swift::trySpecializeApplyOfGeneric(
   SILFunction *SpecializedF = FuncSpecializer.lookupSpecialization();
   if (SpecializedF) {
     // Even if the pre-specialization exists already, try to preserve it
-    // if it is whitelisted.
+    // if it is one of our known pre-specializations for -Onone support.
     linkSpecialization(M, SpecializedF);
   } else {
     SpecializedF = FuncSpecializer.tryCreateSpecialization();
@@ -2435,11 +2435,12 @@ static void keepSpecializationAsPublic(SILFunction *F) {
 static bool linkSpecialization(SILModule &M, SILFunction *F) {
   if (F->isKeepAsPublic())
     return true;
-  // Do not remove functions from the white-list. Keep them around.
-  // Change their linkage to public, so that other applications can refer to it.
+  // Do not remove functions that are known prespecializations.
+  // Keep them around. Change their linkage to public, so that other
+  // applications can refer to them.
   if (M.getOptions().Optimization >= SILOptions::SILOptMode::Optimize &&
       F->getModule().getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT) {
-    if (isWhitelistedSpecialization(F->getName())) {
+    if (isKnownPrespecialization(F->getName())) {
       keepSpecializationAsPublic(F);
       return true;
     }
@@ -2447,9 +2448,9 @@ static bool linkSpecialization(SILModule &M, SILFunction *F) {
   return false;
 }
 
-/// The whitelist of classes and functions from the stdlib,
+/// The list of classes and functions from the stdlib
 /// whose specializations we want to preserve.
-static const char *const WhitelistedSpecializations[] = {
+static const char *const KnownPrespecializations[] = {
     "Array",
     "_ArrayBuffer",
     "_ContiguousArrayBuffer",
@@ -2477,9 +2478,7 @@ static const char *const WhitelistedSpecializations[] = {
     "_toStringReadOnlyPrintable",
 };
 
-/// Check of a given name could be a name of a white-listed
-/// specialization.
-bool swift::isWhitelistedSpecialization(StringRef SpecName) {
+bool swift::isKnownPrespecialization(StringRef SpecName) {
   // TODO: Once there is an efficient API to check if
   // a given symbol is a specialization of a specific type,
   // use it instead. Doing demangling just for this check
@@ -2489,7 +2488,7 @@ bool swift::isWhitelistedSpecialization(StringRef SpecName) {
 
   StringRef DemangledName = DemangledNameString;
 
-  DEBUG(llvm::dbgs() << "Check if whitelisted: " << DemangledName << "\n");
+  DEBUG(llvm::dbgs() << "Check if known: " << DemangledName << "\n");
 
   auto pos = DemangledName.find("generic ", 0);
   auto oldpos = pos;
@@ -2522,7 +2521,7 @@ bool swift::isWhitelistedSpecialization(StringRef SpecName) {
 
   pos += OfStr.size();
 
-  for (auto NameStr: WhitelistedSpecializations) {
+  for (auto NameStr : KnownPrespecializations) {
     StringRef Name = NameStr;
     auto pos1 = DemangledName.find(Name, pos);
     if (pos1 == pos && !isalpha(DemangledName[pos1+Name.size()])) {
@@ -2546,7 +2545,7 @@ static SILFunction *lookupExistingSpecialization(SILModule &M,
   // TODO: Cache optimized specializations and perform lookup here?
   // Only check that this function exists, but don't read
   // its body. It can save some compile-time.
-  if (isWhitelistedSpecialization(FunctionName))
+  if (isKnownPrespecialization(FunctionName))
     return M.findFunction(FunctionName, SILLinkage::PublicExternal);
 
   return nullptr;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -717,7 +717,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // - member references T.foo, T.Type, T.self, etc.
       // - constructor calls T()
       if (auto *ParentExpr = Parent.getAsExpr()) {
-        // This is the white-list of accepted syntactic forms.
+        // This is an exhaustive list of the accepted syntactic forms.
         if (isa<ErrorExpr>(ParentExpr) ||
             isa<DotSelfExpr>(ParentExpr) ||               // T.self
             isa<CallExpr>(ParentExpr) ||                  // T()

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5295,7 +5295,7 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
 
   emitDelayedDiags();
 
-  // Except in specific whitelisted cases for Foundation/Swift
+  // Except in specific hardcoded cases for Foundation/Swift
   // standard library compatibility, an _ObjectiveCBridgeable
   // conformance must appear in the same module as the definition of
   // the conforming type.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2261,12 +2261,12 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // mandatory function bodies.
   for (const SILFunction &F : *SILMod) {
     if (emitDeclarationsForOnoneSupport) {
-      // Only declarations of whitelisted pre-specializations from with
+      // Only declarations of hardcoded pre-specializations with
       // public linkage need to be serialized as they will be used
-      // by UsePrespecializations pass during -Onone compilation to
+      // by the UsePrespecializations pass during -Onone compilation to
       // check for availability of concrete pre-specializations.
       if (!hasPublicVisibility(F.getLinkage()) ||
-          !isWhitelistedSpecialization(F.getName()))
+          !isKnownPrespecialization(F.getName()))
         continue;
     }
 

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -89,7 +89,7 @@ func testNonsplittableFactoryMethod() {
   _ = NSObjectFactory.factoryBuildingWidgets()
 }
 
-func testFactoryMethodBlacklist() {
+func testFactoryMethodAPINotes() {
   _ = NCWidgetController.widgetController()
 }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -13,7 +13,8 @@ public class BridgedClass : NSObject, NSCopying {
 
 public class BridgedClassSub : BridgedClass { }
 
-// Attempt to bridge to a non-whitelisted type from another module.
+// Attempt to bridge to a type from another module. We only allow this for a
+// few specific types, like String.
 extension LazyFilterIterator : _ObjectiveCBridgeable { // expected-error{{conformance of 'LazyFilterIterator' to '_ObjectiveCBridgeable' can only be written in module 'Swift'}}
   public typealias _ObjectiveCType = BridgedClassSub
 


### PR DESCRIPTION
The [etymology](https://en.wikipedia.org/wiki/Blacklisting) of these terms isn't about race, but "black" = "blocked" and "white" = "allowed" isn't really a good look these days. In most cases we weren't using these terms particularly precisely anyway, so the rephrasing is actually an improvement.

Putting [words](https://twitter.com/UINT_MIN/status/898334312927342594) to action now that I'm back from vacation. This change isn't as widely discussed as "master/slave" vs. "primary/replica" in database circles, but it made sense when I saw it pointed out.