### PR TITLE
[TypeChecker] Mark test-case for rdar://problem/17024694 as "fast"

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
@@ -2,7 +2,7 @@
 // REQUIRES: tools-release,no_asserts
 
 2...100.reversed().filter({ $0 % 11 == 0 }).map {
-  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  // expected-error@-1 {{value of type 'Int' has no member 'reversed'}}
   "\($0) bottles of beer on the wall, \($0) bottles of beer;\n"
   + "  take eleven down, pass 'em around, \($0-11) bottles of beer on the wall!"
 }


### PR DESCRIPTION
Changes related to literal binding application improved one of the
type-checker performance test-cases.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
