### PR TITLE
Allow Codable synthesis in same-file extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2051,8 +2051,8 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
 
 // Derived conformances
 
-ERROR(cannot_synthesize_in_extension,none,
-      "implementation of %0 cannot be automatically synthesized in an extension yet", (Type))
+ERROR(cannot_synthesize_in_different_file,none,
+      "implementation of %0 can only be synthesized in the same source file as %1", (Type, Type))
 
 ERROR(broken_raw_representable_requirement,none,
       "RawRepresentable protocol is broken: unexpected requirement", ())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6693,6 +6693,60 @@ public:
                                 desiredAccessScope, access);
       }
       TC.checkConformancesInContext(ED, ED);
+
+      // If we just extended a nominal type with a protocol conformance (which
+      // may have just gotten derived), members which are synthesized might need
+      // to be visited for validation (since the extended type might have
+      // otherwise finished being validated).
+      if (auto extendedTy = ED->getExtendedType()) {
+        if (auto nominal = extendedTy->getAnyNominal()) {
+          // Put together the list of protocols that the nominal type inherited
+          // from this extension.
+          SmallVector<ProtocolDecl *, 2> inheritedProtocols;
+          for (auto typeLoc : ED->getInherited()) {
+            if (!typeLoc.wasValidated() || typeLoc.isError() ||
+                typeLoc.isNull())
+              break;
+
+            // The type being inherited here can be a direct protocol
+            // conformance (e.g. extension Foo : Sequence), or an existential
+            // composition of conformances (e.g. extension Foo : Codable, where
+            // typealias Codable = Encodable & Decodable).
+            auto canType = typeLoc.getType()->getCanonicalType();
+            if (canType->isExistentialType()) {
+              auto layout = canType->getExistentialLayout();
+              for (auto protocolType : layout.getProtocols())
+                inheritedProtocols.push_back(protocolType->getDecl());
+            } else if (auto *inheritedNominal = canType->getAnyNominal()) {
+              if (auto *protocolDecl = dyn_cast<ProtocolDecl>(inheritedNominal))
+                inheritedProtocols.push_back(protocolDecl);
+            }
+          }
+
+          // Any protocol witness satisfied by an implicit decl in any of these
+          // protocols may just have been synthesized, and should be visited.
+          for (auto *protocol : inheritedProtocols) {
+            SmallVector<ProtocolConformance *, 1> conformances;
+            if (!nominal->lookupConformance(nullptr, protocol, conformances))
+              continue;
+
+            for (auto *conformance : conformances) {
+              auto *normal = dyn_cast<NormalProtocolConformance>(conformance);
+              if (!normal)
+                continue;
+
+              normal->forEachValueWitness(&TC, [=](ValueDecl *requirement,
+                                                   Witness witness) {
+                // We need to visit the witness if the requirement has been met,
+                // and the witness was synthesized.
+                auto *witnessDecl = witness.getDecl();
+                if (witnessDecl && witnessDecl->isImplicit())
+                  visit(witnessDecl);
+              });
+            }
+          }
+        }
+      }
     }
 
     for (Decl *Member : ED->getMembers())

