### PR TITLE
Add experimental support for tracking the invocations of runtime functions

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -107,6 +107,7 @@ set(SWIFTLIB_ESSENTIAL
   REPL.swift
   Reverse.swift
   Runtime.swift.gyb
+  RuntimeFunctionCounters.swift
   SipHash.swift.gyb
   SentinelCollection.swift
   Sequence.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -164,6 +164,7 @@
     "Print.swift",
     "REPL.swift",
     "Runtime.swift",
+    "RuntimeFunctionCounters.swift",
     "Shims.swift",
     "ThreadLocalStorage.swift",
     "Unmanaged.swift",

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -1,0 +1,502 @@
+//===--- RuntimeFunctionCounters.swift ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the experimental support for collecting the state of
+//  runtime function counters, which are used to determine how many times
+//  a given runtime function was called.
+//
+//  It is possible to get the global counters, which represent the total
+//  number of invocations, or per-object counters, which represent the
+//  number of runtime functions calls for a specific object.
+
+/// Collect all references inside the object using Mirrors.
+/// - Parameter value: the value to be inspected
+/// - Parameter references: the array which should contain the collected
+///                         references
+/// - Parameter visitedItems: the dictionary for keeping track of visited
+///                           objects
+internal func _collectAllReferencesInsideObjectImpl(
+  _ value: Any,
+  references: inout [UnsafeRawPointer],
+  visitedItems: inout [ObjectIdentifier : Int]
+  ) {
+  // Use the structural reflection and ignore any
+  // custom reflectable overrides.
+  let mirror = Mirror(
+    legacy: _reflect(value),
+    subjectType: type(of: value))
+
+  let count = mirror.children.count
+
+  let id: ObjectIdentifier?
+  let toAnyObject: AnyObject?
+  if type(of: value) is AnyObject.Type {
+    // Object is a class (but not an ObjC-bridged struct)
+    toAnyObject = _unsafeDowncastToAnyObject(fromAny: value)
+    id = ObjectIdentifier(toAnyObject!)
+  } else if type(of: value) is Builtin.BridgeObject.Type ||
+    type(of: value) is Builtin.NativeObject.Type  {
+    toAnyObject = _unsafeDowncastToAnyObject(fromAny: value)
+    id = ObjectIdentifier(toAnyObject!)
+  } else if let metatypeInstance = value as? Any.Type {
+    // Object is a metatype
+    id = ObjectIdentifier(metatypeInstance)
+    toAnyObject = nil
+  } else {
+    id = nil
+    toAnyObject = nil
+  }
+
+  if let theId = id {
+    // Bail if this object was seen already.
+    if visitedItems[theId] != nil {
+      return
+    }
+    // Remember that this object was seen already.
+    let identifier = visitedItems.count
+    visitedItems[theId] = identifier
+  }
+
+  // If it is a reference, add it to the result.
+  if let toAnyObject = toAnyObject {
+    references.append(
+      UnsafeRawPointer(Unmanaged.passUnretained(toAnyObject).toOpaque()))
+  }
+
+  // Recursively visit the children of the current value.
+  var currentIndex = mirror.children.startIndex
+  for _ in 0..<count {
+    let (_, child) = mirror.children[currentIndex]
+    mirror.children.formIndex(after: &currentIndex)
+    _collectAllReferencesInsideObjectImpl(
+      child,
+      references: &references,
+      visitedItems: &visitedItems)
+  }
+}
+
+/// This is a namespace for runtime functions related to management
+/// of runtime function counters.
+public // @testable
+struct _RuntimeFunctionCounters {
+  public typealias RuntimeFunctionCountersUpdateHandler =
+   @convention(c) (_ object: UnsafeRawPointer, _ functionId: Int64) -> Void
+
+  public static let runtimeFunctionNames =
+    getRuntimeFunctionNames()
+  public static let runtimeFunctionCountersOffsets =
+    _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
+  public static let numRuntimeFunctionCounters =
+    _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+  public static let runtimtFunctionNameToIndex: [String : Int] =
+    getRuntimeFunctionNameToIndex()
+
+  /// Get the names of all runtime functions whose calls are being
+  /// tracked.
+  @_silgen_name("getRuntimeFunctionNames")
+  static public func _getRuntimeFunctionNames() ->
+    UnsafePointer<UnsafePointer<CChar>>
+
+  static public func getRuntimeFunctionNames() -> [String] {
+    let runtimeFunctionNames = _RuntimeFunctionCounters._getRuntimeFunctionNames()
+    let numRuntimeFunctionCounters =
+      _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+    var runtimtFunctionNames : [String] = []
+    for index in 0..<numRuntimeFunctionCounters {
+      let name = String(cString:runtimeFunctionNames[index])
+      runtimtFunctionNames.append(name)
+    }
+    return runtimtFunctionNames
+  }
+
+  /// Get the offsets of the collected runtime function counters inside
+  /// the state.
+  @_silgen_name("getRuntimeFunctionCountersOffsets")
+  static public func getRuntimeFunctionCountersOffsets() ->
+    UnsafePointer<UInt16>
+
+  /// Get the number of different runtime functions whose calls are being
+  /// tracked.
+  @_silgen_name("getNumRuntimeFunctionCounters")
+  static public func getNumRuntimeFunctionCounters() -> Int
+
+  /// Dump all per-object runtime function counters.
+  @_silgen_name("dumpObjectsRuntimeFunctionPointers")
+  static public func dumpObjectsRuntimeFunctionPointers()
+
+  @_silgen_name("setGlobalRuntimeFunctionCountersUpdateHandler")
+  static public func setGlobalRuntimeFunctionCountersUpdateHandler(
+    handler: RuntimeFunctionCountersUpdateHandler?) ->
+    RuntimeFunctionCountersUpdateHandler?
+
+  /// Collect all references inside the object using Mirrors.
+  static public func collectAllReferencesInsideObject(_ value: Any) ->
+    [UnsafeRawPointer] {
+    var visited : [ObjectIdentifier : Int] = [:]
+    var references: [UnsafeRawPointer] = []
+    _collectAllReferencesInsideObjectImpl(value,
+                                          references: &references,
+                                          visitedItems: &visited)
+    return references
+  }
+
+  /// Build a map from counter name to counter index inside the state struct.
+  static internal func getRuntimeFunctionNameToIndex() -> [String : Int] {
+    let runtimeFunctionNames = _RuntimeFunctionCounters.getRuntimeFunctionNames()
+    var runtimtFunctionNameToIndex : [String : Int] = [:]
+    let numRuntimeFunctionCounters =
+    _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+    for index in 0..<numRuntimeFunctionCounters {
+      let name = runtimeFunctionNames[index]
+      runtimtFunctionNameToIndex[name] = index
+    }
+    return runtimtFunctionNameToIndex
+  }
+}
+
+/// This protocol defines a set of operations for accessing runtime function
+/// counters statistics.
+public // @testable
+protocol _RuntimeFunctionCountersStats {
+  init()
+
+  /// Dump the current state of all counters.
+  func dump(skipUnchanged: Bool)
+
+  /// Dump the diff between the current state and a different state of all
+  /// counters.
+  func dumpDiff(_ after: Self, skipUnchanged: Bool)
+
+  /// Compute a diff between two states of runtime function counters.
+  /// Return a new state representing the diff.
+  func diff(_ other: Self) -> Self
+
+  /// Access counters by name.
+  subscript(_ index: String) -> UInt32 { get set }
+
+  /// Access counters by index.
+  subscript(_ index: Int) -> UInt32 { get set }
+}
+
+// A helper type that encapsulates the logic for collecting runtime function
+// counters. This type should not be used directly. You should use its
+// wrappers GlobalRuntimeFunctionCountersState and
+// ObjectRuntimeFunctionCountersState instead.
+internal struct _RuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
+  /// Reserve enough space for 64 elements.
+  typealias Counters =
+  (
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32, UInt32,
+    UInt32, UInt32, UInt32, UInt32
+  )
+
+  private var counters: Counters = (
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0), UInt32(0),
+    UInt32(0), UInt32(0), UInt32(0), UInt32(0)
+  )
+
+  // Use counter name as index.
+  subscript(_ index: String) -> UInt32 {
+    get {
+      if let index = _RuntimeFunctionCounters.runtimtFunctionNameToIndex[index] {
+        return self[index]
+      }
+      fatalError("Unknown counter name: \(index)")
+    }
+
+    set {
+      if let index = _RuntimeFunctionCounters.runtimtFunctionNameToIndex[index] {
+        self[index] = newValue
+        return
+      }
+      fatalError("Unknown counter name: \(index)")
+    }
+  }
+
+  subscript(_ index: Int) -> UInt32 {
+    @inline(never)
+    get {
+      if (index >= _RuntimeFunctionCounters.numRuntimeFunctionCounters) {
+        fatalError("Counter index should be in the range " +
+          "0..<\(_RuntimeFunctionCounters.numRuntimeFunctionCounters)")
+      }
+      var tmpCounters = counters
+      var counter: UInt32 = withUnsafePointer(to: &tmpCounters) { ptr in
+        return ptr.withMemoryRebound(to: UInt32.self, capacity: 64) { buf in
+          return buf[index]
+        }
+      }
+      return counter
+    }
+
+    @inline(never)
+    set {
+      if (index >= _RuntimeFunctionCounters.numRuntimeFunctionCounters) {
+        fatalError("Counter index should be in the range " +
+          "0..<\(_RuntimeFunctionCounters.numRuntimeFunctionCounters)")
+      }
+      withUnsafeMutablePointer(to: &counters) {
+        $0.withMemoryRebound(to: UInt32.self, capacity: 64) {
+          $0[index] = newValue
+        }
+      }
+    }
+  }
+}
+
+extension _RuntimeFunctionCounters {
+  @_silgen_name("getObjectRuntimeFunctionCounters")
+  static internal func getObjectRuntimeFunctionCounters(
+    _ object: UnsafeRawPointer, _ result: inout _RuntimeFunctionCountersState)
+
+  @_silgen_name("getGlobalRuntimeFunctionCounters")
+  static internal func getGlobalRuntimeFunctionCounters(
+    _ result: inout _RuntimeFunctionCountersState)
+
+  @_silgen_name("setGlobalRuntimeFunctionCounters")
+  static internal func setGlobalRuntimeFunctionCounters(
+    _ state: inout _RuntimeFunctionCountersState)
+
+  @_silgen_name("setObjectRuntimeFunctionCounters")
+  static internal func setObjectRuntimeFunctionCounters(
+    _ object: UnsafeRawPointer,
+    _ state: inout _RuntimeFunctionCountersState)
+
+  @_silgen_name("setGlobalRuntimeFunctionCountersMode")
+  static
+  public // @testable
+  func setGlobalRuntimeFunctionCountersMode(enable: Bool) -> Bool
+
+  @_silgen_name("setPerObjectRuntimeFunctionCountersMode")
+  static
+  public // @testable
+  func setPerObjectRuntimeFunctionCountersMode(enable: Bool) -> Bool
+
+  /// Enable runtime function counters updates by the runtime.
+  static
+  public // @testable
+  func enableRuntimeFunctionCountersUpdates(
+    mode: (globalMode: Bool, perObjectMode: Bool) = (true, true)) {
+    _ = _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersMode(
+      enable: mode.globalMode)
+    _ = _RuntimeFunctionCounters.setPerObjectRuntimeFunctionCountersMode(
+      enable: mode.perObjectMode)
+  }
+
+  /// Disable runtime function counters updates by the runtime.
+  static
+  public // @testable
+  func disableRuntimeFunctionCountersUpdates() ->
+    (globalMode: Bool, perObjectMode: Bool) {
+      let oldGlobalMode =
+        _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersMode(
+          enable: false)
+      let oldPerObjectMode =
+        _RuntimeFunctionCounters.setPerObjectRuntimeFunctionCountersMode(
+          enable: false)
+      return (oldGlobalMode, oldPerObjectMode)
+  }
+}
+
+extension _RuntimeFunctionCountersStats {
+  typealias Counters = _RuntimeFunctionCounters
+  @inline(never)
+  public // @testable
+  func dump(skipUnchanged: Bool = false) {
+    for i in 0..<Counters.numRuntimeFunctionCounters {
+      if skipUnchanged && self[i] == 0 {
+        continue
+      }
+      print("counter \(i) : " +
+        "\(Counters.runtimeFunctionNames[i])" +
+        " at offset: " +
+        "\(Counters.runtimeFunctionCountersOffsets[i]):" +
+        "  \(self[i])")
+    }
+  }
+
+  @inline(never)
+  public // @testable
+  func dumpDiff(_ after: Self, skipUnchanged: Bool = false) {
+    for i in 0..<Counters.numRuntimeFunctionCounters {
+      if self[i] == 0 && after[i] == 0 {
+        continue
+      }
+      if skipUnchanged && self[i] == after[i] {
+        continue
+      }
+      print("counter \(i) : " +
+        "\(Counters.runtimeFunctionNames[i])" +
+        " at offset: " +
+        "\(Counters.runtimeFunctionCountersOffsets[i]): " +
+        "before \(self[i]) " +
+        "after \(after[i])" + " diff=\(after[i]-self[i])")
+    }
+  }
+
+  public // @testable
+  func diff(_ other: Self) -> Self {
+    var result = Self()
+    for i in 0..<Counters.numRuntimeFunctionCounters {
+      result[i] = other[i] - self[i]
+    }
+    return result
+  }
+}
+
+/// This type should be used to collect statistics about the global runtime
+/// function pointers.
+public // @testable
+struct _GlobalRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
+  var state = _RuntimeFunctionCountersState()
+
+  public init() {
+    getGlobalRuntimeFunctionCounters()
+  }
+
+  mutating public func getGlobalRuntimeFunctionCounters() {
+    _RuntimeFunctionCounters.getGlobalRuntimeFunctionCounters(&state)
+  }
+
+  mutating public func setGlobalRuntimeFunctionCounters() {
+    _RuntimeFunctionCounters.setGlobalRuntimeFunctionCounters(&state)
+  }
+
+  public subscript(_ index: String) -> UInt32 {
+    get {
+      return state[index]
+    }
+    set {
+      state[index] = newValue
+    }
+  }
+
+  public subscript(_ index: Int) -> UInt32 {
+    get {
+      return state[index]
+    }
+    set {
+      state[index] = newValue
+    }
+  }
+}
+
+/// This type should be used to collect statistics about object runtime
+/// function pointers.
+public // @testable
+struct _ObjectRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
+  var state = _RuntimeFunctionCountersState()
+
+  // Initialize with the counters for a given object.
+  public init(_ p: UnsafeRawPointer) {
+    getObjectRuntimeFunctionCounters(p)
+  }
+
+  public init() {
+  }
+
+  mutating public func getObjectRuntimeFunctionCounters(_ o: UnsafeRawPointer) {
+    _RuntimeFunctionCounters.getObjectRuntimeFunctionCounters(o, &state)
+  }
+
+  mutating public func setObjectRuntimeFunctionCounters(_ o: UnsafeRawPointer) {
+    _RuntimeFunctionCounters.setObjectRuntimeFunctionCounters(o, &state)
+  }
+
+  public subscript(_ index: String) -> UInt32 {
+    get {
+      return state[index]
+    }
+    set {
+      state[index] = newValue
+    }
+  }
+
+  public subscript(_ index: Int) -> UInt32 {
+    get {
+      return state[index]
+    }
+    set {
+      state[index] = newValue
+    }
+  }
+}
+
+/// Collects all references inside an object.
+/// Runtime counters tracking is disabled for the duration of this operation
+/// so that it does not affect those counters.
+public // @testable
+func _collectReferencesInsideObject(_ value: Any) -> [UnsafeRawPointer] {
+  let savedMode = _RuntimeFunctionCounters.disableRuntimeFunctionCountersUpdates()
+  // Collect all references inside the object
+  let refs = _RuntimeFunctionCounters.collectAllReferencesInsideObject(value)
+  _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(mode: savedMode)
+  return refs
+}
+
+/// A helper method to measure how global and per-object function counters
+/// were changed during execution of a closure provided as a parameter.
+/// Returns counter diffs for global counters and for the object-specific
+/// counters related to a given object.
+public // @testable
+func _measureRuntimeFunctionCountersDiffs(
+  objects: [UnsafeRawPointer], _ f: () -> Void) ->
+  (_GlobalRuntimeFunctionCountersState, [_ObjectRuntimeFunctionCountersState]) {
+    let savedMode =
+      _RuntimeFunctionCounters.disableRuntimeFunctionCountersUpdates()
+    let globalCountersBefore = _GlobalRuntimeFunctionCountersState()
+    var objectsCountersBefore: [_ObjectRuntimeFunctionCountersState] = []
+    for object in objects {
+      objectsCountersBefore.append(_ObjectRuntimeFunctionCountersState(object))
+    }
+    // Enable counters updates.
+    _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(
+      mode: (globalMode: true, perObjectMode: true))
+    f()
+    // Disable counters updates.
+    _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(
+    mode: (globalMode: false, perObjectMode: false))
+
+    let globalCountersAfter = _GlobalRuntimeFunctionCountersState()
+    var objectsCountersDiff: [_ObjectRuntimeFunctionCountersState] = []
+    for (idx, object) in objects.enumerated() {
+      let objectCountersAfter = _ObjectRuntimeFunctionCountersState(object)
+      objectsCountersDiff.append(
+        objectsCountersBefore[idx].diff(objectCountersAfter))
+    }
+
+    _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(
+      mode: savedMode)
+    return (globalCountersBefore.diff(globalCountersAfter), objectsCountersDiff)
+}

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -58,6 +58,7 @@ set(swift_runtime_sources
     ProtocolConformance.cpp
     RefCount.cpp
     RuntimeEntrySymbols.cpp
+    RuntimeInvocationsTracking.cpp
     "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "MetadataCache.h"
 #include "Private.h"
+#include "RuntimeInvocationsTracking.h"
 #include "WeakReference.h"
 #include "swift/Runtime/Debug.h"
 #include <algorithm>
@@ -297,6 +298,7 @@ void swift::swift_nonatomic_retain(HeapObject *object) {
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain)(HeapObject *object) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.incrementNonAtomic(1);
 }
