### PR TITLE
[swift-format] Set exec path in initializer (NFC)

### DIFF
--- a/tools/driver/swift_format_main.cpp
+++ b/tools/driver/swift_format_main.cpp
@@ -96,9 +96,8 @@ private:
   }
 
 public:
-  void setMainExecutablePath(const std::string &Path) {
-    MainExecutablePath = Path;
-  }
+  SwiftFormatInvocation(const std::string &ExecPath)
+      : MainExecutablePath(ExecPath) {}
 
   const std::string &getOutputFilename() { return OutputFilename; }
 
@@ -241,10 +240,8 @@ int swift_format_main(ArrayRef<const char *> Args, const char *Argv0,
   PrintingDiagnosticConsumer PDC;
   Instance.addDiagnosticConsumer(&PDC);
 
-  SwiftFormatInvocation Invocation;
-  std::string MainExecutablePath =
-      llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
-  Invocation.setMainExecutablePath(MainExecutablePath);
+  SwiftFormatInvocation Invocation(
+      llvm::sys::fs::getMainExecutable(Argv0, MainAddr));
 
   DiagnosticEngine &Diags = Instance.getDiags();
   if (Invocation.parseArgs(Args, Diags) != 0)


### PR DESCRIPTION
Rather than define `SwiftFormatInvocation::setMainExecutablePath()` and use it in the one spot where a `SwiftFormatInvocation` is initialized, have `SwiftFormatInvocation` take an executable path in its initializer. No functional change, but slightly fewer lines of code.

+cc @danielmartin