### PR TITLE
IRGen: Remove a hack that no longer seems necessary

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2134,18 +2134,6 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
     auto associatedConformance =
       sourceConformance.getAssociatedConformance(sourceType, association,
                                                  associatedRequirement);
-
-    // FIXME: this should be taken care of automatically by
-    // getAssociatedConformance.
-    if (!associatedConformance.isConcrete() &&
-        !isa<ArchetypeType>(associatedType)) {
-      if (auto concreteConf =
-            IGF.IGM.getSwiftModule()->lookupConformance(associatedType,
-                                                      associatedRequirement)) {
-        associatedConformance = *concreteConf;
-      }
-    }
-
     sourceKey.Kind =
       LocalTypeDataKind::forProtocolWitnessTable(associatedConformance);
 


### PR DESCRIPTION
Generally we want to avoid calls to lookupConformance() after type
checking.