### PR TITLE
Create fewer generic signature builders

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -846,6 +846,16 @@ public:
   /// not necessarily loaded.
   void getVisibleTopLevelClangModules(SmallVectorImpl<clang::Module*> &Modules) const;
 
+private:
+  /// Register the given generic signature builder to be used as the canonical
+  /// generic signature builder for the given signature, if we don't already
+  /// have one.
+  void registerGenericSignatureBuilder(GenericSignature *sig,
+                                       ModuleDecl &module,
+                                       GenericSignatureBuilder &&builder);
+  friend class GenericSignatureBuilder;
+
+public:
   /// Retrieve or create the stored generic signature builder for the given
   /// canonical generic signature and module.
   GenericSignatureBuilder *getOrCreateGenericSignatureBuilder(CanGenericSignature sig,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4574,7 +4574,7 @@ public:
   /// Clone constructor, allocates a new ParamDecl identical to the first.
   /// Intentionally not defined as a typical copy constructor to avoid
   /// accidental copies.
-  ParamDecl(ParamDecl *PD);
+  ParamDecl(ParamDecl *PD, bool withTypes);
   
   /// Retrieve the argument (API) name for this function parameter.
   Identifier getArgumentName() const { return ArgumentName; }

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -570,9 +570,6 @@ public:
                       bool allowConcreteGenericParams = false) &&;
 
 private:
-  /// \brief Build the generic signature.
-  GenericSignature *getGenericSignature();
-
   /// Finalize the set of requirements, performing any remaining checking
   /// required before generating archetypes.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -240,6 +240,17 @@ public:
       /// anchor was cached.
       unsigned numMembers;
     } archetypeAnchorCache;
+
+    /// Describes a cached nested type.
+    struct CachedNestedType {
+      unsigned numConformancesPresent;
+      CanType superclassPresent;
+      llvm::TinyPtrVector<TypeDecl *> types;
+    };
+
+    /// Cached nested-type information, which contains the best declaration
+    /// for a given name.
+    llvm::SmallDenseMap<Identifier, CachedNestedType> nestedTypeNameCache;
   };
 
   friend class RequirementSource;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -566,6 +566,7 @@ public:
   /// After this point, one cannot introduce new requirements, and the
   /// generic signature builder no longer has valid state.
   GenericSignature *computeGenericSignature(
+                      ModuleDecl &module,
                       SourceLoc loc,
                       bool allowConcreteGenericParams = false) &&;
 
@@ -1481,6 +1482,12 @@ private:
     while (auto parent = pa->getParent())
       pa = parent;
     return pa->parentOrBuilder.get<GenericSignatureBuilder *>();
+  }
+
+  // Replace the generic signature builder.
+  void replaceBuilder(GenericSignatureBuilder *builder) {
+    assert(parentOrBuilder.is<GenericSignatureBuilder *>());
+    parentOrBuilder = builder;
   }
 
   friend class GenericSignatureBuilder;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -530,9 +530,6 @@ public:
   /// \brief Add all of a generic signature's parameters and requirements.
   void addGenericSignature(GenericSignature *sig);
 
-  /// \brief Build the generic signature.
-  GenericSignature *getGenericSignature();
-
   /// Infer requirements from the given type, recursively.
   ///
   /// This routine infers requirements from a type that occurs within the
@@ -566,10 +563,15 @@ public:
   /// \brief Finalize the set of requirements and compute the generic
   /// signature.
   ///
-  /// After this point, one cannot introduce new requirements.
+  /// After this point, one cannot introduce new requirements, and the
+  /// generic signature builder no longer has valid state.
   GenericSignature *computeGenericSignature(
                       SourceLoc loc,
-                      bool allowConcreteGenericParams = false);
+                      bool allowConcreteGenericParams = false) &&;
+
+private:
+  /// \brief Build the generic signature.
+  GenericSignature *getGenericSignature();
 
   /// Finalize the set of requirements, performing any remaining checking
   /// required before generating archetypes.
@@ -580,6 +582,7 @@ public:
                 ArrayRef<GenericTypeParamType *> genericParams,
                 bool allowConcreteGenericParams=false);
 
+public:
   /// Process any delayed requirements that can be handled now.
   void processDelayedRequirements();
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1498,6 +1498,12 @@ public:
     return parentOrBuilder.dyn_cast<PotentialArchetype *>();
   }
 
+  /// Retrieve the type declaration to which this nested type was resolved.
+  TypeDecl *getResolvedType() const {
+    assert(getParent() && "Not an associated type");
+    return identifier.assocTypeOrConcrete;
+  }
+
   /// Retrieve the associated type to which this potential archetype
   /// has been resolved.
   AssociatedTypeDecl *getResolvedAssociatedType() const {
@@ -1640,13 +1646,8 @@ public:
                                     ArchetypeResolutionKind kind,
                                     GenericSignatureBuilder &builder);
 
