### PR TITLE
[sil-opaque-values] Fix several issues in the -O pipeline.

### DIFF
--- a/lib/SIL/LoopInfo.cpp
+++ b/lib/SIL/LoopInfo.cpp
@@ -60,10 +60,11 @@ bool SILLoop::canDuplicate(SILInstruction *I) const {
   }
 
   // We can't have a phi of two openexistential instructions of different UUID.
-  SILInstruction *OEI = dyn_cast<OpenExistentialAddrInst>(I);
-  if (OEI || (OEI = dyn_cast<OpenExistentialRefInst>(I)) ||
-      (OEI = dyn_cast<OpenExistentialMetatypeInst>(I))) {
-    for (auto *UI : OEI->getUses())
+  if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
+      isa<OpenExistentialMetatypeInst>(I) ||
+      isa<OpenExistentialValueInst>(I) || isa<OpenExistentialBoxInst>(I) ||
+      isa<OpenExistentialBoxValueInst>(I)) {
+    for (auto *UI : I->getUses())
       if (!contains(UI->getUser()))
         return false;
     return true;

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -928,6 +928,7 @@ bool SILInstruction::mayRelease() const {
     return true;
 
   case ValueKind::UnconditionalCheckedCastAddrInst:
+  case ValueKind::UnconditionalCheckedCastValueInst:
     return true;
 
   case ValueKind::CheckedCastAddrBranchInst: {

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -49,9 +49,10 @@
 ///    that the release occurs in the epilog after any retains associated with
 ///    @owned return values.
 ///
-/// 3. We do not support specialization of closures with arguments passed using
-///    any indirect calling conventions besides @inout and @inout_aliasable.
-///    This is a temporary limitation.
+/// 3. In !useLoweredAddresses mode, we do not support specialization of closures
+///    with arguments passed using any indirect calling conventions besides
+///    @inout and @inout_aliasable.  This is a temporary limitation that goes
+///    away with sil-opaque-values.
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "closure-specialization"
@@ -581,8 +582,9 @@ ClosureSpecCloner::initCloned(const CallSiteDescriptor &CallSiteDesc,
     ParameterConvention ParamConv;
     if (PInfo.isFormalIndirect()) {
       ParamConv = PInfo.getConvention();
-      assert(ParamConv == ParameterConvention::Indirect_Inout ||
-             ParamConv == ParameterConvention::Indirect_InoutAliasable);
+      assert(!SILModuleConventions(M).useLoweredAddresses()
+             || ParamConv == ParameterConvention::Indirect_Inout
+             || ParamConv == ParameterConvention::Indirect_InoutAliasable);
     } else {
       ParamConv = ClosedOverFunConv.getSILType(PInfo).isTrivial(M)
                       ? ParameterConvention::Direct_Unowned

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -626,7 +626,9 @@ emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
         ReInfo.createSpecializedType(SubstitutedType, Builder.getModule());
   }
 
-  assert(OrigArgs.size() == ReInfo.getNumArguments() && "signature mismatch");
+  assert(!substConv.useLoweredAddresses()
+         || OrigArgs.size() == ReInfo.getNumArguments() &&
+         "signature mismatch");
 
   CallArgs.reserve(OrigArgs.size());
   SILValue StoreResultTo;

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -173,7 +173,8 @@ static bool expandReleaseValue(ReleaseValueInst *DV) {
 
   // If we have an address only type, do nothing.
   SILType Type = Value->getType();
-  assert(Type.isLoadable(Module) &&
+  assert(!SILModuleConventions(Module).useLoweredAddresses()
+         || Type.isLoadable(Module) &&
          "release_value should never be called on a non-loadable type.");
 
   if (!shouldExpand(Module, Type.getObjectType()))

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -200,8 +200,9 @@ static bool expandRetainValue(RetainValueInst *CV) {
 
   // If we have an address only type, do nothing.
   SILType Type = Value->getType();
-  assert(Type.isLoadable(Module) && "Copy Value can only be called on loadable "
-         "types.");
+  assert(!SILModuleConventions(Module).useLoweredAddresses()
+         || Type.isLoadable(Module) &&
+         "Copy Value can only be called on loadable types.");
 
   if (!shouldExpand(Module, Type.getObjectType()))
     return false;

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -53,7 +53,8 @@ swift::createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
 
   // If Ptr is refcounted itself, create the strong_retain and
   // return.
-  if (Ptr->getType().isReferenceCounted(B.getModule()))
+  auto &TL = B.getModule().getTypeLowering(Ptr->getType());
+  if (!TL.isAddressOnly() && TL.isReferenceCounted())
     return B.createStrongRetain(Loc, Ptr, B.getDefaultAtomicity());
 
   // Otherwise, create the retain_value.
@@ -73,7 +74,8 @@ swift::createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
   auto Loc = RegularLocation(SourceLoc());
 
   // If Ptr has reference semantics itself, create a strong_release.
-  if (Ptr->getType().isReferenceCounted(B.getModule()))
+  auto &TL = B.getModule().getTypeLowering(Ptr->getType());
+  if (!TL.isAddressOnly() && TL.isReferenceCounted())
     return B.createStrongRelease(Loc, Ptr, B.getDefaultAtomicity());
 
   // Otherwise create a release value.

--- a/test/SILOptimizer/closure_specialize_opaque.sil
+++ b/test/SILOptimizer/closure_specialize_opaque.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -closure-specialize %s | %FileCheck %s
+
+struct TestView {}
+struct TestRange {}
+struct TestSlice {}
+
+// helper
+sil @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
+bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
+  %1284 = tuple ()
+  return %1284 : $()
+}
+
+// helper
+sil @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out () {
+bb0(%0 : $*TestView, %1 : $@callee_owned (@inout TestView) ->()):
+  %call = apply %1(%0) : $@callee_owned (@inout TestView) -> ()
+  %1284 = tuple ()
+  return %1284 : $()
+}
+
+// Test that ClosureSpecializer can handle captured @in args, in addition to direct args.
+//
+// CHECK-LABEL: sil @testSpecializeThunk : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
+// CHECK: bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
+// CHECK:   [[CLOSURE:%.*]] = function_ref @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
+// CHECK:   [[SPECIALIZED:%.*]] = function_ref @_T05thunk7closure4main9TestRangeVAC0D5SliceVTf1nc_n : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out () // user: %6
+// CHECK:   [[THUNK:%.*]] = function_ref @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+// CHECK:   [[CALL:%.*]] = apply [[SPECIALIZED]](%0, %1, %2) : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out ()
+// CHECK:   %{{.*}} = tuple ()
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'testSpecializeThunk'
+sil @testSpecializeThunk : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
+bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
+  %closurefn = function_ref @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
+  %pa = partial_apply %closurefn(%1, %2) : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
+  %thunk = function_ref @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+  strong_retain %pa : $@callee_owned (@inout TestView) -> ()
+  %call = apply %thunk(%0, %pa) : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+  %1284 = tuple ()
+  return %1284 : $()
+}

--- a/test/SILOptimizer/funcsig_opaque.sil
+++ b/test/SILOptimizer/funcsig_opaque.sil
@@ -1,0 +1,44 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -function-signature-opts %s | %FileCheck %s
+
+import Builtin
+
+struct R<T> {
+  var base: T
+}
+
+struct S {
+  var val: Builtin.Int32
+}
+
+sil @testAggregateArgHelper : $@convention(thin) (@owned R<S>) -> ()
+
+// Test owned-to-guaranteed transformation of opaque arguments.
+//
+// CHECK-LABEL: sil [thunk] [always_inline] @testAggregateArg : $@convention(thin) (@in R<S>) -> @out () {
+// CHECK: bb0(%0 : $R<S>):
+// CHECK:   [[F:%.*]] = function_ref @_T016testAggregateArgTf4g_n : $@convention(thin) (@in_guaranteed R<S>) -> @out ()
+// CHECK:   [[CALL:%.*]] = apply [[F]](%0) : $@convention(thin) (@in_guaranteed R<S>) -> @out ()
+// CHECK:   release_value %0 : $R<S>
+// CHECK:   return [[CALL]] : $()
+// CHECK-LABEL: } // end sil function 'testAggregateArg'
+//
+// CHECK-LABEL: sil shared @_T016testAggregateArgTf4g_n : $@convention(thin) (@in_guaranteed R<S>) -> @out () {
+// CHECK: bb0(%0 : $R<S>):
+// CHECK:   [[COPY:%.*]] = copy_value %0 : $R<S>
+// CHECK:   retain_value %0 : $R<S>
+// CHECK:   [[F:%.*]] = function_ref @testAggregateArgHelper : $@convention(thin) (@owned R<S>) -> ()
+// CHECK:   [[CALL:%.*]] = apply [[F]]([[COPY]]) : $@convention(thin) (@owned R<S>) -> ()
+// CHECK:   destroy_value %0 : $R<S>
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '_T016testAggregateArgTf4g_n'
+sil @testAggregateArg : $@convention(thin) (@in R<S>) -> @out () {
+bb0(%0 : $R<S>):
+  %9 = copy_value %0 : $R<S>
+  retain_value %0 : $R<S>
+  %10 = function_ref @testAggregateArgHelper : $@convention(thin) (@owned R<S>) -> ()
+  %12 = apply %10(%9) : $@convention(thin) (@owned R<S>) -> ()
+  destroy_value %0 : $R<S>
+  release_value %0 : $R<S>
+  %1284 = tuple ()
+  return %1284 : $()
+}


### PR DESCRIPTION
-Onone stdlib builds pass with -enable-opaque-values.

This additionally fixes several issues in the optimized pipeline for stdlib builds.

I have unit tests where it's feasible and worthwhile to do so. I don't have a way of testing the functionality as a whole other than on my own branch.