@@ -308,6 +310,7 @@ void swift::swift_nonatomic_release(HeapObject *object) {
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_release)(HeapObject *object) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_release);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinitNonAtomic(1);
 }
@@ -316,6 +319,7 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_retain)(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_retain);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.increment(1);
 }
@@ -329,6 +333,7 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_retain_n)(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_retain_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.increment(n);
 }
@@ -342,6 +347,7 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain_n)(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.incrementNonAtomic(n);
 }
@@ -355,6 +361,7 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_release)(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_release);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinit(1);
 }
@@ -368,11 +375,13 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_release_n)(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_release_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinit(n);
 }
 
 void swift::swift_setDeallocating(HeapObject *object) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_setDeallocating);
   object->refCounts.decrementFromOneNonAtomic();
 }
 
@@ -385,6 +394,7 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_release_n)(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_release_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinitNonAtomic(n);
 }
@@ -399,6 +409,7 @@ size_t swift::swift_unownedRetainCount(HeapObject *object) {
 
 void swift::swift_unownedRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetain);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -407,6 +418,7 @@ void swift::swift_unownedRetain(HeapObject *object)
 
 void swift::swift_unownedRelease(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRelease);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -425,6 +437,7 @@ void swift::swift_unownedRelease(HeapObject *object)
 
 void swift::swift_nonatomic_unownedRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetain);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -433,6 +446,7 @@ void swift::swift_nonatomic_unownedRetain(HeapObject *object)
 
 void swift::swift_nonatomic_unownedRelease(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRelease);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -451,6 +465,7 @@ void swift::swift_nonatomic_unownedRelease(HeapObject *object)
 
 void swift::swift_unownedRetain_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetain_n);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -459,6 +474,7 @@ void swift::swift_unownedRetain_n(HeapObject *object, int n)
 
 void swift::swift_unownedRelease_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRelease_n);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -476,6 +492,7 @@ void swift::swift_unownedRelease_n(HeapObject *object, int n)
 
 void swift::swift_nonatomic_unownedRetain_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetain_n);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -484,6 +501,7 @@ void swift::swift_nonatomic_unownedRetain_n(HeapObject *object, int n)
 
 void swift::swift_nonatomic_unownedRelease_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRelease_n);
   if (!isValidPointerForNativeRetain(object))
     return;
 
