### PR TITLE
Record whether a class method or protocol requirement is static

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -111,8 +111,7 @@ class MethodDescriptorFlags {
 public:
   typedef uint32_t int_type;
   enum class Kind {
-    InstanceMethod,
-    StaticMethod,
+    Method,
     Init,
     Getter,
     Setter,
@@ -122,7 +121,8 @@ public:
 private:
   enum : int_type {
     KindMask = 0x0F,                // 16 kinds should be enough for anybody
-    DynamicMask = 0x10,
+    IsInstanceMask = 0x10,
+    IsDynamicMask = 0x20,
   };
 
   int_type Value;
@@ -130,19 +130,34 @@ private:
 public:
   MethodDescriptorFlags(Kind kind) : Value(unsigned(kind)) {}
 
+  MethodDescriptorFlags withIsInstance(bool isInstance) const {
+    auto copy = *this;
+    if (isInstance) {
+      copy.Value |= IsInstanceMask;
+    } else {
+      copy.Value &= ~IsInstanceMask;
+    }
+    return copy;
+  }
+
   MethodDescriptorFlags withIsDynamic(bool isDynamic) const {
     auto copy = *this;
     if (isDynamic)
-      copy.Value |= DynamicMask;
+      copy.Value |= IsDynamicMask;
     else
-      copy.Value &= ~DynamicMask;
+      copy.Value &= ~IsDynamicMask;
     return copy;
   }
 
   Kind getKind() const { return Kind(Value & KindMask); }
 
   /// Is the method marked 'dynamic'?
-  bool isDynamic() const { return Value & DynamicMask; }
+  bool isDynamic() const { return Value & IsDynamicMask; }
+
+  /// Is the method an instance member?
+  ///
+  /// Note that 'init' is not considered an instance member.
+  bool isInstance() const { return Value & IsInstanceMask; }
 
   int_type getIntValue() const { return Value; }
 };
@@ -454,8 +469,7 @@ public:
   typedef uint32_t int_type;
   enum class Kind {
     BaseProtocol,
-    InstanceMethod,
-    StaticMethod,
+    Method,
     Init,
     Getter,
     Setter,
@@ -467,6 +481,7 @@ public:
 private:
   enum : int_type {
     KindMask = 0x0F,                // 16 kinds should be enough for anybody
+    IsInstanceMask = 0x10,
   };
 
   int_type Value;
@@ -474,7 +489,22 @@ private:
 public:
   ProtocolRequirementFlags(Kind kind) : Value(unsigned(kind)) {}
 
+  ProtocolRequirementFlags withIsInstance(bool isInstance) const {
+    auto copy = *this;
+    if (isInstance) {
+      copy.Value |= IsInstanceMask;
+    } else {
+      copy.Value &= ~IsInstanceMask;
+    }
+    return copy;
+  }
+
   Kind getKind() const { return Kind(Value & KindMask); }
+
+  /// Is the method an instance member?
+  ///
+  /// Note that 'init' is not considered an instance member.
+  bool isInstance() const { return Value & IsInstanceMask; }
 
   int_type getIntValue() const { return Value; }
 };

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -47,9 +47,9 @@ protocol ABO : A, B, O { func abo() }
 // CHECK-SAME: @_PROTOCOL_METHOD_TYPES__TtP17protocol_metadata1O_
 // CHECK-SAME: }
 
-// CHECK: [[A_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 1, i32 0 }]
-// CHECK: [[B_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 1, i32 0 }]
-// CHECK: [[C_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 1, i32 0 }]
+// CHECK: [[A_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 17, i32 0 }]
+// CHECK: [[B_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 17, i32 0 }]
+// CHECK: [[C_REQTS]] = internal unnamed_addr constant [1 x %swift.protocol_requirement] [%swift.protocol_requirement { i32 17, i32 0 }]
 
 // -- @objc protocol OPT uses ObjC symbol mangling and layout
 // CHECK: @_PROTOCOL__TtP17protocol_metadata3OPT_ = private constant { {{.*}} i32, [4 x i8*]*, i8*, i8* } {
@@ -67,7 +67,7 @@ protocol ABO : A, B, O { func abo() }
 // CHECK:   %swift.protocol* @_T017protocol_metadata1AMp,
 // CHECK:   %swift.protocol* @_T017protocol_metadata1BMp
 // CHECK: }
-// CHECK: [[AB_REQTS:@.*]] = internal unnamed_addr constant [3 x %swift.protocol_requirement] [%swift.protocol_requirement zeroinitializer, %swift.protocol_requirement zeroinitializer, %swift.protocol_requirement { i32 1, i32 0 }]
+// CHECK: [[AB_REQTS:@.*]] = internal unnamed_addr constant [3 x %swift.protocol_requirement] [%swift.protocol_requirement zeroinitializer, %swift.protocol_requirement zeroinitializer, %swift.protocol_requirement { i32 17, i32 0 }]
 // CHECK: @_T017protocol_metadata2ABMp = hidden constant %swift.protocol { 
 // CHECK-SAME:   [[AB_INHERITED]]
 // CHECK-SAME:   i32 72, i32 7,
@@ -81,6 +81,27 @@ protocol ABO : A, B, O { func abo() }
 // CHECK:   %swift.protocol* @_T017protocol_metadata1BMp,
 // CHECK:   {{.*}}* @_PROTOCOL__TtP17protocol_metadata1O_
 // CHECK: }
+
+protocol Comprehensive {
+  associatedtype Assoc : A
+  init()
+  func instanceMethod()
+  static func staticMethod()
+  var instance: Assoc { get set }
+  static var global: Assoc { get set }
+}
+// CHECK: [[COMPREHENSIVE_REQTS:@.*]] = internal unnamed_addr constant [11 x %swift.protocol_requirement]
+// CHECK-SAME:  [%swift.protocol_requirement { i32 6, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 19, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 20, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 21, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 3, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 4, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 5, i32 0 }]
 
 func reify_metadata<T>(_ x: T) {}
 

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -15,13 +15,13 @@ import resilient_protocol
 // Protocol is public -- needs resilient witness table
 
 // CHECK: [[RP_REQTS:@.*]] = internal unnamed_addr constant [8 x %swift.protocol_requirement]
-// CHECK-SAME:  [%swift.protocol_requirement { i32 7, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 8, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultC to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 4, i32 1) to {{i32|i64}})){{ | to i32\) }}},
-// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultD to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 5, i32 1) to {{i32|i64}})){{ | to i32\) }}},
-// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultE to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 6, i32 1) to {{i32|i64}})){{ | to i32\) }}},
-// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultF to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 7, i32 1) to {{i32|i64}})){{ | to i32\) }}}]
+// CHECK-SAME:  [%swift.protocol_requirement { i32 6, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultC to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 4, i32 1) to {{i32|i64}})){{ | to i32\) }}},
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultD to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 5, i32 1) to {{i32|i64}})){{ | to i32\) }}},
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultE to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 6, i32 1) to {{i32|i64}})){{ | to i32\) }}},
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32{{ | trunc \(i64 }}sub ({{i32|i64}} ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultF to {{i32|i64}}), {{i32|i64}} ptrtoint (i32* getelementptr inbounds ([8 x %swift.protocol_requirement], [8 x %swift.protocol_requirement]* [[RP_REQTS]], i32 0, i32 7, i32 1) to {{i32|i64}})){{ | to i32\) }}}]
 
 // CHECK: @_T019protocol_resilience17ResilientProtocolMp = {{(protected )?}}constant %swift.protocol {
 // CHECK-SAME:   i32 1031,

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -973,17 +973,17 @@ struct TestProtocol {
 
     using Flags = ProtocolRequirementFlags;
 
-    requirements[0].Flags = Flags(Flags::Kind::InstanceMethod);
+    requirements[0].Flags = Flags(Flags::Kind::Method);
     requirements[0].DefaultImplementation = nullptr;
-    requirements[1].Flags = Flags(Flags::Kind::InstanceMethod);
+    requirements[1].Flags = Flags(Flags::Kind::Method);
     requirements[1].DefaultImplementation = nullptr;
-    requirements[2].Flags = Flags(Flags::Kind::InstanceMethod);
+    requirements[2].Flags = Flags(Flags::Kind::Method);
     requirements[2].DefaultImplementation = nullptr;
-    requirements[3].Flags = Flags(Flags::Kind::InstanceMethod);
+    requirements[3].Flags = Flags(Flags::Kind::Method);
     initializeRelativePointer(
       (int32_t *) &requirements[3].DefaultImplementation,
       fakeDefaultWitness1);
-    requirements[4].Flags = Flags(Flags::Kind::InstanceMethod);
+    requirements[4].Flags = Flags(Flags::Kind::Method);
     initializeRelativePointer(
       (int32_t *) &requirements[4].DefaultImplementation,
       fakeDefaultWitness2);


### PR DESCRIPTION
Do it in a more comprehensive way than we were before so that we handle static accessors correctly.