### PR TITLE
[stdlib] Eliminate the last direct use of Builtin.UnknownObject

### DIFF
--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -236,10 +236,7 @@ extension Equatable {
 public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
-    return Bool(Builtin.cmp_eq_RawPointer(
-        Builtin.bridgeToRawPointer(Builtin.castToUnknownObject(l)),
-        Builtin.bridgeToRawPointer(Builtin.castToUnknownObject(r))
-      ))
+    return ObjectIdentifier(l) == ObjectIdentifier(r)
   case (nil, nil):
     return true
   default:


### PR DESCRIPTION
At the Swift level, this is equivalent to AnyObject, which we've done much more testing of. This commit paves the way for taking UnknownObject out of the SIL type system and just using it as type metadata. Filed [SR-5926](https://bugs.swift.org/browse/SR-5926) to track that work.