### PR TITLE
[test] Attempt to gather more information if cursor_no_cancel crashes

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_no_cancel.swift
+++ b/test/SourceKit/CursorInfo/cursor_no_cancel.swift
@@ -13,8 +13,8 @@ func myFunc() {
 // RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
 // RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
 // RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
-// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s 2>&1 \
-// RUN:   | %FileCheck %s -implicit-check-not='Request Cancel'
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s &> %t.1.log
+// RUN: %FileCheck %s -implicit-check-not='Request Cancel' < %t.1.log || (cat %t.1.log && exit 1)
 
 // CHECK: source.lang.swift.decl.function.free
 // CHECK: source.lang.swift.decl.function.free
@@ -33,8 +33,8 @@ func myFunc() {
 // RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
 // RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
 // RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
-// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s 2>&1 \
-// RUN:   | %FileCheck %s -check-prefix=RANGE -implicit-check-not='Request Cancel'
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s &> %t.2.log
+// RUN: %FileCheck %s -check-prefix=RANGE -implicit-check-not='Request Cancel' < %t.2.log || (cat %t.2.log && exit 1)
 
 // RANGE: source.lang.swift.range.singleexpression
 // RANGE: source.lang.swift.range.singleexpression


### PR DESCRIPTION
We saw this test crash once, but the stack trace was eaten by FileCheck
because we are consuming stderr. Now if the test fails it should dump
the full output, which should include the stack trace.