### PR TITLE
[AST/Unittest] Don't swallow a const qualifier.

### DIFF
--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -23,7 +23,8 @@ namespace swift {
   void PrintTo(SourceLoc loc, std::ostream *os) {
     *os << loc.getOpaquePointerValue();
     if (loc.isValid())
-      *os << " '" << *(char *)loc.getOpaquePointerValue() << "'";
+      *os << " '" << *static_cast<const char *>(loc.getOpaquePointerValue())
+          << "'";
   }
 
   void PrintTo(SourceRange range, std::ostream *os) {


### PR DESCRIPTION
I found this by inspection (also, I found that newer
clang versions also warns for this under -Wall). While here,
convert to static_cast<> for a more idiomatic C++.