@@ -501,6 +519,7 @@ void swift::swift_nonatomic_unownedRelease_n(HeapObject *object, int n)
 
 HeapObject *swift::swift_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_tryPin);
   assert(isValidPointerForNativeRetain(object));
 
   // Try to set the flag.  If this succeeds, the caller will be
@@ -515,6 +534,7 @@ HeapObject *swift::swift_tryPin(HeapObject *object)
 
 void swift::swift_unpin(HeapObject *object)
   SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unpin);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndUnpinAndMaybeDeinit();
 }
@@ -526,6 +546,7 @@ HeapObject *swift::swift_tryRetain(HeapObject *object)
 
 HeapObject *swift::swift_nonatomic_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_tryPin);
   assert(object);
 
   // Try to set the flag.  If this succeeds, the caller will be
@@ -540,6 +561,7 @@ HeapObject *swift::swift_nonatomic_tryPin(HeapObject *object)
 
 void swift::swift_nonatomic_unpin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unpin);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndUnpinAndMaybeDeinitNonAtomic();
 }
@@ -548,6 +570,7 @@ SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 HeapObject *SWIFT_RT_ENTRY_IMPL(swift_tryRetain)(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_tryRetain);
   if (!isValidPointerForNativeRetain(object))
     return nullptr;
 
@@ -570,6 +593,7 @@ bool SWIFT_RT_ENTRY_IMPL(swift_isDeallocating)(HeapObject *object) {
 
 void swift::swift_unownedRetainStrong(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetainStrong);
   if (!isValidPointerForNativeRetain(object))
     return;
   assert(object->refCounts.getUnownedCount() &&
@@ -581,6 +605,7 @@ void swift::swift_unownedRetainStrong(HeapObject *object)
 
 void swift::swift_nonatomic_unownedRetainStrong(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetainStrong);
   if (!isValidPointerForNativeRetain(object))
     return;
   assert(object->refCounts.getUnownedCount() &&
@@ -592,6 +617,7 @@ void swift::swift_nonatomic_unownedRetainStrong(HeapObject *object)
 
 void swift::swift_unownedRetainStrongAndRelease(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetainStrongAndRelease);
   if (!isValidPointerForNativeRetain(object))
     return;
   assert(object->refCounts.getUnownedCount() &&
@@ -608,6 +634,7 @@ void swift::swift_unownedRetainStrongAndRelease(HeapObject *object)
 
 void swift::swift_nonatomic_unownedRetainStrongAndRelease(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetainStrongAndRelease);
   if (!isValidPointerForNativeRetain(object))
     return;
   assert(object->refCounts.getUnownedCount() &&

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -84,6 +84,8 @@ SWIFT_RT_ENTRY_IMPL(swift_allocObject)(HeapMetadata const *metadata,
   // If leak tracking is enabled, start tracking this object.
   SWIFT_LEAKS_START_TRACKING_OBJECT(object);
 
+  SWIFT_RT_TRACK_INVOCATION(object, swift_allocObject);
+
   return object;
 }
 
@@ -93,6 +95,7 @@ swift::swift_initStackObject(HeapMetadata const *metadata,
   object->metadata = metadata;
   object->refCounts.initForNotFreeing();
 
+  SWIFT_RT_TRACK_INVOCATION(object, swift_initStackObject);
   return object;
 }
 
@@ -113,6 +116,7 @@ static void initStaticObjectWithContext(void *OpaqueCtx) {
 HeapObject *
 swift::swift_initStaticObject(HeapMetadata const *metadata,
                               HeapObject *object) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_initStaticObject);
   // The token is located at a negative offset from the object header.
   swift_once_t *token = ((swift_once_t *)object) - 1;
 
@@ -765,6 +769,7 @@ void swift::swift_deallocObject(HeapObject *object, size_t allocatedSize,
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   assert(isAlignmentMask(allocatedAlignMask));
   assert(object->refCounts.isDeiniting());
+  SWIFT_RT_TRACK_INVOCATION(object, swift_deallocObject);
 #ifdef SWIFT_RUNTIME_CLOBBER_FREED_OBJECTS
   memset_pattern8((uint8_t *)object + sizeof(HeapObject),
                   "\xAB\xAD\x1D\xEA\xF4\xEE\xD0\bB9",

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
@@ -1,0 +1,215 @@
+//===--- RuntimeInvocationsTracking.cpp - Track runtime invocations -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Track invocations of Swift runtime functions. This can be used for performance
+// analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/DenseMap.h"
+#include "RuntimeInvocationsTracking.h"
+#include "swift/Runtime/HeapObject.h"
+
+using namespace swift;
+
+/// If set, global runtime function counters should be tracked.
+static bool UpdatePerObjectRuntimeFunctionCounters = false;
+/// If set, per object runtime function counters should be tracked.
+static bool UpdateGlobalRuntimeFunctionCounters = false;
+/// TODO: Add support for enabling/disabling counters on a per object basis?
+
+/// Global set of counters tracking the total number of runtime invocations.
+static RuntimeFunctionCountersState RuntimeGlobalFunctionCountersState;
+
+/// The object state cache mapping objects to the collected state associated with
+/// them.
+/// TODO: Do we need to make it thread-safe?
+static llvm::DenseMap<HeapObject *, RuntimeFunctionCountersState> RuntimeObjectStateCache;
+
+/// Define names of runtime functions.
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION) #RT_FUNCTION,
+
+static const char *RuntimeFunctionNames[] {
+  RT_FUNCTIONS_TO_TRACK
+  nullptr
+};
+
+#define RT_FUNCTION_ID(RT_FUNCTION) ID_##RT_FUNCTION
+
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION) RT_FUNCTION_ID(RT_FUNCTION),
+
+/// Define an enum where each enumerator corresponds to a runtime function being
+/// tracked. Their order is the same as the order of the counters in the
+/// RuntimeObjectState structure.
+enum RuntimeFunctionNamesIDs : uint32_t {
+  RT_FUNCTIONS_TO_TRACK
+  ID_LastRuntimeFunctionName,
+};
+
+/// The global handler to be invoked on runtime function counters updates.
+static RuntimeFunctionCountersUpdateHandler
+    GlobalRuntimeFunctionCountersUpdateHandler;
+
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION)                                 \
+  (sizeof(uint16_t) * (unsigned)RT_FUNCTION_ID(RT_FUNCTION)),
+
+/// The offsets of the runtime function counters being tracked inside the
+/// RuntimeObjectState structure. The array is indexed by
+/// the enumerators from RuntimeFunctionNamesIDs.
+static uint16_t RuntimeFunctionCountersOffsets[] = {
+  RT_FUNCTIONS_TO_TRACK
+};
+
+/// Define implementations of tracking functions.
+/// TODO: Track only objects that were registered for tracking?
+/// TODO: Perform atomic increments?
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION)                                 \
+  void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION, OBJ)(HeapObject * OBJ) {    \
+    /* Update global counters. */                                              \
+    if (UpdateGlobalRuntimeFunctionCounters) {                                 \
+      RuntimeGlobalFunctionCountersState                                       \
+          .SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION)++;           \
+      if (GlobalRuntimeFunctionCountersUpdateHandler) {                        \
+        auto oldGlobalMode = setGlobalRuntimeFunctionCountersMode(0);          \
+        auto oldPerObjectMode = setPerObjectRuntimeFunctionCountersMode(0);    \
+        GlobalRuntimeFunctionCountersUpdateHandler(                            \
+            OBJ, RT_FUNCTION_ID(RT_FUNCTION));                                 \
+        setGlobalRuntimeFunctionCountersMode(oldGlobalMode);                   \
+        setPerObjectRuntimeFunctionCountersMode(oldPerObjectMode);             \
+      }                                                                        \
+    }                                                                          \
+    /* Update per object counters. */                                          \
+    if (UpdatePerObjectRuntimeFunctionCounters && OBJ) {                       \
+      RuntimeObjectStateCache[OBJ].SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(  \
+          RT_FUNCTION)++;                                                      \
+      /* TODO: Remember the order/history of operations? */                    \
+    }                                                                          \
+  }
+
+RT_FUNCTIONS_TO_TRACK
+
+/// Public APIs
+
+/// Get the runtime object state associated with an object.
+SWIFT_RT_ENTRY_VISIBILITY
+void getObjectRuntimeFunctionCounters(HeapObject *object,
+                                      RuntimeFunctionCountersState &result) {
+  result = RuntimeObjectStateCache[object];
+}
+
+/// Set the runtime object state associated with an object from a provided
+/// state.
+SWIFT_RT_ENTRY_VISIBILITY
+void setObjectRuntimeFunctionCounters(HeapObject *object,
+                                      RuntimeFunctionCountersState &state) {
+  RuntimeObjectStateCache[object] = state;
+}
+
+/// Get the global runtime state containing the total numbers of invocations for
+/// each runtime function of interest.
+SWIFT_RT_ENTRY_VISIBILITY
+void getGlobalRuntimeFunctionCounters(RuntimeFunctionCountersState &result) {
+  result = RuntimeGlobalFunctionCountersState;
+}
+
+/// Set the global runtime state of function pointers from a provided state.
+SWIFT_RT_ENTRY_VISIBILITY
+void setGlobalRuntimeFunctionCounters(RuntimeFunctionCountersState &state) {
+  RuntimeGlobalFunctionCountersState = state;
+}
+
+/// Return the names of the runtime functions being tracked.
+/// Their order is the same as the order of the counters in the
+/// RuntimeObjectState structure.
+SWIFT_RT_ENTRY_VISIBILITY
+const char **getRuntimeFunctionNames() {
+  return RuntimeFunctionNames;
+}
+
+/// Return the offsets of the runtime function counters being tracked.
+/// Their order is the same as the order of the counters in the
+/// RuntimeObjectState structure.
+SWIFT_RT_ENTRY_VISIBILITY
+const uint16_t *getRuntimeFunctionCountersOffsets() {
+  return RuntimeFunctionCountersOffsets;
+}
+
+/// Return the number of runtime functions being tracked.
+SWIFT_RT_ENTRY_VISIBILITY
+uint64_t getNumRuntimeFunctionCounters() {
+  return ID_LastRuntimeFunctionName;
+}
+
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION)                                 \
+  tmp = State.SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION);          \
+  if (tmp != 0)                                                                \
+    printf("%s = %d\n",                                                        \
+           RuntimeFunctionNames[(int)RT_FUNCTION_ID(RT_FUNCTION)], tmp);
+
+static void dumpRuntimeCounters(RuntimeFunctionCountersState &State) {
+  uint32_t tmp;
+  RT_FUNCTIONS_TO_TRACK
+}
+
+/// Dump all per-object runtime function pointers.
+SWIFT_RT_ENTRY_VISIBILITY
+void dumpObjectsRuntimeFunctionPointers() {
+  for (auto &Pair : RuntimeObjectStateCache) {
+    printf("\n\nRuntime counters for object at address %p:\n", Pair.getFirst());
+    dumpRuntimeCounters(Pair.getSecond());
+    printf("\n");
+  }
+}
+
+/// Set mode for global runtime function counters.
+/// Return the old value of this flag.
+SWIFT_RT_ENTRY_VISIBILITY
+int setGlobalRuntimeFunctionCountersMode(int mode) {
+  int oldMode = UpdateGlobalRuntimeFunctionCounters;
+  UpdateGlobalRuntimeFunctionCounters = mode ? 1 : 0;
+  return oldMode;
+}
+
+/// Set mode for per object runtime function counters.
+/// Return the old value of this flag.
+SWIFT_RT_ENTRY_VISIBILITY
+int setPerObjectRuntimeFunctionCountersMode(int mode) {
+  int oldMode = UpdatePerObjectRuntimeFunctionCounters;
+  UpdatePerObjectRuntimeFunctionCounters = mode ? 1 : 0;
+  return oldMode;
+}
+
+/// Add the ability to call custom handlers when a counter
+/// is being updated. The handler should take the object and may be
+/// the name of the runtime function as parameters. And this handler
+/// could e.g. check some conditions and stop the program under
+/// a debuggger if a certain condition is met, like a refcount has
+/// reached a certain value.
+/// We could allow for setting global handlers or even per-object
+/// handlers.
+SWIFT_RT_ENTRY_VISIBILITY
+RuntimeFunctionCountersUpdateHandler
+setGlobalRuntimeFunctionCountersUpdateHandler(
+    RuntimeFunctionCountersUpdateHandler handler) {
+  auto oldHandler = GlobalRuntimeFunctionCountersUpdateHandler;
+  GlobalRuntimeFunctionCountersUpdateHandler = handler;
+  return oldHandler;
+}
+
+/// TODO: Provide an API to remove any counters releated to a specific object
+/// or all objects.
+/// This is useful if you want to reset the stats for some/all objects.

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
@@ -19,6 +19,11 @@
 #include "RuntimeInvocationsTracking.h"
 #include "swift/Runtime/HeapObject.h"
 
