### PR TITLE
Unified stats reporter fixes for swift 4.0 branch

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -74,6 +74,8 @@ public:
   struct AlwaysOnFrontendCounters
   {
     size_t NumSourceBuffers;
+    size_t NumSourceLines;
+    size_t NumSourceLinesPerSecond;
     size_t NumLinkLibraries;
     size_t NumLoadedModules;
     size_t NumImportedExternalDefinitions;
@@ -132,6 +134,7 @@ public:
 
 private:
   SmallString<128> Filename;
+  llvm::TimeRecord StartedTime;
   std::unique_ptr<llvm::NamedRegionTimer> Timer;
 
   std::unique_ptr<AlwaysOnDriverCounters> DriverCounters;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -65,7 +65,6 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Option/OptTable.h"
@@ -403,25 +402,6 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
     C.NumPrefixOperators = SF->PrefixOperators.size();
     C.NumPrecedenceGroups = SF->PrecedenceGroups.size();
     C.NumUsedConformances = SF->getUsedConformances().size();
-  }
-}
-
-static void countStatsPostIRGen(UnifiedStatsReporter &Stats,
-                                const llvm::Module& Module) {
-  auto &C = Stats.getFrontendCounters();
-  // FIXME: calculate these in constant time if possible.
-  C.NumIRGlobals = Module.getGlobalList().size();
-  C.NumIRFunctions = Module.getFunctionList().size();
-  C.NumIRAliases = Module.getAliasList().size();
-  C.NumIRIFuncs = Module.getIFuncList().size();
-  C.NumIRNamedMetaData = Module.getNamedMDList().size();
-  C.NumIRValueSymbols = Module.getValueSymbolTable().size();
-  C.NumIRComdatSymbols = Module.getComdatSymbolTable().size();
-  for (auto const &Func : Module) {
-    for (auto const &BB : Func) {
-      C.NumIRBasicBlocks++;
-      C.NumIRInsts += BB.size();
-    }
   }
 }
 
@@ -959,10 +939,6 @@ static bool performCompile(CompilerInstance &Instance,
   // modules.
   if (!IRModule) {
     return HadError;
-  }
-
-  if (Stats) {
-    countStatsPostIRGen(*Stats, *IRModule);
   }
 
   bool allSymbols = false;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -372,6 +372,27 @@ static bool emitIndexData(SourceFile *PrimarySourceFile,
       const CompilerInvocation &Invocation,
       CompilerInstance &Instance);
 
+static void countStatsOfSourceFile(UnifiedStatsReporter &Stats,
+                                   CompilerInstance &Instance,
+                                   SourceFile *SF) {
+  auto &C = Stats.getFrontendCounters();
+  auto &SM = Instance.getSourceMgr();
+  C.NumDecls += SF->Decls.size();
+  C.NumLocalTypeDecls += SF->LocalTypeDecls.size();
+  C.NumObjCMethods += SF->ObjCMethods.size();
+  C.NumInfixOperators += SF->InfixOperators.size();
+  C.NumPostfixOperators += SF->PostfixOperators.size();
+  C.NumPrefixOperators += SF->PrefixOperators.size();
+  C.NumPrecedenceGroups += SF->PrecedenceGroups.size();
+  C.NumUsedConformances += SF->getUsedConformances().size();
+
+  auto bufID = SF->getBufferID();
+  if (bufID.hasValue()) {
+    C.NumSourceLines +=
+      SM.getEntireTextForBuffer(bufID.getValue()).count('\n');
+  }
+}
+
 static void countStatsPostSema(UnifiedStatsReporter &Stats,
                                CompilerInstance& Instance) {
   auto &C = Stats.getFrontendCounters();
@@ -395,19 +416,13 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
   }
 
   if (auto *SF = Instance.getPrimarySourceFile()) {
-    C.NumDecls = SF->Decls.size();
-    C.NumLocalTypeDecls = SF->LocalTypeDecls.size();
-    C.NumObjCMethods = SF->ObjCMethods.size();
-    C.NumInfixOperators = SF->InfixOperators.size();
-    C.NumPostfixOperators = SF->PostfixOperators.size();
-    C.NumPrefixOperators = SF->PrefixOperators.size();
-    C.NumPrecedenceGroups = SF->PrecedenceGroups.size();
-    C.NumUsedConformances = SF->getUsedConformances().size();
-
-    auto bufID = SF->getBufferID();
-    if (bufID.hasValue()) {
-      C.NumSourceLines =
-        SM.getEntireTextForBuffer(bufID.getValue()).count('\n');
+    countStatsOfSourceFile(Stats, Instance, SF);
+  } else if (auto *M = Instance.getMainModule()) {
+    // No primary source file, but a main module; this is WMO-mode
+    for (auto *F : M->getFiles()) {
+      if (auto *SF = dyn_cast<SourceFile>(F)) {
+        countStatsOfSourceFile(Stats, Instance, SF);
+      }
     }
   }
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -375,7 +375,8 @@ static bool emitIndexData(SourceFile *PrimarySourceFile,
 static void countStatsPostSema(UnifiedStatsReporter &Stats,
                                CompilerInstance& Instance) {
   auto &C = Stats.getFrontendCounters();
-  C.NumSourceBuffers = Instance.getSourceMgr().getLLVMSourceMgr().getNumBuffers();
+  auto &SM = Instance.getSourceMgr();
+  C.NumSourceBuffers = SM.getLLVMSourceMgr().getNumBuffers();
   C.NumLinkLibraries = Instance.getLinkLibraries().size();
 
   auto const &AST = Instance.getASTContext();
@@ -402,6 +403,12 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
     C.NumPrefixOperators = SF->PrefixOperators.size();
     C.NumPrecedenceGroups = SF->PrecedenceGroups.size();
     C.NumUsedConformances = SF->getUsedConformances().size();
+
+    auto bufID = SF->getBufferID();
+    if (bufID.hasValue()) {
+      C.NumSourceLines =
+        SM.getEntireTextForBuffer(bufID.getValue()).count('\n');
+    }
   }
 }
 

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -15,6 +15,7 @@
 // RUN: %FileCheck -input-file %t/driver.csv %s
 // RUN: %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
 
+// CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}
 // CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
 // CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
 

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -2,6 +2,10 @@
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -c -wmo -num-threads 4 -o %t/out.o -stats-output-dir %t %s
+// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %FileCheck -input-file %t/frontend.csv %s
 // RUN: echo '9000000000	"LLVM.NumLLVMBytesOutput"	1' >>%t/frontend.csv
 // RUN: not %utils/process-stats-dir.py --compare-to-csv-baseline %t/frontend.csv %t
 
@@ -11,7 +15,8 @@
 // RUN: %FileCheck -input-file %t/driver.csv %s
 // RUN: %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
 
-// CHECK: LLVM.NumLLVMBytesOutput
+// CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
+// CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
 
 public func foo() {
     print("hello")


### PR DESCRIPTION
Backports a couple statistics fixes for -wmo and -num-threads>1 (and a pair of new counters) from master to 4.0 branch. Helps with gathering stats and comparing between versions of the compiler.

rdar://33912068
