### PR TITLE
[copy-forwarding] Move a DEBUG log of an instruction to before we destroy the instruction...

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -535,8 +535,6 @@ propagateCopy(CopyAddrInst *CopyInst, bool hoistingDestroy) {
   assert(CopyInst->isTakeOfSrc() || hoistingDestroy);
   if (auto *srcCopy = findCopyIntoDeadTemp(CopyInst)) {
     if (forwardDeadTempCopy(srcCopy, CopyInst)) {
-      DEBUG(llvm::dbgs() << "  Temp Copy:" << *srcCopy
-            << "         to " << *CopyInst);
       HasChanged = true;
       ++NumDeadTemp;
       return true;
@@ -648,6 +646,9 @@ CopyAddrInst *CopyForwarding::findCopyIntoDeadTemp(CopyAddrInst *destCopy) {
 ///   attempts to destroy this uninitialized value.
 bool CopyForwarding::
 forwardDeadTempCopy(CopyAddrInst *srcCopy, CopyAddrInst *destCopy) {
+  DEBUG(llvm::dbgs() << "  Temp Copy:" << *srcCopy
+        << "         to " << *destCopy);
+
   assert(srcCopy->getDest() == destCopy->getSrc());
   
   // This pattern can be trivially folded without affecting %temp destroys:


### PR DESCRIPTION
[copy-forwarding] Move a DEBUG log of an instruction to before we destroy the instruction...

Found while debugging dc8b1c2c3a4c2a2cea95de2e0b88bf051c95e46c.
