### PR TITLE
Handle re-exported Clang modules

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -488,7 +488,7 @@ public:
   }
 
   /// Returns the associated clang module if one exists.
-  const clang::Module *findUnderlyingClangModule();
+  const clang::Module *findUnderlyingClangModule() const;
 
   SourceRange getSourceRange() const { return SourceRange(); }
 
@@ -719,7 +719,9 @@ public:
   }
 
   /// Returns the associated clang module if one exists.
-  virtual const clang::Module *getUnderlyingClangModule() { return nullptr; }
+  virtual const clang::Module *getUnderlyingClangModule() const {
+    return nullptr;
+  }
 
   /// Traverse the decls within this file.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -317,6 +317,15 @@ public:
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,
                              ArrayRef<clang::Module *> Exported);
-}
+
+/// Determine whether \c overlayDC is within an overlay module for the
+/// imported context enclosing \c importedDC.
+///
+/// This routine is used for various hacks that are only permitted within
+/// overlays of imported modules, e.g., Objective-C bridging conformances.
+bool isInOverlayModuleForImportedModule(DeclContext *overlayDC,
+                                        DeclContext *importedDC);
+
+} // end namespace swift
 
 #endif

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -102,7 +102,7 @@ public:
 
   virtual StringRef getFilename() const override;
 
