### PR TITLE
sema for conditional conformances.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1379,11 +1379,15 @@ ERROR(protocol_derivation_is_broken,none,
       "protocol %0 is broken; cannot derive conformance for type %1", (Type, Type))
 ERROR(type_does_not_inherit,none,
       "%0 requires that %1 inherit from %2", (Type, Type, Type))
-NOTE(type_does_not_inherit_requirement,none,
+NOTE(type_does_not_inherit_or_conform_requirement,none,
      "requirement specified as %0 : %1%2", (Type, Type, StringRef))
 ERROR(types_not_equal,none,
       "%0 requires the types %1 and %2 be equivalent",
       (Type, Type, Type))
+ERROR(type_does_not_conform_owner,none,
+      "%0 requires that %1 conform to %2", (Type, Type, Type))
+NOTE(requirement_implied_by_conditional_conformance,none,
+     "requirement from conditional conformance of %0 to %1", (Type, Type))
 NOTE(candidate_types_equal_requirement,none,
      "candidate requires that the types %0 and %1 be equivalent "
      "(requirement specified as %2 == %3%4)",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1350,9 +1350,6 @@ ERROR(extension_stored_property,none,
       "extensions must not contain stored properties", ())
 ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0", (Type))
-ERROR(extension_constrained_inheritance,none,
-      "extension of type %0 with constraints cannot have an "
-      "inheritance clause", (Type))
 ERROR(extension_protocol_inheritance,none,
       "extension of protocol %0 cannot have an inheritance clause", (Type))
 ERROR(objc_generic_extension_using_type_parameter,none,

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -296,6 +296,12 @@ public:
   /// The type parameters must be known to not be concrete within the context.
   bool areSameTypeParameterInContext(Type type1, Type type2);
 
+  /// Determine if \c sig can prove \c requirement, meaning that it can deduce
+  /// T: Foo or T == U (etc.) with the information it knows. This includes
+  /// checking against global state, if any/all of the types in the requirement
+  /// are concrete, not type parameters.
+  bool isRequirementSatisfied(Requirement requirement);
+
   /// Return the canonical version of the given type under this generic
   /// signature.
   CanType getCanonicalTypeInContext(Type type);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -574,8 +574,7 @@ public:
   /// inconsistent, in which case a diagnostic will have been issued.
   ConstraintResult addRequirement(const Requirement &req,
                                   FloatingRequirementSource source,
-                                  ModuleDecl *inferForModule,
-                                  const SubstitutionMap *subMap = nullptr);
+                                  ModuleDecl *inferForModule);
 
   /// \brief Add all of a generic signature's parameters and requirements.
   void addGenericSignature(GenericSignature *sig);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -412,11 +412,14 @@ private:
 
   /// \brief Add a new type requirement specifying that the given
   /// type conforms-to or is a superclass of the second type.
-  ConstraintResult addTypeRequirement(
-                          UnresolvedType subject,
-                          UnresolvedType constraint,
-                          FloatingRequirementSource source,
-                          UnresolvedHandlingKind unresolvedHandling);
+  ///
+  /// \param inferForModule Infer additional requirements from the types
+  /// relative to the given module.
+  ConstraintResult addTypeRequirement(UnresolvedType subject,
+                                      UnresolvedType constraint,
+                                      FloatingRequirementSource source,
+                                      UnresolvedHandlingKind unresolvedHandling,
+                                      ModuleDecl *inferForModule);
 
   /// Note that we have added the nested type nestedPA
   void addedNestedType(PotentialArchetype *nestedPA);

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "swift/AST/Requirement.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Type.h"
 
@@ -128,6 +129,10 @@ public:
 
   /// Create a canonical conformance from the current one.
   ProtocolConformanceRef getCanonicalConformanceRef() const;
+
+  /// Get any additional requirements that are required for this conformance to
+  /// be satisfied.
+  ArrayRef<Requirement> getConditionalRequirements() const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -120,6 +120,7 @@ public:
   }
 
   void dump() const;
+  void dump(raw_ostream &out) const;
   void print(raw_ostream &os, const PrintOptions &opts) const;
   void print(ASTPrinter &printer, const PrintOptions &opts) const;
 };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2786,6 +2786,11 @@ void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
       out << '\n';
       conformance.dump(out, indent + 2);
     }
+    for (auto requirement : normal->getConditionalRequirements()) {
+      out << '\n';
+      out.indent(indent + 2);
+      requirement.dump(out);
+    }
     break;
   }
 
