### PR TITLE
[CMake] Remove Xcode effective platform name check

### DIFF
--- a/cmake/modules/SwiftXcodeSupport.cmake
+++ b/cmake/modules/SwiftXcodeSupport.cmake
@@ -1,15 +1,6 @@
 # This file contains cmake configuration specifically related to support for the
 # Xcode generator in CMake.
 
-function(get_effective_platform_for_triple triple output)
-  string(FIND "${triple}" "macos" IS_MACOS)
-  if (NOT IS_MACOS EQUAL -1)
-    set(${output} "" PARENT_SCOPE)
-    return()
-  endif()
-  message(FATAL_ERROR "Can not create an effective platform name for triple: ${triple}")
-endfunction()
-
 function(escape_path_for_xcode config path result_var_name)
   # If we are not using the Xcode generator, be defensive and early exit.
   if (NOT XCODE)
@@ -17,11 +8,10 @@ function(escape_path_for_xcode config path result_var_name)
     return()
   endif()
 
-  get_effective_platform_for_triple("${SWIFT_HOST_TRIPLE}" SWIFT_EFFECTIVE_PLATFORM_NAME)
   # Hack to deal with the fact that paths contain the build-time
   # variables. Note that this fix is Xcode-specific.
   string(REPLACE "$(CONFIGURATION)" "${config}" result "${path}")
-  string(REPLACE "$(EFFECTIVE_PLATFORM_NAME)" "${SWIFT_EFFECTIVE_PLATFORM_NAME}" result "${result}")
+  string(REPLACE "$(EFFECTIVE_PLATFORM_NAME)" "" result "${result}")
   set("${result_var_name}" "${result}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
The CMake function `get_effective_platform_for_triple` appears to only be used in one location: from within `escape_path_for_xcode`. The `get_effective_platform_for_triple` function's only purpose appears to be to check whether `SWIFT_HOST_TRIPLE` contains the string "macos", and if not, it emits an error.

However, on macOS hosts the `build-script-impl` is responsible for setting the `SWIFT_HOST_TRIPLE` variable, and so when `cmake -G Xcode` is invoked *directly* to configure the Swift project, this variable is unset, causing `get_effective_platform_for_triple` to emit an error.

I considered two solutions:

1. Have `swift/CMakeLists.txt` set a default `SWIFT_HOST_TRIPLE`, [as it does for Linux](https://github.com/apple/swift/blob/53a5389daa0f67b4a62dfca349925a03abf943d0/CMakeLists.txt#L622-L636). This would prevent `get_effective_platform_for_triple` from emitting an error.
2. Remove `get_effective_platform_for_triple` altogether.

I chose (2) here. `get_effective_platform_for_triple` doesn't appear to do anything besides restrict the host platform arbitrarily. If users are somehow able to configure the project using `cmake -G Xcode` on Linux, shouldn't the Swift's CMake allow them to do so?

Test plan:
1. Configure and build using Xcode and an in-tree Swift checkout.
2. Configure and build using `utils/build-script --xcode`.

---

Adding @gottesmm as a reviewer since he was one of the last people to touch this code, in https://github.com/apple/swift/commit/455d3a1960333983f224dafa911b40a19f09bd4f and https://github.com/apple/swift/commit/9e2a0b1979bd3dd526a4ee2db73a9bcb948d920d. 