### PR TITLE
[silgen] Add the ability to push an RValue through an ArgumentScope.

### DIFF
--- a/lib/SILGen/ArgumentScope.h
+++ b/lib/SILGen/ArgumentScope.h
@@ -62,6 +62,10 @@ public:
   /// Pop the formal evaluation and argument scopes preserving the value mv.
   ManagedValue popPreservingValue(ManagedValue mv);
 
+  void verify() {
+    formalEvalScope.verify();
+  }
+
 private:
   void popImpl() {
     // We must always pop the formal eval scope before the normal scope since

--- a/lib/SILGen/ArgumentScope.h
+++ b/lib/SILGen/ArgumentScope.h
@@ -62,6 +62,9 @@ public:
   /// Pop the formal evaluation and argument scopes preserving the value mv.
   ManagedValue popPreservingValue(ManagedValue mv);
 
+  // Pop the formal evaluation and argument scopes, preserving rv.
+  RValue popPreservingValue(RValue &&rv);
+
   void verify() {
     formalEvalScope.verify();
   }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5822,8 +5822,11 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
 }
 
 ManagedValue ArgumentScope::popPreservingValue(ManagedValue mv) {
-  CleanupCloner cloner(SGF, mv);
-  SILValue value = mv.forward(SGF);
-  pop();
-  return cloner.clone(value);
+  formalEvalScope.pop();
+  return normalScope.popPreservingValue(mv);
+}
+
+RValue ArgumentScope::popPreservingValue(RValue &&rv) {
+  formalEvalScope.pop();
+  return normalScope.popPreservingValue(std::move(rv));
 }


### PR DESCRIPTION
[silgen] Add the ability to push an RValue through an ArgumentScope.

This comes down to popping the formal evaluation scope and then performing a
popPreservingValue through the resulting normal Scope.

As a cleanup, I changed ArgumentScope.popPreservingValue(ManagedValue) to just
Scope::popPreservingValue instead of reimplementing said functionality.

rdar://31521023