@@ -2803,6 +2808,11 @@ void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
     out << '\n';
     for (auto sub : conf->getGenericSubstitutions()) {
       sub.dump(out, indent + 2);
+      out << '\n';
+    }
+    for (auto subReq : conf->getConditionalRequirements()) {
+      out.indent(indent + 2);
+      subReq.dump(out);
       out << '\n';
     }
     conf->getGenericConformance()->dump(out, indent + 2);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3940,27 +3940,31 @@ void GenericSignature::dump() const {
 }
 
 void Requirement::dump() const {
+  dump(llvm::errs());
+  llvm::errs() << '\n';
+}
+void Requirement::dump(raw_ostream &out) const {
   switch (getKind()) {
   case RequirementKind::Conformance:
-    llvm::errs() << "conforms_to: ";
+    out << "conforms_to: ";
     break;
   case RequirementKind::Layout:
-    llvm::errs() << "layout: ";
+    out << "layout: ";
     break;
   case RequirementKind::Superclass:
-    llvm::errs() << "superclass: ";
+    out << "superclass: ";
     break;
   case RequirementKind::SameType:
-    llvm::errs() << "same_type: ";
+    out << "same_type: ";
     break;
   }
 
-  if (getFirstType()) llvm::errs() << getFirstType() << " ";
+  if (getFirstType())
+    out << getFirstType() << " ";
   if (getKind() != RequirementKind::Layout && getSecondType())
-    llvm::errs() << getSecondType();
+    out << getSecondType();
   else if (getLayoutConstraint())
-    llvm::errs() << getLayoutConstraint();
-  llvm::errs() << "\n";
+    out << getLayoutConstraint();
 }
 
 void Requirement::print(raw_ostream &os, const PrintOptions &opts) const {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -245,8 +245,12 @@ getSubstitutionMap(TypeSubstitutionFn subs,
         auto conformance = lookupConformance(canTy,
                                              currentReplacement,
                                              protoType);
-        if (conformance)
+        if (conformance) {
+          assert(conformance->getConditionalRequirements().empty() &&
+                 "unhandled conditional requirements");
+
           subMap.addConformance(canTy, *conformance);
+        }
       }
 
       return false;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -98,6 +98,8 @@ STATISTIC(NumDelayedRequirementResolved,
           "Delayed requirements resolved");
 STATISTIC(NumDelayedRequirementUnresolved,
           "Delayed requirements left unresolved");
+STATISTIC(NumConditionalRequirementsAdded,
+          "# of conditional requirements added");
 
 struct GenericSignatureBuilder::Implementation {
   /// Allocator.
@@ -2058,6 +2060,23 @@ ConstraintResult GenericSignatureBuilder::handleUnresolvedRequirement(
   }
 }
 
+// Function for feeding through any other requirements that the conformance
+// requires to be satisfied. These are things we're inferring.
+static void addConditionalRequirements(GenericSignatureBuilder &builder,
+                                       ProtocolConformanceRef conformance) {
+  // Abstract conformances don't have associated decl-contexts/modules, but also
+  // don't have conditional requirements.
+  if (conformance.isConcrete()) {
+    auto mod = conformance.getConcrete()->getDeclContext()->getParentModule();
+    auto source = FloatingRequirementSource::forInferred(nullptr);
+    for (auto requirement : conformance.getConditionalRequirements()) {
+      builder.addRequirement(requirement, source,
+                             /*inferForModule=*/mod);
+      ++NumConditionalRequirementsAdded;
+    }
+  }
+}
+
 const RequirementSource *
 GenericSignatureBuilder::resolveConcreteConformance(PotentialArchetype *pa,
                                                     ProtocolDecl *proto) {
@@ -2097,6 +2116,9 @@ GenericSignatureBuilder::resolveConcreteConformance(PotentialArchetype *pa,
   concreteSource = concreteSource->viaConcrete(*this, *conformance);
   paEquivClass->conformsTo[proto].push_back({pa, proto, concreteSource});
   ++NumConformanceConstraints;
+
+  addConditionalRequirements(*this, *conformance);
+
   return concreteSource;
 }
 
@@ -2129,6 +2151,9 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
     superclassSource->viaSuperclass(*this, *conformance);
   paEquivClass->conformsTo[proto].push_back({pa, proto, superclassSource});
   ++NumConformanceConstraints;
+
+  addConditionalRequirements(*this, *conformance);
+
   return superclassSource;
 }
 
@@ -3596,10 +3621,9 @@ toRequirementRHS(GenericSignatureBuilder::UnresolvedType unresolved) {
 }
 
 ConstraintResult GenericSignatureBuilder::addTypeRequirement(
-                             UnresolvedType subject,
-                             UnresolvedType constraint,
-                             FloatingRequirementSource source,
-                             UnresolvedHandlingKind unresolvedHandling) {
+    UnresolvedType subject, UnresolvedType constraint,
+    FloatingRequirementSource source, UnresolvedHandlingKind unresolvedHandling,
+    ModuleDecl *inferForModule) {
   // Resolve the constraint.
   auto resolvedConstraint = resolve(constraint, source);
   if (!resolvedConstraint) {
@@ -3650,21 +3674,43 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
                                      unresolvedHandling);
   }
 
-  // If the resolved subject is a type, we can probably perform diagnostics
-  // here.
+  // If the resolved subject is a type, there may be things we can infer (if it
+  // conditionally conforms to the protocol), and we can probably perform
+  // diagnostics here.
   if (resolvedSubject->isType()) {
+    auto subjectType = resolvedSubject->getType();
+
+    if (constraintType->isExistentialType()) {
+      auto layout = constraintType->getExistentialLayout();
+      for (auto *proto : layout.getProtocols()) {
+        // We have a pure concrete type, and there's no guarantee of dependent
+        // type that makes sense to use here, but, in practice, all
+        // getLookupConformanceFns used in here don't use that parameter anyway.
+        auto dependentType = CanType();
+        auto conformance =
+            getLookupConformanceFn()(dependentType, subjectType, proto);
+
+        // FIXME: diagnose if there's no conformance.
+        if (conformance) {
+          auto inferredSource = FloatingRequirementSource::forInferred(nullptr);
+          for (auto req : conformance->getConditionalRequirements()) {
+            addRequirement(req, inferredSource, inferForModule);
+          }
+        }
+      }
+    }
+
     // One cannot explicitly write a constraint on a concrete type.
     if (source.isExplicit()) {
       if (source.getLoc().isValid()) {
         Impl->HadAnyError = true;
         Diags.diagnose(source.getLoc(), diag::requires_not_suitable_archetype,
-                       TypeLoc::withoutLoc(resolvedSubject->getType()));
+                       TypeLoc::withoutLoc(subjectType));
       }
 
       return ConstraintResult::Concrete;
     }
 
-    // FIXME: Check the constraint now.
     return ConstraintResult::Resolved;
   }
 
@@ -4108,10 +4154,10 @@ ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
                         getFloatingSource(typeRepr, /*forInferred=*/true));
     }
 
-    return addTypeRequirement(type, inheritedType,
-                              getFloatingSource(typeRepr,
-                                                /*forInferred=*/false),
-                              UnresolvedHandlingKind::GenerateConstraints);
+    return addTypeRequirement(
+        type, inheritedType, getFloatingSource(typeRepr,
+                                               /*forInferred=*/false),
+        UnresolvedHandlingKind::GenerateConstraints, inferForModule);
   };
 
   return visitInherited(decl->getInherited(), visitType);