-  virtual const clang::Module *getUnderlyingClangModule() override {
+  virtual const clang::Module *getUnderlyingClangModule() const override {
     return getClangModule();
   }
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -193,7 +193,7 @@ public:
 
   bool hasEntryPoint() const override;
 
-  virtual const clang::Module *getUnderlyingClangModule() override;
+  virtual const clang::Module *getUnderlyingClangModule() const override;
 
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1214,7 +1214,7 @@ bool ModuleDecl::walk(ASTWalker &Walker) {
   return false;
 }
 
-const clang::Module *ModuleDecl::findUnderlyingClangModule() {
+const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
   for (auto *FU : getFiles()) {
     if (auto *Mod = FU->getUnderlyingClangModule())
       return Mod;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3323,3 +3323,16 @@ importName(const clang::NamedDecl *D,
   return Impl.importFullName(D, Impl.CurrentVersion, preferredName).
     getDeclName();
 }
+
+bool swift::isInOverlayModuleForImportedModule(DeclContext *overlayDC,
+                                               DeclContext *importedDC) {
+  overlayDC = overlayDC->getModuleScopeContext();
+  importedDC = importedDC->getModuleScopeContext();
+
+  auto importedClangModuleUnit = dyn_cast<ClangModuleUnit>(importedDC);
+  if (!importedClangModuleUnit)
+    return false;
+
+  auto overlayModule = overlayDC->getParentModule();
+  return overlayModule == importedClangModuleUnit->getAdapterModule();
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3334,5 +3334,12 @@ bool swift::isInOverlayModuleForImportedModule(DeclContext *overlayDC,
     return false;
 
   auto overlayModule = overlayDC->getParentModule();
-  return overlayModule == importedClangModuleUnit->getAdapterModule();
+  if (overlayModule == importedClangModuleUnit->getAdapterModule())
+    return true;
+
+  // Is this a private module that's re-exported to the public (overlay) name?
+  auto clangModule =
+    importedClangModuleUnit->getClangModule()->getTopLevelModule();
+  return !clangModule->ExportAsModule.empty() &&
+    clangModule->ExportAsModule == overlayModule->getName().str();
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -22,8 +22,8 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Types.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Parse/Lexer.h"
-#include "swift/ClangImporter/ClangModule.h" // FIXME: SDK overlay semantics
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
@@ -1327,19 +1327,7 @@ static bool isObjCClassExtensionInOverlay(DeclContext *dc) {
   if (!classDecl)
     return false;
 
-  // The class must be defined in Objective-C.
-  if (!classDecl->hasClangNode())
-    return false;
-
-  // Find the Clang module unit that stores the class.
-  auto classModuleUnit
-    = dyn_cast<ClangModuleUnit>(classDecl->getModuleScopeContext());
-  if (!classModuleUnit)
-    return false;
-
-  // Check whether the extension is in the overlay.
-  auto extModule = ext->getDeclContext()->getParentModule();
-  return extModule == classModuleUnit->getAdapterModule();
+  return isInOverlayModuleForImportedModule(ext, classDecl);
 }
 
 void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5429,9 +5429,9 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   if (Proto->isSpecificProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
     if (auto nominal = Adoptee->getAnyNominal()) {
       if (!TC.Context.isTypeBridgedInExternalModule(nominal)) {
-        auto nominalModule = nominal->getParentModule();
-        auto conformanceModule = DC->getParentModule();
-        if (nominalModule->getName() != conformanceModule->getName()) {
+        if (nominal->getParentModule() != DC->getParentModule() &&
+            !isInOverlayModuleForImportedModule(DC, nominal)) {
+          auto nominalModule = nominal->getParentModule();
           TC.diagnose(Loc, diag::nonlocal_bridged_to_objc, nominal->getName(),
                       Proto->getName(), nominalModule->getName());
         }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -531,6 +531,15 @@ IdentifierID Serializer::addModuleRef(const ModuleDecl *M) {
   if (M == clangImporter->getImportedHeaderModule())
     return OBJC_HEADER_MODULE_ID;
 
+  // If we're referring to a member of a private module that will be
+  // re-exported via a public module, record the public module's name.
+  if (auto clangModule = M->findUnderlyingClangModule()) {
+    if (!clangModule->ExportAsModule.empty()) {
+      auto publicModuleName =
+        M->getASTContext().getIdentifier(clangModule->ExportAsModule);
+      return addDeclBaseNameRef(publicModuleName);
+    }
+  }
   assert(!M->getName().empty());
   return addDeclBaseNameRef(M->getName());
 }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -614,7 +614,7 @@ StringRef SerializedASTFile::getFilename() const {
   return File.getModuleFilename();
 }
 
-const clang::Module *SerializedASTFile::getUnderlyingClangModule() {
+const clang::Module *SerializedASTFile::getUnderlyingClangModule() const {
   if (auto *ShadowedModule = File.getShadowedModule())
     return ShadowedModule->findUnderlyingClangModule();
   return nullptr;

--- a/test/ClangImporter/Inputs/privateframeworks/overlay/SomeKit.swift
+++ b/test/ClangImporter/Inputs/privateframeworks/overlay/SomeKit.swift
@@ -1,0 +1,9 @@
+@_exported import SomeKit
+
+extension SKWidget {
+  public func extensionMethod() -> ExtensionType { return ExtensionType() }
+
+  public struct ExtensionType { }
+}
+
+

--- a/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SKWidget.h
@@ -1,0 +1,4 @@
+@import ObjectiveC;
+
+@interface SKWidget : NSObject
+@end

--- a/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SomeKit.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SomeKit.h
@@ -1,0 +1,1 @@
+#import <SomeKit/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module SomeKit {
+  umbrella header "SomeKit.h"
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Headers/SKWidget.h
@@ -1,0 +1,1 @@
+#import <SomeKitCore/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Headers/SomeKit.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Headers/SomeKit.h
@@ -1,0 +1,1 @@
+#import <SomeKit/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module SomeKit {
+  umbrella header "SomeKit.h"
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SKWidget.h
@@ -1,0 +1,4 @@
+@import ObjectiveC;
+
+@interface SKWidget : NSObject
+@end

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SomeKitCore.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SomeKitCore.h
@@ -1,0 +1,1 @@
+#import <SomeKitCore/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module SomeKitCore {
+  umbrella header "SomeKitCore.h"
+  export_as SomeKit
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -7,9 +7,10 @@
 // Use the overlay with private frameworks.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/privateframeworks/withprivate -I %t %s -verify
 
+// Use the overlay without private frameworks.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/privateframeworks/withoutprivate -I %t %s -verify
+
 import SomeKit
-
-
 
 func testWidget(widget: SKWidget) {
   _ = widget.extensionMethod()

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// Build the overlay with private frameworks.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -F %S/Inputs/privateframeworks/withprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
+
+// Use the overlay with private frameworks.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/privateframeworks/withprivate -I %t %s -verify
+
+import SomeKit
+
+
+
+func testWidget(widget: SKWidget) {
+  _ = widget.extensionMethod()
+}
+

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -10,6 +10,8 @@
 // Use the overlay without private frameworks.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/privateframeworks/withoutprivate -I %t %s -verify
 
+// REQUIRES: objc_interop
+
 import SomeKit
 
 func testWidget(widget: SKWidget) {


### PR DESCRIPTION
Private Clang modules can state that they re-export their interfaces through a public module. When the Clang module states that it does so, treat entities from the private module "as if" they came from the public module:

* Allow those entities to behave as if they were written in the public module when compiling an overlay for that public module
* Serialize cross-references to the private module entity as references to the re-exporting public module
* When deserializing cross-references, allow us to find entities within any of the private modules re-exported to a public module when we expect them to be in the public module.

Addresses rdar://problem/34438586.