### PR TITLE
[mandatory-inline] Move fixupReferenceCounts to /before/ inlining.

### DIFF
--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -28,7 +28,7 @@ void SILOpenedArchetypesTracker::addOpenedArchetypeDef(CanArchetypeType archetyp
       OldDef = SILValue();
     }
   }
-  assert(!OldDef &&
+  assert((!OldDef || OldDef == Def) &&
          "There can be only one definition of an opened archetype");
   OpenedArchetypeDefs[archetype] = Def;
 }

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -479,24 +479,8 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
 
       // If we intend to inline a thick function, then we need to balance the
       // reference counts for correctness.
-      if (IsThick && II != ApplyBlock->begin()) {
-        // We need to find an appropriate location for our fix up code
-        // We used to do this after inlining Without any modifications
-        // This caused us to add a release in a wrong place:
-        // It would release a value *before* retaining it!
-        // It is really problematic to do this after inlining -
-        // Finding a valid insertion point is tricky:
-        // Inlining might add new basic blocks and/or remove the apply
-        // We want to add the fix up *just before* where the current apply is!
-        // Unfortunately, we *can't* add the fix up code here:
-        // Inlining might fail for any reason -
-        // If that occurred we'd need to undo our fix up code.
-        // Instead, we split the current basic block -
-        // Making sure we have a basic block that starts with our apply.
-        SILBuilderWithScope B(II);
-        ApplyBlock = splitBasicBlockAndBranch(B, &*II, nullptr, nullptr);
-        II = ApplyBlock->begin();
-      }
+      if (IsThick)
+        fixupReferenceCounts(II, CalleeValue, CaptureArgs);
 
       // Decrement our iterator (carefully, to avoid going off the front) so it
       // is valid after inlining is done.  Inlining deletes the apply, and can
@@ -514,11 +498,6 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
 
       // Update the iterator when instructions are removed.
       DeleteInstructionsHandler DeletionHandler(II);
-
-      // If the inlined apply was a thick function, then we need to balance the
-      // reference counts for correctness.
-      if (IsThick)
-        fixupReferenceCounts(II, CalleeValue, CaptureArgs);
 
       // Now that the IR is correct, see if we can remove dead callee
       // computations (e.g. dead partial_apply closures).

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -139,3 +139,76 @@ sil private @part_apply_callee : $@convention(thin) (@owned Builtin.Int64, () ->
 bb0(%0 : $Builtin.Int64, %1 : $() -> @owned BigStruct):
   return undef : $BigStruct
 }
