### PR TITLE
stdlib: generalise TLS to support Windows

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -114,28 +114,28 @@ double _swift_stdlib_squareRoot(double _self) {
 // TLS - thread local storage
 
 #if defined(__ANDROID__)
-typedef int __swift_pthread_key_t;
+typedef int __swift_thread_key_t;
 #elif defined(__linux__)
-typedef unsigned int __swift_pthread_key_t;
+typedef unsigned int __swift_thread_key_t;
 #elif defined(__FreeBSD__)
-typedef int __swift_pthread_key_t;
+typedef int __swift_thread_key_t;
+#elif defined(_WIN32)
+typedef unsigned long __swift_thread_key_t;
 #else
-typedef unsigned long __swift_pthread_key_t;
+typedef unsigned long __swift_thread_key_t;
 #endif
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-int _swift_stdlib_pthread_key_create(
-  __swift_pthread_key_t * _Nonnull key, void
-  (* _Nullable destructor)(void * _Nullable )
-);
+int
+_swift_stdlib_thread_key_create(__swift_thread_key_t * _Nonnull key,
+                                void (* _Nullable destructor)(void * _Nullable));
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-void * _Nullable _swift_stdlib_pthread_getspecific(__swift_pthread_key_t key);
+void * _Nullable _swift_stdlib_thread_getspecific(__swift_thread_key_t key);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-int _swift_stdlib_pthread_setspecific(
-  __swift_pthread_key_t key, const void * _Nullable value
-);
+int _swift_stdlib_thread_setspecific(__swift_thread_key_t key,
+                                     const void * _Nullable value);
 
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER

--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -64,7 +64,7 @@ internal struct _ThreadLocalStorage {
   static internal func getPointer()
     -> UnsafeMutablePointer<_ThreadLocalStorage>
   {
-    let tlsRawPtr = _swift_stdlib_pthread_getspecific(_tlsKey)
+    let tlsRawPtr = _swift_stdlib_thread_getspecific(_tlsKey)
     if _fastPath(tlsRawPtr != nil) {
       return tlsRawPtr._unsafelyUnwrappedUnchecked.assumingMemoryBound(
         to: _ThreadLocalStorage.self)
@@ -116,10 +116,10 @@ internal func _destroyTLS(_ ptr: UnsafeMutableRawPointer?) {
 }
 
 // Lazily created global key for use with pthread TLS
-internal let _tlsKey: __swift_pthread_key_t = {
-  let sentinelValue = __swift_pthread_key_t.max
-  var key: __swift_pthread_key_t = sentinelValue
-  let success = _swift_stdlib_pthread_key_create(&key, _destroyTLS)
+internal let _tlsKey: __swift_thread_key_t = {
+  let sentinelValue = __swift_thread_key_t.max
+  var key: __swift_thread_key_t = sentinelValue
+  let success = _swift_stdlib_thread_key_create(&key, _destroyTLS)
   _sanityCheck(success == 0, "somehow failed to create TLS key")
   _sanityCheck(key != sentinelValue, "Didn't make a new key")
   return key
@@ -129,7 +129,7 @@ internal let _tlsKey: __swift_pthread_key_t = {
 internal func _initializeThreadLocalStorage()
   -> UnsafeMutablePointer<_ThreadLocalStorage>
 {
-  _sanityCheck(_swift_stdlib_pthread_getspecific(_tlsKey) == nil,
+  _sanityCheck(_swift_stdlib_thread_getspecific(_tlsKey) == nil,
     "already initialized")
 
   // Create and initialize one.
@@ -146,7 +146,7 @@ internal func _initializeThreadLocalStorage()
   tlsPtr.initialize(
     to: _ThreadLocalStorage(_uBreakIterator: newUBreakIterator)
   )
-  let success = _swift_stdlib_pthread_setspecific(_tlsKey, tlsPtr)
+  let success = _swift_stdlib_thread_setspecific(_tlsKey, tlsPtr)
   _sanityCheck(success == 0, "setspecific failed")
   return tlsPtr
 }


### PR DESCRIPTION
Rename the explicit `pthread` to `thread` to indicate that this is not
`pthread` specifically.  This allows us to implement the TLS support for
Windows using Fibers.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
