### PR TITLE
Move legacy argparser

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -245,8 +245,6 @@ class BuildScriptInvocation(object):
 
     @staticmethod
     def apply_default_arguments(toolchain, args):
-        driver_arguments.apply_default_arguments(args)
-
         # infer if ninja is required
         ninja_required = (
             args.cmake_generator == 'Ninja' or args.build_foundation)

--- a/utils/build_swift/README.md
+++ b/utils/build_swift/README.md
@@ -1,0 +1,12 @@
+# build_swift
+
+The `build_swift` module contains data-structures and functions used by
+the Swift build-script.
+
+## Unit Tests
+
+You may run the unit test suite using the command:
+
+```sh
+$ python -m unittest discover -s utils/build_swift
+```

--- a/utils/build_swift/tests/__init__.py
+++ b/utils/build_swift/tests/__init__.py
@@ -1,0 +1,7 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -46,7 +46,7 @@ EXPECTED_DEFAULTS = {
     'build_libicu': False,
     'build_llbuild': False,
     'build_lldb': False,
-    'build_ninja': True,
+    'build_ninja': False,
     'build_playgroundlogger': False,
     'build_playgroundsupport': False,
     'build_runtime_with_host_compiler': False,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -1,0 +1,494 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import argparse
+
+
+__all__ = [
+    'Option',
+    'AppendOption',
+    'ChoicesOption',
+    'IntOption',
+    'PathOption',
+    'StrOption',
+    'ToggleOption',
+    'UnsupportedOption',
+    'EXPECTED_OPTIONS',
+    'EXPECTED_DEFAULTS',
+]
+
+
+# -----------------------------------------------------------------------------
+
+EXPECTED_DEFAULTS = {
+    'android': False,
+    'android_api_level': '21',
+    'android_deploy_device_path': '/data/local/tmp',
+    'android_icu_i18n': None,
+    'android_icu_i18n_include': None,
+    'android_icu_uc': None,
+    'android_icu_uc_include': None,
+    'android_ndk': None,
+    'android_ndk_gcc_version': '4.9',
+    'assertions': True,
+    'benchmark': False,
+    'benchmark_num_o_iterations': 3,
+    'benchmark_num_onone_iterations': 3,
+    'build_args': [],
+    'build_foundation': False,
+    'build_jobs': 4,
+    'build_libdispatch': False,
+    'build_libicu': False,
+    'build_llbuild': False,
+    'build_lldb': False,
+    'build_ninja': True,
+    'build_playgroundlogger': False,
+    'build_playgroundsupport': False,
+    'build_runtime_with_host_compiler': False,
+    'build_stdlib_deployment_targets': ['all'],
+    'build_subdir': 'Ninja-DebugAssert',
+    'build_swift_dynamic_sdk_overlay': True,
+    'build_swift_dynamic_stdlib': True,
+    'build_swift_static_sdk_overlay': False,
+    'build_swift_static_stdlib': False,
+    'build_swift_stdlib_unittest_extra': False,
+    'build_swiftpm': False,
+    'build_variant': 'Debug',
+    'build_xctest': False,
+    'clang_compiler_version': None,
+    'clang_profile_instr_use': None,
+    'clang_user_visible_version': '5.0.0',
+    'clean': False,
+    'cmake': None,
+    'cmake_generator': 'Ninja',
+    'cmark_assertions': True,
+    'cmark_build_variant': 'Debug',
+    'compiler_vendor': 'none',
+    'coverage_db': None,
+    'cross_compile_hosts': [],
+    'darwin_deployment_version_ios': '7.0',
+    'darwin_deployment_version_osx': '10.9',
+    'darwin_deployment_version_tvos': '9.0',
+    'darwin_deployment_version_watchos': '2.0',
+    'darwin_xcrun_toolchain': 'default',
+    'distcc': False,
+    'dry_run': False,
+    'enable_asan': False,
+    'enable_lsan': False,
+    'enable_sil_ownership': False,
+    'enable_tsan': False,
+    'enable_tsan_runtime': None,
+    'enable_ubsan': False,
+    'export_compile_commands': False,
+    'extra_cmake_options': [],
+    'extra_swift_args': [],
+    'force_optimized_typechecker': False,
+    'foundation_build_variant': 'Debug',
+    'host_cc': None,
+    'host_cxx': None,
+    'host_libtool': None,
+    'host_lipo': None,
+    'host_target': 'macosx-x86_64',
+    'host_test': False,
+    'install_prefix': '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+                      'XcodeDefault.xctoolchain/usr',
+    'install_symroot': None,
+    'ios': False,
+    'ios_all': False,
+    'legacy_impl': True,
+    'libdispatch_build_variant': 'Debug',
+    'libicu_build_variant': 'Debug',
+    'lit_args': '-sv',
+    'lldb_assertions': None,
+    'lldb_build_variant': 'Debug',
+    'llvm_assertions': True,
+    'llvm_build_variant': 'Debug',
+    'llvm_max_parallel_lto_link_jobs': 0,
+    'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips',
+    'long_test': False,
+    'lto_type': None,
+    'show_sdks': False,
+    'skip_build': False,
+    'skip_build_android': True,
+    'skip_build_benchmarks': False,
+    'skip_build_cygwin': False,
+    'skip_build_freebsd': False,
+    'skip_build_ios': False,
+    'skip_build_ios_device': True,
+    'skip_build_ios_simulator': True,
+    'skip_build_linux': False,
+    'skip_build_osx': False,
+    'skip_build_tvos': False,
+    'skip_build_tvos_device': True,
+    'skip_build_tvos_simulator': True,
+    'skip_build_watchos': False,
+    'skip_build_watchos_device': True,
+    'skip_build_watchos_simulator': True,
+    'skip_test_android_host': True,
+    'skip_test_cygwin': True,
+    'skip_test_freebsd': True,
+    'skip_test_ios': True,
+    'skip_test_ios_32bit_simulator': False,
+    'skip_test_ios_host': True,
+    'skip_test_ios_simulator': True,
+    'skip_test_linux': True,
+    'skip_test_osx': True,
+    'skip_test_tvos': True,
+    'skip_test_tvos_host': True,
+    'skip_test_tvos_simulator': True,
+    'skip_test_watchos': True,
+    'skip_test_watchos_host': True,
+    'skip_test_watchos_simulator': True,
+    'stdlib_deployment_targets': [
+        'macosx-x86_64',
+        'iphonesimulator-i386',
+        'iphonesimulator-x86_64',
+        'appletvsimulator-x86_64',
+        'watchsimulator-i386',
+        'iphoneos-armv7',
+        'iphoneos-armv7s',
+        'iphoneos-arm64',
+        'appletvos-arm64',
+        'watchos-armv7k'
+    ],
+    'swift_analyze_code_coverage': 'false',
+    'swift_assertions': True,
+    'swift_build_variant': 'Debug',
+    'swift_compiler_version': None,
+    'swift_stdlib_assertions': True,
+    'swift_stdlib_build_variant': 'Debug',
+    'swift_tools_max_parallel_lto_link_jobs': 0,
+    'swift_user_visible_version': '4.1',
+    'symbols_package': None,
+    'test': None,
+    'test_optimize_for_size': None,
+    'test_optimized': None,
+    'tvos': False,
+    'tvos_all': False,
+    'validation_test': None,
+    'verbose_build': False,
+    'watchos': False,
+    'watchos_all': False
+}
+
+
+# -----------------------------------------------------------------------------
+
+class _BaseOption(object):
+
+    def __init__(self, option_string, dest, default=None):
+        self.option_string = option_string
+        self.dest = dest
+
+        if default is None:
+            default = EXPECTED_DEFAULTS.get(dest, None)
+
+        self.default = default
+
+    def sanitized_str(self):
+        if self.option_string.startswith('--'):
+            return self.option_string[2:].replace('-', '_')
+
+        if len(self.option_string) == 2 and self.option_string[0] == '-':
+            return self.option_string[1]
+
+        raise ValueError('invalid option_string format: ' + self.option_string)
+
+
+class Option(_BaseOption):
+    """Option that accepts no arguments."""
+
+    def __init__(self, *args, **kwargs):
+        self.value = kwargs.pop('value', None)
+        super(Option, self).__init__(*args, **kwargs)
+
+
+class ToggleOption(_BaseOption):
+    """Option that accepts no argument or an optional bool argument."""
+
+    pass
+
+
+class ChoicesOption(_BaseOption):
+    """Option that accepts an argument from a predifined list of choices."""
+
+    def __init__(self, *args, **kwargs):
+        self.choices = kwargs.pop('choices', None)
+        super(ChoicesOption, self).__init__(*args, **kwargs)
+
+
+class IntOption(_BaseOption):
+    """Option that accepts an int argument."""
+
+    pass
+
+
+class StrOption(_BaseOption):
+    """Option that accepts a str argument."""
+
+    pass
+
+
+class PathOption(_BaseOption):
+    """Option that accepts a path argument."""
+
+    pass
+
+
+class AppendOption(_BaseOption):
+    """Option that can be called more than once to append argument to internal
+    list.
+    """
+
+    pass
+
+
+class UnsupportedOption(_BaseOption):
+    """Option that is not supported."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs['dest'] = kwargs.get('dest')
+        super(UnsupportedOption, self).__init__(*args, **kwargs)
+
+
+# -----------------------------------------------------------------------------
+
+EXPECTED_OPTIONS = [
+    # Ignore the help options since they always call sys.exit(0)
+    _BaseOption('-h', dest='help', default=argparse.SUPPRESS),
+    _BaseOption('--help', dest='help', default=argparse.SUPPRESS),
+
+    Option('--assertions', dest='assertions', value=True),
+    Option('--benchmark', dest='benchmark', value=True),
+    Option('--clean', dest='clean', value=True),
+    Option('--cmark-assertions', dest='cmark_assertions', value=True),
+    Option('--debug', dest='build_variant', value='Debug'),
+    Option('--debug-cmark', dest='cmark_build_variant', value='Debug'),
+    Option('--debug-foundation',
+           dest='foundation_build_variant', value='Debug'),
+    Option('--debug-libdispatch',
+           dest='libdispatch_build_variant', value='Debug'),
+    Option('--debug-libicu', dest='libicu_build_variant', value='Debug'),
+    Option('--debug-lldb', dest='lldb_build_variant', value='Debug'),
+    Option('--debug-llvm', dest='llvm_build_variant', value='Debug'),
+    Option('--debug-swift', dest='swift_build_variant', value='Debug'),
+    Option('--debug-swift-stdlib',
+           dest='swift_stdlib_build_variant', value='Debug'),
+    Option('--dry-run', dest='dry_run', value=True),
+    Option('--eclipse', dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
+    Option('--enable-sil-ownership', dest='enable_sil_ownership', value=True),
+    Option('--force-optimized-typechecker',
+           dest='force_optimized_typechecker', value=True),
+    Option('--ios', dest='ios', value=True),
+    Option('--llbuild', dest='build_llbuild', value=True),
+    Option('--lldb', dest='build_lldb', value=True),
+    Option('--lldb-assertions', dest='lldb_assertions', value=True),
+    Option('--llvm-assertions', dest='llvm_assertions', value=True),
+    Option('--make', dest='cmake_generator', value='Unix Makefiles'),
+    Option('--no-assertions', dest='assertions', value=False),
+    Option('--no-legacy-impl', dest='legacy_impl', value=False),
+    Option('--no-lldb-assertions', dest='lldb_assertions', value=False),
+    Option('--no-llvm-assertions', dest='llvm_assertions', value=False),
+    Option('--no-swift-assertions', dest='swift_assertions', value=False),
+    Option('--no-swift-stdlib-assertions',
+           dest='swift_stdlib_assertions', value=False),
+    Option('--playgroundlogger', dest='build_playgroundlogger', value=True),
+    Option('--playgroundsupport', dest='build_playgroundsupport', value=True),
+    Option('--release', dest='build_variant', value='Release'),
+    Option('--release-debuginfo',
+           dest='build_variant', value='RelWithDebInfo'),
+    Option('--skip-build', dest='skip_build', value=True),
+    Option('--skip-ios', dest='ios', value=False),
+    Option('--skip-tvos', dest='tvos', value=False),
+    Option('--skip-watchos', dest='watchos', value=False),
+    Option('--swift-assertions', dest='swift_assertions', value=True),
+    Option('--swift-stdlib-assertions',
+           dest='swift_stdlib_assertions', value=True),
+    Option('--swiftpm', dest='build_swiftpm', value=True),
+    Option('--xcode', dest='cmake_generator', value='Xcode'),
+    Option('-B', dest='benchmark', value=True),
+    Option('-R', dest='build_variant', value='Release'),
+    Option('-S', dest='skip_build', value=True),
+    Option('-T', dest='validation_test', value=True),
+    Option('-b', dest='build_llbuild', value=True),
+    Option('-c', dest='clean', value=True),
+    Option('-d', dest='build_variant', value='Debug'),
+    Option('-e', dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
+    Option('-i', dest='ios', value=True),
+    Option('-l', dest='build_lldb', value=True),
+    Option('-m', dest='cmake_generator', value='Unix Makefiles'),
+    Option('-n', dest='dry_run', value=True),
+    Option('-o', dest='test_optimized', value=True),
+    Option('-p', dest='build_swiftpm', value=True),
+    Option('-r', dest='build_variant', value='RelWithDebInfo'),
+    Option('-s', dest='test_optimize_for_size', value=True),
+    Option('-t', dest='test', value=True),
+    Option('-x', dest='cmake_generator', value='Xcode'),
+
+    ToggleOption('--android', dest='android'),
+    ToggleOption('--build-ninja', dest='build_ninja'),
+    ToggleOption('--build-runtime-with-host-compiler',
+                 dest='build_runtime_with_host_compiler'),
+    ToggleOption('--build-swift-dynamic-sdk-overlay',
+                 dest='build_swift_dynamic_sdk_overlay'),
+    ToggleOption('--build-swift-dynamic-stdlib',
+                 dest='build_swift_dynamic_stdlib'),
+    ToggleOption('--build-swift-static-sdk-overlay',
+                 dest='build_swift_static_sdk_overlay'),
+    ToggleOption('--build-swift-static-stdlib',
+                 dest='build_swift_static_stdlib'),
+    ToggleOption('--build-swift-stdlib-unittest-extra',
+                 dest='build_swift_stdlib_unittest_extra'),
+    ToggleOption('--distcc', dest='distcc'),
+    ToggleOption('--enable-asan', dest='enable_asan'),
+    ToggleOption('--enable-lsan', dest='enable_lsan'),
+    ToggleOption('--enable-tsan', dest='enable_tsan'),
+    ToggleOption('--enable-ubsan', dest='enable_ubsan'),
+    ToggleOption('--export-compile-commands', dest='export_compile_commands'),
+    ToggleOption('--foundation', dest='build_foundation'),
+    ToggleOption('--host-test', dest='host_test'),
+    ToggleOption('--libdispatch', dest='build_libdispatch'),
+    ToggleOption('--libicu', dest='build_libicu'),
+    ToggleOption('--long-test', dest='long_test'),
+    ToggleOption('--show-sdks', dest='show_sdks'),
+    ToggleOption('--skip-build-android', dest='skip_build_android'),
+    ToggleOption('--skip-build-benchmarks', dest='skip_build_benchmarks'),
+    ToggleOption('--skip-build-cygwin', dest='skip_build_cygwin'),
+    ToggleOption('--skip-build-freebsd', dest='skip_build_freebsd'),
+    ToggleOption('--skip-build-ios', dest='skip_build_ios'),
+    ToggleOption('--skip-build-ios-device', dest='skip_build_ios_device'),
+    ToggleOption('--skip-build-ios-simulator',
+                 dest='skip_build_ios_simulator'),
+    ToggleOption('--skip-build-linux', dest='skip_build_linux'),
+    ToggleOption('--skip-build-osx', dest='skip_build_osx'),
+    ToggleOption('--skip-build-tvos', dest='skip_build_tvos'),
+    ToggleOption('--skip-build-tvos-device', dest='skip_build_tvos_device'),
+    ToggleOption('--skip-build-tvos-simulator',
+                 dest='skip_build_tvos_simulator'),
+    ToggleOption('--skip-build-watchos', dest='skip_build_watchos'),
+    ToggleOption('--skip-build-watchos-device',
+                 dest='skip_build_watchos_device'),
+    ToggleOption('--skip-build-watchos-simulator',
+                 dest='skip_build_watchos_simulator'),
+    ToggleOption('--skip-test-android-host', dest='skip_test_android_host'),
+    ToggleOption('--skip-test-cygwin', dest='skip_test_cygwin'),
+    ToggleOption('--skip-test-freebsd', dest='skip_test_freebsd'),
+    ToggleOption('--skip-test-ios', dest='skip_test_ios'),
+    ToggleOption('--skip-test-ios-32bit-simulator',
+                 dest='skip_test_ios_32bit_simulator'),
+    ToggleOption('--skip-test-ios-host', dest='skip_test_ios_host'),
+    ToggleOption('--skip-test-ios-simulator', dest='skip_test_ios_simulator'),
+    ToggleOption('--skip-test-linux', dest='skip_test_linux'),
+    ToggleOption('--skip-test-osx', dest='skip_test_osx'),
+    ToggleOption('--skip-test-tvos', dest='skip_test_tvos'),
+    ToggleOption('--skip-test-tvos-host', dest='skip_test_tvos_host'),
+    ToggleOption('--skip-test-tvos-simulator',
+                 dest='skip_test_tvos_simulator'),
+    ToggleOption('--skip-test-watchos', dest='skip_test_watchos'),
+    ToggleOption('--skip-test-watchos-host', dest='skip_test_watchos_host'),
+    ToggleOption('--skip-test-watchos-simulator',
+                 dest='skip_test_watchos_simulator'),
+    ToggleOption('--test', dest='test'),
+    ToggleOption('--test-optimize-for-size', dest='test_optimize_for_size'),
+    ToggleOption('--test-optimized', dest='test_optimized'),
+    ToggleOption('--tvos', dest='tvos'),
+    ToggleOption('--validation-test', dest='validation_test'),
+    ToggleOption('--verbose-build', dest='verbose_build'),
+    ToggleOption('--watchos', dest='watchos'),
+    ToggleOption('--xctest', dest='build_xctest'),
+
+    ChoicesOption('--android-ndk-gcc-version',
+                  dest='android_ndk_gcc_version',
+                  choices=['4.8', '4.9']),
+    ChoicesOption('--compiler-vendor',
+                  dest='compiler_vendor',
+                  choices=['none', 'apple']),
+    ChoicesOption('--swift-analyze-code-coverage',
+                  dest='swift_analyze_code_coverage',
+                  choices=['false', 'not-merged', 'merged']),
+
+    StrOption('--android-api-level', dest='android_api_level'),
+    StrOption('--build-args', dest='build_args'),
+    StrOption('--build-stdlib-deployment-targets',
+              dest='build_stdlib_deployment_targets'),
+    StrOption('--darwin-deployment-version-ios',
+              dest='darwin_deployment_version_ios'),
+    StrOption('--darwin-deployment-version-osx',
+              dest='darwin_deployment_version_osx'),
+    StrOption('--darwin-deployment-version-tvos',
+              dest='darwin_deployment_version_tvos'),
+    StrOption('--darwin-deployment-version-watchos',
+              dest='darwin_deployment_version_watchos'),
+    StrOption('--darwin-xcrun-toolchain', dest='darwin_xcrun_toolchain'),
+    StrOption('--enable-tsan-runtime', dest='enable_tsan_runtime'),
+    StrOption('--host-target', dest='host_target'),
+    StrOption('--lit-args', dest='lit_args'),
+    StrOption('--llvm-targets-to-build', dest='llvm_targets_to_build'),
+
+    PathOption('--android-deploy-device-path',
+               dest='android_deploy_device_path'),
+    PathOption('--android-icu-i18n', dest='android_icu_i18n'),
+    PathOption('--android-icu-i18n-include', dest='android_icu_i18n_include'),
+    PathOption('--android-icu-uc', dest='android_icu_uc'),
+    PathOption('--android-icu-uc-include', dest='android_icu_uc_include'),
+    PathOption('--android-ndk', dest='android_ndk'),
+    PathOption('--build-subdir', dest='build_subdir'),
+    PathOption('--clang-profile-instr-use', dest='clang_profile_instr_use'),
+    PathOption('--cmake', dest='cmake'),
+    PathOption('--coverage-db', dest='coverage_db'),
+    PathOption('--host-cc', dest='host_cc'),
+    PathOption('--host-cxx', dest='host_cxx'),
+    PathOption('--host-libtool', dest='host_libtool'),
+    PathOption('--host-lipo', dest='host_lipo'),
+    PathOption('--install-prefix', dest='install_prefix'),
+    PathOption('--install-symroot', dest='install_symroot'),
+    PathOption('--symbols-package', dest='symbols_package'),
+
+    IntOption('--benchmark-num-o-iterations',
+              dest='benchmark_num_o_iterations'),
+    IntOption('--benchmark-num-onone-iterations',
+              dest='benchmark_num_onone_iterations'),
+    IntOption('--jobs', dest='build_jobs'),
+    IntOption('--llvm-max-parallel-lto-link-jobs',
+              dest='llvm_max_parallel_lto_link_jobs'),
+    IntOption('--swift-tools-max-parallel-lto-link-jobs',
+              dest='swift_tools_max_parallel_lto_link_jobs'),
+    IntOption('-j', dest='build_jobs'),
+
+    AppendOption('--cross-compile-hosts', dest='cross_compile_hosts'),
+    AppendOption('--extra-cmake-options', dest='extra_cmake_options'),
+    AppendOption('--extra-swift-args', dest='extra_swift_args'),
+    AppendOption('--stdlib-deployment-targets',
+                 dest='stdlib_deployment_targets'),
+
+    UnsupportedOption('--build-jobs'),
+    UnsupportedOption('--common-cmake-options'),
+    UnsupportedOption('--ios-all'),
+    UnsupportedOption('--only-execute'),
+    UnsupportedOption('--skip-test-optimize-for-size'),
+    UnsupportedOption('--skip-test-optimized'),
+    UnsupportedOption('--tvos-all'),
+    UnsupportedOption('--watchos-all'),
+    UnsupportedOption('-I'),
+
+    # FIXME: LTO flag is a special case that acts both as an option and has
+    # valid choices
+    Option('--lto', dest='lto_type'),
+    ChoicesOption('--lto', dest='lto_type', choices=['thin', 'full']),
+
+    # NOTE: We'll need to manually test the behavior of these since they
+    # validate compiler version strings.
+    _BaseOption('--clang-compiler-version',
+                dest='clang_compiler_version'),
+    _BaseOption('--clang-user-visible-version',
+                dest='clang_user_visible_version'),
+    _BaseOption('--swift-compiler-version',
+                dest='swift_compiler_version'),
+    _BaseOption('--swift-user-visible-version',
+                dest='swift_user_visible_version'),
+]

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -13,6 +13,8 @@ __all__ = [
     'Option',
     'AppendOption',
     'ChoicesOption',
+    'HelpOption',
+    'IgnoreOption',
     'IntOption',
     'PathOption',
     'StrOption',
@@ -208,6 +210,12 @@ class Option(_BaseOption):
         super(Option, self).__init__(*args, **kwargs)
 
 
+class HelpOption(_BaseOption):
+    """Option that prints the help message and exits."""
+
+    pass
+
+
 class ToggleOption(_BaseOption):
     """Option that accepts no argument or an optional bool argument."""
 
@@ -252,16 +260,25 @@ class UnsupportedOption(_BaseOption):
     """Option that is not supported."""
 
     def __init__(self, *args, **kwargs):
-        kwargs['dest'] = kwargs.get('dest')
+        kwargs['dest'] = kwargs.pop('dest', None)
         super(UnsupportedOption, self).__init__(*args, **kwargs)
+
+
+class IgnoreOption(_BaseOption):
+    """Option that should be ignored when generating tests. Instead a test
+    should be written manually as the behavior cannot or should not be auto-
+    generated.
+    """
+
+    pass
 
 
 # -----------------------------------------------------------------------------
 
 EXPECTED_OPTIONS = [
     # Ignore the help options since they always call sys.exit(0)
-    _BaseOption('-h', dest='help', default=argparse.SUPPRESS),
-    _BaseOption('--help', dest='help', default=argparse.SUPPRESS),
+    HelpOption('-h', dest='help', default=argparse.SUPPRESS),
+    HelpOption('--help', dest='help', default=argparse.SUPPRESS),
 
     Option('--assertions', dest='assertions', value=True),
     Option('--benchmark', dest='benchmark', value=True),
@@ -476,19 +493,19 @@ EXPECTED_OPTIONS = [
     UnsupportedOption('--watchos-all'),
     UnsupportedOption('-I'),
 
-    # FIXME: LTO flag is a special case that acts both as an option and has
+    # NOTE: LTO flag is a special case that acts both as an option and has
     # valid choices
     Option('--lto', dest='lto_type'),
     ChoicesOption('--lto', dest='lto_type', choices=['thin', 'full']),
 
     # NOTE: We'll need to manually test the behavior of these since they
     # validate compiler version strings.
-    _BaseOption('--clang-compiler-version',
-                dest='clang_compiler_version'),
-    _BaseOption('--clang-user-visible-version',
-                dest='clang_user_visible_version'),
-    _BaseOption('--swift-compiler-version',
-                dest='swift_compiler_version'),
-    _BaseOption('--swift-user-visible-version',
-                dest='swift_user_visible_version'),
+    IgnoreOption('--clang-compiler-version',
+                 dest='clang_compiler_version'),
+    IgnoreOption('--clang-user-visible-version',
+                 dest='clang_user_visible_version'),
+    IgnoreOption('--swift-compiler-version',
+                 dest='swift_compiler_version'),
+    IgnoreOption('--swift-user-visible-version',
+                 dest='swift_user_visible_version'),
 ]

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -143,6 +143,13 @@ class TestDriverArgumentParserMeta(type):
         return test
 
     @classmethod
+    def _generate_help_option_test(cls, option):
+        def test(self):
+            with redirect_stdout() as output, self.assertRaises(ParserError):
+                self.parse_args([option.option_string])
+                self.assertNotEmpty(output)
+
+    @classmethod
     def _generate_int_option_test(cls, option):
         def test(self):
             with self.assertNotRaises(ParserError):
@@ -220,6 +227,8 @@ class TestDriverArgumentParserMeta(type):
             return cls._generate_append_option_test(option)
         elif option.__class__ is expected_options.ChoicesOption:
             return cls._generate_choices_option_test(option)
+        elif option.__class__ is expected_options.HelpOption:
+            return cls._generate_help_option_test(option)
         elif option.__class__ is expected_options.IntOption:
             return cls._generate_int_option_test(option)
         elif option.__class__ is expected_options.PathOption:
@@ -231,8 +240,8 @@ class TestDriverArgumentParserMeta(type):
         elif option.__class__ is expected_options.UnsupportedOption:
             return cls._generate_unsupported_option_test(option)
 
-        # Ignore all _BaseOption tests since they should be manually tested
-        elif option.__class__ is expected_options._BaseOption:
+        # Ignore all IgnoreOption tests since they should be manually tested
+        elif option.__class__ is expected_options.IgnoreOption:
             return lambda self: None
 
         # Catch-all meaningless test
@@ -304,15 +313,6 @@ class TestDriverArgumentParser(unittest.TestCase):
 
     # -------------------------------------------------------------------------
     # Manual option tests
-
-    def test_help_options(self):
-        with redirect_stdout() as output, self.assertRaises(ParserError):
-            self.parse_args(['-h'])
-            self.assertNotEmpty(output)
-
-        with redirect_stdout() as output, self.assertRaises(ParserError):
-            self.parse_args(['--help'])
-            self.assertNotEmpty(output)
 
     def test_option_clang_compiler_version(self):
         option_string = '--clang-compiler-version'

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -1,0 +1,536 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+from __future__ import print_function
+
+import os
+import sys
+import unittest
+
+from contextlib import contextmanager
+from io import StringIO
+
+from build_swift import driver_arguments
+from build_swift.tests import expected_options
+
+from swift_build_support.swift_build_support import migration
+from swift_build_support.swift_build_support.SwiftBuildSupport import (
+    get_all_preset_names,
+    get_preset_options,
+)
+
+FILE_PATH = os.path.abspath(__file__)
+TESTS_PATH = os.path.abspath(os.path.join(FILE_PATH, os.pardir))
+BUILD_SWIFT_PATH = os.path.abspath(os.path.join(TESTS_PATH, os.pardir))
+UTILS_PATH = os.path.abspath(os.path.join(BUILD_SWIFT_PATH, os.pardir))
+
+BUILD_SCRIPT_IMPL = os.path.join(UTILS_PATH, 'build-script-impl')
+
+PRESETS_FILES = [
+    os.path.join(UTILS_PATH, 'build-presets.ini'),
+]
+
+
+class ParserError(Exception):
+    pass
+
+
+@contextmanager
+def quiet_stderr():
+    devnull = open(os.devnull, 'w')
+    old_stderr, sys.stderr = sys.stderr, devnull
+    try:
+        yield devnull
+    finally:
+        sys.stderr = old_stderr
+
+
+@contextmanager
+def quiet_stdout():
+    devnull = open(os.devnull, 'w')
+    old_stdout, sys.stdout = sys.stdout, devnull
+    try:
+        yield devnull
+    finally:
+        sys.stdout = old_stdout
+
+
+@contextmanager
+def redirect_stdout():
+    output = StringIO()
+    old_stdout, sys.stdout = sys.stdout, output
+    try:
+        yield output
+    finally:
+        sys.stdout = old_stdout
+
+
+def _load_all_presets(presets_files):
+    preset_names = get_all_preset_names(presets_files)
+
+    # Hack to filter out mixins which are not expected to be valid presets
+    preset_names = [n for n in preset_names if not n.startswith('mixin')]
+
+    substitutions = {
+        'install_destdir': '/tmp/install',
+        'install_symroot': '/tmp/symroot',
+        'installable_package': '/tmp/xcode-xyz-root.tar.gz',
+    }
+
+    presets = dict()
+    for name in preset_names:
+        try:
+            # Attempt to parse preset
+            presets[name] = get_preset_options(substitutions,
+                                               presets_files, name)
+        except SystemExit:
+            continue
+
+    return presets
+
+
+class TestDriverArgumentParserMeta(type):
+    """Metaclass used to dynamically generate test methods for each of the
+    individual options accepted by the parser and methods to validate all of
+    the presets.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        # Generate tests for each expected option
+        for option in expected_options.EXPECTED_OPTIONS:
+            test_name = 'test_option_' + option.sanitized_str()
+            attrs[test_name] = cls.generate_option_test(option)
+
+        # Generate tests for each preset
+        presets = _load_all_presets(PRESETS_FILES)
+
+        for name, args in presets.items():
+            test_name = 'test_preset_' + name
+            attrs[test_name] = cls.generate_preset_test(name, args)
+
+        return super(TestDriverArgumentParserMeta, cls).__new__(
+            cls, name, bases, attrs)
+
+    @classmethod
+    def _generate_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                args = self.parse_args([option.option_string])
+                self.assertEqual(getattr(args, option.dest), option.value)
+
+            with self.assertRaises(ParserError):
+                self.parse_args([option.option_string, 'foo'])
+
+        return test
+
+    @classmethod
+    def _generate_append_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                # Range size is arbitrary, just needs to be more than once
+                for i in range(1, 4):
+                    args = self.parse_args([option.option_string, 'ARG'] * i)
+                    self.assertEqual(getattr(args, option.dest), ['ARG'] * i)
+
+        return test
+
+    @classmethod
+    def _generate_choices_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                for choice in option.choices:
+                    args = self.parse_args([option.option_string, str(choice)])
+                    self.assertEqual(getattr(args, option.dest), choice)
+
+            with self.assertRaises(ParserError):
+                self.parse_args([option.option_string, 'INVALID'])
+
+        return test
+
+    @classmethod
+    def _generate_int_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                for i in [0, 1, 42]:
+                    args = self.parse_args([option.option_string, str(i)])
+                    self.assertEqual(int(getattr(args, option.dest)), i)
+
+            # FIXME: int-type options should not accept non-int strings
+            # with self.assertRaises(ParserError):
+            #     self.parse_args([option.option_string, str(0.0)])
+            #     self.parse_args([option.option_string, str(1.0)])
+            #     self.parse_args([option.option_string, str(3.14)])
+            #     self.parse_args([option.option_string, 'NaN'])
+
+        return test
+
+    @classmethod
+    def _generate_path_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                self.parse_args([option.option_string, sys.executable])
+
+            # FIXME: path-type options should not accept non-path inputs
+            # with self.assertRaises(ParserError):
+            #     self.parse_args([option.option_string, 'foo'])
+
+        return test
+
+    @classmethod
+    def _generate_str_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                self.parse_args([option.option_string, 'foo'])
+
+        return test
+
+    @classmethod
+    def _generate_toggle_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                # Standalone argument
+                self.parse_args([option.option_string])
+
+                # True values
+                # self.parse_args([option.option_string, True])
+                # self.parse_args([option.option_string, 1])
+                self.parse_args([option.option_string, '1'])
+                self.parse_args([option.option_string, 'true'])
+                self.parse_args([option.option_string, 'True'])
+                # self.parse_args([option.option_string, 'TRUE'])
+
+                # False values
+                # self.parse_args([option.option_string, False])
+                # self.parse_args([option.option_string, 0])
+                self.parse_args([option.option_string, '0'])
+                self.parse_args([option.option_string, 'false'])
+                self.parse_args([option.option_string, 'False'])
+                # self.parse_args([option.option_string, 'FALSE'])
+
+        return test
+
+    @classmethod
+    def _generate_unsupported_option_test(cls, option):
+        def test(self):
+            with self.assertRaises(ParserError):
+                self.parse_args([option.option_string])
+
+        return test
+
+    @classmethod
+    def generate_option_test(cls, option):
+        if option.__class__ is expected_options.Option:
+            return cls._generate_option_test(option)
+        elif option.__class__ is expected_options.AppendOption:
+            return cls._generate_append_option_test(option)
+        elif option.__class__ is expected_options.ChoicesOption:
+            return cls._generate_choices_option_test(option)
+        elif option.__class__ is expected_options.IntOption:
+            return cls._generate_int_option_test(option)
+        elif option.__class__ is expected_options.PathOption:
+            return cls._generate_path_option_test(option)
+        elif option.__class__ is expected_options.StrOption:
+            return cls._generate_str_option_test(option)
+        elif option.__class__ is expected_options.ToggleOption:
+            return cls._generate_toggle_option_test(option)
+        elif option.__class__ is expected_options.UnsupportedOption:
+            return cls._generate_unsupported_option_test(option)
+
+        # Ignore all _BaseOption tests since they should be manually tested
+        elif option.__class__ is expected_options._BaseOption:
+            return lambda self: None
+
+        # Catch-all meaningless test
+        return lambda self: \
+            self.fail('Unexpected option "{}"'.format(option.option_string))
+
+    @classmethod
+    def generate_preset_test(cls, preset_name, preset_args):
+        def test(self):
+            try:
+                self.parse_args(preset_args, check_impl_args=True)
+            except ParserError as e:
+                self.fail('Failed to parse preset "{}": {}'.format(
+                    preset_name, e))
+
+        return test
+
+
+class TestDriverArgumentParser(unittest.TestCase):
+
+    __metaclass__ = TestDriverArgumentParserMeta
+
+    def parse_args(self, args, error_message=None, check_impl_args=False):
+        if error_message is None:
+            error_message = 'failed to parse arguments: ' + str(args)
+
+        try:
+            with quiet_stderr(), quiet_stdout():
+                namespace = migration.parse_args(self.parser, args)
+        except (SystemExit, ValueError) as e:
+            raise ParserError(error_message, e)
+
+        if not namespace.build_script_impl_args and not check_impl_args:
+            return namespace
+
+        try:
+            with quiet_stderr(), quiet_stdout():
+                migration.check_impl_args(BUILD_SCRIPT_IMPL,
+                                          namespace.build_script_impl_args)
+        except (SystemExit, ValueError) as e:
+            raise ParserError(error_message, e)
+
+        return namespace
+
+    @contextmanager
+    def assertNotRaises(self, exception):
+        assert issubclass(exception, BaseException)
+
+        try:
+            yield
+        except exception as e:
+            self.fail(str(e))
+
+    def setUp(self):
+        self.parser = driver_arguments.create_argument_parser()
+
+    def test_option_default_values(self):
+        parsed_values = self.parse_args([]).__dict__
+
+        for dest, default_value in expected_options.EXPECTED_DEFAULTS.items():
+            parsed_value = parsed_values[dest]
+            if default_value.__class__ is str:
+                parsed_value = str(parsed_value)
+
+            self.assertEqual(default_value, parsed_value)
+
+    # -------------------------------------------------------------------------
+    # Manual option tests
+
+    def test_help_options(self):
+        with redirect_stdout() as output, self.assertRaises(ParserError):
+            self.parse_args(['-h'])
+            self.assertNotEmpty(output)
+
+        with redirect_stdout() as output, self.assertRaises(ParserError):
+            self.parse_args(['--help'])
+            self.assertNotEmpty(output)
+
+    def test_option_clang_compiler_version(self):
+        option_string = '--clang-compiler-version'
+
+        with self.assertNotRaises(ParserError):
+            self.parse_args([option_string, '5.0.0'])
+            self.parse_args([option_string, '5.0.1'])
+            self.parse_args([option_string, '5.0.0.1'])
+
+        with self.assertRaises(ParserError):
+            self.parse_args([option_string, '1'])
+            self.parse_args([option_string, '1.2'])
+            self.parse_args([option_string, '0.0.0.0.1'])
+
+    def test_option_clang_user_visible_version(self):
+        option_string = '--clang-user-visible-version'
+
+        with self.assertNotRaises(ParserError):
+            self.parse_args([option_string, '5.0.0'])
+            self.parse_args([option_string, '5.0.1'])
+            self.parse_args([option_string, '5.0.0.1'])
+
+        with self.assertRaises(ParserError):
+            self.parse_args([option_string, '1'])
+            self.parse_args([option_string, '1.2'])
+            self.parse_args([option_string, '0.0.0.0.1'])
+
+    def test_option_swift_compiler_version(self):
+        option_string = '--swift-compiler-version'
+
+        with self.assertNotRaises(ParserError):
+            self.parse_args([option_string, '4.1'])
+            self.parse_args([option_string, '4.0.1'])
+            self.parse_args([option_string, '200.99.1'])
+
+        with self.assertRaises(ParserError):
+            self.parse_args([option_string, '1'])
+            self.parse_args([option_string, '0.0.0.1'])
+
+    def test_option_swift_user_visible_version(self):
+        option_string = '--swift-user-visible-version'
+
+        with self.assertNotRaises(ParserError):
+            self.parse_args([option_string, '4.1'])
+            self.parse_args([option_string, '4.0.1'])
+            self.parse_args([option_string, '200.99.1'])
+
+        with self.assertRaises(ParserError):
+            self.parse_args([option_string, '1'])
+            self.parse_args([option_string, '0.0.0.1'])
+
+    # -------------------------------------------------------------------------
+    # Implied defaults tests
+
+    def test_implied_defaults_assertions(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--assertions'])
+
+            self.assertTrue(args.cmark_assertions)
+            self.assertTrue(args.llvm_assertions)
+            self.assertTrue(args.swift_assertions)
+            self.assertTrue(args.swift_stdlib_assertions)
+
+    def test_implied_defaults_cmark_build_variant(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--debug-cmark'])
+            self.assertTrue(args.build_cmark)
+
+    def test_implied_defaults_lldb_build_variant(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--debug-lldb'])
+            self.assertTrue(args.build_lldb)
+
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--lldb-assertions'])
+            self.assertTrue(args.build_lldb)
+
+    def test_implied_defaults_build_variant(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--debug'])
+
+            self.assertEquals(args.cmark_build_variant, 'Debug')
+            self.assertEquals(args.foundation_build_variant, 'Debug')
+            self.assertEquals(args.libdispatch_build_variant, 'Debug')
+            self.assertEquals(args.libicu_build_variant, 'Debug')
+            self.assertEquals(args.lldb_build_variant, 'Debug')
+            self.assertEquals(args.llvm_build_variant, 'Debug')
+            self.assertEquals(args.swift_build_variant, 'Debug')
+            self.assertEquals(args.swift_stdlib_build_variant, 'Debug')
+
+    def test_implied_defaults_skip_build(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-build'])
+
+            self.assertTrue(args.skip_build_benchmarks)
+
+            self.assertTrue(args.skip_build_linux)
+            self.assertTrue(args.skip_build_android)
+            self.assertTrue(args.skip_build_freebsd)
+            self.assertTrue(args.skip_build_cygwin)
+            self.assertTrue(args.skip_build_osx)
+            self.assertTrue(args.skip_build_ios)
+            self.assertTrue(args.skip_build_tvos)
+            self.assertTrue(args.skip_build_watchos)
+
+            self.assertFalse(args.build_foundation)
+            self.assertFalse(args.build_libdispatch)
+            self.assertFalse(args.build_libicu)
+            self.assertFalse(args.build_lldb)
+            self.assertFalse(args.build_llbuild)
+            self.assertFalse(args.build_playgroundlogger)
+            self.assertFalse(args.build_playgroundsupport)
+            self.assertFalse(args.build_swiftpm)
+            self.assertFalse(args.build_xctest)
+
+    def test_implied_defaults_skip_build_ios(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-build-ios'])
+            self.assertTrue(args.skip_build_ios_device)
+            self.assertTrue(args.skip_build_ios_simulator)
+
+            # Also implies that the tests should be skipped
+            self.assertTrue(args.skip_test_ios_host)
+            self.assertTrue(args.skip_test_ios_simulator)
+
+    def test_implied_defaults_skip_build_tvos(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-build-tvos'])
+            self.assertTrue(args.skip_build_tvos_device)
+            self.assertTrue(args.skip_build_tvos_simulator)
+
+            # Also implies that the tests should be skipped
+            self.assertTrue(args.skip_test_tvos_host)
+            self.assertTrue(args.skip_test_tvos_simulator)
+
+    def test_implied_defaults_skip_build_watchos(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-build-watchos'])
+            self.assertTrue(args.skip_build_watchos_device)
+            self.assertTrue(args.skip_build_watchos_simulator)
+
+            # Also implies that the tests should be skipped
+            self.assertTrue(args.skip_test_watchos_host)
+            self.assertTrue(args.skip_test_watchos_simulator)
+
+    def test_implied_defaults_validation_test(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--validation-test'])
+            self.assertTrue(args.test)
+
+    def test_implied_defaults_test_optimized(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--test-optimized'])
+            self.assertTrue(args.test)
+
+    def test_implied_defaults_test_optimize_for_size(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--test-optimize-for-size'])
+            self.assertTrue(args.test)
+
+    def test_implied_defaults_skip_all_tests(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args([
+                '--test', '0',
+                '--validation-test', '0',
+                '--long-test', '0',
+            ])
+
+            self.assertTrue(args.skip_test_linux)
+            self.assertTrue(args.skip_test_freebsd)
+            self.assertTrue(args.skip_test_cygwin)
+            self.assertTrue(args.skip_test_osx)
+            self.assertTrue(args.skip_test_ios)
+            self.assertTrue(args.skip_test_tvos)
+            self.assertTrue(args.skip_test_watchos)
+
+    def test_implied_defaults_skip_test_ios(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-test-ios'])
+            self.assertTrue(args.skip_test_ios_host)
+            self.assertTrue(args.skip_test_ios_simulator)
+
+    def test_implied_defaults_skip_test_tvos(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-test-tvos'])
+            self.assertTrue(args.skip_test_tvos_host)
+            self.assertTrue(args.skip_test_tvos_simulator)
+
+    def test_implied_defaults_skip_test_watchos(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-test-watchos'])
+            self.assertTrue(args.skip_test_watchos_host)
+            self.assertTrue(args.skip_test_watchos_simulator)
+
+    def test_implied_defaults_skip_build_android(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--android', '0'])
+            self.assertTrue(args.skip_test_android_host)
+
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--skip-build-android'])
+            self.assertTrue(args.skip_test_android_host)
+
+    def test_implied_defaults_host_test(self):
+        with self.assertNotRaises(ParserError):
+            args = self.parse_args(['--host-test', '0'])
+            self.assertTrue(args.skip_test_ios_host)
+            self.assertTrue(args.skip_test_tvos_host)
+            self.assertTrue(args.skip_test_watchos_host)
+            self.assertTrue(args.skip_test_android_host)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Purpose

This PR is part of the staging necessary for #11827 and builds on the staging from #11880 and #11882. Put simply this PR bundles up the current argument parser and the `_apply_default_arguments` function into an `ApplyDefaultsArgumentParser` class that will call `_apply_default_arguments` anytime the `parse_args` method is called. The new parser bundles up these two interconnected behaviors making it easier to test the expected outputs.

In addition I've also taken the time to implement a new suite of unit-tests to ensure the expected behavior for the argument parser. These tests should make it easier to transition to the new system in #11827, giving reviewers more confidence that it actually works.

The unit-test suite (ab)uses Python meta classes to dynamically generate tests for each preset and argument, ensuring that they all have coverage. There's still a handful of tests types left to implement for the arguments and these tests have uncovered a preset that is broken (which will either be removed or fixed).

rdar://problem/34336890