### PR TITLE
Add Builtin.type_join* family of functions.

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -516,6 +516,17 @@ BUILTIN_SANITIZER_OPERATION(TSanInoutAccess, "tsanInoutAccess", "")
 
 #undef BUILTIN_SANITIZER_OPERATION
 
+/// Builtins for compile-time type-checking operations used for unit testing.
+#ifndef BUILTIN_TYPE_CHECKER_OPERATION
+#define BUILTIN_TYPE_CHECKER_OPERATION(Id, Name) BUILTIN(Id, #Name, "n")
+#endif
+
+BUILTIN_TYPE_CHECKER_OPERATION(TypeJoin, type_join)
+BUILTIN_TYPE_CHECKER_OPERATION(TypeJoinInout, type_join_inout)
+BUILTIN_TYPE_CHECKER_OPERATION(TypeJoinMeta, type_join_meta)
+
+#undef BUILTIN_TYPE_CHECKER_OPERATION
+
 // BUILTIN_TYPE_TRAIT_OPERATION - Compile-time type trait operations.
 #ifndef BUILTIN_TYPE_TRAIT_OPERATION
 #define BUILTIN_TYPE_TRAIT_OPERATION(Id, Name) \

--- a/include/swift/SIL/SILBuiltinVisitor.h
+++ b/include/swift/SIL/SILBuiltinVisitor.h
@@ -40,6 +40,11 @@ public:
 
     if (auto BuiltinKind = BI->getBuiltinKind()) {
       switch (BuiltinKind.getValue()) {
+      // BUILTIN_TYPE_CHECKER_OPERATION does not live past the type checker.
+#define BUILTIN_TYPE_CHECKER_OPERATION(ID, NAME)                               \
+  case BuiltinValueKind::ID:                                                   \
+    llvm_unreachable("Unexpected type checker operation seen in SIL!");
+
 #define BUILTIN(ID, NAME, ATTRS)                                               \
   case BuiltinValueKind::ID:                                                   \
     return asImpl().visit##ID(BI, ATTRS);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -944,6 +944,34 @@ static ValueDecl *getAddressOfOperation(ASTContext &Context, Identifier Id) {
   return builder.build(Id);
 }
 
+static ValueDecl *getTypeJoinOperation(ASTContext &Context, Identifier Id) {
+  // <T,U,V> (T.Type, U.Type) -> V.Type
+  BuiltinGenericSignatureBuilder builder(Context, 3);
+  builder.addParameter(makeMetatype(makeGenericParam(0)));
+  builder.addParameter(makeMetatype(makeGenericParam(1)));
+  builder.setResult(makeMetatype(makeGenericParam(2)));
+  return builder.build(Id);
+}
+
+static ValueDecl *getTypeJoinInoutOperation(ASTContext &Context,
+                                            Identifier Id) {
+  // <T,U,V> (inout T, U.Type) -> V.Type
+  BuiltinGenericSignatureBuilder builder(Context, 3);
+  builder.addInOutParameter(makeGenericParam(0));
+  builder.addParameter(makeMetatype(makeGenericParam(1)));
+  builder.setResult(makeMetatype(makeGenericParam(2)));
+  return builder.build(Id);
+}
+
+static ValueDecl *getTypeJoinMetaOperation(ASTContext &Context, Identifier Id) {
+  // <T,U,V> (T.Type, U.Type) -> V.Type
+  BuiltinGenericSignatureBuilder builder(Context, 3);
+  builder.addParameter(makeMetatype(makeGenericParam(0)));
+  builder.addParameter(makeMetatype(makeGenericParam(1)));
+  builder.setResult(makeMetatype(makeGenericParam(2)));
+  return builder.build(Id);
+}
+
 static ValueDecl *getCanBeObjCClassOperation(ASTContext &Context,
                                              Identifier Id) {
   // <T> T.Type -> Builtin.Int8
@@ -1123,6 +1151,7 @@ static const OverloadedBuiltinKind OverloadedBuiltinKinds[] = {
    OverloadedBuiltinKind::overload,
 #define BUILTIN_SANITIZER_OPERATION(id, name, attrs) \
   OverloadedBuiltinKind::None,
+#define BUILTIN_TYPE_CHECKER_OPERATION(id, name) OverloadedBuiltinKind::Special,
 #define BUILTIN_TYPE_TRAIT_OPERATION(id, name) \
    OverloadedBuiltinKind::Special,
 #define BUILTIN_RUNTIME_CALL(id, attrs, name) \
@@ -1801,6 +1830,15 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
     return getBuiltinFunction(Id,
                               {},
                               TupleType::getEmpty(Context));
+
+  case BuiltinValueKind::TypeJoin:
+    return getTypeJoinOperation(Context, Id);
+
+  case BuiltinValueKind::TypeJoinInout:
+    return getTypeJoinInoutOperation(Context, Id);
+
+  case BuiltinValueKind::TypeJoinMeta:
+    return getTypeJoinMetaOperation(Context, Id);
   }
 
   llvm_unreachable("bad builtin value!");

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1196,6 +1196,9 @@ public:
     return {true, UseLifetimeConstraint::MustBeLive};
   }
 
+    // BUILTIN_TYPE_CHECKER_OPERATION does not live past the type checker.
+#define BUILTIN_TYPE_CHECKER_OPERATION(ID, NAME)
+
 #define BUILTIN(ID, NAME, ATTRS)                                               \
   OwnershipUseCheckerResult visit##ID(BuiltinInst *BI, StringRef Attr);
 #include "swift/AST/Builtins.def"

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -971,6 +971,7 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   case BuiltinValueKind::Id:
 #define BUILTIN_SIL_OPERATION(Id, Name, Overload)
 #define BUILTIN_SANITIZER_OPERATION(Id, Name, Attrs)
+#define BUILTIN_TYPE_CHECKER_OPERATION(Id, Name)
 #define BUILTIN_TYPE_TRAIT_OPERATION(Id, Name)
 #include "swift/AST/Builtins.def"
   case BuiltinValueKind::None:
@@ -991,7 +992,12 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   case BuiltinValueKind::Id:                                                \
     llvm_unreachable("Sanitizer builtin called directly?");
 
-  // Lower away type trait builtins when they're trivially solvable.
+#define BUILTIN_TYPE_CHECKER_OPERATION(Id, Name)                               \
+  case BuiltinValueKind::Id:                                                   \
+    llvm_unreachable(                                                          \
+        "Compile-time type checker operation should not make it to SIL!");
+
+    // Lower away type trait builtins when they're trivially solvable.
 #define BUILTIN_TYPE_TRAIT_OPERATION(Id, Name)                              \
   case BuiltinValueKind::Id:                                                \
     return SpecializedEmitter(&emitBuiltinTypeTrait<&TypeBase::Name,        \

--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+
+import Swift
+
+class C {}
+class D : C {}
+
+public func expectEqualType<T>(_: T.Type, _: T.Type) {}
+
+expectEqualType(Builtin.type_join(Int.self, Int.self), Int.self)
+expectEqualType(Builtin.type_join_meta(D.self, C.self), C.self)


### PR DESCRIPTION
These will be used for unit-testing the `Type::join` functionality in the
type checker. The result of the join is replaced during constraint
generation with the actual type.

There is currently no checking for whether the arguments can be used to
statically compute the value, so bad things will likely happen if
e.g. they are type variables. Once more of the basic functionality of
`Type::join` is working I'll make this a bit more bullet-proof in that
regard.

They include:
```
  // Compute the join of T and U and return the metatype of that type.
  Builtin.type_join<T, U, V>(_: T.Type, _: U.Type) -> V.Type

  // Compute the join of &T and U and return the metatype of that type.
  Builtin.type_join_inout<T, U, V>(_: inout T, _: U.Type) -> V.Type

  // Compute the join of T.Type and U.Type and return that type.
  Builtin.type_join_meta<T, U, V>(_: T.Type, _: U.Type) -> V.Type
```
I've added a couple simple tests to start off, based on what currently
works (aka doesn't cause an assert, crash, etc.).
