### PR TITLE
[SE implementation] Ownership keyword removal in protocols

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3115,6 +3115,13 @@ ERROR(invalid_weak_ownership_not_optional,none,
       "'weak' variable should have optional type %0", (Type))
 ERROR(invalid_weak_let,none,
       "'weak' must be a mutable variable, because it may change at runtime", ())
+ERROR(ownership_invalid_in_protocols,none,
+      "'%select{strong|weak|unowned|unowned}0' cannot be applied to a property declaration in a protocol",
+      (/*Ownership*/unsigned))
+WARNING(ownership_invalid_in_protocols_compat_warning,none,
+      "'%select{strong|weak|unowned|unowned}0' should not be applied to a property declaration "
+      "in a protocol and will be disallowed in future versions",
+      (/*Ownership*/unsigned))
 
 // required
 ERROR(required_initializer_nonclass,none,

--- a/test/Compatibility/ownership_protocol.swift
+++ b/test/Compatibility/ownership_protocol.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+// Generate a swift 4 compatible warning if ownership is specified in a protocol
+
+class SomeClass {}
+
+protocol P {
+  weak var foo: SomeClass? { get set } // expected-warning {{'weak' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+  unowned var foo2: SomeClass { get set } // expected-warning {{'unowned' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+  weak var foo3: Int? { get set } // expected-error {{'weak' may only be applied to class and class-bound protocol types, not 'Int'}}
+  unowned var foo4: Int { get set } // expected-error {{'unowned' may only be applied to class and class-bound protocol types, not 'Int'}}
+}
+

--- a/test/SILGen/Inputs/weak_other.swift
+++ b/test/SILGen/Inputs/weak_other.swift
@@ -11,7 +11,7 @@ extension Router {
 }
 
 public protocol Environment : class {
-  unowned var router: Router { get }
+  var router: Router { get }
 }
 
 open class UI {

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -850,7 +850,7 @@ struct ObservingPropertiesWithOwnershipTypesInferred {
 
 // <rdar://problem/16554876> property accessor synthesization of weak variables doesn't work
 protocol WeakPropertyProtocol {
- weak var maybePresent : Ref? { get set }
+ var maybePresent : Ref? { get set }
 }
 
 struct WeakPropertyStruct : WeakPropertyProtocol {

--- a/test/decl/protocol/ownership_protocol.swift
+++ b/test/decl/protocol/ownership_protocol.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+class SomeClass {}
+
+protocol P {
+  weak var foo: SomeClass? { get set } // expected-error {{'weak' cannot be applied to a property declaration in a protocol}}
+  unowned var foo2: SomeClass { get set } // expected-error {{'unowned' cannot be applied to a property declaration in a protocol}}
+  weak var foo3: Int? { get set } // expected-error {{'weak' may only be applied to class and class-bound protocol types, not 'Int'}}
+  unowned var foo4: Int { get set } // expected-error {{'unowned' may only be applied to class and class-bound protocol types, not 'Int'}}
+  var foo9: SomeClass? { get }
+}
+
+extension P {
+  weak var foo5: SomeClass? // expected-error {{extensions must not contain stored properties}}
+  unowned var foo6: SomeClass // expected-error {{extensions must not contain stored properties}}
+  
+  weak var foo7: SomeClass? { // Okay
+    return SomeClass()
+  }
+
+  unowned var foo8: SomeClass { // Okay
+    return SomeClass()
+  }
+
+  weak var foo9: SomeClass? { // Okay
+    return nil
+  }
+}
+

--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -103,7 +103,7 @@ mirrors.test("struct/StructHasNativeWeakReference") {
 import Foundation
 
 @objc protocol ObjCClassExistential : class {
-  weak var weakProperty: AnyObject? { get set }
+  var weakProperty: AnyObject? { get set }
   var x: Int { get }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is an implementation of a draft Swift Evolution proposal [apple/swift-evolution#707](https://github.com/apple/swift-evolution/pull/707) to remove support for 'weak' and 'unowned' keywords for property declarations in protocols.

[As suggested](https://github.com/apple/swift-evolution/pull/707#issuecomment-321391004) on the evolution pull request this implementation warns in existing Swift 3 and 4 modes and offers a fixit to remove the keyword. For Swift 5 mode it errors and of course also offers a fixit.

I'm new to contributing to Swift, I'm happy to take feedback and any direction to improve the implementation or proposal.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-479](https://bugs.swift.org/browse/SR-479).