### PR TITLE
[ClangImporter] Support Swift 5 API notes

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -786,6 +786,24 @@ inline OutputIterator transform(const Container &C, OutputIterator result,
   return std::transform(C.begin(), C.end(), result, op);
 }
 
+/// Provides default implementations of !=, <=, >, and >= based on == and <.
+template <typename T>
+class RelationalOperationsBase {
+public:
+  friend bool operator>(const T &left, const T &right) {
+    return right < left;
+  }
+  friend bool operator>=(const T &left, const T &right) {
+    return !(left < right);
+  }
+  friend bool operator<=(const T &left, const T &right) {
+    return !(right < left);
+  }
+  friend bool operator!=(const T &left, const T &right) {
+    return !(left == right);
+  }
+};
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_INTERLEAVE_H

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -437,7 +437,7 @@ clang::SwiftNewtypeAttr *
 importer::getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl,
                               ImportNameVersion version) {
   // Newtype was introduced in Swift 3
-  if (version < ImportNameVersion::Swift3 )
+  if (version <= ImportNameVersion::swift2())
     return nullptr;
   return retrieveNewTypeAttr(decl);
 }
@@ -448,7 +448,7 @@ clang::TypedefNameDecl *importer::findSwiftNewtype(const clang::NamedDecl *decl,
                                                    clang::Sema &clangSema,
                                                    ImportNameVersion version) {
   // Newtype was introduced in Swift 3
-  if (version < ImportNameVersion::Swift3 )
+  if (version <= ImportNameVersion::swift2())
     return nullptr;
 
   auto varDecl = dyn_cast<clang::VarDecl>(decl);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1650,7 +1650,7 @@ ClangImporter::Implementation::Implementation(ASTContext &ctx,
       BridgingHeaderExplicitlyRequested(!opts.BridgingHeader.empty()),
       DisableAdapterModules(opts.DisableAdapterModules),
       IsReadingBridgingPCH(false),
-      CurrentVersion(nameVersionFromOptions(ctx.LangOpts)),
+      CurrentVersion(ImportNameVersion::fromOptions(ctx.LangOpts)),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
       platformAvailability(ctx.LangOpts),
       nameImporter() {}
@@ -3152,10 +3152,8 @@ void ClangImporter::Implementation::lookupValue(
         const clang::NamedDecl *recentClangDecl =
             clangDecl->getMostRecentDecl();
 
-        forEachImportNameVersionFromCurrent(CurrentVersion,
-                                            [&](ImportNameVersion nameVersion) {
-          if (nameVersion == CurrentVersion)
-            return;
+        CurrentVersion.forEachOtherImportNameVersion(
+            [&](ImportNameVersion nameVersion) {
           if (anyMatching)
             return;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2508,32 +2508,34 @@ ClangModuleUnit::lookupNestedType(Identifier name,
 
     bool anyMatching = false;
     TypeDecl *originalDecl = nullptr;
-    owner.forEachDistinctName(clangTypeDecl, [&](ImportedName newName,
-                                                 ImportNameVersion nameVersion){
+    owner.forEachDistinctName(clangTypeDecl,
+                              [&](ImportedName newName,
+                                  ImportNameVersion nameVersion) -> bool {
       if (anyMatching)
-        return;
+        return true;
       if (!newName.getDeclName().isSimpleName(name))
-        return;
+        return true;
 
       auto decl = dyn_cast_or_null<TypeDecl>(
           owner.importDeclReal(clangTypeDecl, nameVersion));
       if (!decl)
-        return;
+        return false;
 
       if (!originalDecl)
         originalDecl = decl;
       else if (originalDecl == decl)
-        return;
+        return true;
 
       auto *importedContext = decl->getDeclContext()->
           getAsNominalTypeOrNominalTypeExtensionContext();
       if (importedContext != baseType)
-        return;
+        return true;
 
       assert(decl->getFullName().matchesRef(name) &&
              "importFullName behaved differently from importDecl");
       results.push_back(decl);
       anyMatching = true;
+      return true;
     });
   }
 
@@ -3211,12 +3213,12 @@ void ClangImporter::Implementation::lookupObjCMembers(
 
     forEachDistinctName(clangDecl,
                         [&](ImportedName importedName,
-                            ImportNameVersion nameVersion) {
+                            ImportNameVersion nameVersion) -> bool {
       // Import the declaration.
       auto decl =
           cast_or_null<ValueDecl>(importDeclReal(clangDecl, nameVersion));
       if (!decl)
-        return;
+        return false;
 
       // If the name we found matches, report the declaration.
       // FIXME: If we didn't need to check alternate decls here, we could avoid
@@ -3232,6 +3234,7 @@ void ClangImporter::Implementation::lookupObjCMembers(
           consumer.foundDecl(alternate, DeclVisibilityKind::DynamicLookup);
         }
       }
+      return true;
     });
   }
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6921,9 +6921,7 @@ getSwiftNameFromClangName(StringRef replacement) {
   {
     // Render a swift_name string.
     llvm::raw_svector_ostream os(renamed);
-    printSwiftName(importedName,
-                   /*fullyQualified=*/true,
-                   os);
+    printSwiftName(importedName, CurrentVersion, /*fullyQualified=*/true, os);
   }
 
   return SwiftContext.AllocateCopy(StringRef(renamed));

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -68,7 +68,7 @@ void EnumInfo::classifyEnum(ASTContext &ctx, const clang::EnumDecl *decl,
   // If API notes have /removed/ a FlagEnum or EnumExtensibility attribute,
   // then we don't need to check the macros.
   for (auto *attr : decl->specific_attrs<clang::SwiftVersionedAttr>()) {
-    if (!attr->getVersion().empty())
+    if (!attr->getIsReplacedByActive())
       continue;
     if (isa<clang::FlagEnumAttr>(attr->getAttrToAdd()) ||
         isa<clang::EnumExtensibilityAttr>(attr->getAttrToAdd())) {

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -110,7 +110,7 @@ public:
   /// FIXME: All other version information is in Version.h. Can this go there
   /// instead?
   static constexpr inline ImportNameVersion maxVersion() {
-    return ImportNameVersion{4, AsConstExpr};
+    return ImportNameVersion{5, AsConstExpr};
   }
 
   /// The version which should be used for importing types, which need to have

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -141,11 +141,6 @@ class ImportedName {
     /// For an initializer, the kind of initializer to import.
     CtorInitializerKind initKind;
 
-    /// The version of Swift this name corresponds to.
-    ///
-    /// \see ImportNameVersion
-    unsigned rawVersion : 2;
-
     /// What kind of accessor this name refers to, if any.
     ImportedAccessorKind accessorKind : NumImportedAccessorKindBits;
 
@@ -167,9 +162,9 @@ class ImportedName {
 
     Info()
         : errorInfo(), selfIndex(), initKind(CtorInitializerKind::Designated),
-          rawVersion(), accessorKind(ImportedAccessorKind::None),
-          hasCustomName(false), droppedVariadic(false), importAsMember(false),
-          hasSelfIndex(false), hasErrorInfo(false) {}
+          accessorKind(ImportedAccessorKind::None), hasCustomName(false),
+          droppedVariadic(false), importAsMember(false), hasSelfIndex(false),
+          hasErrorInfo(false) {}
   } info;
 
 public:
@@ -187,16 +182,6 @@ public:
   }
   void setEffectiveContext(EffectiveClangContext ctx) {
     effectiveContext = ctx;
-  }
-
-  /// The highest version of Swift that this name comes from
-  ImportNameVersion getVersion() const {
-    return static_cast<ImportNameVersion>(info.rawVersion);
-  }
-
-  void setVersion(ImportNameVersion version) {
-    info.rawVersion = static_cast<unsigned>(version);
-    assert(getVersion() == version && "not enough bits");
   }
 
   /// For an initializer, the kind of initializer to import.

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -20,6 +20,7 @@
 #include "ImportEnumInfo.h"
 #include "SwiftLookupTable.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Basic/Version.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -40,77 +41,87 @@ enum class ImportedAccessorKind : unsigned {
 enum { NumImportedAccessorKindBits = 3 };
 
 /// The name version
-enum class ImportNameVersion : unsigned {
-  /// Names as they appear in C/ObjC
-  Raw = 0,
+class ImportNameVersion : public RelationalOperationsBase<ImportNameVersion> {
+  unsigned rawValue;
+  friend llvm::DenseMapInfo<ImportNameVersion>;
 
-  /// Names as they appeared in Swift 2 family
-  Swift2,
+  enum AsConstExpr_t { AsConstExpr };
 
-  /// Names as they appeared in Swift 3 family
-  Swift3,
+  constexpr ImportNameVersion() : rawValue(0) {}
+  constexpr ImportNameVersion(unsigned version, AsConstExpr_t)
+      : rawValue(version) {}
+  explicit ImportNameVersion(unsigned version) : rawValue(version) {
+    assert(version >= 2 && "only Swift 2 and later are supported");
+  }
+public:
+  /// Map a language version into an import name version.
+  static ImportNameVersion fromOptions(const LangOptions &langOpts) {
+    return ImportNameVersion(langOpts.EffectiveLanguageVersion[0]);
+  }
 
-  /// Names as they appeared in Swift 4 family
-  Swift4,
+  unsigned majorVersionNumber() const {
+    assert(*this != ImportNameVersion::raw());
+    return rawValue;
+  }
 
-  /// A placeholder for the latest version, to be used in loops and such.
-  LAST_VERSION = Swift4,
+  bool operator==(ImportNameVersion other) const {
+    return rawValue == other.rawValue;
+  }
+  bool operator<(ImportNameVersion other) const {
+    return rawValue < other.rawValue;
+  }
+
+  /// Calls \p action for each name version other than this one, first going
+  /// backwards until ImportNameVersion::raw(), and then going forwards to
+  /// ImportNameVersion::maxVersion().
+  ///
+  /// This is the most useful order for importing compatibility stubs.
+  void forEachOtherImportNameVersion(
+      llvm::function_ref<void(ImportNameVersion)> action) const {
+    assert(*this >= ImportNameVersion::swift2());
+
+    ImportNameVersion nameVersion = *this;
+    while (nameVersion > ImportNameVersion::swift2()) {
+      --nameVersion.rawValue;
+      action(nameVersion);
+    }
+
+    action(ImportNameVersion::raw());
+
+    nameVersion = *this;
+    while (nameVersion < ImportNameVersion::maxVersion()) {
+      ++nameVersion.rawValue;
+      action(nameVersion);
+    }
+  }
+
+  /// Names as they appear in C/ObjC.
+  static constexpr inline ImportNameVersion raw() {
+    return ImportNameVersion{};
+  }
+
+  /// Names as they appeared in Swift 2 family.
+  static constexpr inline ImportNameVersion swift2() {
+    return ImportNameVersion{2, AsConstExpr};
+  }
+
+  /// The latest supported version.
+  ///
+  /// FIXME: All other version information is in Version.h. Can this go there
+  /// instead?
+  static constexpr inline ImportNameVersion maxVersion() {
+    return ImportNameVersion{4, AsConstExpr};
+  }
 
   /// The version which should be used for importing types, which need to have
   /// one canonical definition.
   ///
   /// FIXME: Is this supposed to be the /newest/ version, or a canonical
   /// version that lasts forever as part of the ABI?
-  ForTypes = Swift4
+  static constexpr inline ImportNameVersion forTypes() {
+    return ImportNameVersion::maxVersion();
+  }
 };
-
-static inline ImportNameVersion &operator++(ImportNameVersion &value) {
-  assert(value != ImportNameVersion::LAST_VERSION);
-  value = static_cast<ImportNameVersion>(static_cast<unsigned>(value) + 1);
-  return value;
-}
-
-static inline ImportNameVersion &operator--(ImportNameVersion &value) {
-  assert(value != ImportNameVersion::Raw);
-  value = static_cast<ImportNameVersion>(static_cast<unsigned>(value) - 1);
-  return value;
-}
-
-/// Calls \p action for each name version, starting with \p current, then going
-/// backwards until ImportNameVersion::Raw, and then finally going forwards to
-/// ImportNameVersion::LAST_VERSION.
-///
-/// This is the most useful order for importing compatibility stubs.
-static inline void forEachImportNameVersionFromCurrent(
-    ImportNameVersion current,
-    llvm::function_ref<void(ImportNameVersion)> action) {
-  action(current);
-  ImportNameVersion nameVersion = current;
-  while (nameVersion != ImportNameVersion::Raw) {
-    --nameVersion;
-    action(nameVersion);
-  }
-  nameVersion = current;
-  while (nameVersion != ImportNameVersion::LAST_VERSION) {
-    ++nameVersion;
-    action(nameVersion);
-  }
-}
-
-/// Calls \p action for each name version, starting with ImportNameVersion::Raw
-/// and going forwards.
-static inline void
-forEachImportNameVersion(llvm::function_ref<void(ImportNameVersion)> action) {
-  auto limit = static_cast<unsigned>(ImportNameVersion::LAST_VERSION);
-  for (unsigned raw = 0; raw <= limit; ++raw)
-    action(static_cast<ImportNameVersion>(raw));
-}
-
-/// Map a language version into an import name version.
-ImportNameVersion nameVersionFromOptions(const LangOptions &langOpts);
-
-/// Map an import name version into a language version.
-unsigned majorVersionNumberForNameVersion(ImportNameVersion version);
 
 /// Describes a name that was imported from Clang.
 class ImportedName {
@@ -257,11 +268,6 @@ public:
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
-/// Find the swift_name attribute associated with this declaration, if any,
-/// appropriate for \p version.
-const clang::SwiftNameAttr *findSwiftNameAttr(const clang::Decl *decl,
-                                              ImportNameVersion version);
-
 /// Class to determine the Swift name of foreign entities. Currently fairly
 /// stateless and borrows from the ClangImporter::Implementation, but in the
 /// future will be more self-contained and encapsulated.
@@ -372,7 +378,7 @@ template <> struct DenseMapInfo<swift::importer::ImportNameVersion> {
     return (ImportNameVersion)DMIU::getTombstoneKey();
   }
   static unsigned getHashValue(const ImportNameVersion &Val) {
-    return DMIU::getHashValue((unsigned)Val);
+    return DMIU::getHashValue(Val.rawValue);
   }
   static bool isEqual(const ImportNameVersion &LHS,
                       const ImportNameVersion &RHS) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -640,7 +640,9 @@ public:
 
   /// Print an imported name as a string suitable for the swift_name attribute,
   /// or the 'Rename' field of AvailableAttr.
-  void printSwiftName(importer::ImportedName, bool fullyQualified,
+  void printSwiftName(importer::ImportedName name,
+                      importer::ImportNameVersion version,
+                      bool fullyQualified,
                       llvm::raw_ostream &os);
 
   /// \brief Import the given Clang identifier into Swift.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1232,8 +1232,8 @@ public:
   /// If \p action returns false, the current name will \e not be added to the
   /// set of seen names.
   ///
-  /// The names are generated in the same order as
-  /// forEachImportNameVersionFromCurrent. The current name is always first.
+  /// The active name is always first, followed by the other names in the order
+  /// of ImportNameVersion::forEachOtherImportNameVersion.
   void forEachDistinctName(
       const clang::NamedDecl *decl,
       llvm::function_ref<bool(importer::ImportedName,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1131,7 +1131,14 @@ private:
   void insertMembersAndAlternates(const clang::NamedDecl *nd,
                                   SmallVectorImpl<Decl *> &members);
   void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
-  void addMemberAndAlternatesToExtension(
+
+  /// Imports \p decl under \p nameVersion with the name \p newName, and adds
+  /// it and its alternates to \p ext.
+  ///
+  /// \returns true if \p decl was successfully imported, whether or not it was
+  /// ultimately added to \p ext. This matches the behavior of
+  /// forEachDistinctName's callback.
+  bool addMemberAndAlternatesToExtension(
       clang::NamedDecl *decl, importer::ImportedName newName,
       importer::ImportNameVersion nameVersion, ExtensionDecl *ext);
 
@@ -1222,11 +1229,14 @@ public:
   /// will eventually reference that declaration, the contexts will still be
   /// considered distinct.
   ///
+  /// If \p action returns false, the current name will \e not be added to the
+  /// set of seen names.
+  ///
   /// The names are generated in the same order as
   /// forEachImportNameVersionFromCurrent. The current name is always first.
   void forEachDistinctName(
       const clang::NamedDecl *decl,
-      llvm::function_ref<void(importer::ImportedName,
+      llvm::function_ref<bool(importer::ImportedName,
                               importer::ImportNameVersion)> action);
 
   /// Dump the Swift-specific name lookup tables we generate.

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1625,8 +1625,8 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   }
 
   // If we have a name to import as, add this entry to the table.
-  ImportNameVersion currentVersion =
-      nameVersionFromOptions(nameImporter.getLangOpts());
+  auto currentVersion =
+      ImportNameVersion::fromOptions(nameImporter.getLangOpts());
   if (auto importedName = nameImporter.importName(named, currentVersion)) {
     SmallPtrSet<DeclName, 8> distinctNames;
     distinctNames.insert(importedName.getDeclName());
@@ -1640,9 +1640,8 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
                               ArrayRef<Identifier>()),
                      named, importedName.getEffectiveContext());
 
-    forEachImportNameVersion([&] (ImportNameVersion alternateVersion) {
-      if (alternateVersion == currentVersion)
-        return;
+    currentVersion.forEachOtherImportNameVersion(
+        [&](ImportNameVersion alternateVersion) {
       auto alternateName = nameImporter.importName(named, alternateVersion);
       if (!alternateName)
         return;

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -65,6 +65,23 @@ Functions:
 Tags:
   - Name: InnerInSwift4
     SwiftName: Outer.Inner
+Globals:
+  - Name: multiVersionedGlobal34Notes
+    SwiftName: multiVersionedGlobal34Notes_NEW
+  - Name: multiVersionedGlobal34Both
+    SwiftName: multiVersionedGlobal34Both_NEW
+  - Name: multiVersionedGlobal345Notes
+    SwiftName: multiVersionedGlobal345Notes_NEW
+  - Name: multiVersionedGlobal345Both
+    SwiftName: multiVersionedGlobal345Both_NEW
+  - Name: multiVersionedGlobal4Notes
+    SwiftName: multiVersionedGlobal4Notes_NEW
+  - Name: multiVersionedGlobal4Both
+    SwiftName: multiVersionedGlobal4Both_NEW
+  - Name: multiVersionedGlobal45Notes
+    SwiftName: multiVersionedGlobal45Notes_NEW
+  - Name: multiVersionedGlobal45Both
+    SwiftName: multiVersionedGlobal45Both_NEW
 SwiftVersions:
   - Version: 3.0
     Classes:
@@ -207,3 +224,72 @@ SwiftVersions:
         SwiftName: aliasRenamedSwift3
       - Name: OptionyEnumRenamed
         SwiftName: renamedSwift3
+    Globals:
+      - Name: multiVersionedGlobal34
+        SwiftName: multiVersionedGlobal34_3
+      - Name: multiVersionedGlobal34Header
+        SwiftName: multiVersionedGlobal34Header_3
+      - Name: multiVersionedGlobal34Notes
+        SwiftName: multiVersionedGlobal34Notes_3
+      - Name: multiVersionedGlobal34Both
+        SwiftName: multiVersionedGlobal34Both_3
+      - Name: multiVersionedGlobal345
+        SwiftName: multiVersionedGlobal345_3
+      - Name: multiVersionedGlobal345Header
+        SwiftName: multiVersionedGlobal345Header_3
+      - Name: multiVersionedGlobal345Notes
+        SwiftName: multiVersionedGlobal345Notes_3
+      - Name: multiVersionedGlobal345Both
+        SwiftName: multiVersionedGlobal345Both_3
+  - Version: 5
+    Globals:
+      - Name: multiVersionedGlobal345
+        SwiftName: multiVersionedGlobal345_5
+      - Name: multiVersionedGlobal345Header
+        SwiftName: multiVersionedGlobal345Header_5
+      - Name: multiVersionedGlobal345Notes
+        SwiftName: multiVersionedGlobal345Notes_5
+      - Name: multiVersionedGlobal345Both
+        SwiftName: multiVersionedGlobal345Both_5
+      - Name: multiVersionedGlobal45
+        SwiftName: multiVersionedGlobal45_5
+      - Name: multiVersionedGlobal45Header
+        SwiftName: multiVersionedGlobal45Header_5
+      - Name: multiVersionedGlobal45Notes
+        SwiftName: multiVersionedGlobal45Notes_5
+      - Name: multiVersionedGlobal45Both
+        SwiftName: multiVersionedGlobal45Both_5
+  - Version: 4 # Versions are deliberately ordered as "3, 5, 4" to catch bugs.
+    Globals:
+      - Name: multiVersionedGlobal34
+        SwiftName: multiVersionedGlobal34_4
+      - Name: multiVersionedGlobal34Header
+        SwiftName: multiVersionedGlobal34Header_4
+      - Name: multiVersionedGlobal34Notes
+        SwiftName: multiVersionedGlobal34Notes_4
+      - Name: multiVersionedGlobal34Both
+        SwiftName: multiVersionedGlobal34Both_4
+      - Name: multiVersionedGlobal345
+        SwiftName: multiVersionedGlobal345_4
+      - Name: multiVersionedGlobal345Header
+        SwiftName: multiVersionedGlobal345Header_4
+      - Name: multiVersionedGlobal345Notes
+        SwiftName: multiVersionedGlobal345Notes_4
+      - Name: multiVersionedGlobal345Both
+        SwiftName: multiVersionedGlobal345Both_4
+      - Name: multiVersionedGlobal4
+        SwiftName: multiVersionedGlobal4_4
+      - Name: multiVersionedGlobal4Header
+        SwiftName: multiVersionedGlobal4Header_4
+      - Name: multiVersionedGlobal4Notes
+        SwiftName: multiVersionedGlobal4Notes_4
+      - Name: multiVersionedGlobal4Both
+        SwiftName: multiVersionedGlobal4Both_4
+      - Name: multiVersionedGlobal45
+        SwiftName: multiVersionedGlobal45_4
+      - Name: multiVersionedGlobal45Header
+        SwiftName: multiVersionedGlobal45Header_4
+      - Name: multiVersionedGlobal45Notes
+        SwiftName: multiVersionedGlobal45Notes_4
+      - Name: multiVersionedGlobal45Both
+        SwiftName: multiVersionedGlobal45Both_4

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -32,6 +32,7 @@ __attribute__((objc_root_class))
 
 #import <APINotesFrameworkTest/Classes.h>
 #import <APINotesFrameworkTest/Enums.h>
+#import <APINotesFrameworkTest/Globals.h>
 #import <APINotesFrameworkTest/ImportAsMember.h>
 #import <APINotesFrameworkTest/Properties.h>
 #import <APINotesFrameworkTest/Protocols.h>

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Globals.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Globals.h
@@ -1,0 +1,23 @@
+#pragma clang assume_nonnull begin
+
+int multiVersionedGlobal4;
+int multiVersionedGlobal4Notes;
+int multiVersionedGlobal4Header __attribute__((swift_name("multiVersionedGlobal4Header_NEW")));
+int multiVersionedGlobal4Both __attribute__((swift_name("multiVersionedGlobal4Both_OLD")));
+
+int multiVersionedGlobal34;
+int multiVersionedGlobal34Notes;
+int multiVersionedGlobal34Header __attribute__((swift_name("multiVersionedGlobal34Header_NEW")));
+int multiVersionedGlobal34Both __attribute__((swift_name("multiVersionedGlobal34Both_OLD")));
+
+int multiVersionedGlobal45;
+int multiVersionedGlobal45Notes;
+int multiVersionedGlobal45Header __attribute__((swift_name("multiVersionedGlobal45Header_NEW")));
+int multiVersionedGlobal45Both __attribute__((swift_name("multiVersionedGlobal45Both_OLD")));
+
+int multiVersionedGlobal345;
+int multiVersionedGlobal345Notes;
+int multiVersionedGlobal345Header __attribute__((swift_name("multiVersionedGlobal345Header_NEW")));
+int multiVersionedGlobal345Both __attribute__((swift_name("multiVersionedGlobal345Both_OLD")));
+
+#pragma clang assume_nonnull end

--- a/test/APINotes/versioned-multi.swift
+++ b/test/APINotes/versioned-multi.swift
@@ -1,0 +1,142 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 3 | %FileCheck -check-prefix=CHECK-SWIFT-3 %s
+
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 %s
+
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal4_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Notes_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4Notes: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal4Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Header_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4Header: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal4Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Both_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4Both: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal4Both_4: Int32
+
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal34_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Notes_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Notes: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal34Notes_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34Notes_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Header_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Header: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal34Header_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34Header_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Both_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Both: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal34Both_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34Both_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Both_4: Int32
+
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal45_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Notes_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45Notes: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal45Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Header_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45Header: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal45Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Both_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45Both: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal45Both_4: Int32
+
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal345_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Notes_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Notes: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal345Notes_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345Notes_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Header_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Header: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal345Header_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345Header_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Both_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Both: Int32
+// CHECK-SWIFT-3: var multiVersionedGlobal345Both_3: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345Both_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Both_4: Int32
+
+
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal4_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4Notes: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal4Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4Header: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal4Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4Both: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal4Both_4: Int32
+
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal34_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Notes: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Notes_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal34Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Header: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Header_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal34Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Both: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Both_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal34Both_4: Int32
+
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal45_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45Notes: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal45Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45Header: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal45Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45Both: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal45Both_4: Int32
+
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal345_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Notes: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Notes_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal345Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Header: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Header_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal345Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Both: Int32
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Both_3: Int32
+// CHECK-SWIFT-4: var multiVersionedGlobal345Both_4: Int32

--- a/test/APINotes/versioned-multi.swift
+++ b/test/APINotes/versioned-multi.swift
@@ -4,18 +4,26 @@
 
 // RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 %s
 
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 %s
+
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal4: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal4_4: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Notes_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal4Notes: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal4Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal4Notes_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4Notes_NEW: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Header_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal4Header: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal4Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal4Header_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4Header_NEW: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Both_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal4Both: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal4Both_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal4Both_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal4Both_NEW: Int32
 
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal34: Int32
@@ -27,50 +35,72 @@
 // CHECK-SWIFT-3: var multiVersionedGlobal34Notes_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34Notes_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal34Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal34Notes_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Notes_NEW: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Header_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal34Header: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal34Header_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34Header_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal34Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal34Header_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Header_NEW: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Both_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal34Both: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal34Both_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal34Both_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal34Both_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal34Both_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal34Both_NEW: Int32
 
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal45: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal45_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45_5: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Notes_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal45Notes: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal45Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45Notes_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45Notes_5: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Header_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal45Header: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal45Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45Header_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45Header_5: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Both_4")
 // CHECK-SWIFT-3: var multiVersionedGlobal45Both: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal45Both_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45Both_4")
+// CHECK-SWIFT-3: var multiVersionedGlobal45Both_5: Int32
 
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal345_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345_5: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Notes_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345Notes: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal345Notes_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345Notes_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345Notes_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345Notes_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Notes_5: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Header_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345Header: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal345Header_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345Header_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345Header_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345Header_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Header_5: Int32
 // CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Both_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345Both: Int32
 // CHECK-SWIFT-3: var multiVersionedGlobal345Both_3: Int32
 // CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "multiVersionedGlobal345Both_3")
 // CHECK-SWIFT-3: var multiVersionedGlobal345Both_4: Int32
+// CHECK-SWIFT-3: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345Both_3")
+// CHECK-SWIFT-3: var multiVersionedGlobal345Both_5: Int32
 
 
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4_4")
@@ -79,12 +109,18 @@
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Notes_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal4Notes: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal4Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal4Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4Notes_NEW: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Header_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal4Header: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal4Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal4Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4Header_NEW: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Both_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal4Both: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal4Both_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal4Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal4Both_NEW: Int32
 
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal34: Int32
@@ -96,47 +132,166 @@
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Notes_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal34Notes_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal34Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal34Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Notes_NEW: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Header_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal34Header: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Header_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal34Header_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal34Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal34Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Header_NEW: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Both_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal34Both: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Both_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal34Both_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal34Both_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal34Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal34Both_NEW: Int32
 
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal45: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal45_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45_5: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Notes_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal45Notes: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal45Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45Notes_5: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Header_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal45Header: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal45Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45Header_5: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Both_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal45Both: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal45Both_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal45Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal45Both_5: Int32
 
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal345_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345_5: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Notes_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345Notes: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Notes_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345Notes_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal345Notes_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345Notes_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Notes_5: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Header_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345Header: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Header_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345Header_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal345Header_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345Header_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Header_5: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Both_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345Both: Int32
 // CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Both_4")
 // CHECK-SWIFT-4: var multiVersionedGlobal345Both_3: Int32
 // CHECK-SWIFT-4: var multiVersionedGlobal345Both_4: Int32
+// CHECK-SWIFT-4: @available(swift, introduced: 5, renamed: "multiVersionedGlobal345Both_4")
+// CHECK-SWIFT-4: var multiVersionedGlobal345Both_5: Int32
+
+
+// CHECK-SWIFT-5: var multiVersionedGlobal4: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4")
+// CHECK-SWIFT-5: var multiVersionedGlobal4_4: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Notes_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal4Notes: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4Notes_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal4Notes_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal4Notes_NEW: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Header_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal4Header: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4Header_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal4Header_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal4Header_NEW: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Both_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal4Both: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4Both_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal4Both_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal4Both_NEW: Int32
+
+// CHECK-SWIFT-5: var multiVersionedGlobal34: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34")
+// CHECK-SWIFT-5: var multiVersionedGlobal34_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34")
+// CHECK-SWIFT-5: var multiVersionedGlobal34_4: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Notes_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Notes: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Notes_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Notes_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34Notes_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Notes_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal34Notes_NEW: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Header_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Header: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Header_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Header_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34Header_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Header_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal34Header_NEW: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Both_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Both: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Both_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Both_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34Both_NEW")
+// CHECK-SWIFT-5: var multiVersionedGlobal34Both_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal34Both_NEW: Int32
+
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal45_5: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Notes_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45Notes: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45Notes_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45Notes_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal45Notes_5: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Header_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45Header: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45Header_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45Header_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal45Header_5: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Both_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45Both: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45Both_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal45Both_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal45Both_5: Int32
+
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal345_5: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Notes_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Notes: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Notes_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Notes_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345Notes_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Notes_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal345Notes_5: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Header_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Header: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Header_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Header_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345Header_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Header_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal345Header_5: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Both_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Both: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Both_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Both_3: Int32
+// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345Both_5")
+// CHECK-SWIFT-5: var multiVersionedGlobal345Both_4: Int32
+// CHECK-SWIFT-5: var multiVersionedGlobal345Both_5: Int32


### PR DESCRIPTION
Refactor name importing and the ImportNameVersion type in particular to make it easier to add a new Swift version…then actually do so. This finishes off the work in #11507; we can now use -swift-version 5 end-to-end.

Depends on apple/swift-clang#122 and apple/swift-clang#123, or rather their inclusion into the Clang swift-4.1-branch. Tests pass locally, of course.