### PR TITLE
add /usr/include/sysexits.h to Glibc module

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -428,6 +428,12 @@ module SwiftGlibc [system] {
         export *
       }
     }
+% if CMAKE_SDK in ["LINUX", "FREEBSD"]:
+    module sysexits {
+      header "${GLIBC_INCLUDE_PATH}/sysexits.h"
+      export *
+    }
+% end
     module termios {
       header "${GLIBC_INCLUDE_PATH}/termios.h"
       export *


### PR DESCRIPTION
This adds the `sysexits.h` header to the Glibc system module.
`sysexits.h` is part of the Darwin module, but is not imported by Linux's Glibc. Since the file also exists on Linux and FreeBSD, including it removes a small, seemingly unnecessary inconsistency.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3436](https://bugs.swift.org/browse/SR-3436).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->