### PR TITLE
[NFC] Remove old forward declarations

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1171,10 +1171,6 @@ struct TargetVTableDescriptor {
   }
 };
 
-struct ClassTypeDescriptor;
-struct StructTypeDescriptor;
-struct EnumTypeDescriptor;
-
 /// Common information about all nominal types. For generic types, this
 /// descriptor is shared for all instantiations of the generic type.
 template <typename Runtime>


### PR DESCRIPTION
AFAICT these haven't been used for years at this point.

Noticed by inspection.