### PR TITLE
[SE-0157] Make *Collection.SubSequence conform to corresponding *Collection

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -415,6 +415,7 @@ public:
   /// Mark this conformance as invalid.
   void setInvalid() {
     ContextAndInvalid.setInt(true);
+    SignatureConformances = {};
   }
 
   /// Determine whether this conformance is lazily loaded.
@@ -512,6 +513,16 @@ public:
   /// Copy the given protocol conformances for the requirement signature into
   /// the normal conformance.
   void setSignatureConformances(ArrayRef<ProtocolConformanceRef> conformances);
+
+  /// Retrieves a function object that should be called with each of the
+  /// conformances required by the requirement signature.
+  ///
+  /// This can be used to iteratively build up the signature conformances in
+  /// the type checker (rather than emitting them in a batch via
+  /// \c setSignatureConformances). The callee is responsible for calling
+  /// the returned function object with protocol conformances that line up
+  /// with the conformance requirements in the requirement signature (in order).
+  std::function<void(ProtocolConformanceRef)> populateSignatureConformances();
 
   /// Determine whether the witness for the given type requirement
   /// is the default definition.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2140,7 +2140,8 @@ static void concretizeNestedTypeFromConcreteParent(
     witnessType =
       conformance.getConcrete()
         ->getTypeWitness(assocType, builder.getLazyResolver());
