### PR TITLE
Revert "Driver: Pass the new -sil-merge-partial-modules flag"

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -687,14 +687,6 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   // serialized ASTs.
   Arguments.push_back("-parse-as-library");
 
-  // Merge serialized SIL from partial modules.
-  Arguments.push_back("-sil-merge-partial-modules");
-
-  // Disable SIL optimization passes; we've already optimized the code in each
-  // partial mode.
-  Arguments.push_back("-disable-diagnostic-passes");
-  Arguments.push_back("-disable-sil-perf-optzns");
-
   addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
                         Arguments);
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);

--- a/validation-test/Evolution/test_function_change_transparent_body.swift
+++ b/validation-test/Evolution/test_function_change_transparent_body.swift
@@ -1,5 +1,8 @@
-// RUN: %target-resilience-test
+// RUN: %target-resilience-test-wmo
 // REQUIRES: executable_test
+
+// FIXME: shouldn't need -whole-module-optimization here; we need to fix the
+// frontend to merge serialized SIL functions from different translation units
 
 import StdlibUnittest
 import function_change_transparent_body


### PR DESCRIPTION
This reverts commit 86d241b38ed75deec0ae689d8591ae57fc566a38.

My change broke the release build of swift-xcode-playground-support. Looks like the SIL linker needs more work before I can enable this. Reduced test case is to just build this with `-O -sil-merge-partial-modules`:

```
public func foo(object x: Any) -> Mirror {
    return Mirror(reflecting: x)
}
```