### PR TITLE
Cleanup inheritance clause parsing

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1418,7 +1418,7 @@ ERROR(expected_generics_parameter_name,PointsToFirstBadToken,
 ERROR(unexpected_class_constraint,none,
        "'class' constraint can only appear on protocol declarations", ())
 NOTE(suggest_anyobject,none,
-     "did you mean to constrain %0 with the 'AnyObject' protocol?", (Identifier))
+     "did you mean to write an 'AnyObject' constraint?", ())
 ERROR(expected_generics_type_restriction,none,
       "expected a class type or protocol-constrained type restricting %0",
       (Identifier))
@@ -1427,8 +1427,6 @@ ERROR(requires_single_equal,none,
 ERROR(expected_requirement_delim,none,
       "expected ':' or '==' to indicate a conformance or same-type requirement",
       ())
-ERROR(invalid_class_requirement,none,
-      "'class' requirement only applies to protocols", ())
 ERROR(redundant_class_requirement,none,
       "redundant 'class' requirement", ())
 ERROR(late_class_requirement,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -685,8 +685,6 @@ ERROR(expected_identifier_for_type,PointsToFirstBadToken,
       "expected identifier for type name", ())
 ERROR(expected_rangle_generic_arg_list,PointsToFirstBadToken,
       "expected '>' to complete generic argument list", ())
-ERROR(expected_ident_type_in_inheritance,none,
-      "inheritance from non-named type %0", (TypeLoc))
 
 
 // Function types

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -747,8 +747,6 @@ ERROR(tuple_type_multiple_labels,none,
 // Protocol Types
 ERROR(expected_rangle_protocol,PointsToFirstBadToken,
       "expected '>' to complete protocol-constrained type", ())
-ERROR(disallowed_protocol_composition,PointsToFirstBadToken,
-      "protocol-constrained type is neither allowed nor needed here", ())
 
 WARNING(swift3_deprecated_protocol_composition,none,
         "'protocol<...>' composition syntax is deprecated; join the protocols using '&'", ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -882,20 +882,6 @@ public:
                                    bool HandleCodeCompletion = true,
                                    bool IsSILFuncDecl = false);
 
-  /// \brief Parse any type, but diagnose all types except type-identifier or
-  /// type-composition with non-type-identifier.
-  ///
-  /// In some places the grammar allows only type-identifier, but when it is
-  /// not ambiguous, we want to parse any type for recovery purposes.
-  ///
-  /// \param MessageID a generic diagnostic for a syntax error in the type
-  /// \param NonIdentifierTypeMessageID a diagnostic for a non-identifier type
-  ///
-  /// \returns null, IdentTypeRepr, CompositionTypeRepr or ErrorTypeRepr.
-  ParserResult<TypeRepr>
-  parseTypeForInheritance(Diag<> MessageID,
-                          Diag<TypeLoc> NonIdentifierTypeMessageID);
-
   ParserResult<TypeRepr> parseTypeSimpleOrComposition();
   ParserResult<TypeRepr>
     parseTypeSimpleOrComposition(Diag<> MessageID,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -773,7 +773,8 @@ public:
   ParserResult<ImportDecl> parseDeclImport(ParseDeclOptions Flags,
                                            DeclAttributes &Attributes);
   ParserStatus parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
-                                bool allowClassRequirement);
+                                bool allowClassRequirement,
+                                bool allowAnyObject);
   ParserStatus parseDeclItem(bool &PreviousHadSemi,
                              Parser::ParseDeclOptions Options,
                              llvm::function_ref<void(Decl*)> handler);

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -239,6 +239,13 @@ void ConformanceLookupTable::inheritConformances(ClassDecl *classDecl,
           superclassLoc = inherited.getSourceRange().Start;
           return superclassLoc;
         }
+        if (inheritedType->isExistentialType()) {
+          auto layout = inheritedType->getExistentialLayout();
+          if (layout.superclass) {
+            superclassLoc = inherited.getSourceRange().Start;
+            return superclassLoc;
+          }
+        }
       }
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2705,9 +2705,7 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
       continue;
     }
 
