### PR TITLE
runtime: return the argument from swift_retain family of functions

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -190,6 +190,15 @@
 
 #endif
 
+// The runtime implementation uses the preserve_most convention to save
+// registers spills on the hot path.
+#if __has_attribute(preserve_most) &&                                          \
+    (defined(__aarch64__) || defined(__x86_64__))
+#define SWIFT_CC_PreserveMost __attribute__((preserve_most))
+#else
+#define SWIFT_CC_PreserveMost
+#endif
+
 // Generates a name of the runtime entry's implementation by
 // adding an underscore as a prefix and a suffix.
 #define SWIFT_RT_ENTRY_IMPL(Name) _##Name##_

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -204,6 +204,10 @@ void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
 ///
 /// \param object - may be null, in which case this is a no-op
 ///
+/// \return object - we return the object because this enables tail call
+/// optimization and the argument register to be live through the call on
+/// architectures whose argument and return register is the same register.
+///
 /// POSSIBILITIES: We may end up wanting a bunch of different variants:
 ///  - the general version which correctly handles null values, swift
 ///     objects, and ObjC objects
@@ -213,34 +217,35 @@ void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
 /// It may also prove worthwhile to have this use a custom CC
 /// which preserves a larger set of registers.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_retain(HeapObject *object)
+HeapObject *swift_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-void (*SWIFT_CC(RegisterPreservingCC) _swift_retain)(HeapObject *object);
+HeapObject *(*SWIFT_CC(RegisterPreservingCC) _swift_retain)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_retain_n(HeapObject *object, uint32_t n)
+HeapObject *swift_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-void (*SWIFT_CC(RegisterPreservingCC) _swift_retain_n)(HeapObject *object,
-                                                       uint32_t n);
+HeapObject *(*SWIFT_CC(RegisterPreservingCC)
+                 _swift_retain_n)(HeapObject *object, uint32_t n);
 
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_nonatomic_retain(HeapObject *object)
+HeapObject *swift_nonatomic_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain)(HeapObject *object);
+HeapObject *(*SWIFT_CC(RegisterPreservingCC)
+                 _swift_nonatomic_retain)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
+HeapObject* swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain_n)(HeapObject *object,
-                                                       uint32_t n);
+HeapObject *(*SWIFT_CC(RegisterPreservingCC)
+                 _swift_nonatomic_retain_n)(HeapObject *object, uint32_t n);
 
 /// Atomically increments the reference count of an object, unless it has
 /// already been destroyed. Returns nil if the object is dead.
