### PR TITLE
Declare DomTreeBuilder template instantiations in Dominance.h

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -25,6 +25,18 @@ extern template class llvm::DominatorTreeBase<swift::SILBasicBlock, false>;
 extern template class llvm::DominatorTreeBase<swift::SILBasicBlock, true>;
 extern template class llvm::DomTreeNodeBase<swift::SILBasicBlock>;
 
+namespace llvm {
+namespace DomTreeBuilder {
+using SILDomTree = llvm::DomTreeBase<swift::SILBasicBlock>;
+using SILPostDomTree = llvm::PostDomTreeBase<swift::SILBasicBlock>;
+
+extern template void Calculate<SILDomTree, swift::SILFunction>(
+    SILDomTree &DT, swift::SILFunction &F);
+extern template void Calculate<SILPostDomTree, swift::SILFunction>(
+    SILPostDomTree &DT, swift::SILFunction &F);
+} // namespace DomTreeBuilder
+} // namespace llvm
+
 namespace swift {
 
 using DominatorTreeBase = llvm::DominatorTreeBase<swift::SILBasicBlock, false>;

--- a/lib/SIL/Dominance.cpp
+++ b/lib/SIL/Dominance.cpp
@@ -14,7 +14,6 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/Dominance.h"
-#include "llvm/Support/GenericDomTree.h"
 #include "llvm/Support/GenericDomTreeConstruction.h"
 
 using namespace swift;
@@ -22,14 +21,15 @@ using namespace swift;
 template class llvm::DominatorTreeBase<SILBasicBlock, false>;
 template class llvm::DominatorTreeBase<SILBasicBlock, true>;
 template class llvm::DomTreeNodeBase<SILBasicBlock>;
-using SILDomTree = llvm::DomTreeBase<SILBasicBlock>;
-using SILPostDomTree = llvm::PostDomTreeBase<SILBasicBlock>;
-template void
-llvm::DomTreeBuilder::Calculate<SILDomTree, swift::SILFunction>(
+
+namespace llvm {
+namespace DomTreeBuilder {
+template void Calculate<SILDomTree, swift::SILFunction>(
     SILDomTree &DT, swift::SILFunction &F);
-template void
-llvm::DomTreeBuilder::Calculate<SILPostDomTree, swift::SILFunction>(
+template void Calculate<SILPostDomTree, swift::SILFunction>(
     SILPostDomTree &DT, swift::SILFunction &F);
+} // namespace DomTreeBuilder
+} // namespace llvm
 
 /// Compute the immediate-dominators map.
 DominanceInfo::DominanceInfo(SILFunction *F)


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/11075.

John had suggested that I declare the template instantiations in the header file, and I'm finally getting around to doing that.