-  /// \brief Retrieve (or create) a nested type with a known associated type.
-  PotentialArchetype *getNestedType(AssociatedTypeDecl *assocType,
-                                    GenericSignatureBuilder &builder);
-
-  /// \brief Retrieve (or create) a nested type with a known concrete type
-  /// declaration.
-  PotentialArchetype *getNestedType(TypeDecl *concreteDecl,
+  /// \brief Retrieve (or create) a nested type with a known type.
+  PotentialArchetype *getNestedType(TypeDecl *type,
                                     GenericSignatureBuilder &builder);
 
   /// \brief Retrieve (or create) a nested type that is the current best
@@ -1666,8 +1667,8 @@ public:
   /// type or typealias of the given protocol, unless the \c kind implies that
   /// a potential archetype should not be created if it's missing.
   PotentialArchetype *updateNestedTypeForConformance(
-                      PointerUnion<AssociatedTypeDecl *, TypeDecl *> type,
-                      ArchetypeResolutionKind kind);
+                        TypeDecl *type,
+                        ArchetypeResolutionKind kind);
 
   /// Update the named nested type when we know this type conforms to the given
   /// protocol.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -215,6 +215,14 @@ public:
     /// a superclass requirement.
     bool isConformanceSatisfiedBySuperclass(ProtocolDecl *proto) const;
 
+    /// Lookup a nested type with the given name within this equivalence
+    /// class.
+    ///
+    /// \param otherConcreteTypes If non-null, will be filled in the all of the
+    /// concrete types we found (other than the result) with the same name.
+    TypeDecl *lookupNestedType(Identifier name,
+                               SmallVectorImpl<TypeDecl *> *otherConcreteTypes);
+
     /// Dump a debugging representation of this equivalence class.
     void dump(llvm::raw_ostream &out) const;
 

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -128,9 +128,15 @@ public:
     Implicit = 0x01,
     /// The cloned pattern is for an inherited constructor; mark default
     /// arguments as inherited, and mark unnamed arguments as named.
-    Inherited = 0x02
+    Inherited = 0x02,
+    /// The cloned pattern will strip type information.
+    WithoutTypes = 0x04,
   };
-  
+
+  friend OptionSet<CloneFlags> operator|(CloneFlags flag1, CloneFlags flag2) {
+    return OptionSet<CloneFlags>(flag1) | flag2;
+  }
+
   /// Make a duplicate copy of this parameter list.  This allocates copies of
   /// the ParamDecls, so they can be reparented into a new DeclContext.
   ParameterList *clone(const ASTContext &C,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -42,6 +42,7 @@
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Allocator.h"
@@ -50,6 +51,12 @@
 #include <memory>
 
 using namespace swift;
+
+#define DEBUG_TYPE "ASTContext"
+STATISTIC(NumRegisteredGenericSignatureBuilders,
+          "# of generic signature builders successfully registered");
+STATISTIC(NumRegisteredGenericSignatureBuildersAlready,
+          "# of generic signature builders already registered");
 
 /// Define this to 1 to enable expensive assertions of the
 /// GenericSignatureBuilder.
@@ -1427,8 +1434,12 @@ void ASTContext::registerGenericSignatureBuilder(
                                        GenericSignatureBuilder &&builder) {
   auto canSig = sig->getCanonicalSignature();
   auto known = Impl.GenericSignatureBuilders.find({canSig, &module});
-  if (known != Impl.GenericSignatureBuilders.end()) return;
+  if (known != Impl.GenericSignatureBuilders.end()) {
+    ++NumRegisteredGenericSignatureBuildersAlready;
+    return;
+  }
 
+  ++NumRegisteredGenericSignatureBuilders;
   Impl.GenericSignatureBuilders[{canSig, &module}] =
     llvm::make_unique<GenericSignatureBuilder>(std::move(builder));
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4589,7 +4589,7 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   builder.addRequirement(requirement, source, nullptr);
 
-  CanGenericSignature genericSig(builder.computeGenericSignature(SourceLoc()));
+  CanGenericSignature genericSig(std::move(builder).computeGenericSignature(SourceLoc()));
 
   auto result = Impl.ExistentialSignatures.insert(
     std::make_pair(existential, genericSig));

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -491,7 +491,8 @@ namespace {
         Builder.addGenericParameter(gp);
       }
 
-      auto GenericSig = Builder.computeGenericSignature(SourceLoc());
+      auto GenericSig =
+        std::move(Builder).computeGenericSignature(SourceLoc());
       GenericEnv = GenericSig->createGenericEnvironment(*ctx.TheBuiltinModule);
     }
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -492,7 +492,8 @@ namespace {
       }
 
       auto GenericSig =
-        std::move(Builder).computeGenericSignature(SourceLoc());
+        std::move(Builder).computeGenericSignature(*ctx.TheBuiltinModule,
+                                                   SourceLoc());
       GenericEnv = GenericSig->createGenericEnvironment(*ctx.TheBuiltinModule);
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3326,7 +3326,7 @@ void ProtocolDecl::computeRequirementSignature() {
 
   // Compute and record the signature.
   auto requirementSig =
-    std::move(builder).computeGenericSignature(SourceLoc());
+    std::move(builder).computeGenericSignature(*module, SourceLoc());
   RequirementSignature = requirementSig->getRequirements().data();
   assert(RequirementSignature != nullptr);
   NumRequirementsInSignature = requirementSig->getRequirements().size();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3325,7 +3325,8 @@ void ProtocolDecl::computeRequirementSignature() {
          nullptr);
 
   // Compute and record the signature.
-  auto requirementSig = builder.computeGenericSignature(SourceLoc());
+  auto requirementSig =
+    std::move(builder).computeGenericSignature(SourceLoc());
   RequirementSignature = requirementSig->getRequirements().data();
   assert(RequirementSignature != nullptr);
   NumRequirementsInSignature = requirementSig->getRequirements().size();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4123,10 +4123,11 @@ ParamDecl::ParamDecl(Specifier specifier,
 
 /// Clone constructor, allocates a new ParamDecl identical to the first.
 /// Intentionally not defined as a copy constructor to avoid accidental copies.
-ParamDecl::ParamDecl(ParamDecl *PD)
+ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
   : VarDecl(DeclKind::Param, /*IsStatic*/false, PD->getSpecifier(),
             /*IsCaptureList*/false, PD->getNameLoc(), PD->getName(),
-            PD->hasType() ? PD->getType() : Type(), PD->getDeclContext()),
+            PD->hasType() && withTypes? PD->getType() : Type(),
+            PD->getDeclContext()),
     ArgumentName(PD->getArgumentName()),
     ArgumentNameLoc(PD->getArgumentNameLoc()),
     SpecifierLoc(PD->getSpecifierLoc()),
@@ -4134,7 +4135,10 @@ ParamDecl::ParamDecl(ParamDecl *PD)
     IsTypeLocImplicit(PD->IsTypeLocImplicit),
     defaultArgumentKind(PD->defaultArgumentKind) {
   typeLoc = PD->getTypeLoc().clone(PD->getASTContext());
-  if (PD->hasInterfaceType())
+  if (!withTypes && typeLoc.getTypeRepr())
+    typeLoc.setType(Type());
+
+  if (withTypes && PD->hasInterfaceType())
     setInterfaceType(PD->getInterfaceType());
 }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6288,25 +6288,18 @@ static void collectRequirements(GenericSignatureBuilder &builder,
   });
 }
 
