### PR TITLE
[process-stats-dir] Treat module-grouped timers as timers too.

### DIFF
--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -239,7 +239,7 @@ def compare_stats(args, old_stats, new_stats):
         old = old_stats[name]
         new = new_stats.get(name, 0)
         (delta, delta_pct) = diff_and_pct(old, new)
-        if (name.startswith("time.") and
+        if ((name.startswith("time.") or '.time.' in name) and
            abs(delta) < args.delta_usec_thresh):
             continue
         if abs(delta_pct) < args.delta_pct_thresh:


### PR DESCRIPTION
Fix a little thinko in process-stats-dir.py around judging counters to be timers when grouped by module names.