### PR TITLE
[WIP] [ConstraintSolver] Prioritize certain type variables while looking for bindings

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2553,9 +2553,6 @@ private:
     /// The number of defaultable bindings.
     unsigned NumDefaultableBindings = 0;
 
-    /// Is this type variable on the RHS of a BindParam constraint?
-    bool IsRHSOfBindParam = false;
-
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
 
@@ -2568,14 +2565,12 @@ private:
     /// \c x is a better set of bindings that \c y.
     friend bool operator<(const PotentialBindings &x,
                           const PotentialBindings &y) {
-      return std::make_tuple(!x.hasNonDefaultableBindings(),
-                             x.FullyBound, x.IsRHSOfBindParam,
+      return std::make_tuple(!x.hasNonDefaultableBindings(), x.FullyBound,
                              x.SubtypeOfExistentialType,
                              static_cast<unsigned char>(x.LiteralBinding),
                              x.InvolvesTypeVariables,
                              -(x.Bindings.size() - x.NumDefaultableBindings)) <
-             std::make_tuple(!y.hasNonDefaultableBindings(),
-                             y.FullyBound, y.IsRHSOfBindParam,
+             std::make_tuple(!y.hasNonDefaultableBindings(), y.FullyBound,
                              y.SubtypeOfExistentialType,
                              static_cast<unsigned char>(y.LiteralBinding),
                              y.InvolvesTypeVariables,

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -504,3 +504,21 @@ func rdar27700622<E: Comparable>(_ input: [E]) -> [E] {
 
   return rdar27700622(lhs) + [pivot] + rdar27700622(rhs) // Ok
 }
+
+// rdar://problem/22898292 - Type inference failure with constrained subclass
+public protocol P_22898292 {}
+public func init_22898292<T: P_22898292>(_ construct: () -> T) -> T {}
+
+class C_22898292 { init() {} }
+class S_22898292 : C_22898292 { override init() {} }
+
+extension S_22898292: P_22898292 {}
+
+func foo_22898292(_ expr: String) -> S_22898292 {}
+func bar_22898292(_ name: String, _ value: C_22898292) {}
+
+func rdar_22898292() {
+  let x = init_22898292 { foo_22898292("B") } // returns S_22898292
+  bar_22898292("A", x) // Ok
+  bar_22898292("A", init_22898292 { foo_22898292("B") }) // Ok
+}


### PR DESCRIPTION
Presence of some constraints (BindParam/Subtype at least) requires
a certain contextual ranking of the type variables associated
with them when it comes to picking bindings, otherwise it might
lead to no or invalid solutions, because only a set of the bindings
for the best type variable is attempted.

Resolves: rdar://problem/22898292

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