-GenericSignature *GenericSignatureBuilder::getGenericSignature() {
-  assert(Impl->finalized && "Must finalize builder first");
-
-  // Collect the requirements placed on the generic parameter types.
-  SmallVector<Requirement, 4> requirements;
-  collectRequirements(*this, Impl->GenericParams, requirements);
-
-  auto sig = GenericSignature::get(Impl->GenericParams, requirements);
-  return sig;
-}
-
 GenericSignature *GenericSignatureBuilder::computeGenericSignature(
                                           SourceLoc loc,
                                           bool allowConcreteGenericParams) && {
   // Finalize the builder, producing any necessary diagnostics.
   finalize(loc, Impl->GenericParams, allowConcreteGenericParams);
 
-  // Determine the generic signature.
-  auto sig = getGenericSignature();
+  // Collect the requirements placed on the generic parameter types.
+  SmallVector<Requirement, 4> requirements;
+  collectRequirements(*this, Impl->GenericParams, requirements);
+
+  // Form the generic signature.
+  auto sig = GenericSignature::get(Impl->GenericParams, requirements);
 
   // Wipe out the internal state, ensuring that nobody uses this builder for
   // anything more.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2311,16 +2311,9 @@ PotentialArchetype *PotentialArchetype::getNestedType(
 }
 
 PotentialArchetype *PotentialArchetype::getNestedType(
-                                            AssociatedTypeDecl *assocType,
+                                            TypeDecl *type,
                                             GenericSignatureBuilder &builder) {
-  return updateNestedTypeForConformance(assocType,
-                                        ArchetypeResolutionKind::WellFormed);
-}
-
-PotentialArchetype *PotentialArchetype::getNestedType(
-                                            TypeDecl *getConcreteTypeDecl,
-                                            GenericSignatureBuilder &builder) {
-  return updateNestedTypeForConformance(getConcreteTypeDecl,
+  return updateNestedTypeForConformance(type,
                                         ArchetypeResolutionKind::WellFormed);
 }
 
@@ -2363,18 +2356,12 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
 }
 
 PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
-                      PointerUnion<AssociatedTypeDecl *, TypeDecl *> type,
-                      ArchetypeResolutionKind kind) {
-  auto *assocType = type.dyn_cast<AssociatedTypeDecl *>();
-  auto *concreteDecl = type.dyn_cast<TypeDecl *>();
-  if (!assocType && !concreteDecl)
-    return nullptr;
+                                              TypeDecl *type,
+                                              ArchetypeResolutionKind kind) {
+  if (!type) return nullptr;
 
-  // FIXME: Silly hack for a bad interface.
-  if (concreteDecl && isa<AssociatedTypeDecl>(concreteDecl)) {
-    assocType = cast<AssociatedTypeDecl>(concreteDecl);
-    concreteDecl = nullptr;
-  }
+  AssociatedTypeDecl *assocType = dyn_cast<AssociatedTypeDecl>(type);
+  TypeDecl *concreteDecl = assocType ? nullptr : type;
 
   // If we were asked for a complete, well-formed archetype, make sure we
   // process delayed requirements if anything changed.
@@ -3646,13 +3633,8 @@ void GenericSignatureBuilder::addedNestedType(PotentialArchetype *nestedPA) {
   auto parentRepPA = parentPA->getRepresentative();
   if (parentPA == parentRepPA) return;
 
-  PotentialArchetype *existingPA;
-  if (auto assocType = nestedPA->getResolvedAssociatedType()) {
-    existingPA = parentRepPA->getNestedType(assocType, *this);
-  } else {
-    existingPA = parentRepPA->getNestedType(nestedPA->getConcreteTypeDecl(),
-                                            *this);
-  }
+  PotentialArchetype *existingPA =
+    parentRepPA->getNestedType(nestedPA->getResolvedType(), *this);
 
   auto sameNamedSource =
     FloatingRequirementSource::forNestedTypeNameMatch(

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3918,8 +3918,10 @@ ConstraintResult GenericSignatureBuilder::addSameTypeRequirement(
   return addSameTypeRequirement(paOrT1, paOrT2, source, unresolvedHandling,
                                 [&](Type type1, Type type2) {
       Impl->HadAnyError = true;
-      Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,
-                     type1, type2);
+      if (source.getLoc().isValid()) {
+        Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,
+                       type1, type2);
+      }
     });
 }
 
@@ -4197,10 +4199,11 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
         firstType, secondType, source,
         UnresolvedHandlingKind::GenerateConstraints,
         [&](Type type1, Type type2) {
-          if (source.getLoc().isValid())
-            Impl->HadAnyError = true;
+          Impl->HadAnyError = true;
+          if (source.getLoc().isValid()) {
             Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,
                            type1, type2);
+          }
         });
   }
   }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -76,6 +76,10 @@ STATISTIC(NumArchetypeAnchorCacheHits,
           "# of hits in the archetype anchor cache");
 STATISTIC(NumArchetypeAnchorCacheMisses,
           "# of misses in the archetype anchor cache");
