### PR TITLE
Move more of the signature validation of accessors into Sema

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3060,6 +3060,9 @@ ERROR(sugar_type_not_found,none,
       "broken standard library: cannot find "
       "%select{Array|Optional|ImplicitlyUnwrappedOptional|Dictionary|"
       "Error}0 type", (unsigned))
+ERROR(pointer_type_not_found,none,
+      "broken standard library: cannot find "
+      "%select{UnsafePointer|UnsafeMutablePointer}0 type", (unsigned))
 ERROR(optional_intrinsics_not_found,none,
       "broken standard library: cannot find intrinsic operations on "
       "Optional<T>", ())

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2193,11 +2193,10 @@ public:
         if (!var->getDeclContext()->contextHasLazyGenericEnvironment()) {
           paramType = var->getDeclContext()->mapTypeIntoContext(paramType);
           if (!paramType->isEqual(typeForAccessors)) {
-            Out << "property and setter param have mismatched types: '";
-            typeForAccessors.print(Out);
-            Out << "' vs. '";
-            paramType.print(Out);
-            Out << "'\n";
+            Out << "property and setter param have mismatched types:\n";
+            typeForAccessors.dump(Out, 2);
+            Out << "vs.\n";
+            paramType.dump(Out, 2);
             abort();
           }
         }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -950,6 +950,8 @@ public:
   Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
   Type getOptionalType(SourceLoc loc, Type elementType);
   Type getImplicitlyUnwrappedOptionalType(SourceLoc loc, Type elementType);
+  Type getUnsafePointerType(SourceLoc loc, Type pointeeType);
+  Type getUnsafeMutablePointerType(SourceLoc loc, Type pointeeType);
   Type getStringType(DeclContext *dc);
   Type getSubstringType(DeclContext *dc);
   Type getIntType(DeclContext *dc);

--- a/test/Constraints/invalid_constraint_lookup.swift
+++ b/test/Constraints/invalid_constraint_lookup.swift
@@ -9,8 +9,7 @@ func f<U: P>(_ rhs: U) -> X<U.A> { // expected-error {{use of undeclared type 'X
 }
 
 struct Zzz<T> {
-  // FIXME: Duplicate diagnostics
-  subscript (a: Foo) -> Zzz<T> { // expected-error 2{{use of undeclared type 'Foo'}}
+  subscript (a: Foo) -> Zzz<T> { // expected-error {{use of undeclared type 'Foo'}}
   get: // expected-error {{expected '{' to start getter definition}}
   set:
     for i in value {}

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -2216,15 +2216,7 @@
         key.usr: "s:8__main__16ComputedPropertyC5valueSivs",
         key.offset: 910,
         key.length: 49,
-        key.fully_annotated_decl: "<decl.function.accessor.setter><decl.name>set(newVal)</decl.name> {}</decl.function.accessor.setter>",
-        key.entities: [
-          {
-            key.kind: source.lang.swift.decl.var.local,
-            key.name: "newVal",
-            key.offset: 843,
-            key.length: 3
-          }
-        ]
+        key.fully_annotated_decl: "<decl.function.accessor.setter><decl.name>set(newVal)</decl.name> {}</decl.function.accessor.setter>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -2360,15 +2352,7 @@
         key.usr: "s:8__main__3CC2CS2icis",
         key.offset: 1193,
         key.length: 31,
-        key.fully_annotated_decl: "<decl.function.accessor.setter><decl.name>set(vvv)</decl.name> {}</decl.function.accessor.setter>",
-        key.entities: [
-          {
-            key.kind: source.lang.swift.decl.var.local,
-            key.name: "vvv",
-            key.offset: 1152,
-            key.length: 3
-          }
-        ]
+        key.fully_annotated_decl: "<decl.function.accessor.setter><decl.name>set(vvv)</decl.name> {}</decl.function.accessor.setter>"
       }
     ]
   },

