### PR TITLE
[Metadata] Unpoison memory being returned from the metadata allocator

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2746,7 +2746,7 @@ void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
                                               std::memory_order_relaxed)) {
       // If that succeeded, we've successfully allocated.
       __msan_allocated_memory(allocation, size);
-      __asan_poison_memory_region(allocation, size);
+      __asan_unpoison_memory_region(allocation, size);
       return allocation;
     }
 


### PR DESCRIPTION
Call __asan_unpoison_memory_region() rather than __asan_poison_memory_region().  Otherwise ASAN reports an error on the first use of the memory.
