### PR TITLE
Fix flipped argument state

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -341,22 +341,22 @@ def create_argument_parser():
     projects_group.add_argument(
         "--xctest",
         help="build xctest",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         dest="build_xctest")
     projects_group.add_argument(
         "--foundation",
         help="build foundation",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         dest="build_foundation")
     projects_group.add_argument(
         "--libdispatch",
         help="build libdispatch",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         dest="build_libdispatch")
     projects_group.add_argument(
         "--libicu",
         help="build libicu",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         dest="build_libicu")
     projects_group.add_argument(
         "--playgroundlogger",
@@ -371,7 +371,7 @@ def create_argument_parser():
     projects_group.add_argument(
         "--build-ninja",
         help="build the Ninja tool",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
 
     extra_actions_group = parser.add_argument_group(
         title="Extra actions to perform before or in addition to building")
@@ -382,7 +382,7 @@ def create_argument_parser():
     extra_actions_group.add_argument(
         "--export-compile-commands",
         help="generate compilation databases in addition to building",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     extra_actions_group.add_argument(
         "--symbols-package",
         metavar="PATH",
@@ -571,7 +571,7 @@ def create_argument_parser():
     run_tests_group.add_argument(
         "--test",
         help="test Swift after building",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_tests_group.add_argument(
         "-T",
         help="run the validation test suite (implies --test)",
@@ -581,7 +581,7 @@ def create_argument_parser():
     run_tests_group.add_argument(
         "--validation-test",
         help="run the validation test suite (implies --test)",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_tests_group.add_argument(
         "--test-paths",
         help="run tests located in specific directories and/or files \
@@ -597,7 +597,7 @@ def create_argument_parser():
     run_tests_group.add_argument(
         "--test-optimized",
         help="run the test suite in optimized mode too (implies --test)",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_tests_group.add_argument(
         "-s",
         help="run the test suite in optimize for size mode too \
@@ -609,15 +609,15 @@ def create_argument_parser():
         "--test-optimize-for-size",
         help="run the test suite in optimize for size mode too \
         (implies --test)",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_tests_group.add_argument(
         "--long-test",
         help="run the long test suite",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_tests_group.add_argument(
         "--host-test",
         help="run executable tests on host devices (such as iOS or tvOS)",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_tests_group.add_argument(
         "-B", "--benchmark",
         help="run the Swift Benchmark Suite after building",
@@ -634,53 +634,53 @@ iterations with -O",
     run_tests_group.add_argument(
         "--skip-test-osx",
         dest='test_osx',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing Swift stdlibs for Mac OS X")
     run_tests_group.add_argument(
         "--skip-test-linux",
         dest='test_linux',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing Swift stdlibs for Linux")
     run_tests_group.add_argument(
         "--skip-test-freebsd",
         dest='test_freebsd',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing Swift stdlibs for FreeBSD")
     run_tests_group.add_argument(
         "--skip-test-cygwin",
         dest='test_cygwin',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing Swift stdlibs for Cygwin")
     parser.add_argument(
         "--build-runtime-with-host-compiler",
         help="Use the host compiler, not the self-built one to compile the "
              "Swift runtime",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
 
     run_build_group = parser.add_argument_group(
         title="Run build")
     run_build_group.add_argument(
         "--build-swift-dynamic-stdlib",
         help="build dynamic variants of the Swift standard library",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         default=True)
     run_build_group.add_argument(
         "--build-swift-static-stdlib",
         help="build static variants of the Swift standard library",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_build_group.add_argument(
         "--build-swift-dynamic-sdk-overlay",
         help="build dynamic variants of the Swift SDK overlay",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         default=True)
     run_build_group.add_argument(
         "--build-swift-static-sdk-overlay",
         help="build static variants of the Swift SDK overlay",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_build_group.add_argument(
         "--build-swift-stdlib-unittest-extra",
         help="Build optional StdlibUnittest components",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     run_build_group.add_argument(
         "-S", "--skip-build",
         help="generate build directory only without building",
@@ -688,94 +688,94 @@ iterations with -O",
     run_build_group.add_argument(
         "--skip-build-linux",
         dest='build_linux',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for Linux")
     run_build_group.add_argument(
         "--skip-build-freebsd",
         dest='build_freebsd',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for FreeBSD")
     run_build_group.add_argument(
         "--skip-build-cygwin",
         dest='build_cygwin',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for Cygwin")
     run_build_group.add_argument(
         "--skip-build-osx",
         dest='build_osx',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for MacOSX")
 
     run_build_group.add_argument(
         "--skip-build-ios",
         dest='build_ios',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for iOS")
     run_build_group.add_argument(
         "--skip-build-ios-device",
         dest='build_ios_device',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for iOS devices "
              "(i.e. build simulators only)")
     run_build_group.add_argument(
         "--skip-build-ios-simulator",
         dest='build_ios_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for iOS simulator "
              "(i.e. build devices only)")
 
     run_build_group.add_argument(
         "--skip-build-tvos",
         dest='build_tvos',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for tvOS")
     run_build_group.add_argument(
         "--skip-build-tvos-device",
         dest='build_tvos_device',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for tvOS devices "
              "(i.e. build simulators only)")
     run_build_group.add_argument(
         "--skip-build-tvos-simulator",
         dest='build_tvos_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for tvOS simulator "
              "(i.e. build devices only)")
 
     run_build_group.add_argument(
         "--skip-build-watchos",
         dest='build_watchos',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for watchOS")
     run_build_group.add_argument(
         "--skip-build-watchos-device",
         dest='build_watchos_device',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for watchOS devices "
              "(i.e. build simulators only)")
     run_build_group.add_argument(
         "--skip-build-watchos-simulator",
         dest='build_watchos_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for watchOS simulator "
              "(i.e. build devices only)")
 
     run_build_group.add_argument(
         "--skip-build-android",
         dest='build_android',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift stdlibs for Android")
 
     run_build_group.add_argument(
         "--skip-build-benchmarks",
         dest='build_benchmarks',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip building Swift Benchmark Suite")
 
     run_build_group.add_argument(
         "--build-external-benchmarks",
         dest='build_external_benchmarks',
-        action=arguments.action.optional_true,
+        action=arguments.action.enable,
         help="skip building Swift Benchmark Suite")
 
     skip_test_group = parser.add_argument_group(
@@ -783,63 +783,63 @@ iterations with -O",
     skip_test_group.add_argument(
         "--skip-test-ios",
         dest='test_ios',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing all iOS targets. Equivalent to specifying both "
              "--skip-test-ios-simulator and --skip-test-ios-host")
     skip_test_group.add_argument(
         "--skip-test-ios-simulator",
         dest='test_ios_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing iOS simulator targets")
     skip_test_group.add_argument(
         "--skip-test-ios-32bit-simulator",
         dest='test_ios_32bit_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing iOS 32 bit simulator targets")
     skip_test_group.add_argument(
         "--skip-test-ios-host",
         dest='test_ios_host',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing iOS device targets on the host machine (the phone "
              "itself)")
     skip_test_group.add_argument(
         "--skip-test-tvos",
         dest='test_tvos',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing all tvOS targets. Equivalent to specifying both "
              "--skip-test-tvos-simulator and --skip-test-tvos-host")
     skip_test_group.add_argument(
         "--skip-test-tvos-simulator",
         dest='test_tvos_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing tvOS simulator targets")
     skip_test_group.add_argument(
         "--skip-test-tvos-host",
         dest='test_tvos_host',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing tvOS device targets on the host machine (the TV "
              "itself)")
     skip_test_group.add_argument(
         "--skip-test-watchos",
         dest='test_watchos',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing all tvOS targets. Equivalent to specifying both "
              "--skip-test-watchos-simulator and --skip-test-watchos-host")
     skip_test_group.add_argument(
         "--skip-test-watchos-simulator",
         dest='test_watchos_simulator',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing watchOS simulator targets")
     skip_test_group.add_argument(
         "--skip-test-watchos-host",
         dest='test_watchos_host',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing watchOS device targets on the host machine (the "
              "watch itself)")
     skip_test_group.add_argument(
         "--skip-test-android-host",
         dest='test_android_host',
-        action=arguments.action.optional_false,
+        action=arguments.action.disable,
         help="skip testing Android device targets on the host machine (the "
              "phone itself)")
 
@@ -863,11 +863,11 @@ iterations with -O",
         "--tvos",
         help="also build for tvOS, but disallow tests that require a tvos "
              "device",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     parser.add_argument(
         "--tvos-all",
         help="also build for tvOS, and allow all tvOS tests",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         dest="tvos_all")
     parser.add_argument(
         "--skip-tvos",
@@ -879,11 +879,11 @@ iterations with -O",
         "--watchos",
         help="also build for watchOS, but disallow tests that require an "
              "watchOS device",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     parser.add_argument(
         "--watchos-all",
         help="also build for Apple watchOS, and allow all Apple watchOS tests",
-        action=arguments.action.optional_bool,
+        action=arguments.action.enable,
         dest="watchos_all")
     parser.add_argument(
         "--skip-watchos",
@@ -894,7 +894,7 @@ iterations with -O",
     parser.add_argument(
         "--android",
         help="also build for Android",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
 
     parser.add_argument(
         "--swift-analyze-code-coverage",
@@ -941,7 +941,7 @@ iterations with -O",
     parser.add_argument(
         "--show-sdks",
         help="print installed Xcode and SDK versions",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
 
     parser.add_argument(
         "--extra-swift-args",
@@ -1027,26 +1027,26 @@ iterations with -O",
     parser.add_argument(
         "--distcc",
         help="use distcc in pump mode",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     parser.add_argument(
         "--enable-asan",
         help="enable Address Sanitizer",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     parser.add_argument(
         "--enable-ubsan",
         help="enable Undefined Behavior Sanitizer",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     parser.add_argument(
         "--enable-tsan",
         help="enable Thread Sanitizer for swift tools",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
     parser.add_argument(
         "--enable-tsan-runtime",
         help="enable Thread Sanitizer on the swift runtime")
     parser.add_argument(
         "--enable-lsan",
         help="enable Leak Sanitizer for swift tools",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
 
     parser.add_argument(
         "--compiler-vendor",
@@ -1117,7 +1117,7 @@ iterations with -O",
     parser.add_argument(
         "--verbose-build",
         help="print the commands executed during the build",
-        action=arguments.action.optional_bool)
+        action=arguments.action.enable)
 
     parser.add_argument(
         "--lto",


### PR DESCRIPTION
# Purpose

This PR resolves issue [SR-5911](https://bugs.swift.org/browse/SR-5911). My previous PR #11952 changed the internal 'destinations' for all the `--skip-build-*` and `--skip-test-*` flags from the form `skip_build_*` and `skip_test_*` to the affirmative `build_*` and `test_*`. When swapping those states I failed to account for the more advanced optional boolean behavior on each of these skip flags. It is possible for many flags to accept an optional boolean state to toggle them on or off manually, with skip flags it can be rather confusing since `--skip-build-benchmarks True` means that we should not build benchmarks. Before this fix the optional boolean was being directly set on these new inverted destinations, thus `--skip-build-benchmarks True` was setting the destination `build_benchmarks` to `True` rather than the expected `False`.

~~In addition to fixing the erroneous behavior I've also taken the liberty to revamp the testing suite again making a more clear distinction between flags that accept optional booleans, those that only toggle the state `True` or `False` and those that store constant values. The test suite now covers all these cases and has more strict testing for their edge cases.~~

~~A small note for reviewers, there's a lot of noise in the testing suite dealing with parsing arguments. To accurately test that each flag accepts the expected argument values and acts accordingly it was necessary to be able to parse flags without applying the defaults. Thus there's now the methods `parse_args` and `parse_default_args` on the main test case class.~~

rdar://34526897