@@ -525,7 +530,7 @@ struct UnownedReference {
 
 /// Increment the unowned retain count.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_unownedRetain(HeapObject *value)
+HeapObject *swift_unownedRetain(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Decrement the unowned retain count.
@@ -535,7 +540,7 @@ void swift_unownedRelease(HeapObject *value)
 
 /// Increment the unowned retain count.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_nonatomic_unownedRetain(HeapObject *value)
+void *swift_nonatomic_unownedRetain(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Decrement the unowned retain count.
@@ -545,7 +550,7 @@ void swift_nonatomic_unownedRelease(HeapObject *value)
 
 /// Increment the unowned retain count by n.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_unownedRetain_n(HeapObject *value, int n)
+HeapObject *swift_unownedRetain_n(HeapObject *value, int n)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Decrement the unowned retain count by n.
@@ -555,7 +560,7 @@ void swift_unownedRelease_n(HeapObject *value, int n)
 
 /// Increment the unowned retain count by n.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_nonatomic_unownedRetain_n(HeapObject *value, int n)
+HeapObject *swift_nonatomic_unownedRetain_n(HeapObject *value, int n)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Decrement the unowned retain count by n.
@@ -566,13 +571,13 @@ void swift_nonatomic_unownedRelease_n(HeapObject *value, int n)
 /// Increment the strong retain count of an object, aborting if it has
 /// been deallocated.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_unownedRetainStrong(HeapObject *value)
+HeapObject *swift_unownedRetainStrong(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Increment the strong retain count of an object, aborting if it has
 /// been deallocated.
 SWIFT_RT_ENTRY_VISIBILITY
-void swift_nonatomic_unownedRetainStrong(HeapObject *value)
+HeapObject *swift_nonatomic_unownedRetainStrong(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Increment the strong retain count of an object which may have been
@@ -770,46 +775,46 @@ void *swift_nonatomic_bridgeObjectRetain_n(void *value, int n)
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-void swift_unknownRetain(void *value)
+void *swift_unknownRetain(void *value)
     SWIFT_CC(DefaultCC);
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object by n.
 SWIFT_RUNTIME_EXPORT
-void swift_unknownRetain_n(void *value, int n)
+void *swift_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-void swift_nonatomic_unknownRetain(void *value)
+void *swift_nonatomic_unknownRetain(void *value)
     SWIFT_CC(DefaultCC);
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object by n.
 SWIFT_RUNTIME_EXPORT
-void swift_nonatomic_unknownRetain_n(void *value, int n)
+void *swift_nonatomic_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 
 #else
 
-static inline void swift_unknownRetain(void *value)
+static inline void *swift_unknownRetain(void *value)
     SWIFT_CC(DefaultCC) {
-  swift_retain(static_cast<HeapObject *>(value));
+  return swift_retain(static_cast<HeapObject *>(value));
 }
 
-static inline void swift_unknownRetain_n(void *value, int n)
+static inline void *swift_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC) {
-  swift_retain_n(static_cast<HeapObject *>(value), n);
+  return swift_retain_n(static_cast<HeapObject *>(value), n);
 }
 
-static inline void swift_nonatomic_unknownRetain(void *value)
+static inline void *swift_nonatomic_unknownRetain(void *value)
     SWIFT_CC(DefaultCC) {
-  swift_nonatomic_retain(static_cast<HeapObject *>(value));
+  return swift_nonatomic_retain(static_cast<HeapObject *>(value));
 }
 
-static inline void swift_nonatomic_unknownRetain_n(void *value, int n)
+static inline void *swift_nonatomic_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC) {
-  swift_nonatomic_retain_n(static_cast<HeapObject *>(value), n);
+  return swift_nonatomic_retain_n(static_cast<HeapObject *>(value), n);
 }
 
 

--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -29,11 +29,11 @@ SWIFT_RUNTIME_EXPORT
 BoxPair::Return (*_swift_allocBox)(Metadata const *type);
 
 SWIFT_RUNTIME_EXPORT
-void (*_swift_retain)(HeapObject *object);
+HeapObject *(*_swift_retain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-void (*_swift_retain_n)(HeapObject *object, uint32_t n);
+HeapObject *(*_swift_retain_n)(HeapObject *object, uint32_t n);
 SWIFT_RUNTIME_EXPORT
-void (*_swift_nonatomic_retain)(HeapObject *object);
+HeapObject *(*_swift_nonatomic_retain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*_swift_tryRetain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -159,12 +159,12 @@ FUNCTION(CopyPOD, swift_copyPOD, DefaultCC,
          ARGS(OpaquePtrTy, OpaquePtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_retain(void *ptr);
+// void *swift_retain(void *ptr);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeStrongRetain, swift_retain,
          _swift_retain,  _swift_retain_, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_release(void *ptr);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeStrongRelease, swift_release,
@@ -173,19 +173,19 @@ FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeStrongRelease, swift_release,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_retain_n(void *ptr, int32_t n);
+// void *swift_retain_n(void *ptr, int32_t n);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeStrongRetainN, swift_retain_n,
          _swift_retain_n, _swift_retain_n_, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
-// void swift_release_n(void *ptr, int32_t n);
+// void *swift_release_n(void *ptr, int32_t n);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeStrongReleaseN, swift_release_n,
          _swift_release_n, _swift_release_n_, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_setDeallocating(void *ptr);
 FUNCTION(NativeSetDeallocating, swift_setDeallocating,
@@ -194,12 +194,12 @@ FUNCTION(NativeSetDeallocating, swift_setDeallocating,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_nonatomic_retain_n(void *ptr, int32_t n);
+// void *swift_nonatomic_retain_n(void *ptr, int32_t n);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongRetainN, swift_nonatomic_retain_n,
          _swift_nonatomic_retain_n, _swift_nonatomic_retain_n_, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_release_n(void *ptr, int32_t n);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongReleaseN, swift_nonatomic_release_n,
@@ -208,12 +208,12 @@ FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongReleaseN, swift_nonato
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
-// void swift_unknownRetain_n(void *ptr, int32_t n);
+// void *swift_unknownRetain_n(void *ptr, int32_t n);
 FUNCTION(UnknownRetainN, swift_unknownRetain_n,
          DefaultCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unknownRelease_n(void *ptr, int32_t n);
 FUNCTION(UnknownReleaseN, swift_unknownRelease_n,
@@ -222,12 +222,12 @@ FUNCTION(UnknownReleaseN, swift_unknownRelease_n,
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
-// void swift_nonatomic_unknownRetain_n(void *ptr, int32_t n);
+// void *swift_nonatomic_unknownRetain_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnknownRetainN, swift_nonatomic_unknownRetain_n,
          DefaultCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_unknownRelease_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnknownReleaseN, swift_nonatomic_unknownRelease_n,
@@ -264,12 +264,12 @@ FUNCTION(NonAtomicBridgeObjectReleaseN, swift_nonatomic_bridgeObjectRelease_n,
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
-// void swift_nonatomic_retain(void *ptr);
+// void *swift_nonatomic_retain(void *ptr);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongRetain, swift_nonatomic_retain,
          _swift_nonatomic_retain, _swift_nonatomic_retain_, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void *swift_tryPin(void *ptr);
 FUNCTION(NativeTryPin, swift_tryPin, RegisterPreservingCC,
@@ -316,11 +316,11 @@ FUNCTION(NonAtomicNativeUnpin, swift_nonatomic_unpin, RegisterPreservingCC,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_unknownRetain(void *ptr);
+// void *swift_unknownRetain(void *ptr);
 FUNCTION(UnknownRetain, swift_unknownRetain, DefaultCC,
-         RETURNS(VoidTy),
+         RETURNS(UnknownRefCountedPtrTy),
          ARGS(UnknownRefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unknownRelease(void *ptr);
 FUNCTION(UnknownRelease, swift_unknownRelease, DefaultCC,
@@ -328,11 +328,11 @@ FUNCTION(UnknownRelease, swift_unknownRelease, DefaultCC,
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_nonatomic_unknownRetain(void *ptr);
+// void *swift_nonatomic_unknownRetain(void *ptr);
 FUNCTION(NonAtomicUnknownRetain, swift_nonatomic_unknownRetain, DefaultCC,
-         RETURNS(VoidTy),
+         RETURNS(UnknownRefCountedPtrTy),
          ARGS(UnknownRefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unknownRelease(void *ptr);
 FUNCTION(NonAtomicUnknownRelease, swift_nonatomic_unknownRelease, DefaultCC,
@@ -377,11 +377,11 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease, DefaultCC,
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_unownedRetain(void *ptr);
+// void *swift_unownedRetain(void *ptr);
 FUNCTION(NativeUnownedRetain, swift_unownedRetain, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unownedRelease(void *ptr);
 FUNCTION(NativeUnownedRelease, swift_unownedRelease, RegisterPreservingCC,
@@ -389,12 +389,12 @@ FUNCTION(NativeUnownedRelease, swift_unownedRelease, RegisterPreservingCC,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_nonatomic_unownedRetain(void *ptr);
+// void *swift_nonatomic_unownedRetain(void *ptr);
 FUNCTION(NonAtomicNativeUnownedRetain, swift_nonatomic_unownedRetain,
          RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_unownedRelease(void *ptr);
 FUNCTION(NonAtomicNativeUnownedRelease, swift_nonatomic_unownedRelease,
@@ -403,12 +403,12 @@ FUNCTION(NonAtomicNativeUnownedRelease, swift_nonatomic_unownedRelease,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-// void swift_unownedRetain_n(void *ptr, int32_t n);
+// void *swift_unownedRetain_n(void *ptr, int32_t n);
 FUNCTION(UnownedRetainN, swift_unownedRetain_n,
          RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unownedRelease_n(void *ptr, int32_t n);
 FUNCTION(UnownedReleaseN, swift_unownedRelease_n,
@@ -417,12 +417,12 @@ FUNCTION(UnownedReleaseN, swift_unownedRelease_n,
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
-// void swift_nonatomic_unownedRetain_n(void *ptr, int32_t n);
+// void *swift_nonatomic_unownedRetain_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnownedRetainN, swift_nonatomic_unownedRetain_n,
          RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_unownedRelease_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnownedReleaseN, swift_nonatomic_unownedRelease_n,
@@ -431,18 +431,18 @@ FUNCTION(NonAtomicUnownedReleaseN, swift_nonatomic_unownedRelease_n,
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
-// void swift_unownedRetainStrong(void *ptr);
+// void *swift_unownedRetainStrong(void *ptr);
 FUNCTION(NativeStrongRetainUnowned, swift_unownedRetainStrong, RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
-// void swift_nonatomic_unownedRetainStrong(void *ptr);
+// void *swift_nonatomic_unownedRetainStrong(void *ptr);
 FUNCTION(NonAtomicNativeStrongRetainUnowned, swift_nonatomic_unownedRetainStrong,
          RegisterPreservingCC,
-         RETURNS(VoidTy),
+         RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unownedRetainStrongAndRelease(void *ptr);
 FUNCTION(NativeStrongRetainAndUnownedRelease,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -553,10 +553,14 @@ llvm::Constant *swift::getWrapperFn(llvm::Module &Module,
 
 
     auto fnPtr = Builder.CreateLoad(globalFnPtr, "load");
+
     auto call = Builder.CreateCall(fnPtr, args);
     call->setCallingConv(cc);
     call->setTailCall(true);
-
+    for (auto Attr : attrs)
+      if (isReturnedAttribute(Attr)) {
+        call->addParamAttr(0, llvm::Attribute::Returned);
+      }
     auto VoidTy = llvm::Type::getVoidTy(Module.getContext());
     if (retTypes.size() == 1 && *retTypes.begin() == VoidTy)
       Builder.CreateRetVoid();

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -29,6 +29,7 @@ namespace RuntimeConstants {
   const auto NoReturn = llvm::Attribute::NoReturn;
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;
+  const auto FirstParamReturned = llvm::Attribute::Returned;
 }
 
 using namespace RuntimeConstants;
@@ -229,7 +230,6 @@ private:
     if (Retain)
       return Retain.get();
     auto *ObjectPtrTy = getObjectPtrTy();
-    auto *VoidTy = Type::getVoidTy(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
     Retain = getWrapperFn(
@@ -237,7 +237,8 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_retain" : "swift_retain",
         isNonAtomic(OrigI) ? SWIFT_RT_ENTRY_REF_AS_STR(swift_nonatomic_retain)
                            : SWIFT_RT_ENTRY_REF_AS_STR(swift_retain),
-        RegisterPreservingCC, {VoidTy}, {ObjectPtrTy}, {NoUnwind});
+        RegisterPreservingCC, {ObjectPtrTy}, {ObjectPtrTy},
+        {NoUnwind, FirstParamReturned});
 
     return Retain.get();
   }
@@ -285,7 +286,6 @@ private:
       return RetainN.get();
     auto *ObjectPtrTy = getObjectPtrTy();
     auto *Int32Ty = Type::getInt32Ty(getModule().getContext());
-    auto *VoidTy = Type::getVoidTy(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
     RetainN = getWrapperFn(
@@ -293,7 +293,8 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_retain_n" : "swift_retain_n",
         isNonAtomic(OrigI) ? SWIFT_RT_ENTRY_REF_AS_STR(swift_nonatomic_retain_n)
                            : SWIFT_RT_ENTRY_REF_AS_STR(swift_retain_n),
-        RegisterPreservingCC, {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+        RegisterPreservingCC, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
+        {NoUnwind, FirstParamReturned});
 
     return RetainN.get();
   }
@@ -324,14 +325,14 @@ private:
       return UnknownRetainN.get();
     auto *ObjectPtrTy = getObjectPtrTy();
     auto *Int32Ty = Type::getInt32Ty(getModule().getContext());
-    auto *VoidTy = Type::getVoidTy(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
     UnknownRetainN =
         getRuntimeFn(getModule(), cache,
                      isNonAtomic(OrigI) ? "swift_nonatomic_unknownRetain_n"
                                         : "swift_unknownRetain_n",
-                     DefaultCC, {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+                     DefaultCC, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
+                     {NoUnwind, FirstParamReturned});
 
     return UnknownRetainN.get();
   }

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -742,7 +742,7 @@ class RefCounts {
   // Out-of-line slow paths.
 
   LLVM_ATTRIBUTE_NOINLINE
-  void incrementSlow(RefCountBits oldbits, uint32_t inc);
+  void incrementSlow(RefCountBits oldbits, uint32_t inc) SWIFT_CC(PreserveMost);
 
   LLVM_ATTRIBUTE_NOINLINE
   void incrementNonAtomicSlow(RefCountBits oldbits, uint32_t inc);

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -290,21 +290,22 @@ HeapObject *swift::swift_allocEmptyBox() {
 extern "C" LLVM_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED 
 void _swift_release_dealloc(HeapObject *object) SWIFT_CC(RegisterPreservingCC_IMPL);
 
-void swift::swift_retain(HeapObject *object)
+HeapObject *swift::swift_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  SWIFT_RT_ENTRY_REF(swift_retain)(object);
+  return SWIFT_RT_ENTRY_REF(swift_retain)(object);
 }
 
-void swift::swift_nonatomic_retain(HeapObject *object) {
-  SWIFT_RT_ENTRY_REF(swift_nonatomic_retain)(object);
+HeapObject *swift::swift_nonatomic_retain(HeapObject *object) {
+  return SWIFT_RT_ENTRY_REF(swift_nonatomic_retain)(object);
 }
 
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
-extern "C"
-void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain)(HeapObject *object) {
+extern "C" HeapObject *
+SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain)(HeapObject *object) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.incrementNonAtomic(1);
+  return object;
 }
 
 void swift::swift_nonatomic_release(HeapObject *object) {
@@ -321,39 +322,42 @@ void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_release)(HeapObject *object) {
 
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
-void SWIFT_RT_ENTRY_IMPL(swift_retain)(HeapObject *object)
+HeapObject *SWIFT_RT_ENTRY_IMPL(swift_retain)(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_retain);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.increment(1);
+  return object;
 }
 
-void swift::swift_retain_n(HeapObject *object, uint32_t n)
+HeapObject *swift::swift_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  SWIFT_RT_ENTRY_REF(swift_retain_n)(object, n);
+  return SWIFT_RT_ENTRY_REF(swift_retain_n)(object, n);
 }
 
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
-void SWIFT_RT_ENTRY_IMPL(swift_retain_n)(HeapObject *object, uint32_t n)
+HeapObject *SWIFT_RT_ENTRY_IMPL(swift_retain_n)(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_retain_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.increment(n);
+  return object;
 }
 
-void swift::swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
+HeapObject *swift::swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  SWIFT_RT_ENTRY_REF(swift_nonatomic_retain_n)(object, n);
+  return SWIFT_RT_ENTRY_REF(swift_nonatomic_retain_n)(object, n);
 }
 
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
-extern "C"
-void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain_n)(HeapObject *object, uint32_t n)
+extern "C" HeapObject *
+SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain_n)(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.incrementNonAtomic(n);
+  return object;
 }
 
 void swift::swift_release(HeapObject *object)
@@ -411,13 +415,14 @@ size_t swift::swift_unownedRetainCount(HeapObject *object) {
   return object->refCounts.getUnownedCount();
 }
 
-void swift::swift_unownedRetain(HeapObject *object)
+HeapObject *swift::swift_unownedRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetain);
   if (!isValidPointerForNativeRetain(object))
-    return;
+    return object;
 
   object->refCounts.incrementUnowned(1);
+  return object;
 }
 
 void swift::swift_unownedRelease(HeapObject *object)
@@ -439,13 +444,14 @@ void swift::swift_unownedRelease(HeapObject *object)
   }
 }
 
-void swift::swift_nonatomic_unownedRetain(HeapObject *object)
+void *swift::swift_nonatomic_unownedRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetain);
   if (!isValidPointerForNativeRetain(object))
-    return;
+    return object;
 
   object->refCounts.incrementUnownedNonAtomic(1);
+  return object;
 }
 
 void swift::swift_nonatomic_unownedRelease(HeapObject *object)
@@ -467,13 +473,14 @@ void swift::swift_nonatomic_unownedRelease(HeapObject *object)
   }
 }
 
-void swift::swift_unownedRetain_n(HeapObject *object, int n)
+HeapObject *swift::swift_unownedRetain_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetain_n);
   if (!isValidPointerForNativeRetain(object))
-    return;
+    return object;
 
   object->refCounts.incrementUnowned(n);
+  return object;
 }
 
 void swift::swift_unownedRelease_n(HeapObject *object, int n)
@@ -494,13 +501,14 @@ void swift::swift_unownedRelease_n(HeapObject *object, int n)
   }
 }
 
-void swift::swift_nonatomic_unownedRetain_n(HeapObject *object, int n)
+HeapObject *swift::swift_nonatomic_unownedRetain_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetain_n);
   if (!isValidPointerForNativeRetain(object))
-    return;
+    return object;
 
   object->refCounts.incrementUnownedNonAtomic(n);
+  return object;
 }
 
 void swift::swift_nonatomic_unownedRelease_n(HeapObject *object, int n)
@@ -595,28 +603,30 @@ bool SWIFT_RT_ENTRY_IMPL(swift_isDeallocating)(HeapObject *object) {
   return object->refCounts.isDeiniting();
 }
 
-void swift::swift_unownedRetainStrong(HeapObject *object)
+HeapObject *swift::swift_unownedRetainStrong(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetainStrong);
   if (!isValidPointerForNativeRetain(object))
-    return;
+    return object;
   assert(object->refCounts.getUnownedCount() &&
          "object is not currently unowned-retained");
 
   if (! object->refCounts.tryIncrement())
     swift::swift_abortRetainUnowned(object);
+  return object;
 }
 
-void swift::swift_nonatomic_unownedRetainStrong(HeapObject *object)
+HeapObject *swift::swift_nonatomic_unownedRetainStrong(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_unownedRetainStrong);
   if (!isValidPointerForNativeRetain(object))
-    return;
+    return object;
   assert(object->refCounts.getUnownedCount() &&
          "object is not currently unowned-retained");
 
   if (! object->refCounts.tryIncrementNonAtomic())
     swift::swift_abortRetainUnowned(object);
+  return object;
 }
 
 void swift::swift_unownedRetainStrongAndRelease(HeapObject *object)

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -492,15 +492,16 @@ static uintptr_t const objectPointerIsObjCBit = 0x4000000000000000ULL;
 static uintptr_t const objectPointerIsObjCBit = 0x00000002U;
 #endif
 
-void swift::swift_unknownRetain_n(void *object, int n)
+void *swift::swift_unknownRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
-  if (isObjCTaggedPointerOrNull(object)) return;
+  if (isObjCTaggedPointerOrNull(object)) return object;
   if (objectUsesNativeSwiftReferenceCounting(object)) {
-    swift_retain_n(static_cast<HeapObject *>(object), n);
-    return;
+    return swift_retain_n(static_cast<HeapObject *>(object), n);
   }
   for (int i = 0; i < n; ++i)
     objc_retain(static_cast<id>(object));
+
+  return object;
 }
 
 void swift::swift_unknownRelease_n(void *object, int n)
@@ -512,14 +513,13 @@ void swift::swift_unknownRelease_n(void *object, int n)
     objc_release(static_cast<id>(object));
 }
 
-void swift::swift_unknownRetain(void *object)
+void *swift::swift_unknownRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
-  if (isObjCTaggedPointerOrNull(object)) return;
+  if (isObjCTaggedPointerOrNull(object)) return object;
   if (objectUsesNativeSwiftReferenceCounting(object)) {
-    swift_retain(static_cast<HeapObject *>(object));
-    return;
+    return swift_retain(static_cast<HeapObject *>(object));
   }
-  objc_retain(static_cast<id>(object));
+  return objc_retain(static_cast<id>(object));
 }
 
 void swift::swift_unknownRelease(void *object)
@@ -530,15 +530,15 @@ void swift::swift_unknownRelease(void *object)
   return objc_release(static_cast<id>(object));
 }
 
-void swift::swift_nonatomic_unknownRetain_n(void *object, int n)
+void *swift::swift_nonatomic_unknownRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
-  if (isObjCTaggedPointerOrNull(object)) return;
+  if (isObjCTaggedPointerOrNull(object)) return object;
   if (objectUsesNativeSwiftReferenceCounting(object)) {
-    swift_nonatomic_retain_n(static_cast<HeapObject *>(object), n);
-    return;
+    return swift_nonatomic_retain_n(static_cast<HeapObject *>(object), n);
   }
   for (int i = 0; i < n; ++i)
     objc_retain(static_cast<id>(object));
+  return object;
 }
 
 void swift::swift_nonatomic_unknownRelease_n(void *object, int n)
@@ -550,14 +550,13 @@ void swift::swift_nonatomic_unknownRelease_n(void *object, int n)
     objc_release(static_cast<id>(object));
 }
 
-void swift::swift_nonatomic_unknownRetain(void *object)
+void *swift::swift_nonatomic_unknownRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
-  if (isObjCTaggedPointerOrNull(object)) return;
+  if (isObjCTaggedPointerOrNull(object)) return object;
   if (objectUsesNativeSwiftReferenceCounting(object)) {
-    swift_nonatomic_retain(static_cast<HeapObject *>(object));
-    return;
+    return swift_nonatomic_retain(static_cast<HeapObject *>(object));
   }
-  objc_retain(static_cast<id>(object));
+  return objc_retain(static_cast<id>(object));
 }
 
 void swift::swift_nonatomic_unknownRelease(void *object)

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -174,7 +174,7 @@ class SuperSub : SuperBase {
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret, %T22big_types_corner_cases10MUseStructV* noalias nocapture swiftself dereferenceable({{.*}})) #0 {
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK: [[LOAD:%.*]] = load %swift.refcounted*, %swift.refcounted** %.callInternalLet.data
-// CHECK: call swiftcc void %6(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret [[ALLOC]], %swift.refcounted* swiftself [[LOAD]])
+// CHECK: call swiftcc void %7(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret [[ALLOC]], %swift.refcounted* swiftself [[LOAD]])
 // CHECK: ret void
 public struct MUseStruct {
   var x = BigStruct()

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -151,7 +151,7 @@ func assign_test(_ value: Builtin.Int64, ptr: Builtin.RawPointer) {
 // CHECK: define hidden {{.*}}%swift.refcounted* @_T08builtins16load_object_test{{[_0-9a-zA-Z]*}}F
 func load_object_test(_ ptr: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[T0:%.*]] = load [[REFCOUNT]]*, [[REFCOUNT]]**
-  // CHECK: call void @swift_rt_swift_retain([[REFCOUNT]]* [[T0]])
+  // CHECK: call [[REFCOUNT]]* @swift_rt_swift_retain([[REFCOUNT]]* returned [[T0]])
   // CHECK: ret [[REFCOUNT]]* [[T0]]
   return Builtin.load(ptr)
 }
@@ -159,7 +159,7 @@ func load_object_test(_ ptr: Builtin.RawPointer) -> Builtin.NativeObject {
 // CHECK: define hidden {{.*}}%swift.refcounted* @_T08builtins20load_raw_object_test{{[_0-9a-zA-Z]*}}F
 func load_raw_object_test(_ ptr: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[T0:%.*]] = load [[REFCOUNT]]*, [[REFCOUNT]]**
-  // CHECK: call void @swift_rt_swift_retain([[REFCOUNT]]* [[T0]])
+  // CHECK: call [[REFCOUNT]]* @swift_rt_swift_retain([[REFCOUNT]]* returned [[T0]])
   // CHECK: ret [[REFCOUNT]]* [[T0]]
   return Builtin.loadRaw(ptr)
 }
@@ -788,7 +788,7 @@ func is_same_metatype_test(_ t1: Any.Type, _ t2: Any.Type) {
 }
 
 // CHECK-LABEL: define {{.*}} @{{.*}}generic_unsafeGuaranteed_test
-// CHECK:  call void @{{.*}}swift_{{.*}}etain({{.*}}* %0)
+// CHECK:  call {{.*}}* @{{.*}}swift_{{.*}}etain({{.*}}* returned %0)
 // CHECK:  call void @{{.*}}swift_{{.*}}elease({{.*}}* %0)
 // CHECK:  ret {{.*}}* %0
 func generic_unsafeGuaranteed_test<T: AnyObject>(_ t : T) -> T {
@@ -798,7 +798,7 @@ func generic_unsafeGuaranteed_test<T: AnyObject>(_ t : T) -> T {
 
 // CHECK-LABEL: define {{.*}} @{{.*}}unsafeGuaranteed_test
 // CHECK:  [[LOCAL:%.*]] = alloca %swift.refcounted*
-// CHECK:  call void @swift_rt_swift_retain(%swift.refcounted* %0)
+// CHECK:  call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %0)
 // CHECK:  store %swift.refcounted* %0, %swift.refcounted** [[LOCAL]]
 // CHECK:  call void @swift_rt_swift_release(%swift.refcounted* %0)
 // CHECK:  ret %swift.refcounted* %0

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -94,7 +94,7 @@ func class_bounded_archetype_method<T : ClassBoundBinary>(_ x: T, y: T) {
   // CHECK: [[WITNESS_ENTRY:%.*]] = getelementptr inbounds i8*, i8** %T.ClassBoundBinary, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ENTRY]], align 8
   // CHECK: [[WITNESS_FUNC:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %objc_object*, %swift.type*, i8**)
-  // CHECK: call void @swift_unknownRetain(%objc_object* [[Y:%.*]])
+  // CHECK: call %objc_object* @swift_unknownRetain(%objc_object* returned [[Y:%.*]])
   // CHECK: call swiftcc void [[WITNESS_FUNC]](%objc_object* [[Y]], %objc_object* swiftself %0, %swift.type* %T, i8** %T.ClassBoundBinary)
 }
 

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -40,7 +40,7 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // CHECK:   [[WITNESS:%.*]] = load i8**, i8*** [[WITNESSADDR]], align 8
 // CHECK:   [[BOXADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [16 x i8], %swift.refcounted* }>, <{ %swift.refcounted, [16 x i8], %swift.refcounted* }>* [[CONTEXT]], i32 0, i32 2
 // CHECK:   [[BOX:%.*]] = load %swift.refcounted*, %swift.refcounted** [[BOXADDR]], align 8
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[BOX]])
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[BOX]])
 // CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %1)
 // CHECK:   [[RES:%.*]] = tail call swiftcc i64 @_T07closure1bS2icx3seq_tAA9OrdinableRzlFS2icfU_(i64 %0, %swift.refcounted* [[BOX]], %swift.type* [[TYPE]], i8** [[WITNESS]])
 // CHECK:   ret i64 [[RES]]

--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -32,8 +32,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NEXT: [[VAL1:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP1]], align 8
 // CHECK: [[GEP2:%.*]] = getelementptr inbounds %T019copy_value_destroy_B03FooV, %T019copy_value_destroy_B03FooV* %1, i32 0, i32 5
 // CHECK-NEXT: [[VAL2:%.*]] = load %swift.refcounted*, %swift.refcounted** [[GEP2]], align 8
-// CHECK: call void @swift_rt_swift_retain(%swift.refcounted* [[VAL1]])
-// CHECK: call void @swift_rt_swift_retain(%swift.refcounted* [[VAL2]])
+// CHECK: call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[VAL1]])
+// CHECK: call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[VAL2]])
 // CHECK: call void @swift_rt_swift_release(%swift.refcounted* [[VAL1]])
 // CHECK: call void @swift_rt_swift_release(%swift.refcounted* [[VAL2]])
 sil @non_trivial : $@convention(thin) (Foo) -> () {

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -39,7 +39,7 @@ public func g() {
 // CHECK-NO-OPT-DAG: @_swift_allocObject = external dllimport global %swift.refcounted* (%swift.type*, i32, i32)*
 // CHECK-NO-OPT-DAG: @_swift_deallocObject = external dllimport global void (%swift.refcounted*, i32, i32)*
 // CHECK-NO-OPT-DAG: @_swift_release = external dllimport global void (%swift.refcounted*)
-// CHECK-NO-OPT-DAG: @_swift_retain = external dllimport global void (%swift.refcounted*)
+// CHECK-NO-OPT-DAG: @_swift_retain = external dllimport global %swift.refcounted* (%swift.refcounted*)
 // CHECK-NO-OPT-DAG: @_swift_slowAlloc = external dllimport global i8* (i32, i32)*
 // CHECK-NO-OPT-DAG: @_swift_slowDealloc = external dllimport global void (i8*, i32, i32)*
 // CHECK-NO-OPT-DAG: @_T09dllexport1cCN = external dllimport global %swift.type
@@ -52,10 +52,10 @@ public func g() {
 // CHECK-NO-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 // CHECK-NO-OPT-DAG: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc(i32, i32)
 // CHECK-NO-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_release(%swift.refcounted*)
-// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_retain(%swift.refcounted*)
+// CHECK-NO-OPT-DAG: define linkonce_odr hidden %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned)
 // CHECK-NO-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_slowDealloc(i8*, i32, i32)
 
-// CHECK-OPT-DAG: @_swift_retain = external dllimport local_unnamed_addr global void (%swift.refcounted*)
+// CHECK-OPT-DAG: @_swift_retain = external dllimport local_unnamed_addr global %swift.refcounted* (%swift.refcounted*)
 // CHECK-OPT-DAG: @_T0BoWV = external dllimport global i8*
 // CHECK-OPT-DAG: @_T09dllexport1cCN = external dllimport global %swift.type
 // CHECK-OPT-DAG: @_T09dllexport1pMp = external dllimport global %swift.protocol

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -408,7 +408,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        call %swift.opaque* %initializeWithCopy(%swift.opaque* noalias {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      <label>:[[RIGHT]]
-  // CHECK:        call void @swift_rt_swift_retain
+  // CHECK:        call %swift.refcounted* @swift_rt_swift_retain
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      <label>:[[TRIVIAL]]
   // CHECK:        call void @llvm.memcpy

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -27,10 +27,10 @@ enum NullableRefcounted {
 // CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
 // CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
 // CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %3, align 8
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %4) {{#[0-9]+}}
 // CHECK:   store %swift.refcounted* %4, %swift.refcounted** %2, align 8
-// CHECK:   %5 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %5
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases18NullableRefcountedOwca(%swift.opaque* %dest, %swift.opaque* %src, %swift.type* %NullableRefcounted) {{.*}} {
@@ -41,11 +41,11 @@ enum NullableRefcounted {
 // CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
 // CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
 // CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* %5) {{#[0-9]+}}
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5) {{#[0-9]+}}
 // CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
 // CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
-// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %6
+// CHECK:   %7 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %7
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases18NullableRefcountedOwta(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %NullableRefcounted) {{.*}} {
@@ -181,7 +181,7 @@ enum AllRefcounted {
 // --                              0x3fffffffffffffff
 // CHECK:         %4 = and i64 %3, 4611686018427387903
 // CHECK:         %5 = inttoptr i64 %4 to %swift.refcounted*
-// CHECK:         call void @swift_rt_swift_retain(%swift.refcounted* %5)
+// CHECK:         call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5)
 // CHECK:         %6 = bitcast %T34enum_value_semantics_special_cases13AllRefcountedO* %0 to i64*
 // -- NB: The original loaded value is stored, not the masked one.
 // CHECK:         store i64 %3, i64* %6, align 8

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -12,12 +12,12 @@ protocol CP: class {}
 sil @class_existential_unowned : $@convention(thin) (@owned CP) -> @owned CP {
 entry(%s : $CP):
   %u = ref_to_unowned %s : $CP to $@sil_unowned CP
-  // CHECK: call void @swift_rt_swift_unownedRetain(%swift.refcounted* %0)
+  // CHECK: call %swift.refcounted* @swift_rt_swift_unownedRetain(%swift.refcounted* returned %0)
   unowned_retain %u : $@sil_unowned CP
   // CHECK: call void @swift_rt_swift_unownedRelease(%swift.refcounted* %0)
   unowned_release %u : $@sil_unowned CP
 
-  // CHECK: call void @swift_rt_swift_unownedRetainStrong(%swift.refcounted* %0)
+  // CHECK: call %swift.refcounted* @swift_rt_swift_unownedRetainStrong(%swift.refcounted* returned %0)
   strong_retain_unowned %u : $@sil_unowned CP
   %t = unowned_to_ref %u : $@sil_unowned CP to $CP
   // CHECK: call void @swift_rt_swift_release(%swift.refcounted* %0)
@@ -44,7 +44,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: store i8** [[SRC_WITNESS]], i8*** [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_weakInit(%swift.weak* [[DEST_REF_ADDR]], %swift.refcounted* [[SRC_REF]])
+  // CHECK: call %swift.weak* @swift_weakInit(%swift.weak* returned [[DEST_REF_ADDR]], %swift.refcounted* [[SRC_REF]])
   store_weak %a to [initialization] %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} %swift.refcounted*
@@ -52,7 +52,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: store i8** [[SRC_WITNESS]], i8*** [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_weakAssign(%swift.weak* [[DEST_REF_ADDR]], %swift.refcounted* [[SRC_REF]])
+  // CHECK: call %swift.weak* @swift_weakAssign(%swift.weak* returned [[DEST_REF_ADDR]], %swift.refcounted* [[SRC_REF]])
   store_weak %a to                  %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
@@ -69,7 +69,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_weakTakeInit(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_weakTakeInit(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1
@@ -78,7 +78,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_weakTakeAssign(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_weakTakeAssign(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1
@@ -87,7 +87,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_weakCopyInit(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_weakCopyInit(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1
@@ -96,7 +96,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_weakCopyAssign(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_weakCopyAssign(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -80,7 +80,7 @@ entry(%s : $CP):
   // CHECK: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[U1]], i32 0, i32 1
   // CHECK: store i8** %1, i8*** [[T0]], align 8
   // CHECK: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[U1]], i32 0, i32 0
-  // CHECK: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* [[T0]], %objc_object* %0)
+  // CHECK: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* returned [[T0]], %objc_object* %0)
 
   // CHECK: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[U1]], i32 0, i32 0
   // CHECK: [[T1:%.*]] = call %objc_object* @swift_unknownUnownedLoadStrong(%swift.unowned* [[T0]])
@@ -112,7 +112,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: store i8** [[SRC_WITNESS]], i8*** [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_unknownWeakInit(%swift.weak* [[DEST_REF_ADDR]], %objc_object* [[SRC_REF]])
+  // CHECK: call %swift.weak* @swift_unknownWeakInit(%swift.weak* returned [[DEST_REF_ADDR]], %objc_object* [[SRC_REF]])
   store_weak %a to [initialization] %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} %objc_object*
@@ -120,7 +120,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: store i8** [[SRC_WITNESS]], i8*** [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_unknownWeakAssign(%swift.weak* [[DEST_REF_ADDR]], %objc_object* [[SRC_REF]])
+  // CHECK: call %swift.weak* @swift_unknownWeakAssign(%swift.weak* returned [[DEST_REF_ADDR]], %objc_object* [[SRC_REF]])
   store_weak %a to                  %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
@@ -137,7 +137,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_unknownWeakTakeInit(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_unknownWeakTakeInit(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1
@@ -146,7 +146,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_unknownWeakTakeAssign(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_unknownWeakTakeAssign(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1
@@ -155,7 +155,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_unknownWeakCopyInit(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_unknownWeakCopyInit(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1
@@ -164,7 +164,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-  // CHECK: call %swift.weak* @swift_unknownWeakCopyAssign(%swift.weak* [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
+  // CHECK: call %swift.weak* @swift_unknownWeakCopyAssign(%swift.weak* returned [[DEST_REF_ADDR]], %swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]], align 8
   // CHECK: [[DEST_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 1

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -325,7 +325,7 @@ bb0(%0 : $*Existential):
 // CHECK:   [[SRC_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.refcounted**
 // CHECK:   [[DEST_REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[DEST_REFADDR]]
 // CHECK:   [[SRC_REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[SRC_REFADDR]]
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[SRC_REF]])
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[SRC_REF]])
 // CHECK:   call void @swift_rt_swift_release(%swift.refcounted* [[DEST_REF]])
 // CHECK:   store %swift.refcounted* [[SRC_REF]], %swift.refcounted** [[DEST_REFADDR]]
 // CHECK:   br label %done
@@ -382,7 +382,7 @@ bb0(%0 : $*Existential):
 // CHECK:   [[DEST_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.refcounted**
 // CHECK:   [[SRC_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.refcounted**
 // CHECK:   [[SRC_REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[SRC_REFADDR]]
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[SRC_REF]])
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[SRC_REF]])
 // CHECK:   store %swift.refcounted* [[SRC_REF]], %swift.refcounted** [[DEST_REFADDR]]
 // CHECK:   br label %dest-inline-cont
 //
@@ -418,7 +418,7 @@ bb0(%0 : $*Existential):
 // CHECK:   [[DEST_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[DEST_BUFFERADDR]] to %swift.refcounted**
 // CHECK:   [[SRC_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRC_BUFFERADDR]] to %swift.refcounted**
 // CHECK:   [[SRC_REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[SRC_REFADDR]]
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[SRC_REF]])
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[SRC_REF]])
 // CHECK:   store %swift.refcounted* [[SRC_REF]], %swift.refcounted** [[DEST_REFADDR]]
 // CHECK:   br label %dest-outline-cont
 //

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -23,11 +23,11 @@ entry(%x : $@convention(thin) () -> ()):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @thick_func_value(i8*, %swift.refcounted*) {{.*}} {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    call void @swift_rt_swift_retain(%swift.refcounted* %1) {{#[0-9]+}}
+// CHECK-NEXT:    call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %1) {{#[0-9]+}}
 // CHECK-NEXT:    call void @swift_rt_swift_release(%swift.refcounted* %1) {{#[0-9]+}}
-// CHECK-NEXT:    %2 = insertvalue { i8*, %swift.refcounted* } undef, i8* %0, 0
-// CHECK-NEXT:    %3 = insertvalue { i8*, %swift.refcounted* } %2, %swift.refcounted* %1, 1
-// CHECK-NEXT:    ret { i8*, %swift.refcounted* } %3
+// CHECK-NEXT:    %3 = insertvalue { i8*, %swift.refcounted* } undef, i8* %0, 0
+// CHECK-NEXT:    %4 = insertvalue { i8*, %swift.refcounted* } %3, %swift.refcounted* %1, 1
+// CHECK-NEXT:    ret { i8*, %swift.refcounted* } %4
 // CHECK-NEXT:  }
 sil @thick_func_value : $@convention(thin) (@owned () -> ()) -> @owned () -> () {
 entry(%x : $() -> ()):

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -49,7 +49,7 @@ func dupC<T : C>(_ x: T) -> (T, T) { return (x, x) }
 // CHECK-LABEL: define hidden swiftcc { %T14generic_tuples1CC*, %T14generic_tuples1CC* } @_T014generic_tuples4dupCx_xtxAA1CCRbzlF(%T14generic_tuples1CC*, %swift.type* %T)
 // CHECK-NEXT: entry:
 // CHECK:      [[REF:%.*]] = bitcast %T14generic_tuples1CC* %0 to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[REF]])
+// CHECK-NEXT: call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[REF]])
 // CHECK-NEXT: [[TUP1:%.*]] = insertvalue { %T14generic_tuples1CC*, %T14generic_tuples1CC* } undef, %T14generic_tuples1CC* %0, 0
 // CHECK-NEXT: [[TUP2:%.*]] = insertvalue { %T14generic_tuples1CC*, %T14generic_tuples1CC* } [[TUP1:%.*]], %T14generic_tuples1CC* %0, 1
 // CHECK-NEXT: ret { %T14generic_tuples1CC*, %T14generic_tuples1CC* } [[TUP2]]
@@ -58,15 +58,15 @@ func callDupC(_ c: C) { _ = dupC(c) }
 // CHECK-LABEL: define hidden swiftcc void @_T014generic_tuples8callDupCyAA1CCF(%T14generic_tuples1CC*)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[REF:%.*]] = bitcast %T14generic_tuples1CC* %0 to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[REF]])
+// CHECK-NEXT: call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[REF]])
 // CHECK-NEXT: [[METATYPE:%.*]] = call %swift.type* @_T014generic_tuples1CCMa()
 // CHECK-NEXT: [[TUPLE:%.*]] = call swiftcc { %T14generic_tuples1CC*, %T14generic_tuples1CC* } @_T014generic_tuples4dupCx_xtxAA1CCRbzlF(%T14generic_tuples1CC* %0, %swift.type* [[METATYPE]])
 // CHECK-NEXT: [[LEFT:%.*]] = extractvalue { %T14generic_tuples1CC*, %T14generic_tuples1CC* } [[TUPLE]], 0
 // CHECK-NEXT: [[RIGHT:%.*]] = extractvalue { %T14generic_tuples1CC*, %T14generic_tuples1CC* } [[TUPLE]], 1
 // CHECK-NEXT: [[LEFT_CAST:%.*]] = bitcast %T14generic_tuples1CC* [[LEFT]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[LEFT_CAST]]
+// CHECK-NEXT: call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[LEFT_CAST]]
 // CHECK-NEXT: [[RIGHT_CAST:%.*]] = bitcast %T14generic_tuples1CC* [[RIGHT]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[RIGHT_CAST]]
+// CHECK-NEXT: call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[RIGHT_CAST]]
 // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T14generic_tuples1CC*)*)(%T14generic_tuples1CC* [[LEFT]])
 // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T14generic_tuples1CC*)*)(%T14generic_tuples1CC* [[RIGHT]])
 // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T14generic_tuples1CC*)*)(%T14generic_tuples1CC* [[RIGHT]])

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -134,7 +134,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 // CHECK-NEXT:    %2 = getelementptr inbounds { %objc_block, %swift.refcounted* }, { %objc_block, %swift.refcounted* }* %0, i32 0, i32 1
 // CHECK-NEXT:    %3 = getelementptr inbounds { %objc_block, %swift.refcounted* }, { %objc_block, %swift.refcounted* }* %1, i32 0, i32 1
 // CHECK-NEXT:    %4 = load %swift.refcounted*, %swift.refcounted** %3, align 8
-// CHECK-NEXT:    call void @swift_rt_swift_retain(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK-NEXT:    call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %4) {{#[0-9]+}}
 // CHECK-NEXT:    store %swift.refcounted* %4, %swift.refcounted** %2, align 8
 // CHECK-NEXT:    ret void
 

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -195,9 +195,9 @@ sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q>
 // CHECK:   [[WBADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted,{{.*}} %T23partial_apply_forwarder1SV, %T23partial_apply_forwarder7WeakBoxC* }>, <{ %swift.refcounted,{{.*}} %T23partial_apply_forwarder1SV, %T23partial_apply_forwarder7WeakBoxC* }>* [[CONTEXT]], i32 0, i32 {{(2|3)}}
 // CHECK:   [[WB:%.*]] = load %T23partial_apply_forwarder7WeakBoxC*, %T23partial_apply_forwarder7WeakBoxC** [[WBADDR]]
 // CHECK:   [[WBREF:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* [[WB]] to %swift.refcounted*
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[WBREF]])
+// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[WBREF]])
 // CHECK:   [[TYADDR:%.*]] = getelementptr inbounds %T23partial_apply_forwarder7WeakBoxC, %T23partial_apply_forwarder7WeakBoxC* [[WB]], i32 0, i32 0, i32 0
-// CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** %7
+// CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** [[TYADDR]] 
 // CHECK:   %.asUnsubstituted = bitcast %T23partial_apply_forwarder7WeakBoxC* [[WB]] to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %0)
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**

--- a/test/IRGen/unowned.sil
+++ b/test/IRGen/unowned.sil
@@ -31,7 +31,7 @@ bb0(%0 : $@sil_unowned C):
   %4 = return %3 : $()
 }
 // CHECK:    define{{( protected)?}} swiftcc void @test_weak_rr_class([[C]]*) {{.*}} {
-// CHECK:      call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
+// CHECK:      call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned %0)
 // CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
 
@@ -43,7 +43,7 @@ bb0(%0 : $@sil_unowned P):
   %4 = return %3 : $()
 }
 // CHECK:    define{{( protected)?}} swiftcc void @test_weak_rr_proto(%swift.refcounted*, i8**) {{.*}} {
-// CHECK:      call void @swift_rt_swift_unownedRetain(%swift.refcounted* %0)
+// CHECK:      call %swift.refcounted* @swift_rt_swift_unownedRetain(%swift.refcounted* returned %0)
 // CHECK:      call void @swift_rt_swift_unownedRelease(%swift.refcounted* %0)
 // CHECK-NEXT: ret void
 
@@ -57,7 +57,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -80,7 +80,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -94,7 +94,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X_C:%.*]] = bitcast %swift.unowned* [[SRC_X]] to [[C]]*
 // CHECK-NEXT: [[NEW:%.*]] = load [[C]]*, [[C]]** [[SRC_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[NEW]])
+// CHECK-NEXT: call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned [[NEW]])
 // CHECK-NEXT: [[DEST_X_C:%.*]] = bitcast %swift.unowned* [[DEST_X]] to [[C]]*
 // CHECK-NEXT: [[OLD:%.*]] = load [[C]]*, [[C]]** [[DEST_X_C]], align 8
 // CHECK-NEXT: store [[C]]* [[NEW]], [[C]]** [[DEST_X_C]], align 8

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -37,7 +37,7 @@ bb0(%0 : $@sil_unowned C):
   %4 = return %3 : $()
 }
 // CHECK:    define{{( protected)?}} swiftcc void @test_weak_rr_class([[C]]*) {{.*}} {
-// CHECK:      call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
+// CHECK:      call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned %0)
 // CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
 
@@ -58,12 +58,12 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 1
   // CHECK-NEXT: store i8** [[PP:%1]], i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* [[T0]], [[UNKNOWN]]* [[PV:%0]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[PV:%0]])
   store_unowned %p to [initialization] %x : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0
   // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedCopyInit(%swift.unowned* [[T0]], %swift.unowned* [[T1]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedCopyInit(%swift.unowned* returned [[T0]], %swift.unowned* [[T1]])
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 1
   // CHECK-NEXT: [[WT:%.*]] = load i8**, i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
@@ -81,7 +81,7 @@ bb0(%p : $P, %q : $P):
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0
   // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedCopyAssign(%swift.unowned* [[T0]], %swift.unowned* [[T1]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedCopyAssign(%swift.unowned* returned [[T0]], %swift.unowned* [[T1]])
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 1
   // CHECK-NEXT: [[WT:%.*]] = load i8**, i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
@@ -91,12 +91,12 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
   // CHECK-NEXT: store i8** [[QP:%3]], i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedAssign(%swift.unowned* [[T0]], [[UNKNOWN]]* [[QV:%2]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedAssign(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[QV:%2]])
   store_unowned %q to %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0
   // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedTakeAssign(%swift.unowned* [[T0]], %swift.unowned* [[T1]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedTakeAssign(%swift.unowned* returned [[T0]], %swift.unowned* [[T1]])
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 1
   // CHECK-NEXT: [[WT:%.*]] = load i8**, i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
@@ -105,7 +105,7 @@ bb0(%p : $P, %q : $P):
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
   // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedTakeInit(%swift.unowned* [[T0]], %swift.unowned* [[T1]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedTakeInit(%swift.unowned* returned [[T0]], %swift.unowned* [[T1]])
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
   // CHECK-NEXT: [[WT:%.*]] = load i8**, i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 1
@@ -121,7 +121,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 1
   // CHECK-NEXT: store i8** [[TP]], i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
-  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* [[T0]], [[UNKNOWN]]* [[TV]])
+  // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[TV]])
   store_unowned %t1 to [initialization] %x : $*@sil_unowned P
 
   // CHECK-NEXT: call void @swift_unknownRelease([[UNKNOWN]]* [[TV]])
@@ -159,7 +159,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -182,7 +182,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -196,7 +196,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X_C:%.*]] = bitcast %swift.unowned* [[SRC_X]] to [[C]]*
 // CHECK-NEXT: [[NEW:%.*]] = load [[C]]*, [[C]]** [[SRC_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[NEW]])
+// CHECK-NEXT: call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_rt_swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned [[NEW]])
 // CHECK-NEXT: [[DEST_X_C:%.*]] = bitcast %swift.unowned* [[DEST_X]] to [[C]]*
 // CHECK-NEXT: [[OLD:%.*]] = load [[C]]*, [[C]]** [[DEST_X_C]], align 8
 // CHECK-NEXT: store [[C]]* [[NEW]], [[C]]** [[DEST_X_C]], align 8

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -47,7 +47,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
 // CHECK-NEXT: [[T0:%.*]] = call [[C]]* bitcast ([[REF]]* ([[WEAK]]*)* @swift_weakLoadStrong to [[C]]* ([[WEAK]]*)*)([[WEAK]]* [[X]])
 // CHECK-NEXT: %3 = ptrtoint  %T4weak1CC* %2 to i64
 // CHECK-NEXT: %4 = inttoptr
-// CHECK-NEXT: call [[WEAK]]* bitcast ([[WEAK]]* ([[WEAK]]*, [[REF]]*)* @swift_weakAssign to [[WEAK]]* ([[WEAK]]*, [[C]]*)*)([[WEAK]]* [[X]], [[C]]* %4)
+// CHECK-NEXT: call [[WEAK]]* bitcast ([[WEAK]]* ([[WEAK]]*, [[REF]]*)* @swift_weakAssign to [[WEAK]]* ([[WEAK]]*, [[C]]*)*)([[WEAK]]* returned [[X]], [[C]]* %4)
 // CHECK-NEXT: %6 = inttoptr i64 %3 to %swift.refcounted*
 // CHECK-NEXT: call void @swift_rt_swift_release([[REF]]* %6)
 // CHECK-NEXT: ret void
@@ -76,7 +76,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 1
 // CHECK-NEXT: store i8** [[TMPTAB]], i8*** [[T0]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
-// CHECK-NEXT: call [[WEAK]]* @swift_unknownWeakAssign([[WEAK]]* [[T0]], [[UNKNOWN]]* [[TMPOBJ]])
+// CHECK-NEXT: call [[WEAK]]* @swift_unknownWeakAssign([[WEAK]]* returned [[T0]], [[UNKNOWN]]* [[TMPOBJ]])
 // CHECK: call void @_T0SqWe
 
 sil @test_weak_alloc_stack : $@convention(thin) (Optional<P>) -> () {
@@ -95,7 +95,7 @@ bb0(%0 : $Optional<P>):
 // CHECK: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 1
 // CHECK-NEXT: store i8** [[TMPTAB:%.*]], i8*** [[T0]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
-// CHECK-NEXT: call [[WEAK]]* @swift_unknownWeakInit([[WEAK]]* [[T0]], [[UNKNOWN]]* [[TMPOBJ:%.*]])
+// CHECK-NEXT: call [[WEAK]]* @swift_unknownWeakInit([[WEAK]]* returned [[T0]], [[UNKNOWN]]* [[TMPOBJ:%.*]])
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
 // CHECK-NEXT: call void @swift_unknownWeakDestroy([[WEAK]]* [[T0]])
 // CHECK-NEXT: bitcast
@@ -110,7 +110,7 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[SRC:%.*]] = bitcast [[BUFFER]]* [[SRCBUF]] to [[A]]*
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[A]], [[A]]* [[DEST]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
-// CHECK-NEXT: call [[WEAK]]* @swift_weakCopyInit([[WEAK]]* [[T0]], [[WEAK]]* [[T1]])
+// CHECK-NEXT: call [[WEAK]]* @swift_weakCopyInit([[WEAK]]* returned [[T0]], [[WEAK]]* [[T1]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
@@ -133,7 +133,7 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[SRC:%.*]] = bitcast [[OPAQUE]]* [[SRC_OPQ]] to [[A]]*
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[A]], [[A]]* [[DEST]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
-// CHECK-NEXT: call [[WEAK]]* @swift_weakCopyInit([[WEAK]]* [[T0]], [[WEAK]]* [[T1]])
+// CHECK-NEXT: call [[WEAK]]* @swift_weakCopyInit([[WEAK]]* returned [[T0]], [[WEAK]]* [[T1]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
@@ -146,7 +146,7 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[SRC:%.*]] = bitcast [[OPAQUE]]* [[SRC_OPQ]] to [[A]]*
 // CHECK-NEXT: [[DEST_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[DEST]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
-// CHECK-NEXT: call [[WEAK]]* @swift_weakCopyAssign([[WEAK]]* [[DEST_X]], [[WEAK]]* [[SRC_X]])
+// CHECK-NEXT: call [[WEAK]]* @swift_weakCopyAssign([[WEAK]]* returned [[DEST_X]], [[WEAK]]* [[SRC_X]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
@@ -159,7 +159,7 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[SRC:%.*]] = bitcast [[OPAQUE]]* [[SRC_OPQ]] to [[A]]*
 // CHECK-NEXT: [[DEST_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[DEST]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
-// CHECK-NEXT: call [[WEAK]]* @swift_weakTakeAssign([[WEAK]]* [[DEST_X]], [[WEAK]]* [[SRC_X]])
+// CHECK-NEXT: call [[WEAK]]* @swift_weakTakeAssign([[WEAK]]* returned [[DEST_X]], [[WEAK]]* [[SRC_X]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 

--- a/test/IRGen/weak_class_protocol.sil
+++ b/test/IRGen/weak_class_protocol.sil
@@ -14,8 +14,8 @@ protocol Foo: class { }
 // CHECK:         [[WTABLE_SLOT:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
 // CHECK:         store i8** [[WTABLE]], i8*** [[WTABLE_SLOT]], align 8
 // CHECK:         [[INSTANCE_SLOT:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
-// CHECK-objc:    call %swift.weak* @swift_unknownWeakAssign(%swift.weak* [[INSTANCE_SLOT]], %objc_object* [[INSTANCE]]) {{#[0-9]+}}
-// CHECK-native:  call %swift.weak* @swift_weakAssign(%swift.weak* [[INSTANCE_SLOT]], %swift.refcounted* [[INSTANCE]]) {{#[0-9]+}}
+// CHECK-objc:    call %swift.weak* @swift_unknownWeakAssign(%swift.weak* returned [[INSTANCE_SLOT]], %objc_object* [[INSTANCE]]) {{#[0-9]+}}
+// CHECK-native:  call %swift.weak* @swift_weakAssign(%swift.weak* returned [[INSTANCE_SLOT]], %swift.refcounted* [[INSTANCE]]) {{#[0-9]+}}
 // CHECK:         ret void
 // CHECK:       }
 sil @store_weak : $@convention(thin) (@owned Foo?) -> @out @sil_weak Foo? {

--- a/test/IRGen/weak_value_witnesses.sil
+++ b/test/IRGen/weak_value_witnesses.sil
@@ -30,7 +30,7 @@ struct Gen<T> {
 // CHECK-NEXT: [[SRC:%.*]] = bitcast [24 x i8]* %src to %T20weak_value_witnesses8JustWeakV*
 // CHECK-NEXT: [[DEST_X:%.*]] = getelementptr inbounds %T20weak_value_witnesses8JustWeakV, %T20weak_value_witnesses8JustWeakV* [[DEST]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds %T20weak_value_witnesses8JustWeakV, %T20weak_value_witnesses8JustWeakV* [[SRC]], i32 0, i32 0
-// CHECK-NEXT: call %swift.weak* @swift_weakTakeInit(%swift.weak* [[DEST_X]], %swift.weak* [[SRC_X]])
+// CHECK-NEXT: call %swift.weak* @swift_weakTakeInit(%swift.weak* returned [[DEST_X]], %swift.weak* [[SRC_X]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast %T20weak_value_witnesses8JustWeakV* [[DEST]] to %swift.opaque*
 // CHECK-NEXT: ret %swift.opaque* [[T0]]
 
@@ -52,7 +52,7 @@ struct Gen<T> {
 // CHECK-NEXT: store %T20weak_value_witnesses1CC* [[T0]], %T20weak_value_witnesses1CC** [[DEST_X]], align 8
 // CHECK-NEXT: [[DEST_Y:%.*]] = getelementptr inbounds %T20weak_value_witnesses8SomeWeakV, %T20weak_value_witnesses8SomeWeakV* [[DEST]], i32 0, i32 1
 // CHECK-NEXT: [[SRC_Y:%.*]] = getelementptr inbounds %T20weak_value_witnesses8SomeWeakV, %T20weak_value_witnesses8SomeWeakV* [[SRC]], i32 0, i32 1
-// CHECK-NEXT: call %swift.weak* @swift_weakTakeInit(%swift.weak* [[DEST_Y]], %swift.weak* [[SRC_Y]])
+// CHECK-NEXT: call %swift.weak* @swift_weakTakeInit(%swift.weak* returned [[DEST_Y]], %swift.weak* [[SRC_Y]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast %T20weak_value_witnesses8SomeWeakV* [[DEST]] to %swift.opaque*
 // CHECK-NEXT: ret %swift.opaque* [[T0]]
 

--- a/test/LLVMPasses/contract.ll
+++ b/test/LLVMPasses/contract.ll
@@ -11,9 +11,9 @@ declare %swift.refcounted* @swift_rt_swift_allocObject(%swift.heapmetadata* , i6
 declare %swift.bridge* @swift_bridgeObjectRetain(%swift.bridge*)
 declare void @swift_bridgeObjectRelease(%swift.bridge* )
 declare void @swift_rt_swift_release(%swift.refcounted* nocapture)
-declare void @swift_rt_swift_retain(%swift.refcounted* ) nounwind
+declare %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* ) nounwind
 declare void @swift_unknownRelease(%swift.refcounted* nocapture)
-declare void @swift_unknownRetain(%swift.refcounted* ) nounwind
+declare %swift.refcounted* @swift_unknownRetain(%swift.refcounted* ) nounwind
 declare void @__swift_fixLifetime(%swift.refcounted*)
 declare void @noread_user(%swift.refcounted*) readnone
 declare void @user(%swift.refcounted*)
@@ -42,37 +42,37 @@ entry:
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainN(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -80,31 +80,31 @@ bb3:
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
-; CHECK-NEXT: %0 = bitcast %swift.refcounted* %A to %swift.refcounted*
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: %1 = bitcast %swift.refcounted* %A to %swift.refcounted*
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainNWithRCIdentity(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
-  %0 = bitcast %swift.refcounted* %A to %swift.refcounted*
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %0)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
+  %1 = bitcast %swift.refcounted* %A to %swift.refcounted*
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %1)
   br label %bb3
 
 bb2:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -189,20 +189,20 @@ entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -233,53 +233,53 @@ bb3:
 ; But do make sure that we can form retainN, releaseN in between such uses
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 3)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 3)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -317,12 +317,12 @@ bb3:
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: tail call void @swift_rt_swift_release_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
@@ -343,14 +343,14 @@ entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
-  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* %A)
   tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   tail call void @swift_rt_swift_release(%swift.refcounted* %A)
@@ -373,53 +373,53 @@ bb3:
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractUnknownRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK: tail call void @swift_unknownRetain(%swift.refcounted* %A)
+; CHECK: tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_unknownRetain_n(%swift.refcounted* %A, i32 3)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain_n(%swift.refcounted* %A, i32 3)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_unknownRetain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_unknownRetain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_unknownRetain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @swift_unknownRetain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractUnknownRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -457,12 +457,12 @@ bb3:
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractUnknownRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @swift_unknownRetain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: tail call void @swift_unknownRelease_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @swift_unknownRetain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call %swift.refcounted* @swift_unknownRetain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: tail call void @swift_unknownRelease(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
@@ -483,14 +483,14 @@ entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   tail call void @swift_unknownRelease(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   tail call void @swift_unknownRelease(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
-  tail call void @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
+  tail call %swift.refcounted* @swift_unknownRetain(%swift.refcounted* %A)
   tail call void @swift_unknownRelease(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   tail call void @swift_unknownRelease(%swift.refcounted* %A)

--- a/unittests/runtime/Refcounting.cpp
+++ b/unittests/runtime/Refcounting.cpp
@@ -270,8 +270,10 @@ TEST(RefcountingTest, nonatomic_retain_release_n) {
   size_t value = 0;
   auto object = allocTestObject(&value, 1);
   EXPECT_EQ(0u, value);
-  swift_nonatomic_retain_n(object, 32);
-  swift_nonatomic_retain(object);
+  auto res = swift_nonatomic_retain_n(object, 32);
+  EXPECT_EQ(object, res);
+  res = swift_nonatomic_retain(object);
+  EXPECT_EQ(object, res);
   EXPECT_EQ(0u, value);
   EXPECT_EQ(34u, swift_retainCount(object));
   swift_nonatomic_release_n(object, 31);
@@ -289,8 +291,10 @@ TEST(RefcountingTest, nonatomic_unknown_retain_release_n) {
   size_t value = 0;
   auto object = allocTestObject(&value, 1);
   EXPECT_EQ(0u, value);
-  swift_nonatomic_unknownRetain_n(object, 32);
-  swift_nonatomic_unknownRetain(object);
+  auto res = swift_nonatomic_unknownRetain_n(object, 32);
+  EXPECT_EQ(object, res);
+  res = swift_nonatomic_unknownRetain(object);
+  EXPECT_EQ(object, res);
   EXPECT_EQ(0u, value);
   EXPECT_EQ(34u, swift_retainCount(object));
   swift_nonatomic_unknownRelease_n(object, 31);


### PR DESCRIPTION
On architectures where the calling convention uses the same argument register as
return register this allows the argument register to be live through the calls. It also enables tail calls to be optimized in functions that call swift_retain as the last thing and return its argument.