### PR TITLE
Sema: Fix assertion failure when overriding a dynamic method with a final method [4.0]

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6235,6 +6235,10 @@ public:
     }
 
     void visitDynamicAttr(DynamicAttr *attr) {
+      // Final overrides are not dynamic.
+      if (Override->isFinal())
+        return;
+
       makeDynamic(TC.Context, Override);
     }
 

--- a/test/SILGen/vtables.swift
+++ b/test/SILGen/vtables.swift
@@ -1,11 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs -emit-silgen -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
-
-// FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
-
-import gizmo
-
-// TODO: Generic base classes
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 // Test for compilation order independence
 class C : B {
@@ -72,64 +65,6 @@ class B : A {
 // CHECK:   #B.zim!1: {{.*}} : _T07vtables1BC3zim{{[_0-9a-zA-Z]*}}F
 // CHECK:   #B.zang!1: {{.*}} : _T07vtables1BC4zang{{[_0-9a-zA-Z]*}}F
 // CHECK: }
-
-// Test ObjC base class
-
-class Hoozit : Gizmo {
-  // Overrides Gizmo.frob
-  override func frob() {}
-  // Overrides Gizmo.funge
-  override func funge() {}
-
-  func anse() {}
-  func incorrige() {}
-}
-
-// Entries only exist for native Swift methods
-
-// CHECK: sil_vtable Hoozit {
-// CHECK-NEXT:   #Hoozit.anse!1: {{.*}} : _T07vtables6HoozitC4anse{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:   #Hoozit.incorrige!1: {{.*}} : _T07vtables6HoozitC9incorrige{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> () -> Hoozit! : _T07vtables6HoozitCSQyACGycfc
-// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> (Int) -> Hoozit! : _T07vtables6HoozitCSQyACGSi7bellsOn_tcfc
-// CHECK-NEXT:   #Hoozit.deinit!deallocator: _T07vtables6HoozitCfD
-// CHECK-NEXT: }
-
-class Wotsit : Hoozit {
-  override func funge() {}
-  override func incorrige() {}
-}
-
-// CHECK: sil_vtable Wotsit {
-// CHECK-NEXT:   #Hoozit.anse!1: {{.*}} : _T07vtables6HoozitC4anse{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:   #Hoozit.incorrige!1: {{.*}} : _T07vtables6WotsitC9incorrige{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> () -> Hoozit! : _T07vtables6WotsitCSQyACGycfc
-// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> (Int) -> Hoozit! : _T07vtables6WotsitCSQyACGSi7bellsOn_tcfc
-// CHECK-NEXT:   #Wotsit.deinit!deallocator: _T07vtables6WotsitCfD
-// CHECK-NEXT: }
-
-// <rdar://problem/15282548>
-// CHECK: sil_vtable Base {
-// CHECK:   #Base.init!initializer.1: {{.*}} : _T07vtables4BaseC{{[_0-9a-zA-Z]*}}fc
-// CHECK: }
-// CHECK: sil_vtable Derived {
-// CHECK:   #Base.init!initializer.1: {{.*}} : _T07vtables7DerivedC{{[_0-9a-zA-Z]*}}fc
-// CHECK: }
-@objc class Base {}
-
-extension Base {
-  // note: does not have a vtable slot, because it is from an extension
-  func identify() -> Int {
-    return 0
-  }
-}
-
-class Derived : Base {
-  override func identify() -> Int {
-    return 1
-  }
-}
-
 
 // CHECK: sil_vtable RequiredInitDerived {
 // CHECK-NEXT: #SimpleInitBase.init!initializer.1: {{.*}} : _T07vtables19RequiredInitDerivedC{{[_0-9a-zA-Z]*}}fc

--- a/test/SILGen/vtables_objc.swift
+++ b/test/SILGen/vtables_objc.swift
@@ -9,11 +9,48 @@ import gizmo
 class Hoozit : Gizmo {
   // Overrides Gizmo.frob
   override func frob() {}
+
   // Overrides Gizmo.funge
   override func funge() {}
 
+  // Overrides Gizmo.foo
+  final override func foo() {}
+
   func anse() {}
   func incorrige() {}
+}
+
+// CHECK-LABEL: sil hidden @_T012vtables_objc10callHoozityAA0D0CF : $@convention(thin) (@owned Hoozit) -> ()
+func callHoozit(_ h: Hoozit) {
+  // CHECK: class_method [volatile] {{.*}} : $Hoozit, #Hoozit.frob!1.foreign
+  h.frob()
+  // CHECK: function_ref @_T012vtables_objc6HoozitC3fooyyF
+  h.foo()
+  // CHECK: class_method {{.*}} : $Hoozit, #Hoozit.anse!1
+  h.anse()
+  // CHECK: return
+}
+
+class Wotsit : Hoozit {
+  // Overrides Gizmo.funge
+  override func funge() {}
+
+  // Overrides Hoozit.incorrige
+  override func incorrige() {}
+
+  // Overrides Gizmo.frob
+  final override func frob() {}
+}
+
+// CHECK-LABEL: sil hidden @_T012vtables_objc10callWotsityAA0D0CF : $@convention(thin) (@owned Wotsit) -> ()
+func callWotsit(_ w: Wotsit) {
+  // CHECK: class_method [volatile] {{.*}} : $Wotsit, #Wotsit.funge!1.foreign
+  w.funge()
+  // CHECK: class_method {{.*}} : $Wotsit, #Wotsit.incorrige!1
+  w.incorrige()
+  // CHECK: function_ref @_T012vtables_objc6WotsitC4frobyyF
+  w.frob()
+  // CHECK: return
 }
 
 // Entries only exist for native Swift methods
@@ -25,11 +62,6 @@ class Hoozit : Gizmo {
 // CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> (Int) -> Hoozit! : _T012vtables_objc6HoozitCSQyACGSi7bellsOn_tcfc
 // CHECK-NEXT:   #Hoozit.deinit!deallocator: _T012vtables_objc6HoozitCfD
 // CHECK-NEXT: }
-
-class Wotsit : Hoozit {
-  override func funge() {}
-  override func incorrige() {}
-}
 
 // CHECK: sil_vtable Wotsit {
 // CHECK-NEXT:   #Hoozit.anse!1: {{.*}} : _T012vtables_objc6HoozitC4anse{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/vtables_objc.swift
+++ b/test/SILGen/vtables_objc.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -sdk %S/Inputs -emit-silgen -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import gizmo
+
+// Test ObjC base class
+
+class Hoozit : Gizmo {
+  // Overrides Gizmo.frob
+  override func frob() {}
+  // Overrides Gizmo.funge
+  override func funge() {}
+
+  func anse() {}
+  func incorrige() {}
+}
+
+// Entries only exist for native Swift methods
+
+// CHECK: sil_vtable Hoozit {
+// CHECK-NEXT:   #Hoozit.anse!1: {{.*}} : _T012vtables_objc6HoozitC4anse{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:   #Hoozit.incorrige!1: {{.*}} : _T012vtables_objc6HoozitC9incorrige{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> () -> Hoozit! : _T012vtables_objc6HoozitCSQyACGycfc
+// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> (Int) -> Hoozit! : _T012vtables_objc6HoozitCSQyACGSi7bellsOn_tcfc
+// CHECK-NEXT:   #Hoozit.deinit!deallocator: _T012vtables_objc6HoozitCfD
+// CHECK-NEXT: }
+
+class Wotsit : Hoozit {
+  override func funge() {}
+  override func incorrige() {}
+}
+
+// CHECK: sil_vtable Wotsit {
+// CHECK-NEXT:   #Hoozit.anse!1: {{.*}} : _T012vtables_objc6HoozitC4anse{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:   #Hoozit.incorrige!1: {{.*}} : _T012vtables_objc6WotsitC9incorrige{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> () -> Hoozit! : _T012vtables_objc6WotsitCSQyACGycfc
+// CHECK-NEXT:   #Hoozit.init!initializer.1: (Hoozit.Type) -> (Int) -> Hoozit! : _T012vtables_objc6WotsitCSQyACGSi7bellsOn_tcfc
+// CHECK-NEXT:   #Wotsit.deinit!deallocator: _T012vtables_objc6WotsitCfD
+// CHECK-NEXT: }
+
+// <rdar://problem/15282548>
+// CHECK: sil_vtable Base {
+// CHECK:   #Base.init!initializer.1: {{.*}} : _T012vtables_objc4BaseC{{[_0-9a-zA-Z]*}}fc
+// CHECK: }
+// CHECK: sil_vtable Derived {
+// CHECK:   #Base.init!initializer.1: {{.*}} : _T012vtables_objc7DerivedC{{[_0-9a-zA-Z]*}}fc
+// CHECK: }
+@objc class Base {}
+
+extension Base {
+  // note: does not have a vtable slot, because it is from an extension
+  func identify() -> Int {
+    return 0
+  }
+}
+
+class Derived : Base {
+  override func identify() -> Int {
+    return 1
+  }
+}


### PR DESCRIPTION
* Description: Fixes an assertion failure when overriding an imported method (or property) with a final method (or property).

* Scope of the issue: Affects builds with assertions on, like downloadable snapshots.

* Origination: The underlying bug has been there forever I think, but became easier to hit when overrides of imported methods started to be marked 'dynamic' as part of the Swift 3/4 mix-and-match support.

* Risk: Low. The change has been in the master branch for a while now with no apparent fallout.

* Tested: New tests added.

* Reviewed by: @jrose-apple