### PR TITLE
[stdlib] Fix strideable methods for large unsigned values

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1651,7 +1651,7 @@ ${operatorComment(x.nonMaskingOperator, False)}
 extension BinaryInteger {
   // FIXME(ABI): using Int as the return type is wrong.
   @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
+  @inline(__always)
   public func distance(to other: Self) -> Int {
     if !Self.isSigned {
       if self > other {
@@ -1680,7 +1680,7 @@ extension BinaryInteger {
 
   // FIXME(ABI): using Int as the parameter type is wrong.
   @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
+  @inline(__always)
   public func advanced(by n: Int) -> Self {
     if !Self.isSigned {
       return n < (0 as Int)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1653,9 +1653,27 @@ extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func distance(to other: Self) -> Int {
-    let distance = other - self
-    if let result = Int(exactly: distance) {
-      return result
+    if !Self.isSigned {
+      if self > other {
+        if let result = Int(exactly: self - other) {
+          return -result
+        }
+      } else {
+        if let result = Int(exactly: other - self) {
+          return result
+        }
+      }
+    } else {
+      let isNegative = self < (0 as Self)
+      if isNegative == (other < (0 as Self)) {
+        if let result = Int(exactly: other - self) {
+          return result
+        }
+      } else {
+        if let result = Int(exactly: self.magnitude + other.magnitude) {
+          return isNegative ? result : -result
+        }
+      }
     }
     _preconditionFailure("Distance is not representable in Int")
   }
@@ -1664,12 +1682,17 @@ extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func advanced(by n: Int) -> Self {
-    var advanced: Int = Int(self)
-    advanced += n
-    if let result = Self(exactly: advanced) {
-      return result
+    if !Self.isSigned {
+      return n < (0 as Int)
+        ? self - Self(-n)
+        : self + Self(n)
     }
-    _preconditionFailure("The result of advanced(by:) is not representable")
+    if (self < (0 as Self)) == (n < (0 as Self)) {
+      return self + Self(n)
+    }
+    return self.magnitude < n.magnitude
+      ? Self(Int(self) + n)
+      : self + Self(n)
   }
 }
 

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -600,6 +600,28 @@ tests.test("MultiplyMinByMinusOne") {
   _ = f(Int.min)
 }
 
+tests.test("Strideable") {
+  func dist<T: BinaryInteger>(_ a: T, _ b: T) -> Int {
+    return a.distance(to: b)
+  }
+% for u in ['U', '']:
+  let ${u}x = ${u}Int.max - 10
+  expectEqual(${u}x.advanced(by: 10), ${u}Int.max)
+  expectEqual(${u}Int.max.advanced(by: -10), ${u}x)
+  expectEqual(dist(${u}x, ${u}Int.max), 10)
+  expectEqual(dist(${u}Int.max, ${u}x), -10)
+
+  // FIXME: The compiler spuriously flags these as overflowing:
+  // https://bugs.swift.org/browse/SR-5882
+  // expectEqual(${u}x.distance(to: ${u}Int.max), 10)
+% end
+
+  expectEqual(dist(UInt8.min, UInt8.max), 255)
+  expectEqual(dist(UInt8.max, UInt8.min), -255)
+  expectEqual(dist(Int8.min, Int8.max), 255)
+  expectEqual(dist(Int8.max, Int8.min), -255)
+}
+
 tests.test("signum/generic") {
   func check<T : BinaryInteger>(_ expected: T, _ x: T) {
     expectEqual(expected, x.signum())


### PR DESCRIPTION
`Int` is still an insufficient stride type for binary integers, but this improves the situation for values at the extremes of the concrete integer types.
