### PR TITLE
Add check if importType succeds

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4970,6 +4970,9 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
       decl->getUnderlyingType(), ImportTypeKind::Value, isInSystemModule(dc),
       Bridgeability::None, OTK_None);
 
+  if (!storedUnderlyingType)
+    return nullptr;
+
   if (auto objTy = storedUnderlyingType->getAnyOptionalObjectType())
     storedUnderlyingType = objTy;
 

--- a/test/ClangImporter/Inputs/bad-ns-extensible-string-enum.h
+++ b/test/ClangImporter/Inputs/bad-ns-extensible-string-enum.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+typedef NSString MyString __attribute__((swift_wrapper(struct)));
+extern MyString * const MyStringOne;

--- a/test/ClangImporter/bad-ns-extensible-string-enum.swift
+++ b/test/ClangImporter/bad-ns-extensible-string-enum.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -import-objc-header %S/Inputs/bad-ns-extensible-string-enum.h -verify
+// REQUIRES: objc_interop
+
+let string = MyString.MyStringOne // expected-error {{use of unresolved identifier 'MyString'}}


### PR DESCRIPTION
SwiftDeclConverter::importSwiftNewtype now check if the storedUnderlyingType is null and return a nullptr to drop the typedef.

Resolves [SR-5614](https://bugs.swift.org/browse/SR-5614).