### PR TITLE
[SILValue] Prefer const_cast<> to C-style cast.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -260,7 +260,7 @@ class SILValue {
 
 public:
   SILValue(const ValueBase *V = nullptr)
-    : Value((ValueBase *)V) { }
+    : Value(const_cast<ValueBase *>(V)) { }
 
   ValueBase *operator->() const { return Value; }
   ValueBase &operator*() const { return *Value; }


### PR DESCRIPTION
Prevents a quite spammy warning with new versions of clang
(in the particular case, trunk as per today).