### PR TITLE
runtime: clean up last of -Wqual-cast warnings

### DIFF
--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -258,7 +258,7 @@ CharSourceRange RawComment::getCharSourceRange() {
     return CharSourceRange();
   }
   auto End = this->Comments.back().Range.getEnd();
-  auto Length = (char *)End.getOpaquePointerValue() -
-                (char* )Start.getOpaquePointerValue();
+  auto Length = static_cast<const char *>(End.getOpaquePointerValue()) -
+                static_cast<const char *>(Start.getOpaquePointerValue());
   return CharSourceRange(Start, Length);
 }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -773,8 +773,9 @@ calculateContentRange(ArrayRef<Token> Tokens) {
   auto StartLoc = StartTok.hasComment() ?
     StartTok.getCommentStart() : StartTok.getLoc();
   auto EndLoc = EndTok.getRange().getEnd();
-  return CharSourceRange(StartLoc, (char*)EndLoc.getOpaquePointerValue() -
-    (char*)StartLoc.getOpaquePointerValue());
+  auto Length = static_cast<const char *>(EndLoc.getOpaquePointerValue()) -
+                static_cast<const char *>(StartLoc.getOpaquePointerValue());
+  return CharSourceRange(StartLoc, Length);
 }
 
 bool DeclaredDecl::operator==(const DeclaredDecl& Other) {

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -449,7 +449,7 @@ ide::replacePlaceholders(std::unique_ptr<llvm::MemoryBuffer> InputBuf,
     assert(Id.size() == Occur.FullPlaceholder.size());
 
     unsigned Offset = Occur.FullPlaceholder.data() - InputBuf->getBufferStart();
-    char *Ptr = (char*)NewBuf->getBufferStart() + Offset;
+    char *Ptr = const_cast<char *>(NewBuf->getBufferStart()) + Offset;
     std::copy(Id.begin(), Id.end(), Ptr);
 
     Occur.IdentifierReplacement = Id.str();

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -325,7 +325,7 @@ void Lexer::skipUpToEndOfLine() {
         return;
       default:
         // If this is a "high" UTF-8 character, validate it.
-        if (*((signed char *)CurPtr) < 0) {
+        if (*reinterpret_cast<const signed char *>(CurPtr) < 0) {
           const char *CharStart = CurPtr;
           if (validateUTF8CharacterAndAdvance(CurPtr, BufferEnd) == ~0U)
             diagnose(CharStart, diag::lex_invalid_utf8);

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -561,16 +561,17 @@ struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
 
   template <class Container, class... A>
   static void storeExtraInhabitant(Container *dest, int index, A... args) {
-    swift_storeHeapObjectExtraInhabitant((HeapObject**) dest->getValueSlot(),
+    Metadata **MD = const_cast<Metadata **>(dest->getValueSlot());
+    swift_storeHeapObjectExtraInhabitant(reinterpret_cast<HeapObject **>(MD),
                                          index);
   }
 
   template <class Container, class... A>
   static int getExtraInhabitantIndex(const Container *src, A... args) {
+    Metadata **MD = const_cast<Metadata **>(src->getValueSlot());
     return swift_getHeapObjectExtraInhabitantIndex(
-                                  (HeapObject* const *) src->getValueSlot());
+        reinterpret_cast<HeapObject *const *>(MD));
   }
-  
 };
 
 /// A box implementation class for an existential metatype container

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -130,8 +130,11 @@ const Metadata *TypeMetadataRecord::getCanonicalTypeMetadata() const {
   switch (getTypeKind()) {
   case TypeMetadataRecordKind::UniqueDirectType:
     return getDirectType();
-  case TypeMetadataRecordKind::NonuniqueDirectType:
-    return swift_getForeignTypeMetadata((ForeignTypeMetadata *)getDirectType());
+  case TypeMetadataRecordKind::NonuniqueDirectType: {
+    const ForeignTypeMetadata *FMD =
+        static_cast<const ForeignTypeMetadata *>(getDirectType());
+    return swift_getForeignTypeMetadata(const_cast<ForeignTypeMetadata *>(FMD));
+  }
   case TypeMetadataRecordKind::UniqueDirectClass:
     if (auto *ClassMetadata =
           static_cast<const ::ClassMetadata *>(getDirectType()))

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -91,15 +91,18 @@ template<> void ProtocolConformanceRecord::dump() const {
 /// Take the type reference inside a protocol conformance record and fetch the
 /// canonical metadata pointer for the type it refers to.
 /// Returns nil for universal or generic type references.
-template<> const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata()
-const {
+template <>
+const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
   switch (getTypeKind()) {
   case TypeMetadataRecordKind::UniqueDirectType:
     // Already unique.
     return getDirectType();
-  case TypeMetadataRecordKind::NonuniqueDirectType:
+  case TypeMetadataRecordKind::NonuniqueDirectType: {
     // Ask the runtime for the unique metadata record we've canonized.
-    return swift_getForeignTypeMetadata((ForeignTypeMetadata*)getDirectType());
+    const ForeignTypeMetadata *FMD =
+        static_cast<const ForeignTypeMetadata *>(getDirectType());
+    return swift_getForeignTypeMetadata(const_cast<ForeignTypeMetadata *>(FMD));
+  }
   case TypeMetadataRecordKind::UniqueIndirectClass:
     // The class may be ObjC, in which case we need to instantiate its Swift
     // metadata. The class additionally may be weak-linked, so we have to check


### PR DESCRIPTION
This fixes up the remaining cast qualifier warnings from GCC 6.  Use
multiple casts to adjust the const qualification.  Prefer C++ style
casts.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