--- a/test/decl/protocol/special/coding/Inputs/class_codable_simple_multi_extension1.swift
+++ b/test/decl/protocol/special/coding/Inputs/class_codable_simple_multi_extension1.swift
@@ -1,0 +1,17 @@
+// Simple classes with all Codable properties should get derived conformance to
+// Codable.
+class SimpleClass { // expected-note {{did you mean 'init'?}}
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  // These lines have to be within the SimpleClass type because
+  // CodingKeys should be private.
+  func foo() {
+    // They should not get a CodingKeys type.
+    let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    let _ = SimpleClass.CodingKeys.x // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    let _ = SimpleClass.CodingKeys.y // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+  }
+}

--- a/test/decl/protocol/special/coding/Inputs/class_codable_simple_multi_extension2.swift
+++ b/test/decl/protocol/special/coding/Inputs/class_codable_simple_multi_extension2.swift
@@ -1,0 +1,14 @@
+extension SimpleClass : Codable {} // expected-error {{implementation of 'Decodable' can only be synthesized in the same source file as 'SimpleClass'}}
+// expected-error@-1 {{implementation of 'Decodable' can only be synthesized in the same source file as 'SimpleClass'}}
+// expected-error@-2 {{implementation of 'Encodable' can only be synthesized in the same source file as 'SimpleClass'}}
+// expected-error@-3 {{implementation of 'Encodable' can only be synthesized in the same source file as 'SimpleClass'}}
+
+// These are wrapped in a dummy function to avoid binding a global variable.
+func foo() {
+  // They should not receive Codable methods.
+  let _ = SimpleClass.init(from:) // expected-error {{type 'SimpleClass' has no member 'init(from:)'}}
+  let _ = SimpleClass.encode(to:) // expected-error {{type 'SimpleClass' has no member 'encode(to:)'}}
+
+  // They should not get a CodingKeys type.
+  let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+}

--- a/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi_extension1.swift
+++ b/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi_extension1.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+// Simple structs where Codable conformance is added in a different-file
+// extension should not derive conformance.
+struct SimpleStruct { // expected-note {{did you mean 'init'?}}
+  var x: Int
+  var y: Double
+  static var z: String = "foo"
+
+  func foo() {
+    // They should not receive a synthesized CodingKeys enum.
+    let _ = SimpleStruct.CodingKeys.self // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    let _ = SimpleStruct.CodingKeys.x // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    let _ = SimpleStruct.CodingKeys.y // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+  }
+}

--- a/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi_extension2.swift
+++ b/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi_extension2.swift
@@ -1,0 +1,14 @@
+extension SimpleStruct : Codable {} // expected-error {{implementation of 'Decodable' can only be synthesized in the same source file as 'SimpleStruct'}}
+// expected-error@-1 {{implementation of 'Decodable' can only be synthesized in the same source file as 'SimpleStruct'}}
+// expected-error@-2 {{implementation of 'Encodable' can only be synthesized in the same source file as 'SimpleStruct'}}
+// expected-error@-3 {{implementation of 'Encodable' can only be synthesized in the same source file as 'SimpleStruct'}}
+
+// These are wrapped in a dummy function to avoid binding a global variable.
+func foo() {
+  // They should not receive Codable methods.
+  let _ = SimpleStruct.init(from:) // expected-error {{type 'SimpleStruct' has no member 'init(from:)'}}
+  let _ = SimpleStruct.encode(to:) // expected-error {{type 'SimpleStruct' has no member 'encode(to:)'}}
+
+  // They should not get a CodingKeys type.
+  let _ = SimpleStruct.CodingKeys.self // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+}

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -125,9 +125,3 @@ class C6 : Codable {
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
   // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
 }
-
-// Classes cannot yet synthesize Encodable or Decodable in extensions.
-class C7 {}
-extension C7 : Codable {}
-// CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension yet
-// CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension yet

--- a/test/decl/protocol/special/coding/class_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension.swift
@@ -1,29 +1,33 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
-// Simple classes where Codable conformance is added in extensions should not
-// derive conformance yet.
-class SimpleClass { // expected-note {{did you mean 'init'?}}
+// Simple classes where Codable conformance is added in a same-file extension
+// should derive conformance.
+class SimpleClass {
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"
 
+  // These lines have to be within the SimpleClass type because CodingKeys
+  // should be private.
   func foo() {
-    // They should not get a CodingKeys type.
-    let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.x // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.y // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    // They should receive a synthesized CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = SimpleClass.CodingKeys.x
+    let _ = SimpleClass.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass.CodingKeys' has no member 'z'}}
   }
 }
 
-extension SimpleClass : Codable {} // expected-error {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
-// expected-error@-3 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+extension SimpleClass : Codable {}
 
-// They should not receive Codable methods.
-let _ = SimpleClass.init(from:) // expected-error {{type 'SimpleClass' has no member 'init(from:)'}}
-let _ = SimpleClass.encode(to:) // expected-error {{type 'SimpleClass' has no member 'encode(to:)'}}
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleClass.init(from:)
+let _ = SimpleClass.encode(to:)
 
-// They should not get a CodingKeys type.
-let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_multi_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_multi_extension.swift
@@ -1,0 +1,2 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %S/Inputs/class_codable_simple_multi_extension1.swift %S/Inputs/class_codable_simple_multi_extension2.swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %S/Inputs/class_codable_simple_multi_extension2.swift %S/Inputs/class_codable_simple_multi_extension1.swift

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -63,10 +63,6 @@ struct S5 : Codable {
   }
 }
 
-// Structs cannot yet synthesize Encodable or Decodable in extensions.
-struct S6 {}
-extension S6 : Codable {}
-
 // Decodable diagnostics are output first here {
 
 // CHECK: error: type 'S1' does not conform to protocol 'Decodable'
@@ -91,8 +87,6 @@ extension S6 : Codable {}
 // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
 
-// CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension yet
-
 // }
 
 // Encodable {
@@ -114,7 +108,5 @@ extension S6 : Codable {}
 // CHECK: note: CodingKey case 'a2' does not match any stored properties
 // CHECK: note: CodingKey case 'b2' does not match any stored properties
 // CHECK: note: CodingKey case 'c2' does not match any stored properties
-
-// CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension yet
 
 // }

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
@@ -1,29 +1,33 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
-// Simple structs where Codable conformance is added in extensions should not
-// derive conformance yet.
-struct SimpleStruct { // expected-note {{did you mean 'init'?}}
+// Simple structs where Codable conformance is added in a same-file extension
+// should derive conformance.
+struct SimpleStruct {
   var x: Int
   var y: Double
   static var z: String = "foo"
 
+  // These lines have to be within the SimpleStruct type because CodingKeys
+  // should be private.
   func foo() {
-    // They should not receive a synthesized CodingKeys enum.
-    let _ = SimpleStruct.CodingKeys.self // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
-    let _ = SimpleStruct.CodingKeys.x // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
-    let _ = SimpleStruct.CodingKeys.y // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
-    let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    // They should receive a synthesized CodingKeys enum.
+    let _ = SimpleStruct.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = SimpleStruct.CodingKeys.x
+    let _ = SimpleStruct.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct.CodingKeys' has no member 'z'}}
   }
 }
 
-extension SimpleStruct : Codable {} // expected-error {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
-// expected-error@-3 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+extension SimpleStruct : Codable {}
 
-// They should not receive Codable methods.
-let _ = SimpleStruct.init(from:) // expected-error {{type 'SimpleStruct' has no member 'init(from:)'}}
-let _ = SimpleStruct.encode(to:) // expected-error {{type 'SimpleStruct' has no member 'encode(to:)'}}
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleStruct.init(from:)
+let _ = SimpleStruct.encode(to:)
 
-// They should not get a CodingKeys type.
-let _ = SimpleStruct.CodingKeys.self // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_multi_extension.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_multi_extension.swift
@@ -1,0 +1,2 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %S/Inputs/struct_codable_simple_multi_extension1.swift %S/Inputs/struct_codable_simple_multi_extension2.swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %S/Inputs/struct_codable_simple_multi_extension2.swift %S/Inputs/struct_codable_simple_multi_extension1.swift


### PR DESCRIPTION
**What's in this pull request?**
Resolves [SR-4920](https://bugs.swift.org/browse/SR-4920) by lifting the restriction that prevented `Codable` synthesis in same-file extensions.

Arbitrary synthesis of `Codable` in extensions is still disallowed, though.