### PR TITLE
In Linux setting SWIFT_PACKAGE=buildbot_linux,no_test as the test tak…

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -14,7 +14,7 @@ cd "$(dirname $0)/.." || exit
 SRC_DIR=$PWD
 
 DRY_RUN=
-if [[ "$1" == "-n" || "$1" == "--dry-run" ]] ; then
+if [[ "$2" == "-n" || "$2" == "--dry-run" ]] ; then
     DRY_RUN="-n"
     shift
 fi
@@ -40,7 +40,11 @@ SYMBOLS_PACKAGE="${SRC_DIR}/${SYM_ARCHIVE}"
 if [[ "$(uname -s)" == "Darwin" ]] ; then
     SWIFT_PACKAGE=buildbot_osx_package
 else
-    SWIFT_PACKAGE=buildbot_linux,no_test
+    if [[ "$2" == "-t" || "$2" == "--test" ]] ; then
+        SWIFT_PACKAGE=buildbot_linux
+    else
+        SWIFT_PACKAGE=buildbot_linux,no_test
+    fi
 fi
 
 ./utils/build-script ${DRY_RUN} --preset="${SWIFT_PACKAGE}" \

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -40,7 +40,7 @@ SYMBOLS_PACKAGE="${SRC_DIR}/${SYM_ARCHIVE}"
 if [[ "$(uname -s)" == "Darwin" ]] ; then
     SWIFT_PACKAGE=buildbot_osx_package
 else
-    SWIFT_PACKAGE=buildbot_linux
+    SWIFT_PACKAGE=buildbot_linux,no_test
 fi
 
 ./utils/build-script ${DRY_RUN} --preset="${SWIFT_PACKAGE}" \


### PR DESCRIPTION
…es very long time

<!-- What's in this pull request? -->
build-toolchain takes too long in Linux, so trying to run it without the lengthy tests

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
