### PR TITLE
[sil-opaque-values] Don't set reference-counted flag during lowering.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -258,8 +258,10 @@ public:
   /// True if the type, or the referenced type of an address type, is trivial.
   bool isTrivial(SILModule &M) const;
 
-  /// True if the type, or the referenced type of an address type, is a
-  /// scalar reference-counted type.
+  /// True if the type, or the referenced type of an address type, is known to
+  /// be a scalar reference-counted type. If this is false, then some part of
+  /// the type may be opaque. It may become reference counted later after
+  /// specialization.
   bool isReferenceCounted(SILModule &M) const;
 
   /// Returns true if the referenced type is a function type that never

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1116,7 +1116,7 @@ namespace {
   class OpaqueValueTypeLowering : public LeafLoadableTypeLowering {
   public:
     OpaqueValueTypeLowering(SILType type)
-      : LeafLoadableTypeLowering(type, IsAddressOnly, IsReferenceCounted) {}
+      : LeafLoadableTypeLowering(type, IsAddressOnly, IsNotReferenceCounted) {}
 
     void emitCopyInto(SILBuilder &B, SILLocation loc,
                       SILValue src, SILValue dest, IsTake_t isTake,

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -53,8 +53,7 @@ swift::createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
 
   // If Ptr is refcounted itself, create the strong_retain and
   // return.
-  auto &TL = B.getModule().getTypeLowering(Ptr->getType());
-  if (!TL.isAddressOnly() && TL.isReferenceCounted())
+  if (Ptr->getType().isReferenceCounted(B.getModule()))
     return B.createStrongRetain(Loc, Ptr, B.getDefaultAtomicity());
 
   // Otherwise, create the retain_value.
@@ -74,8 +73,7 @@ swift::createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
   auto Loc = RegularLocation(SourceLoc());
 
   // If Ptr has reference semantics itself, create a strong_release.
-  auto &TL = B.getModule().getTypeLowering(Ptr->getType());
-  if (!TL.isAddressOnly() && TL.isReferenceCounted())
+  if (Ptr->getType().isReferenceCounted(B.getModule()))
     return B.createStrongRelease(Loc, Ptr, B.getDefaultAtomicity());
 
   // Otherwise create a release value.

--- a/test/SILOptimizer/sil_combine_opaque.sil
+++ b/test/SILOptimizer/sil_combine_opaque.sil
@@ -1,0 +1,25 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+
+struct S<T> {
+  var t : T
+}
+
+// Test SIL combine's handling of retain_value/release_value.
+//
+// CHECK-LABEL: sil @testSpecializeOpaque : $@convention(thin) <T> (@in S<T>) -> () {
+// CHECK-LABEL: bb0(%0 : $S<T>):
+// CHECK:   retain_value %0 : $S<T>
+// CHECK:   [[F:%.*]] = function_ref @testSpecializeOpaque : $@convention(thin) <τ_0_0> (@in S<τ_0_0>) -> ()
+// CHECK:   [[CALL:%.*]] = apply [[F]]<T>(%0) : $@convention(thin) <τ_0_0> (@in S<τ_0_0>) -> ()
+// CHECK:   release_value %0 : $S<T>
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'testSpecializeOpaque'
+sil @testSpecializeOpaque : $@convention(thin) <T> (@in S<T>) -> () {
+bb0(%0 : $S<T>):
+  %retain = retain_value %0 : $S<T>
+  %f = function_ref @testSpecializeOpaque : $@convention(thin) <T> (@in S<T>) -> ()
+  %call = apply %f<T>(%0) : $@convention(thin) <τ_0_0> (@in S<τ_0_0>) -> ()
+  %release = release_value %0 : $S<T>
+  %999 = tuple ()
+  return %999 : $()
+}


### PR DESCRIPTION
With sil-combine test case.