### PR TITLE
[4.0][stdlib] Better message for unavailable String.init(_:UTF8Buffer)

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -57,6 +57,8 @@ extension String {
   ///         print(firstName)
   ///     }
   ///     // Prints "Marie"
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
   public struct CharacterView {
     @_versioned
     internal var _core: _StringCore
@@ -82,6 +84,8 @@ extension String {
   }
 
   /// A view of the string's contents as a collection of characters.
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
   public var characters: CharacterView {
     get {
       return CharacterView(self)

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -391,7 +391,10 @@ extension String {
   /// slice of the `picnicGuest.utf8` view.
   ///
   /// - Parameter utf8: A UTF-8 code sequence.
-  @available(swift, deprecated: 3.2, obsoleted: 4.0)
+  @available(swift, deprecated: 3.2,
+    message: "Failable initializer was removed in Swift 4. When upgrading to Swift 4, please use non-failable String.init(_:UTF8View)")
+  @available(swift, obsoleted: 4.0,
+    message: "Please use non-failable String.init(_:UTF8View) instead")
   public init?(_ utf8: UTF8View) {
     if utf8.startIndex._transcodedOffset != 0
     || utf8.endIndex._transcodedOffset != 0 {
@@ -420,7 +423,8 @@ extension String {
   }
 
   /// Creates a string corresponding to the given sequence of UTF-8 code units.
-  @available(swift, introduced: 4.0)
+  @available(swift, introduced: 4.0, message:
+    "Please use failable String.init?(_:UTF8View) when in Swift 3.2 mode")
   public init(_ utf8: UTF8View) {
     self = String(utf8._core)
   }

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -386,6 +386,10 @@ extension StringProtocol {
 %   View = ViewPrefix + 'View'
 %   RangeReplaceable = 'RangeReplaceable' if property == 'unicodeScalars' else ''
 extension Substring {
+  % if View == 'CharacterView':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
   public struct ${View} {
     var _slice: ${RangeReplaceable}BidirectionalSlice<String.${View}>
   }
@@ -424,6 +428,10 @@ extension Substring.${View} : BidirectionalCollection {
 }
 
 extension Substring {
+  % if View == 'CharacterView':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
   public var ${property}: ${View} {
     get {
       return ${View}(_wholeString.${property}, _bounds: startIndex..<endIndex)

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -418,7 +418,7 @@ extension Array where Element: Hashable {
     }
 }
 
-func rdar29633747(characters: String.CharacterView) {
+func rdar29633747(characters: String) {
   let _ = Array(characters).trimmed(["("])
 }
 

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -421,7 +421,6 @@ func resyncParserB11() {}
 // rdar://21346928
 func optStr() -> String? { return nil }
 let x = (optStr() ?? "autoclosure").#^TOP_LEVEL_AUTOCLOSURE_1^#
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      unicodeScalars[#String.UnicodeScalarView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
 

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -55,7 +55,6 @@ func giveMeAString() -> Int {
   return "Here's a string".#^LITERAL5^# // try .characters.count here
 }
 
-// LITERAL5-DAG:     Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]{{; name=.+$}}
 // LITERAL5-DAG:     Decl[InstanceVar]/CurrNominal:      endIndex[#String.Index#]{{; name=.+$}}
 // LITERAL5-DAG:     Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: reserveCapacity({#(n): Int#})[#Void#]{{; name=.+$}}
 // LITERAL5-DAG:     Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: append({#(c): Character#})[#Void#]{{; name=.+$}}

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1730,7 +1730,6 @@ func testThrows006() {
 
 // rdar://21346928
 // Just sample some String API to sanity check.
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      unicodeScalars[#String.UnicodeScalarView#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
 func testWithAutoClosure1(_ x: String?) {

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1127,7 +1127,7 @@ func test22436880() {
 
 // sr-184
 let x: String? // expected-note 2 {{constant defined here}}
-print(x?.characters.count as Any) // expected-error {{constant 'x' used before being initialized}}
+print(x?.count as Any) // expected-error {{constant 'x' used before being initialized}}
 print(x!) // expected-error {{constant 'x' used before being initialized}}
 
 

--- a/test/stdlib/Renames.swift
+++ b/test/stdlib/Renames.swift
@@ -503,7 +503,7 @@ func _String<S : Sequence>(s: S, sep: String) where S.Iterator.Element == String
   _ = s.joinWithSeparator(sep) // expected-error {{'joinWithSeparator' has been renamed to 'joined(separator:)'}} {{9-26=joined}} {{27-27=separator: }} {{none}}
 }
 
-func _StringCharacterView<S, C>(x: String.CharacterView, s: S, c: C, i: String.CharacterView.Index)
+func _StringCharacterView<S, C>(x: String, s: S, c: C, i: String.Index)
   where S : Sequence, S.Iterator.Element == Character, C : Collection, C.Iterator.Element == Character {
   var x = x
   x.replaceRange(i..<i, with: c) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange'}} {{5-17=replaceSubrange}} {{none}}

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -3,12 +3,20 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // FIXME: deprecate CharacterView. This call currently gets paired with default popFirst from Collection :-(
+  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // ok
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
+
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charSubView)
 }
 

--- a/test/stdlib/StringCompatibilityDiagnostics3.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics3.swift
@@ -3,14 +3,22 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
-    // TODO: ^^^ deprecate the view, and update the warning here
+  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
   _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // ok
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
+
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  dump(charSubView)
 }
 
 

--- a/test/stdlib/StringCompatibilityDiagnostics4.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics4.swift
@@ -1,11 +1,11 @@
-// RUN: %swift -typecheck -swift-version 3 %s -verify
+// RUN: %swift -typecheck -swift-version 4 %s -verify
 
 func testPopFirst() {
   var str = "abc"
-  _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
   _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
-    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
-  _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
   var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
   charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
@@ -20,7 +20,10 @@ func testPopFirst() {
   charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
   dump(charSubView)
 
-  var _ = String(str.utf8) ?? "" // expected-warning{{'init' is deprecated: Failable initializer was removed in Swift 4. When upgrading to Swift 4, please use non-failable String.init(_:UTF8View)}}
-  var _: String = String(str.utf8) // expected-error{{'init' is unavailable: Please use failable String.init?(_:UTF8View) when in Swift 3.2 mode}}
+  var _ = String(str.utf8) ?? "" // expected-warning{{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}}
+  var _: String = String(str.utf8)! // expected-error{{'init' is unavailable: Please use non-failable String.init(_:UTF8View) instead}}
+  var _: String = String(str.utf8) // ok
 }
+
+
 

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -82,7 +82,7 @@ func testStringCollectionTypes(s: String) {
   acceptsBidirectionalCollection(s.unicodeScalars)
   acceptsRandomAccessCollection(s.unicodeScalars) // expected-error{{argument type 'String.UnicodeScalarView' does not conform to expected type 'RandomAccessCollection'}}
 
-  acceptsCollection(s.characters)
-  acceptsBidirectionalCollection(s.characters)
-  acceptsRandomAccessCollection(s.characters) // expected-error{{argument type 'String.CharacterView' does not conform to expected type 'RandomAccessCollection'}}
+  acceptsCollection(s)
+  acceptsBidirectionalCollection(s)
+  acceptsRandomAccessCollection(s) // expected-error{{argument type 'String' does not conform to expected type 'RandomAccessCollection'}}
 }

--- a/test/stdlib/StringDiagnostics_without_Foundation.swift
+++ b/test/stdlib/StringDiagnostics_without_Foundation.swift
@@ -19,9 +19,9 @@ func testStringCollectionTypes(s: String) {
   acceptsBidirectionalCollection(s.unicodeScalars)
   acceptsRandomAccessCollection(s.unicodeScalars) // expected-error{{argument type 'String.UnicodeScalarView' does not conform to expected type 'RandomAccessCollection'}}
 
-  acceptsCollection(s.characters)
-  acceptsBidirectionalCollection(s.characters)
-  acceptsRandomAccessCollection(s.characters) // expected-error{{argument type 'String.CharacterView' does not conform to expected type 'RandomAccessCollection'}}
+  acceptsCollection(s)
+  acceptsBidirectionalCollection(s)
+  acceptsRandomAccessCollection(s) // expected-error{{argument type 'String' does not conform to expected type 'RandomAccessCollection'}}
 }
 
 struct NotLosslessStringConvertible {}

--- a/test/stdlib/UnavailableStringAPIs.swift.gyb
+++ b/test/stdlib/UnavailableStringAPIs.swift.gyb
@@ -49,7 +49,7 @@ func test_UnicodeScalarView(s: String.UnicodeScalarView, i: String.UnicodeScalar
   _ = s.distance(from: i, to: i) // OK
 }
 
-func test_CharacterView(s: String.CharacterView, i: String.CharacterView.Index, d: Int) {
+func test_CharacterView(s: String, i: String.Index, d: Int) {
   _ = s.index(after: i) // OK
   _ = s.index(before: i) // OK
   _ = s.index(i, offsetBy: d) // OK


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is the 4.0 cherry-pick of https://github.com/apple/swift/pull/11862 and https://github.com/apple/swift/pull/11425

CCC:
Explanation: This deprecates String.CharacterView and .characters, encouraging users to use String directly. It also adds better messages for a deprecated String.init, to guide users to which init they should use and when.
Scope: Limited. Deprecates a could types/properties and adds some messages to other deprecations.
Radar (and possibly SR Issue): <rdar://problem/33771896>
Risk: Very low. Doesn't affect what is or is not valid code, just issues deprecation warnings and affects the message printed.
Testing: Full CI testing.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->