### PR TITLE
[ConstraintSolver] NFC: Increase default shrinking termination threshold

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -173,7 +173,7 @@ namespace swift {
 
     /// \brief The upper bound to number of sub-expressions unsolved
     /// before termination of the shrink phrase of the constraint solver.
-    unsigned SolverShrinkUnsolvedThreshold = 5;
+    unsigned SolverShrinkUnsolvedThreshold = 10;
 
     /// The maximum depth to which to test decl circularity.
     unsigned MaxCircularityDepth = 500;


### PR DESCRIPTION
* Description: We've found in practice that multiple different types of expressions
are still going to benefit from shrinking continuing even when it
couldn't simplify up to 10 sub-expressions.

* Origination: Threshold for shrinking allows to produce diagnostic about expression being too complex faster, in some conditions, which improves user experience by reducing the compilation time, but the down-side is that some expressions that were fast to type-check have gotten much slower. By increasing this threshold it makes all known cases of slowness fast again but might cause slower compilation time if expressions are truly complex, which is the same behavior as previous versions of compiler.

* Risk: Low.

* Tested: Swift CI.

* Reviewed by: Mark Lacey.

* Resolves: rdar://problem/33785291

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
