### PR TITLE
SimplifyCFG: limit the number of jump threading through a basic block.

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -67,10 +67,9 @@ namespace {
     llvm::SmallDenseMap<SILBasicBlock*, unsigned, 32> WorklistMap;
     // Keep track of loop headers - we don't want to jump-thread through them.
     SmallPtrSet<SILBasicBlock *, 32> LoopHeaders;
-    // The number of times jump threading was done through a switch_enum in
-    // a loop header. Used to limit that to prevent an infinite jump threading
-    // loop.
-    llvm::SmallDenseMap<SILBasicBlock*, unsigned, 8> JumpThreadedLoopHeaders;
+    // The number of times jump threading was done through a block.
+    // Used to prevent infinite jump threading loops.
+    llvm::SmallDenseMap<SILBasicBlock*, unsigned, 8> JumpThreadedBlocks;
 
     // Dominance and post-dominance info for the current function
     DominanceInfo *DT = nullptr;
@@ -1042,14 +1041,13 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
   if (DestIsLoopHeader) {
     if (!isa<SwitchEnumInst>(DestBB->getTerminator()))
       return false;
-
-    // Limit the number we jump-thread through an switch_enum loop header.
-    // In case the CFG contains an infinite loop through such a header we
-    // otherwise may end up with jump-threading indefinitely.
-    unsigned &NumThreaded = JumpThreadedLoopHeaders[DestBB];
-    if (++NumThreaded > 8)
-      return false;
   }
+
+  // Limit the number we jump-thread through a block.
+  // Otherwise we may end up with jump-threading indefinitely.
+  unsigned &NumThreaded = JumpThreadedBlocks[DestBB];
+  if (++NumThreaded > 16)
+    return false;
 
   DEBUG(llvm::dbgs() << "jump thread from bb" << SrcBB->getDebugID() <<
         " to bb" << DestBB->getDebugID() << '\n');

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -107,3 +107,51 @@ bb13:
   return %65 : $()
 }
 
+sil @some_function : $@convention(thin) (AA) -> Optional<AA>
+
+// Another test for checking that SimplifyCFG does not hang.
+// CHECK-LABEL: test_other_infinite_loop
+sil hidden @test_other_infinite_loop : $@convention(method) (@owned AA) -> () {
+bb0(%5 : $AA):
+  strong_retain %5 : $AA
+  %6 = enum $Optional<AA>, #Optional.some!enumelt.1, %5 : $AA
+  br bb1(%6 : $Optional<AA>)
+
+bb1(%8 : $Optional<AA>):
+  retain_value %8 : $Optional<AA>
+  switch_enum %8 : $Optional<AA>, case #Optional.some!enumelt.1: bb3, default bb2
+
+bb2:
+  release_value %8 : $Optional<AA>
+  br bb6
+
+bb3:
+  cond_br undef, bb4, bb5
+
+bb4:
+  %85 = tuple ()
+  return %85 : $()
+
+bb5:
+  br bb6
+
+bb6:
+  switch_enum %8 : $Optional<AA>, case #Optional.none!enumelt: bb7, default bb8
+
+bb7:
+  br bb9(%8 : $Optional<AA>)
+
+bb8:
+  %23 = unchecked_enum_data %8 : $Optional<AA>, #Optional.some!enumelt.1
+  strong_retain %23 : $AA
+  %25 = function_ref @some_function : $@convention(thin) (AA) -> Optional<AA>
+  %26 = apply %25(%23) : $@convention(thin) (AA) -> Optional<AA>
+  strong_release %23 : $AA
+  br bb9(%26 : $Optional<AA>)
+
+bb9(%29 : $Optional<AA>):
+  release_value %8 : $Optional<AA>
+  br bb1(%29 : $Optional<AA>)
+
+}
+


### PR DESCRIPTION
So far we did this only for loop headers, but there are cases where we need it for all blocks to prevent infinite loops in SimplifyCFG.

The limit for the number of jump threading iterations for a block doubled from 8 to 16, which is large enough to be hit very seldom (tested with compiling the benchmarks). So the chances of false positives (meaning: limiting optimization even if there would be no infinite loop) are very low.

rdar://problem/34576609
