### PR TITLE
[silgen] Split the Base emission code out of visitRec into their own …

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2025,37 +2025,33 @@ LValue SILGenFunction::emitLValue(Expr *e, AccessKind accessKind,
   return r;
 }
 
-LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
-                              LValueOptions options,
-                              AbstractionPattern orig) {
-  // First see if we have an lvalue type. If we do, then quickly handle that and
-  // return.
-  if (e->getType()->is<LValueType>() || e->isSemanticallyInOutExpr()) {
-    auto lv = visit(e, accessKind, options);
-    // If necessary, handle reabstraction with a SubstToOrigComponent that
-    // handles
-    // writeback in the original representation.
-    if (orig.isValid()) {
-      auto &origTL = SGF.getTypeLowering(orig, e->getType()->getRValueType());
-      if (lv.getTypeOfRValue() != origTL.getLoweredType().getObjectType())
-        lv.addSubstToOrigComponent(orig,
-                                   origTL.getLoweredType().getObjectType());
-    }
-    return lv;
+static LValue visitRecInOut(SILGenLValue &SGL, Expr *e, AccessKind accessKind,
+                            LValueOptions options, AbstractionPattern orig) {
+  auto lv = SGL.visit(e, accessKind, options);
+  // If necessary, handle reabstraction with a SubstToOrigComponent that handles
+  // writeback in the original representation.
+  if (orig.isValid()) {
+    auto &origTL = SGL.SGF.getTypeLowering(orig, e->getType()->getRValueType());
+    if (lv.getTypeOfRValue() != origTL.getLoweredType().getObjectType())
+      lv.addSubstToOrigComponent(orig, origTL.getLoweredType().getObjectType());
   }
 
-  // Otherwise we have a non-lvalue type (references, values, metatypes,
-  // etc). These act as the root of a logical lvalue.
-  SGFContext Ctx;
-  ManagedValue rv;
+  return lv;
+}
 
-  // Calls through opaque protocols can be done with +0 rvalues.  This allows
-  // us to avoid materializing copies of existentials.
-  if (SGF.SGM.Types.isIndirectPlusZeroSelfParameter(e->getType()))
-    Ctx = SGFContext::AllowGuaranteedPlusZero;
-  else if (auto *DRE = dyn_cast<DeclRefExpr>(e)) {
+// Otherwise we have a non-lvalue type (references, values, metatypes,
+// etc). These act as the root of a logical lvalue.
+static ManagedValue visitRecNonInOutBase(SILGenLValue &SGL, Expr *e,
+                                         AccessKind accessKind,
+                                         LValueOptions options,
+                                         AbstractionPattern orig) {
+  SGFContext ctx;
+  auto &SGF = SGL.SGF;
+
+  if (auto *DRE = dyn_cast<DeclRefExpr>(e)) {
     // Any reference to "self" can be done at +0 so long as it is a direct
     // access, since we know it is guaranteed.
+    //
     // TODO: it would be great to factor this even lower into SILGen to the
     // point where we can see that the parameter is +0 guaranteed.  Note that
     // this handles the case in initializers where there is actually a stack
@@ -2063,7 +2059,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
     if (isa<ParamDecl>(DRE->getDecl()) &&
         DRE->getDecl()->getFullName() == SGF.getASTContext().Id_self &&
         DRE->getDecl()->isImplicit()) {
-      Ctx = SGFContext::AllowGuaranteedPlusZero;
+      ctx = SGFContext::AllowGuaranteedPlusZero;
       if (SGF.SelfInitDelegationState != SILGenFunction::NormalSelf) {
         // This needs to be inlined since there is a Formal Evaluation Scope
         // in emitRValueForDecl that causing any borrow for this LValue to be
@@ -2072,30 +2068,51 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
         ManagedValue selfLValue =
             SGF.emitLValueForDecl(DRE, vd, DRE->getType()->getCanonicalType(),
                                   AccessKind::Read, DRE->getAccessSemantics());
-        rv = SGF.emitFormalEvaluationRValueForSelfInDelegationInit(
-                    e, DRE->getType()->getCanonicalType(),
-                    selfLValue.getLValueAddress(), Ctx)
-                 .getScalarValue();
+        return SGF
+            .emitFormalEvaluationRValueForSelfInDelegationInit(
+                e, DRE->getType()->getCanonicalType(),
+                selfLValue.getLValueAddress(), ctx)
+            .getAsSingleValue(SGF, e);
       }
-    } else if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+    }
+
+    if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
       // All let values are guaranteed to be held alive across their lifetime,
       // and won't change once initialized.  Any loaded value is good for the
       // duration of this expression evaluation.
-      if (VD->isLet())
-        Ctx = SGFContext::AllowGuaranteedPlusZero;
+      if (VD->isLet()) {
+        ctx = SGFContext::AllowGuaranteedPlusZero;
+      }
     }
   }
 
-  if (!rv) {
-    // For an rvalue base, apply the reabstraction (if any) eagerly, since
-    // there's no need for writeback.
-    if (orig.isValid())
-      rv = SGF.emitRValueAsOrig(
-          e, orig, SGF.getTypeLowering(orig, e->getType()->getRValueType()));
-    else
-      rv = SGF.emitRValueAsSingleValue(e, Ctx);
+  if (SGF.SGM.Types.isIndirectPlusZeroSelfParameter(e->getType())) {
+    ctx = SGFContext::AllowGuaranteedPlusZero;
   }
 
+  // For an rvalue base, apply the reabstraction (if any) eagerly, since
+  // there's no need for writeback.
+  if (orig.isValid()) {
+    return SGF.emitRValueAsOrig(
+        e, orig, SGF.getTypeLowering(orig, e->getType()->getRValueType()));
+  }
+
+  // Otherwise, just go through normal emission.
+  return SGF.emitRValueAsSingleValue(e, ctx);
+}
+
+LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
+                              LValueOptions options, AbstractionPattern orig) {
+  // First see if we have an lvalue type. If we do, then quickly handle that and
+  // return.
+  if (e->getType()->is<LValueType>() || e->isSemanticallyInOutExpr()) {
+    return visitRecInOut(*this, e, accessKind, options, orig);
+  }
+
+  // Otherwise we have a non-lvalue type (references, values, metatypes,
+  // etc). These act as the root of a logical lvalue. Compute the root value,
+  // wrap it in a ValueComponent, and return it for our caller.
+  ManagedValue rv = visitRecNonInOutBase(*this, e, accessKind, options, orig);
   CanType formalType = getSubstFormalRValueType(e);
   auto typeData = getValueTypeData(formalType, rv.getValue());
   LValue lv;


### PR DESCRIPTION
…helper functions.

It makes the code easier to read.