### PR TITLE
Diagnose unreachable optional evaluation exprs

### DIFF
--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -111,6 +111,15 @@ func testUnreachableCase5(a : Tree) {
   }
 }
 
+func testOptionalEvaluationBreak(a : Tree) {
+  class SR5763 { func foo() {} }
+  func createOptional() -> SR5763? { return SR5763() }
+  switch a {
+  case _:
+    break
+    createOptional()?.foo() // expected-warning {{code after 'break' will never be executed}}
+  }
+}
 
 func testUnreachableAfterThrow(e: Error) throws {
   throw e


### PR DESCRIPTION
OptionalEvaluationExprs are always implicit and were
being let through SILGen's unreachable diagnostics
branch.  Decompose the expr structure to check to see if its
contents are not implicit expressions.  If that is the
case, then diagnose them.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5763](https://bugs.swift.org/browse/SR-5763).
