### PR TITLE
[ConstraintSolver] NFC: Cleanup dead-code related to contraction of s…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1700,40 +1700,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       LLVM_FALLTHROUGH;
 
     case ConstraintKind::Subtype:
-      // Subtype constraints are subject for edge contraction,
-      // which is inappropriate in this case, because it's going to
-      // erase/lose 'inout' modifier after merging equivalence classes
-      // (if inout constraints type var, see ConstraintGraph::contractEdges()),
-      // since right-hand side type variable must not be materializable
-      // it can simply get left-hand side as a fixed binding, otherwise fail.
-      if (type1->is<InOutType>() &&
-          type1->getInOutObjectType()->isTypeVariableOrMember() && typeVar2) {
-        // Left-hand side type is not materializable, so we need to
-        // check if it's even appropriate to have such a constraint
-        // between these two types, or fail early otherwise if right-hand
-        // side must be materializable.
-        if (typeVar2->getImpl().mustBeMaterializable())
-          return SolutionKind::Error;
-
-        // Constraints like `inout T0 subtype T1` where (T0 must be
-        // materializable) are created when closures are part of the generic
-        // function parameters e.g. `func foo<T>(_ t: T, (inout T) -> Void) {}`
-        // so when such function gets called e.g.
-        // ```
-        //  var x = 42
-        //  foo(x) { $0 = 0 }
-        // ```
-        // it's going to try and map closure parameters type (inout T0), where
-        // T0 is opened generic parameter T, to argument type (T1), which can
-        // be 'inout' but it's uncertain at this stage, but since closure
-        // 'declaration' `{ $0 = 0 }` is wrapped inside of a function call,
-        // it has to 'map' parameters to arguments instead of converting them,
-        // see `ConstraintSystem::matchFunctionTypes`.
-        assignFixedType(typeVar2, type1);
-        return SolutionKind::Solved;
-      }
-      LLVM_FALLTHROUGH;
-
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::OperatorArgumentTupleConversion:
     case ConstraintKind::OperatorArgumentConversion:

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -588,3 +588,14 @@ SR5202<()>().map{ return 0 }
 SR5202<()>().map{ _ in return 0 }
 SR5202<Void>().map{ return 0 }
 SR5202<Void>().map{ _ in return 0 }
+
+func sr3520_2<T>(_ item: T, _ update: (inout T) -> Void) {
+  var x = item
+  update(&x)
+}
+var sr3250_arg = 42
+sr3520_2(sr3250_arg) { $0 += 3 } // ok
+
+// SR-1976/SR-3073: Inference of inout
+func sr1976<T>(_ closure: (inout T) -> Void) {}
+sr1976({ $0 += 2 }) // ok

--- a/test/Constraints/closures_swift3.swift
+++ b/test/Constraints/closures_swift3.swift
@@ -18,17 +18,3 @@ r32432145 { _ in let _ = 42 } // Ok in Swift 3
 r32432145 { _ in // Ok in Swift 3
   print("answer is 42")
 }
-
-// FIXME: rdar://problem/34137342: This should compile under
-// -swift-version 4 as well but does not currently.
-func sr3520_2<T>(_ item: T, _ update: (inout T) -> Void) {
-  var x = item
-  update(&x)
-}
-var sr3250_arg = 42
-sr3520_2(sr3250_arg) { $0 += 3 } // ok
-
-// FIXME: rdar://problem/34136625 - this crashes in diagnostics in -swift-version 4
-// SR-1976/SR-3073: Inference of inout
-func sr1976<T>(_ closure: (inout T) -> Void) {}
-sr1976({ $0 += 2 }) // ok


### PR DESCRIPTION
…ubtype constraints in `matchTypes`

Since we no longer allow constraction of subtype constraints, workaround
which exists in `matchTypes`, for situations where left-hand side of such
constraint is going to be wrapped in `inout` type, is no longer required.

Resolves: rdar://problem/34137342, rdar://problem/34136625

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
