### PR TITLE
Bump Swift Compiler version to 4.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ set_property(CACHE SWIFT_ANALYZE_CODE_COVERAGE PROPERTY
 # SWIFT_VERSION is deliberately /not/ cached so that an existing build directory
 # can be reused when a new version of Swift comes out (assuming the user hasn't
 # manually set it as part of their own CMake configuration).
-set(SWIFT_VERSION "4.0")
+set(SWIFT_VERSION "4.0.1")
 
 set(SWIFT_VENDOR "" CACHE STRING
     "The vendor name of the Swift compiler")

--- a/test/Parse/ConditionalCompilation/language_version_explicit.swift
+++ b/test/Parse/ConditionalCompilation/language_version_explicit.swift
@@ -21,7 +21,7 @@
   asdf asdf asdf asdf
 #endif
 
-#if swift(>=4.0.1)
+#if swift(>=4.0.2)
   // This shouldn't emit any diagnostics.
   asdf asdf asdf asdf
 #else

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -14,7 +14,7 @@ public class Sub: Base {
 
 // CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please file a bug report with your project and the crash log
 // CHECK-CRASH-3-NOT: note
-// CHECK-CRASH-4: note: compiling as Swift 4.0, with 'Lib' built as Swift 3.2
+// CHECK-CRASH-4: note: compiling as Swift 4.0.1, with 'Lib' built as Swift 3.2
 // CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE (please include this section in any bug report) ***
 // CHECK-CRASH: could not find 'disappearingMethod()' in parent class
 // CHECK-CRASH: While loading members for 'Sub' in module 'Lib'

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -16,8 +16,8 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
-class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0) because it has overridable members that could not be loaded in Swift 3.2}}
-class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.0) because it has requirements that could not be loaded in Swift 3.2}}
+class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0.1) because it has overridable members that could not be loaded in Swift 3.2}}
+class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.0.1) because it has requirements that could not be loaded in Swift 3.2}}
 
 #else // TEST
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -2060,7 +2060,7 @@ iterations with -O",
         "--swift-user-visible-version",
         help="User-visible version of the embedded Swift compiler",
         type=arguments.type.swift_compiler_version,
-        default="4.0",
+        default="4.0.1",
         metavar="MAJOR.MINOR")
 
     parser.add_argument(


### PR DESCRIPTION
<!-- What's in this pull request? -->
Bumps the Swift Compiler version to 4.0.1

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://34471818

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
