### PR TITLE
SIL ownership and reabstraction thunks.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -693,6 +693,7 @@ void SILGenModule::emitFunction(FuncDecl *fd) {
 
     emitOrDelayFunction(*this, constant, [this,constant,fd](SILFunction *f){
       preEmitFunction(constant, fd, f, fd);
+      PrettyStackTraceSILFunction X("silgen emitFunction", f);
       if (fd->getAccessorKind() == AccessorKind::IsMaterializeForSet)
         SILGenFunction(*this, *f).emitMaterializeForSet(fd);
       else

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -748,7 +748,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   SILValue addrOnlyBuf;
   ManagedValue nextBufOrValue;
 
-  if (optTL.isAddressOnly())
+  if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses())
     addrOnlyBuf = SGF.emitTemporaryAllocation(S, optTL.getLoweredType());
 
   // Create a new basic block and jump into it.
@@ -763,7 +763,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   //
   // Advance the generator.  Use a scope to ensure that any temporary stack
   // allocations in the subexpression are immediately released.
-  if (optTL.isAddressOnly()) {
+  if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses()) {
     Scope InnerForScope(SGF.Cleanups, CleanupLocation(S->getIteratorNext()));
     auto nextInit = SGF.useBufferAsTemporary(addrOnlyBuf, optTL);
     SGF.emitExprInto(S->getIteratorNext(), nextInit.get());
@@ -815,7 +815,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
           //
           // *NOTE* If we do not have an address only value, then inputValue is
           // *already properly unwrapped.
-          if (optTL.isAddressOnly()) {
+          if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses()) {
             inputValue =
                 SGF.emitManagedBufferWithCleanup(nextBufOrValue.getValue());
             inputValue = SGF.emitUncheckedGetOptionalValueFrom(

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Scope.h"
+#include "swift/Basic/Range.h"
 
 using namespace swift;
 using namespace Lowering;
@@ -116,6 +117,31 @@ RValue Scope::popPreservingValue(RValue &&rv) {
 
   // And then assemble the managed values into a rvalue.
   return RValue(SGF, std::move(managedValues), type, numEltsRemaining);
+}
+
+void Scope::popPreservingValues(ArrayRef<ManagedValue> innerValues,
+                                MutableArrayRef<ManagedValue> outerValues) {
+  auto &SGF = cleanups.SGF;
+  assert(innerValues.size() == outerValues.size());
+
+  // Record the cleanup information for each preserved value and deactivate its
+  // cleanup.
+  SmallVector<CleanupCloner, 4> cleanups;
+  cleanups.reserve(innerValues.size());
+  for (auto &mv : innerValues) {
+    cleanups.emplace_back(SGF, mv);
+    mv.forward(SGF);
+  }
+
+  // Pop any unpreserved cleanups.
+  pop();
+
+  // Create a managed value for each preserved value, cloning its cleanup.
+  // Since the CleanupCloner does not remember its SILValue, grab it from the
+  // original, now-deactivated managed value.
+  for (auto index : indices(innerValues)) {
+    outerValues[index] = cleanups[index].clone(innerValues[index].getValue());
+  }
 }
 
 void Scope::popImpl() {

--- a/lib/SILGen/Scope.h
+++ b/lib/SILGen/Scope.h
@@ -65,6 +65,12 @@ public:
   /// plus zero rvalue.
   RValue popPreservingValue(RValue &&rv);
 
+  /// Pop the scope pushing the +1 ManagedValues in `innerValues` through the
+  /// scope. Asserts if any ManagedValue is plus zero. Each cleanup is recreated
+  /// in the outer scope and associated with a managed value in `outerValues`.
+  void popPreservingValues(ArrayRef<ManagedValue> innerValues,
+                           MutableArrayRef<ManagedValue> outerValues);
+
 private:
   /// Internal private implementation of popImpl so we can use it in Scope::pop
   /// and in Scope's destructor.

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -959,7 +959,7 @@ func s440__cleanupEmission<T>(_ x: T) {
 // Test SILGenBuilder.loadCopy().
 // ---
 // CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s450__________lastValxSayxGd_tlF : $@convention(thin) <T> (@owned Array<T>) -> @out T
-// CHECK: [[LOAD:%.*]] = load [copy] %34 : $*T
+// CHECK: [[LOAD:%.*]] = load [copy] %{{.*}} : $*T
 // CHECK: return [[LOAD]] : $T
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s450__________lastValxSayxGd_tlF'
 func s450__________lastVal<T>(_ rest: T...) -> T {

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -90,15 +90,19 @@ enum AddressOnlyEnum {
 // ---
 // CHECK-LABEL: sil private @_T020opaque_values_silgen16OpaqueTupleClassC8inAndOutx_xtx_xt1x_tFAA0dF0CADxxAE_tFTV : $@convention(method) <U> (@in (U, U), @guaranteed OpaqueTupleClass<U>) -> @out (U, U) {
 // CHECK: bb0([[ARG0:%.*]] : $(U, U), [[ARG1:%.*]] : $OpaqueTupleClass<U>):
-// CHECK:   [[TELEM0:%.*]] = tuple_extract [[ARG0]] : $(U, U), 0
-// CHECK:   [[TELEM1:%.*]] = tuple_extract [[ARG0]] : $(U, U), 1
-// CHECK:   [[APPLY:%.*]] = apply {{.*}}<U>([[TELEM0]], [[TELEM1]], [[ARG1]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @in τ_0_0, @guaranteed OpaqueTupleClass<τ_0_0>) -> (@out τ_0_0, @out τ_0_0)
-// CHECK:   [[BORROWED_T:%.*]] = begin_borrow [[APPLY]]
-// CHECK:   [[BORROWED_T_EXT0:%.*]] = tuple_extract [[BORROWED_T]] : $(U, U), 0
-// CHECK:   [[RETVAL0:%.*]] = copy_value [[BORROWED_T_EXT0]] : $U
-// CHECK:   [[BORROWED_T_EXT1:%.*]] = tuple_extract [[BORROWED_T]] : $(U, U), 1
-// CHECK:   [[RETVAL1:%.*]] = copy_value [[BORROWED_T_EXT1]] : $U
-// CHECK:   end_borrow [[BORROWED_T]]
+// CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]] : $(U, U)
+// CHECK:   [[TELEM0:%.*]] = tuple_extract [[BORROWED_ARG0]] : $(U, U), 0
+// CHECK:   [[COPY0:%.*]] = copy_value [[TELEM0]] : $U
+// CHECK:   [[TELEM1:%.*]] = tuple_extract [[BORROWED_ARG0]] : $(U, U), 1
+// CHECK:   [[COPY1:%.*]] = copy_value [[TELEM1]] : $U
+// CHECK:   end_borrow [[BORROWED_ARG0]]
+// CHECK:   [[APPLY:%.*]] = apply {{.*}}<U>([[COPY0]], [[COPY1]], [[ARG1]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @in τ_0_0, @guaranteed OpaqueTupleClass<τ_0_0>) -> (@out τ_0_0, @out τ_0_0)
+// CHECK:   [[BORROWED_CALL:%.*]] = begin_borrow [[APPLY]]
+// CHECK:   [[BORROWED_CALL_EXT0:%.*]] = tuple_extract [[BORROWED_CALL]] : $(U, U), 0
+// CHECK:   [[RETVAL0:%.*]] = copy_value [[BORROWED_CALL_EXT0]] : $U
+// CHECK:   [[BORROWED_CALL_EXT1:%.*]] = tuple_extract [[BORROWED_CALL]] : $(U, U), 1
+// CHECK:   [[RETVAL1:%.*]] = copy_value [[BORROWED_CALL_EXT1]] : $U
+// CHECK:   end_borrow [[BORROWED_CALL]]
 // CHECK:   [[RETVAL:%.*]] = tuple ([[RETVAL0]] : $U, [[RETVAL1]] : $U)
 // CHECK:   return [[RETVAL]]
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen16OpaqueTupleClassC8inAndOutx_xtx_xt1x_tFAA0dF0CADxxAE_tFTV'
@@ -900,12 +904,19 @@ func s420__globalLvalueGet(_ i : Int) -> Int {
 // CHECK:   [[APPLY_T:%.*]] = apply %{{.*}}<((T) -> (), T)>() : $@convention(thin) <τ_0_0> () -> @out Optional<(Int, τ_0_0)>
 // CHECK:   switch_enum [[APPLY_T]] : $Optional<(Int, (@callee_owned (@in T) -> @out (), T))>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb2([[ENUMARG:%.*]] : $(Int, (@callee_owned (@in T) -> @out (), T))):
-// CHECK:   [[TELEM0:%.*]] = tuple_extract [[ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T)), 0
-// CHECK:   [[TELEM1:%.*]] = tuple_extract [[ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T)), 1
-// CHECK:   [[TELEM1P0:%.*]] = tuple_extract [[TELEM1]] : $(@callee_owned (@in T) -> @out (), T), 0
-// CHECK:   [[TELEM1P1:%.*]] = tuple_extract [[TELEM1]] : $(@callee_owned (@in T) -> @out (), T), 1
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}<T>([[TELEM1P0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @out ()) -> ()
-// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_owned (@in T) -> (), [[TELEM1P1]] : $T)
+// CHECK:   [[BORROWED_ENUMARG:%.*]] = begin_borrow [[ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T))
+// CHECK:   [[TELEM0:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T)), 0
+// CHECK:   [[TELEM1:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T)), 1
+// CHECK:   [[COPY1:%.*]] = copy_value [[TELEM1]] : $(@callee_owned (@in T) -> @out (), T)
+// CHECK:   end_borrow [[BORROWED_ENUMARG]]
+// CHECK:   [[BORROWED_COPY1:%.*]] = begin_borrow [[COPY1]] : $(@callee_owned (@in T) -> @out (), T)
+// CHECK:   [[TELEM1P0:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_owned (@in T) -> @out (), T), 0
+// CHECK:   [[COPY1P0:%.*]] = copy_value [[TELEM1P0]] : $@callee_owned (@in T) -> @out ()
+// CHECK:   [[TELEM1P1:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_owned (@in T) -> @out (), T), 1
+// CHECK:   [[COPY1P1:%.*]] = copy_value [[TELEM1P1]] : $T
+// CHECK:   end_borrow [[BORROWED_COPY1]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}<T>([[COPY1P0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @out ()) -> ()
+// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_owned (@in T) -> (), [[COPY1P1]] : $T)
 // CHECK:   [[NEWT1:%.*]] = tuple ([[TELEM0]] : $Int, [[NEWT0]] : $(@callee_owned (@in T) -> (), T))
 // CHECK:   [[NEWENUM:%.*]] = enum $Optional<(Int, (@callee_owned (@in T) -> (), T))>, #Optional.some!enumelt.1, [[NEWT1]] : $(Int, (@callee_owned (@in T) -> (), T))
 // CHECK:   br bb3([[NEWENUM]] : $Optional<(Int, (@callee_owned (@in T) -> (), T))>)

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -emit-silgen -verify %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen -verify %s | %FileCheck %s
 
 // SR-3090:
 
@@ -10,9 +10,52 @@ class Box<T> {
     }
 }
 
-let box = Box((22, { () in }))
-let foo = box.value.0
-print(foo)
+// CHECK: sil @_T04main7testBoxyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   // function_ref Box.__allocating_init(_:)
+// CHECK:   [[INIT_F:%.*]] = function_ref @_T04main3BoxCACyxGxcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0> // user: %26
+// CHECK:   // function_ref closure #1 in testBox()
+// CHECK:   [[CLOSURE:%.*]] = function_ref @_T04main7testBoxyyFyycfU_ : $@convention(thin) () -> ()
+// CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) () -> () to $@callee_owned () -> ()
+// CHECK:   [[TUPLEA:%.*]] = tuple (%{{.*}} : $Int, [[THICK]] : $@callee_owned () -> ())
+// CHECK:   [[BORROWA:%.*]] = begin_borrow [[TUPLEA]] : $(Int, @callee_owned () -> ())
+// CHECK:   [[ELTA_0:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_owned () -> ()), 0
+// CHECK:   [[ELTA_1:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_owned () -> ()), 1
+// CHECK:   [[COPYA_1:%.*]] = copy_value [[ELTA_1]] : $@callee_owned () -> () 
+// CHECK:   end_borrow [[BORROWA]] from %{{.*}} : $(Int, @callee_owned () -> ()), $(Int, @callee_owned () -> ())
+// CHECK:   [[THUNK1:%.*]] = function_ref @_T0Ix_ytytIxir_TR : $@convention(thin) (@in (), @owned @callee_owned () -> ()) -> @out ()
+// CHECK:   [[PA:%.*]] = partial_apply [[THUNK1]]([[COPYA_1]]) : $@convention(thin) (@in (), @owned @callee_owned () -> ()) -> @out ()
+// CHECK:   [[TUPLEB:%.*]] = tuple ([[ELTA_0]] : $Int, [[PA]] : $@callee_owned (@in ()) -> @out ())
+// CHECK:   [[BORROWB:%.*]] = begin_borrow [[TUPLEB]] : $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   [[TUPLEB_0:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_owned (@in ()) -> @out ()), 0
+// CHECK:   [[TUPLEB_1:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_owned (@in ()) -> @out ()), 1
+// CHECK:   [[COPYB_1:%.*]] = copy_value [[TUPLEB_1]] : $@callee_owned (@in ()) -> @out ()
+// CHECK:   [[CALL:%.*]] = apply [[INIT_F]]<(Int, () -> ())>(%{{.*}}, %{{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
+// CHECK:   end_borrow [[BORROWB]] from %{{.*}} : $(Int, @callee_owned (@in ()) -> @out ()), $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   destroy_value [[TUPLEB]] : $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   destroy_value [[TUPLEA]] : $(Int, @callee_owned () -> ())
+// CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [[CALL]] : $Box<(Int, () -> ())> 
+// CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_CALL]] : $Box<(Int, () -> ())>, #Box.value
+// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[REF]] : $*(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   [[TUPLEC:%.*]] = load [copy] [[READ]] : $*(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   [[BORROW_TUPLEC:%.*]] = begin_borrow [[TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   [[TUPLEC_0:%.*]] = tuple_extract [[BORROW_TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ()), 0
+// CHECK:   [[TUPLEC_1:%.*]] = tuple_extract [[BORROW_TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ()), 1
+// CHECK:   [[COPYC_1:%.*]] = copy_value [[TUPLEC_1]] : $@callee_owned (@in ()) -> @out ()
+// CHECK:   [[THUNK2:%.*]] = function_ref @_T0ytytIxir_Ix_TR : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> ()
+// CHECK:   [[PA2:%.*]] = partial_apply [[THUNK2]]([[COPYC_1]]) : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> ()
+// CHECK:   end_access [[READ]] : $*(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   destroy_value [[PA2]] : $@callee_owned () -> ()    
+// CHECK:   end_borrow [[BORROW_TUPLEC]] from %{{.*}} : $(Int, @callee_owned (@in ()) -> @out ()), $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   destroy_value [[TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   end_borrow [[BORROW_CALL]] from %{{.*}} : $Box<(Int, () -> ())>, $Box<(Int, () -> ())>
+// CHECK-LABEL: } // end sil function '_T04main7testBoxyyF'
+public func testBox() {
+  let box = Box((22, { () in }))
+  let foo = box.value.0
+  print(foo)
+}
+
 
 // Another crash -- re-abstracting function type inside optional in tuple
 // in-place


### PR DESCRIPTION
I noticed we were missing borrow scopes while testing opaque values.

I spent a lot of time trying to refactor the code but ended up creating more complexity. So this is just a simple "hack" that Michael pointed me toward. It's not too ugly and will be cleaned up once we introduce SIL `destructure`.