### PR TITLE
Fix printing of class-constrained protocols [4.0]

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3489,9 +3489,6 @@ private:
 class ProtocolDecl : public NominalTypeDecl {
   SourceLoc ProtocolLoc;
 
-  /// The location of the 'class' keyword for class-bound protocols.
-  SourceLoc ClassRequirementLoc;
-
   /// The syntactic representation of the where clause in a protocol like
   /// `protocol ... where ... { ... }`.
   TrailingWhereClause *TrailingWhere;
@@ -3570,17 +3567,6 @@ public:
     ProtocolDeclBits.RequiresClassValid = true;
     ProtocolDeclBits.RequiresClass = requiresClass;
   }
-
-  /// Specify that this protocol is class-bounded, recording the location of
-  /// the 'class' keyword.
-  void setClassBounded(SourceLoc loc) {
-    ClassRequirementLoc = loc;
-    ProtocolDeclBits.RequiresClassValid = true;
-    ProtocolDeclBits.RequiresClass = true;
-  }
-
-  /// Retrieve the source location of the 'class' keyword.
-  SourceLoc getClassBoundedLoc() const { return ClassRequirementLoc; }
 
   /// Determine whether an existential conforming to this protocol can be
   /// matched with a generic type parameter constrained to this protocol.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -763,7 +763,7 @@ public:
   ParserResult<ImportDecl> parseDeclImport(ParseDeclOptions Flags,
                                            DeclAttributes &Attributes);
   ParserStatus parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
