### PR TITLE
[overlay] Weakly link against ModelIO Framework

### DIFF
--- a/stdlib/public/SDK/ModelIO/CMakeLists.txt
+++ b/stdlib/public/SDK/ModelIO/CMakeLists.txt
@@ -11,7 +11,5 @@ add_swift_library(swiftModelIO ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_O
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation CoreGraphics Dispatch Foundation IOKit ObjectiveC simd # auto-updated
   SWIFT_MODULE_DEPENDS_IOS Darwin CoreFoundation CoreGraphics Dispatch Foundation ObjectiveC simd # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreFoundation CoreGraphics Dispatch Foundation ObjectiveC simd # auto-updated
-  FRAMEWORK_DEPENDS ModelIO
-
-  DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_MODELIO_OSX}
+  FRAMEWORK_DEPENDS_WEAK ModelIO
 )


### PR DESCRIPTION
Multiple overlays depend on ModelIO transitively, inlcuding GLKit. So an
app linked against GLKit will successfully build and run on the modern
OSes, but will crash on load if back-deployed to an OS where ModelIO did
not exist.

<rdar://problem/33960842>
<rdar://problem/33471433>

(cherry picked from commit 1c385f189caa48dcc21466d55c6953ac415166df)