### PR TITLE
[stdlib] Error recovery hook

### DIFF
--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -18,10 +18,6 @@ import SwiftShims
 public var _swift_stdlib_errorHandler: ((_: StaticString, _: String,
                         _: StaticString, _: UInt, _: UInt32, _: Int32) -> ())?
 
-// Is Int32(Builtin.assert_configuration()) a constant?
-// Is it related to the toolchain or the application compile?
-public let _swift_stdlib_assertConfig = Int32(Builtin.assert_configuration())
-
 // Implementation Note: this file intentionally uses very LOW-LEVEL
 // CONSTRUCTS, so that assert and fatal may be used liberally in
 // building library abstractions without fear of infinite recursion.
@@ -36,8 +32,7 @@ func _isDebugAssertConfiguration() -> Bool {
   // 0: Debug
   // 1: Release
   // 2: Fast
-  return _swift_stdlib_assertConfig == 0 || _swift_stdlib_errorHandler != nil
-    // When function above, traps compiler at DeadCodeElimination.cpp, line 656.
+  return Int32(Builtin.assert_configuration()) == 0
 }
 
 @_versioned
@@ -97,7 +92,7 @@ func _assertionFailure(
   flags: UInt32
 ) -> Never {
   _swift_stdlib_errorHandler?(prefix, message.description, file, line, flags,
-                              _swift_stdlib_assertConfig)
+                              Int32(Builtin.assert_configuration()))
   prefix.withUTF8Buffer {
     (prefix) -> Void in
     message.withUTF8Buffer {
@@ -130,7 +125,7 @@ func _assertionFailure(
   flags: UInt32
 ) -> Never {
   _swift_stdlib_errorHandler?(prefix, message, file, line, flags,
-                              _swift_stdlib_assertConfig)
+                              Int32(Builtin.assert_configuration()))
   prefix.withUTF8Buffer {
     (prefix) -> Void in
     message._withUnsafeBufferPointerToUTF8 {
@@ -164,7 +159,7 @@ func _fatalErrorMessage(
   flags: UInt32
 ) -> Never {
   _swift_stdlib_errorHandler?(prefix, message.description, file, line, flags,
-                              _swift_stdlib_assertConfig)
+                              Int32(Builtin.assert_configuration()))
 #if INTERNAL_CHECKS_ENABLED
   prefix.withUTF8Buffer {
     (prefix) in


### PR DESCRIPTION
Hi Apple,

I was wondering if you would consider merging this relatively change into master. It gives developers the possibility of creating a custom fatal error handler to intercept a crash and perhaps log it or even unwind the stack to a safe point where the error can be handled. An example of this is [Fortify.swift](https://github.com/johnno1962/Fortify/blob/master/Sources/Fortify.swift) which has been tested with an [Xcode toolchain](http://johnholdsworth.com/swift-LOCAL-2017-09-20-a-osx.tar.gz) and is portable to Linux and Android. This could form a key component of an effort to make Swift better suited to use in application servers which can not afford to have a failure in one part of the program take the whole process down though it would also have applications for mobile devices.

Cheers.