+// This file is compiled always, even if assertions are disabled and no runtime
+// functions are being tracked. This is done to avoid recompiling Swift clients
+// using these APIs. They should be able to link against the standard library
+// independent of the fact whether assertions are enabled or not.
+
 #define SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION)                 \
   invocationCounter_##RT_FUNCTION
 

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
@@ -29,7 +29,6 @@ namespace swift {
 struct RuntimeFunctionCountersState {
 #define FUNCTION_TO_TRACK(RT_FUNCTION)                                         \
   uint32_t SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION) = 0;
-
 // Provide one counter per runtime function being tracked.
 #include "RuntimeInvocationsTracking.def"
 };
@@ -54,7 +53,6 @@ static llvm::DenseMap<HeapObject *, RuntimeFunctionCountersState> RuntimeObjectS
 static const char *RuntimeFunctionNames[] {
 /// Define names of runtime functions.
 #define FUNCTION_TO_TRACK(RT_FUNCTION) #RT_FUNCTION,
-
 #include "RuntimeInvocationsTracking.def"
   nullptr
 };
@@ -67,7 +65,6 @@ static const char *RuntimeFunctionNames[] {
 enum RuntimeFunctionNamesIDs : uint32_t {
 /// Defines names of enum cases for each function being tracked.
 #define FUNCTION_TO_TRACK(RT_FUNCTION) RT_FUNCTION_ID(RT_FUNCTION),
-
 #include "RuntimeInvocationsTracking.def"
   ID_LastRuntimeFunctionName,
 };
@@ -83,7 +80,6 @@ static uint16_t RuntimeFunctionCountersOffsets[] = {
 /// Define offset for each function being tracked.
 #define FUNCTION_TO_TRACK(RT_FUNCTION)                                         \
   (sizeof(uint16_t) * (unsigned)RT_FUNCTION_ID(RT_FUNCTION)),
-
 #include "RuntimeInvocationsTracking.def"
 };
 
@@ -112,7 +108,6 @@ static uint16_t RuntimeFunctionCountersOffsets[] = {
       /* TODO: Remember the order/history of operations? */                    \
     }                                                                          \
   }
-
 #include "RuntimeInvocationsTracking.def"
 
 /// Public APIs
@@ -175,7 +170,6 @@ static void dumpRuntimeCounters(RuntimeFunctionCountersState *State) {
   if (tmp != 0)                                                                \
     printf("%s = %d\n",                                                        \
            RuntimeFunctionNames[(int)RT_FUNCTION_ID(RT_FUNCTION)], tmp);
-
 #include "RuntimeInvocationsTracking.def"
 }
 

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.def
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.def
@@ -1,0 +1,55 @@
+//===--- RuntimeInvocationsTracking.def - Functions to track ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines x-macros used for metaprogramming with the set of
+// runtime functions, whose invocations should be tracked.
+//
+//===----------------------------------------------------------------------===//
+
+/// FUNCTION_TO_TRACK(Id)
+/// Id is the name of the runtime function to be tracked.
+
+/// Set of runtime functions that whose invocations need to be tracked.
+/// Edit this list to add new runtime functions or remove the old ones.
+FUNCTION_TO_TRACK(swift_retain)
+FUNCTION_TO_TRACK(swift_release)
+FUNCTION_TO_TRACK(swift_retain_n)
+FUNCTION_TO_TRACK(swift_release_n)
+FUNCTION_TO_TRACK(swift_nonatomic_retain)
+FUNCTION_TO_TRACK(swift_nonatomic_release)
+FUNCTION_TO_TRACK(swift_nonatomic_retain_n)
+FUNCTION_TO_TRACK(swift_nonatomic_release_n)
+FUNCTION_TO_TRACK(swift_setDeallocating)
+FUNCTION_TO_TRACK(swift_unownedRetain)
+FUNCTION_TO_TRACK(swift_unownedRelease)
+FUNCTION_TO_TRACK(swift_nonatomic_unownedRetain)
+FUNCTION_TO_TRACK(swift_nonatomic_unownedRelease)
+FUNCTION_TO_TRACK(swift_unownedRetain_n)
+FUNCTION_TO_TRACK(swift_unownedRelease_n)
+FUNCTION_TO_TRACK(swift_nonatomic_unownedRetain_n)
+FUNCTION_TO_TRACK(swift_nonatomic_unownedRelease_n)
+FUNCTION_TO_TRACK(swift_allocObject)
+FUNCTION_TO_TRACK(swift_deallocObject)
+FUNCTION_TO_TRACK(swift_initStackObject)
+FUNCTION_TO_TRACK(swift_initStaticObject)
+FUNCTION_TO_TRACK(swift_tryPin)
+FUNCTION_TO_TRACK(swift_unpin)
+FUNCTION_TO_TRACK(swift_nonatomic_tryPin)
+FUNCTION_TO_TRACK(swift_nonatomic_unpin)
+FUNCTION_TO_TRACK(swift_tryRetain)
+FUNCTION_TO_TRACK(swift_tryRelease)
+FUNCTION_TO_TRACK(swift_unownedRetainStrong)
+FUNCTION_TO_TRACK(swift_nonatomic_unownedRetainStrong)
+FUNCTION_TO_TRACK(swift_unownedRetainStrongAndRelease)
+FUNCTION_TO_TRACK(swift_nonatomic_unownedRetainStrongAndRelease)
+
+#undef FUNCTION_TO_TRACK

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.def
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.def
@@ -18,6 +18,10 @@
 /// FUNCTION_TO_TRACK(Id)
 /// Id is the name of the runtime function to be tracked.
 
+#ifndef FUNCTION_TO_TRACK
+#error "Must define FUNCTION_TO_TRACK to include RuntimeInvocationsTracking.def"
+#endif
+
 /// Set of runtime functions that whose invocations need to be tracked.
 /// Edit this list to add new runtime functions or remove the old ones.
 FUNCTION_TO_TRACK(swift_retain)

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -49,7 +49,6 @@ struct RuntimeFunctionCountersState;
 
 #define FUNCTION_TO_TRACK(RT_FUNCTION)                                         \
   extern void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)(HeapObject * OBJ);
-
 /// Declarations of external functions for invocations tracking.
 #include "RuntimeInvocationsTracking.def"
 

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -18,10 +18,22 @@
 #ifndef SWIFT_STDLIB_RUNTIME_INVOCATIONS_TRACKING_H
 #define SWIFT_STDLIB_RUNTIME_INVOCATIONS_TRACKING_H
 
