### PR TITLE
[SourceKit] Add range for attributes in a structure (SR-5587)

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -671,7 +671,7 @@ ObjCAttr *ObjCAttr::createNullary(ASTContext &Ctx, SourceLoc AtLoc,
                                   SourceLoc NameLoc, Identifier Name,
                                   SourceLoc RParenLoc) {
   void *mem = Ctx.Allocate(totalSizeToAlloc<SourceLoc>(3), alignof(ObjCAttr));
-  return new (mem) ObjCAttr(AtLoc, SourceRange(ObjCLoc),
+  return new (mem) ObjCAttr(AtLoc, SourceRange(ObjCLoc, RParenLoc),
                             ObjCSelector(Ctx, 0, Name),
                             SourceRange(LParenLoc, RParenLoc),
                             NameLoc);
@@ -690,7 +690,7 @@ ObjCAttr *ObjCAttr::createSelector(ASTContext &Ctx, SourceLoc AtLoc,
   assert(NameLocs.size() == Names.size());
   void *mem = Ctx.Allocate(totalSizeToAlloc<SourceLoc>(NameLocs.size() + 2),
                            alignof(ObjCAttr));
-  return new (mem) ObjCAttr(AtLoc, SourceRange(ObjCLoc),
+  return new (mem) ObjCAttr(AtLoc, SourceRange(ObjCLoc, RParenLoc),
                             ObjCSelector(Ctx, Names.size(), Names),
                             SourceRange(LParenLoc, RParenLoc),
                             NameLocs);

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1000,7 +1000,7 @@
       key.attributes: [
         {
           key.offset: 1474,
-          key.length: 5,
+          key.length: 11,
           key.attribute: source.decl.attribute.objc.name
         }
       ],
@@ -1025,7 +1025,7 @@
           key.attributes: [
             {
               key.offset: 1524,
-              key.length: 5,
+              key.length: 10,
               key.attribute: source.decl.attribute.objc.name
             }
           ]

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -50,6 +50,8 @@
           key.namelength: 10,
           key.attributes: [
             {
+              key.offset: 41,
+              key.length: 9,
               key.attribute: source.decl.attribute.iboutlet
             }
           ]
@@ -105,6 +107,8 @@
           key.bodylength: 5,
           key.attributes: [
             {
+              key.offset: 136,
+              key.length: 9,
               key.attribute: source.decl.attribute.ibaction
             }
           ]
@@ -124,6 +128,8 @@
       key.bodylength: 0,
       key.attributes: [
         {
+          key.offset: 175,
+          key.length: 13,
           key.attribute: source.decl.attribute.ibdesignable
         }
       ]
@@ -152,6 +158,8 @@
           key.namelength: 17,
           key.attributes: [
             {
+              key.offset: 221,
+              key.length: 14,
               key.attribute: source.decl.attribute.ibinspectable
             }
           ]
@@ -168,6 +176,8 @@
           key.namelength: 17,
           key.attributes: [
             {
+              key.offset: 268,
+              key.length: 14,
               key.attribute: source.decl.attribute.gkinspectable
             }
           ]
@@ -938,6 +948,8 @@
       ],
       key.attributes: [
         {
+          key.offset: 1406,
+          key.length: 5,
           key.attribute: source.decl.attribute.objc
         }
       ],
@@ -961,6 +973,8 @@
           key.bodylength: 0,
           key.attributes: [
             {
+              key.offset: 1449,
+              key.length: 5,
               key.attribute: source.decl.attribute.objc
             }
           ]
@@ -985,6 +999,8 @@
       ],
       key.attributes: [
         {
+          key.offset: 1474,
+          key.length: 5,
           key.attribute: source.decl.attribute.objc.name
         }
       ],
@@ -1008,6 +1024,8 @@
           key.bodylength: 0,
           key.attributes: [
             {
+              key.offset: 1524,
+              key.length: 5,
               key.attribute: source.decl.attribute.objc.name
             }
           ]

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -5380,6 +5380,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 21,
         key.attributes: [
           {
+            key.offset: 3991,
+            key.length: 11,
             key.attribute: source.decl.attribute.convenience
           }
         ],
@@ -5975,6 +5977,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 10,
         key.attributes: [
           {
+            key.offset: 6061,
+            key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
         ]
@@ -5991,6 +5995,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 16,
         key.attributes: [
           {
+            key.offset: 6114,
+            key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
         ]
@@ -6040,6 +6046,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 7,
         key.attributes: [
           {
+            key.offset: 6263,
+            key.length: 4,
             key.attribute: source.decl.attribute.weak
           }
         ]
@@ -6091,6 +6099,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 19,
         key.attributes: [
           {
+            key.offset: 6390,
+            key.length: 11,
             key.attribute: source.decl.attribute.convenience
           }
         ],
@@ -6116,6 +6126,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 12,
         key.attributes: [
           {
+            key.offset: 6432,
+            key.length: 39,
             key.attribute: source.decl.attribute.available
           }
         ]
@@ -6130,6 +6142,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 24,
         key.attributes: [
           {
+            key.offset: 6509,
+            key.length: 23,
             key.attribute: source.decl.attribute.available
           }
         ]
@@ -6144,6 +6158,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 27,
         key.attributes: [
           {
+            key.offset: 6582,
+            key.length: 47,
             key.attribute: source.decl.attribute.available
           }
         ]
@@ -6179,6 +6195,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
+        key.offset: 6703,
+        key.length: 63,
         key.attribute: source.decl.attribute.available
       }
     ],
@@ -6285,6 +6303,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 3,
         key.attributes: [
           {
+            key.offset: 7094,
+            key.length: 8,
             key.attribute: source.decl.attribute.override
           }
         ]

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -449,6 +449,8 @@ internal enum Colors {
         key.namelength: 3,
         key.attributes: [
           {
+            key.offset: 319,
+            key.length: 8,
             key.attribute: source.decl.attribute.override
           }
         ]

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -204,7 +204,7 @@ enum subject_enum: Int {
   case subject_enumElement2
 
   @objc(subject_enumElement3)
-  case subject_enumElement3, subject_enumElement4 // expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-8=}}
+  case subject_enumElement3, subject_enumElement4 // expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-30=}}
 
   @objc   // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement5, subject_enumElement6
@@ -221,7 +221,7 @@ enum subject_enum: Int {
 
 enum subject_enum2 {
   @objc(subject_enum2Element1)
-  case subject_enumElement1 // expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-8=}}
+  case subject_enumElement1 // expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-31=}}
 }
 
 @objc
@@ -1839,7 +1839,7 @@ class BadClass2 {
   }
 
   var prop3: Int {
-    @objc(setProperty:) didSet { } // expected-error{{observing accessors are not allowed to be marked @objc}} {{5-10=}}
+    @objc(setProperty:) didSet { } // expected-error{{observing accessors are not allowed to be marked @objc}} {{5-25=}}
   }
 
   @objc

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -218,7 +218,7 @@ public:
                                          StringRef RuntimeName,
                                          StringRef SelectorName,
                                          ArrayRef<StringRef> InheritedTypes,
-                                         ArrayRef<UIdent> Attrs) = 0;
+                                         ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) = 0;
 
   virtual bool endDocumentSubStructure() = 0;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1101,7 +1101,9 @@ public:
                                                     BufferID);
         }
 
-        Attrs.push_back({AttrUID.getValue(), AttrOffset, AttrEnd - AttrOffset});
+        auto AttrTuple = std::make_tuple(AttrUID.getValue(), AttrOffset,
+                                         AttrEnd - AttrOffset);
+        Attrs.push_back(AttrTuple);
       }
     }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1085,7 +1085,25 @@ public:
     SmallString<64> SelectorNameBuf;
     StringRef SelectorName = getObjCSelectorName(Node.Dcl, SelectorNameBuf);
 
