### PR TITLE
[4.0] RangeInfo: Add several defensive null pointer checks. rdar://32047178

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -712,11 +712,13 @@ public:
         // For each continue/break statement, record its target's range and the
         // orphan kind.
         if (auto *CS = dyn_cast<ContinueStmt>(S)) {
-          Ranges.emplace_back(CS->getTarget()->getSourceRange(),
-                              OrphanKind::Continue);
+          if (auto *Target = CS->getTarget()) {
+            Ranges.emplace_back(Target->getSourceRange(), OrphanKind::Continue);
+          }
         } else if (auto *BS = dyn_cast<BreakStmt>(S)) {
-          Ranges.emplace_back(BS->getTarget()->getSourceRange(),
-                              OrphanKind::Break);
+          if (auto *Target = BS->getTarget()) {
+            Ranges.emplace_back(Target->getSourceRange(), OrphanKind::Break);
+          }
         }
         return true;
       }
@@ -832,6 +834,11 @@ public:
 
   void analyzeDeclRef(ValueDecl *VD, SourceLoc Start, Type Ty,
                       ReferenceMetaData Data) {
+    // Add defensive check in case the given type is null.
+    // FIXME: we should receive error type instead of null type.
+    if (Ty.isNull())
+      return;
+
     // Only collect decl ref.
     if (Data.Kind != SemaReferenceKind::DeclRef)
       return;


### PR DESCRIPTION
Explanation: This patch adds several null pointer checks in the range info resolver to ensure available refactoring requests don't crash sourcekitd service.
Radar: rdar://problem/32047178
Risk: Very Low; just add several defensive null pointer checks.
Testing: The original reproducing test case is long and hard to reduce. Since the patch only adds null pointer checks, existing tests cover all of the unchanged behaviors.