+#include "swift/Runtime/Config.h"
+
+#if defined(__cplusplus)
+
 namespace swift {
 struct HeapObject;
 struct RuntimeFunctionCountersState;
 } // end namespace swift
+
+using namespace swift;
+#else
+
+struct HeapObject;
+struct RuntimeFunctionCountersState;
+
+#endif
 
 /// The name of a helper function for tracking the calls of a runtime function.
 #define SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)                            \
@@ -35,9 +47,8 @@ struct RuntimeFunctionCountersState;
 #define SWIFT_RT_TRACK_INVOCATION(OBJ, RT_FUNCTION)                            \
   SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)(OBJ)
 
-#define FUNCTION_TO_TRACK(RT_FUNCTION)                                      \
-  extern void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)(swift::HeapObject *  \
-                                                          OBJ);
+#define FUNCTION_TO_TRACK(RT_FUNCTION)                                         \
+  extern void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)(HeapObject * OBJ);
 
 /// Declarations of external functions for invocations tracking.
 #include "RuntimeInvocationsTracking.def"
@@ -53,54 +64,54 @@ struct RuntimeFunctionCountersState;
 /// function.
 using RuntimeFunctionCountersUpdateHandler =
   __attribute__((swiftcall))
-  void (*)(swift::HeapObject *object, int64_t runtimeFunctionID);
+  void (*)(HeapObject *object, int64_t runtimeFunctionID);
 
 /// Public APIs
 
 /// Get the runtime object state associated with an object and store it
 /// into the result.
-extern "C" void
-getObjectRuntimeFunctionCounters(swift::HeapObject *object,
-                                 swift::RuntimeFunctionCountersState *result);
+SWIFT_RT_ENTRY_VISIBILITY void
+getObjectRuntimeFunctionCounters(HeapObject *object,
+                                 RuntimeFunctionCountersState *result);
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest and store it into the result.
-extern "C" void
+SWIFT_RT_ENTRY_VISIBILITY void
 getGlobalRuntimeFunctionCounters(swift::RuntimeFunctionCountersState *result);
 
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure.
-extern "C" const char **getRuntimeFunctionNames();
+SWIFT_RT_ENTRY_VISIBILITY const char **getRuntimeFunctionNames();
 
 /// Return the offsets of the runtime function counters being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeFunctionCountersState structure.
-extern "C" const uint16_t *getRuntimeFunctionCountersOffsets();
+SWIFT_RT_ENTRY_VISIBILITY const uint16_t *getRuntimeFunctionCountersOffsets();
 
 /// Return the number of runtime functions being tracked.
-extern "C" uint64_t getNumRuntimeFunctionCounters();
+SWIFT_RT_ENTRY_VISIBILITY uint64_t getNumRuntimeFunctionCounters();
 
 /// Dump all per-object runtime function pointers.
-extern "C" void dumpObjectsRuntimeFunctionPointers();
+SWIFT_RT_ENTRY_VISIBILITY void dumpObjectsRuntimeFunctionPointers();
 
 /// Set mode for global runtime function counters.
 /// Return the old value of this flag.
-extern "C" int setPerObjectRuntimeFunctionCountersMode(int mode);
+SWIFT_RT_ENTRY_VISIBILITY int setPerObjectRuntimeFunctionCountersMode(int mode);
 
 /// Set mode for per object runtime function counters.
 /// Return the old value of this flag.
-extern "C" int setGlobalRuntimeFunctionCountersMode(int mode);
+SWIFT_RT_ENTRY_VISIBILITY int setGlobalRuntimeFunctionCountersMode(int mode);
 
 /// Set the global runtime state of function pointers from a provided state.
-extern "C" void
+SWIFT_RT_ENTRY_VISIBILITY void
 setGlobalRuntimeFunctionCounters(swift::RuntimeFunctionCountersState *state);
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
-extern "C" void
-setObjectRuntimeFunctionCounters(swift::HeapObject *object,
-                                 swift::RuntimeFunctionCountersState *state);
+SWIFT_RT_ENTRY_VISIBILITY void
+setObjectRuntimeFunctionCounters(HeapObject *object,
+                                 RuntimeFunctionCountersState *state);
 
 /// Set the global runtime function counters update handler.
 extern "C" RuntimeFunctionCountersUpdateHandler

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -1,0 +1,158 @@
+//===--- RuntimeInvocationsTracking.h ---------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Track invocations of Swift runtime functions. This can be used for
+// performance analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_RUNTIME_INVOCATIONS_TRACKING_H
+#define SWIFT_STDLIB_RUNTIME_INVOCATIONS_TRACKING_H
+
+namespace swift {
+struct HeapObject;
+}
+
+/// Instrument the runtime functions only if it is a build with
+/// enabled assertions.
+#if !defined(NDEBUG)
+
+/// The name of a helper function for tracking the calls of a runtime function.
+#define SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION, OBJ)                       \
+  swift_trackRuntimeInvocation_##RT_FUNCTION
+
+/// The name of the counter for tracking the calls of a runtime function.
+#define SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION_NAME)            \
+  invocationCounter_##RT_FUNCTION_NAME
+
+/// Invoke a helper function for tracking the calls of a runtime function.
+#define SWIFT_RT_TRACK_INVOCATION(OBJ, RT_FUNCTION)                            \
+  SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION, OBJ)(OBJ)
+
+/// Set of runtime functions that whose invocations need to be tracked.
+/// Edit this list to add new runtime functions or remove the old ones.
+#define RT_FUNCTIONS_TO_TRACK                                                  \
+  RT_FUNCTION_TO_TRACK(object, swift_retain)                                   \
+  RT_FUNCTION_TO_TRACK(object, swift_release)                                  \
+  RT_FUNCTION_TO_TRACK(object, swift_retain_n)                                 \
+  RT_FUNCTION_TO_TRACK(object, swift_release_n)                                \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_retain)                         \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_release)                        \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_retain_n)                       \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_release_n)                      \
+  RT_FUNCTION_TO_TRACK(object, swift_setDeallocating)                          \
+  RT_FUNCTION_TO_TRACK(object, swift_unownedRetain)                            \
+  RT_FUNCTION_TO_TRACK(object, swift_unownedRelease)                           \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetain)                  \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRelease)                 \
+  RT_FUNCTION_TO_TRACK(object, swift_unownedRetain_n)                          \
+  RT_FUNCTION_TO_TRACK(object, swift_unownedRelease_n)                         \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetain_n)                \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRelease_n)               \
+  RT_FUNCTION_TO_TRACK(object, swift_tryPin)                                   \
+  RT_FUNCTION_TO_TRACK(object, swift_unpin)                                    \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_tryPin)                         \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unpin)                          \
+  RT_FUNCTION_TO_TRACK(object, swift_tryRetain)                                \
+  RT_FUNCTION_TO_TRACK(object, swift_tryRelease)                               \
+  RT_FUNCTION_TO_TRACK(object, swift_unownedRetainStrong)                      \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetainStrong)            \
+  RT_FUNCTION_TO_TRACK(object, swift_unownedRetainStrongAndRelease)            \
+  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetainStrongAndRelease)
+
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION)                                 \
+  extern void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION,                      \
+                                             OBJ)(swift::HeapObject * OBJ);
+
+/// Declarations of external functions for invocations tracking
+RT_FUNCTIONS_TO_TRACK
+
+#undef RT_FUNCTION_TO_TRACK
+#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION_NAME)                            \
+  uint32_t SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION_NAME) = 0;
+
+#else
+
+/// It is just a NOP if assertions are not enabled.
+#define SWIFT_RT_TRACK_INVOCATION(OBJ, RT_FUNCTION)
+
+#define RT_FUNCTIONS_TO_TRACK
+
+#endif // NDEBUG
+
+/// This type defines a callback to be called on any intercepted runtime
+/// function.
+using RuntimeFunctionCountersUpdateHandler =
+  __attribute__((swiftcall))
+  void (*)(swift::HeapObject *object, int64_t runtimeFunctionID);
+
+// Define counters used for tracking the total number of invocations of runtime
+// functions.
+struct RuntimeFunctionCountersState {
+  // Provide one counter per runtime function being tracked.
+  RT_FUNCTIONS_TO_TRACK
+};
+
+/// Public APIs
+
+/// Get the runtime object state associated with an object and store it
+/// into the result.
+extern "C" void
+getObjectRuntimeFunctionCounters(swift::HeapObject *object,
+                                 RuntimeFunctionCountersState &result);
+
+/// Get the global runtime state containing the total numbers of invocations for
+/// each runtime function of interest and store it into the result.
+extern "C" void
+getGlobalRuntimeFunctionCounters(RuntimeFunctionCountersState &result);
+
+/// Return the names of the runtime functions being tracked.
+/// Their order is the same as the order of the counters in the
+/// RuntimeObjectState structure.
+extern "C" const char **getRuntimeFunctionNames();
+
+/// Return the offsets of the runtime function counters being tracked.
+/// Their order is the same as the order of the counters in the
+/// RuntimeFunctionCountersState structure.
+extern "C" const uint16_t *getRuntimeFunctionCountersOffsets();
+
+/// Return the number of runtime functions being tracked.
+extern "C" uint64_t getNumRuntimeFunctionCounters();
+
+/// Dump all per-object runtime function pointers.
+extern "C" void dumpObjectsRuntimeFunctionPointers();
+
+/// Set mode for global runtime function counters.
+/// Return the old value of this flag.
+extern "C" int setPerObjectRuntimeFunctionCountersMode(int mode);
+
+/// Set mode for per object runtime function counters.
+/// Return the old value of this flag.
+extern "C" int setGlobalRuntimeFunctionCountersMode(int mode);
+
+/// Set the global runtime state of function pointers from a provided state.
+extern "C" void
+setGlobalRuntimeFunctionCounters(RuntimeFunctionCountersState &state);
+
+/// Set the runtime object state associated with an object from a provided
+/// state.
+extern "C" void
+setObjectRuntimeFunctionCounters(swift::HeapObject *object,
+                                 RuntimeFunctionCountersState &state);
+
+/// Set the global runtime function counters update handler.
+extern "C" RuntimeFunctionCountersUpdateHandler
+setGlobalRuntimeFunctionCountersUpdateHandler(
+    RuntimeFunctionCountersUpdateHandler handler);
+
+#endif

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -20,77 +20,32 @@
 
 namespace swift {
 struct HeapObject;
-}
+struct RuntimeFunctionCountersState;
+} // end namespace swift
 
