### PR TITLE
[WIP/Experiment] [ConstraintSolver] Attempt literal bindings earlier

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1791,11 +1791,8 @@ bool ConstraintSystem::solveSimplified(
   // not fully bound, and is either not a literal or is a collection
   // literal, or we have no disjunction to attempt instead, go ahead
   // and try the bindings for this type variable.
-  if (bestBindings &&
-      (!disjunction ||
-       (!bestBindings.InvolvesTypeVariables && !bestBindings.FullyBound &&
-        (bestBindings.LiteralBinding == LiteralBindingKind::None ||
-         bestBindings.LiteralBinding == LiteralBindingKind::Collection)))) {
+  if (bestBindings && (!disjunction || (!bestBindings.InvolvesTypeVariables &&
+                                        !bestBindings.FullyBound))) {
     return tryTypeVariableBindings(solverState->depth, bestTypeVar,
                                    bestBindings.Bindings, solutions,
                                    allowFreeTypeVariables);


### PR DESCRIPTION
If the best bindings we could get on the current step are bindings
to literal type without any other type variable involved, let's try
to attempt them right away, that should help to prune search space.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
