### PR TITLE
[DO NOT MERGE] [WIP] SR-5860 Support "swift -e" for immediate execution

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -286,6 +286,10 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   Flags<[HelpHidden]>,
   HelpText<"Disable automatic generation of bridging PCH files">;
 
+def e : Separate<["-"], "e">,
+  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Evaluate one line of Swift code. Multiple -e's allowed.">;
+
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
   Flags<[FrontendOption]>,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1057,7 +1057,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
 
   if (driverKind == DriverKind::Interactive) {
     OI.CompilerMode = OutputInfo::Mode::Immediate;
-    if (Inputs.empty())
+    if (Inputs.empty() && !Args.hasArg(options::OPT_e))
       OI.CompilerMode = OutputInfo::Mode::REPL;
     OI.CompilerOutputType = types::TY_Nothing;
 
@@ -1518,7 +1518,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     break;
   }
   case OutputInfo::Mode::Immediate: {
-    if (Inputs.empty())
+    if (Inputs.empty() && !Args.hasArg(options::OPT_e))
       return;
 
     assert(OI.CompilerOutputType == types::TY_Nothing);
@@ -1634,6 +1634,12 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
 
   if (Args.hasArg(options::OPT_v)) {
     printVersion(TC, llvm::errs());
+    SuppressNoInputFilesError = true;
+  }
+  
+  // SR-5860: TODO: change this to emit a diagnostic here: -e can't have
+  // input files (diagnostics are defined in DiagnosticsDriver.def).
+  if (Args.hasArg(options::OPT_e)) {
     SuppressNoInputFilesError = true;
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -512,6 +512,10 @@ ToolChain::constructInvocation(const InterpretJobAction &job,
   Arguments.push_back(context.Args.MakeArgString(context.OI.ModuleName));
 
   context.Args.AddAllArgs(Arguments, options::OPT_l, options::OPT_framework);
+  
+  if (context.Args.hasArg(options::OPT_e)) {
+    context.Args.AddAllArgs(Arguments, options::OPT_e);
+  }
 
   // The immediate arguments must be last.
   context.Args.AddLastArg(Arguments, options::OPT__DASH_DASH);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -161,6 +161,8 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   for (unsigned i = 0, e = Invocation.getInputBuffers().size(); i != e; ++i) {
     // CompilerInvocation doesn't own the buffers, copy to a new buffer.
     auto *InputBuffer = Invocation.getInputBuffers()[i];
+    
+    // SR-5860: It crashes here, on the InputBuffer->getBuffer()
     auto Copy = std::unique_ptr<llvm::MemoryBuffer>(
         llvm::MemoryBuffer::getMemBufferCopy(
             InputBuffer->getBuffer(), InputBuffer->getBufferIdentifier()));


### PR DESCRIPTION
I'm making a little progress but blocked by a crash in `CompilerInstance::setup(...)`, when it attempts to make the copy of the `InputBuffer`. Since I don't know my way around yet I'm not sure how to address this.

I _think_ I'm setting up the `MemoryBuffer` correctly in `CompilerInvocation` but because it's crashing, I'm not very confident that's the case.

Thanks for your help.