### PR TITLE
[build-script] Add `--test-paths` option to run subset of tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -303,6 +303,19 @@ foreach(SDK ${SWIFT_SDKS})
             DEPENDS ${dependencies}
             COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
             USES_TERMINAL)
+
+        add_custom_target("check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}-custom"
+            ${command_upload_stdlib}
+            ${command_upload_swift_reflection_test}
+            ${command_clean_test_results_dir}
+            COMMAND
+              ${PYTHON_EXECUTABLE} "${LIT}"
+              ${LIT_ARGS}
+              "--param" "swift_test_subset=${test_subset}"
+              "--param" "swift_test_mode=${test_mode}"
+            DEPENDS ${dependencies}
+            COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE} from custom test locations"
+            USES_TERMINAL)
       endforeach()
     endforeach()
   endforeach()

--- a/utils/build-script
+++ b/utils/build-script
@@ -470,6 +470,9 @@ class BuildScriptInvocation(object):
             impl_args += [
                 "--cross-compile-hosts", " ".join(args.cross_compile_hosts)]
 
+        if args.test_paths:
+            impl_args += ["--test-paths", " ".join(args.test_paths)]
+
         if toolchain.ninja:
             impl_args += ["--ninja-bin=%s" % toolchain.ninja]
         if args.distcc:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -152,6 +152,7 @@ KNOWN_SETTINGS=(
     skip-test-android-host      ""               "set to skip testing the host parts of the Android toolchain"
     validation-test             "0"              "set to run the validation test suite"
     long-test                   "0"              "set to run the long test suite"
+    test-paths                  ""               "run tests located in specific directories and/or files"
     skip-test-benchmarks        ""               "set to skip running Swift Benchmark Suite"
     skip-test-optimized         ""               "set to skip testing the test suite in optimized mode"
     skip-test-optimize-for-size ""               "set to skip testing the test suite in optimize for size mode"
@@ -2938,6 +2939,20 @@ for host in "${ALL_HOSTS[@]}"; do
                 echo "--- ${target} ---"
                 trap "tests_busted ${product} '(${target})'" ERR
 
+                test_target="$target"
+                test_paths=()
+
+                if [[ ${test_target} == check-swift* ]]; then
+                    if [[ "${TEST_PATHS}" ]]; then
+                        test_target="${test_target}-custom"
+                        for path in ${TEST_PATHS}; do
+                            test_paths+=(
+                                "${build_dir}/$(echo ${path} | sed -E "s/^(validation-test|test)/\1-${host}/")"
+                            )
+                        done
+                    fi
+                fi
+
                 # NOTE: In dry-run mode, build_dir might not exist yet. In that
                 #       case, -n query will fail. So, in dry-run mode,
                 #       we don't expand test script.
@@ -2950,12 +2965,17 @@ for host in "${ALL_HOSTS[@]}"; do
                     # shell to execute that.
                     # However, if we do this in a subshell in the ``sh -e -x -c`` line,
                     # errors in the command will not stop the script as they should.
-                    echo "Generating dry run test command from: ${build_cmd[@]} -n -v ${target}"
-                    dry_run_command_output="$(${build_cmd[@]} -n -v ${target} | sed -e 's/[^]]*] //')"
+                    echo "Generating dry run test command from: ${build_cmd[@]} -n -v ${test_target}"
+                    dry_run_command_output="$(${build_cmd[@]} -n -v ${test_target} | sed -e 's/[^]]*] //')"
                     echo "Test command: ${dry_run_command_output}"
-                    sh -e -x -c "${dry_run_command_output}"
+
+                    if [[ ! "${test_paths}" ]]; then
+                        sh -e -x -c "${dry_run_command_output}"
+                    else
+                        sh -e -x -c "${dry_run_command_output} $(echo ${test_paths[@]})"
+                    fi
                 else
-                    call "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${target}
+                    call "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${test_target}
                 fi
                 echo "-- ${target} finished --"
             fi

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -192,6 +192,16 @@ def _apply_default_arguments(args):
     if args.test_optimize_for_size:
         args.test = True
 
+    # --test-paths implies --test and/or --validation-test
+    # depending on what directories/files have been specified.
+    if args.test_paths:
+        for path in args.test_paths:
+            if path.startswith('test'):
+                args.test = True
+            elif path.startswith('validation-test'):
+                args.test = True
+                args.validation_test = True
+
     # If none of tests specified skip swift stdlib test on all platforms
     if not args.test and not args.validation_test and not args.long_test:
         args.test_linux = False
@@ -571,6 +581,12 @@ def create_argument_parser():
         "--validation-test",
         help="run the validation test suite (implies --test)",
         action=arguments.action.optional_bool)
+    run_tests_group.add_argument(
+        "--test-paths",
+        help="run tests located in specific directories and/or files \
+        (implies --test and/or --validation-test)",
+        action=arguments.action.concat, type=arguments.type.shell_split,
+        default=[])
     run_tests_group.add_argument(
         "-o",
         help="run the test suite in optimized mode too (implies --test)",

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -164,6 +164,7 @@ EXPECTED_DEFAULTS = {
     'test_optimize_for_size': None,
     'test_optimized': None,
     'test_osx': False,
+    'test_paths': [],
     'test_tvos': False,
     'test_tvos_device': False,
     'test_tvos_simulator': False,
@@ -482,6 +483,7 @@ EXPECTED_OPTIONS = [
     AppendOption('--extra-swift-args', dest='extra_swift_args'),
     AppendOption('--stdlib-deployment-targets',
                  dest='stdlib_deployment_targets'),
+    AppendOption('--test-paths', dest='test_paths'),
 
     UnsupportedOption('--build-jobs'),
     UnsupportedOption('--common-cmake-options'),


### PR DESCRIPTION
Sometimes it's useful to be able to run tests located in specific
directories and/or files, let's enable this in `utils/build-script`
using `--test-paths` option which accepts a list of viable test locations.

Resolves: rdar://problem/32004487

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
