### PR TITLE
Make generic argument names on methods of PropertyList/JSON-Encoder/Decoder match each other

### DIFF
--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -49,7 +49,7 @@ open class PropertyListEncoder {
     /// - returns: A new `Data` value containing the encoded property list data.
     /// - throws: `EncodingError.invalidValue` if a non-comforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
     /// - throws: An error if any value throws an error during encoding.
-    open func encode<Value : Encodable>(_ value: Value) throws -> Data {
+    open func encode<T : Encodable>(_ value: T) throws -> Data {
         let encoder = _PlistEncoder(options: self.options)
         try value.encode(to: encoder)
 


### PR DESCRIPTION
These are the method signatures of `encode(_:)` and `decode(_:from:)` on Swift's available encoders/decoders:

`JSONEncoder`:

```swift
func encode<T>(_ value: T) throws -> Data where T : Encodable
```

`JSONDecoder`:

```swift
func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
```

`PropertyListEncoder`:

```swift
func encode<Value>(_ value: Value) throws -> Data where Value : Encodable
```

`PropertyListDecoder`:

```swift
func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable

func decode<T>(_ type: T.Type, from data: Data, format: inout PropertyListSerialization.PropertyListFormat) throws -> T where T : Decodable
```

As can be seen the signature of `encode(_:)` on `PropertyListEncoder` is not like the others when it comes to the generic argument's name: `Value` vs. `T`.

This PR aims to unify the naming of these methods by changing `Value` to `T`.