### PR TITLE
[4.0] IRGen: Add function to module before passing it to IRGenFunction's co…

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1060,9 +1060,9 @@ void IRGenModule::emitEnableReportErrorsToDebugger() {
   llvm::Function *NewFn = llvm::Function::Create(
       llvm::FunctionType::get(VoidTy, false), llvm::GlobalValue::PrivateLinkage,
       "_swift_enable_report_errors_to_debugger");
+  Module.getFunctionList().push_back(NewFn);
   IRGenFunction NewIGF(*this, NewFn);
   NewFn->setAttributes(constructInitialAttributes());
-  Module.getFunctionList().push_back(NewFn);
   NewFn->setCallingConv(DefaultCC);
 
   llvm::Value *addr =


### PR DESCRIPTION
…nstructor

IRGenFunction's constructor assumes the function has a parent (or better LLVM's
IRBuilder does).

• Explanation: LLVM’s IRBuilder assumes in certain CreateFooInst that a function has a parent. A crash will ensue if it does not.  emitEnableReportErrorsToDebugger will create a function, call IRGenFunction constructor and only later add the function to the llvm module. This is the wrong order for certain versions of LLVM. This commit changes the order to first add the function to the LLVM module.

• Scope of Issue: Introduced by a commit that added the EnableReportErrorsToDebugger feature.

* Risk: Low. We just change the order to “createFunction, add to module, call IRGenFunction constructor

No test because you need certain versions of LLVM to expose this.

rdar://34468106
