### PR TITLE
[swiftc (54 vs. 5592)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28840-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28840-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}typealias a=(t:Self.a{}typealias a:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 54 (5592 resolved)

Stack trace:

```
0 0x0000000003e86f24 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e86f24)
1 0x0000000003e87266 SignalHandler(int) (/path/to/swift/bin/swift+0x3e87266)
2 0x00007f20209a0390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000016c77d4 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16c77d4)
4 0x00000000012c67b1 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12c67b1)
5 0x00000000013123ce resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13123ce)
6 0x0000000001311b2a swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1311b2a)
7 0x00000000013128f0 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13128f0)
8 0x0000000001313f3b (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1313f3b)
9 0x00000000013127fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13127fc)
10 0x00000000013110dd swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13110dd)
11 0x0000000001292a25 validateTypealiasType(swift::TypeChecker&, swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x1292a25)
12 0x0000000001291895 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1291895)
13 0x00000000012a2abf (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12a2abf)
14 0x000000000128f948 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x128f948)
15 0x000000000128f853 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x128f853)
16 0x00000000013203b4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13203b4)
17 0x0000000001045247 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1045247)
18 0x00000000004bd856 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bd856)
19 0x00000000004bc60e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc60e)
20 0x0000000000474c54 main (/path/to/swift/bin/swift+0x474c54)
21 0x00007f201eeb0830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000472509 _start (/path/to/swift/bin/swift+0x472509)
```