### PR TITLE
runtime: make LLP64 clean

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -54,7 +54,7 @@
 /// According to the Objective-C ABI, this is true only for 64-bit
 /// platforms.
 #ifndef SWIFT_HAS_ISA_MASKING
-#if SWIFT_OBJC_INTEROP && defined(__LP64__)
+#if SWIFT_OBJC_INTEROP && __POINTER_WIDTH__ == 64
 #define SWIFT_HAS_ISA_MASKING 1
 #else
 #define SWIFT_HAS_ISA_MASKING 0

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -660,7 +660,7 @@ const ExtraInhabitantsValueWitnessTable METATYPE_VALUE_WITNESS_SYM(Bo); // Built
 
 /// Return the value witnesses for unmanaged pointers.
 static inline const ValueWitnessTable &getUnmanagedPointerValueWitnesses() {
-#ifdef __LP64__
+#if __POINTER_WIDTH__ == 64
   return VALUE_WITNESS_SYM(Bi64_);
 #else
   return VALUE_WITNESS_SYM(Bi32_);

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -733,14 +733,14 @@ class SideTableRefCountBits : public RefCountBitsT<RefCountNotInline>
 template <typename RefCountBits>
 class RefCounts {
   std::atomic<RefCountBits> refCounts;
-#if !__LP64__
+#if __POINTER_WIDTH__ == 32
   // FIXME: hack - something somewhere is assuming a 3-word header on 32-bit
   // See also other fixmes marked "small header for 32-bit"
   uintptr_t unused SWIFT_ATTRIBUTE_UNAVAILABLE;
 #endif
 
   // Out-of-line slow paths.
-  
+
   LLVM_ATTRIBUTE_NOINLINE
   void incrementSlow(RefCountBits oldbits, uint32_t inc);
 
@@ -773,7 +773,7 @@ class RefCounts {
   // Refcount of a new object is 1.
   constexpr RefCounts(Initialized_t)
     : refCounts(RefCountBits(0, 1))
-#if !__LP64__ && !__has_attribute(unavailable)
+#if __POINTER_WIDTH__ == 32 && !__has_attribute(unavailable)
       , unused(0)
 #endif
   { }

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -39,7 +39,7 @@ constexpr const char TypeMetadataRecordSection[] = "__swift2_types";
 template<const char *SECTION_NAME,
          void CONSUME_BLOCK(const void *start, uintptr_t size)>
 void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
-#ifdef __LP64__
+#if __POINTER_WIDTH__ == 64
   using mach_header_platform = mach_header_64;
   assert(mh->magic == MH_MAGIC_64 && "loaded non-64-bit image?!");
 #else

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1194,7 +1194,7 @@ namespace {
     uint32_t Flags;
     uint32_t InstanceStart;
     uint32_t InstanceSize;
-#ifdef __LP64__
+#if __POINTER_WIDTH__ == 64
     uint32_t Reserved;
 #endif
     const uint8_t *IvarLayout;

--- a/stdlib/public/runtime/StaticBinaryELF.cpp
+++ b/stdlib/public/runtime/StaticBinaryELF.cpp
@@ -37,7 +37,7 @@
 using namespace std;
 using namespace llvm;
 
-#ifdef __LP64__
+#if __POINTER_WIDTH__ == 64
 #define ELFCLASS ELFCLASS64
 typedef Elf64_Ehdr Elf_Ehdr;
 typedef Elf64_Shdr Elf_Shdr;


### PR DESCRIPTION
This is a blanket pass replacing use of `__LP64__` with
`__POINTER_WIDTH__ == 64`.  The latter is more expressive and also LLP64
clean.  This change is needed to enable support for Windows x86_64 which
is a LLP64 environment.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
