### PR TITLE
 [GSB]  Rework nested-type-name-match constraints.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1703,6 +1703,12 @@ public:
   UnresolvedType lhs;
   RequirementRHS rhs;
   FloatingRequirementSource source;
+
+  /// Dump a debugging representation of this delayed requirement class.
+  void dump(llvm::raw_ostream &out) const;
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
+                            "only for use in the debugger");
 };
 
 /// Whether the given constraint result signals an error.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1460,10 +1460,12 @@ class GenericSignatureBuilder::PotentialArchetype {
   {
   }
 
+public:
   /// \brief Retrieve the representative for this archetype, performing
   /// path compression on the way.
   PotentialArchetype *getRepresentative() const;
 
+private:
   /// Retrieve the generic signature builder with which this archetype is
   /// associated.
   GenericSignatureBuilder *getBuilder() const {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -316,6 +316,14 @@ private:
                                              ProtocolDecl *Proto,
                                              const RequirementSource *Source);
 
+  /// "Expand" the conformance of the given \c pa to the protocol \c proto,
+  /// adding the requirements from its requirement signature, rooted at
+  /// the given requirement \c source.
+  ConstraintResult expandConformanceRequirement(
+                                      PotentialArchetype *pa,
+                                      ProtocolDecl *proto,
+                                      const RequirementSource *source);
+
 public:
   /// \brief Add a new same-type requirement between two fully resolved types
   /// (output of \c GenericSignatureBuilder::resolve).

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -316,15 +316,16 @@ private:
                                              ProtocolDecl *Proto,
                                              const RequirementSource *Source);
 
+public:
   /// "Expand" the conformance of the given \c pa to the protocol \c proto,
   /// adding the requirements from its requirement signature, rooted at
   /// the given requirement \c source.
   ConstraintResult expandConformanceRequirement(
                                       PotentialArchetype *pa,
                                       ProtocolDecl *proto,
-                                      const RequirementSource *source);
+                                      const RequirementSource *source,
+                                      bool onlySameTypeConstraints);
 
-public:
   /// \brief Add a new same-type requirement between two fully resolved types
   /// (output of \c GenericSignatureBuilder::resolve).
   ///
@@ -832,6 +833,11 @@ public:
     /// A requirement that was resolved based on structural derivation from
     /// another requirement.
     Derived,
+
+    /// A requirement that was provided for another potential archetype in the
+    /// same equivalence class, but which we want to "re-root" on a new
+    /// potential archetype.
+    EquivalentType,
   };
 
   /// The kind of requirement source.
@@ -890,6 +896,7 @@ private:
     case Parent:
     case Concrete:
     case Derived:
+    case EquivalentType:
       return 0;
     }
 
@@ -935,6 +942,7 @@ private:
     case Parent:
     case Concrete:
     case Derived:
+    case EquivalentType:
       return false;
     }
 
@@ -1019,6 +1027,18 @@ public:
            "RequirementSource kind/storageKind mismatch");
   }
 
+  RequirementSource(Kind kind, const RequirementSource *parent,
+                    PotentialArchetype *newPA)
+    : kind(kind), storageKind(StorageKind::RootArchetype),
+      hasTrailingWrittenRequirementLoc(false),
+      usesRequirementSignature(false), parent(parent) {
+    assert((static_cast<bool>(parent) != isRootKind(kind)) &&
+           "Root RequirementSource should not have parent (or vice versa)");
+    assert(isAcceptableStorageKind(kind, storageKind) &&
+           "RequirementSource kind/storageKind mismatch");
+    storage.rootArchetype = newPA;
+  }
+
 public:
   /// Retrieve an abstract requirement source.
   static const RequirementSource *forAbstract(PotentialArchetype *root);
@@ -1083,6 +1103,11 @@ public:
   /// A constraint source that describes a constraint that is structurally
   /// derived from another constraint but does not require further information.
   const RequirementSource *viaDerived(GenericSignatureBuilder &builder) const;
+
+  /// A constraint source that describes a constraint that is structurally
+  /// derived from another constraint but does not require further information.
+  const RequirementSource *viaEquivalentType(GenericSignatureBuilder &builder,
+                                             PotentialArchetype *newPA) const;
 
   /// Form a new requirement source without the subpath [start, end).
   ///

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5356,6 +5356,53 @@ static void collapseSameTypeComponentsThroughDelayedRequirements(
                          collapsedParents.end());
 }
 
