### PR TITLE
[runtime] Add some missing -isNSWhatever__ methods to SwiftObject.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -407,13 +407,16 @@ static NSString *_getClassDescription(Class cls) {
 
 // Foundation collections expect these to be implemented.
 - (BOOL)isNSArray__      { return NO; }
-- (BOOL)isNSDictionary__ { return NO; }
-- (BOOL)isNSSet__        { return NO; }
-- (BOOL)isNSOrderedSet__ { return NO; }
-- (BOOL)isNSNumber__     { return NO; }
+- (BOOL)isNSCFConstantString__  { return NO; }
 - (BOOL)isNSData__       { return NO; }
 - (BOOL)isNSDate__       { return NO; }
+- (BOOL)isNSDictionary__ { return NO; }
+- (BOOL)isNSObject__     { return NO; }
+- (BOOL)isNSOrderedSet__ { return NO; }
+- (BOOL)isNSNumber__     { return NO; }
+- (BOOL)isNSSet__        { return NO; }
 - (BOOL)isNSString__     { return NO; }
+- (BOOL)isNSTimeZone__   { return NO; }
 - (BOOL)isNSValue__      { return NO; }
 
 @end

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -405,6 +405,12 @@ void TestSwiftObjectNSObject(id c, id d)
   expectTrue ([[C_meta description] isEqual:@"SwiftObjectNSObject.C"]);
   expectTrue ([[S_meta description] isEqual:@"SwiftObject"]);
 
+  // NSLog() calls -description and also some private methods.
+  // This output is checked by FileCheck in SwiftObjectNSObject.swift.
+  NSLog(@"c ##%@##", c);
+  NSLog(@"d ##%@##", d);
+  NSLog(@"S ##%@##", S);
+
 
   printf("NSObjectProtocol.debugDescription\n");
 

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -14,7 +14,7 @@
 // 
 // RUN: %target-clang %S/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m -c -o %t/SwiftObjectNSObject.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/SwiftObjectNSObject/ -Xlinker %t/SwiftObjectNSObject.o -o %t/SwiftObjectNSObject
-// RUN: %target-run %t/SwiftObjectNSObject
+// RUN: %target-run %t/SwiftObjectNSObject 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
@@ -33,6 +33,11 @@ class D : C {
 
 @_silgen_name("TestSwiftObjectNSObject") 
 func TestSwiftObjectNSObject(_ c: C, _ d: D)
+
+// This check is for NSLog() output from TestSwiftObjectNSObject().
+// CHECK: c ##SwiftObjectNSObject.C##
+// CHECK-NEXT: d ##SwiftObjectNSObject.D##
+// CHECK-NEXT: S ##SwiftObject##
 
 TestSwiftObjectNSObject(C(), D())
 // does not return


### PR DESCRIPTION
SR-5636, rdar://33764085

Explanation: This improves NSLog("%@") of bridged Swift objects. As of macOS 10.13 it crashes with an unrecognized selector error.
Risk: Low.
Testing: New NSLog test added. Other existing tests are sufficient for validation.