@@ -4172,7 +4218,8 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
                                       Req->getConstraintLoc().getTypeRepr()));
     }
     return addTypeRequirement(subject, constraint, source,
-                              UnresolvedHandlingKind::GenerateConstraints);
+                              UnresolvedHandlingKind::GenerateConstraints,
+                              inferForModule);
   }
 
   case RequirementReprKind::SameType: {
@@ -4246,7 +4293,8 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
     }
 
     return addTypeRequirement(firstType, secondType, source,
-                              UnresolvedHandlingKind::GenerateConstraints);
+                              UnresolvedHandlingKind::GenerateConstraints,
+                              inferForModule);
   }
 
   case RequirementKind::Layout: {
@@ -4794,9 +4842,10 @@ void GenericSignatureBuilder::processDelayedRequirements() {
       ConstraintResult reqResult;
       switch (req.kind) {
       case DelayedRequirement::Type:
-        reqResult = addTypeRequirement(
-                       req.lhs, asUnresolvedType(req.rhs), req.source,
-                       UnresolvedHandlingKind::GenerateUnresolved);
+        reqResult =
+            addTypeRequirement(req.lhs, asUnresolvedType(req.rhs), req.source,
+                               UnresolvedHandlingKind::GenerateUnresolved,
+                               /*inferForModule=*/nullptr);
         break;
 
       case DelayedRequirement::Layout:

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -107,6 +107,8 @@ ProtocolConformanceRef::subst(Type origType,
   if (auto result = conformances(origType->getCanonicalType(),
                                  substType,
                                  proto->getDeclaredType())) {
+    assert(result->getConditionalRequirements().empty() &&
+           "unhandled conditional requirements");
     return *result;
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3010,6 +3010,8 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
 
     if (!conformance) return failed();
     if (!conformance->isConcrete()) return failed();
+    assert(conformance->getConditionalRequirements().empty() &&
+           "unhandled conditional requirements");
 
     // Retrieve the type witness.
     auto witness =

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -630,6 +630,10 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
         input, result, reqtOrigTy->getExtInfo());
   }
 
+  // FIXME: this needs to pull out the conformances/witness-tables for any
+  // conditional requirements from the witness table and pass them to the
+  // underlying function in the thunk.
+
   // Lower the witness thunk type with the requirement's abstraction level.
   auto witnessSILFnType =
     getNativeSILFunctionType(M, AbstractionPattern(reqtOrigTy),

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1449,7 +1449,7 @@ void FunctionSignaturePartialSpecializer::addRequirements(
 
   for (auto &reqReq : Reqs) {
     DEBUG(llvm::dbgs() << "\n\nRe-mapping the requirement:\n"; reqReq.dump());
-    Builder.addRequirement(reqReq, source, SM, &SubsMap);
+    Builder.addRequirement(*reqReq.subst(SubsMap), source, SM);
   }
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -160,6 +160,8 @@ static DeclTy *findNamedWitnessImpl(
     if (!conformance)
       return nullptr;
   }
+  assert(conformance->getConditionalRequirements().empty() &&
+         "unhandled conditional conformance");
 
   // For a type with dependent conformance, just return the requirement from
   // the protocol. There are no protocol conformance tables.
@@ -471,6 +473,9 @@ namespace {
               tc.conformsToProtocol(baseTy, proto, cs.DC,
                                     (ConformanceCheckFlags::InExpression|
                                          ConformanceCheckFlags::Used));
+            assert((!conformance ||
+                    conformance->getConditionalRequirements().empty()) &&
+                   "unhandled conditional conformance");
             if (conformance && conformance->isConcrete()) {
               if (auto witness =
                         conformance->getConcrete()->getWitnessDecl(decl, &tc)) {
@@ -2235,6 +2240,8 @@ namespace {
         tc.conformsToProtocol(conformingType, proto, cs.DC,
                               ConformanceCheckFlags::InExpression);
       assert(conformance && "object literal type conforms to protocol");
+      assert(conformance->getConditionalRequirements().empty() &&
+             "unhandled conditional conformance");
 
       Expr *base = TypeExpr::createImplicitHack(expr->getLoc(), conformingType,
                                                 ctx);
@@ -2684,6 +2691,8 @@ namespace {
         tc.conformsToProtocol(arrayTy, arrayProto, cs.DC,
                               ConformanceCheckFlags::InExpression);
       assert(conformance && "Type does not conform to protocol?");
+      assert(conformance->getConditionalRequirements().empty() &&
+             "unhandled conditional conformance");
 
       // Call the witness that builds the array literal.
       // FIXME: callWitness() may end up re-doing some work we already did
@@ -2765,6 +2774,9 @@ namespace {
                               ConformanceCheckFlags::InExpression);
       if (!conformance)
         return nullptr;
+
+      assert(conformance->getConditionalRequirements().empty() &&
+             "unhandled conditional conformance");
 
       // Call the witness that builds the dictionary literal.
       // FIXME: callWitness() may end up re-doing some work we already did
@@ -6070,6 +6082,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                               (ConformanceCheckFlags::InExpression |
                                ConformanceCheckFlags::Used));
       assert(conformance && "must conform to Hashable");
+      assert(conformance->getConditionalRequirements().empty() &&
+             "unhandled conditional conformance");
+
       return cs.cacheType(
           new (tc.Context) AnyHashableErasureExpr(expr, toType, *conformance));
     }
@@ -6507,6 +6522,9 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
       (builtinConformance =
          tc.conformsToProtocol(type, builtinProtocol, cs.DC,
                                ConformanceCheckFlags::InExpression))) {
+    assert(builtinConformance->getConditionalRequirements().empty() &&
+           "conditional conformance to builtins not handled");
+
     // Find the builtin argument type we'll use.
     Type argType;
     if (builtinLiteralType.is<Type>())
@@ -6561,6 +6579,8 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
   auto conformance = tc.conformsToProtocol(type, protocol, cs.DC,
                                            ConformanceCheckFlags::InExpression);
   assert(conformance && "must conform to literal protocol");
+  assert(conformance->getConditionalRequirements().empty() &&
+         "unexpected conditional requirements");
 
   // Figure out the (non-builtin) argument type if there is one.
   Type argType;
@@ -6654,6 +6674,8 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
       (builtinConformance =
          tc.conformsToProtocol(type, builtinProtocol, cs.DC,
                                ConformanceCheckFlags::InExpression))) {
+    assert(builtinConformance->getConditionalRequirements().empty() &&
+           "conditional conformance to builtins not handled");
     // Find the witness that we'll use to initialize the type via a builtin
     // literal.
     auto witness = findNamedWitnessImpl<AbstractFunctionDecl>(
@@ -6702,6 +6724,8 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
   auto conformance = tc.conformsToProtocol(type, protocol, cs.DC,
                                            ConformanceCheckFlags::InExpression);
   assert(conformance && "must conform to literal protocol");
+  assert(conformance->getConditionalRequirements().empty() &&
+         "unexpected conditional requirements");
 
   // Dig out the literal type and perform a builtin literal conversion to it.
   if (!literalType.empty()) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1593,6 +1593,9 @@ namespace {
       FuncDecl *fn = nullptr;
 
       if (bridgedToObjectiveCConformance) {
+        assert(bridgedToObjectiveCConformance->getConditionalRequirements()
+                   .empty() &&
+               "cannot conditionally conform to _BridgedToObjectiveC");
         // The conformance to _BridgedToObjectiveC is statically known.
         // Retrieve the bridging operation to be used if a static conformance
         // to _BridgedToObjectiveC can be proven.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6150,8 +6150,9 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
       return !(first->hasTypeParameter() || first->isTypeVariableOrMember());
     }
 
-    bool diagnoseUnsatisfiedRequirement(const Requirement &req, Type first,
-                                        Type second) override {
+    bool diagnoseUnsatisfiedRequirement(
+        const Requirement &req, Type first, Type second,
+        ArrayRef<ParentConditionalConformance> parents) override {
       Diag<Type, Type, Type, Type, StringRef> note;
       switch (req.getKind()) {
       case RequirementKind::Conformance:
@@ -6201,6 +6202,10 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
                   rawFirstType, rawSecondType,
                   genericSig->gatherGenericParamBindingsText(
                                  {rawFirstType, rawSecondType}, Substitutions));
+
+      ParentConditionalConformance::diagnoseConformanceStack(
+          TC.Diags, Candidate->getLoc(), parents);
+
       return true;
     }
   };

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -190,39 +190,38 @@ static bool isNominallySuperclassOf(Type type1, Type type2) {
 
 /// Determine the relationship between the self types of the given declaration
 /// contexts..
-static SelfTypeRelationship computeSelfTypeRelationship(TypeChecker &tc,
-                                                        DeclContext *dc,
-                                                        DeclContext *dc1,
-                                                        DeclContext *dc2){
+static std::pair<SelfTypeRelationship, Optional<ProtocolConformanceRef>>
+computeSelfTypeRelationship(TypeChecker &tc, DeclContext *dc, DeclContext *dc1,
+                            DeclContext *dc2) {
   // If at least one of the contexts is a non-type context, the two are
   // unrelated.
   if (!dc1->isTypeContext() || !dc2->isTypeContext())
-    return SelfTypeRelationship::Unrelated;
+    return {SelfTypeRelationship::Unrelated, None};
 
   Type type1 = dc1->getDeclaredInterfaceType();
   Type type2 = dc2->getDeclaredInterfaceType();
 
   // If the types are equal, the answer is simple.
   if (type1->isEqual(type2))
-    return SelfTypeRelationship::Equivalent;
+    return {SelfTypeRelationship::Equivalent, None};
 
   // If both types can have superclasses, which whether one is a superclass
   // of the other. The subclass is the common base type.
   if (type1->mayHaveSuperclass() && type2->mayHaveSuperclass()) {
     if (isNominallySuperclassOf(type1, type2))
-      return SelfTypeRelationship::Superclass;
+      return {SelfTypeRelationship::Superclass, None};
 
     if (isNominallySuperclassOf(type2, type1))
-      return SelfTypeRelationship::Subclass;
+      return {SelfTypeRelationship::Subclass, None};
 
-    return SelfTypeRelationship::Unrelated;
+    return {SelfTypeRelationship::Unrelated, None};
   }
 
   // If neither or both are protocol types, consider the bases unrelated.
   bool isProtocol1 = isa<ProtocolDecl>(dc1);
   bool isProtocol2 = isa<ProtocolDecl>(dc2);
   if (isProtocol1 == isProtocol2)
-    return SelfTypeRelationship::Unrelated;
+    return {SelfTypeRelationship::Unrelated, None};
 
   // Just one of the two is a protocol. Check whether the other conforms to
   // that protocol.
@@ -232,12 +231,15 @@ static SelfTypeRelationship computeSelfTypeRelationship(TypeChecker &tc,
 
   // If the model type does not conform to the protocol, the bases are
   // unrelated.
-  if (!tc.conformsToProtocol(modelTy, proto, dc,
-                             ConformanceCheckFlags::InExpression))
-    return SelfTypeRelationship::Unrelated;
+  auto conformance = tc.conformsToProtocol(modelTy, proto, dc,
+                                           ConformanceCheckFlags::InExpression);
+  if (!conformance)
+    return {SelfTypeRelationship::Unrelated, None};
 
-  return isProtocol1? SelfTypeRelationship::ConformedToBy
-                    : SelfTypeRelationship::ConformsTo;
+  if (isProtocol1)
+    return {SelfTypeRelationship::ConformedToBy, conformance};
+
+  return {SelfTypeRelationship::ConformsTo, conformance};
 }
 
 // Given a type and a declaration context, return a type with a curried
@@ -524,7 +526,11 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // Determine the relationship between the 'self' types and add the
       // appropriate constraints. The constraints themselves never fail, but
       // they help deduce type variables that were opened.
-      switch (computeSelfTypeRelationship(tc, dc, outerDC1, outerDC2)) {
+      auto selfTypeRelationship =
+          computeSelfTypeRelationship(tc, dc, outerDC1, outerDC2);
+      auto relationshipKind = selfTypeRelationship.first;
+      auto conformance = selfTypeRelationship.second;
+      switch (relationshipKind) {
       case SelfTypeRelationship::Unrelated:
         // Skip the self types parameter entirely.
         break;
@@ -542,16 +548,27 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         break;
 
       case SelfTypeRelationship::ConformsTo:
+        assert(conformance);
         cs.addConstraint(ConstraintKind::ConformsTo, selfTy1,
                          cast<ProtocolDecl>(outerDC2)->getDeclaredType(),
                          locator);
         break;
 
       case SelfTypeRelationship::ConformedToBy:
+        assert(conformance);
         cs.addConstraint(ConstraintKind::ConformsTo, selfTy2,
                          cast<ProtocolDecl>(outerDC1)->getDeclaredType(),
                          locator);
         break;
+      }
+
+      if (conformance) {
+        assert(relationshipKind == SelfTypeRelationship::ConformsTo ||
+               relationshipKind == SelfTypeRelationship::ConformedToBy);
+
+        for (auto requirement : conformance->getConditionalRequirements()) {
+          cs.addConstraint(requirement, locator);
+        }
       }
 
       bool fewerEffectiveParameters = false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2604,6 +2604,16 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
                                 ConformanceCheckFlags::InExpression)) {
       CheckedConformances.push_back({getConstraintLocator(locator),
                                      *conformance});
+
+      // This conformance may be conditional, in which case we need to consider
+      // those requirements as constraints too.
+      //
+      // FIXME: this doesn't seem to be right; the requirements are sometimes
+      // phrased in terms of the type's generic parameters, not type variables
+      // in this context.
+      for (auto req : conformance->getConditionalRequirements()) {
+        addConstraint(req, locator);
+      }
       return SolutionKind::Solved;
     }
     break;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4859,6 +4859,43 @@ ConstraintSystem::addKeyPathConstraint(Type keypath,
   }
 }
 
+void ConstraintSystem::addConstraint(Requirement req,
+                                     ConstraintLocatorBuilder locator,
+                                     bool isFavored) {
+  bool conformsToAnyObject = false;
+  Optional<ConstraintKind> kind;
+  switch (req.getKind()) {
+  case RequirementKind::Conformance:
+    kind = ConstraintKind::ConformsTo;
+    break;
+  case RequirementKind::Superclass:
+    conformsToAnyObject = true;
+    kind = ConstraintKind::Subtype;
+    break;
+  case RequirementKind::SameType:
+    kind = ConstraintKind::Equal;
+    break;
+  case RequirementKind::Layout:
+    // Only a class constraint can be modeled as a constraint, and only that can
+    // appear outside of a @_specialize at the moment anyway.
+    if (req.getLayoutConstraint()->isClass()) {
+      conformsToAnyObject = true;
+      break;
+    }
+    return;
+  }
+
+  auto firstType = req.getFirstType();
+  if (kind) {
+    addConstraint(*kind, req.getFirstType(), req.getSecondType(), locator,
+                  isFavored);
+  }
+
+  if (conformsToAnyObject) {
+    auto anyObject = getASTContext().getAnyObjectType();
+    addConstraint(ConstraintKind::ConformsTo, firstType, anyObject, locator);
+  }
+}
 
 void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
                                      Type second,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1044,55 +1044,33 @@ void ConstraintSystem::openGeneric(
 
   // Add the requirements as constraints.
   for (auto req : sig->getRequirements()) {
-  switch (req.getKind()) {
+    Optional<Requirement> openedReq;
+    auto openedFirst = openType(req.getFirstType(), replacements);
+
+    auto kind = req.getKind();
+    switch (kind) {
     case RequirementKind::Conformance: {
-      auto subjectTy = openType(req.getFirstType(), replacements);
       auto proto = req.getSecondType()->castTo<ProtocolType>();
       auto protoDecl = proto->getDecl();
-
       // Determine whether this is the protocol 'Self' constraint we should
       // skip.
       if (skipProtocolSelfConstraint &&
           protoDecl == outerDC &&
           protoDecl->getSelfInterfaceType()->isEqual(req.getFirstType()))
-        break;
-
-      addConstraint(ConstraintKind::ConformsTo, subjectTy, proto,
-                    locatorPtr);
+        continue;
+      openedReq = Requirement(kind, openedFirst, proto);
       break;
     }
-
-    case RequirementKind::Layout: {
-      auto subjectTy = openType(req.getFirstType(), replacements);
-      auto layoutConstraint = req.getLayoutConstraint();
-
-      if (layoutConstraint->isClass())
-        addConstraint(ConstraintKind::ConformsTo, subjectTy,
-                      TC.Context.getAnyObjectType(),
-                      locatorPtr);
-
-      // Nothing else can appear outside of @_specialize yet, and Sema
-      // doesn't know how to check.
+    case RequirementKind::Superclass:
+    case RequirementKind::SameType:
+      openedReq = Requirement(kind, openedFirst,
+                              openType(req.getSecondType(), replacements));
+      break;
+    case RequirementKind::Layout:
+      openedReq = Requirement(kind, openedFirst, req.getLayoutConstraint());
       break;
     }
-
-    case RequirementKind::Superclass: {
-      auto subjectTy = openType(req.getFirstType(), replacements);
-      auto boundTy = openType(req.getSecondType(), replacements);
-      addConstraint(ConstraintKind::Subtype, subjectTy, boundTy, locatorPtr);
-      addConstraint(ConstraintKind::ConformsTo, subjectTy,
-                    TC.Context.getAnyObjectType(),
-                    locatorPtr);
-      break;
-    }
-
-    case RequirementKind::SameType: {
-      auto firstTy = openType(req.getFirstType(), replacements);
-      auto secondTy = openType(req.getSecondType(), replacements);
-      addConstraint(ConstraintKind::Bind, firstTy, secondTy, locatorPtr);
-      break;
-    }
-  }
+    addConstraint(*openedReq, locatorPtr);
   }
 }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1715,6 +1715,10 @@ public:
                      ConstraintLocatorBuilder locator,
                      bool isFavored = false);
 
+  /// \brief Add a requirement as a constraint to the constraint system.
+  void addConstraint(Requirement req, ConstraintLocatorBuilder locator,
+                     bool isFavored = false);
+
   /// \brief Add a key path application constraint to the constraint system.
   void addKeyPathApplicationConstraint(Type keypath, Type root, Type value,
                                        ConstraintLocatorBuilder locator,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1624,6 +1624,15 @@ Expr *ExprTypeCheckListener::appliedSolution(Solution &solution, Expr *expr) {
   return expr;
 }
 
+void ParentConditionalConformance::diagnoseConformanceStack(
+    DiagnosticEngine &diags, SourceLoc loc,
+    ArrayRef<ParentConditionalConformance> conformances) {
+  for (auto history : reversed(conformances)) {
+    diags.diagnose(loc, diag::requirement_implied_by_conditional_conformance,
+                   history.ConformingType, history.Protocol);
+  }
+}
+
 GenericRequirementsCheckListener::~GenericRequirementsCheckListener() {}
 
 bool GenericRequirementsCheckListener::shouldCheck(RequirementKind kind,
@@ -1637,7 +1646,8 @@ void GenericRequirementsCheckListener::satisfiedConformance(
 }
 
 bool GenericRequirementsCheckListener::diagnoseUnsatisfiedRequirement(
-    const Requirement &req, Type first, Type second) {
+    const Requirement &req, Type first, Type second,
+    ArrayRef<ParentConditionalConformance> parents) {
   return false;
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2982,7 +2982,13 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
     // primitive literal protocols.
     auto conformsToProtocol = [&](KnownProtocolKind protoKind) {
         ProtocolDecl *proto = TC.getProtocol(ED->getLoc(), protoKind);
-        return TC.conformsToProtocol(rawTy, proto, ED->getDeclContext(), None);
+        auto conformance =
+            TC.conformsToProtocol(rawTy, proto, ED->getDeclContext(), None);
+        if (conformance)
+          assert(conformance->getConditionalRequirements().empty() &&
+                 "conditionally conforming to literal protocol not currently "
+                 "supported");
+        return conformance;
     };
 
     static auto otherLiteralProtocolKinds = {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -367,17 +367,6 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
         return;
       }
     }
-
-    // Constrained extensions cannot have inheritance clauses.
-    if (!inheritedClause.empty() &&
-        ext->getGenericParams() &&
-        ext->getGenericParams()->hasTrailingWhereClause()) {
-      diagnose(ext->getLoc(), diag::extension_constrained_inheritance,
-               ext->getExtendedType())
-      .highlight(SourceRange(inheritedClause.front().getSourceRange().Start,
-                             inheritedClause.back().getSourceRange().End));
-      ext->setInherited({ });
-    }
   }
 
   // Retrieve the location of the start of the inheritance clause.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1268,6 +1268,8 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         // pass it on up.
         return status;
       case RequirementCheckResult::Success:
+        assert(result.getConformance().getConditionalRequirements().empty() &&
+               "unhandled conditional requirements");
         // Report the conformance.
         if (listener && valid) {
           listener->satisfiedConformance(rawReq.getFirstType(), firstType,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1268,8 +1268,10 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         // pass it on up.
         return status;
       case RequirementCheckResult::Success:
-        assert(result.getConformance().getConditionalRequirements().empty() &&
-               "unhandled conditional requirements");
+        // FIXME: we should possibly have a queue of requirements (or
+        // ArrayRef<Requirements>) that this function works through, and add the
+        // conditional requirements to the end of this.
+
         // Report the conformance.
         if (listener && valid) {
           listener->satisfiedConformance(rawReq.getFirstType(), firstType,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6571,6 +6571,12 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         inferStaticInitializeObjCMetadata(classDecl);
       }
     }
+
+    // When requested, print out information about this conformance.
+    if (Context.LangOpts.DebugGenericSignatures) {
+      dc->dumpContext();
+      conformance->dump();
+    }
   }
 
   // Check all conformances.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5968,6 +5968,9 @@ bool TypeChecker::useObjectiveCBridgeableConformances(DeclContext *dc,
         WasUnsatisfied |= result.hasUnsatisfiedDependency();
         if (WasUnsatisfied)
           return Action::Stop;
+        if (result.getStatus() == RequirementCheckResult::Success)
+          assert(result.getConformance().getConditionalRequirements().empty() &&
+                 "cannot conform conditionally to _ObjectiveCBridgeable");
 
         // Set and Dictionary bridging also requires the conformance
         // of the key type to Hashable.
@@ -6062,6 +6065,9 @@ void TypeChecker::useBridgedNSErrorConformances(DeclContext *dc, Type type) {
   auto conformance = conformsToProtocol(type, bridgedStoredNSError, dc,
                                         ConformanceCheckFlags::Used);
   if (conformance && conformance->isConcrete()) {
+    assert(conformance->getConditionalRequirements().empty() &&
+           "cannot conform condtionally to _BridgedStoredNSError");
+
     // Hack: If we've used a conformance to the _BridgedStoredNSError
     // protocol, also use the RawRepresentable and _ErrorCodeProtocol
     // conformances on the Code associated type witness.
@@ -6080,6 +6086,9 @@ void TypeChecker::useBridgedNSErrorConformances(DeclContext *dc, Type type) {
                      (ConformanceCheckFlags::SuppressDependencyTracking|
                       ConformanceCheckFlags::Used));
   if (conformance && conformance->isConcrete()) {
+    assert(conformance->getConditionalRequirements().empty() &&
+           "cannot conform condtionally to _ErrorCodeProtocol");
+
     if (Type errorType = ProtocolConformanceRef::getTypeWitnessByName(
           type, *conformance, Context.Id_ErrorType, this)) {
       (void)conformsToProtocol(errorType, bridgedStoredNSError, dc,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -613,7 +613,10 @@ public:
                               sequence->getLoc());
       if (!conformance)
         return nullptr;
-      
+
+      assert(conformance->getConditionalRequirements().empty() &&
+             "conditionally conforming to Sequence is not currently supported");
+
       generatorTy = TC.getWitnessType(sequenceType, sequenceProto,
                                       *conformance,
                                       TC.Context.Id_Iterator,
@@ -664,7 +667,10 @@ public:
                             sequence->getLoc());
     if (!genConformance)
       return nullptr;
-    
+    assert(
+        genConformance->getConditionalRequirements().empty() &&
+        "conditionally conforming to IteratorProtocol not currently supported");
+
     Type elementTy = TC.getWitnessType(generatorTy, generatorProto,
                                        *genConformance, TC.Context.Id_Element,
                                        diag::iterator_protocol_broken);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -346,6 +346,28 @@ public:
                                 Expr *expr);
 };
 
+/// A conditional conformance that implied some other requirements. That is, \c
+/// ConformingType conforming to \c Protocol may have required additional
+/// requirements to be satisfied.
+///
+/// This is designed to be used in a stack of such requirements, which can be
+/// formatted with \c diagnoseConformanceStack.
+struct ParentConditionalConformance {
+  Type ConformingType;
+  ProtocolType *Protocol;
+
+  /// Format the stack \c conformances as a series of notes that trace a path of
+  /// conditional conformances that lead to some other failing requirement (that
+  /// is not in \c conformances).
+  ///
+  /// The end of \c conformances is the active end of the stack, i.e. \c
+  /// conformances[0] is a conditional conformance that requires \c
+  /// conformances[1], etc.
+  static void
+  diagnoseConformanceStack(DiagnosticEngine &diags, SourceLoc location,
+                           ArrayRef<ParentConditionalConformance> conformances);
+};
+
 /// An abstract interface that is used by `checkGenericArguments`.
 class GenericRequirementsCheckListener {
 public:
@@ -387,8 +409,9 @@ public:
   /// possibly represented by its generic substitute.
   ///
   /// \returns true if problem has been diagnosed, false otherwise.
-  virtual bool diagnoseUnsatisfiedRequirement(const Requirement &req,
-                                              Type first, Type second);
+  virtual bool diagnoseUnsatisfiedRequirement(
+      const Requirement &req, Type first, Type second,
+      ArrayRef<ParentConditionalConformance> parents);
 };
 
 /// The result of `checkGenericRequirement`.

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -89,3 +89,21 @@ struct ClassLessSpecific<T: C3> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific<T>
 // CHECK-NEXT: (normal_conformance type=ClassLessSpecific<T> protocol=P2)
 extension ClassLessSpecific: P2 where T: C1 {}
+
+
+// FIXME: these cases should be equivalent (and both with the same output as the
+// first), but the second one choses T as the representative of the
+// equivalence class containing both T and U in the extension's generic
+// signature, meaning the stored conditional requirement is T: P1, which isn't
+// true in the original type's generic signature.
+struct RedundancyOrderDependenceGood<T: P1, U> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood<T, T>
+// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, T> protocol=P2
+// CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
+extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
+struct RedundancyOrderDependenceBad<T, U: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad<T, T>
+// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, T> protocol=P2
+// CHECK-NEXT:   conforms_to: τ_0_0 P1
+// CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
+extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -1,0 +1,91 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %FileCheck %s < %t.dump
+
+protocol P1 {}
+protocol P2 {}
+protocol P3 {}
+protocol P4: P1 {}
+
+struct Free<T> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Free<T>
+// CHECK-NEXT: (normal_conformance type=Free<T> protocol=P2
+// CHECK-NEXT:   conforms_to: τ_0_0 P1)
+extension Free: P2 where T: P1 {}
+
+
+struct Constrained<T: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained<T>
+// CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
+// CHECK-NEXT:   conforms_to: τ_0_0 P3)
+extension Constrained: P2 where T: P3 {}
+
+
+struct RedundantSame<T: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame<T>
+// CHECK-NEXT: (normal_conformance type=RedundantSame<T> protocol=P2)
+extension RedundantSame: P2 where T: P1 {}
+
+struct RedundantSuper<T: P4> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper<T>
+// CHECK-NEXT: (normal_conformance type=RedundantSuper<T> protocol=P2)
+extension RedundantSuper: P2 where T: P1 {}
+
+struct OverlappingSub<T: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub<T>
+// CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
+// CHECK-NEXT:   conforms_to: τ_0_0 P4)
+extension OverlappingSub: P2 where T: P4 {}
+
+
+struct SameType<T> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType<Int>
+// CHECK-NEXT: (normal_conformance type=SameType<Int> protocol=P2
+// CHECK-NEXT:   same_type: τ_0_0 Int)
+extension SameType: P2 where T == Int {}
+
+
+struct SameTypeGeneric<T, U> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric<T, T>
+// CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, T> protocol=P2
+// CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
+extension SameTypeGeneric: P2 where T == U {}
+
+
+struct Infer<T, U> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer<Constrained<U>, U>
+// CHECK-NEXT: (normal_conformance type=Infer<Constrained<U>, U> protocol=P2
+// CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>
+// CHECK-NEXT:   conforms_to:  τ_0_1 P1)
+extension Infer: P2 where T == Constrained<U> {}
+
+
+struct InferRedundant<T, U: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant<Constrained<U>, U>
+// CHECK-NEXT: (normal_conformance type=InferRedundant<Constrained<U>, U> protocol=P2
+// CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>)
+extension InferRedundant: P2 where T == Constrained<U> {}
+
+
+class C1 {}
+class C2: C1 {}
+class C3: C2 {}
+
+struct ClassFree<T> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree<T>
+// CHECK-NEXT: (normal_conformance type=ClassFree<T> protocol=P2
+// CHECK-NEXT:   superclass: τ_0_0 C1)
+extension ClassFree: P2 where T: C1 {}
+
+
+struct ClassMoreSpecific<T: C1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific<T>
+// CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
+// CHECK-NEXT:   superclass: τ_0_0 C3)
+extension ClassMoreSpecific: P2 where T: C3 {}
+
+
+struct ClassLessSpecific<T: C3> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific<T>
+// CHECK-NEXT: (normal_conformance type=ClassLessSpecific<T> protocol=P2)
+extension ClassLessSpecific: P2 where T: C1 {}

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -7,19 +7,45 @@ protocol P2 {}
 protocol P3 {}
 protocol P4: P1 {}
 
+protocol Assoc { associatedtype AT }
+
+func takes_P2<X: P2>(_: X) {}
+// expected-note@-1{{in call to function 'takes_P2'}}
+// expected-note@-2{{in call to function 'takes_P2'}}
+// expected-note@-3{{in call to function 'takes_P2'}}
+// expected-note@-4{{in call to function 'takes_P2'}}
+// expected-note@-5{{in call to function 'takes_P2'}}
+// expected-note@-6{{in call to function 'takes_P2'}}
+// expected-note@-7{{in call to function 'takes_P2'}}
+// expected-note@-8{{in call to function 'takes_P2'}}
+// expected-note@-9{{in call to function 'takes_P2'}}
+// expected-note@-10{{in call to function 'takes_P2'}}
+
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free<T>
 // CHECK-NEXT: (normal_conformance type=Free<T> protocol=P2
 // CHECK-NEXT:   conforms_to: τ_0_0 P1)
 extension Free: P2 where T: P1 {}
-
+func free_good<U: P1>(_: U) {
+    takes_P2(Free<U>())
+}
+func free_bad<U>(_: U) {
+    takes_P2(Free<U>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
 
 struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained<T>
 // CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
 // CHECK-NEXT:   conforms_to: τ_0_0 P3)
 extension Constrained: P2 where T: P3 {}
-
+func constrained_good<U: P1 & P3>(_: U) {
+    takes_P2(Constrained<U>())
+}
+func constrained_bad<U: P1>(_: U) {
+    takes_P2(Constrained<U>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
 
 struct RedundantSame<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame<T>
@@ -36,6 +62,13 @@ struct OverlappingSub<T: P1> {}
 // CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
 // CHECK-NEXT:   conforms_to: τ_0_0 P4)
 extension OverlappingSub: P2 where T: P4 {}
+func overlapping_sub_good<U: P4>(_: U) {
+    takes_P2(OverlappingSub<U>())
+}
+func overlapping_sub_bad<U: P1>(_: U) {
+    takes_P2(OverlappingSub<U>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
 
 
 struct SameType<T> {}
@@ -43,6 +76,18 @@ struct SameType<T> {}
 // CHECK-NEXT: (normal_conformance type=SameType<Int> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 Int)
 extension SameType: P2 where T == Int {}
+// FIXME: the compiler gets this... exactly backwards. :( For the incorrectly
+// accepted cases, it seems the compiler ends up with a (specialized_conformance
+// type=SameType<Float> ... same_type: Int Int ...) for the (normal_conformance
+// type=SameType<Int> ...).
+func same_type_good() {
+    takes_P2(SameType<Int>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
+func same_type_bad<U>(_: U) {
+    takes_P2(SameType<U>())
+    takes_P2(SameType<Float>())
+}
 
 
 struct SameTypeGeneric<T, U> {}
@@ -50,6 +95,21 @@ struct SameTypeGeneric<T, U> {}
 // CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, T> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
 extension SameTypeGeneric: P2 where T == U {}
+func same_type_generic_good<U, V>(_: U, _: V)
+  where U: Assoc, V: Assoc, U.AT == V.AT
+{
+    takes_P2(SameTypeGeneric<Int, Int>())
+    takes_P2(SameTypeGeneric<U, U>())
+    takes_P2(SameTypeGeneric<U.AT, V.AT>())
+}
+func same_type_bad<U, V>(_: U, _: V) {
+    takes_P2(SameTypeGeneric<U, V>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    takes_P2(SameTypeGeneric<U, Int>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    takes_P2(SameTypeGeneric<Int, Float>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
 
 
 struct Infer<T, U> {}
@@ -58,13 +118,30 @@ struct Infer<T, U> {}
 // CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>
 // CHECK-NEXT:   conforms_to:  τ_0_1 P1)
 extension Infer: P2 where T == Constrained<U> {}
-
+func infer_good<U: P1>(_: U) {
+    takes_P2(Infer<Constrained<U>, U>())
+}
+func infer_bad<U: P1, V>(_: U, _: V) {
+    takes_P2(Infer<Constrained<U>, V>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    takes_P2(Infer<Constrained<V>, V>())
+    // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
+}
 
 struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant<Constrained<U>, U>
 // CHECK-NEXT: (normal_conformance type=InferRedundant<Constrained<U>, U> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>)
 extension InferRedundant: P2 where T == Constrained<U> {}
+func infer_redundant_good<U: P1>(_: U) {
+    takes_P2(InferRedundant<Constrained<U>, U>())
+}
+func infer_redundant_bad<U: P1, V>(_: U, _: V) {
+    takes_P2(InferRedundant<Constrained<U>, V>())
+    // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
+    takes_P2(InferRedundant<Constrained<V>, V>())
+    // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
+}
 
 
 class C1 {}
@@ -76,13 +153,26 @@ struct ClassFree<T> {}
 // CHECK-NEXT: (normal_conformance type=ClassFree<T> protocol=P2
 // CHECK-NEXT:   superclass: τ_0_0 C1)
 extension ClassFree: P2 where T: C1 {}
-
+func class_free_good<U: C1>(_: U) {
+    takes_P2(ClassFree<U>())
+}
+func class_free_bad<U>(_: U) {
+    takes_P2(ClassFree<U>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
 
 struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific<T>
 // CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
 // CHECK-NEXT:   superclass: τ_0_0 C3)
 extension ClassMoreSpecific: P2 where T: C3 {}
+func class_more_specific_good<U: C3>(_: U) {
+    takes_P2(ClassMoreSpecific<U>())
+}
+func class_more_specific_bad<U: C1>(_: U) {
+    takes_P2(ClassMoreSpecific<U>())
+    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+}
 
 
 struct ClassLessSpecific<T: C3> {}

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -11,15 +11,16 @@ protocol Assoc { associatedtype AT }
 
 func takes_P2<X: P2>(_: X) {}
 // expected-note@-1{{in call to function 'takes_P2'}}
-// expected-note@-2{{in call to function 'takes_P2'}}
-// expected-note@-3{{in call to function 'takes_P2'}}
-// expected-note@-4{{in call to function 'takes_P2'}}
-// expected-note@-5{{in call to function 'takes_P2'}}
-// expected-note@-6{{in call to function 'takes_P2'}}
-// expected-note@-7{{in call to function 'takes_P2'}}
-// expected-note@-8{{in call to function 'takes_P2'}}
-// expected-note@-9{{in call to function 'takes_P2'}}
-// expected-note@-10{{in call to function 'takes_P2'}}
+// expected-note@-2{{candidate requires that the types 'U' and 'V' be equivalent (requirement specified as 'U' == 'V')}}
+// expected-note@-3{{requirement from conditional conformance of 'SameTypeGeneric<U, V>' to 'P2'}}
+// expected-note@-4{{candidate requires that the types 'U' and 'Int' be equivalent (requirement specified as 'U' == 'Int')}}
+// expected-note@-5{{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
+// expected-note@-6{{candidate requires that the types 'Int' and 'Float' be equivalent (requirement specified as 'Int' == 'Float')}}
+// expected-note@-7{{requirement from conditional conformance of 'SameTypeGeneric<Int, Float>' to 'P2'}}
+// expected-note@-8{{candidate requires that 'C1' inherit from 'U' (requirement specified as 'U' : 'C1')}}
+// expected-note@-9{{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
+// expected-note@-10{{candidate requires that 'C3' inherit from 'U' (requirement specified as 'U' : 'C3')}}
+// expected-note@-11{{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
 
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free<T>
@@ -31,7 +32,9 @@ func free_good<U: P1>(_: U) {
 }
 func free_bad<U>(_: U) {
     takes_P2(Free<U>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P1'}}
+    // expected-note@-2{{requirement specified as 'U' : 'P1'}}
+    // expected-note@-3{{requirement from conditional conformance of 'Free<U>' to 'P2'}}
 }
 
 struct Constrained<T: P1> {}
@@ -44,7 +47,9 @@ func constrained_good<U: P1 & P3>(_: U) {
 }
 func constrained_bad<U: P1>(_: U) {
     takes_P2(Constrained<U>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P3'}}
+    // expected-note@-2{{requirement specified as 'U' : 'P3'}}
+    // expected-note@-3{{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
 }
 
 struct RedundantSame<T: P1> {}
@@ -67,7 +72,9 @@ func overlapping_sub_good<U: P4>(_: U) {
 }
 func overlapping_sub_bad<U: P1>(_: U) {
     takes_P2(OverlappingSub<U>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'U' conform to 'P4'}}
+    // expected-note@-2{{requirement specified as 'U' : 'P4'}}
+    // expected-note@-3{{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
 }
 
 
@@ -104,11 +111,11 @@ func same_type_generic_good<U, V>(_: U, _: V)
 }
 func same_type_bad<U, V>(_: U, _: V) {
     takes_P2(SameTypeGeneric<U, V>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<U, V>)'}}
     takes_P2(SameTypeGeneric<U, Int>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<U, Int>)'}}
     takes_P2(SameTypeGeneric<Int, Float>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(SameTypeGeneric<Int, Float>)'}}
 }
 
 
@@ -123,7 +130,9 @@ func infer_good<U: P1>(_: U) {
 }
 func infer_bad<U: P1, V>(_: U, _: V) {
     takes_P2(Infer<Constrained<U>, V>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{'<X where X : P2> (X) -> ()' requires that 'V' conform to 'P1'}}
+    // expected-note@-2{{requirement specified as 'V' : 'P1'}}
+    // expected-note@-3{{requirement from conditional conformance of 'Infer<Constrained<U>, V>' to 'P2'}}
     takes_P2(Infer<Constrained<V>, V>())
     // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
 }
@@ -137,10 +146,10 @@ func infer_redundant_good<U: P1>(_: U) {
     takes_P2(InferRedundant<Constrained<U>, U>())
 }
 func infer_redundant_bad<U: P1, V>(_: U, _: V) {
-    takes_P2(InferRedundant<Constrained<U>, V>())
-    // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
-    takes_P2(InferRedundant<Constrained<V>, V>())
-    // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
+  takes_P2(InferRedundant<Constrained<U>, V>())
+  // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
+  takes_P2(InferRedundant<Constrained<V>, V>())
+  // expected-error@-1{{type 'V' does not conform to protocol 'P1'}}
 }
 
 
@@ -158,7 +167,7 @@ func class_free_good<U: C1>(_: U) {
 }
 func class_free_bad<U>(_: U) {
     takes_P2(ClassFree<U>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(ClassFree<U>)'}}
 }
 
 struct ClassMoreSpecific<T: C1> {}
@@ -171,7 +180,7 @@ func class_more_specific_good<U: C3>(_: U) {
 }
 func class_more_specific_bad<U: C1>(_: U) {
     takes_P2(ClassMoreSpecific<U>())
-    // expected-error@-1{{generic parameter 'X' could not be inferred}}
+    // expected-error@-1{{cannot invoke 'takes_P2(_:)' with an argument list of type '(ClassMoreSpecific<U>)'}}
 }
 
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -399,3 +399,28 @@ protocol P31 { }
 // CHECK-LABEL: .sameTypeNameMatch1@
 // CHECK: Generic signature: <T where T : P29, T : P30, T.X : P31, T.X == T.X>
 func sameTypeNameMatch1<T: P29 & P30>(_: T) where T.X: P31 { }
+
+// ----------------------------------------------------------------------------
+// Infer requirements from conditional conformances
+// ----------------------------------------------------------------------------
+
+protocol P32 {}
+protocol P33 {
+  associatedtype A: P32
+}
+protocol P34 {}
+struct Foo<T> {}
+extension Foo: P32 where T: P34 {}
+
+// Inference chain: U.A: P32 => Foo<V>: P32 => V: P34
+
+// CHECK-LABEL: conditionalConformance1@
+// CHECK: Generic signature: <U, V where U : P33, V : P34, U.A == Foo<V>>
+// CHECK: Canonical generic signature: <τ_0_0, τ_0_1 where τ_0_0 : P33, τ_0_1 : P34, τ_0_0.A == Foo<τ_0_1>>
+func conditionalConformance1<U: P33, V>(_: U) where U.A == Foo<V> {}
+
+struct Bar<U: P32> {}
+// CHECK-LABEL: conditionalConformance2@
+// CHECK: Generic signature: <V where V : P34>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P34>
+func conditionalConformance2<V>(_: Bar<Foo<V>>) {}

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -134,7 +134,7 @@ func genericClassNotEquatable<T>(_ gc: GenericClass<T>, x: T, y: T) {
 
 extension Array where Element == String { }
 
-extension GenericClass : P3 where T : P3 { } // expected-error{{extension of type 'GenericClass' with constraints cannot have an inheritance clause}}
+extension GenericClass : P3 where T : P3 { }
 
 extension GenericClass where Self : P3 { }
 // expected-error@-1{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}} {{30-34=GenericClass}}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1132,9 +1132,10 @@ extension rdar17391625derived {
 }
 
 // <rdar://problem/27671033> Crash when defining property inside an invalid extension
+// (This extension is no longer invalid.)
 public protocol rdar27671033P {}
 struct rdar27671033S<Key, Value> {}
-extension rdar27671033S : rdar27671033P where Key == String { // expected-error {{extension of type 'rdar27671033S' with constraints cannot have an inheritance clause}}
+extension rdar27671033S : rdar27671033P where Key == String {
   let d = rdar27671033S<Int, Int>() // expected-error {{extensions must not contain stored properties}}
 }
 

--- a/validation-test/compiler_crashers_fixed/28838-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28838-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{typealias e:A
 protocol A:P{}typealias a
 class a<a


### PR DESCRIPTION
Currently just removes restriction and adds some basic recording of conditionality, and feeds that information through to the GSB and constraint solver and anywhere else that needs it. This doesn't do the SILGen/IRGen/Runtime work required to be able to actually interact with these conformances at runtime.