### PR TITLE
[WIP] [TypeChecker] NFC: Revert some perf tests to their original intervals

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 7 --end 12 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 7 --end 15 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 let a = [0]

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 8 --end 16 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 5 --end 10 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Attempt to return some perf tests to their original intervals (original problem
was related to shrink threshold increase to 10) in the light of improved scale-test
fitting algorithm.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
