### PR TITLE
[RFC] Disable marking as ObjC when interop disabled

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2403,6 +2403,9 @@ static Optional<ObjCReason> shouldMarkAsObjC(TypeChecker &TC,
                                              bool allowImplicit = false){
   assert(!isa<ClassDecl>(VD));
 
+  if (!TC.Context.LangOpts.EnableObjCInterop)
+    return None;
+
   ProtocolDecl *protocolContext =
       dyn_cast<ProtocolDecl>(VD->getDeclContext());
   bool isMemberOfObjCProtocol =
@@ -7061,6 +7064,9 @@ void TypeChecker::typeCheckDecl(Decl *D, bool isFirstPass) {
 // an explicit @objc attribute, or its superclass is @objc.
 static Optional<ObjCReason> shouldMarkClassAsObjC(TypeChecker &TC,
                                                   ClassDecl *CD) {
+  if (!TC.Context.LangOpts.EnableObjCInterop)
+    return None;
+
   ObjCClassKind kind = CD->checkObjCAncestry();
 
   if (auto attr = CD->getAttrs().getAttribute<ObjCAttr>()) {


### PR DESCRIPTION
This PR disables @objc on non-Darwin platforms. Since it leads to false positive compilation errors.

For example:

```swift
import Foundation

@objc(AClass)
class A: NSObject {
    @objc(superMethod)
    func method() -> String {
        return "42"
    }
}
```

This is correctly compiled on Darwin platforms. But produce errors on Linux. Here is [demo](http://swift.sandbox.bluemix.net/#/repl/59a7009ad2729d2be9c06411)

And it makes more difficult to reuse code between Darwin non-Darwin platforms