-                                SourceLoc *classRequirementLoc);
+                                bool allowClassRequirement);
   ParserStatus parseDeclItem(bool &PreviousHadSemi,
                              Parser::ParseDeclOptions Options,
                              llvm::function_ref<void(Decl*)> handler);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1310,8 +1310,12 @@ bestRequirementPrintLocation(ProtocolDecl *proto, const Requirement &req) {
 
     // A requirement like Self : Protocol or Self.T : Class might be from an
     // inheritance, or might be a where clause.
-    if (req.getKind() != RequirementKind::Layout && result.second) {
-      auto inherited = req.getSecondType();
+    if (result.second) {
+      Type inherited;
+      if (req.getKind() == RequirementKind::Layout)
+        inherited = proto->getASTContext().getAnyObjectType();
+      else
+        inherited = req.getSecondType();
       inWhereClause =
           none_of(result.first->getInherited(), [&](const TypeLoc &loc) {
             return loc.getType()->isEqual(inherited);

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -486,7 +486,7 @@ protocol d0130_TestProtocol {
 }
 
 protocol d0150_TestClassProtocol : class {}
-// PASS_COMMON-LABEL: {{^}}protocol d0150_TestClassProtocol : class {{{$}}
+// PASS_COMMON-LABEL: {{^}}protocol d0150_TestClassProtocol : AnyObject where Self : AnyObject {{{$}}
 
 @objc protocol d0151_TestClassProtocol {}
 // PASS_COMMON-LABEL: {{^}}@objc protocol d0151_TestClassProtocol {{{$}}

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -486,7 +486,7 @@ protocol d0130_TestProtocol {
 }
 
 protocol d0150_TestClassProtocol : class {}
-// PASS_COMMON-LABEL: {{^}}protocol d0150_TestClassProtocol : AnyObject where Self : AnyObject {{{$}}
+// PASS_COMMON-LABEL: {{^}}protocol d0150_TestClassProtocol : AnyObject {{{$}}
 
 @objc protocol d0151_TestClassProtocol {}
 // PASS_COMMON-LABEL: {{^}}@objc protocol d0151_TestClassProtocol {{{$}}

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -7,7 +7,10 @@
 
 sil_stage canonical
 
+import Builtin
 import gizmo
+
+typealias AnyObject = Builtin.AnyObject
 
 // rdar://16621578
 

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -28,7 +28,11 @@
 // CHECK-native:  call void @__swift_fixLifetime(%swift.refcounted*
 // CHECK-native:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%T11fixlifetime1CC**)*)(%T11fixlifetime1CC**
 
+import Builtin
+
 sil_stage canonical
+
+typealias AnyObject = Builtin.AnyObject
 
 class C {}
 sil_vtable C {}

--- a/test/IRGen/unowned.sil
+++ b/test/IRGen/unowned.sil
@@ -7,8 +7,12 @@
 // CHECK: [[OPAQUE:%swift.opaque]] = type opaque
 // CHECK: [[A:%T7unowned1AV]] = type <{ %swift.unowned }>
 
+import Builtin
+
 class C {}
 sil_vtable C {}
+
+typealias AnyObject = Builtin.AnyObject
 protocol P : class {
   func explode()
 }

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -3,6 +3,8 @@
 // REQUIRES: CPU=x86_64
 // XFAIL: linux
 
+import Builtin
+
 //   These types end up in a completely different order with interop disabled.
 // CHECK: [[TYPE:%swift.type]] = type
 // CHECK: [[OPAQUE:%swift.opaque]] = type opaque
@@ -12,6 +14,7 @@
 
 class C {}
 sil_vtable C {}
+typealias AnyObject = Builtin.AnyObject
 protocol P : class {
   func explode()
 }

--- a/test/SIL/clone_init_existential.sil
+++ b/test/SIL/clone_init_existential.sil
@@ -7,6 +7,8 @@ sil_stage canonical
 
 import Builtin
 
+typealias AnyObject = Builtin.AnyObject
+
 protocol ClassProto1 : class {
 }
 

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -15,7 +15,7 @@ import Builtin
 
 sil @allocate_object : $@convention(thin) () -> @owned Builtin.NativeObject
 
-public protocol AnyObject : class {}
+typealias AnyObject = Builtin.AnyObject
 
 public protocol Error {}
 

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -7,6 +7,8 @@ enum Optional<T> {
 
 precedencegroup AssignmentPrecedence {}
 
+typealias AnyObject = Builtin.AnyObject
+
 // -- Class-bound archetypes and existentials are *not* address-only and can
 //    be manipulated using normal reference type value semantics.
 

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -89,9 +89,9 @@ public func genericBlockBridging<T: Ansible>(x: GenericClass<T>) {
 }
 
 // CHECK-LABEL: sil @_T021objc_imported_generic0C13BlockBridging{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_T0xxIyBya_xxIxxo_RlzC21objc_imported_generic7AnsibleRzlTR
+// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_T0xxIyBya_xxIxxo_21objc_imported_generic7AnsibleRzlTR
 // CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T>
-// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_T0xxIxxo_xxIyBya_RlzC21objc_imported_generic7AnsibleRzlTR
+// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_T0xxIxxo_xxIyBya_21objc_imported_generic7AnsibleRzlTR
 // CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T>
 
 // CHECK-LABEL: sil @_T021objc_imported_generic20arraysOfGenericParam{{[_0-9a-zA-Z]*}}F

--- a/test/SILOptimizer/address_projection.sil
+++ b/test/SILOptimizer/address_projection.sil
@@ -5,6 +5,7 @@ import Builtin
 sil_stage canonical
 // CHECK: sil_stage lowered
 
+typealias AnyObject = Builtin.AnyObject
 typealias Int = Builtin.Int64
 
 // CHECK-LABEL: sil hidden @f010_addrlower_identity : $@convention(thin) <T> (@in T) -> @out T {

--- a/test/SILOptimizer/rcidentity.sil
+++ b/test/SILOptimizer/rcidentity.sil
@@ -6,6 +6,8 @@ import Builtin
 // NonTest Utilities //
 ///////////////////////
 
+typealias AnyObject = Builtin.AnyObject
+
 protocol FakeAnyObject : class {}
 
 class C : FakeAnyObject {

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -600,7 +600,7 @@ func hasLocalizationKey2() {}
 // FIXME: ref.class - rdar://problem/25014968
 
 // RUN: %sourcekitd-test -req=cursor -pos=150:10 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK66
-// CHECK66: <decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name> :  <syntaxtype.keyword>class</syntaxtype.keyword>, <ref.protocol usr="s:11cursor_info2P1P">P1</ref.protocol></decl.protocol>
+// CHECK66: <decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name> : <ref.typealias usr="s:s9AnyObjecta">AnyObject</ref.typealias>, <ref.protocol usr="s:11cursor_info2P1P">P1</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr="s:11cursor_info2P2P4Selfxmfp">Self</ref.generic_type_param> : AnyObject</decl.generic_type_requirement></decl.protocol>
 
 // RUN: %sourcekitd-test -req=cursor -pos=114:18 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK67
 // CHECK67: source.lang.swift.decl.associatedtype (114:18-114:19)

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -600,7 +600,7 @@ func hasLocalizationKey2() {}
 // FIXME: ref.class - rdar://problem/25014968
 
 // RUN: %sourcekitd-test -req=cursor -pos=150:10 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK66
-// CHECK66: <decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name> : <ref.typealias usr="s:s9AnyObjecta">AnyObject</ref.typealias>, <ref.protocol usr="s:11cursor_info2P1P">P1</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr="s:11cursor_info2P2P4Selfxmfp">Self</ref.generic_type_param> : AnyObject</decl.generic_type_requirement></decl.protocol>
+// CHECK66: <decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name> : <ref.typealias usr="s:s9AnyObjecta">AnyObject</ref.typealias>, <ref.protocol usr="s:11cursor_info2P1P">P1</ref.protocol></decl.protocol>
 
 // RUN: %sourcekitd-test -req=cursor -pos=114:18 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK67
 // CHECK67: source.lang.swift.decl.associatedtype (114:18-114:19)

--- a/test/decl/protocol/req/class.swift
+++ b/test/decl/protocol/req/class.swift
@@ -5,5 +5,7 @@ protocol P1 : class { }
 protocol P2 : class, class { } // expected-error{{redundant 'class' requirement}}{{20-27=}}
 
 protocol P3 : P2, class { } // expected-error{{'class' must come first in the requirement list}}{{15-15=class, }}{{17-24=}}
+// expected-warning@-1 {{redundant layout constraint 'Self' : 'AnyObject'}}
+// expected-note@-2 {{layout constraint constraint 'Self' : 'AnyObject' implied here}}
 
 struct X : class { } // expected-error{{'class' requirement only applies to protocols}} {{12-18=}}


### PR DESCRIPTION
* Description: In Swift 4.0, we implemented SE-0156, which stipulates that 'protocol P : AnyObject' should be equivalent to 'protocol P : class'. Because of unfortunate representational issues, the generated interface for such a protocol produced ridiculous output like 'protocol P : class, AnyObject where Self : AnyObject'. This PR fixes that and now it just says 'protocol P : AnyObject'.

* Scope of the issue: This is just a cosmetic issue, but it was reported by a user on Twitter, who was confused by the redundant constraints. It's also a regression in the sense that we're not asking users to write 'AnyObject' instead of 'class' everywhere, and the new form had this problem.

* Tested: New test added to ensure the generated interface looks reasonable.

* Risk: Low, I think we tested subclass existentials well enough that folding ': class' into ': AnyObject' in the parser should work as before.

* Radar: <rdar://problem/34274386>

* Reviewed by: @DougGregor 