### PR TITLE
[swiftc (51 vs. 5592)] Add crasher in swift::ProtocolType::canonicalizeProtocols

### DIFF
--- a/validation-test/compiler_crashers/28837-swift-protocolcompositiontype-get-swift-astcontext-const-llvm-arrayref-swift-typ.swift
+++ b/validation-test/compiler_crashers/28837-swift-protocolcompositiontype-get-swift-astcontext-const-llvm-arrayref-swift-typ.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol b:Self.a&(Int
+protocol b{}


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolType::canonicalizeProtocols`.

Current number of unresolved compiler crashers: 51 (5592 resolved)

Stack trace:

```
0 0x0000000003e849d4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e849d4)
1 0x0000000003e84d16 SignalHandler(int) (/path/to/swift/bin/swift+0x3e84d16)
2 0x00007f8696c53390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000016c9cc4 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16c9cc4)
4 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
5 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
6 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
7 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
8 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
9 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
10 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
11 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
12 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
13 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
14 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
15 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
16 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
17 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
18 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
19 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
20 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
21 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
22 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
23 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
24 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
25 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
26 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
27 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
28 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
29 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
30 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
31 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
32 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
33 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
34 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
35 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
36 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
37 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
38 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
39 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
40 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
41 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
42 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
43 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
44 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
45 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
46 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
47 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
48 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
49 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
50 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
51 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
52 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
53 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
54 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
55 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
56 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
57 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
58 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
59 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
60 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
61 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
62 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
63 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
64 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
65 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
66 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
67 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
68 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
69 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
70 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
71 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
72 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
73 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
74 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
75 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
76 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
77 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
78 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
79 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
80 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
81 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
82 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
83 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
84 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
85 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
86 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
87 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
88 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
89 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
90 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
91 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
92 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
93 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
94 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
95 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
96 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
97 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
98 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
99 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
100 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
101 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
102 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
103 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
104 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
105 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
106 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
107 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
108 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
109 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
110 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
111 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
112 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
113 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
114 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
115 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
116 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
117 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
118 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
119 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
120 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
121 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
122 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
123 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
124 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
125 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
126 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
127 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
128 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
129 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
130 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
131 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
132 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
133 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
134 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
135 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
136 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
137 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
138 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
139 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
140 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
141 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
142 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
143 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
144 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
145 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
146 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
147 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
148 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
149 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
150 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
151 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
152 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
153 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
154 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
155 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
156 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
157 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
158 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
159 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
160 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
161 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
162 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
163 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
164 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
165 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
166 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
167 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
168 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
169 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
170 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
171 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
172 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
173 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
174 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
175 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
176 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
177 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
178 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
179 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
180 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
181 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
182 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
183 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
184 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
185 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
186 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
187 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
188 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
189 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
190 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
191 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
192 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
193 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
194 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
195 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
196 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
197 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
198 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
199 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
200 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
201 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
202 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
203 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
204 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
205 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
206 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
207 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
208 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
209 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
210 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
211 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
212 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
213 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
214 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
215 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
216 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
217 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
218 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
219 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
220 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
221 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
222 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
223 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
224 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
225 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
226 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
227 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
228 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
229 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
230 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
231 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
232 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
233 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
234 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
235 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
236 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
237 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
238 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
239 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
240 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
241 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
242 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
243 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
244 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
245 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
246 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
247 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
248 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
249 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
250 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
251 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
252 0x00000000016caa8a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16caa8a)
253 0x00000000016c649c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c649c)
254 0x0000000001637765 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1637765)
255 0x00000000016ca0a0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ca0a0)
```