### PR TITLE
runtime: fix the DLL storage attribute

### DIFF
--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -113,7 +113,7 @@ setObjectRuntimeFunctionCounters(HeapObject *object,
                                  RuntimeFunctionCountersState *state);
 
 /// Set the global runtime function counters update handler.
-extern "C" RuntimeFunctionCountersUpdateHandler
+SWIFT_RT_ENTRY_VISIBILITY RuntimeFunctionCountersUpdateHandler
 setGlobalRuntimeFunctionCountersUpdateHandler(
     RuntimeFunctionCountersUpdateHandler handler);
 


### PR DESCRIPTION
Ensure that the proper DLL storage is annotated on the declaration.
This currently mismatched on Windows.  On non-COFF targets, we would
just honour the visibility as specified on the definition.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
