### PR TITLE
Modify crasher for SR-5836 to require asserts

### DIFF
--- a/validation-test/compiler_crashers_2/sr-5836.swift
+++ b/validation-test/compiler_crashers_2/sr-5836.swift
@@ -1,4 +1,5 @@
 // RUN: not --crash %target-typecheck-verify-swift
+// REQUIRES: asserts
 
 extension Dictionary {
   func doSomething<T>() -> [T : Value] {


### PR DESCRIPTION
Fix a test that is currently failing-to-fail on non-assert builds.

(If that's not enough double negatives for you!)