### PR TITLE
[di] Expand a test to use non-trivial types.

### DIFF
--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -708,6 +708,19 @@ class r18199087SubClassA: r18199087BaseClass {
   }
 }
 
+class r18199087BaseClassNonTrivial {
+  let data: SomeClass
+  init(val: SomeClass) {
+    data = val
+  }
+}
+
+class r18199087SubClassANonTrivial: r18199087BaseClassNonTrivial {
+  init() {
+    super.init(val: self.data)  // expected-error {{use of 'self' in property access 'data' before super.init initializes self}}
+  }
+}
+
 // <rdar://problem/18414728> QoI: DI should talk about "implicit use of self" instead of individual properties in some cases
 class rdar18414728Base {
   var prop:String? { return "boo" }


### PR DESCRIPTION
This ensures that DI handles the more difficult non-trivial diagnostic case.

rdar://31521023