### PR TITLE
[TypeChecker] NFC: Adjust "too complex" error position of rdar://problem/20859567 perf test

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
@@ -8,6 +8,6 @@ struct Stringly {
 }
 
 [Int](0..<1).map {
-  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
   print(Stringly(format: "%d: ", $0 * 2) + ["a", "b", "c", "d"][$0 * 2] + ",")
+  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
 }


### PR DESCRIPTION
"Expression is too complex" error is reported on `print` call.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
