### PR TITLE
[stdlib] Put new standard operators in the right place [NFC]

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -74,11 +74,6 @@ public typealias IntMax = ${IntMax}
 @available(swift, obsoleted: 4.0, renamed: "${UIntMax}")
 public typealias UIntMax = ${UIntMax}
 
-infix operator &<< : BitwiseShiftPrecedence
-infix operator &<<= : AssignmentPrecedence
-infix operator &>> : BitwiseShiftPrecedence
-infix operator &>>= : AssignmentPrecedence
-
 //===----------------------------------------------------------------------===//
 //===--- Bits for the Stdlib ----------------------------------------------===//
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -602,6 +602,7 @@ precedencegroup BitwiseShiftPrecedence {
 // Standard postfix operators.
 postfix operator ++
 postfix operator --
+postfix operator ...
 
 // Optional<T> unwrapping operator is built into the compiler as a part of
 // postfix expression grammar.
@@ -615,13 +616,17 @@ prefix operator !
 prefix operator ~
 prefix operator +
 prefix operator -
+prefix operator ...
+prefix operator ..<
 
 // Standard infix operators.
 
 // "Exponentiative"
 
-infix operator << : BitwiseShiftPrecedence
-infix operator >> : BitwiseShiftPrecedence
+infix operator  << : BitwiseShiftPrecedence
+infix operator &<< : BitwiseShiftPrecedence
+infix operator  >> : BitwiseShiftPrecedence
+infix operator &>> : BitwiseShiftPrecedence
 
 // "Multiplicative"
 
@@ -643,15 +648,13 @@ infix operator   ^ : AdditionPrecedence
 // FIXME: is this the right precedence level for "..." ?
 infix operator  ... : RangeFormationPrecedence
 infix operator  ..< : RangeFormationPrecedence
-postfix operator ...
-prefix operator ...
-prefix operator ..<
 
 // The cast operators 'as' and 'is' are hardcoded as if they had the
 // following attributes:
 // infix operator as : CastingPrecedence
 
 // "Coalescing"
+
 infix operator ?? : NilCoalescingPrecedence
 
 // "Comparative"
@@ -675,7 +678,6 @@ infix operator && : LogicalConjunctionPrecedence
 
 infix operator || : LogicalDisjunctionPrecedence
 
-
 // User-defined ternary operators are not supported. The ? : operator is
 // hardcoded as if it had the following attributes:
 // operator ternary ? : : TernaryPrecedence
@@ -686,16 +688,18 @@ infix operator || : LogicalDisjunctionPrecedence
 
 // Compound
 
-infix operator  *= : AssignmentPrecedence
-infix operator  /= : AssignmentPrecedence
-infix operator  %= : AssignmentPrecedence
-infix operator  += : AssignmentPrecedence
-infix operator  -= : AssignmentPrecedence
-infix operator <<= : AssignmentPrecedence
-infix operator >>= : AssignmentPrecedence
-infix operator  &= : AssignmentPrecedence
-infix operator  ^= : AssignmentPrecedence
-infix operator  |= : AssignmentPrecedence
+infix operator   *= : AssignmentPrecedence
+infix operator   /= : AssignmentPrecedence
+infix operator   %= : AssignmentPrecedence
+infix operator   += : AssignmentPrecedence
+infix operator   -= : AssignmentPrecedence
+infix operator  <<= : AssignmentPrecedence
+infix operator &<<= : AssignmentPrecedence
+infix operator  >>= : AssignmentPrecedence
+infix operator &>>= : AssignmentPrecedence
+infix operator   &= : AssignmentPrecedence
+infix operator   ^= : AssignmentPrecedence
+infix operator   |= : AssignmentPrecedence
 
 // Workaround for <rdar://problem/14011860> SubTLF: Default
 // implementations in protocols.  Library authors should ensure


### PR DESCRIPTION
While browsing through the new integer protocols, I noticed that four new operators (e.g., `&<<`) are defined in that file, even though all other standard operators are defined in `Policy.swift`.

This PR moves these four new standard operators to `Policy.swift`. While we're there, we move the new prefix and postfix range operators up a few lines to their respective proper sections.

Although cosmetic, this change serves to restore the original design where all operator definitions are collected in one file in a self-documenting order.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
