### PR TITLE
[ScaleTest] Fix -Xfrontend options to be passed with "-" to with compiler

### DIFF
--- a/utils/scale-test
+++ b/utils/scale-test
@@ -89,7 +89,7 @@ def run_once_with_primary(args, ast, rng, primary_idx):
         elif args.optimize_unchecked:
             opts = ['-Ounchecked']
 
-        extra = args.Xfrontend[:]
+        extra = ["-" + arg for arg in args.Xfrontend[:]]
         if args.debuginfo:
             extra.append('-g')
 


### PR DESCRIPTION
Since `argparse` doesn't allow values of -Xfrontend option to be passed
with "-" prefix, which means that "-" has to be added while forming
command line for compiler execution.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
