### PR TITLE
build: allow skipping test/install of libdispatch on Linux

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2867,11 +2867,12 @@ for host in "${ALL_HOSTS[@]}"; do
                 continue
                 ;;
             libdispatch)
+                if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
+                    continue
+                fi
+
                 case "${host}" in
                 macosx-*)
-                  if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
-                      continue
-                  fi
                   LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                   echo "--- Running tests for ${product} ---"
                   with_pushd "${LIBDISPATCH_BUILD_DIR}" \
@@ -3127,11 +3128,12 @@ for host in "${ALL_HOSTS[@]}"; do
                 continue
                 ;;
             libdispatch)
+                if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
+                    continue
+                fi
+
                 case "${host}" in
                 macosx-*)
-                  if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
-                      continue
-                  fi
                   if [[ -z "${INSTALL_DESTDIR}" ]] ; then
                       echo "--install-destdir is required to install products."
                       exit 1


### PR DESCRIPTION
The conversion was too aggressive and always forced the test and
installation of libdispatch.  The CI system does not install libdispatch
and this broke the build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
