### PR TITLE
Revert "Paser: IfConfigDecl should reflect the underlying source. rdar://34315827"

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -293,9 +293,6 @@ namespace swift {
     /// Returns the value for the given platform condition or an empty string.
     StringRef getPlatformConditionValue(PlatformConditionKind Kind) const;
 
-    /// Check whether the given platform condition matches the given value.
-    bool checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const;
-
     /// Explicit conditional compilation flags, initialized via the '-D'
     /// compiler flag.
     void addCustomConditionalCompilationFlag(StringRef Name) {

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -116,21 +116,6 @@ LangOptions::getPlatformConditionValue(PlatformConditionKind Kind) const {
   return StringRef();
 }
 
-bool LangOptions::
-checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
-  // Check a special case that "macOS" is an alias of "OSX".
-  if (Kind == PlatformConditionKind::OS && Value == "macOS")
-    return true;
-
-  for (auto &Opt : reversed(PlatformConditionValues)) {
-    if (Opt.first == Kind)
-      if (Opt.second == Value)
-        return true;
-  }
-
-  return false;
-}
-
 bool LangOptions::isCustomConditionalCompilationFlagSet(StringRef Name) const {
   return std::find(CustomConditionalCompilationFlags.begin(),
                    CustomConditionalCompilationFlags.end(), Name)

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -304,6 +304,15 @@ public:
       return nullptr;
     }
 
+    // FIXME: Perform the replacement macOS -> OSX elsewhere.
+    if (Kind == PlatformConditionKind::OS && *ArgStr == "macOS") {
+      *ArgStr = "OSX";
+      ArgP->setSubExpr(
+          new (Ctx) UnresolvedDeclRefExpr(Ctx.getIdentifier(*ArgStr),
+                                          DeclRefKind::Ordinary,
+                                          DeclNameLoc(Arg->getLoc())));
+    }
+
     std::vector<StringRef> suggestions;
     if (!LangOptions::checkPlatformConditionSupported(*Kind, *ArgStr,
                                                       suggestions)) {
@@ -451,7 +460,8 @@ public:
 
     auto Val = getDeclRefStr(Arg);
     auto Kind = getPlatformConditionKind(KindName).getValue();
-    return Ctx.LangOpts.checkPlatformCondition(Kind, Val);
+    auto Target = Ctx.LangOpts.getPlatformConditionValue(Kind);
+    return Target == Val;
   }
 
   bool visitPrefixUnaryExpr(PrefixUnaryExpr *E) {

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -608,10 +608,6 @@ func keywordInCaseAndLocalArgLabel(_ for: Int, for in: Int, class _: Int) {
   }
 }
 
-#if os(macOS)
-#endif
-// CHECK: <#kw>#if</#kw> <#id>os</#id>(<#id>macOS</#id>)
-
 // Keep this as the last test
 /**
   Trailing off ...


### PR DESCRIPTION
For test failure witnessed in bots: https://ci.swift.org/job/oss-swift-incremental-RA-osx/462/

