### PR TITLE
Reworking ClangImporter to not depend on Sema, part 2

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -387,7 +387,10 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
         }
       }
 
-      if (isa<TypeAliasDecl>(typeDecl)) {
+      // FIXME: This is a hack, we should be able to remove this entire 'if'
+      // statement once we learn how to deal with the circularity here.
+      if (isa<TypeAliasDecl>(typeDecl) &&
+          isa<ProtocolDecl>(typeDecl->getDeclContext())) {
         if (!type->is<ArchetypeType>() &&
             !type->isTypeParameter() &&
             memberType->hasTypeParameter() &&

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3483,6 +3483,16 @@ InferredAssociatedTypesByWitnesses
 ConformanceChecker::inferTypeWitnessesViaValueWitnesses(
                     const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                     ValueDecl *req) {
+  // Conformances constructed by the ClangImporter should have explicit type
+  // witnesses already.
+  if (isa<ClangModuleUnit>(Conformance->getDeclContext()->getModuleScopeContext())) {
+    llvm::errs() << "Cannot infer associated types for imported conformance:\n";
+    Conformance->getType().dump(llvm::errs());
+    for (auto assocTypeDecl : allUnresolved)
+      assocTypeDecl->dump(llvm::errs());
+    abort();
+  }
+
   InferredAssociatedTypesByWitnesses result;
 
   auto isExtensionUsableForInference = [&](ExtensionDecl *extension) -> bool {

--- a/stdlib/public/core/NewtypeWrapper.swift.gyb
+++ b/stdlib/public/core/NewtypeWrapper.swift.gyb
@@ -23,6 +23,8 @@ extension _SwiftNewtypeWrapper where Self.RawValue : Hashable {
 
 #if _runtime(_ObjC)
 extension _SwiftNewtypeWrapper where Self.RawValue : _ObjectiveCBridgeable {
+  public typealias _ObjectiveCType = Self.RawValue._ObjectiveCType
+
   public func _bridgeToObjectiveC() -> Self.RawValue._ObjectiveCType {
     return rawValue._bridgeToObjectiveC()
   }

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -122,7 +122,8 @@ extension MySeq {
   }
 }
 
-// Specific diagnosis for trying to use complex typealiases in generic constraints
+// Typealiases whose underlying type is a structural type written in terms of
+// associated types
 protocol P1 {
     associatedtype A
     typealias F = (A) -> ()
@@ -186,7 +187,7 @@ struct T5 : P5 {
   var v9 = P6.B.self // expected-error {{type alias 'B' can only be used with a concrete type or generic parameter base}}
 }
 
-// Unqualified lookup finds typealiases in protocol extensions, though
+// Unqualified lookup finds typealiases in protocol extensions
 protocol P7 {
   associatedtype A
 }
@@ -215,3 +216,30 @@ protocol P8 {
 }
 
 func testP8<T: P8>(_: T) where T.A == Int { } // expected-error{{'A' has been renamed to 'B'}}{{34-35=B}}
+
+// Associated type resolution via lookup should find typealiases in protocol extensions
+protocol Edible {
+  associatedtype Snack
+}
+
+protocol CandyWrapper {
+  associatedtype Wrapped
+}
+
+extension CandyWrapper where Wrapped : Edible {
+  typealias Snack = Wrapped.Snack
+}
+
+struct Candy {}
+
+struct CandyBar : CandyWrapper {
+  typealias Wrapped = CandyEdible
+}
+
+struct CandyEdible : Edible {
+  typealias Snack = Candy
+}
+
+// Edible.Snack is witnessed by 'typealias Snack' inside the
+// constrained extension of CandyWrapper above
+extension CandyBar : Edible {}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/11795 which addresses the remaining case of a non-bridged newtype whose raw type is bridged.

Also, we now assert when attempting to infer an associated type for an imported conformance. This should no longer happen, and if it does, we've uncovered a case that might fail if we're importing a type after Sema has been torn down.