-    std::vector<UIdent> Attrs = SwiftLangSupport::UIDsFromDeclAttributes(Node.Attrs);
+    std::vector<std::tuple<UIdent, unsigned, unsigned>> Attrs;
+
+    for (auto Attr : Node.Attrs) {
+      if (auto AttrUID = SwiftLangSupport::getUIDForDeclAttribute(Attr)) {
+        unsigned AttrOffset = 0;
+        unsigned AttrEnd = 0;
+        auto AttrRange = Attr->getRangeWithAt();
+        if (AttrRange.isValid()) {
+          auto CharRange = Lexer::getCharSourceRangeFromSourceRange(SrcManager,
+                                                                    AttrRange);
+          AttrOffset = SrcManager.getLocOffsetInBuffer(CharRange.getStart(),
+                                                       BufferID);
+          AttrEnd = SrcManager.getLocOffsetInBuffer(CharRange.getEnd(),
+                                                    BufferID);
+        }
+
+        Attrs.push_back({AttrUID.getValue(), AttrOffset, AttrEnd - AttrOffset});
+      }
+    }
 
     Consumer.beginDocumentSubStructure(StartOffset, EndOffset - StartOffset,
                                        Kind, AccessLevel, SetterAccessLevel,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -305,6 +305,8 @@ public:
 
   static SourceKit::UIdent getUIDForRefactoringRangeKind(swift::ide::RefactoringRangeKind Kind);
 
+  static Optional<UIdent> getUIDForDeclAttribute(const swift::DeclAttribute *Attr);
+
   static std::vector<UIdent> UIDsFromDeclAttributes(const swift::DeclAttributes &Attrs);
 
   static SourceKit::UIdent getUIDForNameKind(swift::ide::NameKind Kind);

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
@@ -38,7 +38,7 @@ public:
                          llvm::StringRef RuntimeName,
                          llvm::StringRef SelectorName,
                          llvm::ArrayRef<llvm::StringRef> InheritedTypes,
-                         llvm::ArrayRef<SourceKit::UIdent> Attrs);
+                         llvm::ArrayRef<std::tuple<SourceKit::UIdent, unsigned, unsigned>> Attrs);
 
   void addElement(SourceKit::UIdent Kind, unsigned Offset, unsigned Length);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2000,7 +2000,7 @@ public:
                                  StringRef RuntimeName,
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<UIdent> Attrs) override;
+                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override;
 
   bool endDocumentSubStructure() override;
 