-    auto ParsedTypeResult = parseTypeForInheritance(
-        diag::expected_identifier_for_type,
-        diag::expected_ident_type_in_inheritance);
+    auto ParsedTypeResult = parseType();
     Status |= ParsedTypeResult;
 
     // Record the type if its a single type.

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -72,8 +72,7 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
       ParserResult<TypeRepr> Ty;
       
       if (Tok.isAny(tok::identifier, tok::code_complete, tok::kw_protocol, tok::kw_Any)) {
-        Ty = parseTypeForInheritance(diag::expected_identifier_for_type,
-                                     diag::expected_ident_type_in_inheritance);
+        Ty = parseType();
       } else if (Tok.is(tok::kw_class)) {
         diagnose(Tok, diag::unexpected_class_constraint);
         diagnose(Tok, diag::suggest_anyobject)
@@ -289,9 +288,7 @@ ParserStatus Parser::parseGenericWhereClause(
         }
       } else {
         // Parse the protocol or composition.
-        ParserResult<TypeRepr> Protocol =
-            parseTypeForInheritance(diag::expected_identifier_for_type,
-                                    diag::expected_ident_type_in_inheritance);
+        ParserResult<TypeRepr> Protocol = parseType();
 
         if (Protocol.isNull()) {
           Status.setIsParseError();

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -91,7 +91,7 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
         Inherited.push_back(Ty.get());
     }
 
-    // We always create generic type parameters with a depth of zero.
+    // We always create generic type parameters with an invalid depth.
     // Semantic analysis fills in the depth when it processes the generic
     // parameter list.
     auto Param = new (Context) GenericTypeParamDecl(

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -76,7 +76,7 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
                                      diag::expected_ident_type_in_inheritance);
       } else if (Tok.is(tok::kw_class)) {
         diagnose(Tok, diag::unexpected_class_constraint);
-        diagnose(Tok, diag::suggest_anyobject, Name)
+        diagnose(Tok, diag::suggest_anyobject)
           .fixItReplace(Tok.getLoc(), "AnyObject");
         consumeToken();
         Invalid = true;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -470,42 +470,6 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
                                                specifierLoc));
 }
 