-/// Instrument the runtime functions only if it is a build with
-/// enabled assertions.
+/// Instrument the runtime functions only if we are building with
+/// assertions enabled.
 #if !defined(NDEBUG)
 
 /// The name of a helper function for tracking the calls of a runtime function.
-#define SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION, OBJ)                       \
+#define SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)                            \
   swift_trackRuntimeInvocation_##RT_FUNCTION
-
-/// The name of the counter for tracking the calls of a runtime function.
-#define SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION_NAME)            \
-  invocationCounter_##RT_FUNCTION_NAME
 
 /// Invoke a helper function for tracking the calls of a runtime function.
 #define SWIFT_RT_TRACK_INVOCATION(OBJ, RT_FUNCTION)                            \
-  SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION, OBJ)(OBJ)
+  SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)(OBJ)
 
-/// Set of runtime functions that whose invocations need to be tracked.
-/// Edit this list to add new runtime functions or remove the old ones.
-#define RT_FUNCTIONS_TO_TRACK                                                  \
-  RT_FUNCTION_TO_TRACK(object, swift_retain)                                   \
-  RT_FUNCTION_TO_TRACK(object, swift_release)                                  \
-  RT_FUNCTION_TO_TRACK(object, swift_retain_n)                                 \
-  RT_FUNCTION_TO_TRACK(object, swift_release_n)                                \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_retain)                         \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_release)                        \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_retain_n)                       \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_release_n)                      \
-  RT_FUNCTION_TO_TRACK(object, swift_setDeallocating)                          \
-  RT_FUNCTION_TO_TRACK(object, swift_unownedRetain)                            \
-  RT_FUNCTION_TO_TRACK(object, swift_unownedRelease)                           \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetain)                  \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRelease)                 \
-  RT_FUNCTION_TO_TRACK(object, swift_unownedRetain_n)                          \
-  RT_FUNCTION_TO_TRACK(object, swift_unownedRelease_n)                         \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetain_n)                \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRelease_n)               \
-  RT_FUNCTION_TO_TRACK(object, swift_allocObject)                              \
-  RT_FUNCTION_TO_TRACK(object, swift_deallocObject)                            \
-  RT_FUNCTION_TO_TRACK(object, swift_initStackObject)                          \
-  RT_FUNCTION_TO_TRACK(object, swift_initStaticObject)                         \
-  RT_FUNCTION_TO_TRACK(object, swift_tryPin)                                   \
-  RT_FUNCTION_TO_TRACK(object, swift_unpin)                                    \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_tryPin)                         \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unpin)                          \
-  RT_FUNCTION_TO_TRACK(object, swift_tryRetain)                                \
-  RT_FUNCTION_TO_TRACK(object, swift_tryRelease)                               \
-  RT_FUNCTION_TO_TRACK(object, swift_unownedRetainStrong)                      \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetainStrong)            \
-  RT_FUNCTION_TO_TRACK(object, swift_unownedRetainStrongAndRelease)            \
-  RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetainStrongAndRelease)
+#define FUNCTION_TO_TRACK(RT_FUNCTION)                                      \
+  extern void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)(swift::HeapObject *  \
+                                                          OBJ);
 
-#undef RT_FUNCTION_TO_TRACK
-#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION)                                 \
-  extern void SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION,                      \
-                                             OBJ)(swift::HeapObject * OBJ);
-
-/// Declarations of external functions for invocations tracking
-RT_FUNCTIONS_TO_TRACK
-
-#undef RT_FUNCTION_TO_TRACK
-#define RT_FUNCTION_TO_TRACK(OBJ, RT_FUNCTION_NAME)                            \
-  uint32_t SWIFT_RT_FUNCTION_INVOCATION_COUNTER_NAME(RT_FUNCTION_NAME) = 0;
+/// Declarations of external functions for invocations tracking.
+#include "RuntimeInvocationsTracking.def"
 
 #else
 
 /// It is just a NOP if assertions are not enabled.
 #define SWIFT_RT_TRACK_INVOCATION(OBJ, RT_FUNCTION)
-
-#define RT_FUNCTIONS_TO_TRACK
 
 #endif // NDEBUG
 
@@ -100,25 +55,18 @@ using RuntimeFunctionCountersUpdateHandler =
   __attribute__((swiftcall))
   void (*)(swift::HeapObject *object, int64_t runtimeFunctionID);
 
-// Define counters used for tracking the total number of invocations of runtime
-// functions.
-struct RuntimeFunctionCountersState {
-  // Provide one counter per runtime function being tracked.
-  RT_FUNCTIONS_TO_TRACK
-};
-
 /// Public APIs
 
 /// Get the runtime object state associated with an object and store it
 /// into the result.
 extern "C" void
 getObjectRuntimeFunctionCounters(swift::HeapObject *object,
-                                 RuntimeFunctionCountersState &result);
+                                 swift::RuntimeFunctionCountersState *result);
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest and store it into the result.
 extern "C" void
-getGlobalRuntimeFunctionCounters(RuntimeFunctionCountersState &result);
+getGlobalRuntimeFunctionCounters(swift::RuntimeFunctionCountersState *result);
 
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
@@ -146,13 +94,13 @@ extern "C" int setGlobalRuntimeFunctionCountersMode(int mode);
 
 /// Set the global runtime state of function pointers from a provided state.
 extern "C" void
-setGlobalRuntimeFunctionCounters(RuntimeFunctionCountersState &state);
+setGlobalRuntimeFunctionCounters(swift::RuntimeFunctionCountersState *state);
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
 extern "C" void
 setObjectRuntimeFunctionCounters(swift::HeapObject *object,
-                                 RuntimeFunctionCountersState &state);
+                                 swift::RuntimeFunctionCountersState *state);
 
 /// Set the global runtime function counters update handler.
 extern "C" RuntimeFunctionCountersUpdateHandler

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -58,6 +58,10 @@ struct HeapObject;
   RT_FUNCTION_TO_TRACK(object, swift_unownedRelease_n)                         \
   RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRetain_n)                \
   RT_FUNCTION_TO_TRACK(object, swift_nonatomic_unownedRelease_n)               \
+  RT_FUNCTION_TO_TRACK(object, swift_allocObject)                              \
+  RT_FUNCTION_TO_TRACK(object, swift_deallocObject)                            \
+  RT_FUNCTION_TO_TRACK(object, swift_initStackObject)                          \
+  RT_FUNCTION_TO_TRACK(object, swift_initStaticObject)                         \
   RT_FUNCTION_TO_TRACK(object, swift_tryPin)                                   \
   RT_FUNCTION_TO_TRACK(object, swift_unpin)                                    \
   RT_FUNCTION_TO_TRACK(object, swift_nonatomic_tryPin)                         \

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -23,13 +23,13 @@ struct HeapObject;
 struct RuntimeFunctionCountersState;
 } // end namespace swift
 
-/// Instrument the runtime functions only if we are building with
-/// assertions enabled.
-#if !defined(NDEBUG)
-
 /// The name of a helper function for tracking the calls of a runtime function.
 #define SWIFT_RT_TRACK_INVOCATION_NAME(RT_FUNCTION)                            \
   swift_trackRuntimeInvocation_##RT_FUNCTION
+
+/// Instrument the runtime functions only if we are building with
+/// assertions enabled.
+#if !defined(NDEBUG)
 
 /// Invoke a helper function for tracking the calls of a runtime function.
 #define SWIFT_RT_TRACK_INVOCATION(OBJ, RT_FUNCTION)                            \

