### PR TITLE
Code updates from review on #11953

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -78,8 +78,6 @@ bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
   bindFromGenericRequirementsBuffer(IGF, requirements,
     Address(args, IGF.IGM.getPointerAlignment()),
     [&](CanType t) {
-      if (!genericEnv)
-        return t;
       return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
     });
 }
@@ -263,8 +261,6 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
       bindFromGenericRequirementsBuffer(IGF, requirements,
         Address(args, IGF.IGM.getPointerAlignment()),
         [&](CanType t) {
-          if (!genericEnv)
-            return t;
           return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
         });
     }
@@ -532,8 +528,6 @@ getInitializerForComputedComponent(IRGenModule &IGM,
       bindFromGenericRequirementsBuffer(IGF, requirements,
         Address(src, IGF.IGM.getPointerAlignment()),
         [&](CanType t) {
-          if (!genericEnv)
-            return t;
           return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
         });
 
@@ -674,8 +668,6 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
         bindFromGenericRequirementsBuffer(IGF, requirements,
           Address(bindingsBufPtr, getPointerAlignment()),
           [&](CanType t) {
-            if (!genericEnv)
-              return t;
             return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
           });
       

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3020,9 +3020,8 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenFunction &SGF,
   // Find the function and see if we already created it.
   SmallVector<CanType, 2> interfaceSubs;
   for (auto &sub : subs) {
-    interfaceSubs.push_back((genericEnv
-      ? genericEnv->mapTypeOutOfContext(sub.getReplacement())
-      : sub.getReplacement())
+    interfaceSubs.push_back(
+      GenericEnvironment::mapTypeOutOfContext(genericEnv, sub.getReplacement())
       ->getCanonicalType());
   }
   auto name = Mangle::ASTMangler()
@@ -3145,9 +3144,8 @@ SILFunction *getOrCreateKeyPathSetter(SILGenFunction &SGF,
   
   SmallVector<CanType, 2> interfaceSubs;
   for (auto &sub : subs) {
-    interfaceSubs.push_back((genericEnv
-      ? genericEnv->mapTypeOutOfContext(sub.getReplacement())
-      : sub.getReplacement())
+    interfaceSubs.push_back(
+      GenericEnvironment::mapTypeOutOfContext(genericEnv, sub.getReplacement())
       ->getCanonicalType());
   }
   auto name = Mangle::ASTMangler().mangleKeyPathSetterThunkHelper(property,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4251,7 +4251,8 @@ namespace {
         for (auto indexType : indexTypes) {
           auto conformance =
             cs.TC.conformsToProtocol(indexType.getType(), hashable,
-                                     cs.DC, ConformanceCheckFlags::Used);
+                                     cs.DC, ConformanceCheckFlags::Used
+                                          |ConformanceCheckFlags::InExpression);
           if (!conformance) {
             cs.TC.diagnose(component.getIndexExpr()->getLoc(),
                            diag::expr_keypath_subscript_index_not_hashable,


### PR DESCRIPTION
- Remove dead `if !genericEnv` checks
- Do conformance checks for subscript indexes `InExpression`
- Use `GenericEnvironment::mapTypeOutOfContext` static method instead of null checking everywhere