+STATISTIC(NumNestedTypeCacheHits,
+         "# of hits in the equivalence class nested type cache");
+STATISTIC(NumNestedTypeCacheMisses,
+         "# of misses in the equivalence class nested type cache");
 STATISTIC(NumProcessDelayedRequirements,
           "# of times we process delayed requirements");
 STATISTIC(NumProcessDelayedRequirementsUnchanged,
@@ -1585,6 +1589,38 @@ static int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
 TypeDecl *EquivalenceClass::lookupNestedType(
                              Identifier name,
                              SmallVectorImpl<TypeDecl *> *otherConcreteTypes) {
+  // Populates the result structures from the given cache entry.
+  auto populateResult = [&](const CachedNestedType &cache) -> TypeDecl * {
+    if (otherConcreteTypes)
+      otherConcreteTypes->clear();
+
+    // If there aren't any types in the cache, we're done.
+    if (cache.types.empty()) return nullptr;
+
+    // The first type in the cache is always the final result.
+    // Collect the rest in the concrete-declarations list, if needed.
+    if (otherConcreteTypes) {
+      for (auto type : ArrayRef<TypeDecl *>(cache.types).slice(1)) {
+        otherConcreteTypes->push_back(type);
+      }
+    }
+
+    return cache.types.front();
+  };
+
+  // If we have a cached value that is up-to-date, use that.
+  auto cached = nestedTypeNameCache.find(name);
+  if (cached != nestedTypeNameCache.end() &&
+      cached->second.numConformancesPresent == conformsTo.size() &&
+      (!superclass ||
+       cached->second.superclassPresent == superclass->getCanonicalType())) {
+    ++NumNestedTypeCacheHits;
+    return populateResult(cached->second);
+  }
+
+  // Cache miss; go compute the result.
+  ++NumNestedTypeCacheMisses;
+
   // Look for types with the given name in protocols that we know about.
   AssociatedTypeDecl *bestAssocType = nullptr;
   SmallVector<TypeDecl *, 4> concreteDecls;
@@ -1653,34 +1689,32 @@ TypeDecl *EquivalenceClass::lookupNestedType(
     }
   }
 
-  // If we have an associated type, that's our result.
+  // Form the new cache entry.
+  CachedNestedType entry;
+  entry.numConformancesPresent = conformsTo.size();
+  entry.superclassPresent =
+    superclass ? superclass->getCanonicalType() : CanType();
   if (bestAssocType) {
-    // Populate the list of concrete types, if requested.
-    if (otherConcreteTypes)
-      otherConcreteTypes->assign(concreteDecls.begin(), concreteDecls.end());
+    entry.types.push_back(bestAssocType);
+    entry.types.insert(entry.types.end(),
+                       concreteDecls.begin(), concreteDecls.end());
+  } else if (!concreteDecls.empty()) {
+    // Find the best concrete type.
+    auto bestConcreteTypeIter =
+      std::min_element(concreteDecls.begin(), concreteDecls.end(),
+                       [](TypeDecl *type1, TypeDecl *type2) {
+                         return TypeDecl::compare(type1, type2) < 0;
+                       });
 
-    return bestAssocType;
+    // Put the best concrete type first; the rest will follow.
+    entry.types.push_back(*bestConcreteTypeIter);
+    entry.types.insert(entry.types.end(),
+                       concreteDecls.begin(), bestConcreteTypeIter);
+    entry.types.insert(entry.types.end(),
+                       bestConcreteTypeIter + 1, concreteDecls.end());
   }
 
-  // If there were no concrete types either, lookup failed.
-  if (concreteDecls.empty())
-    return nullptr;
-
-  // Find the best concrete type.
-  auto bestConcreteTypeIter =
-    std::min_element(concreteDecls.begin(), concreteDecls.end(),
-                     [](TypeDecl *type1, TypeDecl *type2) {
-                       return TypeDecl::compare(type1, type2) < 0;
-                     });
-
-  // If were asked to provide all of the concrete types, do so now.
-  if (otherConcreteTypes) {
-    otherConcreteTypes->assign(concreteDecls.begin(), bestConcreteTypeIter);
-    otherConcreteTypes->insert(otherConcreteTypes->end(),
-                               bestConcreteTypeIter + 1, concreteDecls.end());
-  }
-
-  return *bestConcreteTypeIter;
+  return populateResult((nestedTypeNameCache[name] = std::move(entry)));
 }
 
 void EquivalenceClass::dump(llvm::raw_ostream &out) const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6301,8 +6301,17 @@ GenericSignature *GenericSignatureBuilder::getGenericSignature() {
 
 GenericSignature *GenericSignatureBuilder::computeGenericSignature(
                                           SourceLoc loc,
-                                          bool allowConcreteGenericParams) {
+                                          bool allowConcreteGenericParams) && {
+  // Finalize the builder, producing any necessary diagnostics.
   finalize(loc, Impl->GenericParams, allowConcreteGenericParams);
-  return getGenericSignature();
+
+  // Determine the generic signature.
+  auto sig = getGenericSignature();
+
+  // Wipe out the internal state, ensuring that nobody uses this builder for
+  // anything more.
+  Impl.reset();
+
+  return sig;
 }
 

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -88,11 +88,12 @@ ParameterList *ParameterList::clone(const ASTContext &C,
   SmallVector<ParamDecl*, 8> params(begin(), end());
 
   // Remap the ParamDecls inside of the ParameterList.
+  bool withTypes = !options.contains(ParameterList::WithoutTypes);
   for (auto &decl : params) {
     bool hadDefaultArgument =
         decl->getDefaultArgumentKind() == DefaultArgumentKind::Normal;
 
-    decl = new (C) ParamDecl(decl);
+    decl = new (C) ParamDecl(decl, withTypes);
     if (options & Implicit)
       decl->setImplicit();
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7653,7 +7653,7 @@ GenericSignature *ClangImporter::Implementation::buildGenericSignature(
     (void) result;
   }
 
-  return builder.computeGenericSignature(SourceLoc());
+  return std::move(builder).computeGenericSignature(SourceLoc());
 }
 
 // Calculate the generic environment from an imported generic param list.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7653,7 +7653,8 @@ GenericSignature *ClangImporter::Implementation::buildGenericSignature(
     (void) result;
   }
 
-  return std::move(builder).computeGenericSignature(SourceLoc());
+  return std::move(builder).computeGenericSignature(*dc->getParentModule(),
+                                                    SourceLoc());
 }
 
 // Calculate the generic environment from an imported generic param list.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2695,7 +2695,7 @@ buildThunkSignature(SILGenFunction &SGF,
   builder.addRequirement(newRequirement, source, nullptr);
 
   GenericSignature *genericSig =
