### PR TITLE
Re-apply "Preserve SIL when merging modules"

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -663,13 +663,11 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
   if (auto inherited = dyn_cast<InheritedProtocolConformance>(conformance)) {
     // Dig out the conforming nominal type.
     auto rootConformance = inherited->getRootNormalConformance();
-    auto conformingNominal
+    auto conformingClass
       = rootConformance->getType()->getClassOrBoundGenericClass();
 
     // Map up to our superclass's type.
-    Type superclassTy = type->getSuperclass();
-    while (superclassTy->getAnyNominal() != conformingNominal)
-      superclassTy = superclassTy->getSuperclass();
+    auto superclassTy = type->getSuperclassForDecl(conformingClass);
 
     // Compute the conformance for the inherited type.
     auto inheritedConformance = lookupConformance(superclassTy, protocol);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -687,6 +687,14 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   // serialized ASTs.
   Arguments.push_back("-parse-as-library");
 
+  // Merge serialized SIL from partial modules.
+  Arguments.push_back("-sil-merge-partial-modules");
+
+  // Disable SIL optimization passes; we've already optimized the code in each
+  // partial mode.
+  Arguments.push_back("-disable-diagnostic-passes");
+  Arguments.push_back("-disable-sil-perf-optzns");
+
   addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
                         Arguments);
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4034,7 +4034,14 @@ IRGenFunction::emitValueWitnessTableRef(SILType type,
 std::pair<llvm::Value *, llvm::Value *>
 irgen::emitClassFragileInstanceSizeAndAlignMask(IRGenFunction &IGF,
                                                 ClassDecl *theClass,
-                                                llvm::Value *metadata) {  
+                                                llvm::Value *metadata) {
+  // FIXME: The below checks should capture this property already, but
+  // resilient class metadata layout is not fully implemented yet.
+  auto expansion = IGF.IGM.getResilienceExpansionForLayout(theClass);
+  if (IGF.IGM.isResilient(theClass, expansion)) {
+    return emitClassResilientInstanceSizeAndAlignMask(IGF, theClass, metadata);
+  }
+
   // If the class has fragile fixed layout, return the constant size and
   // alignment.
   if (llvm::Constant *size

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -117,16 +117,12 @@ swift::getLinkageForProtocolConformance(const NormalProtocolConformance *C,
   if (C->isBehaviorConformance())
     return (definition ? SILLinkage::Private : SILLinkage::PrivateExternal);
 
-  ModuleDecl *conformanceModule = C->getDeclContext()->getParentModule();
-
   // If the conformance was synthesized by the ClangImporter, give it
   // shared linkage.
-  auto typeDecl = C->getType()->getNominalOrBoundGenericNominal();
-  auto typeUnit = typeDecl->getModuleScopeContext();
-  if (isa<ClangModuleUnit>(typeUnit)
-      && conformanceModule == typeUnit->getParentModule())
+  if (isa<ClangModuleUnit>(C->getDeclContext()->getModuleScopeContext()))
     return SILLinkage::Shared;
 
+  auto typeDecl = C->getType()->getNominalOrBoundGenericNominal();
   AccessLevel access = std::min(C->getProtocol()->getEffectiveAccess(),
                                 typeDecl->getEffectiveAccess());
   switch (access) {

--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/ADT/SmallString.h"
 
@@ -160,6 +161,11 @@ Identifier SILWitnessTable::getIdentifier() const {
 bool SILWitnessTable::conformanceIsSerialized(ProtocolConformance *conformance,
                                               ResilienceStrategy strategy,
                                               bool silSerializeWitnessTables) {
+  // Serialize witness tables for conformances synthesized by
+  // the ClangImporter.
+  if (isa<ClangModuleUnit>(conformance->getDeclContext()->getModuleScopeContext()))
+    return true;
+
   auto *nominal = conformance->getType()->getAnyNominal();
   // Only serialize if the witness table is sufficiently static, and resilience
   // is explicitly enabled for this compilation or if we serialize all eligible

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -1,14 +1,14 @@
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend -DVALUE -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=VALUE
-// RUN: %target-swift-frontend -DEMPTYCATCH -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=EMPTYCATCH
-// RUN: %target-swift-frontend -DASQEXPR -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASQEXPR
-// RUN: %target-swift-frontend -DASBANGEXPR -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASBANGEXPR
-// RUN: %target-swift-frontend -DCATCHIS -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHIS
-// RUN: %target-swift-frontend -DCATCHAS -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHAS
-// RUN: %target-swift-frontend -DGENERICONLY -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=GENERICONLY
+// RUN: %target-swift-frontend -DVALUE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=VALUE
+// RUN: %target-swift-frontend -DEMPTYCATCH -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=EMPTYCATCH
+// RUN: %target-swift-frontend -DASQEXPR -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASQEXPR
+// RUN: %target-swift-frontend -DASBANGEXPR -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASBANGEXPR
+// RUN: %target-swift-frontend -DCATCHIS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHIS
+// RUN: %target-swift-frontend -DCATCHAS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHAS
+// RUN: %target-swift-frontend -DGENERICONLY -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=GENERICONLY
 
-// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
+// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
 // RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-error.h -DERRORS -verify
 
 // RUN: echo '#include "enum-error.h"' > %t.m

--- a/test/IRGen/class_resilience.sil
+++ b/test/IRGen/class_resilience.sil
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class %S/../Inputs/resilient_class.swift -I %t
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %s
+
+// REQUIRES: CPU=x86_64
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+import resilient_class
+
+// Make sure that an alloc_ref of a resilient class loads the size and alignment
+// of the instance from metadata.
+//
+// Perhaps we should not serialize allocating initializers, then this would not
+// be an issue.
+
+// CHECK-LABEL: define {{(protected )?}}swiftcc void @allocResilientOutsideParent()
+// CHECK: [[META:%.*]] = call %swift.type* @_T015resilient_class22ResilientOutsideParentCMa()
+// CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*
+// CHECK-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
+// CHECK-NEXT: [[SIZE_PTR:%.*]] = bitcast i8* [[SIZE_ADDR]] to i32*
+// CHECK-NEXT: [[SIZE_2:%.*]] = load i32, i32* [[SIZE_PTR]], align 8
+// CHECK-NEXT: [[SIZE:%.*]] = zext i32 [[SIZE_2]] to i64
+// CHECK-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
+// CHECK-NEXT: [[ALIGN_PTR:%.*]] = bitcast i8* [[ALIGN_ADDR]] to i16*
+// CHECK-NEXT: [[ALIGN_2:%.*]] = load i16, i16* [[ALIGN_PTR]], align 4
+// CHECK-NEXT: [[ALIGN:%.*]] = zext i16 [[ALIGN_2]] to i64
+// CHECK-NEXT: call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[META]], i64 [[SIZE]], i64 [[ALIGN]])
+
+sil @allocResilientOutsideParent : $@convention(thin) () -> () {
+bb0:
+  %c = alloc_ref $ResilientOutsideParent
+  dealloc_ref %c : $ResilientOutsideParent
+  %result = tuple ()
+  return %result : $()
+}

--- a/test/SILGen/SILDeclRef.swift
+++ b/test/SILGen/SILDeclRef.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -sil-serialize-witness-tables %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -sil-serialize-witness-tables %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
 
 // Check that all SILDeclRefs are represented in the text form with a signature.
 // This allows to avoid ambiguities which sometimes arise e.g. when a
@@ -62,7 +62,7 @@ public func testBase(b: Base) -> Int32 {
 // CHECK-NEXT:  #Base.deinit!deallocator: _T010SILDeclRef4BaseCfD	// Base.__deallocating_deinit
 // CHECK-NEXT: }
 
-// CHECK:sil_witness_table [serialized] Base: P module SILDeclRef {
+// CHECK:sil_witness_table Base: P module SILDeclRef {
 // CHECK-NEXT: method #P.foo!1: <Self where Self : P> (Self) -> () -> Int32 : @_T010SILDeclRef4BaseCAA1PA2aDP3foos5Int32VyFTW	// protocol witness for P.foo()
 // CHECK-NEXT: method #P.foo!1: <Self where Self : P> (Self) -> (Int32) -> () : @_T010SILDeclRef4BaseCAA1PA2aDP3fooys5Int32V1n_tFTW	// protocol witness for P.foo(n:) in conformance Base
 // CHECK-NEXT: }

--- a/test/SILGen/external-associated-type-conformance.swift
+++ b/test/SILGen/external-associated-type-conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -import-objc-header %S/Inputs/external-associated-type-conformance.h %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/external-associated-type-conformance.h %s -enable-sil-ownership | %FileCheck %s
 // REQUIRES: objc_interop
 
 extension BadError: LocalizedError {}

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -sil-serialize-witness-tables %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
 
 protocol Fooable {
   init()
@@ -417,7 +417,7 @@ func AO_curryThunk<T>(_ ao: AO<T>) -> ((AO<T>) -> (Int) -> ()/*, Int -> ()*/) {
 // correctly if we are asked to.
 // ----------------------------------------------------------------------------
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T015guaranteed_self9FakeArrayVAA8SequenceA2aDP17_constrainElement{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in FakeElement, @in_guaranteed FakeArray) -> () {
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self9FakeArrayVAA8SequenceA2aDP17_constrainElement{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in FakeElement, @in_guaranteed FakeArray) -> () {
 // CHECK: bb0([[ARG0_PTR:%.*]] : @trivial $*FakeElement, [[ARG1_PTR:%.*]] : @trivial $*FakeArray):
 // CHECK: [[GUARANTEED_COPY_STACK_SLOT:%.*]] = alloc_stack $FakeArray
 // CHECK: copy_addr [[ARG1_PTR]] to [initialization] [[GUARANTEED_COPY_STACK_SLOT]]

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-silgen -sil-serialize-witness-tables %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables > %t.out
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -enable-sil-ownership > %t.out
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s < %t.out
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.out
 

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -sil-serialize-witness-tables %s -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -enable-sil-ownership | %FileCheck %s
 // For integration testing, ensure we get through IRGen too.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -verify -DIRGEN_INTEGRATION_TEST %s
 

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen -sil-serialize-witness-tables -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 
@@ -94,7 +94,7 @@ public class Positron : Lepton {
   public dynamic var spin: Float = 0.5
 }
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T014objc_witnesses8PositronCAA6LeptonA2aDP4spinSfvgTW
+// CHECK-LABEL: sil private [transparent] [thunk] @_T014objc_witnesses8PositronCAA6LeptonA2aDP4spinSfvgTW
 // CHECK-LABEL: sil shared [transparent] [serializable] [thunk] @_T014objc_witnesses8PositronC4spinSfvgTD
 
 // Override of property defined in @objc extension

--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -sil-serialize-witness-tables %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s -disable-objc-attr-requires-foundation-module -enable-sil-ownership | %FileCheck %s
 
 class RefAggregate {}
 struct ValueAggregate { let x = RefAggregate() }

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -3,9 +3,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -enable-sil-ownership -o %t
 
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
 
 // Just make sure we don't crash later on.
 // RUN: %target-swift-frontend -enable-sil-ownership -emit-ir -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
@@ -62,6 +62,6 @@ public class PublicSub: Base {
 // CHECK-NEXT:  method #Fooable.foo!1: {{.*}} : @_T04main7FooImplVAA7FooableA2aDP3fooyyFTW
 // CHECK-NEXT: }
 
-// CHECK-LABEL: sil_witness_table [serialized] PublicFooImpl: Fooable module main {
+// CHECK-LABEL: sil_witness_table PublicFooImpl: Fooable module main {
 // CHECK-NEXT:  method #Fooable.foo!1: {{.*}} : @_T04main13PublicFooImplVAA7FooableA2aDP3fooyyFTW
 // CHECK-NEXT: }

--- a/test/SILGen/witness_accessibility.swift
+++ b/test/SILGen/witness_accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -sil-serialize-witness-tables -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 public protocol P {
   func publicRequirement()
@@ -39,4 +39,4 @@ public struct S : R {}
 // the use of the 'public' keyword inside an extension of 'R'
 // should generate a warning, since it has no effect.
 
-// CHECK-LABEL: sil [transparent] [thunk] @_T021witness_accessibility1SVAA1PA2aDP17publicRequirementyyFTW
+// CHECK-LABEL: sil private [transparent] [thunk] @_T021witness_accessibility1SVAA1PA2aDP17publicRequirementyyFTW

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 // RUN: %target-swift-frontend -enable-sil-ownership -emit-ir %s
 
 protocol Fooable {
@@ -19,7 +19,7 @@ struct Foo: Fooable {
 }
 
 // rdar://problem/19049566
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T017witness_same_type14LazySequenceOfVyxq_Gs0E0AAsAERz7ElementQzRs_r0_lsAEP12makeIterator0I0QzyFTW : $@convention(witness_method) <τ_0_0, τ_0_1 where τ_0_0 : Sequence, τ_0_1 == τ_0_0.Element> (@in_guaranteed LazySequenceOf<τ_0_0, τ_0_1>) -> @out AnyIterator<τ_0_1>
+// CHECK-LABEL: sil private [transparent] [thunk] @_T017witness_same_type14LazySequenceOfVyxq_Gs0E0AAsAERz7ElementQzRs_r0_lsAEP12makeIterator0I0QzyFTW : $@convention(witness_method) <τ_0_0, τ_0_1 where τ_0_0 : Sequence, τ_0_1 == τ_0_0.Element> (@in_guaranteed LazySequenceOf<τ_0_0, τ_0_1>) -> @out AnyIterator<τ_0_1>
 public struct LazySequenceOf<SS : Sequence, A where SS.Iterator.Element == A> : Sequence {
   public func makeIterator() -> AnyIterator<A> { 
     var opt: AnyIterator<A>?

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module > %t.sil
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module > %t.sil
 // RUN: %FileCheck -check-prefix=TABLE -check-prefix=TABLE-ALL %s < %t.sil
 // RUN: %FileCheck -check-prefix=SYMBOL %s < %t.sil
 
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-testing > %t.testable.sil
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-testing > %t.testable.sil
 // RUN: %FileCheck -check-prefix=TABLE-TESTABLE -check-prefix=TABLE-ALL %s < %t.testable.sil
 // RUN: %FileCheck -check-prefix=SYMBOL-TESTABLE %s < %t.testable.sil
 
@@ -61,11 +61,11 @@ struct ConformingAssoc : AssocReqt {
   func requiredMethod() {}
 }
 // TABLE-LABEL: sil_witness_table hidden ConformingAssoc: AssocReqt module witness_tables {
-// TABLE-TESTABLE-LABEL: sil_witness_table [serialized] ConformingAssoc: AssocReqt module witness_tables {
+// TABLE-TESTABLE-LABEL: sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
 // TABLE-ALL-NEXT:    method #AssocReqt.requiredMethod!1: {{.*}} : @_T014witness_tables15ConformingAssocVAA0D4ReqtA2aDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-ALL-NEXT:  }
 // SYMBOL:      sil private [transparent] [thunk] @_T014witness_tables15ConformingAssocVAA0D4ReqtA2aDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in_guaranteed ConformingAssoc) -> ()
-// SYMBOL-TESTABLE:      sil shared [transparent] [serialized] [thunk] @_T014witness_tables15ConformingAssocVAA0D4ReqtA2aDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in_guaranteed ConformingAssoc) -> ()
+// SYMBOL-TESTABLE:      sil private [transparent] [thunk] @_T014witness_tables15ConformingAssocVAA0D4ReqtA2aDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in_guaranteed ConformingAssoc) -> ()
 
 struct ConformingStruct : AnyProtocol {
   typealias AssocType = SomeAssoc
@@ -94,11 +94,11 @@ func <~>(x: ConformingStruct, y: ConformingStruct) {}
 // SYMBOL:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in SomeAssoc, @in ConformingAssoc, @in_guaranteed ConformingStruct) -> ()
 // SYMBOL:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method) (@in ConformingStruct, @thick ConformingStruct.Type) -> ()
 // SYMBOL:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method) (@in ConformingStruct, @in ConformingStruct, @thick ConformingStruct.Type) -> ()
-// SYMBOL-TESTABLE:      sil shared [transparent] [serialized] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformingStruct, @in_guaranteed ConformingStruct) -> ()
-// SYMBOL-TESTABLE:      sil shared [transparent] [serialized] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in ConformingStruct, @in_guaranteed ConformingStruct) -> ()
-// SYMBOL-TESTABLE:      sil shared [transparent] [serialized] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in SomeAssoc, @in ConformingAssoc, @in_guaranteed ConformingStruct) -> ()
-// SYMBOL-TESTABLE:      sil shared [transparent] [serialized] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method) (@in ConformingStruct, @thick ConformingStruct.Type) -> ()
-// SYMBOL-TESTABLE:      sil shared [transparent] [serialized] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method) (@in ConformingStruct, @in ConformingStruct, @thick ConformingStruct.Type) -> ()
+// SYMBOL-TESTABLE:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformingStruct, @in_guaranteed ConformingStruct) -> ()
+// SYMBOL-TESTABLE:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in ConformingStruct, @in_guaranteed ConformingStruct) -> ()
+// SYMBOL-TESTABLE:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in SomeAssoc, @in ConformingAssoc, @in_guaranteed ConformingStruct) -> ()
+// SYMBOL-TESTABLE:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method) (@in ConformingStruct, @thick ConformingStruct.Type) -> ()
+// SYMBOL-TESTABLE:      sil private [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolA2aDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method) (@in ConformingStruct, @in ConformingStruct, @thick ConformingStruct.Type) -> ()
 
 protocol AddressOnly {}
 

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -sil-serialize-witness-tables %s | %FileCheck %s
+
+public protocol PublicProtocol {}
+
+internal protocol InternalProtocol {}
+
+public struct PublicStruct : PublicProtocol, InternalProtocol {}
+
+internal struct InternalStruct : PublicProtocol, InternalProtocol {}
+
+// CHECK-LABEL: sil_witness_table [serialized] PublicStruct: PublicProtocol
+// CHECK-LABEL: sil_witness_table hidden PublicStruct: InternalProtocol
+
+// CHECK-LABEL: sil_witness_table hidden InternalStruct: PublicProtocol
+// CHECK-LABEL: sil_witness_table hidden InternalStruct: InternalProtocol

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -O -emit-sil -sil-serialize-witness-tables | %FileCheck %s
-// RUN: %target-swift-frontend %s -O -emit-sil -sil-serialize-witness-tables -enable-testing | %FileCheck -check-prefix=CHECK-TESTING %s
+// RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-sil -enable-testing | %FileCheck -check-prefix=CHECK-TESTING %s
 
 // Check if cycles are removed.
 
@@ -214,7 +214,7 @@ internal func donotEliminate() {
 // CHECK: aliveWitness!1: {{.*}} : @{{.*}}aliveWitness
 // CHECK: DeadWitness!1: {{.*}} : nil
 
-// CHECK-TESTING-LABEL: sil_witness_table [serialized] Adopt: Prot
+// CHECK-TESTING-LABEL: sil_witness_table Adopt: Prot
 // CHECK-TESTING: DeadWitness{{.*}}: @{{.*}}DeadWitness
 
 // CHECK-LABEL: sil_default_witness_table hidden Prot

--- a/test/SILOptimizer/devirt_materializeForSet.swift
+++ b/test/SILOptimizer/devirt_materializeForSet.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend -O -emit-sil -sil-serialize-witness-tables %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
 
 // Check that compiler does not crash on the devirtualization of materializeForSet methods
 // and produces a correct code.
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T024devirt_materializeForSet7BaseFooCAA0F0A2aDP3barSSvmTW
+// CHECK-LABEL: sil private [transparent] [thunk] @_T024devirt_materializeForSet7BaseFooCAA0F0A2aDP3barSSvmTW
 // CHECK: checked_cast_br [exact] %{{.*}} : $BaseFoo to $ChildFoo
 // CHECK: thin_function_to_pointer %{{.*}} : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout ChildFoo, @thick ChildFoo.Type) -> () to $Builtin.RawPointer
 // CHECK: enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, %{{.*}} : $Builtin.RawPointer

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -2,12 +2,12 @@
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -sil-serialize-witness-tables -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -sil-serialize-witness-tables -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -sil-serialize-witness-tables -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -sil-serialize-witness-tables %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/multifile/imported-conformance/option-set/library.swift
+++ b/test/multifile/imported-conformance/option-set/library.swift
@@ -1,0 +1,8 @@
+// RUN: true
+
+import Foundation
+
+@inline(__always)
+public func replace(rgx: NSRegularExpression, in: String, with: String, x: NSRange) -> String {
+  return rgx.stringByReplacingMatches(in: `in`, options: [], range: x, withTemplate: with)
+}

--- a/test/multifile/imported-conformance/option-set/main.swift
+++ b/test/multifile/imported-conformance/option-set/main.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %empty-directory(%t/linker)
+// RUN: %target-build-swift -emit-module -emit-library %S/library.swift -o %t/linker/liblibrary.%target-dylib-extension -emit-module-path %t/linker/library.swiftmodule -module-name library
+// RUN: %target-build-swift %S/main.swift -I %t/linker/ -L %t/linker/ -llibrary -o %t/linker/main
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import library
+
+public func rreplace(rgx: NSRegularExpression, in: String, with: String, x: NSRange) -> String {
+  return replace(rgx: rgx, in: `in`, with: with, x: x)
+}

--- a/validation-test/Evolution/test_class_add_override.swift
+++ b/validation-test/Evolution/test_class_add_override.swift
@@ -1,6 +1,5 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
-// REQUIRES: no_asan
 
 import StdlibUnittest
 import class_add_override

--- a/validation-test/Evolution/test_class_add_property.swift
+++ b/validation-test/Evolution/test_class_add_property.swift
@@ -1,6 +1,5 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
-// REQUIRES: no_asan
 
 import StdlibUnittest
 import class_add_property

--- a/validation-test/Evolution/test_class_change_size.swift
+++ b/validation-test/Evolution/test_class_change_size.swift
@@ -1,6 +1,5 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
-// REQUIRES: no_asan
 
 import StdlibUnittest
 import class_change_size

--- a/validation-test/Evolution/test_function_change_transparent_body.swift
+++ b/validation-test/Evolution/test_function_change_transparent_body.swift
@@ -1,8 +1,5 @@
-// RUN: %target-resilience-test-wmo
+// RUN: %target-resilience-test
 // REQUIRES: executable_test
-
-// FIXME: shouldn't need -whole-module-optimization here; we need to fix the
-// frontend to merge serialized SIL functions from different translation units
 
 import StdlibUnittest
 import function_change_transparent_body


### PR DESCRIPTION
I had to revert #8388 in #11938 because `check-swift-validation-optimize` was failing.

This PR fixes two issues exposed by running the tests with optimizations and re-applies the original changes:

- Memory corruption with overly-aggressive inlining of resilient class allocation
- SILGen was not serializing witness tables for imported conformances