### PR TITLE
Reworking ClangImporter to not depend on Sema, part 4

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -306,14 +306,11 @@ void NormalProtocolConformance::setSignatureConformances(
 
 void NormalProtocolConformance::resolveLazyInfo() const {
   assert(Loader);
-  assert(isComplete());
 
   auto *loader = Loader;
   auto *mutableThis = const_cast<NormalProtocolConformance *>(this);
   mutableThis->Loader = nullptr;
-  mutableThis->setState(ProtocolConformanceState::Incomplete);
   loader->finishNormalConformance(mutableThis, LoaderContextData);
-  mutableThis->setState(ProtocolConformanceState::Complete);
 }
 
 void NormalProtocolConformance::setLazyLoader(LazyConformanceLoader *loader,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7411,20 +7411,7 @@ void ClangImporter::Implementation::finishNormalConformance(
     inheritedProtos.push_back(inherited);
   }
   // Sort for deterministic import.
-  llvm::array_pod_sort(inheritedProtos.begin(),
-                       inheritedProtos.end(),
-                       [](ProtocolDecl * const *left,
-                          ProtocolDecl * const *right) -> int {
-    // We know all Objective-C protocols in a translation unit have unique
-    // names, so go by the Objective-C name.
-    auto getDeclName = [](const ProtocolDecl *proto) -> StringRef {
-      if (auto *objCAttr = proto->getAttrs().getAttribute<ObjCAttr>())
-        if (auto name = objCAttr->getName())
-          return name.getValue().getSelectorPieces().front().str();
-      return proto->getName().str();
-    };
-    return getDeclName(*left).compare(getDeclName(*right));
-  });
+  ProtocolType::canonicalizeProtocols(inheritedProtos);
 
   // Schedule any that aren't complete.
   for (auto *inherited : inheritedProtos) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -35,6 +35,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Lexer.h"
@@ -7367,6 +7368,12 @@ void ClangImporter::Implementation::finishNormalConformance(
   PrettyStackTraceType trace(SwiftContext, "completing conformance for",
                              conformance->getType());
   PrettyStackTraceDecl traceTo("... to", proto);
+
+  if (!proto->isObjC())
+    return;
+
+  assert(conformance->isComplete());
+  conformance->setState(ProtocolConformanceState::Incomplete);
 
   // Create witnesses for requirements not already met.
   for (auto req : proto->getMembers()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4642,6 +4642,11 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   PrettyStackTraceDecl traceTo("... to", conformance->getProtocol());
   ++NumNormalProtocolConformancesCompleted;
 
+  assert(conformance->isComplete());
+
+  conformance->setState(ProtocolConformanceState::Incomplete);
+  SWIFT_DEFER { conformance->setState(ProtocolConformanceState::Complete); };
+
   // Find the conformance record.
   BCOffsetRAII restoreOffset(DeclTypeCursor);
   DeclTypeCursor.JumpToBit(contextData);


### PR DESCRIPTION
Follow-up to #11812 which ensures that imported conformances all get signature conformances after the type checker has been torn down.