### PR TITLE
[CMake] Link static libraries as PUBLIC

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -994,7 +994,7 @@ function(_add_swift_library_single target name)
         "${SWIFTLIB_SINGLE_LINK_LIBRARIES}"
         "OBJECT_LIBRARY may not link to anything")
   else()
-    target_link_libraries("${target}" INTERFACE ${SWIFTLIB_SINGLE_LINK_LIBRARIES})
+    target_link_libraries("${target}" PUBLIC ${SWIFTLIB_SINGLE_LINK_LIBRARIES})
   endif()
 
   # Don't add the icucore target.


### PR DESCRIPTION
## Summary

I noticed a curious thing when generating graphviz files based on Swift's CMake: graphs do not show a dependency from swiftDriver to swiftBasic, even though swiftDriver links in swiftBasic.

Using a "standalone" build configuration such as the one I describe in [SR-5778](https://bugs.swift.org/browse/SR-5778), I ran a `cmake --graphviz=` [command](https://gist.github.com/modocache/6f63a3185e54324a708e3c79ec1a9797) in order to generate a graph, as per the CMake documentation [here](https://cmake.org/cmake/help/latest/module/CMakeGraphVizOptions.html). The generated graph did not show a line extending from swiftDriver to swiftBasic, seemingly indicating that there is no dependency between these two libraries.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2F0v203w3p363X2m3c3v/swift-cmake-interface.png?X-CloudApp-Visitor-Id=543005)

In fact, the graph shows no lines pointing to swiftBasic at all, as if no libraries depend upon it.

It turns out that, while swiftDriver [does specify](https://github.com/apple/swift/blob/f2a1ffeb64631348db8d303f15c901376b9a9887/lib/Driver/CMakeLists.txt#L17-L20) `LINK_LIBRARIES swiftBasic` in order to link it in, the libraries themselves are linked as `INTERFACE`.

[According to the CMake mailing list](https://cmake.org/pipermail/cmake/2016-May/063400.html):

> When A links in B as *INTERFACE*, it is saying that A does not use B in its implementation, but B is used in A's public API.

This does not appear to be the case, however, with swiftDriver. One trivial example would be `swift::Driver::printVersion`, which invokes swiftBasic's `getSwiftFullVersion`.

This commit changes the link keyword to `PUBLIC`, which again according to the mailing list means "that A uses B in its implementation and B is also used in A's public API."

It also means that graphs now show a dependency between libraries; notice that in the graph below, an arrow extends from swiftDriver connecting it to swiftBasic:

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0b0S2W2x1v3T2i2q272w/swift-cmake-public.png?X-CloudApp-Visitor-Id=543005)

## Test plan

A clean build and test succeeds: `rm -rf /path/to/build && utils/build-script --test`

---

@jrose-apple, you mentioned someone had recently taken on some responsibilities with Swift CMake, could you point them here for their thoughts?