### PR TITLE
[ConstraintSolver] When ranking bindings prefer type vars with literal bindings

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1788,14 +1788,10 @@ bool ConstraintSystem::solveSimplified(
   std::tie(bestBindings, bestTypeVar) = determineBestBindings();
 
   // If we have a binding that does not involve type variables, and is
-  // not fully bound, and is either not a literal or is a collection
-  // literal, or we have no disjunction to attempt instead, go ahead
-  // and try the bindings for this type variable.
-  if (bestBindings &&
-      (!disjunction ||
-       (!bestBindings.InvolvesTypeVariables && !bestBindings.FullyBound &&
-        (bestBindings.LiteralBinding == LiteralBindingKind::None ||
-         bestBindings.LiteralBinding == LiteralBindingKind::Collection)))) {
+  // not fully bound, or we have no disjunction to attempt instead,
+  // go ahead and try the bindings for this type variable.
+  if (bestBindings && (!disjunction || (!bestBindings.InvolvesTypeVariables &&
+                                        !bestBindings.FullyBound))) {
     return tryTypeVariableBindings(solverState->depth, bestTypeVar,
                                    bestBindings.Bindings, solutions,
                                    allowFreeTypeVariables);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1783,17 +1783,15 @@ bool ConstraintSystem::solveSimplified(
     Constraint *disjunction, SmallVectorImpl<Solution> &solutions,
     FreeTypeVariableBinding allowFreeTypeVariables) {
 
-  TypeVariableType *bestTypeVar = nullptr;
-  PotentialBindings bestBindings;
-  std::tie(bestBindings, bestTypeVar) = determineBestBindings();
+  auto bestBindings = determineBestBindings();
 
   // If we have a binding that does not involve type variables, and is
   // not fully bound, or we have no disjunction to attempt instead,
   // go ahead and try the bindings for this type variable.
-  if (bestBindings && (!disjunction || (!bestBindings.InvolvesTypeVariables &&
-                                        !bestBindings.FullyBound))) {
-    return tryTypeVariableBindings(solverState->depth, bestTypeVar,
-                                   bestBindings.Bindings, solutions,
+  if (bestBindings && (!disjunction || (!bestBindings->InvolvesTypeVariables &&
+                                        !bestBindings->FullyBound))) {
+    return tryTypeVariableBindings(solverState->depth, bestBindings->TypeVar,
+                                   bestBindings->Bindings, solutions,
                                    allowFreeTypeVariables);
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2554,6 +2554,8 @@ private:
     typedef std::tuple<bool, bool, bool, bool, bool,
                        unsigned char, unsigned int> BindingScore;
 
+    TypeVariableType *TypeVar;
+
     /// The set of potential bindings.
     SmallVector<PotentialBinding, 4> Bindings;
 
@@ -2577,6 +2579,8 @@ private:
 
     /// Tracks the position of the last known supertype in the group.
     Optional<unsigned> lastSupertypeIndex;
+
+    PotentialBindings(TypeVariableType *typeVar) : TypeVar(typeVar) {}
 
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
@@ -2717,7 +2721,7 @@ private:
 
   Optional<Type> checkTypeOfBinding(TypeVariableType *typeVar, Type type,
                                     bool *isNilLiteral = nullptr);
-  std::pair<PotentialBindings, TypeVariableType *> determineBestBindings();
+  Optional<PotentialBindings> determineBestBindings();
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar);
 
   bool

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2551,8 +2551,8 @@ private:
   };
 
   struct PotentialBindings {
-    typedef std::tuple<bool, bool, bool, bool, unsigned char,
-                       bool, unsigned int> BindingScore;
+    typedef std::tuple<bool, bool, bool, bool, bool,
+                       unsigned char, unsigned int> BindingScore;
 
     /// The set of potential bindings.
     SmallVector<PotentialBinding, 4> Bindings;
@@ -2591,8 +2591,8 @@ private:
                              b.FullyBound,
                              b.IsRHSOfBindParam,
                              b.SubtypeOfExistentialType,
-                             static_cast<unsigned char>(b.LiteralBinding),
                              b.InvolvesTypeVariables,
+                             static_cast<unsigned char>(b.LiteralBinding),
                              -(b.Bindings.size() - b.NumDefaultableBindings));
     }
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 2 --end 7 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Change the potential binding ranking logic to prefer type variables
which don't have other type variables related to them, but have literal
bindings, over the ones that do have other type variables.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
