### PR TITLE
[ConstraintSolver] Extend position tracking to SubtypeOf constraints

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -188,10 +188,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       continue;
 
     switch (constraint->getKind()) {
+    case ConstraintKind::Subtype:
     case ConstraintKind::BindParam:
       if (simplifyType(constraint->getSecondType())
               ->getAs<TypeVariableType>() == typeVar) {
-        result.IsRHSOfBindParam = true;
+        result.IsRHSOfBindParamOrSubtypeOf = true;
       }
 
       LLVM_FALLTHROUGH;
@@ -199,7 +200,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
     case ConstraintKind::Bind:
     case ConstraintKind::Equal:
     case ConstraintKind::BindToPointerType:
-    case ConstraintKind::Subtype:
     case ConstraintKind::Conversion:
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::ArgumentTupleConversion:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2553,8 +2553,8 @@ private:
     /// The number of defaultable bindings.
     unsigned NumDefaultableBindings = 0;
 
-    /// Is this type variable on the RHS of a BindParam constraint?
-    bool IsRHSOfBindParam = false;
+    /// Is this type variable on the RHS of a BindParam or SubtypeOf constraint?
+    bool IsRHSOfBindParamOrSubtypeOf = false;
 
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
@@ -2569,17 +2569,19 @@ private:
     friend bool operator<(const PotentialBindings &x,
                           const PotentialBindings &y) {
       return std::make_tuple(!x.hasNonDefaultableBindings(),
-                             x.FullyBound, x.IsRHSOfBindParam,
+                             x.FullyBound,
                              x.SubtypeOfExistentialType,
                              static_cast<unsigned char>(x.LiteralBinding),
                              x.InvolvesTypeVariables,
-                             -(x.Bindings.size() - x.NumDefaultableBindings)) <
+                             -(x.Bindings.size() - x.NumDefaultableBindings),
+                             x.IsRHSOfBindParamOrSubtypeOf) <
              std::make_tuple(!y.hasNonDefaultableBindings(),
-                             y.FullyBound, y.IsRHSOfBindParam,
+                             y.FullyBound,
                              y.SubtypeOfExistentialType,
                              static_cast<unsigned char>(y.LiteralBinding),
                              y.InvolvesTypeVariables,
-                             -(y.Bindings.size() - y.NumDefaultableBindings));
+                             -(y.Bindings.size() - y.NumDefaultableBindings),
+                             y.IsRHSOfBindParamOrSubtypeOf);
     }
 
     void foundLiteralBinding(ProtocolDecl *proto) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -504,3 +504,22 @@ func rdar27700622<E: Comparable>(_ input: [E]) -> [E] {
 
   return rdar27700622(lhs) + [pivot] + rdar27700622(rhs) // Ok
 }
+
+// rdar://problem/22898292 - Type inference failure with constrained subclass
+
+public protocol P_22898292 {}
+public func init_22898292<T: P_22898292>(_ construct: () -> T) -> T {}
+
+class C_22898292 { init() {} }
+class S_22898292 : C_22898292 { override init() {} }
+
+extension S_22898292: P_22898292 {}
+
+func foo_22898292(_ expr: String) -> S_22898292 {}
+func bar_22898292(_ name: String, _ value: C_22898292) {}
+
+func rdar_22898292() {
+  let x = init_22898292 { foo_22898292("B") } // returns S_22898292
+  bar_22898292("A", x) // Ok
+  bar_22898292("A", init_22898292 { foo_22898292("B") }) // Ok
+}


### PR DESCRIPTION
While trying to find potential bindings for type variable mark if it's
located on the right-hand side of the subtype-of constraint, so it could
be de-prioritized in favor of bindings found for the left-hand side,
with all else equal.

Resolves: rdar://problem/22898292

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