-ParserResult<TypeRepr> Parser::parseTypeForInheritance(
-    Diag<> MessageID, Diag<TypeLoc> NonIdentifierTypeMessageID) {
-  ParserResult<TypeRepr> Ty = parseTypeSimpleOrComposition(MessageID);
-
-  if (Ty.hasCodeCompletion())
-    return makeParserCodeCompletionResult<TypeRepr>();
-
-  if (Ty.isParseError() || isa<ErrorTypeRepr>(Ty.get()))
-    return Ty;
-
-  if (isa<IdentTypeRepr>(Ty.get()))
-    return Ty;
-
-  if (auto Comp = dyn_cast<CompositionTypeRepr>(Ty.get())) {
-    bool hasNonIdent = false;
-    for (auto T : Comp->getTypes()) {
-      if (isa<IdentTypeRepr>(T))
-        continue;
-      hasNonIdent = true;
-      diagnose(T->getLoc(), NonIdentifierTypeMessageID, T)
-        .highlight(T->getSourceRange());
-    }
-    // IdentType only composition are allowed.
-    if (!hasNonIdent)
-      return Ty;
-  } else {
-    diagnose(Ty.get()->getLoc(), NonIdentifierTypeMessageID, Ty.get())
-      .highlight(Ty.get()->getSourceRange());
-  }
-
-  return makeParserErrorResult(
-    new (Context) ErrorTypeRepr(Ty.get()->getSourceRange()));
-
-  return Ty;
-}
-
 bool Parser::parseGenericArguments(SmallVectorImpl<TypeRepr*> &Args,
                                    SourceLoc &LAngleLoc,
                                    SourceLoc &RAngleLoc) {

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -135,7 +135,7 @@ prefix operator %
 prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.
 
 struct Weak<T: class> { // expected-error {{'class' constraint can only appear on protocol declarations}}
-  // expected-note@-1 {{did you mean to constrain 'T' with the 'AnyObject' protocol?}} {{16-21=AnyObject}}
+  // expected-note@-1 {{did you mean to write an 'AnyObject' constraint?}} {{16-21=AnyObject}}
   weak let value: T // expected-error {{'weak' must be a mutable variable, because it may change at runtime}} expected-error {{'weak' variable should have optional type 'T?'}} expected-error {{'weak' may not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound}}
 }
 

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -145,7 +145,7 @@ public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {
 @_specialize(kind: partial, exported: true, where X == Int, Y == Int)
 @_specialize(kind: partial, kind: partial, where X == Int, Y == Int) // expected-error{{parameter 'kind' was already defined in '_specialize' attribute}}
 
-@_specialize(where X == Int, Y == Int, exported: true, kind: partial) // expected-error{{use of undeclared type 'exported'}} expected-error{{use of undeclared type 'kind'}} expected-error{{use of undeclared type 'partial'}} expected-error{{expected identifier for type name}}
+@_specialize(where X == Int, Y == Int, exported: true, kind: partial) // expected-error{{use of undeclared type 'exported'}} expected-error{{use of undeclared type 'kind'}} expected-error{{use of undeclared type 'partial'}} expected-error{{expected type}}
 public func anotherFuncWithTwoGenericParameters<X: P, Y>(x: X, y: Y) {
 }
 

--- a/test/decl/class/classes.swift
+++ b/test/decl/class/classes.swift
@@ -85,3 +85,23 @@ class HDerived : H {
   override func f(_ x: Int) { }
   override class func f(_ x: Int) { }
 }
+
+// Subclass existentials in inheritance clause
+protocol P {}
+protocol Q {}
+protocol R {}
+class Base : Q & R {}
+
+class Derived : P & Base {}
+
+func f(_: P) {}
+func g(_: Base) {}
+func h(_: Q) {}
+func i(_: R) {}
+
+func testSubclassExistentialsInInheritanceClause() {
+  f(Derived())
+  g(Derived())
+  h(Derived())
+  i(Derived())
+}

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -25,7 +25,7 @@ protocol Q : A { } // expected-error{{non-class type 'Q' cannot inherit from cla
 extension C : A { } // expected-error{{extension of type 'C' cannot inherit from class 'A'}}
 
 // Keywords in inheritance clauses
-struct S2 : struct { } // expected-error{{expected identifier for type name}}
+struct S2 : struct { } // expected-error{{expected type}}
 
 // Protocol composition in inheritance clauses
 struct S3 : P, P & Q { } // expected-error {{redundant conformance of 'S3' to protocol 'P'}}

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -28,17 +28,15 @@ extension C : A { } // expected-error{{extension of type 'C' cannot inherit from
 struct S2 : struct { } // expected-error{{expected identifier for type name}}
 
 // Protocol composition in inheritance clauses
-struct S3 : P, P & Q { } // expected-error {{duplicate inheritance from 'P'}}
-                         // expected-error @-1 {{protocol-constrained type is neither allowed nor needed here}}
-                         // expected-error @-2 {{'Q' requires that 'S3' inherit from 'A'}}
-                         // expected-note @-3 {{requirement specified as 'Self' : 'A' [with Self = S3]}}
+struct S3 : P, P & Q { } // expected-error {{redundant conformance of 'S3' to protocol 'P'}}
+                         // expected-error @-1 {{'Q' requires that 'S3' inherit from 'A'}}
+                         // expected-note @-2 {{requirement specified as 'Self' : 'A' [with Self = S3]}}
+                         // expected-note @-3 {{'S3' declares conformance to protocol 'P' here}}
 struct S4 : P, P { }     // expected-error {{duplicate inheritance from 'P'}}
 struct S6 : P & { }      // expected-error {{expected identifier for type name}}
-                         // expected-error @-1 {{protocol-constrained type is neither allowed nor needed here}}
 struct S7 : protocol<P, Q> { }  // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
-                                // expected-error @-1 {{protocol-constrained type is neither allowed nor needed here}}{{13-22=}} {{26-27=}}
-                                // expected-error @-2 {{'Q' requires that 'S7' inherit from 'A'}}
-                                // expected-note @-3 {{requirement specified as 'Self' : 'A' [with Self = S7]}}
+                                // expected-error @-1 {{'Q' requires that 'S7' inherit from 'A'}}
+                                // expected-note @-2 {{requirement specified as 'Self' : 'A' [with Self = S7]}}
 
 class GenericBase<T> {}
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -209,6 +209,12 @@ struct IntStringGetter : GetATuple {
   func getATuple() -> Tuple {}
 }
 
+protocol ClassConstrainedAssocType {
+  associatedtype T : class
+  // expected-error@-1 {{'class' constraint can only appear on protocol declarations}}
+  // expected-note@-2 {{did you mean to write an 'AnyObject' constraint?}}{{22-27=AnyObject}}
+}
+
 //===----------------------------------------------------------------------===//
 // Default arguments
 //===----------------------------------------------------------------------===//

--- a/test/decl/protocol/req/class.swift
+++ b/test/decl/protocol/req/class.swift
@@ -8,4 +8,4 @@ protocol P3 : P2, class { } // expected-error{{'class' must come first in the re
 // expected-warning@-1 {{redundant layout constraint 'Self' : 'AnyObject'}}
 // expected-note@-2 {{layout constraint constraint 'Self' : 'AnyObject' implied here}}
 
-struct X : class { } // expected-error{{'class' requirement only applies to protocols}} {{12-18=}}
+struct X : class { } // expected-error{{'class' constraint can only appear on protocol declarations}}

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -28,7 +28,6 @@ typealias Any2 = protocol< > // expected-error {{'protocol<>' syntax has been re
 // Okay to inherit a typealias for Any type.
 protocol P5 : Any { }
 protocol P6 : protocol<> { } // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
-                             // expected-error@-1 {{protocol-constrained type is neither allowed nor needed here}}
 typealias P7 = Any & Any1
 
 extension Int : P5 { }
@@ -153,9 +152,9 @@ typealias T07 = P1 & protocol<P2, P3> // expected-error {{protocol<...>' composi
 func fT07(x: T07) -> P1 & P2 & P3 { return x } // OK, 'P1 & protocol<P2, P3>' is parsed as 'P1 & P2 & P3'.
 let _: P1 & P2 & P3 -> P1 & P2 & P3 = fT07 // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{20-20=)}}
 
-struct S01: P5 & P6 {} // expected-error {{protocol-constrained type is neither allowed nor needed here}} {{none}}
+struct S01: P5 & P6 {}
 struct S02: P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
-struct S03: Optional<P5> & P6 {} // expected-error {{inheritance from non-protocol type 'Optional<P5>'}} expected-error {{protocol-constrained type is neither allowed nor needed here}}
+struct S03: Optional<P5> & P6 {} // expected-error {{non-protocol, non-class type 'Optional<P5>' cannot be used within a protocol-constrained type}}
 struct S04<T : P5 & (P6)> {} // expected-error {{inheritance from non-named type '(P6)'}}
 struct S05<T> where T : P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -153,10 +153,10 @@ func fT07(x: T07) -> P1 & P2 & P3 { return x } // OK, 'P1 & protocol<P2, P3>' is
 let _: P1 & P2 & P3 -> P1 & P2 & P3 = fT07 // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{20-20=)}}
 
 struct S01: P5 & P6 {}
-struct S02: P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
+struct S02: P5? & P6 {} // expected-error {{non-protocol, non-class type 'P5?' cannot be used within a protocol-constrained type}}
 struct S03: Optional<P5> & P6 {} // expected-error {{non-protocol, non-class type 'Optional<P5>' cannot be used within a protocol-constrained type}}
-struct S04<T : P5 & (P6)> {} // expected-error {{inheritance from non-named type '(P6)'}}
-struct S05<T> where T : P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
+struct S04<T : P5 & (P6)> {}
+struct S05<T> where T : P5? & P6 {} // expected-error 2{{non-protocol, non-class type 'P5?' cannot be used within a protocol-constrained type}}
 
 // SR-3124 - Protocol Composition Often Migrated Incorrectly
 struct S3124<T: protocol<P1, P3>> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{17-34=P1 & P3>}}

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -451,7 +451,7 @@ protocol ProtoConstraintsSelfToClass where Self : Base<Int> {}
 
 protocol ProtoRefinesClass : Base<Int> {} // FIXME expected-error {{}}
 protocol ProtoRefinesClassAndProtocolAlias : BaseIntAndP2 {}
-protocol ProtoRefinesClassAndProtocolDirect : Base<Int> & P2 {} // FIXME expected-error 2 {{}}
+protocol ProtoRefinesClassAndProtocolDirect : Base<Int> & P2 {}
 protocol ProtoRefinesClassAndProtocolExpanded : Base<Int>, P2 {} // FIXME expected-error {{}}
 
 class ClassConformsToClassProtocolBad1 : ProtoConstraintsSelfToClass {}
@@ -465,23 +465,20 @@ class ClassConformsToClassProtocolBad2 : ProtoRefinesClass {}
 class ClassConformsToClassProtocolGood2 : Derived, ProtoRefinesClass {}
 
 // Subclass existentials inside inheritance clauses
-class CompositionInClassInheritanceClauseAlias : BaseIntAndP2 { // FIXME: expected-error {{}}
+class CompositionInClassInheritanceClauseAlias : BaseIntAndP2 {
   required init(classInit: ()) {
-    super.init(classInit: ()) // FIXME: expected-error {{}}
+    super.init(classInit: ())
   }
 
   required init(protocolInit: ()) {
-    super.init(classInit: ()) // FIXME: expected-error {{}}
+    super.init(classInit: ())
   }
 
   func protocolSelfReturn() -> Self { return self }
   func asBase() -> Base<Int> { return self }
-  // FIXME expected-error@-1 {{}}
 }
 
 class CompositionInClassInheritanceClauseDirect : Base<Int> & P2 {
-  // expected-error@-1 {{protocol-constrained type is neither allowed nor needed here}}
-
   required init(classInit: ()) {
     super.init(classInit: ())
   }

--- a/validation-test/compiler_crashers_fixed/28832-superclass-superclass-hasarchetype-superclass-must-be-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28832-superclass-superclass-hasarchetype-superclass-must-be-interface-type.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 extension CountableRange{{}class a:a&a.a{func a


### PR DESCRIPTION
In order to fully implement SE-0156, we need to implement two additional language changes:

- In Swift 5 mode, warn or error on ': class' in a protocol inheritance clause, offering a fixit to replace 'class' with 'AnyObject' instead.
- Allow subclass existentials and class types in protocol inheritance clauses, to define a protocol whose conforming type must be a subclass of a given class.

Also, we have some code duplication and recursive validation bugs in Sema's inheritance clause checking logic. Cleaning this up will make the code clearer and fix various crashes.

This PR doesn't fully address any of the above, but it cleans up the code in preparation for making those changes. I don't intend on working on this any time soon, but I wanted to finish this cleanup as a quick follow-up to https://github.com/apple/swift/pull/11762.