### PR TITLE
New `defaults` module for `build_swift` argument parser

### DIFF
--- a/utils/build_swift/defaults.py
+++ b/utils/build_swift/defaults.py
@@ -1,0 +1,52 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+"""
+Default option value definitions.
+"""
+
+__all__ = [
+    # Command line configuarable
+    'SWIFT_USER_VISIBLE_VERSION',
+    'CLANG_USER_VISIBLE_VERSION',
+    'SWIFT_ANALYZE_CODE_COVERAGE',
+    'DARWIN_XCRUN_TOOLCHAIN',
+    'DARWIN_DEPLOYMENT_VERSION_OSX',
+    'DARWIN_DEPLOYMENT_VERSION_IOS',
+    'DARWIN_DEPLOYMENT_VERSION_TVOS',
+    'DARWIN_DEPLOYMENT_VERSION_WATCHOS',
+    'UNIX_INSTALL_PREFIX',
+    'DARWIN_INSTALL_PREFIX',
+
+    # Constants
+]
+
+# Options that can be "configured" by command line options
+
+BUILD_VARIANT = 'Debug'
+CMAKE_GENERATOR = 'Ninja'
+
+COMPILER_VENDOR = 'none'
+SWIFT_USER_VISIBLE_VERSION = '4.1'
+CLANG_USER_VISIBLE_VERSION = '5.0.0'
+SWIFT_ANALYZE_CODE_COVERAGE = 'false'
+
+DARWIN_XCRUN_TOOLCHAIN = 'default'
+DARWIN_DEPLOYMENT_VERSION_OSX = '10.9'
+DARWIN_DEPLOYMENT_VERSION_IOS = '7.0'
+DARWIN_DEPLOYMENT_VERSION_TVOS = '9.0'
+DARWIN_DEPLOYMENT_VERSION_WATCHOS = '2.0'
+
+UNIX_INSTALL_PREFIX = '/usr'
+DARWIN_INSTALL_PREFIX = ('/Applications/Xcode.app/Contents/Developer/'
+                         'Toolchains/XcodeDefault.xctoolchain/usr')
+
+# Options that can only be "configured" by editing this file.
+#
+# These options are not exposed as command line options on purpose.  If you
+# need to change any of these, you should do so on trunk or in a branch.

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -12,6 +12,8 @@ import platform
 
 import android.adb.commands
 
+from . import defaults
+
 from swift_build_support.swift_build_support import arguments
 from swift_build_support.swift_build_support import host
 from swift_build_support.swift_build_support import targets
@@ -826,7 +828,8 @@ iterations with -O",
         help="enable code coverage analysis in Swift (false, not-merged, "
              "merged).",
         choices=["false", "not-merged", "merged"],
-        default="false",  # so CMake can see the inert mode as a false value
+        # so CMake can see the inert mode as a false value
+        default=defaults.SWIFT_ANALYZE_CODE_COVERAGE,
         dest="swift_analyze_code_coverage")
 
     parser.add_argument(
@@ -855,7 +858,7 @@ iterations with -O",
     parser.add_argument(
         "--darwin-xcrun-toolchain",
         help="the name of the toolchain to use on Darwin",
-        default="default")
+        default=defaults.DARWIN_XCRUN_TOOLCHAIN)
     parser.add_argument(
         "--cmake",
         help="the path to a CMake executable that will be used to build "
@@ -975,7 +978,7 @@ iterations with -O",
     parser.add_argument(
         "--compiler-vendor",
         choices=["none", "apple"],
-        default="none",
+        default=defaults.COMPILER_VENDOR,
         help="Compiler vendor name")
     parser.add_argument(
         "--clang-compiler-version",
@@ -986,7 +989,7 @@ iterations with -O",
         "--clang-user-visible-version",
         help="User-visible version of the embedded Clang and LLVM compilers",
         type=arguments.type.clang_compiler_version,
-        default="5.0.0",
+        default=defaults.CLANG_USER_VISIBLE_VERSION,
         metavar="MAJOR.MINOR.PATCH")
     parser.add_argument(
         "--swift-compiler-version",
@@ -997,29 +1000,29 @@ iterations with -O",
         "--swift-user-visible-version",
         help="User-visible version of the embedded Swift compiler",
         type=arguments.type.swift_compiler_version,
-        default="4.1",
+        default=defaults.SWIFT_USER_VISIBLE_VERSION,
         metavar="MAJOR.MINOR")
 
     parser.add_argument(
         "--darwin-deployment-version-osx",
         help="minimum deployment target version for OS X",
         metavar="MAJOR.MINOR",
-        default="10.9")
+        default=defaults.DARWIN_DEPLOYMENT_VERSION_OSX)
     parser.add_argument(
         "--darwin-deployment-version-ios",
         help="minimum deployment target version for iOS",
         metavar="MAJOR.MINOR",
-        default="7.0")
+        default=defaults.DARWIN_DEPLOYMENT_VERSION_IOS)
     parser.add_argument(
         "--darwin-deployment-version-tvos",
         help="minimum deployment target version for tvOS",
         metavar="MAJOR.MINOR",
-        default="9.0")
+        default=defaults.DARWIN_DEPLOYMENT_VERSION_TVOS)
     parser.add_argument(
         "--darwin-deployment-version-watchos",
         help="minimum deployment target version for watchOS",
         metavar="MAJOR.MINOR",
-        default="2.0")
+        default=defaults.DARWIN_DEPLOYMENT_VERSION_WATCHOS)
 
     parser.add_argument(
         "--extra-cmake-options",

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -12,8 +12,6 @@ import platform
 
 import android.adb.commands
 
-from . import defaults
-
 from swift_build_support.swift_build_support import arguments
 from swift_build_support.swift_build_support import host
 from swift_build_support.swift_build_support import targets
@@ -21,6 +19,8 @@ from swift_build_support.swift_build_support import workspace
 
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
+
+from . import defaults
 
 
 __all__ = [


### PR DESCRIPTION
# Purpose

This PR is yet another small portion of code for staging #11827 and #11872. It adds a new `defaults` module to `build_swift` that will hold all default values of significant importance which ought be editable from a single source and easily viewable. There's no functional difference with this PR and should be good to just merge once the tests have passed.

<rdar://problem/34425097> 