### PR TITLE
Reworking ClangImporter to not depend on Sema, part 1 

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -242,6 +242,9 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
     // If we haven't set the signature conformances yet, force the issue now.
     if (normal->getSignatureConformances().empty()) {
       auto lazyResolver = type->getASTContext().getLazyResolver();
+      if (lazyResolver == nullptr)
+        return None;
+
       lazyResolver->resolveTypeWitness(normal, nullptr);
 
       // Error case: the conformance is broken, so we cannot handle this

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1383,8 +1383,7 @@ static void makeStructRawValuedWithBridge(
       AccessLevel::Private,
       AccessLevel::Private);
 
-  //
-  // Create a computed value variable
+  // Create a computed value variable.
   auto computedVar = new (ctx) VarDecl(
       /*IsStatic*/false, VarDecl::Specifier::Var, /*IsCaptureList*/false,
       SourceLoc(), computedVarName, bridgedType, structDecl);
@@ -2599,6 +2598,8 @@ namespace {
         enumDecl->addMember(rawValueGetter);
         enumDecl->addMember(rawValue);
         enumDecl->addMember(rawValueBinding);
+
+        addSynthesizedTypealias(enumDecl, C.Id_RawValue, underlyingType);
 
         // If we have an error wrapper, finish it up now that its
         // nested enum has been constructed.
@@ -5220,8 +5221,11 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
   ProtocolDecl *protocols[] = {ctx.getProtocol(KnownProtocolKind::OptionSet)};
   makeStructRawValued(Impl, structDecl, underlyingType,
                       {KnownProtocolKind::OptionSet}, protocols);
+  auto selfType = structDecl->getDeclaredInterfaceType();
   addSynthesizedTypealias(structDecl, ctx.Id_Element,
-                          structDecl->getDeclaredInterfaceType());
+                          selfType);
+  addSynthesizedTypealias(structDecl, ctx.getIdentifier("ArrayLiteralElement"),
+                          selfType);
   return structDecl;
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -120,12 +120,12 @@ static Pattern *createTypedNamedPattern(VarDecl *decl) {
 /// Create a var member for this struct, along with its pattern binding, and add
 /// it as a member
 static std::pair<VarDecl *, PatternBindingDecl *>
-createVarWithPattern(ASTContext &cxt, DeclContext *dc, Identifier name, Type ty,
+createVarWithPattern(ASTContext &ctx, DeclContext *dc, Identifier name, Type ty,
                      VarDecl::Specifier specifier, bool isImplicit,
                      AccessLevel access,
                      AccessLevel setterAccess) {
   // Create a variable to store the underlying value.
-  auto var = new (cxt) VarDecl(
+  auto var = new (ctx) VarDecl(
       /*IsStatic*/false,
       specifier,
       /*IsCaptureList*/false,
@@ -139,7 +139,7 @@ createVarWithPattern(ASTContext &cxt, DeclContext *dc, Identifier name, Type ty,
   // Create a pattern binding to describe the variable.
   Pattern *varPattern = createTypedNamedPattern(var);
   auto patternBinding =
-      PatternBindingDecl::create(cxt, SourceLoc(), StaticSpellingKind::None,
+      PatternBindingDecl::create(ctx, SourceLoc(), StaticSpellingKind::None,
                                  SourceLoc(), varPattern, nullptr, dc);
 
   return {var, patternBinding};
@@ -1277,7 +1277,7 @@ static void makeStructRawValued(
     ArrayRef<ProtocolDecl *> protocols,
     MakeStructRawValuedOptions options = getDefaultMakeStructRawValuedOptions(),
     AccessLevel setterAccess = AccessLevel::Private) {
-  auto &cxt = Impl.SwiftContext;
+  auto &ctx = Impl.SwiftContext;
   addProtocolsToStruct(Impl, structDecl, synthesizedProtocolAttrs, protocols);
 
   // Create a variable to store the underlying value.
@@ -1287,7 +1287,7 @@ static void makeStructRawValued(
                  ? VarDecl::Specifier::Let
                  : VarDecl::Specifier::Var;
   std::tie(var, patternBinding) = createVarWithPattern(
-      cxt, structDecl, cxt.Id_rawValue, underlyingType,
+      ctx, structDecl, ctx.Id_rawValue, underlyingType,
       specifier,
       options.contains(MakeStructRawValuedFlags::IsImplicit),
       AccessLevel::Public,
@@ -1309,7 +1309,7 @@ static void makeStructRawValued(
   structDecl->addMember(patternBinding);
   structDecl->addMember(var);
 
-  addSynthesizedTypealias(structDecl, cxt.Id_RawValue, underlyingType);
+  addSynthesizedTypealias(structDecl, ctx.Id_RawValue, underlyingType);
 }
 
 /// Create a rawValue-ed constructor that bridges to its underlying storage.
@@ -1317,7 +1317,7 @@ static ConstructorDecl *createRawValueBridgingConstructor(
     ClangImporter::Implementation &Impl, StructDecl *structDecl,
     VarDecl *computedRawValue, VarDecl *storedRawValue, bool wantLabel,
     bool wantBody) {
-  auto &cxt = Impl.SwiftContext;
+  auto &ctx = Impl.SwiftContext;
   auto init = createValueConstructor(Impl, structDecl, computedRawValue,
                                      /*wantCtorParamNames=*/wantLabel,
                                      /*wantBody=*/false);
@@ -1326,22 +1326,22 @@ static ConstructorDecl *createRawValueBridgingConstructor(
     auto selfDecl = init->getParameterList(0)->get(0);
 
     // Construct left-hand side.
-    Expr *lhs = new (cxt) DeclRefExpr(selfDecl, DeclNameLoc(),
+    Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
                                       /*Implicit=*/true);
-    lhs = new (cxt) MemberRefExpr(lhs, SourceLoc(), storedRawValue,
+    lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), storedRawValue,
                                   DeclNameLoc(), /*Implicit=*/true);
 
     // Construct right-hand side.
     // FIXME: get the parameter from the init, and plug it in here.
-    auto rhs = new (cxt) CoerceExpr(
-        new (cxt) DeclRefExpr(init->getParameterList(1)->get(0), DeclNameLoc(),
+    auto rhs = new (ctx) CoerceExpr(
+        new (ctx) DeclRefExpr(init->getParameterList(1)->get(0), DeclNameLoc(),
                               /*Implicit=*/true),
         {}, {nullptr, storedRawValue->getType()});
 
     // Add assignment.
-    auto assign = new (cxt) AssignExpr(lhs, SourceLoc(), rhs,
+    auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs,
                                        /*Implicit=*/true);
-    auto body = BraceStmt::create(cxt, SourceLoc(), {assign}, SourceLoc());
+    auto body = BraceStmt::create(ctx, SourceLoc(), {assign}, SourceLoc());
     init->setBody(body);
   }
 
@@ -1368,24 +1368,24 @@ static void makeStructRawValuedWithBridge(
     Type storedUnderlyingType, Type bridgedType,
     ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
     ArrayRef<ProtocolDecl *> protocols, bool makeUnlabeledValueInit = false) {
-  auto &cxt = Impl.SwiftContext;
+  auto &ctx = Impl.SwiftContext;
   addProtocolsToStruct(Impl, structDecl, synthesizedProtocolAttrs, protocols);
 
-  auto storedVarName = cxt.getIdentifier("_rawValue");
-  auto computedVarName = cxt.Id_rawValue;
+  auto storedVarName = ctx.getIdentifier("_rawValue");
+  auto computedVarName = ctx.Id_rawValue;
 
   // Create a variable to store the underlying value.
   VarDecl *storedVar;
   PatternBindingDecl *storedPatternBinding;
   std::tie(storedVar, storedPatternBinding) = createVarWithPattern(
-      cxt, structDecl, storedVarName, storedUnderlyingType,
+      ctx, structDecl, storedVarName, storedUnderlyingType,
       VarDecl::Specifier::Var, /*isImplicit=*/true,
       AccessLevel::Private,
       AccessLevel::Private);
 
   //
   // Create a computed value variable
-  auto computedVar = new (cxt) VarDecl(
+  auto computedVar = new (ctx) VarDecl(
       /*IsStatic*/false, VarDecl::Specifier::Var, /*IsCaptureList*/false,
       SourceLoc(), computedVarName, bridgedType, structDecl);
   computedVar->setInterfaceType(bridgedType);
@@ -1400,7 +1400,7 @@ static void makeStructRawValuedWithBridge(
   // Create a pattern binding to describe the variable.
   Pattern *computedVarPattern = createTypedNamedPattern(computedVar);
   auto computedPatternBinding = PatternBindingDecl::create(
-      cxt, SourceLoc(), StaticSpellingKind::None, SourceLoc(),
+      ctx, SourceLoc(), StaticSpellingKind::None, SourceLoc(),
       computedVarPattern, nullptr, structDecl);
 
   // Don't bother synthesizing the body if we've already finished
@@ -1427,7 +1427,7 @@ static void makeStructRawValuedWithBridge(
   structDecl->addMember(computedVar);
   structDecl->addMember(computedVarGetter);
 
-  addSynthesizedTypealias(structDecl, cxt.Id_RawValue, bridgedType);
+  addSynthesizedTypealias(structDecl, ctx.Id_RawValue, bridgedType);
 }
 
 static Type getGenericMethodType(DeclContext *dc, AnyFunctionType *fnType) {
@@ -2411,7 +2411,7 @@ namespace {
       if (!dc)
         return nullptr;
       
-      ASTContext &cxt = Impl.SwiftContext;
+      ASTContext &ctx = Impl.SwiftContext;
       auto name = importedName.getDeclName().getBaseIdentifier();
 
       // Create the enum declaration and record it.
@@ -2441,8 +2441,8 @@ namespace {
         structDecl->computeType();
 
         ProtocolDecl *protocols[]
-          = {cxt.getProtocol(KnownProtocolKind::RawRepresentable),
-             cxt.getProtocol(KnownProtocolKind::Equatable)};
+          = {ctx.getProtocol(KnownProtocolKind::RawRepresentable),
+             ctx.getProtocol(KnownProtocolKind::Equatable)};
         if (!protocols[0] || !protocols[1])
           return nullptr;
 
@@ -4958,7 +4958,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
     // No other cases yet
   }
 
-  auto &cxt = Impl.SwiftContext;
+  auto &ctx = Impl.SwiftContext;
   auto Loc = Impl.importSourceLoc(decl->getLocation());
 
   auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
@@ -5003,7 +5003,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
 
   // Local function to add a known protocol.
   auto addKnown = [&](KnownProtocolKind kind) {
-    if (auto proto = cxt.getProtocol(kind)) {
+    if (auto proto = ctx.getProtocol(kind)) {
       protocols.push_back(proto);
       synthesizedProtocols.push_back(kind);
     }
@@ -5020,7 +5020,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
     if (!computedNominal)
       return false;
 
-    auto proto = cxt.getProtocol(kind);
+    auto proto = ctx.getProtocol(kind);
     if (!proto)
       return false;
 
@@ -5062,7 +5062,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
                                   /*makeUnlabeledValueInit=*/unlabeledCtor);
 
     if (transferredObjCBridgeable)
-      addSynthesizedTypealias(structDecl, cxt.Id_ObjectiveCType,
+      addSynthesizedTypealias(structDecl, ctx.Id_ObjectiveCType,
                               storedUnderlyingType);
   }
 
@@ -5201,7 +5201,7 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
 NominalTypeDecl *
 SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
                                           const clang::EnumDecl *decl) {
-  ASTContext &cxt = Impl.SwiftContext;
+  ASTContext &ctx = Impl.SwiftContext;
 
   // Compute the underlying type.
   auto underlyingType = Impl.importType(
@@ -5217,10 +5217,10 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
       decl, AccessLevel::Public, Loc, name, Loc, None, nullptr, dc);
   structDecl->computeType();
 
-  ProtocolDecl *protocols[] = {cxt.getProtocol(KnownProtocolKind::OptionSet)};
+  ProtocolDecl *protocols[] = {ctx.getProtocol(KnownProtocolKind::OptionSet)};
   makeStructRawValued(Impl, structDecl, underlyingType,
                       {KnownProtocolKind::OptionSet}, protocols);
-  addSynthesizedTypealias(structDecl, cxt.Id_Element,
+  addSynthesizedTypealias(structDecl, ctx.Id_Element,
                           structDecl->getDeclaredInterfaceType());
   return structDecl;
 }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -108,7 +108,6 @@ namespace {
         conformanceOptions |= ConformanceCheckFlags::InExpression;
 
       DeclContext *foundDC = found->getDeclContext();
-      auto foundProto = foundDC->getAsProtocolOrProtocolExtensionContext();
 
       auto addResult = [&](ValueDecl *result) {
         if (Known.insert({{result, baseDC}, false}).second) {
@@ -150,8 +149,9 @@ namespace {
       }
 
       // Dig out the protocol conformance.
+      auto *foundProto = cast<ProtocolDecl>(foundDC);
       auto conformance = TC.conformsToProtocol(conformingType, foundProto, DC,
-                                                 conformanceOptions);
+                                               conformanceOptions);
       if (!conformance) {
         // If there's no conformance, we have an existential
         // and we found a member from one of the protocols, and

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -80,11 +80,13 @@ var __PrivE2A: __PrivE2 { get }
 enum __PrivNSEnum : Int {
   init?(rawValue: Int)
   var rawValue: Int { get }
+  typealias RawValue = Int
   case A
 }
 enum NSEnum : Int {
   init?(rawValue: Int)
   var rawValue: Int { get }
+  typealias RawValue = Int
   case __privA
   @available(swift, obsoleted: 3, renamed: "__privA")
   static var __PrivA: NSEnum { get }
@@ -95,6 +97,7 @@ struct __PrivNSOptions : OptionSet {
   let rawValue: Int
   typealias RawValue = Int
   typealias Element = __PrivNSOptions
+  typealias ArrayLiteralElement = __PrivNSOptions
   static var A: __PrivNSOptions { get }
 }
 struct NSOptions : OptionSet {
@@ -102,6 +105,7 @@ struct NSOptions : OptionSet {
   let rawValue: Int
   typealias RawValue = Int
   typealias Element = NSOptions
+  typealias ArrayLiteralElement = NSOptions
   static var __privA: NSOptions { get }
   @available(swift, obsoleted: 3, renamed: "__privA")
   static var __PrivA: NSOptions { get }

--- a/test/ClangImporter/enum-with-target.swift
+++ b/test/ClangImporter/enum-with-target.swift
@@ -14,7 +14,7 @@ let calendarUnitsDep: NSCalendarUnitDeprecated = [.eraCalendarUnitDeprecated, .y
 // rdar://problem/21081557
 func pokeRawValue(_ random: SomeRandomEnum) {
   switch (random) {
-  case SomeRandomEnum.RawValue // expected-error{{expression pattern of type 'Int.Type' cannot match values of type 'SomeRandomEnum'}}
+  case SomeRandomEnum.RawValue // expected-error{{expression pattern of type 'SomeRandomEnum.RawValue.Type' (aka 'Int.Type') cannot match values of type 'SomeRandomEnum'}}
     // expected-error@-1{{expected ':' after 'case'}}
   }
 }

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -13,6 +13,7 @@
 // PRINT-CLASS-NEXT:     let rawValue: Int
 // PRINT-CLASS-NEXT:     typealias RawValue = Int
 // PRINT-CLASS-NEXT:     typealias Element = SomeClass
+// PRINT-CLASS-NEXT:     typealias ArrayLiteralElement = SomeClass
 // PRINT-CLASS-NEXT:     static var fuzzyDice: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:     static var spoiler: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:   }

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -91,6 +91,7 @@
 // FOUNDATION-NEXT: {{^}}enum NSRuncingMode : UInt {{{$}}
 // FOUNDATION-NEXT: {{^}}  init?(rawValue: UInt){{$}}
 // FOUNDATION-NEXT: {{^}}  var rawValue: UInt { get }{{$}}
+// FOUNDATION-NEXT: {{^}}  typealias RawValue = UInt
 // FOUNDATION-NEXT: {{^}}  case mince{{$}}
 // FOUNDATION-NEXT: {{^}}  @available(swift, obsoleted: 3, renamed: "mince"){{$}}
 // FOUNDATION-NEXT: {{^}}  static var Mince: NSRuncingMode { get }{{$}}
@@ -105,6 +106,7 @@
 // FOUNDATION-NEXT: {{^}}  let rawValue: UInt{{$}}
 // FOUNDATION-NEXT: {{^}}  typealias RawValue = UInt
 // FOUNDATION-NEXT: {{^}}  typealias Element = NSRuncingOptions
+// FOUNDATION-NEXT: {{^}}  typealias ArrayLiteralElement = NSRuncingOptions
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}
 // FOUNDATION-NEXT: {{^}}  static var none: NSRuncingOptions { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}


### PR DESCRIPTION
SIL serialization is currently somewhat broken because we might deserialize SIL instructions which reference imported types, but importing certain types requires that a Sema instance is present in order to fill out inferred associated types in conformances.

This PR is the first step towards breaking this dependency. Subsequent changes will require further discussion and review, but what I have here should not be controversial. Even if we decide that it is okay for the ClangImporter to assume a Sema instance is always present in general, it seems that synthesizing typealiases explicitly instead of inferring them is good for compile time, avoiding circularity, and overall simplicity.