### PR TITLE
Revert "Normalize version tuples in availability attributes coming from clang to use ".""

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7029,8 +7029,7 @@ void ClangImporter::Implementation::importAttributes(
 
       StringRef message = avail->getMessage();
 
-      clang::VersionTuple deprecated = avail->getDeprecated();
-
+      const auto &deprecated = avail->getDeprecated();
       if (!deprecated.empty()) {
         if (platformAvailability.deprecatedAsUnavailableFilter &&
             platformAvailability.deprecatedAsUnavailableFilter(
@@ -7042,14 +7041,8 @@ void ClangImporter::Implementation::importAttributes(
         }
       }
 
-      clang::VersionTuple obsoleted = avail->getObsoleted();
-      clang::VersionTuple introduced = avail->getIntroduced();
-
-      // Swift only allows "." separators.
-      obsoleted.UseDotAsSeparator();
-      introduced.UseDotAsSeparator();
-      deprecated.UseDotAsSeparator();
-
+      const auto &obsoleted = avail->getObsoleted();
+      const auto &introduced = avail->getIntroduced();
       const auto &replacement = avail->getReplacement();
 
       StringRef swiftReplacement = "";

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h
@@ -32,10 +32,3 @@ struct Arkham;
 @protocol Soul;
 
 typedef struct __attribute__((objc_bridge(id))) __MyLittleCFType *MyLittleCFType;
-
-@interface MaybeAvailable
--(void)method1 __attribute__((availability(macosx, introduced=10.1)));
--(void)method2 __attribute__((availability(macosx, introduced=10_1)));
--(void)method3 __attribute__((availability(macosx, deprecated=10_10)));
--(void)method4 __attribute__((availability(macosx, introduced=10_1, deprecated=10_10, obsoleted=10_11)));
-@end

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
@@ -28,22 +28,3 @@ protocol Superproto {
 
 class MyLittleCFType {
 }
-
-class MaybeAvailable {
-  @available(OSX 10.1, *)
-  class func method1()
-  @available(OSX 10.1, *)
-  func method1()
-  @available(OSX 10.1, *)
-  class func method2()
-  @available(OSX 10.1, *)
-  func method2()
-  @available(OSX, deprecated: 10.10)
-  class func method3()
-  @available(OSX, deprecated: 10.10)
-  func method3()
-  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
-  class func method4()
-  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
-  func method4()
-}

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
@@ -25,22 +25,3 @@ protocol Superproto {
 
 class MyLittleCFType : _CFObject {
 }
-
-class MaybeAvailable {
-  @available(OSX 10.1, *)
-  class func method1()
-  @available(OSX 10.1, *)
-  func method1()
-  @available(OSX 10.1, *)
-  class func method2()
-  @available(OSX 10.1, *)
-  func method2()
-  @available(OSX, deprecated: 10.10)
-  class func method3()
-  @available(OSX, deprecated: 10.10)
-  func method3()
-  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
-  class func method4()
-  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
-  func method4()
-}

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
@@ -28,22 +28,3 @@ protocol Superproto {
 
 class MyLittleCFType : _CFObject {
 }
-
-class MaybeAvailable {
-  @available(OSX 10.1, *)
-  class func method1()
-  @available(OSX 10.1, *)
-  func method1()
-  @available(OSX 10.1, *)
-  class func method2()
-  @available(OSX 10.1, *)
-  func method2()
-  @available(OSX, deprecated: 10.10)
-  class func method3()
-  @available(OSX, deprecated: 10.10)
-  func method3()
-  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
-  class func method4()
-  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
-  func method4()
-}


### PR DESCRIPTION
Reverts apple/swift#11739

I need to fixup the test for non-mac platforms, or factor out the availability checking parts.  Right now this breaks testing.