### PR TITLE
Miscellaneous fixes for recursive protocol constraints

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -415,6 +415,7 @@ public:
   /// Mark this conformance as invalid.
   void setInvalid() {
     ContextAndInvalid.setInt(true);
+    SignatureConformances = {};
   }
 
   /// Determine whether this conformance is lazily loaded.
@@ -512,6 +513,16 @@ public:
   /// Copy the given protocol conformances for the requirement signature into
   /// the normal conformance.
   void setSignatureConformances(ArrayRef<ProtocolConformanceRef> conformances);
+
+  /// Retrieves a function object that should be called with each of the
+  /// conformances required by the requirement signature.
+  ///
+  /// This can be used to iteratively build up the signature conformances in
+  /// the type checker (rather than emitting them in a batch via
+  /// \c setSignatureConformances). The callee is responsible for calling
+  /// the returned function object with protocol conformances that line up
+  /// with the conformance requirements in the requirement signature (in order).
+  std::function<void(ProtocolConformanceRef)> populateSignatureConformances();
 
   /// Determine whether the witness for the given type requirement
   /// is the default definition.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2140,7 +2140,8 @@ static void concretizeNestedTypeFromConcreteParent(
     witnessType =
       conformance.getConcrete()
         ->getTypeWitness(assocType, builder.getLazyResolver());
