### PR TITLE
Fix trivial bug in callee analysis: thin functions aren't necessarily function refs.

### DIFF
--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -201,8 +201,8 @@ CalleeList CalleeCache::getCalleeListForCalleeKind(SILValue Callee) const {
     return CalleeList();
 
   case ValueKind::ThinToThickFunctionInst:
-    Callee = cast<ThinToThickFunctionInst>(Callee)->getOperand();
-    LLVM_FALLTHROUGH;
+    return getCalleeListForCalleeKind(
+        cast<ThinToThickFunctionInst>(Callee)->getOperand());
 
   case ValueKind::FunctionRefInst:
     return CalleeList(cast<FunctionRefInst>(Callee)->getReferencedFunction());

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1430,6 +1430,17 @@ bb3(%6: $X):
   return %8 : $()
 }
 
+// CHECK-LABEL: CG of check_look_through_thin_to_thick
+// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:  End
+sil @check_look_through_thin_to_thick: $(@convention(thin) () -> ()) -> () {
+bb0(%0 : $@convention(thin) () -> ()):
+  %1 = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_owned () -> ()
+  %2 = apply %1() : $@callee_owned () -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
 // X.deinit
 // CHECK-LABEL: CG of _T04main1XCfD
 // CHECK:        Arg %0 Esc: A, Succ:


### PR DESCRIPTION
Explanation: This fixes a compiler crash when a thin function, which is not function reference, is converted to a thick function (a closure).

Scope of Issue: This is a rare case, but we have seen it in real world code

Risk: Low.

Reviewed By: Erik (The original fix is from John: https://github.com/apple/swift/pull/11893)

Testing: There is a regression test for it

Radar: rdar://problem/34498887