### PR TITLE
[inliner] Extract out checking if we can inline from inlineFunction into canInlineFunction. NFC.

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -55,6 +55,12 @@ public:
         Callback(Callback) {
   }
 
+  /// Returns true if we are able to inline \arg AI.
+  ///
+  /// *NOTE* This must be checked before attempting to inline \arg AI. If one
+  /// attempts to inline \arg AI and this returns false, an assert will fire.
+  bool canInlineFunction(FullApplySite AI);
+
   /// inlineFunction - This method inlines a callee function, assuming that it
   /// is called with the given arguments, into the caller at a given instruction
   /// (as specified by a basic block iterator), assuming that the instruction
@@ -62,11 +68,15 @@ public:
   /// performs one step of inlining: it does not recursively inline functions
   /// called by the callee.
   ///
-  /// Returns true on success or false if it is unable to inline the function
-  /// (for any reason). If successful, I now points to the first inlined
-  /// instruction, or the next instruction after the removed instruction in the
-  /// original function, in case the inlined function is completely trivial
-  bool inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args);
+  /// After completion, I now points to the first inlined instruction, or the
+  /// next instruction after the removed instruction in the original function,
+  /// in case the inlined function is completely trivial
+  ///
+  /// *NOTE*: This attempts to perform inlining unconditionally and thus asserts
+  /// if inlining will fail. All users /must/ check that a function is allowed
+  /// to be inlined using SILInliner::canInlineFunction before calling this
+  /// function.
+  void inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args);
 
 private:
   void visitDebugValueInst(DebugValueInst *Inst);

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -476,12 +476,14 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
       SILInliner Inliner(*F, *CalleeFunction,
                          SILInliner::InlineKind::MandatoryInline,
                          ApplySubs, OpenedArchetypesTracker);
-      if (!Inliner.inlineFunction(InnerAI, FullArgs)) {
+      if (!Inliner.canInlineFunction(InnerAI)) {
         I = InnerAI.getInstruction()->getIterator();
         continue;
       }
 
-      // Inlining was successful. Remove the apply.
+      Inliner.inlineFunction(InnerAI, FullArgs);
+
+      // We were able to inline successfully. Remove the apply.
       InnerAI.getInstruction()->eraseFromParent();
 
       // Reestablish our iterator if it wrapped.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -658,12 +658,12 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
                        AI.getSubstitutions(),
                        OpenedArchetypesTracker);
 
-    auto Success = Inliner.inlineFunction(AI, Args);
-    (void) Success;
     // We've already determined we should be able to inline this, so
-    // we expect it to have happened.
-    assert(Success && "Expected inliner to inline this function!");
-
+    // unconditionally inline the function.
+    //
+    // If for whatever reason we can not inline this function, inlineFunction
+    // will assert, so we are safe making this assumption.
+    Inliner.inlineFunction(AI, Args);
     recursivelyDeleteTriviallyDeadInstructions(AI.getInstruction(), true);
 
     NumFunctionsInlined++;


### PR DESCRIPTION
[inliner] Extract out checking if we can inline from inlineFunction into canInlineFunction. NFC.

The reason to do this is:

1. The check in SILInliner if we can inline can be done without triggering
side-effects.

2. This enables us to know if inlining will succeed before attempting to inline.
This enables for arguments to be adjusted with new SILInstructions and the like
before inlining occurs. I use this in a forthcoming patch that updates mandatory
inlining for ownership.

rdar://31521023