### PR TITLE
[swiftc (56 vs. 5592)] Add crasher in swift::GenericSignatureBuilder::Constraint

### DIFF
--- a/validation-test/compiler_crashers/28842-hasval.swift
+++ b/validation-test/compiler_crashers/28842-hasval.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}typealias a:A{}class a
+protocol a protocol A:P{typealias a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::Constraint`.

Current number of unresolved compiler crashers: 56 (5592 resolved)

Assertion failure in `llvm/include/llvm/ADT/Optional.h (line 137)`:

```
Assertion `hasVal' failed.

When executing: T &llvm::Optional<swift::GenericSignatureBuilder::Constraint<swift::Type> >::operator*() & [T = swift::GenericSignatureBuilder::Constraint<swift::Type>]
```

Assertion context:

```c++
  explicit operator bool() const { return hasVal; }
  bool hasValue() const { return hasVal; }
  const T* operator->() const { return getPointer(); }
  T* operator->() { return getPointer(); }
  const T& operator*() const LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
  T& operator*() LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }

  template <typename U>
  constexpr T getValueOr(U &&value) const LLVM_LVALUE_FUNCTION {
    return hasValue() ? getValue() : std::forward<U>(value);
  }
```
Stack trace:

```
0 0x0000000003e86f24 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e86f24)
1 0x0000000003e87266 SignalHandler(int) (/path/to/swift/bin/swift+0x3e87266)
2 0x00007f6c4e004390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f6c4c529428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f6c4c52b02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f6c4c521bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f6c4c521c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000168baa6 swift::GenericSignatureBuilder::Constraint<swift::Type> swift::GenericSignatureBuilder::checkConstraintList<swift::Type, swift::Type>(llvm::ArrayRef<swift::GenericTypeParamType*>, std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > >&, llvm::function_ref<bool (swift::GenericSignatureBuilder::Constraint<swift::Type> const&)>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintRelation (swift::GenericSignatureBuilder::Constraint<swift::Type> const&)>, llvm::Optional<swift::Diag<unsigned int, swift::Type, swift::Type, swift::Type> >, swift::Diag<swift::Type, swift::Type>, swift::Diag<unsigned int, swift::Type, swift::Type>, llvm::function_ref<swift::Type (swift::Type const&)>, bool) (/path/to/swift/bin/swift+0x168baa6)
8 0x000000000167c244 swift::GenericSignatureBuilder::checkConcreteTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x167c244)
9 0x00000000016758c7 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x16758c7)
10 0x000000000167deb3 swift::GenericSignatureBuilder::computeGenericSignature(swift::SourceLoc, bool) (/path/to/swift/bin/swift+0x167deb3)
11 0x000000000163a7e8 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x163a7e8)
12 0x00000000012c3ae8 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12c3ae8)
13 0x00000000012917a3 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12917a3)
14 0x00000000012a2abf (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12a2abf)
15 0x000000000128f948 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x128f948)
16 0x000000000128f853 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x128f853)
17 0x00000000013203b4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13203b4)
18 0x0000000001045247 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1045247)
19 0x00000000004bd856 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bd856)
20 0x00000000004bc60e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc60e)
21 0x0000000000474c54 main (/path/to/swift/bin/swift+0x474c54)
22 0x00007f6c4c514830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000472509 _start (/path/to/swift/bin/swift+0x472509)
```