### PR TITLE
[ConstraintSolver] NFC: Increase default shrinking termination threshold

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -174,7 +174,7 @@ namespace swift {
 
     /// \brief The upper bound to number of sub-expressions unsolved
     /// before termination of the shrink phrase of the constraint solver.
-    unsigned SolverShrinkUnsolvedThreshold = 5;
+    unsigned SolverShrinkUnsolvedThreshold = 10;
 
     /// The maximum depth to which to test decl circularity.
     unsigned MaxCircularityDepth = 500;

--- a/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 7 --end 12 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 7 --end 15 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 let a = [0]

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 5 --end 10 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 8 --end 16 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar32999041.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar32999041.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test -Xfrontend=-propagate-constraints --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
We've found in practice that multiple different types of expressions
are still going to benefit from shrinking continuing even when it
couldn't simplify up to 10 sub-expressions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
