### PR TITLE
[swiftc (57 vs. 5592)] Add crasher in swift::Parser::parseStmtForEach(...)

### DIFF
--- a/validation-test/compiler_crashers/28843-startofcontrol-tok-getloc.swift
+++ b/validation-test/compiler_crashers/28843-startofcontrol-tok-getloc.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{for
+;


### PR DESCRIPTION
Add test case for crash triggered in `swift::Parser::parseStmtForEach(...)`.

Current number of unresolved compiler crashers: 57 (5592 resolved)

/cc @rintaro - just wanted to let you know that this crasher caused an assertion failure for the assertion `StartOfControl != Tok.getLoc()` added on 2017-08-01 by you in commit 546aeb23 :-)

Assertion failure in [`lib/Parse/ParseStmt.cpp (line 1839)`](https://github.com/apple/swift/blob/6f0c787996806bc0b2a3780697ff4421c7927ecd/lib/Parse/ParseStmt.cpp#L1839):

```
Assertion `StartOfControl != Tok.getLoc()' failed.

When executing: ParserResult<swift::Stmt> swift::Parser::parseStmtForEach(swift::LabeledStmtInfo)
```

Assertion context:

```c++
        skipSingle();
    }
    if (Tok.is(tok::code_complete))
      return makeParserCodeCompletionStatus();

    assert(StartOfControl != Tok.getLoc());
    SourceRange ControlRange(StartOfControl, PreviousLoc);
    Container = makeParserErrorResult(new (Context) ErrorExpr(ControlRange));
    diagnose(ForLoc, diag::c_style_for_stmt_removed)
      .highlight(ControlRange);
    Status = makeParserError();
```
Stack trace:

```
0 0x0000000003e86f24 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e86f24)
1 0x0000000003e87266 SignalHandler(int) (/path/to/swift/bin/swift+0x3e87266)
2 0x00007f79f84f1390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f79f6a16428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f79f6a1802a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f79f6a0ebd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f79f6a0ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001576d12 swift::Parser::parseStmtForEach(swift::LabeledStmtInfo) (/path/to/swift/bin/swift+0x1576d12)
8 0x000000000157021a swift::Parser::parseStmt() (/path/to/swift/bin/swift+0x157021a)
9 0x000000000156f3b9 swift::Parser::parseExprOrStmt(swift::ASTNode&) (/path/to/swift/bin/swift+0x156f3b9)
10 0x0000000001571301 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0x1571301)
11 0x00000000015568f8 swift::Parser::parseExprClosure() (/path/to/swift/bin/swift+0x15568f8)
12 0x000000000154d893 swift::Parser::parseExprPostfix(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x154d893)
13 0x000000000154c677 swift::Parser::parseExprSequenceElement(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x154c677)
14 0x000000000154b6d6 swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) (/path/to/swift/bin/swift+0x154b6d6)
15 0x000000000154b5b2 swift::Parser::parseExprImpl(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x154b5b2)
16 0x000000000156f519 swift::Parser::parseExprOrStmt(swift::ASTNode&) (/path/to/swift/bin/swift+0x156f519)
17 0x0000000001571108 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0x1571108)
18 0x0000000001525a6e swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0x1525a6e)
19 0x00000000010c8aa2 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0x10c8aa2)
20 0x0000000001045213 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1045213)
21 0x00000000004bd856 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bd856)
22 0x00000000004bc60e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc60e)
23 0x0000000000474c54 main (/path/to/swift/bin/swift+0x474c54)
24 0x00007f79f6a01830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000472509 _start (/path/to/swift/bin/swift+0x472509)
```