### PR TITLE
Coerce the base of existential keypath applies

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1314,6 +1314,7 @@ namespace {
           ->getElementType(0);
         
         Type valueTy;
+        Type baseTy;
         bool resultIsLValue;
         
         if (auto nom = keyPathTTy->getAs<NominalType>()) {
@@ -1324,12 +1325,14 @@ namespace {
             valueTy = OptionalType::get(valueTy);
             resultIsLValue = false;
             base = cs.coerceToRValue(base);
+            baseTy = cs.getType(base);
           } else {
             llvm_unreachable("unknown key path class!");
           }
         } else {
           auto keyPathBGT = keyPathTTy->castTo<BoundGenericType>();
-          
+          baseTy = keyPathBGT->getGenericArgs()[0];
+
           if (keyPathBGT->getDecl()
                 == cs.getASTContext().getPartialKeyPathDecl()) {
             // PartialKeyPath<T> is rvalue T -> rvalue Any
@@ -1356,6 +1359,12 @@ namespace {
             } else {
               llvm_unreachable("unknown key path class!");
             }
+          }
+
+          // Coerce the base if its anticipated type doesn't match - say we're
+          // applying a keypath with an existential base to a concrete base.
+          if (baseTy->isExistentialType() && !cs.getType(base)->isExistentialType()) {
+            base = coerceToType(base, baseTy, locator);
           }
         }
         if (resultIsLValue)

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -48,6 +48,9 @@ extension Array where Element == A {
   var property: Prop { fatalError() }
 }
 
+protocol P { var member: String { get } }
+extension B : P { var member : String { return "Member Value" } }
+
 struct Exactly<T> {}
 
 func expect<T>(_ x: inout T, toHaveType _: Exactly<T>.Type) {}
@@ -354,6 +357,11 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
 func testKeyPathSubscriptLValue(base: Z, kp: inout KeyPath<Z, Z>) {
   _ = base[keyPath: kp]
 }
+
+func testKeyPathSubscriptExistentialBase(base: B, kp: KeyPath<P, String>) {
+  _ = base[keyPath: kp]
+}
+
 
 struct AA {
   subscript(x: Int) -> Int { return x }


### PR DESCRIPTION
We can wind up in a situation where the base of a keypath
application is concrete but is being applied to a keypath
with an existential source type.  Coerce the base to the
intended type if necessary when building the final subscript
expression.

Resolves [SR-5878](https://bugs.swift.org/browse/SR-5878).