-    if (!witnessType) return;
+    if (!witnessType || witnessType->hasError())
+      return; // FIXME: should we delay here?
   } else {
     witnessType = DependentMemberType::get(concreteParent, assocType);
   }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -240,6 +240,13 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
     // If we haven't set the signature conformances yet, force the issue now.
     if (normal->getSignatureConformances().empty()) {
+      // If we're in the process of checking the type witnesses, fail
+      // gracefully.
+      // FIXME: Seems like we should be able to get at the intermediate state
+      // to use that.
+      if (normal->getState() == ProtocolConformanceState::CheckingTypeWitnesses)
+        return None;
+
       auto lazyResolver = type->getASTContext().getLazyResolver();
       if (lazyResolver == nullptr)
         return None;

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1536,7 +1536,13 @@ extension TestSuite {
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all
   ) where
-    SequenceWithEquatableElement.Iterator.Element : Equatable {
+    SequenceWithEquatableElement.Iterator.Element : Equatable,
+    SequenceWithEquatableElement.SubSequence : Sequence,
+    SequenceWithEquatableElement.SubSequence.Iterator.Element
+      == SequenceWithEquatableElement.Iterator.Element,
+    S.SubSequence : Sequence,
+    S.SubSequence.Iterator.Element == S.Iterator.Element,
+    S.SubSequence.SubSequence == S.SubSequence {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -378,7 +378,11 @@ public func expectTrapping<Bound>(
 public func expectType<T>(_: T.Type, _ x: inout T) {}
 public func expectEqualType<T>(_: T.Type, _: T.Type) {}
 
-public func expectSequenceType<X : Sequence>(_ x: X) -> X {
+public func expectSequenceType<X : Sequence>(_ x: X) -> X
+  where
+  X.SubSequence : Sequence,
+  X.SubSequence.Iterator.Element == X.Iterator.Element,
+  X.SubSequence.SubSequence == X.SubSequence {
   return x
 }
 
@@ -413,7 +417,13 @@ public func expectSequenceAssociatedTypes<X : Sequence>(
   sequenceType: X.Type,
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type
-) {}
+) where
+  // FIXME(ABI)#4 (Associated Types with where clauses): there should be no constraints in
+  // the 'where' clause, all of these should be required by the protocol.
+  X.SubSequence : Sequence,
+  X.SubSequence.Iterator.Element == X.Iterator.Element,
+  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#5 (Recursive Protocol Constraints): can't have this constraint now.
+  X.SubSequence.SubSequence == X.SubSequence {}
 
 /// Check that all associated types of a `Collection` are what we expect them
 /// to be.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -651,9 +651,12 @@ public protocol Collection : _Indexable, Sequence
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence
   // FIXME(ABI) (Revert Where Clauses): remove these conformances:
-  : _IndexableBase
+  : _IndexableBase, Sequence
      = Slice<Self>
-      where SubSequence.Index == Index
+      where SubSequence.SubSequence == SubSequence
+  // FIXME(ABI) (Revert Where Clauses): and this where clause:
+          , Element == SubSequence.Element
+          , SubSequence.Index == Index
             
   // FIXME(ABI)#98 (Recursive Protocol Constraints):
   // FIXME(ABI)#99 (Associated Types with where clauses):

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -426,10 +426,14 @@ internal class _AnyRandomAccessCollectionBox<Element>
 @_fixed_layout
 @_versioned
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
-// FIXME(ABI) (Revert Where Clauses): apply all this only to Sequence:
-%  if Kind != 'Sequence':
   where
   S.SubSequence : ${Kind},
+// FIXME(ABI) (Revert Where Clauses): apply all this only to Sequence:
+%  if Kind == 'Sequence':
+  S.SubSequence.Element == S.Element,
+  S.SubSequence.SubSequence == S.SubSequence
+// FIXME(ABI) (Revert Where Clauses): remove this else clause:
+%  else:
   S.SubSequence.Indices : ${Kind},
   S.Indices : ${Kind}
 %  end
@@ -732,7 +736,10 @@ public struct AnySequence<Element> : Sequence {
   @_inlineable
   public init<S : Sequence>(_ base: S)
     where
-    S.Element == Element {
+    S.Element == Element,
+    S.SubSequence : Sequence,
+    S.SubSequence.Element == Element,
+    S.SubSequence.SubSequence == S.SubSequence {
     self._box = _SequenceBox(_base: base)
   }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -331,9 +331,19 @@ public protocol Sequence {
   associatedtype Iterator : IteratorProtocol where Iterator.Element == Element
 
   /// A type that represents a subsequence of some of the sequence's elements.
-  associatedtype SubSequence : Sequence
-    where Element == SubSequence.Element,
-          SubSequence.SubSequence == SubSequence
+  associatedtype SubSequence
+  // FIXME(ABI)#104 (Recursive Protocol Constraints):
+  // FIXME(ABI)#105 (Associated Types with where clauses):
+  // associatedtype SubSequence : Sequence
+  //   where
+  //   Element == SubSequence.Element,
+  //   SubSequence.SubSequence == SubSequence
+  //
+  // (<rdar://problem/20715009> Implement recursive protocol
+  // constraints)
+  //
+  // These constraints allow processing collections in generic code by
+  // repeatedly slicing them in a loop.
 
   /// Returns an iterator over the elements of this sequence.
   func makeIterator() -> Iterator
@@ -1184,7 +1194,10 @@ extension Sequence where Element : Equatable {
   }
 }
 
-extension Sequence {
+extension Sequence where
+  SubSequence : Sequence,
+  SubSequence.Element == Element,
+  SubSequence.SubSequence == SubSequence {
 
   /// Returns a subsequence containing all but the given number of initial
   /// elements.

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -19,7 +19,7 @@
 @_show_in_interface
 public // @testable
 protocol _SequenceWrapper : Sequence {
-  associatedtype Base : Sequence where Base.Element == Element
+  associatedtype Base : Sequence
   associatedtype Iterator = Base.Iterator
   associatedtype SubSequence = Base.SubSequence
   
@@ -51,7 +51,7 @@ extension _SequenceWrapper where Iterator == Base.Iterator {
   }
 }
 
-extension _SequenceWrapper {
+extension _SequenceWrapper where Element == Base.Element {
   public func map<T>(
     _ transform: (Element) throws -> T
 ) rethrows -> [T] {
@@ -93,6 +93,10 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
   public func suffix(_ maxLength: Int) -> SubSequence {
     return _base.suffix(maxLength)
   }
+}
+
+extension _SequenceWrapper
+  where SubSequence == Base.SubSequence, Element == Base.Element {
 
   public func drop(
     while predicate: (Element) throws -> Bool
@@ -106,6 +110,10 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
     return try _base.prefix(while: predicate)
   }
   
+  public func suffix(_ maxLength: Int) -> SubSequence {
+    return _base.suffix(maxLength)
+  }
+
   public func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool

--- a/validation-test/compiler_crashers_fixed/28824-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28824-hasval.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 extension CountableRange{protocol b{typealias a:RangeReplaceableCollection
 protocol P{}
 class a:RangeReplaceableCollection


### PR DESCRIPTION
A collection of small fixes for recursive protocol constraints that allow us to start rolling out the feature within the standard library:
* Progressively populate signature conformances
* Don't record invalid concrete types via parent conformances in the GSB
* Eliminate infinite recursion through SubstitutionMap and associated type witness inference