### PR TITLE
Allow "protocol P : class, AnyObject..." for Swift 4 compatibility. 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1936,6 +1936,8 @@ WARNING(override_swift3_objc_inference,none,
 // Inheritance
 ERROR(duplicate_inheritance,none,
   "duplicate inheritance from %0", (Type))
+WARNING(duplicate_anyobject_class_inheritance,none,
+  "redundant inheritance from 'AnyObject' and Swift 3 'class' keyword", ())
 ERROR(multiple_inheritance,none,
   "multiple inheritance from classes %0 and %1", (Type, Type))
 ERROR(non_class_inheritance,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -477,8 +477,9 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     if (knownType != inheritedTypes.end()) {
       // If the duplicated type is 'AnyObject', check whether the first was
       // written as 'class'. Downgrade the error to a warning in such cases
-      // for backward compatibility.
-      if (inheritedTy->isAnyObject() &&
+      // for backward compatibility with Swift <= 4.
+      if (!Context.LangOpts.isSwiftVersionAtLeast(5) &&
+          inheritedTy->isAnyObject() &&
           (isa<ProtocolDecl>(decl) || isa<AbstractTypeParamDecl>(decl)) &&
           Lexer::getTokenAtLocation(Context.SourceMgr,
                                     knownType->second.second.Start)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -440,7 +440,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   Type superclassTy;
   SourceRange superclassRange;
   llvm::SmallSetVector<ProtocolDecl *, 4> allProtocols;
-  llvm::SmallDenseMap<CanType, SourceRange> inheritedTypes;
+  llvm::SmallDenseMap<CanType, std::pair<unsigned, SourceRange>> inheritedTypes;
   addImplicitConformances(*this, decl, allProtocols);
   for (unsigned i = 0, n = inheritedClause.size(); i != n; ++i) {
     auto &inherited = inheritedClause[i];
@@ -475,15 +475,32 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     CanType inheritedCanTy = inheritedTy->getCanonicalType();
     auto knownType = inheritedTypes.find(inheritedCanTy);
     if (knownType != inheritedTypes.end()) {
+      // If the duplicated type is 'AnyObject', check whether the first was
+      // written as 'class'. Downgrade the error to a warning in such cases
+      // for backward compatibility.
+      if (inheritedTy->isAnyObject() &&
+          (isa<ProtocolDecl>(decl) || isa<AbstractTypeParamDecl>(decl)) &&
+          Lexer::getTokenAtLocation(Context.SourceMgr,
+                                    knownType->second.second.Start)
+            .is(tok::kw_class)) {
+        SourceLoc classLoc = knownType->second.second.Start;
+        SourceRange removeRange = getRemovalRange(knownType->second.first);
+
+        diagnose(classLoc, diag::duplicate_anyobject_class_inheritance)
+          .fixItRemoveChars(removeRange.Start, removeRange.End);
+        inherited.setInvalidType(Context);
+        continue;
+      }
+
       auto removeRange = getRemovalRange(i);
       diagnose(inherited.getSourceRange().Start,
                diag::duplicate_inheritance, inheritedTy)
         .fixItRemoveChars(removeRange.Start, removeRange.End)
-        .highlight(knownType->second);
+        .highlight(knownType->second.second);
       inherited.setInvalidType(Context);
       continue;
     }
-    inheritedTypes[inheritedCanTy] = inherited.getSourceRange();
+    inheritedTypes[inheritedCanTy] = { i, inherited.getSourceRange() };
 
     // If this is a protocol or protocol composition type, record the
     // protocols.

--- a/test/Compatibility/anyobject_class.swift
+++ b/test/Compatibility/anyobject_class.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+protocol P : class, AnyObject { } // expected-warning{{redundant inheritance from 'AnyObject' and Swift 3 'class' keyword}}{{14-21=}}
+// expected-warning@-1{{redundant layout constraint 'Self' : 'AnyObject'}}
+// expected-note@-2{{layout constraint constraint 'Self' : 'AnyObject' written here}}

--- a/test/Compatibility/anyobject_class.swift
+++ b/test/Compatibility/anyobject_class.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -swift-version 3
 // RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: not %target-swift-frontend -tyepcheck -swift-version 5
 
 protocol P : class, AnyObject { } // expected-warning{{redundant inheritance from 'AnyObject' and Swift 3 'class' keyword}}{{14-21=}}
 // expected-warning@-1{{redundant layout constraint 'Self' : 'AnyObject'}}


### PR DESCRIPTION
Because of the way we modeled the 'class' constraint in Swift <= 4, we
allowed both 'class' and 'AnyObject' to be specified on a protocol,
even in Swift 4 when they became equivalent. Recent refactoring
started rejecting such code; allow it now.

Fixes rdar://problem/34496151.