### PR TITLE
Have #if os(Linux) also be true on Android

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -461,7 +461,8 @@ public:
     auto Val = getDeclRefStr(Arg);
     auto Kind = getPlatformConditionKind(KindName).getValue();
     auto Target = Ctx.LangOpts.getPlatformConditionValue(Kind);
-    return Target == Val;
+    return Target == Val || (Kind == PlatformConditionKind::OS &&
+                             Target == "Android" && Val == "Linux");
   }
 
   bool visitPrefixUnaryExpr(PrefixUnaryExpr *E) {

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -214,7 +214,7 @@ public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
 @available(*, deprecated, message: "use the floatingPointClass property.")
 public func fpclassify(_ value: ${T}) -> Int {
 %if T == 'Double':
-#if os(Linux)
+#if os(Linux) && !os(Android)
   return Int(__fpclassify(CDouble(value)))
 #elseif os(Windows) 
   return Int(_dclass(CDouble(value)))


### PR DESCRIPTION
Hi Apple,

I’ve been looking at compiling various Open Source packages for the Android port of Swift and one change that is required frequently is replacing `#if os(Linux)` with `#if os(Linux) || os(Android)`.

This patch is a “pragmatic” one in that it allows `#if os(Linux)` to also be true when you are compiling for Android which is after all a Linux system. I’ve tested this all the way through to swift-corelibs-foundation and found that only this `tgmath.swift.gyb file` needed to be modified to accomodate the change. This will allow the clean up a good deal of replicated `#if os(Linux) || os(Android)` pattern in Foundation as well. 

I appreciate this creates a documenation burden and may in some rare cases create unexpected behaviour at _compile_ time but this “pragmatic” change will make reusing and maintaining OSS a great deal easier for Android.

Thanks,