### PR TITLE
[swiftc (55 vs. 5592)] Add crasher in swift::ValueDecl::getFormalAccessScope

### DIFF
--- a/validation-test/compiler_crashers/28841-swift-valuedecl-getformalaccessscope-swift-declcontext-const-bool-const.swift
+++ b/validation-test/compiler_crashers/28841-swift-valuedecl-getformalaccessscope-swift-declcontext-const-bool-const.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension a{var f=a}class a:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ValueDecl::getFormalAccessScope`.

Current number of unresolved compiler crashers: 55 (5592 resolved)

Stack trace:

```
0 0x0000000003e86f24 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e86f24)
1 0x0000000003e87266 SignalHandler(int) (/path/to/swift/bin/swift+0x3e87266)
2 0x00007fa0c7650390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x0000000001632e9f swift::ValueDecl::getFormalAccessScope(swift::DeclContext const*, bool) const (/path/to/swift/bin/swift+0x1632e9f)
4 0x000000000128e99a (anonymous namespace)::DeclChecker::checkOverrides(swift::TypeChecker&, swift::ValueDecl*) (/path/to/swift/bin/swift+0x128e99a)
5 0x00000000012921dd swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12921dd)
6 0x00000000012a8ba0 (anonymous namespace)::DeclChecker::visitBoundVariable(swift::VarDecl*) (/path/to/swift/bin/swift+0x12a8ba0)
7 0x00000000016b443f swift::Pattern::forEachVariable(std::function<void (swift::VarDecl*)> const&) const (/path/to/swift/bin/swift+0x16b443f)
8 0x000000000128fb02 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x128fb02)
9 0x00000000012a112b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12a112b)
10 0x000000000128f978 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x128f978)
11 0x000000000128f853 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x128f853)
12 0x00000000013203b4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13203b4)
13 0x0000000001045247 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1045247)
14 0x00000000004bd856 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bd856)
15 0x00000000004bc60e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc60e)
16 0x0000000000474c54 main (/path/to/swift/bin/swift+0x474c54)
17 0x00007fa0c5b60830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
18 0x0000000000472509 _start (/path/to/swift/bin/swift+0x472509)
```