--- a/test/decl/subscript/noescape_accessors.swift
+++ b/test/decl/subscript/noescape_accessors.swift
@@ -1,0 +1,117 @@
+// RUN: %target-typecheck-verify-swift
+
+var global: () -> () = {}
+
+struct Properties {
+  var property1: () -> () {
+    get {
+      return global
+    }
+    set {
+      global = newValue
+    }
+  }
+
+  var property2: () -> () {
+    get {
+      return global
+    }
+    set(value) {
+      global = value
+    }
+  }
+}
+
+func testProperties_property1(nonescaping: () -> (), // expected-note {{implicitly non-escaping}}
+                              escaping: @escaping () -> ()) {
+  var p = Properties()
+  p.property1 = nonescaping // expected-error {{assigning non-escaping parameter}}
+  p.property1 = escaping
+}
+
+func testProperties_property2(nonescaping: () -> (), // expected-note {{implicitly non-escaping}}
+                              escaping: @escaping () -> ()) {
+  var p = Properties()
+  p.property2 = nonescaping // expected-error {{assigning non-escaping parameter}}
+  p.property2 = escaping
+}
+
+struct Subscripts {
+  subscript(value1 fn: Int) -> () -> () {
+    get {
+      return global
+    }
+    set {
+      global = newValue
+    }
+  }
+
+  subscript(value2 fn: Int) -> () -> () {
+    get {
+      return global
+    }
+    set(value) {
+      global = value
+    }
+  }
+
+  // expected-note@+1 2 {{implicitly non-escaping}}
+  subscript(nonescapingIndex fn: () -> ()) -> Int {
+    get {
+      global = fn // expected-error {{assigning non-escaping parameter}}
+      return 0
+    }
+    set {
+      global = fn // expected-error {{assigning non-escaping parameter}}
+    }
+  }
+
+  subscript(escapingIndex fn: @escaping () -> ()) -> Int {
+    get {
+      global = fn
+      return 0
+    }
+    set {
+      global = fn
+    }
+  }
+}
+
+// expected-note@+1 {{implicitly non-escaping}}
+func testSubscripts_value1(nonescaping: () -> (),
+                           escaping: @escaping () -> ()) {
+  var s = Subscripts()
+  _ = s[value1: 0]
+  s[value1: 0] = escaping
+  s[value1: 0] = nonescaping // expected-error {{assigning non-escaping parameter}}
+}
+
+// expected-note@+1 {{implicitly non-escaping}}
+func testSubscripts_value2(nonescaping: () -> (),
+                           escaping: @escaping () -> ()) {
+  var s = Subscripts()
+  _ = s[value2: 0]
+  s[value2: 0] = escaping
+  s[value2: 0] = nonescaping // expected-error {{assigning non-escaping parameter}}
+}
+
+// FIXME: Allow these uses in subscript expressions!
+// expected-note@+1 2 {{implicitly non-escaping}}
+func testSubscripts_nonescapingIndex(nonescaping: () -> (),
+                                     escaping: @escaping () -> ()) {
+  var s = Subscripts()
+  _ = s[nonescapingIndex: nonescaping] // expected-error{{may only be called}}
+  _ = s[nonescapingIndex: escaping]
+  s[nonescapingIndex: nonescaping] = 0 // expected-error{{may only be called}}
+  s[nonescapingIndex: escaping] = 0
+}
+
+// expected-note@+1 2 {{implicitly non-escaping}}
+func testSubscripts_escapingIndex(nonescaping: () -> (),
+                                  escaping: @escaping () -> ()) {
+  var s = Subscripts()
+  _ = s[escapingIndex: nonescaping] // expected-error {{passing non-escaping parameter}}
+  _ = s[escapingIndex: escaping]
+  s[escapingIndex: nonescaping] = 0 // expected-error {{passing non-escaping parameter}}
+  s[escapingIndex: escaping] = 0
+}


### PR DESCRIPTION
Use this to remove the last bit of the hack to suppres noescape on setter
arguments.  Add a more comprehensive test of noescape's interaction with
accessors.