### PR TITLE
SIL serialization and IRGen emission improvements

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -576,7 +576,11 @@ public:
     assert(isDeclKind(getKind()));
     return reinterpret_cast<ValueDecl*>(Pointer);
   }
-  
+
+  bool isSILFunction() const {
+    return getKind() == Kind::SILFunction;
+  }
+
   SILFunction *getSILFunction() const {
     assert(getKind() == Kind::SILFunction);
     return reinterpret_cast<SILFunction*>(Pointer);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1460,6 +1460,11 @@ static void emitLocalSelfMetadata(IRGenSILFunction &IGF) {
 void IRGenModule::emitSILFunction(SILFunction *f) {
   if (f->isExternalDeclaration())
     return;
+  // Do not emit bodies of public_external functions.
+  // The only exception is transparent functions.
+  if (hasPublicVisibility(f->getLinkage()) && f->isAvailableExternally() &&
+      !f->isTransparent())
+    return;
 
   PrettyStackTraceSILFunction stackTrace("emitting IR", f);
   IRGenSILFunction(*this, f).emitSILFunction();

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -381,6 +381,15 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   // FIXME: @objc declarations should be too, but we currently have no way
   // of marking them "used" other than making them external. 
   ValueDecl *d = getDecl();
+
+  // stdlib_binary_only functions should have a public SIL linkage.
+  auto Attrs = d->getAttrs();
+  for (auto *A : Attrs.getAttributes<SemanticsAttr>()) {
+    if (A->Value == "stdlib_binary_only") {
+      return maybeAddExternal(SILLinkage::Public);
+    }
+  }
+
   DeclContext *moduleContext = d->getDeclContext();
   while (!moduleContext->isModuleScopeContext()) {
     if (!isForeign && moduleContext->isLocalContext()) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4199,6 +4199,23 @@ public:
 
     assert(!F->hasForeignBody());
 
+    if (F->hasSemanticsAttr("stdlib_binary_only")) {
+      require(F->getLinkage() == SILLinkage::Public,
+              "@_semantics(\"stdlib_binary_only\") functions should have a "
+              "public SIL linkage");
+    }
+
+    if (F->getModule().getOptions().SILSerializeAll &&
+        F->getName().startswith("global_init")) {
+      require(hasPublicVisibility(F->getLinkage()) &&
+                  F->hasSemanticsAttr("stdlib_binary_only"),
+              "global_init should be public in -sil-serialize-all mode");
+    }
+
+    if (F->isTransparent()) {
+      require(F->isDefinition(), "@_transparent functions should have a body");
+    }
+
     // Make sure that our SILFunction only has context generic params if our
     // SILFunctionType is non-polymorphic.
     if (F->getGenericEnvironment()) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -974,13 +974,11 @@ SILFunction *SILGenModule::emitLazyGlobalInitializer(StringRef funcName,
                       .withRepresentation(FunctionType::Representation::Thin));
   auto initSILType = getLoweredType(initType).castTo<SILFunctionType>();
 
+  // Do not serialize the initializer in the -sil-serialize-all mode.
   auto *f = M.createFunction(
       isMakeModuleFragile() ? SILLinkage::Public : SILLinkage::Private,
       funcName, initSILType, nullptr, SILLocation(binding), IsNotBare,
-      IsNotTransparent, isMakeModuleFragile() ? IsSerialized : IsNotSerialized);
-  // Do not serialize the initializer in the -sil-serialize-all mode.
-  if (isMakeModuleFragile())
-    f->addSemanticsAttr("stdlib_binary_only");
+      IsNotTransparent, IsNotSerialized);
   f->setDebugScope(new (M) SILDebugScope(RegularLocation(binding), f));
   SILGenFunction(*this, *f).emitLazyGlobalInitializer(binding, pbdEntry);
   f->verify();

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -405,7 +405,6 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("LateLoopOpt");
 
   // Delete dead code and drop the bodies of shared functions.
-  P.addExternalFunctionDefinitionsElimination();
   P.addDeadFunctionElimination();
 
   // Perform the final lowering transformations.
@@ -528,12 +527,6 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
   P.addUsePrespecialized();
 
   P.startPipeline("Rest of Onone");
-  // Don't keep external functions from stdlib and other modules.
-  // We don't want that our unoptimized version will be linked instead
-  // of the optimized version from the stdlib.
-  // Here we just convert external definitions to declarations. LLVM will
-  // eventually remove unused declarations.
-  P.addExternalDefsToDecls();
 
   // Has only an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -688,12 +688,18 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   // the signature optimized function without additional setup on the
   // caller side.
   F->setInlineStrategy(AlwaysInline);
+
+  assert(F->isSerialized() == NewF->isSerialized());
+
   // If the new callee is @_semantics("stdlib_binary_only"), it is fine to call
   // it, because it will be exposed as a public symbol in the object file.
-  if (F->hasSemanticsAttr("stdlib_binary_only")) {
+  if (//NewF->isSerialized() == IsNotSerialized &&
+      F->hasSemanticsAttr("stdlib_binary_only")) {
     NewF->addSemanticsAttr("stdlib_binary_only");
+    //NewF->setSerialized(IsNotSerialized);
     // The thunk doesn't need to be stdlib_binary_only anymore.
     F->removeSemanticsAttr("stdlib_binary_only");
+    F->setSerialized(IsSerialized);
     F->setLinkage(SILLinkage::Public);
   }
   SILBasicBlock *ThunkBody = F->createBasicBlock();

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2163,6 +2163,11 @@ bool SILSerializer::shouldEmitFunctionBody(const SILFunction *F,
       !(isReference && hasSharedVisibility(F->getLinkage())))
     return false;
 
+  // Never serialize @_semantics("stdlib_binary_only") functions.
+  if (F->hasSemanticsAttr("stdlib_binary_only")) {
+    return false;
+  }
+
   // If we are asked to serialize everything, go ahead and do it.
   if (ShouldSerializeAll)
     return true;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2163,6 +2163,13 @@ bool SILSerializer::shouldEmitFunctionBody(const SILFunction *F,
       !(isReference && hasSharedVisibility(F->getLinkage())))
     return false;
 
+  // Bail if function should not be serialized.
+  if (F->isSerialized() == IsNotSerialized)
+    return false;
+
+  return true;
+
+#if 0
   // Never serialize @_semantics("stdlib_binary_only") functions.
   if (F->hasSemanticsAttr("stdlib_binary_only")) {
     return false;
@@ -2175,6 +2182,7 @@ bool SILSerializer::shouldEmitFunctionBody(const SILFunction *F,
   // If F is serialized, we should always emit its body.
   if (F->isSerialized() == IsSerialized)
     return true;
+#endif
 
   return false;
 }

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -69,39 +69,6 @@ public func hasArrayOfClosedEnums(closed: [ClosedEnum]) {
   print(closed[0])
 }
 
-// CHECK-LABEL: _T07newtype11compareABIsyyF
-public func compareABIs() {
-  let new = getMyABINewType()
-  let old = getMyABIOldType()
-  takeMyABINewType(new)
-  takeMyABIOldType(old)
-
-  takeMyABINewTypeNonNull(new!)
-  takeMyABIOldTypeNonNull(old!)
-
-  let newNS = getMyABINewTypeNS()
-  let oldNS = getMyABIOldTypeNS()
-  takeMyABINewTypeNonNullNS(newNS!)
-  takeMyABIOldTypeNonNullNS(oldNS!)
-
-  // Make sure that the calling conventions align correctly, that is we don't
-  // have double-indirection or anything else like that
-  // CHECK: declare %struct.__CFString* @getMyABINewType()
-  // CHECK: declare %struct.__CFString* @getMyABIOldType()
-  //
-  // CHECK: declare void @takeMyABINewType(%struct.__CFString*)
-  // CHECK: declare void @takeMyABIOldType(%struct.__CFString*)
-  //
-  // CHECK: declare void @takeMyABINewTypeNonNull(%struct.__CFString*)
-  // CHECK: declare void @takeMyABIOldTypeNonNull(%struct.__CFString*)
-  //
-  // CHECK: declare %0* @getMyABINewTypeNS()
-  // CHECK: declare %0* @getMyABIOldTypeNS()
-  //
-  // CHECK: declare void @takeMyABINewTypeNonNullNS(%0*)
-  // CHECK: declare void @takeMyABIOldTypeNonNullNS(%0*)
-}
-
 // OPT-LABEL: define swiftcc i1 @_T07newtype12compareInitsSbyF
 public func compareInits() -> Bool {
   let mf = MyInt(rawValue: 1)
@@ -225,4 +192,35 @@ public func mutateRef() {
   // OPT: ret void
 }
 
+// CHECK-LABEL: _T07newtype11compareABIsyyF
+public func compareABIs() {
+  let new = getMyABINewType()
+  let old = getMyABIOldType()
+  takeMyABINewType(new)
+  takeMyABIOldType(old)
 
+  takeMyABINewTypeNonNull(new!)
+  takeMyABIOldTypeNonNull(old!)
+
+  let newNS = getMyABINewTypeNS()
+  let oldNS = getMyABIOldTypeNS()
+  takeMyABINewTypeNonNullNS(newNS!)
+  takeMyABIOldTypeNonNullNS(oldNS!)
+
+  // Make sure that the calling conventions align correctly, that is we don't
+  // have double-indirection or anything else like that
+  // CHECK: declare %struct.__CFString* @getMyABINewType()
+  // CHECK: declare %struct.__CFString* @getMyABIOldType()
+  //
+  // CHECK: declare void @takeMyABINewType(%struct.__CFString*)
+  // CHECK: declare void @takeMyABIOldType(%struct.__CFString*)
+  //
+  // CHECK: declare void @takeMyABINewTypeNonNull(%struct.__CFString*)
+  // CHECK: declare void @takeMyABIOldTypeNonNull(%struct.__CFString*)
+  //
+  // CHECK: declare %0* @getMyABINewTypeNS()
+  // CHECK: declare %0* @getMyABIOldTypeNS()
+  //
+  // CHECK: declare void @takeMyABINewTypeNonNullNS(%0*)
+  // CHECK: declare void @takeMyABIOldTypeNonNullNS(%0*)
+}

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -5,18 +5,21 @@ sil_stage canonical
 // CHECK: define{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} internal swiftcc void @public_transparent_fragile_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
-// CHECK: define{{( protected)?}} swiftcc void @hidden_fragile_function_test() {{.*}} {
+// CHECK: define{{( protected| hidden)?}} swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
-// CHECK: define{{( protected)?}} swiftcc void @private_fragile_function_test() {{.*}} {
-// CHECK: define available_externally swiftcc void @public_external_fragile_function_def_test() {{.*}} {
-// CHECK: define{{( protected)?}} available_externally swiftcc void @hidden_external_fragile_function_def_test() {{.*}} {
+// CHECK: define{{( protected| internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {
+// Do not emit bodies of public external functions.
+// CHECK: declare swiftcc void @public_external_fragile_function_def_test()
+// Emit bodies of hidden external functions.
+// CHECK: define linkonce_odr hidden swiftcc void @hidden_external_fragile_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_external_fragile_function_def_test() {{.*}} {
-// CHECK: define{{( protected)?}} available_externally swiftcc void @private_external_fragile_function_def_test() {{.*}} {
+// CHECK: define linkonce_odr hidden swiftcc void @private_external_fragile_function_def_test() {{.*}} {
 // CHECK: define{{( protected)?}} swiftcc void @public_resilient_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_resilient_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_resilient_function_test() {{.*}} {
 // CHECK: define internal swiftcc void @private_resilient_function_test() {{.*}}{
-// CHECK: define available_externally swiftcc void @public_external_resilient_function_def_test() {{.*}} {
+// Do not emit bodies of public external functions.
+// CHECK: declare swiftcc void @public_external_resilient_function_def_test()
 // CHECK: define{{( protected)?}} available_externally hidden swiftcc void @hidden_external_resilient_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_external_resilient_function_def_test() {{.*}} {
 

--- a/test/SILOptimizer/linker.swift
+++ b/test/SILOptimizer/linker.swift
@@ -15,7 +15,7 @@ doSomething2()
 
 // CHECK: sil @unknown
 
-// CHECK: sil [serialized] [noinline] [_semantics "stdlib_binary_only"] @{{.*}}doSomething3{{.*}}
+// CHECK: sil [noinline] [_semantics "stdlib_binary_only"] @{{.*}}doSomething3{{.*}}
 // CHECK-NOT: return
 
 // CHECK: sil {{.*}} @_T0s1AV{{[_0-9a-zA-Z]*}}fC

--- a/test/SILOptimizer/no-external-defs-onone.sil
+++ b/test/SILOptimizer/no-external-defs-onone.sil
@@ -2,7 +2,8 @@
 
 // CHECK-DAG: define linkonce_odr hidden swiftcc void @shared_external_test()
 // CHECK-DAG: declare swiftcc void @public_external_test()
-// CHECK-DAG: declare hidden swiftcc void @hidden_external_test()
+// Any non-public external functions are re-emitted into the client.
+// CHECK-DAG: define available_externally hidden swiftcc void @hidden_external_test()
 // CHECK-NOT: public_external_unused_test
 
 

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -8,7 +8,6 @@
 // CHECK:     ],
 // CHECK:     [
 // CHECK:         "Rest of Onone",
-// CHECK-NEXT:         ["ExternalDefsToDecls","external-defs-to-decls"],
 // CHECK-NEXT:         ["AssumeSingleThreaded","sil-assume-single-threaded"],
 // CHECK-NEXT:         ["SILDebugInfoGenerator","sil-debuginfo-gen"]
 // CHECK:     ]


### PR DESCRIPTION
- Try to avoid increasing the visibility of SILFunctions in IRGen when emitting LLVM IR for them

   Any non-external SIL functions should preserve their linkage, instead of making them `public` in the object file as we did before. This means that clients cannot reference them anymore, which is a good thing. Client should only reference public symbols from the compiled module.

   When it comes to external non-public functions, change their linkage to shared_external and later emit them into the client object file, instead of assuming these functions are available elsewhere.

- Do not SIL serialize bodies of `@_semantics("stdlib_binary_only")` functions

- No need to run `ExternalDefsToDecls` at -Onone and `ExternalFunctionDefinitionsElimination` at -O anymore. The passes are not removed in this commit yet. It will be done later.