-    if (!witnessType) return;
+    if (!witnessType || witnessType->hasError())
+      return; // FIXME: should we delay here?
   } else {
     witnessType = DependentMemberType::get(concreteParent, assocType);
   }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -240,6 +240,13 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
     // If we haven't set the signature conformances yet, force the issue now.
     if (normal->getSignatureConformances().empty()) {
+      // If we're in the process of checking the type witnesses, fail
+      // gracefully.
+      // FIXME: Seems like we should be able to get at the intermediate state
+      // to use that.
+      if (normal->getState() == ProtocolConformanceState::CheckingTypeWitnesses)
+        return None;
+
       auto lazyResolver = type->getASTContext().getLazyResolver();
       if (lazyResolver == nullptr)
         return None;

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -257,8 +257,7 @@ public func checkCollection<${genericParam}, C : Collection>(
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) where C.Iterator.Element == ${Element},
-  C.SubSequence : Collection {
+) where C.Iterator.Element == ${Element} {
 
   checkForwardCollection(expected, collection, message(),
     stackTrace: stackTrace, showFrame: showFrame, file: file, line: line,
@@ -278,7 +277,6 @@ public func check${Traversal}Collection<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
 ) where
   C.Iterator.Element == ${Element},
-  C.SubSequence : ${TraversalCollection},
   ${Element} : Equatable {
 
   check${Traversal}Collection(
@@ -298,8 +296,7 @@ public func check${Traversal}Collection<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
-  C.Iterator.Element == ${Element},
-  C.SubSequence : ${TraversalCollection} {
+  C.Iterator.Element == ${Element} {
 
   checkOneLevelOf${Traversal}Collection(expected, collection, ${trace},
     resiliencyChecks: resiliencyChecks, sameValue: sameValue)
@@ -504,8 +501,7 @@ ${genericParam}, S : ${TraversalCollection}
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
-  S.Iterator.Element == ${Element},
-  S.SubSequence : ${TraversalCollection} {
+  S.Iterator.Element == ${Element} {
 
   let expectedArray = Array(expected)
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -471,15 +471,9 @@ internal enum _SubSequenceSubscriptOnRangeMode {
 %{
   from gyb_stdlib_support import collectionForTraversal
   def testConstraints(protocol):
-    if protocol == 'Collection':
-      subseq_as_collection = 'CollectionWithEquatableElement.SubSequence : Collection,'
-    else:
-      subseq_as_collection=''
     return '''
     C : %(protocol)s,
     CollectionWithEquatableElement : %(protocol)s,
-    %(subseq_as_collection)s
-    C.SubSequence : %(protocol)s,
     C.Indices : %(protocol)s,
     CollectionWithEquatableElement.Iterator.Element : Equatable
   ''' % locals()

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -121,7 +121,6 @@ extension TestSuite {
     isFixedLengthCollection: Bool,
     collectionIsBidirectional: Bool = false
   ) where
-    C.SubSequence : MutableCollection,
     C.Indices : Collection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
@@ -776,7 +775,6 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
   ) where
-    C.SubSequence : BidirectionalCollection & MutableCollection,
     C.Indices : BidirectionalCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
@@ -922,7 +920,6 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
   ) where
-    C.SubSequence : RandomAccessCollection & MutableCollection,
     C.Indices : RandomAccessCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -462,10 +462,8 @@ extension TestSuite {
     outOfBoundsIndexOffset: Int = 1,
     collectionIsBidirectional: Bool = false
   ) where
-    C.SubSequence : Collection,
     C.Indices : Collection,
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection {
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -388,10 +388,6 @@ public func expect${Mutable}CollectionType<X : ${Mutable}Collection>(
 ) where
   // FIXME(ABI)#2 (Associated Types with where clauses): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
-%   if Mutable == '':
-  X.SubSequence : Collection,
-%   end
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#3 (Recursive Protocol Constraints): can't have this constraint now.
   X.Indices : Collection {}
 % end
 
@@ -425,10 +421,6 @@ public func expectCollectionAssociatedTypes<X : Collection>(
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
 ) where
-  // FIXME(ABI)#6 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-  X.SubSequence : Collection,
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#7 (Recursive Protocol Constraints): can't have this constraint now.
   X.Indices : Collection {}
 
 /// Check that all associated types of a `BidirectionalCollection` are what we
@@ -441,10 +433,6 @@ public func expectBidirectionalCollectionAssociatedTypes<X : BidirectionalCollec
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
 ) where
-  // FIXME(ABI)#8 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-  X.SubSequence : BidirectionalCollection,
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#9 (Recursive Protocol Constraints): can't have this constraint now.
   X.Indices : BidirectionalCollection {}
 
 /// Check that all associated types of a `RandomAccessCollection` are what we
@@ -457,10 +445,6 @@ public func expectRandomAccessCollectionAssociatedTypes<X : RandomAccessCollecti
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
 ) where
-  // FIXME(ABI)#10 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-  X.SubSequence : RandomAccessCollection,
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#11 (Recursive Protocol Constraints): can't have this constraint now.
   X.Indices : RandomAccessCollection {}
 
 public struct AssertionResult : CustomStringConvertible {

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -86,9 +86,7 @@ public protocol BidirectionalCollection : _BidirectionalIndexable, Collection
 
   /// A sequence that can represent a contiguous subrange of the collection's
   /// elements.
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): Remove these conformances
-  : _BidirectionalIndexable, Collection
+  associatedtype SubSequence: BidirectionalCollection
     = BidirectionalSlice<Self>
 
   /// A type that represents the indices that are valid for subscripting the

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -622,8 +622,8 @@ public struct IndexingIterator<
 /// the number of contained elements, accessing its `count` property is an
 /// O(*n*) operation.
 public protocol Collection : _Indexable, Sequence
-// FIXME(ABI) (Revert Where Clauses): Restore these
-// where SubSequence: Collection, Indices: Collection,
+// FIXME(ABI) (Revert Where Clauses): Restore this
+// where Indices: Collection,
 {
   /// A type that represents the number of steps between a pair of
   /// indices.
@@ -649,17 +649,13 @@ public protocol Collection : _Indexable, Sequence
   /// This associated type appears as a requirement in the `Sequence`
   /// protocol, but it is restated here with stricter constraints. In a
   /// collection, the subsequence should also conform to `Collection`.
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): remove these conformances:
-  : _IndexableBase
-     = Slice<Self>
-      where SubSequence.Index == Index
-            
-  // FIXME(ABI)#98 (Recursive Protocol Constraints):
+  associatedtype SubSequence : Collection = Slice<Self>
+    where SubSequence.Index == Index
+
   // FIXME(ABI)#99 (Associated Types with where clauses):
-  // associatedtype SubSequence : Collection
-  //   where
-  //   SubSequence.Indices == Indices,
+  //   where SubSequence.Indices == Indices,
+
+
   //
   // (<rdar://problem/20715009> Implement recursive protocol
   // constraints)

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -427,9 +427,8 @@ internal class _AnyRandomAccessCollectionBox<Element>
 @_versioned
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
 // FIXME(ABI) (Revert Where Clauses): apply all this only to Sequence:
-%  if Kind != 'Sequence':
+%  if Kind != 'Sequence' and Kind != 'Collection':
   where
-  S.SubSequence : ${Kind},
   S.SubSequence.Indices : ${Kind},
   S.Indices : ${Kind}
 %  end
@@ -1006,8 +1005,8 @@ protocol _AnyCollectionProtocol : Collection {
 public struct ${Self}<Element>
   : _AnyCollectionProtocol, ${SelfProtocol} {
 
-//  public typealias Indices
-//    = Default${Traversal.replace('Forward', '')}Indices<${Self}>
+  public typealias Indices
+    = Default${Traversal.replace('Forward', '')}Indices<${Self}>
 
   public typealias Iterator = AnyIterator<Element>
 
@@ -1028,7 +1027,6 @@ public struct ${Self}<Element>
   public init<C : ${SubProtocol}>(_ base: C)
     where
     // FIXME(ABI) (Revert Where Clauses): remove next 3 lines
-    C.SubSequence : ${SubProtocol},
     C.SubSequence.Indices : ${SubProtocol},
     C.Indices : ${SubProtocol},
     // FIXME(ABI)#101 (Associated Types with where clauses): these constraints

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -218,7 +218,7 @@ public struct Mirror {
     ancestorRepresentation: AncestorRepresentation = .generated
   ) where C.Element == Child 
   // FIXME(ABI) (Revert Where Clauses): Remove these 
-  , C.SubSequence : Collection, C.SubSequence.Indices : Collection, C.Indices : Collection
+  , C.SubSequence.Indices : Collection, C.Indices : Collection
   {
 
     self.subjectType = Subject.self
@@ -268,7 +268,7 @@ public struct Mirror {
     ancestorRepresentation: AncestorRepresentation = .generated
   ) 
   // FIXME(ABI) (Revert Where Clauses): Remove these two clauses
-  where C.SubSequence : Collection, C.Indices : Collection
+  where C.Indices : Collection
   {
 
     self.subjectType = Subject.self

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -197,13 +197,8 @@ public protocol _MutableIndexable : _Indexable {
 ///     a[i] = x
 ///     let y = x
 public protocol MutableCollection : _MutableIndexable, Collection
-// FIXME(ABI) (Revert Where Clauses): restore this:
-// where SubSequence: MutableCollection
 {
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): remove this conformance:
-  : Collection
-   = MutableSlice<Self>
+  associatedtype SubSequence : MutableCollection = MutableSlice<Self>
 
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -48,22 +48,18 @@ public protocol _RandomAccessIndexable : _BidirectionalIndexable {
 /// `distance(from:to:)` methods with O(1) efficiency.
 public protocol RandomAccessCollection :
   _RandomAccessIndexable, BidirectionalCollection
-// FIXME(ABI) (Revert Where Clauses): Restore this:
-// where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
 {
   /// A collection that represents a contiguous subrange of the collection's
   /// elements.
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): Remove these two constraints:
-   : _RandomAccessIndexable, BidirectionalCollection
-   = RandomAccessSlice<Self>
+  associatedtype SubSequence : RandomAccessCollection
+    = RandomAccessSlice<Self>
 
   /// A type that represents the indices that are valid for subscripting the
   /// collection, in ascending order.
   associatedtype Indices 
-  // FIXME(ABI) (Revert Where Clauses): Remove these two constraints:
-  : _RandomAccessIndexable, BidirectionalCollection
-  = DefaultRandomAccessIndices<Self>
+    // FIXME(ABI) (Revert Where Clauses): Remove these two constraints:
+    : _RandomAccessIndexable, BidirectionalCollection
+      = DefaultRandomAccessIndices<Self>
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -244,8 +244,7 @@ public protocol _RangeReplaceableIndexable : _Indexable {
 public protocol RangeReplaceableCollection
   : _RangeReplaceableIndexable, Collection
 {
-  // FIXME(ABI)#165 (Recursive Protocol Constraints): should require `RangeReplaceableCollection`.
-  associatedtype SubSequence : _RangeReplaceableIndexable /*: RangeReplaceableCollection*/
+  associatedtype SubSequence : RangeReplaceableCollection
     = RangeReplaceableSlice<Self>
 
   //===--- Fundamental Requirements ---------------------------------------===//
@@ -813,7 +812,6 @@ extension RangeReplaceableCollection {
 % for capability in ['', 'Bidirectional', 'RandomAccess']:
 %   if capability:
 extension RangeReplaceableCollection where
-    Self: ${capability}Collection,
     Self.SubSequence == RangeReplaceable${capability}Slice<Self> {
   public subscript(bounds: Range<Index>)
       -> RangeReplaceable${capability}Slice<Self> {
@@ -823,10 +821,6 @@ extension RangeReplaceableCollection where
 %   end
 
 extension RangeReplaceableCollection where
-  Self: MutableCollection,
-%   if capability:
-  Self: ${capability}Collection,
-%   end
   Self.SubSequence == MutableRangeReplaceable${capability}Slice<Self>
 {
   public subscript(bounds: Range<Index>)

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -379,6 +379,9 @@ public struct ReversedRandomAccessCollection<
 
   public typealias IndexDistance = Base.IndexDistance
 
+  public typealias Indices =
+    DefaultRandomAccessIndices<ReversedRandomAccessCollection<Base>>
+
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
   public typealias Iterator = IndexingIterator<

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -15,6 +15,7 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
+    defaultIndicesForTraversal,
     sliceTypeName,
     protocolsForCollectionFeatures
 )
@@ -96,13 +97,9 @@ def get_slice_doc_comment(Self):
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
 %       Self = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
-%       BaseRequirements = ['_' + collectionForTraversal(Traversal).replace('Collection', 'Indexable')]
-%       if Mutable:
-%         BaseRequirements.append('_MutableIndexable')
-%       if RangeReplaceable:
-%         BaseRequirements.append('_RangeReplaceableIndexable')
-%       BaseRequirements = ' & '.join(BaseRequirements)
+%       BaseRequirements = ' & '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
 %       SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
+%       Indices = defaultIndicesForTraversal(Traversal)
 
 ${get_slice_doc_comment(Self)}
 %     if Mutable:
@@ -119,6 +116,7 @@ public struct ${Self}<Base : ${BaseRequirements}>
 
   public typealias Index = Base.Index
   public typealias IndexDistance = Base.IndexDistance
+  public typealias Indices = ${Indices}<${Self}<Base>>
 
   public var _startIndex: Index
   public var _endIndex: Index

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -190,7 +190,6 @@ func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3
 // CHECK-LABEL: RangeReplaceableCollection.f()@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : MutableCollection, τ_0_0 : RangeReplaceableCollection, τ_0_0.SubSequence == MutableRangeReplaceableSlice<τ_0_0>>
 extension RangeReplaceableCollection where
-  Self: MutableCollection,
   Self.SubSequence == MutableRangeReplaceableSlice<Self>
 {
 	func f() { }

--- a/validation-test/compiler_crashers_fixed/28824-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28824-hasval.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 extension CountableRange{protocol b{typealias a:RangeReplaceableCollection
 protocol P{}
 class a:RangeReplaceableCollection


### PR DESCRIPTION
Introduce (recursive) constraints that make the *Collection constraint
of `SubSequence` match that of its enclosing *Collection, e.g.,
`MutableCollection.SubSequence` conforms to `MutableCollection`.

Fixes rdar://problem/20715031 and more of [SR-3453](https://bugs.swift.org/browse/SR-3453).