### PR TITLE
[swiftc (53 vs. 5592)] Add crasher in swift::SubstitutionMap::lookupSubstitution

### DIFF
--- a/validation-test/compiler_crashers/28839-genericsig.swift
+++ b/validation-test/compiler_crashers/28839-genericsig.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a{
+class a<a:A
+protocol A:a{typealias wh:Self.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::SubstitutionMap::lookupSubstitution`.

Current number of unresolved compiler crashers: 53 (5592 resolved)

/cc @swiftix - just wanted to let you know that this crasher caused an assertion failure for the assertion `genericSig` added on 2017-05-01 by you in commit 0aff7c0c :-)

Assertion failure in [`lib/AST/SubstitutionMap.cpp (line 120)`](https://github.com/apple/swift/blob/54908776923bfec41ff730148ddbf8440a38e182/lib/AST/SubstitutionMap.cpp#L120):

```
Assertion `genericSig' failed.

When executing: swift::Type swift::SubstitutionMap::lookupSubstitution(CanSubstitutableType) const
```

Assertion context:

```c++
  // have.
  auto genericParam = cast<GenericTypeParamType>(type);
  auto mutableThis = const_cast<SubstitutionMap *>(this);
  auto replacementTypes = mutableThis->getReplacementTypes();
  auto genericSig = getGenericSignature();
  assert(genericSig);
  auto genericParams = genericSig->getGenericParams();
  auto replacementIndex =
    GenericParamKey(genericParam).findIndexIn(genericParams);

  // If this generic parameter isn't represented, we don't have a replacement
```
Stack trace:

```
0 0x0000000003e86f24 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e86f24)
1 0x0000000003e87266 SignalHandler(int) (/path/to/swift/bin/swift+0x3e87266)
2 0x00007f81f4d05390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f81f322a428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f81f322c02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f81f3222bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f81f3222c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016c3b02 swift::SubstitutionMap::lookupSubstitution(swift::CanTypeWrapper<swift::SubstitutableType>) const (/path/to/swift/bin/swift+0x16c3b02)
8 0x00000000016d5df9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16d5df9)
9 0x00000000016d2336 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16d2336)
10 0x00000000016d264d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16d264d)
11 0x00000000016cd625 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16cd625)
12 0x00000000016d20ac swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::ValueDecl const*, swift::Type) (/path/to/swift/bin/swift+0x16d20ac)
13 0x0000000001669cec swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x1669cec)
14 0x00000000016690d3 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x16690d3)
15 0x000000000166d8db swift::GenericSignatureBuilder::resolvePotentialArchetype(swift::Type, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x166d8db)
16 0x000000000166da71 swift::GenericSignatureBuilder::resolve(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource) (/path/to/swift/bin/swift+0x166da71)
17 0x00000000016725c5 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x16725c5)
18 0x0000000001687a53 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_22>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x1687a53)
19 0x000000000167f682 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x167f682)
20 0x000000000166e00e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x166e00e)
21 0x000000000166e609 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x166e609)
22 0x000000000167289a swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x167289a)
23 0x0000000001687a53 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_22>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x1687a53)
24 0x000000000167f682 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x167f682)
25 0x000000000166e00e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x166e00e)
26 0x000000000166de3e swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x166de3e)
27 0x00000000012bfdd2 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12bfdd2)
28 0x00000000012c36f4 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x12c36f4)
29 0x00000000012c3b23 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12c3b23)
30 0x0000000001291324 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1291324)
31 0x00000000012a19cc (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12a19cc)
32 0x000000000128fa3e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x128fa3e)
33 0x00000000012a1adb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12a1adb)
34 0x000000000128fa3e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x128fa3e)
35 0x000000000128f853 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x128f853)
36 0x00000000013203b4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13203b4)
37 0x0000000001045247 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1045247)
38 0x00000000004bd856 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bd856)
39 0x00000000004bc60e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc60e)
40 0x0000000000474c54 main (/path/to/swift/bin/swift+0x474c54)
41 0x00007f81f3215830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
42 0x0000000000472509 _start (/path/to/swift/bin/swift+0x472509)
```