### PR TITLE
[silgen] Enable ownership on objc factory constructor test and fix exposed problems.

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -355,6 +355,12 @@ public:
   RValue emitRValueForSelfInDelegationInit(SILLocation loc, CanType refType,
                                            SILValue result, SGFContext C);
 
+  /// A version of emitRValueForSelfInDelegationInit that uses formal evaluation
+  /// operations instead of normal scoped operations.
+  RValue emitFormalEvaluationRValueForSelfInDelegationInit(SILLocation loc,
+                                                           CanType refType,
+                                                           SILValue addr,
+                                                           SGFContext C);
   /// The metatype argument to an allocating constructor, if we're emitting one.
   SILValue AllocatorMetatype;
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2072,7 +2072,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
         ManagedValue selfLValue =
             SGF.emitLValueForDecl(DRE, vd, DRE->getType()->getCanonicalType(),
                                   AccessKind::Read, DRE->getAccessSemantics());
-        rv = SGF.emitRValueForSelfInDelegationInit(
+        rv = SGF.emitFormalEvaluationRValueForSelfInDelegationInit(
                     e, DRE->getType()->getCanonicalType(),
                     selfLValue.getLValueAddress(), Ctx)
                  .getScalarValue();

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -40,13 +40,9 @@ class GY<T> : GX<[T]> { }
 // CHECK-LABEL: sil hidden @_T012dynamic_self23testDynamicSelfDispatch{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Y) -> ()
 // CHECK: bb0([[Y:%[0-9]+]] : $Y):
 // CHECK:   [[BORROWED_Y:%.*]] = begin_borrow [[Y]]
-// CHECK:   [[Y_COPY:%.*]] = copy_value [[BORROWED_Y]]
-// CHECK:   [[Y_AS_X_COPY:%[0-9]+]] = upcast [[Y_COPY]] : $Y to $X
-// CHECK:   [[BORROWED_Y_AS_X_COPY:%.*]] = begin_borrow [[Y_AS_X_COPY]]
-// CHECK:   [[X_F:%[0-9]+]] = class_method [[BORROWED_Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
-// => SEMANTIC SIL TODO: This argument here needs to be borrowed.
-// CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
-// CHECK:   destroy_value [[Y_AS_X_COPY]]
+// CHECK:   [[BORROWED_Y_AS_X:%[0-9]+]] = upcast [[BORROWED_Y]] : $Y to $X
+// CHECK:   [[X_F:%[0-9]+]] = class_method [[BORROWED_Y_AS_X]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
+// CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[BORROWED_Y_AS_X]]) : $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   [[Y_RESULT:%[0-9]+]] = unchecked_ref_cast [[X_RESULT]] : $X to $Y
 // CHECK:   destroy_value [[Y_RESULT]] : $Y
 // CHECK:   end_borrow [[BORROWED_Y]] from [[Y]]
@@ -59,12 +55,9 @@ func testDynamicSelfDispatch(y: Y) {
 func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK: bb0([[GY:%[0-9]+]] : $GY<Int>):
   // CHECK:   [[BORROWED_GY:%.*]] = begin_borrow [[GY]]
-  // CHECK:   [[GY_COPY:%.*]] = copy_value [[BORROWED_GY]]
-  // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
-  // CHECK:   [[BORROWED_GY_AS_GX_COPY:%.*]] = begin_borrow [[GY_AS_GX_COPY]]
-  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[BORROWED_GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   destroy_value [[GY_AS_GX_COPY]]
+  // CHECK:   [[BORROWED_GY_AS_GX:%[0-9]+]] = upcast [[BORROWED_GY]] : $GY<Int> to $GX<Array<Int>>
+  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[BORROWED_GY_AS_GX]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[BORROWED_GY_AS_GX]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
   // CHECK:   destroy_value [[GY_RESULT]] : $GY<Int>
   // CHECK:   end_borrow [[BORROWED_GY]] from [[GY]]
@@ -166,13 +159,9 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK-LABEL: sil hidden @_T012dynamic_self18testOptionalResultyAA0dE9InheritorC1v_tF : $@convention(thin) (@owned OptionalResultInheritor) -> () {
 // CHECK: bb0([[ARG:%.*]] : $OptionalResultInheritor):
 // CHECK:      [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-// CHECK:      [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
-// CHECK:      [[BORROWED_CAST_COPY_ARG:%.*]] = begin_borrow [[CAST_COPY_ARG]]
-// CHECK:      [[T0:%.*]] = class_method [[BORROWED_CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
-// CHECK-NEXT: end_borrow [[BORROWED_CAST_COPY_ARG]] from [[CAST_COPY_ARG]]
-// CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
-// CHECK-NEXT: destroy_value [[CAST_COPY_ARG]]
+// CHECK:      [[CAST_BORROWED_ARG:%.*]] = upcast [[BORROWED_ARG]]
+// CHECK:      [[T0:%.*]] = class_method [[CAST_BORROWED_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
+// CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_BORROWED_ARG]])
 // CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[RES]] : $Optional<OptionalResult> to $Optional<OptionalResultInheritor>
 
 func id<T>(_ t: T) -> T { return t }

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -751,12 +751,10 @@ extension ObjCInitRequirement {
   // CHECK:         [[SELF:%.*]] = alloc_ref_dynamic [objc] [[OBJC_SELF_TYPE]] : $@objc_metatype Self.Type, $Self
   // CHECK:         [[WITNESS:%.*]] = witness_method [volatile] $Self, #ObjCInitRequirement.init!initializer.1.foreign : {{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjCInitRequirement> (OC, OC, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:         [[BORROWED_ARG_1:%.*]] = begin_borrow [[ARG]]
-  // CHECK:         [[ARG_COPY_1:%.*]] = copy_value [[BORROWED_ARG_1]]
-  // CHECK:         [[ARG_COPY_1_UPCAST:%.*]] = upcast [[ARG_COPY_1]]
+  // CHECK:         [[BORROWED_ARG_1_UPCAST:%.*]] = upcast [[BORROWED_ARG_1]]
   // CHECK:         [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
-  // CHECK:         [[ARG_COPY_2:%.*]] = copy_value [[BORROWED_ARG_2]]
-  // CHECK:         [[ARG_COPY_2_UPCAST:%.*]] = upcast [[ARG_COPY_2]]
-  // CHECK:         apply [[WITNESS]]<Self>([[ARG_COPY_1_UPCAST]], [[ARG_COPY_2_UPCAST]], [[SELF]])
+  // CHECK:         [[BORROWED_ARG_2_UPCAST:%.*]] = upcast [[BORROWED_ARG_2]]
+  // CHECK:         apply [[WITNESS]]<Self>([[BORROWED_ARG_1_UPCAST]], [[BORROWED_ARG_2_UPCAST]], [[SELF]])
   // CHECK:         end_borrow [[BORROWED_ARG_2]] from [[ARG]]
   // CHECK:         end_borrow [[BORROWED_ARG_1]] from [[ARG]]
   // CHECK: } // end sil function '_T019protocol_extensions19ObjCInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC'


### PR DESCRIPTION
[silgen] Enable ownership on objc factory constructor test and fix exposed problems.

The specific exposed problem had to do with my using the same emission routine
for both lvalues using delegating init self (where we want formal accesses) and
for routines that wanted normal access to self. By splitting them the issue is
resolved.

As a benefit, I added a small peephole that I needed to add for my own purposes
(i.e. to maintain invariants), but that also incidentally improve codegen in
other places!

rdar://31521023
