### PR TITLE
[SR-5856] Fix diagnostic for static stored properties in protocol extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1195,7 +1195,7 @@ ERROR(indirect_case_in_indirect_enum,none,
 // Variables (var and let).
 ERROR(unimplemented_static_var,none,
       "%select{ERROR|static|class}1 stored properties not supported"
-      "%select{ in this context| in generic types| in classes}0"
+      "%select{ in this context| in generic types| in classes| in protocol extensions}0"
       "%select{|; did you mean 'static'?}2",
       (unsigned, StaticSpellingKind, unsigned))
 ERROR(observingprop_requires_initializer,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4103,6 +4103,7 @@ public:
           Misc,
           GenericTypes,
           Classes,
+          ProtocolExtensions
         };
         auto unimplementedStatic = [&](unsigned diagSel) {
           auto staticLoc = PBD->getStaticLoc();
@@ -4120,6 +4121,8 @@ public:
 
         // Stored type variables in a generic context need to logically
         // occur once per instantiation, which we don't yet handle.
+        } else if (DC->getAsProtocolExtensionContext()) {
+            unimplementedStatic(ProtocolExtensions);
         } else if (DC->isGenericContext()
                && !DC->getGenericSignatureOfContext()->areAllParamsConcrete()) {
           unimplementedStatic(GenericTypes);

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -469,7 +469,7 @@ protocol ProtocolWithExtension1 {
 }
 extension ProtocolWithExtension1 {
   var fooExt: Int // expected-error{{extensions may not contain stored properties}}
-  static var fooExtStatic = 4 // expected-error{{static stored properties not supported in generic types}}
+  static var fooExtStatic = 4 // expected-error{{static stored properties not supported in protocol extensions}}
 }
 
 func getS() -> S {

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -35,3 +35,12 @@ struct Foo {
 func & (x: Foo, y: Foo) -> Foo { }
 
 var fooValue: Foo = .Bar & .Wibble
+
+
+public protocol P1 {
+    var bar: String { get }
+}
+
+public extension P1 {
+    public static let baz = "Test" // expected-error {{static stored properties not supported in protocol extensions}}
+}

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -35,12 +35,3 @@ struct Foo {
 func & (x: Foo, y: Foo) -> Foo { }
 
 var fooValue: Foo = .Bar & .Wibble
-
-
-public protocol P1 {
-    var bar: String { get }
-}
-
-public extension P1 {
-    public static let baz = "Test" // expected-error {{static stored properties not supported in protocol extensions}}
-}


### PR DESCRIPTION
This PR fixes a confusing error message "error: static stored properties not supported in generic types" when the compiler detects static properties in a protocol extension.   

Instead if DeclContext->getAsProtocolExtensionContext() is not NULL in this case, the compiler will emit "static stored properties not supported in protocol extensions"

Includes an amended unit test for this diagnostic. However this is my first time submitting a PR for swift so I'm yet to run the full test suite.

Resolves [SR-5856](https://bugs.swift.org/browse/SR-5856) 
