### PR TITLE
Codable synthesis: excluded vars shouldn’t need explicit value assignments

### DIFF
--- a/test/decl/protocol/special/coding/class_codable_excluded_optional_properties.swift
+++ b/test/decl/protocol/special/coding/class_codable_excluded_optional_properties.swift
@@ -1,0 +1,64 @@
+// RUN: %target-typecheck-verify-swift
+
+class ClassWithNonExcludedLetMembers : Codable { // expected-error {{class 'ClassWithNonExcludedLetMembers' has no initializers}}
+    // expected-error@-1 {{type 'ClassWithNonExcludedLetMembers' does not conform to protocol 'Decodable'}}
+    // expected-error@-2 {{type 'ClassWithNonExcludedLetMembers' does not conform to protocol 'Encodable'}}
+
+    // Optional `let`s do not get an implicit nil assignment.
+    let p1: String? // expected-note {{stored property 'p1' without initial value prevents synthesized initializers}}
+    let p2: String! // expected-note {{stored property 'p2' without initial value prevents synthesized initializers}}
+
+    // AnyHashable does not conform to Codable.
+    let p3: AnyHashable? // expected-note {{stored property 'p3' without initial value prevents synthesized initializers}}
+    // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'AnyHashable?' does not conform to 'Decodable'}}
+    // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'AnyHashable?' does not conform to 'Encodable'}}
+    let p4: AnyHashable? // expected-note {{stored property 'p4' without initial value prevents synthesized initializers}}
+    // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'AnyHashable?' does not conform to 'Decodable'}}
+    // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'AnyHashable?' does not conform to 'Encodable'}}
+}
+
+class ClassWithExcludedLetMembers : Codable { // expected-error {{class 'ClassWithExcludedLetMembers' has no initializers}}
+    // expected-error@-1 {{type 'ClassWithExcludedLetMembers' does not conform to protocol 'Decodable'}}
+
+    // Optional `let`s do not get an implicit nil assignment.
+    let p1: String? // expected-note {{stored property 'p1' without initial value prevents synthesized initializers}}
+    let p2: String! // expected-note {{stored property 'p2' without initial value prevents synthesized initializers}}
+
+    // AnyHashable does not conform to Codable.
+    let p3: AnyHashable? // expected-note {{stored property 'p3' without initial value prevents synthesized initializers}}
+    // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'p3' does not have a matching CodingKey and does not have a default value}}
+    let p4: AnyHashable? // expected-note {{stored property 'p4' without initial value prevents synthesized initializers}}
+    // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'p4' does not have a matching CodingKey and does not have a default value}}
+
+    // Explicitly exclude non-Codable properties.
+    enum CodingKeys : String, CodingKey {
+        case p1, p2
+    }
+}
+
+class ClassWithNonExcludedVarMembers : Codable { // expected-error {{type 'ClassWithNonExcludedVarMembers' does not conform to protocol 'Decodable'}}
+    // expected-error@-1 {{type 'ClassWithNonExcludedVarMembers' does not conform to protocol 'Encodable'}}
+
+    var p1: String?
+    var p2: String!
+
+    // AnyHashable does not conform to Codable.
+    var p3: AnyHashable? // expected-note {{cannot automatically synthesize 'Decodable' because 'AnyHashable?' does not conform to 'Decodable'}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'AnyHashable?' does not conform to 'Encodable'}}
+    var p4: AnyHashable! // expected-note {{cannot automatically synthesize 'Decodable' because 'AnyHashable!' does not conform to 'Decodable'}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'AnyHashable!' does not conform to 'Encodable'}}
+}
+
+class ClassWithExcludedVarMembers : Codable {
+    var p1: String?
+    var p2: String!
+
+    // AnyHashable does not conform to Codable.
+    var p3: AnyHashable?
+    var p4: AnyHashable!
+
+    // Explicitly exclude non-Codable properties.
+    enum CodingKeys : String, CodingKey {
+        case p1, p2
+    }
+}

