### PR TITLE
[sil-opaque-values] Fix ownership of enum values.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -371,7 +371,7 @@ public:
   OwnershipUseCheckerResult visitTransformingTerminatorInst(TermInst *TI);
 
   OwnershipUseCheckerResult
-  visitNonTrivialEnum(EnumDecl *E, ValueOwnershipKind RequiredConvention);
+  visitEnumArgument(EnumDecl *E, ValueOwnershipKind RequiredConvention);
   OwnershipUseCheckerResult
   visitApplyParameter(ValueOwnershipKind RequiredConvention,
                       UseLifetimeConstraint Requirement);
@@ -790,7 +790,7 @@ OwnershipCompatibilityUseChecker::checkTerminatorArgumentMatchesDestBB(
     return {matches, lifetimeConstraint};
   }
 
-  return visitNonTrivialEnum(E, DestBlockArgOwnershipKind);
+  return visitEnumArgument(E, DestBlockArgOwnershipKind);
 }
 
 OwnershipUseCheckerResult
@@ -923,7 +923,7 @@ OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
   }
 
   if (auto *E = getType().getEnumOrBoundGenericEnum()) {
-    return visitNonTrivialEnum(E, Base);
+    return visitEnumArgument(E, Base);
   }
 
   return {compatibleWithOwnership(Base),
@@ -1011,42 +1011,31 @@ OwnershipUseCheckerResult OwnershipCompatibilityUseChecker::visitCallee(
   llvm_unreachable("Unhandled ParameterConvention in switch.");
 }
 
-OwnershipUseCheckerResult OwnershipCompatibilityUseChecker::visitNonTrivialEnum(
+// Visit an enum value that is passed at argument position, including block
+// arguments, apply arguments, and return values.
+//
+// The operand definition's ownership kind may be known to be "trivial",
+// but it is still valid to pass that enum to a argument nontrivial type.
+// For example:
+//
+// %val = enum $Optional<SomeClass>, #Optional.none // trivial ownership
+// apply %f(%val) : (@owned Optional<SomeClass>)    // owned argument
+OwnershipUseCheckerResult OwnershipCompatibilityUseChecker::visitEnumArgument(
     EnumDecl *E, ValueOwnershipKind RequiredKind) {
-  // Otherwise, first see if the enum is completely trivial. In such a case, we
-  // need an argument with a trivial convention. If we have an enum with at
-  // least 1 non-trivial case, then we need an argument with a non-trivial
-  // convention. If our parameter is trivial, then we just let it through in
-  // such a case. Otherwise we need to make sure that the non-trivial ownership
-  // convention matches the one on the argument parameter.
-
-  // Check if this enum has at least one case that is non-trivially typed.
-  bool HasNonTrivialCase =
-      llvm::any_of(E->getAllElements(), [this](EnumElementDecl *E) -> bool {
-        if (!E->hasAssociatedValues())
-          return false;
-        SILType EnumEltType = getType().getEnumElementType(E, Mod);
-        return !EnumEltType.isTrivial(Mod);
-      });
-
-  // If we have all trivial cases, make sure we are compatible with a trivial
-  // ownership kind.
-  if (!HasNonTrivialCase) {
-    return {compatibleWithOwnership(ValueOwnershipKind::Trivial),
-            UseLifetimeConstraint::MustBeLive};
-  }
-
-  // Otherwise, if this value is a trivial ownership kind, return.
+  // If this value is already categorized as a trivial ownership kind, it is
+  // safe to pass to any argument convention.
   if (compatibleWithOwnership(ValueOwnershipKind::Trivial)) {
     return {true, UseLifetimeConstraint::MustBeLive};
   }
 
-  // And finally finish by making sure that if we have a non-trivial ownership
-  // kind that it matches the argument's convention.
-  auto lifetimeConstraint = hasExactOwnership(ValueOwnershipKind::Owned)
+  // The operand has a non-trivial ownership kind. It must match the argument
+  // convention.
+  auto ownership = getOwnershipKind();
+  auto lifetimeConstraint = (ownership == ValueOwnershipKind::Owned)
                                 ? UseLifetimeConstraint::MustBeInvalidated
                                 : UseLifetimeConstraint::MustBeLive;
-  return {compatibleWithOwnership(RequiredKind), lifetimeConstraint};
+  return {compatibleOwnershipKinds(ownership, RequiredKind),
+          lifetimeConstraint};
 }
 
 // We allow for trivial cases of enums with non-trivial cases to be passed in
@@ -1060,7 +1049,7 @@ OwnershipUseCheckerResult OwnershipCompatibilityUseChecker::visitApplyParameter(
   if (!E) {
     return {compatibleWithOwnership(Kind), Requirement};
   }
-  return visitNonTrivialEnum(E, Kind);
+  return visitEnumArgument(E, Kind);
 }
 
 // Handle Apply and TryApply.

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -91,6 +91,13 @@ SILModule *ValueBase::getModule() const {
 ValueOwnershipKind::ValueOwnershipKind(SILModule &M, SILType Type,
                                        SILArgumentConvention Convention)
     : Value() {
+  // Trivial types can be passed using a variety of conventions. They always
+  // have trivial ownership.
+  if (Type.isTrivial(M)) {
+    Value = ValueOwnershipKind::Trivial;
+    return;
+  }
+
   switch (Convention) {
   case SILArgumentConvention::Indirect_In:
   case SILArgumentConvention::Indirect_In_Constant:
@@ -112,8 +119,7 @@ ValueOwnershipKind::ValueOwnershipKind(SILModule &M, SILType Type,
     Value = ValueOwnershipKind::Owned;
     return;
   case SILArgumentConvention::Direct_Unowned:
-    Value = Type.isTrivial(M) ? ValueOwnershipKind::Trivial
-                              : ValueOwnershipKind::Unowned;
+    Value = ValueOwnershipKind::Unowned;
     return;
   case SILArgumentConvention::Direct_Guaranteed:
     Value = ValueOwnershipKind::Guaranteed;


### PR DESCRIPTION
This involved a bit of cleanup in both ownership classification and
verification. Trivial argument types now have trivial ownership. Also, the
verifier allows

- enums with non-trivial ownership to be passed to trivial arguments as long as
  it can verify that all payloads are trivial.

- enums with trivial ownership to be passed as owned arguments. Preventing this
  didn't make sense.
