### PR TITLE
[GlobalPropertyOpt] Simplify the code a little bit. NFCI.

### DIFF
--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -68,18 +68,15 @@ class GlobalPropertyOpt {
 
 #ifndef NDEBUG
     friend raw_ostream &operator<<(raw_ostream &os, const Entry &entry) {
-      if (entry.Field) {
-        os << "field " << entry.Field->getName() << '\n';
-      } else if (!entry.Value) {
-        os << "unknown-address\n";
-      } else if (auto *Inst = dyn_cast<SILInstruction>(entry.Value)) {
-        os << Inst->getParent()->getParent()->getName() << ": " << entry.Value;
-      } else if (auto *Arg = dyn_cast<SILArgument>(entry.Value)) {
-        os << Arg->getParent()->getParent()->getName() << ": " << entry.Value;
-      } else {
-        os << entry.Value;
-      }
-      return os;
+      if (entry.Field)
+        return os << "field " << entry.Field->getName() << '\n';
+      if (!entry.Value)
+        return os << "unknown-address\n";
+      if (auto *Inst = dyn_cast<SILInstruction>(entry.Value))
+        os << Inst->getFunction()->getName() << ": " << entry.Value;
+      if (auto *Arg = dyn_cast<SILArgument>(entry.Value))
+        return os << Arg->getFunction()->getName() << ": " << entry.Value;
+      return os << entry.Value;
     }
 #endif
   };


### PR DESCRIPTION
Use getFunction() instead of recursive calls to getParent() and
return early.