+/// Check whether two potential archetypes "structurally" match, e.g.,
+/// the names match up to the root (which must match).
+static bool potentialArchetypesStructurallyMatch(PotentialArchetype *pa1,
+                                                 PotentialArchetype *pa2) {
+  auto parent1 = pa1->getParent();
+  auto parent2 = pa2->getParent();
+  if (!parent1 && !parent2)
+    return pa1->getGenericParamKey() == pa2->getGenericParamKey();
+
+  // Check for depth mismatch.
+  if (static_cast<bool>(parent1) != static_cast<bool>(parent2))
+    return false;
+
+  // Check names.
+  if (pa1->getNestedName() != pa2->getNestedName())
+    return false;
+
+  return potentialArchetypesStructurallyMatch(parent1, parent2);
+}
+
+/// Look for structurally-equivalent types within the given equivalence class,
+/// collapsing their components.
+static void collapseStructurallyEquivalentSameTypeComponents(
+              EquivalenceClass *equivClass,
+              llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
+              SmallVectorImpl<unsigned> &collapsedParents,
+              unsigned &remainingComponents) {
+  for (unsigned i : indices(equivClass->members)) {
+    auto pa1 = equivClass->members[i];
+    auto rep1 = findRepresentative(collapsedParents, componentOf[pa1]);
+    for (unsigned j : indices(equivClass->members).slice(i + 1)) {
+      auto pa2 = equivClass->members[j];
+      auto rep2 = findRepresentative(collapsedParents, componentOf[pa2]);
+      if (rep1 == rep2) continue;
+
+      auto depth = pa1->getNestingDepth();
+      if (depth < 2 || depth != pa2->getNestingDepth()) continue;
+
+      if (potentialArchetypesStructurallyMatch(pa1, pa2) &&
+          unionSets(collapsedParents, rep1, rep2)) {
+        --remainingComponents;
+        rep1 = findRepresentative(collapsedParents, componentOf[pa1]);
+      }
+    }
+  }
+}
+
 /// Collapse same-type components within an equivalence class, minimizing the
 /// number of requirements required to express the equivalence class.
 static void collapseSameTypeComponents(
@@ -5410,9 +5457,19 @@ static void collapseSameTypeComponents(
       --remainingComponents;
   }
 
-  // Collapse same-type components by looking at the delayed requirements.
-  collapseSameTypeComponentsThroughDelayedRequirements(
+  if (remainingComponents > 1) {
+    // Collapse same-type components by looking at the delayed requirements.
+    collapseSameTypeComponentsThroughDelayedRequirements(
       builder, equivClass, componentOf, collapsedParents, remainingComponents);
+  }
+
+  if (remainingComponents > 1) {
+    // Collapse structurally-equivalent components.
+    collapseStructurallyEquivalentSameTypeComponents(equivClass,
+                                                     componentOf,
+                                                     collapsedParents,
+                                                     remainingComponents);
+  }
 
   // If needed, collapse the same-type components merged by a derived
   // nested-type-name-match edge.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -455,6 +455,7 @@ bool RequirementSource::isInferredRequirement(bool includeQuietInferred) const {
       return true;
 
     case QuietlyInferred:
+    case NestedTypeNameMatch:
       return includeQuietInferred;
 
     case ConcreteTypeBinding:
@@ -462,7 +463,6 @@ bool RequirementSource::isInferredRequirement(bool includeQuietInferred) const {
 
     case Concrete:
     case Explicit:
-    case NestedTypeNameMatch:
     case Parent:
     case ProtocolRequirement:
     case RequirementSignatureSelf:
@@ -3468,11 +3468,10 @@ void GenericSignatureBuilder::addedNestedType(PotentialArchetype *nestedPA) {
   assert(allNested.back() == nestedPA);
   if (allNested.size() > 1) {
     auto firstPA = allNested.front();
-    auto sameNamedSource =
-      FloatingRequirementSource::forNestedTypeNameMatch(
-                                                nestedPA->getNestedName());
+    auto quietlyInferredSource =
+      FloatingRequirementSource::forInferred(nullptr, /*quietly=*/true);
 
-    addSameTypeRequirement(firstPA, nestedPA, sameNamedSource,
+    addSameTypeRequirement(firstPA, nestedPA, quietlyInferredSource,
                            UnresolvedHandlingKind::GenerateConstraints);
     return;
   }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5181,10 +5181,15 @@ static unsigned findRepresentative(SmallVectorImpl<unsigned> &parents,
 
 /// Union the same-type components denoted by \c index1 and \c index2.
 ///
+/// \param successThreshold Returns true when two sets have been joined
+/// and both representatives are below the threshold. The default of 0
+/// is equivalent to \c successThreshold == parents.size().
+///
 /// \returns \c true if the two components were separate and have now
 /// been joined; \c false if they were already in the same set.
 static bool unionSets(SmallVectorImpl<unsigned> &parents,
-                      unsigned index1, unsigned index2) {
+                      unsigned index1, unsigned index2,
+                      unsigned successThreshold = 0) {
   // Find the representatives of each component class.
   unsigned rep1 = findRepresentative(parents, index1);
   unsigned rep2 = findRepresentative(parents, index2);
@@ -5196,9 +5201,12 @@ static bool unionSets(SmallVectorImpl<unsigned> &parents,
   else
     parents[rep1] = rep2;
 
-  return true;
+  return (successThreshold == 0) ||
+    (rep1 < successThreshold && rep2 < successThreshold);
 }
 
+/// Determine whether the removal of the given edge will disconnect the
+/// nodes \c from and \c to within the given equivalence class.
 static bool removalDisconnectsEquivalenceClass(
                EquivalenceClass *equivClass,
                llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
@@ -5266,13 +5274,99 @@ static bool isSelfDerivedNestedTypeNameMatchEdge(
   return false;
 }
 
-static void resolveSameTypeEdges(
+/// Collapse same-type components using the "delayed" requirements of the
+/// equivalence class.
+///
+/// This operation looks through the delayed requirements within the equivalence
+/// class to find paths that connect existing potential archetypes.
+static void collapseSameTypeComponentsThroughDelayedRequirements(
+              GenericSignatureBuilder &builder,
+              EquivalenceClass *equivClass,
+              llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
+              SmallVectorImpl<unsigned> &collapsedParents,
+              unsigned &remainingComponents) {
+  unsigned numCollapsedParents = collapsedParents.size();
+
+  /// "Virtual" components for types that aren't resolve to potential
+  /// archetypes.
+  llvm::SmallDenseMap<CanType, unsigned> virtualComponents;
+
+  /// Retrieve the component for a type representing a virtual component
+  auto getTypeVirtualComponent = [&](Type type) {
+    CanType canType = type->getCanonicalType();
+    auto knownVirtual = virtualComponents.find(canType);
+    if (knownVirtual != virtualComponents.end())
+      return knownVirtual->second;
+
+    unsigned component = collapsedParents.size();
+    collapsedParents.push_back(component);
+    virtualComponents[canType] = component;
+    return component;
+  };
+
+  /// Retrieve the component for the given potential archetype.
+  auto getPotentialArchetypeVirtualComponent = [&](PotentialArchetype *pa) {
+    if (pa->getEquivalenceClassIfPresent() == equivClass)
+      return componentOf[pa];
+
+    // We found a potential archetype in another equivalence class. Treat it
+    // as a "virtual" component representing that potential archetype's
+    // equivalence class.
+    return getTypeVirtualComponent(
+                             pa->getRepresentative()->getDependentType({ }));
+  };
+
+  /// Local function to retrieve the component with which the given type is
+  /// associated, for a type that we haven't tried to resolve yet.
+  auto getUnknownTypeVirtualComponent = [&](Type type) {
+    if (auto pa =
+            builder.resolveArchetype(type,
+                                     ArchetypeResolutionKind::AlreadyKnown))
+      return getPotentialArchetypeVirtualComponent(pa);
+
+    return getTypeVirtualComponent(type);
+  };
+
+  for (const auto &delayedReq : equivClass->delayedRequirements) {
+    // Only consider same-type requirements.
+    if (delayedReq.kind != DelayedRequirement::SameType) continue;
+
+    unsigned lhsComponent;
+    if (auto lhsPA = delayedReq.lhs.dyn_cast<PotentialArchetype *>())
+      lhsComponent = getPotentialArchetypeVirtualComponent(lhsPA);
+    else
+      lhsComponent = getUnknownTypeVirtualComponent(delayedReq.lhs.get<Type>());
+
+    unsigned rhsComponent;
+    if (auto rhsPA = delayedReq.rhs.dyn_cast<PotentialArchetype *>())
+      rhsComponent = getPotentialArchetypeVirtualComponent(rhsPA);
+    else
+      rhsComponent = getUnknownTypeVirtualComponent(delayedReq.rhs.get<Type>());
+
+    // Collapse the sets
+    if (unionSets(collapsedParents, lhsComponent, rhsComponent,
+                  numCollapsedParents) &&
+        lhsComponent < numCollapsedParents &&
+        rhsComponent < numCollapsedParents)
+      --remainingComponents;
+  }
+
+  /// Remove any additional collapsed parents we added.
+  collapsedParents.erase(collapsedParents.begin() + numCollapsedParents,
+                         collapsedParents.end());
+}
+
+/// Collapse same-type components within an equivalence class, minimizing the
+/// number of requirements required to express the equivalence class.
+static void collapseSameTypeComponents(
+              GenericSignatureBuilder &builder,
               EquivalenceClass *equivClass,
               llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
               std::vector<IntercomponentEdge> &sameTypeEdges) {
   SmallVector<unsigned, 4> collapsedParents;
-  for (unsigned i : indices(equivClass->derivedSameTypeComponents))
+  for (unsigned i : indices(equivClass->derivedSameTypeComponents)) {
     collapsedParents.push_back(i);
+  }
 
   unsigned remainingComponents = equivClass->derivedSameTypeComponents.size();
   for (unsigned edgeIndex : indices(sameTypeEdges)) {
@@ -5315,6 +5409,10 @@ static void resolveSameTypeEdges(
     if (unionSets(collapsedParents, edge.source, edge.target))
       --remainingComponents;
   }
+
+  // Collapse same-type components by looking at the delayed requirements.
+  collapseSameTypeComponentsThroughDelayedRequirements(
+      builder, equivClass, componentOf, collapsedParents, remainingComponents);
 
   // If needed, collapse the same-type components merged by a derived
   // nested-type-name-match edge.
@@ -5589,7 +5687,8 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
     }
   }
 
-  resolveSameTypeEdges(equivClass, componentOf, nestedTypeNameMatchEdges);
+  collapseSameTypeComponents(*this, equivClass, componentOf,
+                             nestedTypeNameMatchEdges);
 }
 
 /// Resolve any unresolved dependent member types using the given builder.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5083,7 +5083,6 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
 
       // Remove derived-via-concrete constraints.
       (void)removeSelfDerived(constraints, /*proto=*/nullptr);
-        anyDerivedViaConcrete = true;
     }
   }
 

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -17,7 +17,7 @@
 
 
 public protocol _UTFParser {
-  associatedtype Encoding : _UnicodeEncoding_
+  associatedtype Encoding : _UnicodeEncoding
 
   func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8)
   func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar

--- a/stdlib/public/core/UnicodeEncoding.swift
+++ b/stdlib/public/core/UnicodeEncoding.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol _UnicodeEncoding_ {
+public protocol _UnicodeEncoding {
   /// The basic unit of encoding
   associatedtype CodeUnit : UnsignedInteger, FixedWidthInteger
   
@@ -44,12 +44,12 @@ public protocol _UnicodeEncoding_ {
   /// A type that can be used to parse `CodeUnits` into
   /// `EncodedScalar`s.
   associatedtype ForwardParser : Unicode.Parser
-  // where ForwardParser.Encoding == Self
+    where ForwardParser.Encoding == Self
   
   /// A type that can be used to parse a reversed sequence of
   /// `CodeUnits` into `EncodedScalar`s.
   associatedtype ReverseParser : Unicode.Parser
-  // where ReverseParser.Encoding == Self
+    where ReverseParser.Encoding == Self
 
   //===--------------------------------------------------------------------===//
   // FIXME: this requirement shouldn't be here and is mitigated by the default
@@ -60,15 +60,10 @@ public protocol _UnicodeEncoding_ {
   static func _isScalar(_ x: CodeUnit) -> Bool
 }
 
-extension _UnicodeEncoding_ {
+extension _UnicodeEncoding {
   // See note on declaration of requirement, above
   public static func _isScalar(_ x: CodeUnit) -> Bool { return false }
-}
 
-public protocol _UnicodeEncoding : _UnicodeEncoding_
-where ForwardParser.Encoding == Self, ReverseParser.Encoding == Self {}
-
-extension _UnicodeEncoding_ {
   public static func transcode<FromEncoding : Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -43,7 +43,7 @@ extension Unicode {
 /// scalar values.
 public protocol _UnicodeParser {
   /// The encoding with which this parser is associated
-  associatedtype Encoding : _UnicodeEncoding_
+  associatedtype Encoding : _UnicodeEncoding
 
   /// Constructs an instance that can be used to begin parsing `CodeUnit`s at
   /// any Unicode scalar boundary.

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -33,16 +33,16 @@ protocol Q2: Q1 {}
 
 // inheritance without any new requirements
 // CHECK-LABEL: .Q3@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q1>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1>
+// CHECK-NEXT: Requirement signature: <Self where Self : Q1, Self.X == Self.X>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1, τ_0_0.X == τ_0_0.X>
 protocol Q3: Q1 {
     associatedtype X // expected-warning{{redeclaration of associated type 'X'}}
 }
 
 // inheritance adding a new conformance
 // CHECK-LABEL: .Q4@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q1, Self.X : P2>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1, τ_0_0.X : P2>
+// CHECK-NEXT: Requirement signature: <Self where Self : Q1, Self.X : P2, Self.X == Self.X>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1, τ_0_0.X : P2, τ_0_0.X == τ_0_0.X>
 protocol Q4: Q1 {
     associatedtype X: P2 // expected-warning{{redeclaration of associated type 'X'}}
                    // expected-note@-1 2{{'X' declared here}}
@@ -56,8 +56,8 @@ protocol Q5: Q2, Q3, Q4 {}
 
 // multiple inheritance without any new requirements
 // CHECK-LABEL: .Q6@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4>
+// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4, Self.X == Self.X>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4, τ_0_0.X == τ_0_0.X>
 protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X': 'P1' implied here}}
              Q3, Q4 {
     associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X': 'P1'}}
@@ -66,8 +66,8 @@ protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X': 'P1' implied
 
 // multiple inheritance with a new conformance
 // CHECK-LABEL: .Q7@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4, Self.X : P3>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4, τ_0_0.X : P3>
+// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4, Self.X : P3, Self.X == Self.X>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4, τ_0_0.X : P3, τ_0_0.X == τ_0_0.X>
 protocol Q7: Q2, Q3, Q4 {
     associatedtype X: P3 // expected-warning{{redeclaration of associated type 'X'}}
 }

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -176,11 +176,11 @@ protocol P10 {
 }
 
 // CHECK-LABEL: sameTypeConcrete1@
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.A == X3, τ_0_0.B == Int, τ_0_0.C == Int>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.A == X3, τ_0_0.A == X3, τ_0_0.B == Int, τ_0_0.C == Int>
 func sameTypeConcrete1<T : P9 & P10>(_: T) where T.A == X3, T.C == T.B, T.C == Int { }
 
 // CHECK-LABEL: sameTypeConcrete2@
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.B == X3, τ_0_0.C == X3>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.A == τ_0_0.A, τ_0_0.B == X3, τ_0_0.C == X3>
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
 // expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
 // expected-note@-2{{same-type constraint 'T.C' == 'X3' written here}}
@@ -188,7 +188,7 @@ func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3
 // Note: a standard-library-based stress test to make sure we don't inject
 // any additional requirements.
 // CHECK-LABEL: RangeReplaceableCollection.f()@
-// CHECK: <τ_0_0 where τ_0_0 : MutableCollection, τ_0_0 : RangeReplaceableCollection, τ_0_0.SubSequence == MutableRangeReplaceableSlice<τ_0_0>>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : MutableCollection, τ_0_0 : RangeReplaceableCollection, τ_0_0.SubSequence == MutableRangeReplaceableSlice<τ_0_0>>
 extension RangeReplaceableCollection where
   Self: MutableCollection,
   Self.SubSequence == MutableRangeReplaceableSlice<Self>
@@ -399,8 +399,25 @@ struct X28 : P2 {
 }
 
 // CHECK-LABEL: .P28@
-// CHECK-NEXT: Requirement signature: <Self where Self : P3>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : P3>
+// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == X28>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : P3, τ_0_0.P3Assoc == X28>
 protocol P28: P3 {
   typealias P3Assoc = X28   // expected-warning{{typealias overriding associated type}}
 }
+
+// ----------------------------------------------------------------------------
+// Inference of associated types by name match
+// ----------------------------------------------------------------------------
+protocol P29 {
+  associatedtype X
+}
+
+protocol P30 {
+  associatedtype X
+}
+
+protocol P31 { }
+
+// CHECK-LABEL: .sameTypeNameMatch1@
+// Generic signature: <T where T : P29, T : P30, T.X : P31, T.X == T.X>
+func sameTypeNameMatch1<T: P29 & P30>(_: T) where T.X: P31 { }

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -50,7 +50,7 @@ protocol Refined : Associated {
 }
 
 extension Refined {
-  // CHECK-LABEL: sil hidden @_T021same_type_abstraction7RefinedPAAEx3KeyQz12withElements_tcfC : $@convention(method) <Self where Self : Refined> (@in Self.Key, @thick Self.Type) -> @out Self
+  // CHECK-LABEL: sil hidden @_T021same_type_abstraction7RefinedPAAEx5AssocQz12withElements_tcfC : $@convention(method) <Self where Self : Refined> (@in Self.Assoc, @thick Self.Type) -> @out Self
   init(withElements newElements: Key) {
     self.init()
   }

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -20,7 +20,7 @@ protocol P1 {
   associatedtype X : P2
 }
 
-// CHECK: P2
+// CHECK-LABEL: .P2@
 // CHECK: Requirement signature: <Self where Self == Self.Y.X, Self.Y : P1, Self.Z : P1>
 protocol P2 {
   associatedtype Y : P1 where Y.X == Self
@@ -32,9 +32,55 @@ protocol P3 {
 	associatedtype X : P4
 }
 
-// CHECK: .P4@
+// CHECK-LABEL: .P4@
 // CHECK: Requirement signature: <Self where Self == Self.Y.X, Self.Y : P3, Self.Z : P3, Self.Y.X == Self.Z.X>
 protocol P4 {
 	associatedtype Y: P3 where Y.X == Self
 	associatedtype Z: P3 where Z.X == Self
+}
+
+protocol P5 {
+  associatedtype X : P5
+    where X.X == X
+}
+
+// CHECK-LABEL: .P6@
+// CHECK: Requirement signature: <Self where Self : P5, Self.Y : P5>
+protocol P6 : P5 {
+  associatedtype Y : P5
+}
+
+// CHECK: Generic signature: <Self where Self : P6, Self.X == Self.Y.X>
+extension P6 where X == Y.X { }
+
+// SR-5601
+protocol P7 {
+    associatedtype X: P9 where X.Q == Self, X.R == UInt8
+    associatedtype Y: P9 where Y.Q == Self, Y.R == UInt16
+    // NOTE: Removing either X or Y from P7 (and A7) makes the program compile.
+}
+struct A7: P7 {
+    typealias X = S9<UInt8>
+    typealias Y = S9<UInt16>
+}
+protocol P8 { }
+protocol P9 : P8 { // NOTE: Removing ": P8 " here makes the program compile.
+    associatedtype Q: P7
+    associatedtype R
+}
+struct S9<E> : P9 {
+    typealias R = E
+    typealias Q = A7
+}
+
+// SR-5610
+protocol P10 {
+  associatedtype X : P11 where X.Q == Self
+}
+protocol P11 {
+  associatedtype Q : P10
+
+  // CHECK-LABEL: .P11.map@
+  // CHECK: Generic signature: <Self, T where Self : P11, T : P11, Self.Q == T.Q>
+  func map<T>(_: T.Type) where T : P11, Q == T.Q
 }


### PR DESCRIPTION
Rework how we handle nested-type-name-match constraints to fix several problems with generic signature minimization involving recursive constraints:

* When the two nested types of a given potential archetype have the same name, introduce a (quietly) inferred constraint rather than considering the equivalence derived. This allows us future growth if we want to stop inferring the constraint, e.g., because two unrelated protocols with same-named associated types need to be composed (which we don't currently support).
* Detect self-derived nested-type-name-match constraints so we can remove them appropriately; without this change, the self-derived constraints would end up squashing important constraints, leaving to incorrect (overly-minimized) generic signatures.
* Improve the computation of connected components for same-type constraints to minimize same-type constraints.
* Kill off one underscored protocol in the standard library (`_UnicodeEncoding_`).

Fixes SR-5841, SR-5601 and SR-5610.
