### PR TITLE
Add missing REQUIRES: executable_test

### DIFF
--- a/test/Driver/static-stdlib.swift
+++ b/test/Driver/static-stdlib.swift
@@ -1,6 +1,8 @@
 // Statically link a "hello world" program
 // XFAIL: linux
 // REQUIRES: static_stdlib
+// REQUIRES: executable_test
+
 print("hello world!")
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -static-stdlib -o %t/static-stdlib %s

--- a/test/stdlib/RangeReplaceableFilterCompatibility.swift
+++ b/test/stdlib/RangeReplaceableFilterCompatibility.swift
@@ -2,6 +2,8 @@
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 
+// REQUIRES: executable_test
+
 import StdlibUnittest
 
 var tests = TestSuite("RangeReplaceableFilterCompatibility")

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -2,6 +2,8 @@
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 
+// REQUIRES: executable_test
+
 import StdlibUnittest
 
 //===--- MyString ---------------------------------------------------------===//

--- a/test/stdlib/StringFlatMap.swift
+++ b/test/stdlib/StringFlatMap.swift
@@ -2,6 +2,8 @@
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 
+// REQUIRES: executable_test
+
 import StdlibUnittest
 
 #if swift(>=4)


### PR DESCRIPTION
To get check-swift-only_non_executable clean again.