### PR TITLE
reenable disabled Error test

### DIFF
--- a/test/multifile/error-type/one-module/main.swift
+++ b/test/multifile/error-type/one-module/main.swift
@@ -5,7 +5,4 @@
 
 // REQUIRES: executable_test
 
-// FIXME: Fails on iPhone simulator target due to possible MC-JIT bug
-// REQUIRES: disabled 
-
 extension NuclearMeltdown : Error {}


### PR DESCRIPTION
This test was disabled a while back, re-enabling to see if it's still failing.