-    std::move(builder).computeGenericSignature(SourceLoc(),
+    std::move(builder).computeGenericSignature(*mod, SourceLoc(),
                                     /*allowConcreteGenericParams=*/true);
   genericEnv = genericSig->createGenericEnvironment(*mod);
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2695,7 +2695,7 @@ buildThunkSignature(SILGenFunction &SGF,
   builder.addRequirement(newRequirement, source, nullptr);
 
   GenericSignature *genericSig =
-    builder.computeGenericSignature(SourceLoc(),
+    std::move(builder).computeGenericSignature(SourceLoc(),
                                     /*allowConcreteGenericParams=*/true);
   genericEnv = genericSig->createGenericEnvironment(*mod);
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -800,7 +800,7 @@ getGenericEnvironmentAndSignatureWithRequirements(
   }
 
   auto NewGenSig =
-    Builder.computeGenericSignature(SourceLoc(),
+    std::move(Builder).computeGenericSignature(SourceLoc(),
                                    /*allowConcreteGenericParams=*/true);
   auto NewGenEnv = NewGenSig->createGenericEnvironment(*M.getSwiftModule());
   return { NewGenEnv, NewGenSig };
@@ -1490,7 +1490,7 @@ FunctionSignaturePartialSpecializer::
 
   // Finalize the archetype builder.
   auto GenSig =
-      Builder.computeGenericSignature(SourceLoc(),
+      std::move(Builder).computeGenericSignature(SourceLoc(),
                                       /*allowConcreteGenericParams=*/true);
   auto GenEnv = GenSig->createGenericEnvironment(*M.getSwiftModule());
   return { GenEnv, GenSig };

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -800,7 +800,8 @@ getGenericEnvironmentAndSignatureWithRequirements(
   }
 
   auto NewGenSig =
-    std::move(Builder).computeGenericSignature(SourceLoc(),
+    std::move(Builder).computeGenericSignature(*M.getSwiftModule(),
+                                   SourceLoc(),
                                    /*allowConcreteGenericParams=*/true);
   auto NewGenEnv = NewGenSig->createGenericEnvironment(*M.getSwiftModule());
   return { NewGenEnv, NewGenSig };
@@ -1490,7 +1491,8 @@ FunctionSignaturePartialSpecializer::
 
   // Finalize the archetype builder.
   auto GenSig =
-      std::move(Builder).computeGenericSignature(SourceLoc(),
+      std::move(Builder).computeGenericSignature(*M.getSwiftModule(),
+                                      SourceLoc(),
                                       /*allowConcreteGenericParams=*/true);
   auto GenEnv = GenSig->createGenericEnvironment(*M.getSwiftModule());
   return { GenEnv, GenSig };

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -104,7 +104,8 @@ buildIndexForwardingParamList(AbstractStorageDecl *storage,
 
   // Clone the parameter list over for a new decl, so we get new ParamDecls.
   auto indices = subscript->getIndices()->clone(context,
-                                                ParameterList::Implicit);
+                                                ParameterList::Implicit|
+                                                ParameterList::WithoutTypes);
   if (prefix.empty())
     return indices;
   

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -130,14 +130,14 @@ public:
 /// to check the signature of a generic declaration and resolve (for example)
 /// all dependent member refers to archetype members.
 class CompleteGenericTypeResolver : public GenericTypeResolver {
-  TypeChecker &TC;
-  GenericSignatureBuilder &Builder;
-  ArrayRef<GenericTypeParamType *> GenericParams;
+  TypeChecker &tc;
+  GenericSignature *genericSig;
+  ModuleDecl &module;
+  GenericSignatureBuilder &builder;
 
 public:
-  CompleteGenericTypeResolver(TypeChecker &tc, GenericSignatureBuilder &builder,
-                              ArrayRef<GenericTypeParamType *> genericParams)
-    : TC(tc), Builder(builder), GenericParams(genericParams) { }
+  CompleteGenericTypeResolver(TypeChecker &tc, GenericSignature *genericSig,
+                              ModuleDecl &module);
 
   virtual Type mapTypeIntoContext(Type type);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1851,7 +1851,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     Builder.addRequirement(&req, DC->getParentModule());
 
   // Check the result.
-  (void)Builder.computeGenericSignature(attr->getLocation(),
+  (void)std::move(Builder).computeGenericSignature(
+                                        attr->getLocation(),
                                         /*allowConcreteGenericParams=*/true);
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1852,6 +1852,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Check the result.
   (void)std::move(Builder).computeGenericSignature(
+                                        *DC->getParentModule(),
                                         attr->getLocation(),
                                         /*allowConcreteGenericParams=*/true);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5311,10 +5311,18 @@ public:
       // Revert the types within the signature so it can be type-checked with
       // archetypes below.
       TC.revertGenericFuncSignature(FD);
-    } else if (FD->getDeclContext()->getGenericSignatureOfContext()) {
-      (void)TC.validateGenericFuncSignature(FD);
-      // Revert all of the types within the signature of the function.
-      TC.revertGenericFuncSignature(FD);
+    } else if (auto genericSig =
+                 FD->getDeclContext()->getGenericSignatureOfContext()) {
+      if (!FD->getAccessorStorageDecl()) {
+        (void)TC.validateGenericFuncSignature(FD);
+
+        // Revert all of the types within the signature of the function.
+        TC.revertGenericFuncSignature(FD);
+      } else {
+        // We've inherited all of the type information already.
+        TC.configureInterfaceType(FD, genericSig);
+      }
+
       FD->setGenericEnvironment(
           FD->getDeclContext()->getGenericEnvironmentOfContext());
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -827,7 +827,8 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
     prepareGenericParamList(genericParams, DC);
 
     parentEnv = checkGenericEnvironment(genericParams, DC, parentSig,
-                                        /*allowConcreteGenericParams=*/true);
+                                        /*allowConcreteGenericParams=*/true,
+                                        /*ext=*/nullptr);
     parentSig = parentEnv->getGenericSignature();
 
     // Compute the final set of archetypes.
@@ -8125,7 +8126,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   auto *env = tc.checkGenericEnvironment(genericParams,
                                          ext->getDeclContext(), nullptr,
                                          /*allowConcreteGenericParams=*/true,
-                                         inferExtendedTypeReqs);
+                                         ext, inferExtendedTypeReqs);
 
   // Validate the generic parameters for the last time, to splat down
   // actual archetypes.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -763,7 +763,8 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
 
     // The generic function signature is complete and well-formed. Determine
     // the type of the generic function.
-    sig = std::move(builder).computeGenericSignature(func->getLoc());
+    sig = std::move(builder).computeGenericSignature(*func->getParentModule(),
+                                                     func->getLoc());
 
     // The generic signature builder now has all of the requirements, although
     // there might still be errors that have not yet been diagnosed. Revert the
@@ -988,7 +989,9 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
 
     // The generic subscript signature is complete and well-formed. Determine
     // the type of the generic subscript.
-    sig = std::move(builder).computeGenericSignature(subscript->getLoc());
+    sig =
+      std::move(builder).computeGenericSignature(*subscript->getParentModule(),
+                                                 subscript->getLoc());
 
     // The generic signature builder now has all of the requirements, although
     // there might still be errors that have not yet been diagnosed. Revert the
@@ -1127,6 +1130,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
     // Record the generic type parameter types and the requirements.
     sig = std::move(builder).computeGenericSignature(
+                                         *dc->getParentModule(),
                                          genericParams->getSourceRange().Start,
                                          allowConcreteGenericParams);
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -787,7 +787,6 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
     if (Context.LangOpts.DebugGenericSignatures) {
       func->dumpRef(llvm::errs());
       llvm::errs() << "\n";
-      builder.dump(llvm::errs());
       llvm::errs() << "Generic signature: ";
       sig->print(llvm::errs());
       llvm::errs() << "\n";
@@ -1022,7 +1021,6 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
     if (Context.LangOpts.DebugGenericSignatures) {
       subscript->dumpRef(llvm::errs());
       llvm::errs() << "\n";
-      builder.dump(llvm::errs());
       llvm::errs() << "Generic signature: ";
       sig->print(llvm::errs());
       llvm::errs() << "\n";
@@ -1173,7 +1171,6 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     if (Context.LangOpts.DebugGenericSignatures) {
       dc->printContext(llvm::errs());
       llvm::errs() << "\n";
-      builder.dump(llvm::errs());
       llvm::errs() << "Generic signature: ";
       sig->print(llvm::errs());
       llvm::errs() << "\n";

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1157,7 +1157,9 @@ RequirementEnvironment::RequirementEnvironment(
   // FIXME: Pass in a source location for the conformance, perhaps? It seems
   // like this could fail.
   syntheticSignature =
-    std::move(builder).computeGenericSignature(SourceLoc());
+    std::move(builder).computeGenericSignature(
+                                           *conformanceDC->getParentModule(),
+                                           SourceLoc());
   syntheticEnvironment = syntheticSignature->createGenericEnvironment(
                                              *conformanceDC->getParentModule());
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1156,7 +1156,8 @@ RequirementEnvironment::RequirementEnvironment(
   // Produce the generic signature and environment.
   // FIXME: Pass in a source location for the conformance, perhaps? It seems
   // like this could fail.
-  syntheticSignature = builder.computeGenericSignature(SourceLoc());
+  syntheticSignature =
+    std::move(builder).computeGenericSignature(SourceLoc());
   syntheticEnvironment = syntheticSignature->createGenericEnvironment(
                                              *conformanceDC->getParentModule());
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1367,6 +1367,9 @@ public:
   /// context, if not available as part of the \c dc argument (used
   /// for SIL parsing).
   ///
+  /// \param ext The extension for which we're checking the generic
+  /// environment, or null if we're not checking an extension.
+  ///
   /// \param inferRequirements When non-empty, callback that will be invoked
   /// to perform any additional requirement inference that contributes to the
   /// generic environment..
@@ -1377,6 +1380,7 @@ public:
                         DeclContext *dc,
                         GenericSignature *outerSignature,
                         bool allowConcreteGenericParams,
+                        ExtensionDecl *ext,
                         llvm::function_ref<void(GenericSignatureBuilder &)>
                           inferRequirements);
 
@@ -1394,9 +1398,10 @@ public:
                         GenericParamList *genericParams,
                         DeclContext *dc,
                         GenericSignature *outerSignature,
-                        bool allowConcreteGenericParams) {
+                        bool allowConcreteGenericParams,
+                        ExtensionDecl *ext) {
     return checkGenericEnvironment(genericParams, dc, outerSignature,
-                                   allowConcreteGenericParams,
+                                   allowConcreteGenericParams, ext,
                                    [&](GenericSignatureBuilder &) { });
   }
 

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -34,13 +34,6 @@ func typoAssoc3<T : P2, U : P2>(t: T, u: U)
 // expected-error@+1{{'T' does not have a member type named 'Assocp2'; did you mean 'AssocP2'?}}{{39-46=AssocP2}}
 func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 
-
-// CHECK-GENERIC-LABEL: .typoAssoc4@
-// CHECK-GENERIC-NEXT: Requirements:
-// CHECK-GENERIC-NEXT:   τ_0_0 : P2 [τ_0_0: Explicit @ {{.*}}:21]
-// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2 : P1 [τ_0_0: Explicit @ {{.*}}:21 -> Protocol requirement (via Self.AssocP2 in P2)
-// CHECK-GENERIC-NEXT: Potential archetypes
-
 // <rdar://problem/19620340>
 
 func typoFunc1<T : P1>(x: TypoType) { // expected-error{{use of undeclared type 'TypoType'}}

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -14,10 +14,6 @@ protocol Q {
 }
 
 // CHECK-LABEL: .requirementOnNestedTypeAlias@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q [τ_0_0: Explicit @ 22:51]
-// CHECK-NEXT:   τ_0_0[.Q].B : P [τ_0_0: Explicit @ 22:51 -> Protocol requirement (via Self.B in Q)
-// CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [τ_0_0[.Q].B[.P].X: Explicit @ 22:62]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.B.A == Int>
 func requirementOnNestedTypeAlias<T>(_: T) where T: Q, T.B.X == Int {}
 
@@ -33,20 +29,10 @@ protocol Q2 {
 }
 
 // CHECK-LABEL: .requirementOnConcreteNestedTypeAlias@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q2 [τ_0_0: Explicit @ 42:59]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 42:59 -> Protocol requirement (via Self.B in Q2)
-// CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [τ_0_0[.Q2].C: Explicit]
-// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [τ_0_0[.Q2].B[.P2].X: Concrete type binding]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == S<τ_0_0.B.A>>
 func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q2 [τ_0_0: Explicit @ 51:67]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 51:67 -> Protocol requirement (via Self.B in Q2)
-// CHECK-NEXT:   τ_0_0[.Q2].C == τ_0_0[.Q2].B[.P2].A [τ_0_0[.Q2].C: Explicit]
-// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [τ_0_0[.Q2].B[.P2].X: Concrete type binding]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
 func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -72,16 +72,14 @@ struct U<T : Carnivora> {}
 struct V<T : Canidae> {}
 
 // CHECK-LABEL: .inferSuperclassRequirement1@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Canidae
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Canidae>
 func inferSuperclassRequirement1<T : Carnivora>(
 	_ v: V<T>) {}
 // expected-warning@-2{{redundant superclass constraint 'T' : 'Carnivora'}}
 // expected-note@-2{{superclass constraint 'T' : 'Canidae' inferred from type here}}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Canidae
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Canidae>
 func inferSuperclassRequirement2<T : Canidae>(_ v: U<T>) {}
 
 // ----------------------------------------------------------------------------
@@ -110,33 +108,17 @@ protocol PAssoc {
 
 struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 
-// CHECK-LABEL: .inferSameType1@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_1: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P4Assoc in P4)
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3)
-// FIXME: τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0: Inferred]
-func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
+func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) {
+  let u: U.P4Assoc? = nil
+  let _: T.P3Assoc? = u!
+}
 
-// CHECK-LABEL: .inferSameType2@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:25]
-// CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Explicit @ {{.*}}:33]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_1: Explicit @ {{.*}}:33 -> Protocol requirement (via Self.P4Assoc in P4)
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3)
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0[.P3].P3Assoc: Explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
 // expected-warning@-1{{redundant conformance constraint 'T.P3Assoc': 'P2'}}
 // expected-note@-2{{conformance constraint 'T.P3Assoc': 'P2' implied here}}
 
-// CHECK-LABEL: .inferSameType3@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : PCommonAssoc1 [τ_0_0: Explicit @ {{.*}}:25]
-// CHECK-NEXT:   τ_0_0 : PCommonAssoc2 [τ_0_0: Explicit @ {{.*}}:74]
-// CHECK-NEXT:   τ_0_0[.PCommonAssoc1].CommonAssoc : P1 [τ_0_0[.PCommonAssoc1].CommonAssoc: Explicit @ {{.*}}:66]
-// CHECK-NEXT: Potential archetypes
-func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {}
+func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {
+}
 
 protocol P5 {
   associatedtype Element

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -54,11 +54,9 @@ class Fox : P1 {
   func p1() {}
 }
 
-class Box<T : Fox> {
-// CHECK-LABEL: .unpack@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Fox [τ_0_0: Explicit]
+class Box<T : Fox, U> {
   func unpack(_ x: X1<T>) {}
+  func unpackFail(_ X: X1<U>) { } // expected-error{{type 'U' does not conform to protocol 'P1'}}
 }
 
 // ----------------------------------------------------------------------------
@@ -152,7 +150,7 @@ protocol P7 : P6 {
   associatedtype AssocP7: P6
 }
 
-// CHECK-LABEL: P7.nestedSameType1()@
+// CHECK-LABEL: P7@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P7, τ_0_0.AssocP6.Element : P6, τ_0_0.AssocP6.Element == τ_0_0.AssocP7.AssocP6.Element>
 extension P7 where AssocP6.Element : P6, // expected-note{{conformance constraint 'Self.AssocP6.Element': 'P6' written here}}
         AssocP7.AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP6.Element': 'P6'}}
@@ -187,7 +185,7 @@ func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3
 
 // Note: a standard-library-based stress test to make sure we don't inject
 // any additional requirements.
-// CHECK-LABEL: RangeReplaceableCollection.f()@
+// CHECK-LABEL: RangeReplaceableCollection
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : MutableCollection, τ_0_0 : RangeReplaceableCollection, τ_0_0.SubSequence == MutableRangeReplaceableSlice<τ_0_0>>
 extension RangeReplaceableCollection where
   Self: MutableCollection,

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -67,10 +67,6 @@ class S : P2 {
 }
 
 // CHECK: superclassConformance1
-// CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]
-// CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:11 -> Derived]
-// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:11 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance1<T>(t: T)
   where T : C, // expected-note{{conformance constraint 'T': 'P3' implied here}}
@@ -79,10 +75,6 @@ func superclassConformance1<T>(t: T)
 
 
 // CHECK: superclassConformance2
-// CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]
-// CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:11 -> Derived]
-// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:11 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance2<T>(t: T)
   where T : C, // expected-note{{conformance constraint 'T': 'P3' implied here}}
@@ -93,10 +85,6 @@ protocol P4 { }
 class C2 : C, P4 { }
 
 // CHECK: superclassConformance3
-// CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:61]
-// CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:46 -> Derived]
-// CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:61 -> Superclass (C2: P4)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -66,13 +66,6 @@ class S : P2 {
   typealias T = C
 }
 
-extension P2 where Self.T : C {
-  // CHECK: superclass_constraint.(file).P2.concreteTypeWitnessViaSuperclass1
-  // CHECK: Generic signature: <Self where Self : P2, Self.T : C>
-  // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P2, τ_0_0.T : C>
-  func concreteTypeWitnessViaSuperclass1(x: Self.T.T) {}
-}
-
 // CHECK: superclassConformance1
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1345,7 +1345,7 @@ func testForFixitWithNestedMemberRefExpr() {
 // Protocol Conformances
 
 protocol ProtocolWithRequirementMentioningUnavailable {
-      // expected-note@-1 6{{add @available attribute to enclosing protocol}}
+      // expected-note@-1 4{{add @available attribute to enclosing protocol}}
   func hasUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
       

--- a/validation-test/compiler_crashers_fixed/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
+++ b/validation-test/compiler_crashers_fixed/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a:A
 protocol A:a{
 protocol A{struct a{var f:A


### PR DESCRIPTION
The `GenericSignatureBuilder` is slow, so instead of making it fast... build fewer of them!

* Don't create a generic signature builder for non-generic members of generic types; re-use the parent's generic signature instead
* Don't create a generic signature builder for extensions of generic types and protocols that don't add requirements; re-use the nominal type's generic signature instead
* When we've created a generic signature builder and formed a generic signature from it, re-use that generic signature builder as the canonical generic signature builder