### PR TITLE
[silgen] When pushing an RValue through a scope, use dealloc_box on any boxes we create instead of destroy_value.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3617,9 +3617,9 @@ public:
 };
 } // end anonymous namespace
 
-static CleanupHandle enterDeallocBoxCleanup(SILGenFunction &SGF, SILValue box) {
-  SGF.Cleanups.pushCleanup<DeallocateUninitializedBox>(box);
-  return SGF.Cleanups.getTopCleanup();
+CleanupHandle SILGenFunction::enterDeallocBoxCleanup(SILValue box) {
+  Cleanups.pushCleanup<DeallocateUninitializedBox>(box);
+  return Cleanups.getTopCleanup();
 }
 
 /// This is an initialization for a box.
@@ -3706,7 +3706,7 @@ ManagedValue SILGenFunction::emitInjectEnum(SILLocation loc,
 
     CleanupHandle initCleanup = enterDestroyCleanup(box);
     Cleanups.setCleanupState(initCleanup, CleanupState::Dormant);
-    CleanupHandle uninitCleanup = enterDeallocBoxCleanup(*this, box);
+    CleanupHandle uninitCleanup = enterDeallocBoxCleanup(box);
 
     BoxInitialization dest(box, addr, uninitCleanup, initCleanup);
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1668,6 +1668,8 @@ public:
   CleanupHandle enterDormantTemporaryCleanup(SILValue temp,
                                              const TypeLowering &tempTL);
 
+  CleanupHandle enterDeallocBoxCleanup(SILValue box);
+
   /// Enter a currently-dormant cleanup to destroy the value in the
   /// given address.
   CleanupHandle

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -98,9 +98,13 @@ RValue Scope::popPreservingValue(RValue &&rv) {
   pop();
 
   // Then create cleanups for any lifetime extending boxes that we may have to
-  // ensure that the boxes are cleaned up /after/ the value stored in the box.
+  // ensure that the boxes are cleaned up /after/ the value stored in the
+  // box. We assume that our values will be destroyed via a destroy_addr or the
+  // like /before/ the end of our box's lifetime, implying that the value inside
+  // the box should be uninitialized when the box is destroyed, so it is
+  // important that we use a dealloc_box.
   for (auto v : lifetimeExtendingBoxes) {
-    SGF.emitManagedRValueWithCleanup(v);
+    SGF.enterDeallocBoxCleanup(v);
   }
 
   // Reconstruct the managed values from the underlying sil values in the outer


### PR DESCRIPTION
[silgen] When pushing an RValue through a scope, use dealloc_box on any boxes we create instead of destroy_value.

It is only safe to perform a destroy_value on an alloc_box that contains an
initialized value. We preserve the original cleanups for the value we are
pushing through the scope implying that the box will not contain an initialized
value when its lifetime ends (just like an alloc_stack). Thus we must use
dealloc_box here.

The surprising thing about tracking down this error is that I was not hitting
any memory issues at -Onone. Instead what was happening was that at -O, we were
miscompiling (creating non-dominating uses of SSA values) in the face of an
address being taken twice.

This does not seem to hit any SILGen tests today (I hit this when testing a
patch I am trying to land today).

rdar://31521023

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->