### PR TITLE
Miscellaneous fixes for conformance checking

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2630,7 +2630,10 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   recordDeclLoc(decl, [&]{
     Printer << "subscript";
   }, [&] { // Parameters
-    printParameterList(decl->getIndices(), decl->getIndicesInterfaceType(),
+    printParameterList(decl->getIndices(),
+                       decl->hasInterfaceType()
+                         ? decl->getIndicesInterfaceType()
+                         : nullptr,
                        /*isCurried=*/false,
                        /*isAPINameByDefault*/[]()->bool{return false;});
   });

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1264,7 +1264,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         return status;
       case RequirementCheckResult::Success:
         // Report the conformance.
-        if (listener) {
+        if (listener && valid) {
           listener->satisfiedConformance(rawReq.getFirstType(), firstType,
                                          result.getConformance());
         }


### PR DESCRIPTION
Address a few issues that came up while rolling out recursive constraints:

* Print non-type-checked subscript declarations
* Use "local" dependent member types for associated type inference when possible 
* Don't report invalid conformances to clients that cannot handle them.