### PR TITLE
[mandatory-inlining] Turn on ownership verification on all swift tests for mandatory inlining.

### DIFF
--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -primary-file %s -emit-sil -o - -verify | %FileCheck %s
 
 // These tests are deliberately shallow, because I do not want to depend on the
 // specifics of SIL generation, which might change for reasons unrelated to this

--- a/test/SILOptimizer/mandatory_inlining_circular.swift
+++ b/test/SILOptimizer/mandatory_inlining_circular.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -emit-sil %s -o /dev/null -verify
 
 @_transparent func waldo(_ x: Double) -> Double {
   return fred(x); // expected-error {{inlining 'transparent' functions forms circular loop}} expected-note 1 {{while inlining here}}

--- a/test/SILOptimizer/mandatory_inlining_devirt.swift
+++ b/test/SILOptimizer/mandatory_inlining_devirt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -module-name test -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all %s -module-name test -emit-sil -o - -verify | %FileCheck %s
 
 
 // Constructor calls are dispatched dynamically for open classes, even if

--- a/test/SILOptimizer/mandatory_nil_comparison_inlining.swift
+++ b/test/SILOptimizer/mandatory_nil_comparison_inlining.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -module-name=test -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -primary-file %s -module-name=test -emit-sil -o - -verify | %FileCheck %s
 
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}generic_func


### PR DESCRIPTION
[mandatory-inlining] Turn on ownership verification on all swift tests for mandatory inlining.

The sil files have been left alone and mandatory inlining is still only being
applied to SIL without ownership. That is coming in a forthcoming commit.

rdar://31521023