--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -7,9 +7,9 @@
 /// Test functionality related to the runtime function counters.
 
 class C {
-    var next: C? = nil
-    func test(_ c: C) {
-    }
+  var next: C? = nil
+  func test(_ c: C) {
+  }
 }
 
 struct MyStruct {
@@ -105,7 +105,7 @@ func testRuntimeCounters() {
 
   let globalCounters2 = _GlobalRuntimeFunctionCountersState()
 
-  globalCounters1.dumpDiff(globalCounters2)
+  globalCounters1.dumpDiff(globalCounters2, skipUnchanged: true)
 }
 
 /// Test finding references inside a String object.
@@ -117,7 +117,7 @@ func testString(_ s: String) {
   let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
   let _ = [String](repeating: s, count: 4)
   let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
-  objectCounters1.dumpDiff(objectCounters2)
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
 }
 
 /// Test finding references inside a Dictionary object.
@@ -132,7 +132,7 @@ func testDict(_ _dint: [Int : Int]) {
   dint[222] = 222
   dint[2222] = 2222
   let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
-  objectCounters1.dumpDiff(objectCounters2)
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
 }
 
 /// Test finding references inside an object graph with a cycle.
@@ -225,6 +225,7 @@ func updatesHandler(object: UnsafeRawPointer, functionId: Int64) {
 /// CHECK: End handler
 /// Test that you can provide custom handlers for runtime functions counters
 /// updates.
+var globalC: C? = nil
 @inline(never)
 func testFunctionRuntimeCountersUpdateHandler() {
   print("TEST: Provide runtime function counters update handler")
@@ -232,7 +233,8 @@ func testFunctionRuntimeCountersUpdateHandler() {
   let oldHandler =
     _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
       handler: updatesHandler)
-  let c = C()
+  globalC = C()
+  globalC = nil
   let len = length(l!)
   _ = _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
     handler: oldHandler)

--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/test_runtime_function_counters
 // RUN: %target-run %t/test_runtime_function_counters 2>&1 | %FileCheck %s
-// REQUIRES: asserts
+// REQUIRES: swift_stdlib_asserts
 // REQUIRES: executable_test
 
 /// Test functionality related to the runtime function counters.

--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -215,9 +215,14 @@ func updatesHandler(object: UnsafeRawPointer, functionId: Int64) {
   _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(mode: savedMode)
 }
 
+/// Check that it is possible to set your own runtime functions counters
+/// updates handler and this handler is invoked at runtime.
 /// CHECK-LABEL: TEST: Provide runtime function counters update handler
-/// TEST: Start handler
-/// TEST: End handler
+/// CHECK: Start handler
+/// Check that allocations and deallocations are intercepted too.
+/// CHECK: swift_allocObject
+/// CHECK: swift_deallocObject
+/// CHECK: End handler
 /// Test that you can provide custom handlers for runtime functions counters
 /// updates.
 @inline(never)
@@ -227,6 +232,7 @@ func testFunctionRuntimeCountersUpdateHandler() {
   let oldHandler =
     _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
       handler: updatesHandler)
+  let c = C()
   let len = length(l!)
   _ = _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
     handler: oldHandler)

--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -1,0 +1,256 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/test_runtime_function_counters
+// RUN: %target-run %t/test_runtime_function_counters 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+// REQUIRES: executable_test
+
+/// Test functionality related to the runtime function counters.
+
+class C {
+    var next: C? = nil
+    func test(_ c: C) {
+    }
+}
+
+struct MyStruct {
+  var ref1: AnyObject? = C()
+  var ref2: AnyObject = C()
+  var str: String = ""
+}
+
+public final class List<T> {
+  var value: T
+  var next: List<T>?
+
+  init(_ value: T) {
+    self.value = value
+    self.next = nil
+  }
+
+  init(_ value: T, _ tail: List<T>) {
+    self.value = value
+    self.next = tail
+  }
+}
+
+public func length<T>(_ l: List<T>) -> Int {
+  var ll: List<T>? = l
+  var len = 0
+  while ll != nil {
+    len = len + 1
+    ll = ll?.next
+  }
+  return len
+}
+
+/// CHECK-LABEL: TEST: Collect references inside objects
+/// Constant strings do not have an owner, thus no references.
+/// CHECK: Constant string: []
+/// An array has one reference
+/// CHECK: Array<Int>: [{{[0-9a-fA-Fx]+}}]
+/// MyStruct has two references
+/// CHECK: MyStruct: [{{[0-9a-fA-Fx]+}}, {{[0-9a-fA-Fx]+}}]
+/// Dictionary has once reference
+/// CHECK: Dictionary<Int, Int>: [{{[0-9a-fA-Fx]+}}]
+/// Set has once reference
+/// CHECK: Set<Int>: [{{[0-9a-fA-Fx]+}}]
+/// Test collection of references inside different types of objects.
+@inline(never)
+func testCollectReferencesInsideObject() {
+  print("TEST: Collect references inside objects")
+  let s = "MyString"
+  let aint = [1,2,3,4]
+  let dint = [1:1, 2:2]
+  let sint: Set<Int> = [1,2,3,4]
+
+  print("Constant string: \(_collectReferencesInsideObject(s))")
+  print("Array<Int>: \(_collectReferencesInsideObject(aint))")
+  print("MyStruct: \(_collectReferencesInsideObject(MyStruct()))")
+  print("Dictionary<Int, Int>: \(_collectReferencesInsideObject(dint))")
+  print("Set<Int>: \(_collectReferencesInsideObject(sint))")
+
+  var mystring = "MyString"
+  mystring.append("End")
+  testString(mystring)
+  testDict(dint)
+  testObjectCycle()
+}
+
+
+/// CHECK-LABEL: TEST: APIs from _RuntimeFunctionCounters
+/// CHECK: Number of runtime function pointers:
+/// Test some APIs from _RuntimeFunctionCounters
+func testRuntimeCounters() {
+  print("TEST: APIs from _RuntimeFunctionCounters")
+  let numRuntimeFunctionPointer =
+    _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+
+  print("Number of runtime function pointers: \(numRuntimeFunctionPointer)")
+
+  let names = _RuntimeFunctionCounters.getRuntimeFunctionNames()
+  let offsets = _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
+
+  for i in 0..<numRuntimeFunctionPointer {
+    print("Runtime function \(i) : \(names[i]) at offset: \(offsets[i])")
+  }
+
+  var d: [Int : Int] = [:]
+  let globalCounters1 = _GlobalRuntimeFunctionCountersState()
+
+  for i in 0..<50 {
+    let k = i
+    let v = i*i
+    d[k] = v
+  }
+
+  let globalCounters2 = _GlobalRuntimeFunctionCountersState()
+
+  globalCounters1.dumpDiff(globalCounters2)
+}
+
+/// Test finding references inside a String object.
+@inline(never)
+func testString(_ s: String) {
+  print("TEST: Collect references for strings")
+  let refs = _collectReferencesInsideObject(s)
+  print("References are: \(refs)")
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  let _ = [String](repeating: s, count: 4)
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  objectCounters1.dumpDiff(objectCounters2)
+}
+
+/// Test finding references inside a Dictionary object.
+@inline(never)
+func testDict(_ _dint: [Int : Int]) {
+  print("TEST: Collect references for dictionaries")
+  var dint = _dint
+  dint[3] = 3
+  let refs = _collectReferencesInsideObject(dint)
+  print("References are: \(refs)")
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  dint[222] = 222
+  dint[2222] = 2222
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  objectCounters1.dumpDiff(objectCounters2)
+}
+
+/// Test finding references inside an object graph with a cycle.
+/// It should not result in a stack overflow.
+@inline(never)
+func testObjectCycle() {
+  print("TEST: Collect references on object graph with cycles")
+  print("testObjectCycle")
+  let c1 = C()
+  let c2 = C()
+  c1.next = c1
+  c2.next = c1
+  let refs = _collectReferencesInsideObject(c1)
+  print("References are: \(refs)")
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  c1.next = nil
+  c2.next = nil
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
+}
+
+/// Test runtime function counters for a List object.
+@inline(never)
+func testLists() {
+  print("TEST: Runtime function counters for Lists")
+  print("testLists")
+  let globalCounters1 = _GlobalRuntimeFunctionCountersState()
+  var l: List<Int>? = List(1, List(2, List(3, List(4, List(5)))))
+  let refs = _collectReferencesInsideObject(l!)
+  let globalCounters11 = _GlobalRuntimeFunctionCountersState()
+  let _ = _collectReferencesInsideObject(l!)
+  let globalCounters111 = _GlobalRuntimeFunctionCountersState()
+
+  print("Global counters diff for 11")
+  globalCounters1.dumpDiff(globalCounters11, skipUnchanged: true)
+  print("Global counters diff for 111")
+  globalCounters1.dumpDiff(globalCounters111, skipUnchanged: true)
+
+  let len = length(l!)
+  let globalCounters2 = _GlobalRuntimeFunctionCountersState()
+  print("Length of the list is \(len)")
+  print("Global counters diff after constructing a list and computing its length")
+  globalCounters1.dumpDiff(globalCounters2, skipUnchanged: true)
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  l = nil
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  print("List head counters after list becomes unreferenced")
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
+}
+
+/// Test the _measureRuntimeFunctionCountersDiffs API.
+@inline(never)
+func testMeasureRuntimeFunctionCountersDiffs() {
+  print("TEST: Measure runtime function counters diff")
+  let l: List<Int>? = List(1, List(2, List(3, List(4, List(5)))))
+  let refs = _collectReferencesInsideObject(l!)
+  var len = 0
+  let (globalCounters, objectsCountersDiffs) =
+    _measureRuntimeFunctionCountersDiffs(objects: [refs[0]]) {
+    len = length(l!)
+  }
+  print("List length is: \(len)")
+  print("Global counters changes")
+  globalCounters.dump(skipUnchanged: true)
+  print("Objects counters changes")
+  for (i, objectCounters) in objectsCountersDiffs.enumerated() {
+    print("Object counters diff for \(refs[i])")
+    objectCounters.dump(skipUnchanged: true)
+  }
+}
+
+/// This is a handler that is invoked on each runtime functions counters update.
+@inline(never)
+func updatesHandler(object: UnsafeRawPointer, functionId: Int64) {
+  let savedMode = _RuntimeFunctionCounters.disableRuntimeFunctionCountersUpdates()
+  print("Start handler")
+  let functionName = _RuntimeFunctionCounters.runtimeFunctionNames[Int(functionId)]
+  print("Function \(functionName) was invoked on object \(object)")
+  print("End handler")
+  _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(mode: savedMode)
+}
+
+/// CHECK-LABEL: TEST: Provide runtime function counters update handler
+/// TEST: Start handler
+/// TEST: End handler
+/// Test that you can provide custom handlers for runtime functions counters
+/// updates.
+@inline(never)
+func testFunctionRuntimeCountersUpdateHandler() {
+  print("TEST: Provide runtime function counters update handler")
+  let l: List<Int>? = List(1, List(2, List(3, List(4, List(5)))))
+  let oldHandler =
+    _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
+      handler: updatesHandler)
+  let len = length(l!)
+  _ = _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
+    handler: oldHandler)
+  print("Restored old handler")
+  print(len)
+}
+
+/// Enable runtime function counters stats collection.
+_RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates()
+
+/// Test collection of references inside different types of objects.
+testCollectReferencesInsideObject()
+
+/// Test some APIs from _RuntimeFunctionCounters.
+testRuntimeCounters()
+
+/// Test dumping of counters for all objects.
+_RuntimeFunctionCounters.dumpObjectsRuntimeFunctionPointers()
+
+/// Test runtime function counters for a List object.
+testLists()
+
+/// Test the _measureRuntimeFunctionCountersDiffs API.
+testMeasureRuntimeFunctionCountersDiffs()
+
+/// Test that you can provide custom handlers for runtime functions counters updates.
+testFunctionRuntimeCountersUpdateHandler()