--- a/test/decl/protocol/special/coding/struct_codable_excluded_optional_properties.swift
+++ b/test/decl/protocol/special/coding/struct_codable_excluded_optional_properties.swift
@@ -1,0 +1,69 @@
+// RUN: %target-typecheck-verify-swift
+
+struct StructWithNonExcludedLetMembers : Codable { // expected-error {{type 'StructWithNonExcludedLetMembers' does not conform to protocol 'Decodable'}}
+    // expected-error@-1 {{type 'StructWithNonExcludedLetMembers' does not conform to protocol 'Encodable'}}
+
+    // Suppress the memberwise initializer. Optional `let`s do not get an implicit nil assignment.
+    init() {}
+
+    let p1: String?
+    let p2: String!
+
+    // AnyHashable does not conform to Codable.
+    let p3: AnyHashable? // expected-note {{cannot automatically synthesize 'Decodable' because 'AnyHashable?' does not conform to 'Decodable'}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'AnyHashable?' does not conform to 'Encodable'}}
+    let p4: AnyHashable! // expected-note {{cannot automatically synthesize 'Decodable' because 'AnyHashable!' does not conform to 'Decodable'}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'AnyHashable!' does not conform to 'Encodable'}}
+}
+
+struct StructWithExcludedLetMembers : Codable { // expected-error {{type 'StructWithExcludedLetMembers' does not conform to protocol 'Decodable'}}
+
+    // Suppress the memberwise initializer. Optional `let`s do not get an implicit nil assignment.
+    init() {}
+
+    let p1: String?
+    let p2: String!
+
+    // AnyHashable does not conform to Codable.
+    let p3: AnyHashable? // expected-note {{cannot automatically synthesize 'Decodable' because 'p3' does not have a matching CodingKey and does not have a default value}}
+    let p4: AnyHashable! // expected-note {{cannot automatically synthesize 'Decodable' because 'p4' does not have a matching CodingKey and does not have a default value}}
+
+    // Explicitly exclude non-Codable properties.
+    enum CodingKeys : String, CodingKey {
+        case p1, p2
+    }
+}
+
+struct StructWithNonExcludedVarMembers : Codable { // expected-error {{type 'StructWithNonExcludedVarMembers' does not conform to protocol 'Decodable'}}
+    // expected-error@-1 {{type 'StructWithNonExcludedVarMembers' does not conform to protocol 'Encodable'}}
+
+    // Suppress the memberwise initializer.
+    init() {}
+
+    var p1: String?
+    var p2: String!
+
+    // AnyHashable does not conform to Codable.
+    var p3: AnyHashable? // expected-note {{cannot automatically synthesize 'Decodable' because 'AnyHashable?' does not conform to 'Decodable'}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'AnyHashable?' does not conform to 'Encodable'}}
+    var p4: AnyHashable! // expected-note {{cannot automatically synthesize 'Decodable' because 'AnyHashable!' does not conform to 'Decodable'}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'AnyHashable!' does not conform to 'Encodable'}}
+}
+
+struct StructWithExcludedVarMembers : Codable {
+
+    // Suppress the memberwise initializer.
+    init() {}
+
+    var p1: String?
+    var p2: String!
+
+    // AnyHashable does not conform to Codable.
+    var p3: AnyHashable?
+    var p4: AnyHashable!
+
+    // Explicitly exclude non-Codable properties.
+    enum CodingKeys : String, CodingKey {
+        case p1, p2
+    }
+}


### PR DESCRIPTION
**What's in this pull request?**
Properties of `Codable` types which are optional and excluded via the `CodingKeys` enum should not require an explicit `nil` assignment, since in all other cases, optional vars get a default value of `nil`. The following code should get correct synthesis:
```swift
class Foo : Codable {
    // These all get a default value of `nil`.
    var p1: String?
    var p2: String!
    var p3: AnyHashable?
    var p4: AnyHashable!

    private enum CodingKeys : String, CodingKey {
        case p1, p2
    }
}
```

Instead, `p3` and `p4` currently prevent synthesis because they don't have an explicit `nil` assignment.