### PR TITLE
[4.0] 'open' classes within 'public' structs should be considered open

### DIFF
--- a/test/IRGen/Inputs/vtable_symbol_linkage_base.swift
+++ b/test/IRGen/Inputs/vtable_symbol_linkage_base.swift
@@ -10,3 +10,18 @@ open class Base {
   private var privateVar: Int = 29
   internal var internalVar: Int = 30
 }
+
+
+public struct Namespace {
+  open class Nested {
+    public init() {}
+    var storedProp: Int?
+  }
+}
+
+extension Namespace {
+  open class ExtNested {
+    public init() {}
+    var storedProp: Int?
+  }
+}

--- a/test/IRGen/vtable_symbol_linkage.swift
+++ b/test/IRGen/vtable_symbol_linkage.swift
@@ -9,4 +9,5 @@ import BaseModule
 public class Derived : Base {
 }
 
-
+public class DerivedNested : Namespace.Nested {}
+public class DerivedExtNested : Namespace.ExtNested {}


### PR DESCRIPTION
- **Explanation**: Because a subclass's vtable needs to include all entries from the base class's vtable, an `open` base class's overridable members must have public symbols. We have an IRGen-level hack to force this (since we don't want this to affect the semantics of SIL) but the check that we used for this wasn't correct when the base class was nested in another type. This commit fixes that.
- **Scope**: Affects `open` classes nested within other types
- **Issue**: rdar://problem/32885384
- **Reviewed by**: @slavapestov  
- **Risk**: Low. Adds one special case that uses the same code paths as top-level `open` classes.
- **Testing**: Added regression tests, verified that the original test case now passes.