### PR TITLE
[4.0] String.*View.popFirst: availability and 3.2 impl

### DIFF
--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -616,8 +616,7 @@ extension Substring {
 // popFirst() is only present when a collection is its own subsequence. This was
 // dropped in Swift 4.
 extension String {
-  @available(swift, deprecated: 3.2)
-  @available(swift, obsoleted: 4, message:
+  @available(swift, deprecated: 3.2, obsoleted: 4, message:
     "Please use 'first', 'dropFirst()', or 'Substring.popFirst()'.")
   public mutating func popFirst() -> String.Element? {
     guard !isEmpty else { return nil }
@@ -628,8 +627,7 @@ extension String {
   }
 }
 extension String.CharacterView {
-  @available(swift, deprecated: 3.2)
-  @available(swift, obsoleted: 4, message:
+  @available(swift, deprecated: 3.2, obsoleted: 4, message:
     "Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'.")
   public mutating func popFirst() -> String.CharacterView.Element? {
     guard !isEmpty else { return nil }
@@ -640,8 +638,7 @@ extension String.CharacterView {
   }
 }
 extension String.UnicodeScalarView {
-  @available(swift, deprecated: 3.2)
-  @available(swift, obsoleted: 4, message:
+  @available(swift, deprecated: 3.2, obsoleted: 4, message:
     "Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'.")
   public mutating func popFirst() -> String.UnicodeScalarView.Element? {
     guard !isEmpty else { return nil }

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -612,3 +612,42 @@ extension Substring {
   }
 }
 //===----------------------------------------------------------------------===//
+
+// popFirst() is only present when a collection is its own subsequence. This was
+// dropped in Swift 4.
+extension String {
+  @available(swift, deprecated: 3.2)
+  @available(swift, obsoleted: 4, message:
+    "Please use 'first', 'dropFirst()', or 'Substring.popFirst()'.")
+  public mutating func popFirst() -> String.Element? {
+    guard !isEmpty else { return nil }
+    let element = first!
+    let nextIdx = self.index(after: self.startIndex)
+    self = String(self[nextIdx...])
+    return element
+  }
+}
+extension String.CharacterView {
+  @available(swift, deprecated: 3.2)
+  @available(swift, obsoleted: 4, message:
+    "Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'.")
+  public mutating func popFirst() -> String.CharacterView.Element? {
+    guard !isEmpty else { return nil }
+    let element = first!
+    let nextIdx = self.index(after: self.startIndex)
+    self = String(self[nextIdx...]).characters
+    return element
+  }
+}
+extension String.UnicodeScalarView {
+  @available(swift, deprecated: 3.2)
+  @available(swift, obsoleted: 4, message:
+    "Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'.")
+  public mutating func popFirst() -> String.UnicodeScalarView.Element? {
+    guard !isEmpty else { return nil }
+    let element = first!
+    let nextIdx = self.index(after: self.startIndex)
+    self = String(self[nextIdx...]).unicodeScalars
+    return element
+  }
+}

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -356,5 +356,20 @@ Tests.test("LosslessStringConvertible/force unwrap/\(swift)") {
 }
 #endif
 
+#if !swift(>=4)
+Tests.test("popFirst") {
+  var str = "abcdef"
+  expectOptionalEqual("a", str.popFirst())
+  expectOptionalEqual("bcdef", str)
+  expectOptionalEqual("b", str.characters.popFirst())
+  expectOptionalEqual("cdef", str)
+  expectOptionalEqual("c", str.unicodeScalars.popFirst())
+  expectOptionalEqual("def", str)
+  expectOptionalEqual("d", str.popFirst())
+  expectOptionalEqual("e", str.popFirst())
+  expectOptionalEqual("f", str.popFirst())
+  expectNil(str.popFirst())
+}
+#endif
 
 runAllTests()

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -3,7 +3,7 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // TODO: deprecate the view, and update the error here
+  _ = str.characters.popFirst() // FIXME: deprecate CharacterView. This call currently gets paired with default popFirst from Collection :-(
   _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
   var substr = str[...]

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -1,0 +1,14 @@
+// RUN: %swift -typecheck -swift-version 4 %s -verify
+
+func testPopFirst() {
+  var str = "abc"
+  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.characters.popFirst() // TODO: deprecate the view, and update the error here
+  _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+
+  var substr = str[...]
+  _ = substr.popFirst() // ok
+  _ = substr.characters.popFirst() // ok
+  _ = substr.unicodeScalars.popFirst() // ok
+}
+

--- a/test/stdlib/StringCompatibilityDiagnostics3.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics3.swift
@@ -1,0 +1,17 @@
+// RUN: %swift -typecheck -swift-version 3 %s -verify
+
+func testPopFirst() {
+  var str = "abc"
+  _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.characters.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
+    // TODO: ^^^ deprecate the view, and update the warning here
+  _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+
+  var substr = str[...]
+  _ = substr.popFirst() // ok
+  _ = substr.characters.popFirst() // ok
+  _ = substr.unicodeScalars.popFirst() // ok
+}
+
+
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a cherry-pick of parts of https://github.com/apple/swift/pull/11409 that are needed for source compatibility and quality of life for users.

https://bugs.swift.org/browse/SR-5659

CCC:
Explanation: As part of String re-working in Swift 4, we dropped the ability to mutate a String's views with `popFirst`. However, we still need a deprecated version available in Swift 3.2 mode. This adds deprecated support for those methods.
Scope: This is a fix to a source-breaking change to restore source compatibility.
Radar (and possibly SR Issue): https://bugs.swift.org/browse/SR-5659 <rdar://problem/33779236>
Risk: Low, without this change developers are unable to even call the method. With this change, it will perhaps be slower as it performs a copy (to release the old memory), but it can at least be called.
Testing: Full CI testing

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->