+
+//////////////////////
+// Autoclosure Test //
+//////////////////////
+
+class SuperBase {
+}
+
+class SuperSub : SuperBase {
+}
+
+sil @boom : $@convention(thin) (@guaranteed SuperBase) -> BigStruct
+
+sil [transparent] @autoclosure_rhs : $@convention(thin) (@owned SuperSub) -> (BigStruct, @error Error) {
+bb0(%0 : $SuperSub):
+  strong_retain %0 : $SuperSub
+  %5 = upcast %0 : $SuperSub to $SuperBase
+  %6 = function_ref @boom : $@convention(thin) (@guaranteed SuperBase) -> BigStruct
+  %7 = apply %6(%5) : $@convention(thin) (@guaranteed SuperBase) -> BigStruct
+  strong_release %5 : $SuperBase
+  strong_release %0 : $SuperSub
+  return %7 : $BigStruct
+}
+
+sil @get_optional_none : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
+sil @short_circuit_operation : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
+sil @autoclosure_partialapply : $@convention(thin) (@owned @callee_owned () -> (BigStruct, @error Error)) -> (@out BigStruct, @error Error)
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @closure(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*) #0 {
+// CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
+// CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
+// CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
+// CHECK-64: [[ALLOC4:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
+// CHECK-64: call swiftcc void @_T022big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_AFyKXKfu_TA(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC1]], %swift.refcounted* swiftself {{.*}}, %swift.error** nocapture swifterror %swifterror)
+// CHECK: ret void
+sil @closure : $@convention(thin) (@owned SuperSub) -> BigStruct {
+bb0(%0 : $SuperSub):
+  %2 = function_ref @short_circuit_operation : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
+  %3 = alloc_stack $BigStruct
+  %4 = function_ref @get_optional_none : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
+  %5 = alloc_stack $Optional<BigStruct>
+  %6 = metatype $@thin Optional<BigStruct>.Type
+  %7 = apply %4<BigStruct>(%5, %6) : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
+  %8 = load %5 : $*Optional<BigStruct>
+  %9 = alloc_stack $Optional<BigStruct>
+  store %8 to %9 : $*Optional<BigStruct>
+
+  %11 = function_ref @autoclosure_rhs : $@convention(thin) (@owned SuperSub) -> (BigStruct, @error Error)
+  strong_retain %0 : $SuperSub
+  %13 = partial_apply %11(%0) : $@convention(thin) (@owned SuperSub) -> (BigStruct, @error Error)
+
+  %14 = function_ref @autoclosure_partialapply : $@convention(thin) (@owned @callee_owned () -> (BigStruct, @error Error)) -> (@out BigStruct, @error Error)
+  %15 = partial_apply %14(%13) : $@convention(thin) (@owned @callee_owned () -> (BigStruct, @error Error)) -> (@out BigStruct, @error Error)
+  try_apply %2<BigStruct>(%3, %9, %15) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal bb1, error bb2
+
+bb1(%17 : $()):
+  dealloc_stack %9 : $*Optional<BigStruct>
+  dealloc_stack %5 : $*Optional<BigStruct>
+  %20 = load %3 : $*BigStruct
+  dealloc_stack %3 : $*BigStruct
+  strong_release %0 : $SuperSub
+  return %20 : $BigStruct
+
+bb2(%24 : $Error):
+  unreachable
+}
+
+sil_vtable SuperBase {
+}
+
+sil_vtable SuperSub {
+}
+

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -152,7 +152,7 @@ public func enumCallee(_ x: LargeEnum) {
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK-64: [[ALLOC4:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
-// CHECK-64: call swiftcc void @_T022big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_AFyKXKfu_TA(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC1]], %swift.refcounted* swiftself {{.*}}, %swift.error** nocapture swifterror %swifterror)
+// CHECK-64: call swiftcc void @_T022big_types_corner_cases9SuperBaseC4boomAA9BigStructVyF(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC1]], %T22big_types_corner_cases9SuperBaseC* swiftself {{.*}})
 // CHECK: ret void
 class SuperBase {
   func boom() -> BigStruct {

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -522,15 +522,12 @@ bb0(%0 : $@callee_owned (@owned Builtin.NativeObject) -> @owned Builtin.NativeOb
 // CHECK: bb2:
 // CHECK:   strong_retain [[ARG]]
 // CHECK:   strong_retain [[PAI]]
-// CHECK:   br bb3
-//
-// CHECK: bb3:
 // CHECK:   strong_retain [[ARG]]
 // CHECK:   strong_release [[PAI]]
 // CHECK:   [[FN2:%.*]] = function_ref @nativeobject_plus :
 // CHECK:   [[RESULT:%.*]] = apply [[FN2]]([[ARG]], [[ARG]])
 //
-// CHECK: bb4:
+// CHECK: bb3:
 // CHECK:   strong_retain [[PAI]]
 // CHECK:   [[OPAQUE_FN:%.*]] = function_ref @partial_apply_user
 // CHECK:   apply [[OPAQUE_FN]]([[PAI]])
@@ -589,8 +586,10 @@ bb1:
   br bb3(%10 : $Bool)
 
 bb2:
+  %m2 = integer_literal $Builtin.Int32, 2 // Marker
   %12 = load %3a : $*@callee_owned () -> Bool
   strong_retain %12 : $@callee_owned () -> Bool
+  %m3 = integer_literal $Builtin.Int32, 3 // Marker
   %14 = apply %12() : $@callee_owned () -> Bool
   br bb3(%14 : $Bool)
 
@@ -619,20 +618,22 @@ sil @test_short_circuit : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: br [[BB2:.*]](
 
 // CHECK: [[BB2]](
-  // CHECK: br [[BB5:.*]](
+  // CHECK: br [[BB4:.*]](
 
 // CHECK: bb3:
-  // CHECK: br bb4
-
-// CHECK: [[BB4]]:
+  // CHECK: [[OLD_CALLEE:%.*]] = load {{%[0-9]+}} :
+  // CHECK: strong_retain [[OLD_CALLEE]]
+  // Separation marker
+  // CHECK: integer_literal $Builtin.Int32, 3
   // CHECK: strong_retain [[VAL4:%[0-9]*]]
+  // CHECK: strong_release [[OLD_CALLEE]]
   // CHECK: [[ADDR4:%.*]] = project_box [[VAL4]]
   // CHECK: {{%.*}} = tuple ()
   // CHECK: {{%.*}} = load [[ADDR4]]
   // CHECK: strong_release [[VAL4]]
   // CHECK: br [[BB2]](
 
-// CHECK: [[BB5]](
+// CHECK: [[BB4]](
   // CHECK: strong_release [[VAL4]]
   // CHECK: return {{.*}}
 
@@ -648,6 +649,7 @@ bb0(%0 : $Bool, %1 : $Bool):
   %8 = function_ref @closure0 : $@convention(thin) (@owned { var Bool }) -> Bool
   strong_retain %3 : ${ var Bool }
   %10 = partial_apply %8(%3) : $@convention(thin) (@owned { var Bool }) -> Bool
+  %12 = integer_literal $Builtin.Int32, 1 // Marker
   %11 = apply %6(%7, %10) : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool
   strong_release %3 : ${ var Bool }
   strong_release %2 : ${ var Bool }
@@ -666,11 +668,15 @@ sil @test_short_circuit2 : $@convention(thin) (Bool, Bool) -> Bool {
 // CHECK: [[BB2]](
   // CHECK: br [[BB5:.*]](
 
-// CHECK: bb3:
-  // CHECK: br bb4
-
-// CHECK: [[BB4]]:
+// CHECK: [[BB3]]:
+  // Marker -
+  // CHECK: integer_literal $Builtin.Int32, 2
+  // CHECK: [[OLD_CALLEE:%.*]] = load {{%.*}}
+  // CHECK: strong_retain [[OLD_CALLEE]]
+  // Marker -
+  // CHECK: integer_literal $Builtin.Int32, 3
   // CHECK: strong_retain [[VAL4:%[0-9]*]]
+  // CHECK: strong_release [[OLD_CALLEE]]
   // CHECK: [[ADDR4:%.*]] = project_box [[VAL4]]
   // CHECK: {{%.*}} = tuple ()
   // CHECK: {{%.*}} = load [[ADDR4]]
@@ -968,8 +974,6 @@ bb0(%0 : $@callee_owned () -> Builtin.Int8):
 // CHECK-LABEL: sil @testouter_transparent
 sil @testouter_transparent : $@convention(thin) (Builtin.Int8) -> Builtin.Int8 {
 // CHECK: bb0
-// CHECK-NEXT: br bb1
-// CHECK: bb1
 // CHECK-NEXT: return
 bb0(%0 : $Builtin.Int8):
   %2 = function_ref @outer_transparent : $@convention(thin) (@owned @callee_owned () -> Builtin.Int8) -> Builtin.Int8

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -136,8 +136,6 @@ func call_let_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
 // CHECK: sil hidden @{{.*}}test_let_auto_closure_with_value_capture
 // CHECK: bb0(%0 : $Bool):
 // CHECK-NEXT: debug_value %0 : $Bool
-// CHECK-NEXT: br bb1
-// CHECK: bb1:
 // CHECK-NEXT: return %0 : $Bool
 
 func test_let_auto_closure_with_value_capture(_ x: Bool) -> Bool {


### PR DESCRIPTION
[mandatory-inline] Move fixupReferenceCounts to /before/ inlining.

Once this lands, I can land my commit that turns on ownership for mandatory
inlining.

rdar://31521023

----

I also included a small test case fix as well.
