### PR TITLE
test: duplicate some conditions for AArch64

### DIFF
--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -27,6 +27,7 @@ func test_indirect_by_val_alignment() {
 
 
 // We only want to test x86_64.
+// aarch64: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
 // arm64: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
 // armv7k: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
 // armv7s: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -221,6 +221,22 @@ bb0:
 // CHECK-arm64-LABEL: declare i32 @ints(i32)
 // CHECK-arm64-LABEL: declare i32 @unsigneds(i32)
 
+// CHECK-aarch64-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-aarch64:         call signext i8 @chareth(i8 signext %0)
+// CHECK-aarch64:         call signext i8 @signedChareth(i8 signext %1)
+// CHECK-aarch64:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
+// CHECK-aarch64:         call signext i16 @eatMyShorts(i16 signext %3)
+// CHECK-aarch64:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext %4)
+// CHECK-aarch64:         call i32 @ints(i32 %5)
+// CHECK-aarch64:         call i32 @unsigneds(i32 %6)
+// CHECK-aarch64-LABEL: declare signext i8 @chareth(i8 signext)
+// CHECK-aarch64-LABEL: declare signext i8 @signedChareth(i8 signext)
+// CHECK-aarch64-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-aarch64-LABEL: declare signext i16 @eatMyShorts(i16 signext)
+// CHECK-aarch64-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-aarch64-LABEL: declare i32 @ints(i32)
+// CHECK-aarch64-LABEL: declare i32 @unsigneds(i32)
+
 // CHECK-powerpc64-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-powerpc64:         call zeroext i8 @chareth(i8 zeroext %0)
 // CHECK-powerpc64:         call zeroext i8 @signedChareth(i8 zeroext %1)

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -15,6 +15,7 @@ func forceStuff(x: float4, y: float3) -> (Float, Float, Float, Float) {
 
 // x86_64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // i386-LABEL: define{{( protected)?}} <2 x i64> @simd_c_args(<4 x float>)
+// aarch64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // arm64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // armv6-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // armv7-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
@@ -30,6 +31,7 @@ entry(%x : $float4):
 
 // x86_64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
 // i386-LABEL: define{{( protected)?}} <2 x i64> @simd_c_args_float3(<3 x float>)
+// aarch64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // arm64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // armv6-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
 // armv7-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
@@ -48,6 +50,7 @@ entry(%x : $float3):
 
 // x86_64-LABEL: define{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
 // i386-LABEL: define{{( protected)?}} swiftcc void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// aarch64-LABEL: define{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
 // arm64-LABEL: define{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
 // armv6-LABEL: define{{( protected)?}} swiftcc void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
 // armv7-LABEL: define{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
@@ -65,6 +68,7 @@ entry(%x : $float4):
 
 // x86_64-LABEL: define{{( protected)?}} swiftcc { i64, float }  @simd_native_args_float3(i64, float)
 // i386-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// aarch64-LABEL: define{{( protected)?}} swiftcc { i64, float } @simd_native_args_float3(i64, float)
 // arm64-LABEL: define{{( protected)?}} swiftcc { i64, float } @simd_native_args_float3(i64, float)
 // armv6-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
 // armv7-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)

--- a/test/stdlib/FloatingPointIR.swift
+++ b/test/stdlib/FloatingPointIR.swift
@@ -53,6 +53,9 @@ func testConstantFoldFloatLiterals() {
 // arm64: call swiftcc void @_T015FloatingPointIR13acceptFloat32ySfF{{.*}}(float 1.000000e+00)
 // arm64: call swiftcc void @_T015FloatingPointIR13acceptFloat64ySdF{{.*}}(double 1.000000e+00)
 
+// aarch64: call swiftcc void @_T015FloatingPointIR13acceptFloat32ySfF{{.*}}(float 1.000000e+00)
+// aarch64: call swiftcc void @_T015FloatingPointIR13acceptFloat64ySdF{{.*}}(double 1.000000e+00)
+
 // powerpc64: call swiftcc void @_T015FloatingPointIR13acceptFloat32ySfF{{.*}}(float 1.000000e+00)
 // powerpc64: call swiftcc void @_T015FloatingPointIR13acceptFloat64ySdF{{.*}}(double 1.000000e+00)
 


### PR DESCRIPTION
The Linux target has a target-cpu value of AArch64 rather than arm64.
Adjust the tests to account for the difference.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
