### PR TITLE
IRGen: Refactor so that TypeInfos can provide type verifier logic.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1097,12 +1097,8 @@ void IRGenModule::emitTypeVerifier() {
     Builder.CreateCall(VerifierFunction, {});
   }
 
-  IRGenFunction VerifierIGF(*this, VerifierFunction);
-  if (DebugInfo)
-    DebugInfo->emitArtificialFunction(VerifierIGF, VerifierFunction);
-
-  emitTypeLayoutVerifier(VerifierIGF, TypesToVerify);
-  VerifierIGF.Builder.CreateRetVoid();
+  IRGenTypeVerifierFunction VerifierIGF(*this, VerifierFunction);
+  VerifierIGF.emit(TypesToVerify);
 }
 
 /// Get SIL-linkage for something that's not required to be visible

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1771,3 +1771,9 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
 
   return SILType();
 }
+
+void TypeInfo::verify(IRGenTypeVerifierFunction &IGF,
+                      llvm::Value *typeMetadata,
+                      SILType T) const {
+  // By default, no type-specific verifier behavior.
+}

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -955,6 +955,8 @@ public:
   ForeignFunctionInfo getForeignFunctionInfo(CanSILFunctionType type);
 
   llvm::Constant *getSize(Size size);
+  llvm::Constant *getAlignment(Alignment align);
+  llvm::Constant *getBool(bool condition);
 
   Address getAddrOfFieldOffset(VarDecl *D, bool isIndirect,
                                ForDefinition_t forDefinition);

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -41,6 +41,7 @@ namespace irgen {
   class Address;
   class StackAddress;
   class IRGenFunction;
+  class IRGenTypeVerifierFunction;
   class IRGenModule;
   class Explosion;
   class ExplosionSchema;
@@ -467,6 +468,12 @@ public:
 
   /// Get the native (abi) convention for a parameter value of this type.
   const NativeConventionSchema &nativeParameterValueSchema(IRGenModule &IGM) const;
+  
+  /// Emit verifier code that compares compile-time constant knowledge of
+  /// this kind of type's traits to its runtime manifestation.
+  virtual void verify(IRGenTypeVerifierFunction &IGF,
+                      llvm::Value *typeMetadata,
+                      SILType T) const;
 };
 
 } // end namespace irgen


### PR DESCRIPTION
NFC yet, but this will allow things like *StructTypeInfo emitting code to check fixed struct field offsets against the runtime.