### PR TITLE
[sil-serialization] Use a variable width integer instead of a fixed width integer for the max number of specialized attributes

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 360; // Last change: '__consuming'
+const uint16_t VERSION_MINOR = 361; // Last change: BCVBR for specialized attributes.
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -268,7 +268,7 @@ namespace sil_block {
                      BCFixed<1>,  // global_init
                      BCFixed<2>,  // inlineStrategy
                      BCFixed<2>,  // side effect info.
-                     BCFixed<16>,  // number of specialize attributes
+                     BCVBR<8>,    // number of specialize attributes
                      BCFixed<1>,  // has qualified ownership
                      TypeIDField, // SILFunctionType
                      GenericEnvironmentIDField,


### PR DESCRIPTION
It is just to make it more future-proof and avoid overflows we've seen recently.
Thanks Jordan who suggested this change.
