### PR TITLE
[ConstraintSolver] Track number of conformances when picking bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -250,6 +250,8 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       continue;
 
     case ConstraintKind::ConformsTo:
+      ++result.NumConformanceConstraints;
+      LLVM_FALLTHROUGH;
     case ConstraintKind::SelfObjectOfProtocol:
       // Swift 3 allowed the use of default types for normal conformances
       // to expressible-by-literal protocols.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2556,6 +2556,9 @@ private:
     /// Is this type variable on the RHS of a BindParam constraint?
     bool IsRHSOfBindParam = false;
 
+    /// Number of (non-literal) conformances related to given type variable.
+    unsigned NumConformanceConstraints = 0;
+
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
 
@@ -2573,13 +2576,15 @@ private:
                              x.SubtypeOfExistentialType,
                              static_cast<unsigned char>(x.LiteralBinding),
                              x.InvolvesTypeVariables,
-                             -(x.Bindings.size() - x.NumDefaultableBindings)) <
+                             -(x.Bindings.size() - x.NumDefaultableBindings),
+                             x.NumConformanceConstraints) <
              std::make_tuple(!y.hasNonDefaultableBindings(),
                              y.FullyBound, y.IsRHSOfBindParam,
                              y.SubtypeOfExistentialType,
                              static_cast<unsigned char>(y.LiteralBinding),
                              y.InvolvesTypeVariables,
-                             -(y.Bindings.size() - y.NumDefaultableBindings));
+                             -(y.Bindings.size() - y.NumDefaultableBindings),
+                             y.NumConformanceConstraints);
     }
 
     void foundLiteralBinding(ProtocolDecl *proto) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -504,3 +504,22 @@ func rdar27700622<E: Comparable>(_ input: [E]) -> [E] {
 
   return rdar27700622(lhs) + [pivot] + rdar27700622(rhs) // Ok
 }
+
+// rdar://problem/22898292 - Type inference failure with constrained subclass
+
+public protocol P_22898292 {}
+public func init_22898292<T: P_22898292>(_ construct: () -> T) -> T {}
+
+class C_22898292 { init() {} }
+class S_22898292 : C_22898292 { override init() {} }
+
+extension S_22898292: P_22898292 {}
+
+func foo_22898292(_ expr: String) -> S_22898292 {}
+func bar_22898292(_ name: String, _ value: C_22898292) {}
+
+func rdar_22898292() {
+  let x = init_22898292 { foo_22898292("B") } // returns S_22898292
+  bar_22898292("A", x) // Ok
+  bar_22898292("A", init_22898292 { foo_22898292("B") }) // Ok
+}


### PR DESCRIPTION
Since conformances of the potential binding types are not verified by
the `getPotentialBindings` code but instead are determined by the solver
itself requires that bindings with conformance constraints are ranked
lower than other potential bindings.

Resolves: rdar://problem/22898292

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
