### PR TITLE
Revert "[Sequence] Make Sequence.SubSequence conform to Sequence."

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1536,7 +1536,13 @@ extension TestSuite {
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all
   ) where
-    SequenceWithEquatableElement.Iterator.Element : Equatable {
+    SequenceWithEquatableElement.Iterator.Element : Equatable,
+    SequenceWithEquatableElement.SubSequence : Sequence,
+    SequenceWithEquatableElement.SubSequence.Iterator.Element
+      == SequenceWithEquatableElement.Iterator.Element,
+    S.SubSequence : Sequence,
+    S.SubSequence.Iterator.Element == S.Iterator.Element,
+    S.SubSequence.SubSequence == S.SubSequence {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -378,7 +378,11 @@ public func expectTrapping<Bound>(
 public func expectType<T>(_: T.Type, _ x: inout T) {}
 public func expectEqualType<T>(_: T.Type, _: T.Type) {}
 
-public func expectSequenceType<X : Sequence>(_ x: X) -> X {
+public func expectSequenceType<X : Sequence>(_ x: X) -> X
+  where
+  X.SubSequence : Sequence,
+  X.SubSequence.Iterator.Element == X.Iterator.Element,
+  X.SubSequence.SubSequence == X.SubSequence {
   return x
 }
 
@@ -413,7 +417,13 @@ public func expectSequenceAssociatedTypes<X : Sequence>(
   sequenceType: X.Type,
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type
-) {}
+) where
+  // FIXME(ABI)#4 (Associated Types with where clauses): there should be no constraints in
+  // the 'where' clause, all of these should be required by the protocol.
+  X.SubSequence : Sequence,
+  X.SubSequence.Iterator.Element == X.Iterator.Element,
+  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#5 (Recursive Protocol Constraints): can't have this constraint now.
+  X.SubSequence.SubSequence == X.SubSequence {}
 
 /// Check that all associated types of a `Collection` are what we expect them
 /// to be.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -651,9 +651,12 @@ public protocol Collection : _Indexable, Sequence
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence
   // FIXME(ABI) (Revert Where Clauses): remove these conformances:
-  : _IndexableBase
+  : _IndexableBase, Sequence
      = Slice<Self>
-      where SubSequence.Index == Index
+      where SubSequence.SubSequence == SubSequence
+  // FIXME(ABI) (Revert Where Clauses): and this where clause:
+          , Element == SubSequence.Element
+          , SubSequence.Index == Index
             
   // FIXME(ABI)#98 (Recursive Protocol Constraints):
   // FIXME(ABI)#99 (Associated Types with where clauses):

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -426,10 +426,14 @@ internal class _AnyRandomAccessCollectionBox<Element>
 @_fixed_layout
 @_versioned
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
-// FIXME(ABI) (Revert Where Clauses): apply all this only to Sequence:
-%  if Kind != 'Sequence':
   where
   S.SubSequence : ${Kind},
+// FIXME(ABI) (Revert Where Clauses): apply all this only to Sequence:
+%  if Kind == 'Sequence':
+  S.SubSequence.Element == S.Element,
+  S.SubSequence.SubSequence == S.SubSequence
+// FIXME(ABI) (Revert Where Clauses): remove this else clause:
+%  else:
   S.SubSequence.Indices : ${Kind},
   S.Indices : ${Kind}
 %  end
@@ -732,7 +736,10 @@ public struct AnySequence<Element> : Sequence {
   @_inlineable
   public init<S : Sequence>(_ base: S)
     where
-    S.Element == Element {
+    S.Element == Element,
+    S.SubSequence : Sequence,
+    S.SubSequence.Element == Element,
+    S.SubSequence.SubSequence == S.SubSequence {
     self._box = _SequenceBox(_base: base)
   }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -331,9 +331,19 @@ public protocol Sequence {
   associatedtype Iterator : IteratorProtocol where Iterator.Element == Element
 
   /// A type that represents a subsequence of some of the sequence's elements.
-  associatedtype SubSequence : Sequence
-    where Element == SubSequence.Element,
-          SubSequence.SubSequence == SubSequence
+  associatedtype SubSequence
+  // FIXME(ABI)#104 (Recursive Protocol Constraints):
+  // FIXME(ABI)#105 (Associated Types with where clauses):
+  // associatedtype SubSequence : Sequence
+  //   where
+  //   Element == SubSequence.Element,
+  //   SubSequence.SubSequence == SubSequence
+  //
+  // (<rdar://problem/20715009> Implement recursive protocol
+  // constraints)
+  //
+  // These constraints allow processing collections in generic code by
+  // repeatedly slicing them in a loop.
 
   /// Returns an iterator over the elements of this sequence.
   func makeIterator() -> Iterator
@@ -1184,7 +1194,10 @@ extension Sequence where Element : Equatable {
   }
 }
 
-extension Sequence {
+extension Sequence where
+  SubSequence : Sequence,
+  SubSequence.Element == Element,
+  SubSequence.SubSequence == SubSequence {
 
   /// Returns a subsequence containing all but the given number of initial
   /// elements.

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -19,7 +19,7 @@
 @_show_in_interface
 public // @testable
 protocol _SequenceWrapper : Sequence {
-  associatedtype Base : Sequence where Base.Element == Element
+  associatedtype Base : Sequence
   associatedtype Iterator = Base.Iterator
   associatedtype SubSequence = Base.SubSequence
   
@@ -51,7 +51,7 @@ extension _SequenceWrapper where Iterator == Base.Iterator {
   }
 }
 
-extension _SequenceWrapper {
+extension _SequenceWrapper where Element == Base.Element {
   public func map<T>(
     _ transform: (Element) throws -> T
 ) rethrows -> [T] {
@@ -93,6 +93,10 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
   public func suffix(_ maxLength: Int) -> SubSequence {
     return _base.suffix(maxLength)
   }
+}
+
+extension _SequenceWrapper
+  where SubSequence == Base.SubSequence, Element == Base.Element {
 
   public func drop(
     while predicate: (Element) throws -> Bool
@@ -106,6 +110,10 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
     return try _base.prefix(while: predicate)
   }
   
+  public func suffix(_ maxLength: Int) -> SubSequence {
+    return _base.suffix(maxLength)
+  }
+
   public func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool


### PR DESCRIPTION
This reverts commit 7dc8737c9c46e5d0c54fe36415e2fd8ed12b5dac.

I need to address the compile-time performance regressions before I can land these changes. Instead, I'll collect all of the standard library work for recursive constraints in a single PR.