### PR TITLE
build: improve the Windows build infrastructure

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -5,12 +5,22 @@
 # built for each variant.
 set(SWIFT_CONFIGURED_SDKS)
 
+include(SwiftWindowsSupport)
+
 # Report the given SDK to the user.
 function(_report_sdk prefix)
   message(STATUS "${SWIFT_SDK_${prefix}_NAME} SDK:")
   if("${prefix}" STREQUAL "WINDOWS")
-    message(STATUS "  INCLUDE: $ENV{INCLUDE}")
-    message(STATUS "  LIB: $ENV{LIB}")
+    message(STATUS "  UCRT Version: $ENV{UCRTVersion}")
+    message(STATUS "  UCRT SDK Dir: $ENV{UniversalCRTSdkDir}")
+    message(STATUS "  VC Dir: $ENV{VCToolsInstallDir}")
+
+    foreach(arch ${SWIFT_SDK_${prefix}_ARCHITECTURES})
+      swift_windows_include_for_arch(${arch} ${arch}_INCLUDE)
+      swift_windows_lib_for_arch(${arch} ${arch}_LIB)
+      message(STATUS "  ${arch} INCLUDE: ${${arch}_INCLUDE}")
+      message(STATUS "  ${arch} LIB: ${${arch}_LIB}")
+    endforeach()
   else()
     message(STATUS "  Path: ${SWIFT_SDK_${prefix}_PATH}")
   endif()

--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -1,0 +1,60 @@
+
+include(SwiftUtils)
+
+function(swift_windows_arch_spelling arch var)
+  if(${arch} STREQUAL i686)
+    set(${var} x86 PARENT_SCOPE)
+  elseif(${arch} STREQUAL x86_64)
+    set(${var} x64 PARENT_SCOPE)
+  elseif(${arch} STREQUAL armv7)
+    set(${var} arm PARENT_SCOPE)
+  elseif(${arch} STREQUAL aarch64)
+    set(${var} arm64 PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "do not know MSVC spelling for ARCH: `${arch}`")
+  endif()
+endfunction()
+
+function(swift_verify_windows_environment_variables)
+  set(VCToolsInstallDir $ENV{VCToolsInstallDir})
+  set(UniversalCRTSdkDir $ENV{UniversalCRTSdkDir})
+  set(UCRTVersion $ENV{UCRTVersion})
+
+  precondition(VCToolsInstallDir
+               MESSAGE
+                 "VCToolsInstallDir environment variable must be set")
+  precondition(UniversalCRTSdkDir
+               MESSAGE
+                 "UniversalCRTSdkDir environment variable must be set")
+  precondition(UCRTVersion
+               MESSAGE
+                 "UCRTVersion environment variable must be set")
+endfunction()
+
+function(swift_windows_include_for_arch arch var)
+  swift_verify_windows_environment_variables()
+
+  set(paths
+        "$ENV{VCToolsInstallDir}/include"
+        "$ENV{UniversalCRTSdkDir}/Include/$ENV{UCRTVersion}/ucrt"
+        "$ENV{UniversalCRTSdkDir}/Include/$ENV{UCRTVersion}/um"
+        "$ENV{UniversalCRTSdkDir}/Include/$ENV{UCRTVersion}/shared")
+  set(${var} ${paths} PARENT_SCOPE)
+endfunction()
+
+function(swift_windows_lib_for_arch arch var)
+  swift_verify_windows_environment_variables()
+  swift_windows_arch_spelling(${arch} ARCH)
+
+  set(paths)
+  if(${ARCH} STREQUAL x86)
+    list(APPEND paths "$ENV{VCToolsInstallDir}/Lib")
+  else()
+    list(APPEND paths "$ENV{VCToolsInstallDir}/Lib/${ARCH}")
+  endif()
+  list(APPEND paths
+          "$ENV{UniversalCRTSdkDir}/Lib/$ENV{UCRTVersion}/ucrt/${ARCH}"
+          "$ENV{UniversalCRTSdkDir}/Lib/$ENV{UCRTVersion}/um/${ARCH}")
+  set(${var} ${paths} PARENT_SCOPE)
+endfunction()
+

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -11,18 +11,18 @@ are available. Currently, the runtime has been tested to build against the
 Windows 10 SDK at revision 10.10.586.
 
 ```
-export WINKIT_ROOT=".../Windows Kits/10"
-export VC_ROOT=".../Microsoft Visual Studio 14.0/VC"
-export INCLUDE='${VC_ROOT}/include;${WINKIT_ROOT}/Include/10.0.10586.0/ucrt;${WINKIT_ROOT}/Include/10.0.10586.0/um;${WINKIT_ROOT}/Include/10.0.10586.0/shared'
-export LIB='${VC_ROOT}/lib;${WINKIT_ROOT}/Lib/10.0.10586.0/ucrt/x86;${WINKIT_ROOT}/Lib/10.0.10586.0/um/x86'
+# Visual Studio 2015 does not have VCToolsInstallDir, use VCINSTALLDIR's value
+export UCRTVersion=10.0.10586.0
+export UniversalCRTSdkDir=".../Windows Kits/10"
+export VCToolsInstallDir=".../Microsoft Visual Studio/2017/Community"
 ```
 
 ### 2. Setup `visualc` and `ucrt` modules
 The `visualc.modulemap` located at
 `swift/stdlib/public/Platform/visualc.modulemap` needs to be copied into
-`${VC_ROOT}/include`. The `ucrt.modulemap` located at
+`${VCToolsInstallDir}/include`. The `ucrt.modulemap` located at
 `swift/stdlib/public/Platform/ucrt.modulemap` needs to be copied into
-`${WINKIT_ROOT}/Include/10.0.10586.0/ucrt`.
+`${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt`.
 
 ### 3. Configure the runtime to be built with the just built clang
 Ensure that we use the tools from the just built LLVM and clang tools to build


### PR DESCRIPTION
Rather than use the `INCLUDE` and `LIB` environment variables to build
the Windows code, use the `UniversalCRTSdkDir`, `UCRTVersion`, and
`VCToolsInstallDir` variables.  Using these we can compute the right set
of include directories and library search paths for the various
architectures.  This will enable us to build multiple variants of the
Windows stdlib at the same time.

Additionally, rather than relying on the magic environment variables to
be processed by the driver, pass them explicitly to the driver through
the build system.  This also is needed to allow parallel builds of
various architecture variants of the stdlib on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
