### PR TITLE
[overlay] Weakly link against ModelIO Framework

### DIFF
--- a/stdlib/public/SDK/ModelIO/CMakeLists.txt
+++ b/stdlib/public/SDK/ModelIO/CMakeLists.txt
@@ -11,7 +11,5 @@ add_swift_library(swiftModelIO ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_O
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation CoreGraphics Dispatch Foundation IOKit ObjectiveC simd # auto-updated
   SWIFT_MODULE_DEPENDS_IOS Darwin CoreFoundation CoreGraphics Dispatch Foundation ObjectiveC simd # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreFoundation CoreGraphics Dispatch Foundation ObjectiveC simd # auto-updated
-  FRAMEWORK_DEPENDS ModelIO
-
-  DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_MODELIO_OSX}
+  FRAMEWORK_DEPENDS_WEAK ModelIO
 )


### PR DESCRIPTION
* Explanation: Weakly link ModelIO overlay against ObjC ModelIO library.
* Scope of Issue: Multiple overlays depend on ModelIO transitively, inlcuding GLKit. So an
app linked against GLKit will successfully build and run on the modern
OSes, but will crash on load if back-deployed to an OS where ModelIO did
not exist.
* Risk: Minimal
* Reviewed By: Jordan Rose
* Testing: Tested this by creating an app in current XCode 9 Beta and observing a crash on
OSX 10.10, and no crash after the patch has been applied.
* Directions for QA: N/A
* Radars: <rdar://problem/33960842>, <rdar://problem/33471433>