### PR TITLE
stdlib: clean up some whitespace issues

### DIFF
--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -336,9 +336,9 @@ swift::__swift_stdlib_UBreakIterator *swift::__swift_stdlib_ubrk_open(
 #if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   return ptr_cast<swift::__swift_stdlib_UBreakIterator>(
       ubrk_open(static_cast<UBreakIteratorType>(type), locale,
-		reinterpret_cast<const UChar*>(text), textLength,
+                reinterpret_cast<const UChar *>(text), textLength,
                 ptr_cast<UErrorCode>(status)));
-#else      
+#else
   return ptr_cast<swift::__swift_stdlib_UBreakIterator>(
       ubrk_open(static_cast<UBreakIteratorType>(type), locale, text, textLength,
                 ptr_cast<UErrorCode>(status)));


### PR DESCRIPTION
Clean up incorrect whitespace.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
