### PR TITLE
[stl-extras] Provide next_or_default and prev_or_default helpers for iterators.

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -219,17 +219,33 @@ inline void set_union_for_each(const Container1 &C1, const Container2 &C2,
   set_union_for_each(C1.begin(), C1.end(), C2.begin(), C2.end(), f);
 }
 
+/// If \p it is equal to \p end, then return \p defaultIter. Otherwise, return
+/// std::next(\p it).
+template <typename Iterator>
+inline Iterator next_or_default(Iterator it, Iterator end,
+                                Iterator defaultIter) {
+  return (it == end) ? defaultIter : std::next(it);
+}
+
+/// If \p it is equal to \p begin, then return \p defaultIter. Otherwise, return
+/// std::prev(\p it).
+template <typename Iterator>
+inline Iterator prev_or_default(Iterator it, Iterator begin,
+                                Iterator defaultIter) {
+  return (it == begin) ? defaultIter : std::prev(it);
+}
+
 /// Takes an iterator and an iterator pointing to the end of the iterator range.
 /// If the iterator already points to the end of its range, simply return it,
 /// otherwise return the next element.
 template <typename Iterator>
 inline Iterator next_or_end(Iterator it, Iterator end) {
-  return (it == end) ? end : std::next(it);
+  return next_or_default(it, end, end);
 }
 
 template <typename Iterator>
 inline Iterator prev_or_begin(Iterator it, Iterator begin) {
-  return (it == begin) ? begin : std::prev(it);
+  return prev_or_default(it, begin, begin);
 }
 
 /// @}


### PR DESCRIPTION
[stl-extras] Provide next_or_default and prev_or_default helpers for iterators.

These work like next_or_end or prev_or_begin, except that instead of forcing the
default value to be the compared against the value, you can specify the value
used upon going out of range.

i.e., instead of:

(x, y) -> (x == y) ? y : std::next(x)

We have:

(x, y, z) -> (x == y) ? z : std::next(x)

This is a strict generalization of next_or_end and prev_or_begin so I
re-implemented both routines in terms of the new routines, so no source needed
to be updated.
