### PR TITLE
[opened-archetype] When registering values, do not assert on seeing t…

### DIFF
--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -28,7 +28,7 @@ void SILOpenedArchetypesTracker::addOpenedArchetypeDef(CanArchetypeType archetyp
       OldDef = SILValue();
     }
   }
-  assert(!OldDef &&
+  assert((!OldDef || OldDef == Def) &&
          "There can be only one definition of an opened archetype");
   OpenedArchetypeDefs[archetype] = Def;
 }


### PR DESCRIPTION
…he same definition twice.

Do assert though if we see a different definition.

This allows for one to use the same opened archetype tracker to gather dependent
types from multiple instructions safely. Previously, any overlap would result in
this assert firing.

rdar://31521023