--- a/test/stdlib/test_runtime_function_counters_with_disabled_assertions.swift
+++ b/test/stdlib/test_runtime_function_counters_with_disabled_assertions.swift
@@ -1,0 +1,258 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/test_runtime_function_counters
+// RUN: %target-run %t/test_runtime_function_counters 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+
+/// Test functionality related to the runtime function counters.
+
+class C {
+  var next: C? = nil
+  func test(_ c: C) {
+  }
+}
+
+struct MyStruct {
+  var ref1: AnyObject? = C()
+  var ref2: AnyObject = C()
+  var str: String = ""
+}
+
+public final class List<T> {
+  var value: T
+  var next: List<T>?
+
+  init(_ value: T) {
+    self.value = value
+    self.next = nil
+  }
+
+  init(_ value: T, _ tail: List<T>) {
+    self.value = value
+    self.next = tail
+  }
+}
+
+public func length<T>(_ l: List<T>) -> Int {
+  var ll: List<T>? = l
+  var len = 0
+  while ll != nil {
+    len = len + 1
+    ll = ll?.next
+  }
+  return len
+}
+
+/// CHECK-LABEL: TEST: Collect references inside objects
+/// Constant strings do not have an owner, thus no references.
+/// CHECK: Constant string: []
+/// An array has one reference
+/// CHECK: Array<Int>: [{{[0-9a-fA-Fx]+}}]
+/// MyStruct has two references
+/// CHECK: MyStruct: [{{[0-9a-fA-Fx]+}}, {{[0-9a-fA-Fx]+}}]
+/// Dictionary has once reference
+/// CHECK: Dictionary<Int, Int>: [{{[0-9a-fA-Fx]+}}]
+/// Set has once reference
+/// CHECK: Set<Int>: [{{[0-9a-fA-Fx]+}}]
+/// Test collection of references inside different types of objects.
+@inline(never)
+func testCollectReferencesInsideObject() {
+  print("TEST: Collect references inside objects")
+  let s = "MyString"
+  let aint = [1,2,3,4]
+  let dint = [1:1, 2:2]
+  let sint: Set<Int> = [1,2,3,4]
+
+  print("Constant string: \(_collectReferencesInsideObject(s))")
+  print("Array<Int>: \(_collectReferencesInsideObject(aint))")
+  print("MyStruct: \(_collectReferencesInsideObject(MyStruct()))")
+  print("Dictionary<Int, Int>: \(_collectReferencesInsideObject(dint))")
+  print("Set<Int>: \(_collectReferencesInsideObject(sint))")
+
+  var mystring = "MyString"
+  mystring.append("End")
+  testString(mystring)
+  testDict(dint)
+  testObjectCycle()
+}
+
+
+/// CHECK-LABEL: TEST: APIs from _RuntimeFunctionCounters
+/// CHECK: Number of runtime function pointers:
+/// Test some APIs from _RuntimeFunctionCounters
+func testRuntimeCounters() {
+  print("TEST: APIs from _RuntimeFunctionCounters")
+  let numRuntimeFunctionPointer =
+    _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
+
+  print("Number of runtime function pointers: \(numRuntimeFunctionPointer)")
+
+  let names = _RuntimeFunctionCounters.getRuntimeFunctionNames()
+  let offsets = _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
+
+  for i in 0..<numRuntimeFunctionPointer {
+    print("Runtime function \(i) : \(names[i]) at offset: \(offsets[i])")
+  }
+
+  var d: [Int : Int] = [:]
+  let globalCounters1 = _GlobalRuntimeFunctionCountersState()
+
+  for i in 0..<50 {
+    let k = i
+    let v = i*i
+    d[k] = v
+  }
+
+  let globalCounters2 = _GlobalRuntimeFunctionCountersState()
+
+  globalCounters1.dumpDiff(globalCounters2, skipUnchanged: true)
+}
+
+/// Test finding references inside a String object.
+@inline(never)
+func testString(_ s: String) {
+  print("TEST: Collect references for strings")
+  let refs = _collectReferencesInsideObject(s)
+  print("References are: \(refs)")
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  let _ = [String](repeating: s, count: 4)
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
+}
+
+/// Test finding references inside a Dictionary object.
+@inline(never)
+func testDict(_ _dint: [Int : Int]) {
+  print("TEST: Collect references for dictionaries")
+  var dint = _dint
+  dint[3] = 3
+  let refs = _collectReferencesInsideObject(dint)
+  print("References are: \(refs)")
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  dint[222] = 222
+  dint[2222] = 2222
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
+}
+
+/// Test finding references inside an object graph with a cycle.
+/// It should not result in a stack overflow.
+@inline(never)
+func testObjectCycle() {
+  print("TEST: Collect references on object graph with cycles")
+  print("testObjectCycle")
+  let c1 = C()
+  let c2 = C()
+  c1.next = c1
+  c2.next = c1
+  let refs = _collectReferencesInsideObject(c1)
+  print("References are: \(refs)")
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  c1.next = nil
+  c2.next = nil
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
+}
+
+/// Test runtime function counters for a List object.
+@inline(never)
+func testLists() {
+  print("TEST: Runtime function counters for Lists")
+  print("testLists")
+  let globalCounters1 = _GlobalRuntimeFunctionCountersState()
+  var l: List<Int>? = List(1, List(2, List(3, List(4, List(5)))))
+  let refs = _collectReferencesInsideObject(l!)
+  let globalCounters11 = _GlobalRuntimeFunctionCountersState()
+  let _ = _collectReferencesInsideObject(l!)
+  let globalCounters111 = _GlobalRuntimeFunctionCountersState()
+
+  print("Global counters diff for 11")
+  globalCounters1.dumpDiff(globalCounters11, skipUnchanged: true)
+  print("Global counters diff for 111")
+  globalCounters1.dumpDiff(globalCounters111, skipUnchanged: true)
+
+  let len = length(l!)
+  let globalCounters2 = _GlobalRuntimeFunctionCountersState()
+  print("Length of the list is \(len)")
+  print("Global counters diff after constructing a list and computing its length")
+  globalCounters1.dumpDiff(globalCounters2, skipUnchanged: true)
+  let objectCounters1 = _ObjectRuntimeFunctionCountersState(refs[0])
+  l = nil
+  let objectCounters2 = _ObjectRuntimeFunctionCountersState(refs[0])
+  print("List head counters after list becomes unreferenced")
+  objectCounters1.dumpDiff(objectCounters2, skipUnchanged: true)
+}
+
+/// Test the _measureRuntimeFunctionCountersDiffs API.
+@inline(never)
+func testMeasureRuntimeFunctionCountersDiffs() {
+  print("TEST: Measure runtime function counters diff")
+  let l: List<Int>? = List(1, List(2, List(3, List(4, List(5)))))
+  let refs = _collectReferencesInsideObject(l!)
+  var len = 0
+  let (globalCounters, objectsCountersDiffs) =
+    _measureRuntimeFunctionCountersDiffs(objects: [refs[0]]) {
+    len = length(l!)
+  }
+  print("List length is: \(len)")
+  print("Global counters changes")
+  globalCounters.dump(skipUnchanged: true)
+  print("Objects counters changes")
+  for (i, objectCounters) in objectsCountersDiffs.enumerated() {
+    print("Object counters diff for \(refs[i])")
+    objectCounters.dump(skipUnchanged: true)
+  }
+}
+
+/// This is a handler that is invoked on each runtime functions counters update.
+@inline(never)
+func updatesHandler(object: UnsafeRawPointer, functionId: Int64) {
+  let savedMode = _RuntimeFunctionCounters.disableRuntimeFunctionCountersUpdates()
+  print("Start handler")
+  let functionName = _RuntimeFunctionCounters.runtimeFunctionNames[Int(functionId)]
+  print("Function \(functionName) was invoked on object \(object)")
+  print("End handler")
+  _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(mode: savedMode)
+}
+
+/// Check that it is possible to set your own runtime functions counters
+/// updates handler and this handler is invoked at runtime.
+/// CHECK-LABEL: TEST: Provide runtime function counters update handler
+/// Test that you can provide custom handlers for runtime functions counters
+/// updates.
+var globalC: C? = nil
+@inline(never)
+func testFunctionRuntimeCountersUpdateHandler() {
+  print("TEST: Provide runtime function counters update handler")
+  let l: List<Int>? = List(1, List(2, List(3, List(4, List(5)))))
+  let oldHandler =
+    _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
+      handler: updatesHandler)
+  globalC = C()
+  globalC = nil
+  let len = length(l!)
+  _ = _RuntimeFunctionCounters.setGlobalRuntimeFunctionCountersUpdateHandler(
+    handler: oldHandler)
+  print("Restored old handler")
+  print(len)
+}
+
+/// Enable runtime function counters stats collection.
+_RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates()
+
+/// Test collection of references inside different types of objects.
+testCollectReferencesInsideObject()
+
+/// Test some APIs from _RuntimeFunctionCounters.
+testRuntimeCounters()
+
+/// Test dumping of counters for all objects.
+_RuntimeFunctionCounters.dumpObjectsRuntimeFunctionPointers()
+
+/// Test runtime function counters for a List object.
+testLists()
+
+/// Test the _measureRuntimeFunctionCountersDiffs API.
+testMeasureRuntimeFunctionCountersDiffs()
+
+/// Test that you can provide custom handlers for runtime functions counters updates.
+testFunctionRuntimeCountersUpdateHandler()


### PR DESCRIPTION
It allows for collecting the state of runtime function counters, which are used to determine how many times a given runtime function was called.

It is possible to get the global counters, which represent the total number of invocations, or per-object counters, which represent the number of runtime functions calls for a specific object.

The APIs are implemented in the runtime library and are exposed as Swift APIs via the standard library. This way it is possible to write tests and benchmarks which collect very precise data about the amount of runtime functions invocations (e.g. swift_retain/swift_release) for an object or for a given code snippet.