### PR TITLE
Remove ProtocolConformanceRef::getInherited()

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -866,6 +866,11 @@ public:
   /// like `<T>`.
   CanGenericSignature getSingleGenericParameterSignature() const;
 
+  /// Retrieve a generic signature with a single type parameter conforming
+  /// to the given existential type.
+  CanGenericSignature getExistentialSignature(CanType existential,
+                                              ModuleDecl *mod);
+
   /// Whether our effective Swift version is in the Swift 3 family.
   bool isSwiftVersion3() const { return LangOpts.isSwiftVersion3(); }
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -86,11 +86,6 @@ public:
   /// Return the protocol requirement.
   ProtocolDecl *getRequirement() const;
   
-  /// Get the inherited conformance corresponding to the given protocol.
-  /// Returns `this` if `parent` is already the same as the protocol this
-  /// conformance represents.
-  ProtocolConformanceRef getInherited(ProtocolDecl *parent) const;
-
   /// Apply a substitution to the conforming type.
   ProtocolConformanceRef subst(Type origType,
                                TypeSubstitutionFn subs,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -261,6 +261,9 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   /// The single-parameter generic signature with no constraints, <T>.
   CanGenericSignature SingleGenericParameterSignature;
 
+  /// The existential signature <T : P> for each P.
+  llvm::DenseMap<CanType, CanGenericSignature> ExistentialSignatures;
+
   /// \brief Structure that captures data that is segregated into different
   /// arenas.
   struct Arena {
@@ -4507,6 +4510,35 @@ CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {
   auto canonicalSig = CanGenericSignature(sig);
   Impl.SingleGenericParameterSignature = canonicalSig;
   return canonicalSig;
+}
+
+CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
+                                                        ModuleDecl *mod) {
+  auto found = Impl.ExistentialSignatures.find(existential);
+  if (found != Impl.ExistentialSignatures.end())
+    return found->second;
+
+  assert(existential.isExistentialType());
+
+  GenericSignatureBuilder builder(*this, LookUpConformanceInModule(mod));
+
+  auto genericParam = GenericTypeParamType::get(0, 0, *this);
+  builder.addGenericParameter(genericParam);
+
+  Requirement requirement(RequirementKind::Conformance, genericParam,
+                          existential);
+  auto source =
+    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
+  builder.addRequirement(requirement, source, nullptr);
+
+  CanGenericSignature genericSig(builder.computeGenericSignature(SourceLoc()));
+
+  auto result = Impl.ExistentialSignatures.insert(
+    std::make_pair(existential, genericSig));
+  assert(result.second);
+  (void) result;
+
+  return genericSig;
 }
 
 SILLayout *SILLayout::get(ASTContext &C,

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -78,30 +78,6 @@ ProtocolDecl *ProtocolConformanceRef::getRequirement() const {
 }
 
 ProtocolConformanceRef
-ProtocolConformanceRef::getInherited(ProtocolDecl *parent) const {
-  assert((getRequirement() == parent ||
-          getRequirement()->inheritsFrom(parent)) &&
-         "not a parent of this protocol");
-  
-  if (parent == getRequirement())
-    return *this;
-  
-  // For an abstract requirement, simply produce a new abstract requirement
-  // for the parent.
-  if (isAbstract()) {
-    return ProtocolConformanceRef(parent);
-  }
-  
-  // Navigate concrete conformances.
-  if (isConcrete()) {
-    return ProtocolConformanceRef(
-      getConcrete()->getInheritedConformance(parent));
-  }
-  
-  llvm_unreachable("unhandled ProtocolConformanceRef");
-}
-
-ProtocolConformanceRef
 ProtocolConformanceRef::subst(Type origType,
                               TypeSubstitutionFn subs,
                               LookupConformanceFn conformances) const {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2347,9 +2347,7 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
   // more concrete than we're expecting.
   // TODO: make a best effort to devirtualize, maybe?
   auto concreteConformance = conformance.getConcrete();
-  if (concreteConformance->getProtocol() != proto) {
-    concreteConformance = concreteConformance->getInheritedConformance(proto);
-  }
+  assert(concreteConformance->getProtocol() == proto);
 
   // Check immediately for an existing cache entry.
   auto wtable = IGF.tryGetLocalTypeData(

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2823,11 +2823,10 @@ irgen::emitWitnessMethodValue(IRGenFunction &IGF,
                               CanSILFunctionType fnType) {
   auto fn = cast<AbstractFunctionDecl>(member.getDecl());
   auto fnProto = cast<ProtocolDecl>(fn->getDeclContext());
-  
-  conformance = conformance.getInherited(fnProto);
+
+  assert(conformance.getRequirement() == fnProto);
 
   // Find the witness table.
-  // FIXME conformance for concrete type
   llvm::Value *wtable = emitWitnessTableRef(IGF, baseTy, baseMetadataCache,
                                             conformance);
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -710,7 +710,8 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
         [&](CanType origTy, Type substTy,
             ProtocolType *proto) -> Optional<ProtocolConformanceRef> {
           if (substTy->isEqual(ConcreteType)) {
-            return Conformance.getInherited(proto->getDecl());
+            assert(proto->getDecl() == Conformance.getRequirement());
+            return Conformance;
           }
           return ProtocolConformanceRef(proto->getDecl());
         });

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -753,70 +753,69 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
 /// Derive a concrete type of self and conformance from the init_existential
 /// instruction.
 static Optional<std::tuple<ProtocolConformanceRef, CanType, SILValue, SILValue>>
-getConformanceAndConcreteType(FullApplySite AI,
+getConformanceAndConcreteType(ASTContext &Ctx,
+                              FullApplySite AI,
                               SILInstruction *InitExistential,
                               ProtocolDecl *Protocol,
                               ArrayRef<ProtocolConformanceRef> &Conformances) {
   // Try to derive the concrete type of self from the found init_existential.
   CanType ConcreteType;
+  // The existential type result of the found init_existential.
+  CanType ExistentialType;
   SILValue ConcreteTypeDef;
   SILValue NewSelf;
 
+  // FIXME: Factor this out. All we really need here is the ExistentialSig
+  // below, which should be stored directly in the SILInstruction.
   if (auto IE = dyn_cast<InitExistentialAddrInst>(InitExistential)) {
     Conformances = IE->getConformances();
     ConcreteType = IE->getFormalConcreteType();
     NewSelf = IE;
+    ExistentialType = IE->getOperand()->getType().getSwiftRValueType();
   } else if (auto IER = dyn_cast<InitExistentialRefInst>(InitExistential)) {
     Conformances = IER->getConformances();
     ConcreteType = IER->getFormalConcreteType();
     NewSelf = IER->getOperand();
+    ExistentialType = IER->getType().getSwiftRValueType();
   } else if (auto IEM = dyn_cast<InitExistentialMetatypeInst>(InitExistential)){
     Conformances = IEM->getConformances();
     NewSelf = IEM->getOperand();
     ConcreteType = NewSelf->getType().getSwiftRValueType();
-
-    auto ExType = IEM->getType().getSwiftRValueType();
-    while (auto ExMetatype = dyn_cast<ExistentialMetatypeType>(ExType)) {
-      ExType = ExMetatype.getInstanceType();
+    ExistentialType = IEM->getType().getSwiftRValueType();
+    while (auto InstanceType = dyn_cast<ExistentialMetatypeType>(ExistentialType)) {
+      ExistentialType = InstanceType.getInstanceType();
       ConcreteType = cast<MetatypeType>(ConcreteType).getInstanceType();
     }
   } else {
     return None;
   }
 
+  // Construct a substitution map from the existential type's generic
+  // parameter to the concrete type.
+  auto ExistentialSig = Ctx.getExistentialSignature(ExistentialType,
+                                                    AI.getModule().getSwiftModule());
+
+  Substitution ConcreteSub(ConcreteType, Conformances);
+  auto SubMap = ExistentialSig->getSubstitutionMap({&ConcreteSub, 1});
+
+  // If the requirement is in a base protocol that is refined by the
+  // conforming protocol, fish out the exact conformance for the base
+  // protocol using the substitution map.
+  auto ExactConformance = SubMap.lookupConformance(
+    CanType(ExistentialSig->getGenericParams()[0]),
+    Protocol);
+
+  // If the concrete type is another existential, we're "forwarding" an
+  // opened existential type, so we must keep track of the original
+  // defining instruction.
   if (ConcreteType->isOpenedExistential()) {
     assert(!InitExistential->getTypeDependentOperands().empty() &&
            "init_existential is supposed to have a typedef operand");
     ConcreteTypeDef = InitExistential->getTypeDependentOperands()[0].get();
   }
 
-  // Find the conformance for the protocol we're interested in.
-  for (auto Conformance : Conformances) {
-    auto Requirement = Conformance.getRequirement();
-    if (Requirement == Protocol) {
-      return std::make_tuple(Conformance, ConcreteType, ConcreteTypeDef,
-                             NewSelf);
-    }
-    // If Requirement != Protocol, then the abstract conformance cannot be
-    // used as is and we need to create a proper conformance.
-    // FIXME: We can handle only direct inheritance at the moment due to some
-    // limitations of the init_existential_* instructions representation.
-    // Once these instructions start using generic signatures instead of
-    // conformances lists, it should be fairly easy to support the indirect
-    // inheritance here by something like:
-    // Substitution Sub(ConcreteType, Conformances);
-    // IE->getGenericSignature()
-    //   ->getSubstitutionMap({Sub}).lookupConformance(GP00, Protocol);
-    auto InheritedProtocols = Requirement->getInheritedProtocols();
-    if (std::find(InheritedProtocols.begin(), InheritedProtocols.end(),
-                  Protocol) == InheritedProtocols.end())
-      return None;
-    // Requirement is directly inherited from Protocol.
-    return std::make_tuple(Conformance.getInherited(Protocol), ConcreteType,
-                           ConcreteTypeDef, NewSelf);
-  }
-
-  llvm_unreachable("couldn't find matching conformance in substitution?");
+  return std::make_tuple(*ExactConformance, ConcreteType,
+                         ConcreteTypeDef, NewSelf);
 }
 
 /// Propagate information about a concrete type from init_existential_addr
@@ -828,6 +827,8 @@ SILInstruction *
 SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
     ProtocolDecl *Protocol,
     llvm::function_ref<void(CanType , ProtocolConformanceRef)> Propagate) {
+
+  ASTContext &Ctx = Builder.getASTContext();
 
   // Get the self argument.
   SILValue Self;
@@ -854,8 +855,8 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
   // the found init_existential.
   ArrayRef<ProtocolConformanceRef> Conformances;
   auto ConformanceAndConcreteType =
-      getConformanceAndConcreteType(AI, InitExistential,
-                                    Protocol, Conformances);
+    getConformanceAndConcreteType(Ctx, AI, InitExistential,
+                                  Protocol, Conformances);
   if (!ConformanceAndConcreteType)
     return nullptr;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -69,9 +69,49 @@ namespace {
   /// generic requirements. See the \c Witness class for more information about
   /// this synthetic environment.
   class RequirementEnvironment {
+    /// A generic signature that combines the generic parameters of the
+    /// concrete conforming type with the generic parameters of the
+    /// requirement.
+    ///
+    ///
+    /// For example, if you have:
+    ///
+    /// protocol P { func f<T>(_: T) }
+    /// struct S<A, B> : P { func f<T>(_: T) }
+    ///
+    /// The requirement and witness signatures are, respectively:
+    ///
+    /// <Self : P, T>
+    /// <A, B, T>
+    ///
+    /// The synthetic signature in this case is just the witness signature.
+    ///
+    /// It may be that the witness is more generic than the requirement,
+    /// for example:
+    ///
+    /// protocol P { func f(_: Int) }
+    /// struct S<A, B> : P { func f<T>(_: T) { } }
+    ///
+    /// Here, the requirement signature and witness signatures are:
+    ///
+    /// <Self : P>
+    /// <A, B, T>
+    ///
+    /// The synthetic signature is just:
+    ///
+    /// <A, B>
+    ///
+    /// The witness thunk emitted by SILGen uses the synthetic signature.
+    /// Therefore one invariant we preserve is that the witness thunk is
+    /// ABI compatible with the requirement's function type.
     GenericSignature *syntheticSignature = nullptr;
     GenericEnvironment *syntheticEnvironment = nullptr;
+
+    /// The generic signature of the protocol requirement member.
     GenericSignature *reqSig = nullptr;
+
+    /// A substitution map mapping the requirement signature to the
+    /// generic parameters of the synthetic signature.
     SubstitutionMap reqToSyntheticEnvMap;
 
   public:

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -28,11 +28,12 @@ public func testInheritedConformance() {
     (S() as QQQ).f()
 }
 
-// Test that a witness_method instructions is not devirtualized yet, because
-// it uses indirect inheritance.
+// Test that a witness_method instruction using an indirectly-inherited conformance
+// is devirtualized.
+//
 // This test used to crash the compiler because it uses inherited conformances.
 // CHECK-LABEL: sil @_T034devirt_protocol_method_invocations34testIndirectlyInheritedConformanceyyF : $@convention(thin) () -> ()
-// CHECK: witness_method
+// CHECK-NOT: witness_method
 // CHECK: apply
 // CHECK: // end sil function '_T034devirt_protocol_method_invocations34testIndirectlyInheritedConformanceyyF'
 public func testIndirectlyInheritedConformance() {


### PR DESCRIPTION
In various places, we would sometimes be given a conformance of a concrete type to a protocol Q, and asked to produce a witness table entry for a requirement defined in protocol P, where Q refines P. The `ProtocolConformanceRef::getInherited()` utility method was used to handle this case, except it only handled direct refinement. If Q refined P directly, it worked, but if Q refined P0 which refined P, it would fail with an assertion.

It is better to either pass in the exact conformance needed, or use a SubstitutionMap to map the refined conformance to the base conformance using a ConformanceAccessPath. This PR refactors a couple of places in the SIL optimizer and IRGen to do things the right way, and then removes `ProtocolConformanceRef::getInherited()` altogether.