### PR TITLE
[4.0] [ConstraintGraph] Disallow subtype constraint contractions

### DIFF
--- a/validation-test/Sema/rdar34333874.swift
+++ b/validation-test/Sema/rdar34333874.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+class C {
+  var a: Int = 0
+  var b: Int = 0
+}
+
+@inline(never)
+func foo<T>(_ item: T, update: (inout T) throws -> Void) rethrows -> T {
+  var this = item
+  try update(&this)
+  return this
+}
+
+// Test single statement closure because it's type-checked
+// together with the call to `foo`
+
+let rdar34333874_1 = foo(C()) {
+  $0.a = 42
+}
+
+// The multi-statement closure which is type-checked
+// separately from call to `foo`
+
+let rdar34333874_2 = foo(C()) {
+  $0.a = 42
+  $0.b = 0
+}
+
+print(rdar34333874_1)
+print(rdar34333874_2)
+
+// Example which avoids mutating fields of the class
+
+@inline(never)
+func bar(_ o : C) {
+  let _ = foo(o) { (item) in
+  }
+}
+
+bar(C())


### PR DESCRIPTION
* Description: Presently subtype constraint is considered a candidate for contraction
via `shouldContractEdge` when left-hand side of the subtype constraint
is an inout type with type variable inside. Although it's intended to
be used only in combination with BindParam constraint assigned to the
same variable, that is actually never checked and contraction of subtype
constraint like that is invalid.

* Origination: Incorrect type-check results in the runtime crash, reported by [SR-5861](https://bugs.swift.org/browse/SR-5861) 

* Risk: Low.

* Tested: Added new tests, Swift CI.

* Reviewed by Mark Lacey.

* Resolves: rdar://problem/34333874
(cherry picked from commit 0a178fd263c4488e4d43ae72c031d63036d9a5e4)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