@@ -2227,7 +2227,7 @@ SKEditorConsumer::beginDocumentSubStructure(unsigned Offset,
                                             StringRef RuntimeName,
                                             StringRef SelectorName,
                                             ArrayRef<StringRef> InheritedTypes,
-                                            ArrayRef<UIdent> Attrs) {
+                                            ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) {
   if (EnableStructure) {
     DocStructure.beginSubStructure(
         Offset, Length, Kind, AccessLevel, SetterAccessLevel, NameOffset,

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -59,7 +59,7 @@ class NullEditorConsumer : public EditorConsumer {
                                  StringRef RuntimeName,
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<UIdent> Attrs) override {
+                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
     return false;
   }
 

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -64,7 +64,7 @@ private:
                                  StringRef RuntimeName,
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<UIdent> Attrs) override {
+                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
     return false;
   }
 


### PR DESCRIPTION
Adds `key.offset` and `key.length` for attributes in `key.attributes`. The SourceKit part of this PR is working already.

~However, it looks like the parser currently doesn't provide the range for most attributes (all `SimpleDeclAttr`, `ObjCAttr` and probably others).~

~For example, for this program:~

```swift
@available(swift 3.0.2)
@objc(Bar) @IBDesignable final class Foo {
  
}
```

~I get this structure:~

```
{
  key.offset: 0,
  key.length: 72,
  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
  key.substructure: [
    {
      key.kind: source.lang.swift.decl.class,
      key.accessibility: source.lang.swift.accessibility.internal,
      key.name: "Foo",
      key.offset: 55,
      key.length: 16,
      key.runtime_name: "Bar",
      key.nameoffset: 61,
      key.namelength: 3,
      key.bodyoffset: 66,
      key.bodylength: 4,
      key.attributes: [
        {
          key.offset: 49,
          key.length: 0,
          key.attribute: source.decl.attribute.final
        },
        {
          key.offset: 35,
          key.length: 1,
          key.attribute: source.decl.attribute.ibdesignable
        },
        {
          key.offset: 24,
          key.length: 1,
          key.attribute: source.decl.attribute.objc.name
        },
        {
          key.offset: 0,
          key.length: 22,
          key.attribute: source.decl.attribute.available
        }
      ]
    }
  ]
}
```

~Note that only the only length that is correct is the one from `source.decl.attribute.available`.~

~I've looked into changing the parser, but that's a bigger change and I want some input if that'd be desirable in the first place. Some advice on how to do that would be great as well. I think the place that I would need to change is `bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc, DeclAttrKind DK)` in `ParseDecl.cpp`.~


Resolves [SR-5587](https://bugs.swift.org/browse/SR-5587).

// cc @nkcsgexi for advice