### PR TITLE
Trace stats deltas

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -53,84 +53,16 @@ class UnifiedStatsReporter {
 public:
   struct AlwaysOnDriverCounters
   {
-    size_t NumDriverJobsRun;
-    size_t NumDriverJobsSkipped;
-
-    size_t DriverDepCascadingTopLevel;
-    size_t DriverDepCascadingDynamic;
-    size_t DriverDepCascadingNominal;
-    size_t DriverDepCascadingMember;
-    size_t DriverDepCascadingExternal;
-
-    size_t DriverDepTopLevel;
-    size_t DriverDepDynamic;
-    size_t DriverDepNominal;
-    size_t DriverDepMember;
-    size_t DriverDepExternal;
-
-    size_t ChildrenMaxRSS;
+#define DRIVER_STATISTIC(ID) size_t ID;
+#include "Statistics.def"
+#undef DRIVER_STATISTIC
   };
 
   struct AlwaysOnFrontendCounters
   {
-    size_t NumSourceBuffers;
-    size_t NumSourceLines;
-    size_t NumSourceLinesPerSecond;
-    size_t NumLinkLibraries;
-    size_t NumLoadedModules;
-    size_t NumImportedExternalDefinitions;
-    size_t NumTotalClangImportedEntities;
-    size_t NumASTBytesAllocated;
-    size_t NumDependencies;
-    size_t NumReferencedTopLevelNames;
-    size_t NumReferencedDynamicNames;
-    size_t NumReferencedMemberNames;
-    size_t NumDecls;
-    size_t NumLocalTypeDecls;
-    size_t NumObjCMethods;
-    size_t NumInfixOperators;
-    size_t NumPostfixOperators;
-    size_t NumPrefixOperators;
-    size_t NumPrecedenceGroups;
-    size_t NumUsedConformances;
-
-    size_t NumConformancesDeserialized;
-    size_t NumConstraintScopes;
-    size_t NumDeclsDeserialized;
-    size_t NumDeclsValidated;
-    size_t NumFunctionsTypechecked;
-    size_t NumGenericSignatureBuilders;
-    size_t NumLazyGenericEnvironments;
-    size_t NumLazyGenericEnvironmentsLoaded;
-    size_t NumLazyIterableDeclContexts;
-    size_t NominalTypeLookupDirectCount;
-    size_t NumTypesDeserialized;
-    size_t NumTypesValidated;
-    size_t NumUnloadedLazyIterableDeclContexts;
-
-    size_t NumSILGenFunctions;
-    size_t NumSILGenVtables;
-    size_t NumSILGenWitnessTables;
-    size_t NumSILGenDefaultWitnessTables;
-    size_t NumSILGenGlobalVariables;
-
-    size_t NumSILOptFunctions;
-    size_t NumSILOptVtables;
-    size_t NumSILOptWitnessTables;
-    size_t NumSILOptDefaultWitnessTables;
-    size_t NumSILOptGlobalVariables;
-
-    size_t NumIRGlobals;
-    size_t NumIRFunctions;
-    size_t NumIRAliases;
-    size_t NumIRIFuncs;
-    size_t NumIRNamedMetaData;
-    size_t NumIRValueSymbols;
-    size_t NumIRComdatSymbols;
-    size_t NumIRBasicBlocks;
-    size_t NumIRInsts;
-
-    size_t NumLLVMBytesOutput;
+#define FRONTEND_STATISTIC(NAME, ID) size_t ID;
+#include "Statistics.def"
+#undef FRONTEND_STATISTIC
   };
 
 private:

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -1,0 +1,103 @@
+//===--- Statistics.def - Statistics Macro Metaprogramming Database -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the database of always-available statistic counters.
+//
+// DRIVER_STATISTIC(Id)
+//   - Id is an identifier suitable for use in C++
+//
+// FRONTEND_STATISTIC(Subsystem, Id)
+//   - Subsystem is a token to be stringified as a name prefix
+//   - Id is an identifier suitable for use in C++
+//===----------------------------------------------------------------------===//
+
+/// Driver statistics are collected for driver processes
+#ifdef DRIVER_STATISTIC
+DRIVER_STATISTIC(NumDriverJobsRun)
+DRIVER_STATISTIC(NumDriverJobsSkipped)
+
+DRIVER_STATISTIC(DriverDepCascadingTopLevel)
+DRIVER_STATISTIC(DriverDepCascadingDynamic)
+DRIVER_STATISTIC(DriverDepCascadingNominal)
+DRIVER_STATISTIC(DriverDepCascadingMember)
+DRIVER_STATISTIC(DriverDepCascadingExternal)
+
+DRIVER_STATISTIC(DriverDepTopLevel)
+DRIVER_STATISTIC(DriverDepDynamic)
+DRIVER_STATISTIC(DriverDepNominal)
+DRIVER_STATISTIC(DriverDepMember)
+DRIVER_STATISTIC(DriverDepExternal)
+
+DRIVER_STATISTIC(ChildrenMaxRSS)
+#endif
+
+/// Driver statistics are collected for frontend processes
+#ifdef FRONTEND_STATISTIC
+FRONTEND_STATISTIC(AST, NumSourceBuffers)
+FRONTEND_STATISTIC(AST, NumSourceLines)
+FRONTEND_STATISTIC(AST, NumSourceLinesPerSecond)
+FRONTEND_STATISTIC(AST, NumLinkLibraries)
+FRONTEND_STATISTIC(AST, NumLoadedModules)
+FRONTEND_STATISTIC(AST, NumImportedExternalDefinitions)
+FRONTEND_STATISTIC(AST, NumTotalClangImportedEntities)
+FRONTEND_STATISTIC(AST, NumASTBytesAllocated)
+FRONTEND_STATISTIC(AST, NumDependencies)
+FRONTEND_STATISTIC(AST, NumReferencedTopLevelNames)
+FRONTEND_STATISTIC(AST, NumReferencedDynamicNames)
+FRONTEND_STATISTIC(AST, NumReferencedMemberNames)
+FRONTEND_STATISTIC(AST, NumDecls)
+FRONTEND_STATISTIC(AST, NumLocalTypeDecls)
+FRONTEND_STATISTIC(AST, NumObjCMethods)
+FRONTEND_STATISTIC(AST, NumInfixOperators)
+FRONTEND_STATISTIC(AST, NumPostfixOperators)
+FRONTEND_STATISTIC(AST, NumPrefixOperators)
+FRONTEND_STATISTIC(AST, NumPrecedenceGroups)
+FRONTEND_STATISTIC(AST, NumUsedConformances)
+
+FRONTEND_STATISTIC(Sema, NumConformancesDeserialized)
+FRONTEND_STATISTIC(Sema, NumConstraintScopes)
+FRONTEND_STATISTIC(Sema, NumDeclsDeserialized)
+FRONTEND_STATISTIC(Sema, NumDeclsValidated)
+FRONTEND_STATISTIC(Sema, NumFunctionsTypechecked)
+FRONTEND_STATISTIC(Sema, NumGenericSignatureBuilders)
+FRONTEND_STATISTIC(Sema, NumLazyGenericEnvironments)
+FRONTEND_STATISTIC(Sema, NumLazyGenericEnvironmentsLoaded)
+FRONTEND_STATISTIC(Sema, NumLazyIterableDeclContexts)
+FRONTEND_STATISTIC(Sema, NominalTypeLookupDirectCount)
+FRONTEND_STATISTIC(Sema, NumTypesDeserialized)
+FRONTEND_STATISTIC(Sema, NumTypesValidated)
+FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
+
+FRONTEND_STATISTIC(SILModule, NumSILGenFunctions)
+FRONTEND_STATISTIC(SILModule, NumSILGenVtables)
+FRONTEND_STATISTIC(SILModule, NumSILGenWitnessTables)
+FRONTEND_STATISTIC(SILModule, NumSILGenDefaultWitnessTables)
+FRONTEND_STATISTIC(SILModule, NumSILGenGlobalVariables)
+
+FRONTEND_STATISTIC(SILModule, NumSILOptFunctions)
+FRONTEND_STATISTIC(SILModule, NumSILOptVtables)
+FRONTEND_STATISTIC(SILModule, NumSILOptWitnessTables)
+FRONTEND_STATISTIC(SILModule, NumSILOptDefaultWitnessTables)
+FRONTEND_STATISTIC(SILModule, NumSILOptGlobalVariables)
+
+FRONTEND_STATISTIC(IRModule, NumIRGlobals)
+FRONTEND_STATISTIC(IRModule, NumIRFunctions)
+FRONTEND_STATISTIC(IRModule, NumIRAliases)
+FRONTEND_STATISTIC(IRModule, NumIRIFuncs)
+FRONTEND_STATISTIC(IRModule, NumIRNamedMetaData)
+FRONTEND_STATISTIC(IRModule, NumIRValueSymbols)
+FRONTEND_STATISTIC(IRModule, NumIRComdatSymbols)
+FRONTEND_STATISTIC(IRModule, NumIRBasicBlocks)
+FRONTEND_STATISTIC(IRModule, NumIRInsts)
+
+FRONTEND_STATISTIC(LLVM, NumLLVMBytesOutput)
+#endif

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -220,6 +220,9 @@ public:
   /// The path to which we should output statistics files.
   std::string StatsOutputDir;
 
+  /// Trace changes to stats to files in StatsOutputDir.
+  bool TraceStats = false;
+
   /// Indicates whether function body parsing should be delayed
   /// until the end of all files.
   bool DelayedFunctionBodyParsing = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -194,6 +194,9 @@ def driver_time_compilation : Flag<["-"], "driver-time-compilation">,
 def stats_output_dir: Separate<["-"], "stats-output-dir">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Directory to write unified compilation-statistics files to">;
+def trace_stats_events: Flag<["-"], "trace-stats-events">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Trace changes to stats in -stats-output-dir">;
 
 def emit_dependencies : Flag<["-"], "emit-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -149,101 +149,29 @@ UnifiedStatsReporter::getFrontendCounters()
   return *FrontendCounters;
 }
 
-#define PUBLISH_STAT(C,TY,NAME)                               \
-  do {                                                        \
-    static Statistic Stat = {TY, #NAME, #NAME, {0}, false};   \
-    Stat += (C).NAME;                                         \
-  } while (0)
-
 void
 UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
   if (FrontendCounters) {
     auto &C = getFrontendCounters();
-
-    PUBLISH_STAT(C, "AST", NumSourceBuffers);
-    PUBLISH_STAT(C, "AST", NumSourceLines);
-    PUBLISH_STAT(C, "AST", NumSourceLinesPerSecond);
-    PUBLISH_STAT(C, "AST", NumLinkLibraries);
-    PUBLISH_STAT(C, "AST", NumLoadedModules);
-    PUBLISH_STAT(C, "AST", NumImportedExternalDefinitions);
-    PUBLISH_STAT(C, "AST", NumTotalClangImportedEntities);
-    PUBLISH_STAT(C, "AST", NumASTBytesAllocated);
-    PUBLISH_STAT(C, "AST", NumDependencies);
-    PUBLISH_STAT(C, "AST", NumReferencedTopLevelNames);
-    PUBLISH_STAT(C, "AST", NumReferencedDynamicNames);
-    PUBLISH_STAT(C, "AST", NumReferencedMemberNames);
-    PUBLISH_STAT(C, "AST", NumDecls);
-    PUBLISH_STAT(C, "AST", NumLocalTypeDecls);
-    PUBLISH_STAT(C, "AST", NumObjCMethods);
-    PUBLISH_STAT(C, "AST", NumInfixOperators);
-    PUBLISH_STAT(C, "AST", NumPostfixOperators);
-    PUBLISH_STAT(C, "AST", NumPrefixOperators);
-    PUBLISH_STAT(C, "AST", NumPrecedenceGroups);
-    PUBLISH_STAT(C, "AST", NumUsedConformances);
-
-    PUBLISH_STAT(C, "Sema", NumConformancesDeserialized);
-    PUBLISH_STAT(C, "Sema", NumConstraintScopes);
-    PUBLISH_STAT(C, "Sema", NumDeclsDeserialized);
-    PUBLISH_STAT(C, "Sema", NumDeclsValidated);
-    PUBLISH_STAT(C, "Sema", NumFunctionsTypechecked);
-    PUBLISH_STAT(C, "Sema", NumGenericSignatureBuilders);
-    PUBLISH_STAT(C, "Sema", NumLazyGenericEnvironments);
-    PUBLISH_STAT(C, "Sema", NumLazyGenericEnvironmentsLoaded);
-    PUBLISH_STAT(C, "Sema", NumLazyIterableDeclContexts);
-    PUBLISH_STAT(C, "Sema", NominalTypeLookupDirectCount);
-    PUBLISH_STAT(C, "Sema", NumTypesDeserialized);
-    PUBLISH_STAT(C, "Sema", NumTypesValidated);
-    PUBLISH_STAT(C, "Sema", NumUnloadedLazyIterableDeclContexts);
-
-    PUBLISH_STAT(C, "SILModule", NumSILGenFunctions);
-    PUBLISH_STAT(C, "SILModule", NumSILGenVtables);
-    PUBLISH_STAT(C, "SILModule", NumSILGenWitnessTables);
-    PUBLISH_STAT(C, "SILModule", NumSILGenDefaultWitnessTables);
-    PUBLISH_STAT(C, "SILModule", NumSILGenGlobalVariables);
-
-    PUBLISH_STAT(C, "SILModule", NumSILOptFunctions);
-    PUBLISH_STAT(C, "SILModule", NumSILOptVtables);
-    PUBLISH_STAT(C, "SILModule", NumSILOptWitnessTables);
-    PUBLISH_STAT(C, "SILModule", NumSILOptDefaultWitnessTables);
-    PUBLISH_STAT(C, "SILModule", NumSILOptGlobalVariables);
-
-    PUBLISH_STAT(C, "IRModule", NumIRGlobals);
-    PUBLISH_STAT(C, "IRModule", NumIRFunctions);
-    PUBLISH_STAT(C, "IRModule", NumIRAliases);
-    PUBLISH_STAT(C, "IRModule", NumIRIFuncs);
-    PUBLISH_STAT(C, "IRModule", NumIRNamedMetaData);
-    PUBLISH_STAT(C, "IRModule", NumIRValueSymbols);
-    PUBLISH_STAT(C, "IRModule", NumIRComdatSymbols);
-    PUBLISH_STAT(C, "IRModule", NumIRBasicBlocks);
-    PUBLISH_STAT(C, "IRModule", NumIRInsts);
-
-    PUBLISH_STAT(C, "LLVM", NumLLVMBytesOutput);
+#define FRONTEND_STATISTIC(TY, NAME)                            \
+    do {                                                        \
+      static Statistic Stat = {#TY, #NAME, #NAME, {0}, false};  \
+      Stat += (C).NAME;                                         \
+    } while (0);
+#include "swift/Basic/Statistics.def"
+#undef FRONTEND_STATISTIC
   }
   if (DriverCounters) {
     auto &C = getDriverCounters();
-    PUBLISH_STAT(C, "Driver", NumDriverJobsRun);
-    PUBLISH_STAT(C, "Driver", NumDriverJobsSkipped);
-
-    PUBLISH_STAT(C, "Driver", DriverDepCascadingTopLevel);
-    PUBLISH_STAT(C, "Driver", DriverDepCascadingDynamic);
-    PUBLISH_STAT(C, "Driver", DriverDepCascadingNominal);
-    PUBLISH_STAT(C, "Driver", DriverDepCascadingMember);
-    PUBLISH_STAT(C, "Driver", DriverDepCascadingExternal);
-
-    PUBLISH_STAT(C, "Driver", DriverDepTopLevel);
-    PUBLISH_STAT(C, "Driver", DriverDepDynamic);
-    PUBLISH_STAT(C, "Driver", DriverDepNominal);
-    PUBLISH_STAT(C, "Driver", DriverDepMember);
-    PUBLISH_STAT(C, "Driver", DriverDepExternal);
-    PUBLISH_STAT(C, "Driver", ChildrenMaxRSS);
+#define DRIVER_STATISTIC(NAME)                                       \
+    do {                                                             \
+      static Statistic Stat = {"Driver", #NAME, #NAME, {0}, false};  \
+      Stat += (C).NAME;                                              \
+    } while (0);
+#include "swift/Basic/Statistics.def"
+#undef DRIVER_STATISTIC
   }
 }
-
-#define PRINT_STAT(OS,DELIM,C,TY,NAME)                   \
-  do {                                                   \
-    OS << DELIM << "\t\"" TY "." #NAME "\": " << C.NAME; \
-    delim = ",\n";                                       \
-  } while (0)
 
 void
 UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
@@ -252,83 +180,23 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
   const char *delim = "";
   if (FrontendCounters) {
     auto &C = getFrontendCounters();
-
-    PRINT_STAT(OS, delim, C, "AST", NumSourceBuffers);
-    PRINT_STAT(OS, delim, C, "AST", NumSourceLines);
-    PRINT_STAT(OS, delim, C, "AST", NumSourceLinesPerSecond);
-    PRINT_STAT(OS, delim, C, "AST", NumLinkLibraries);
-    PRINT_STAT(OS, delim, C, "AST", NumLoadedModules);
-    PRINT_STAT(OS, delim, C, "AST", NumImportedExternalDefinitions);
-    PRINT_STAT(OS, delim, C, "AST", NumTotalClangImportedEntities);
-    PRINT_STAT(OS, delim, C, "AST", NumASTBytesAllocated);
-    PRINT_STAT(OS, delim, C, "AST", NumDependencies);
-    PRINT_STAT(OS, delim, C, "AST", NumReferencedTopLevelNames);
-    PRINT_STAT(OS, delim, C, "AST", NumReferencedDynamicNames);
-    PRINT_STAT(OS, delim, C, "AST", NumReferencedMemberNames);
-    PRINT_STAT(OS, delim, C, "AST", NumDecls);
-    PRINT_STAT(OS, delim, C, "AST", NumLocalTypeDecls);
-    PRINT_STAT(OS, delim, C, "AST", NumObjCMethods);
-    PRINT_STAT(OS, delim, C, "AST", NumInfixOperators);
-    PRINT_STAT(OS, delim, C, "AST", NumPostfixOperators);
-    PRINT_STAT(OS, delim, C, "AST", NumPrefixOperators);
-    PRINT_STAT(OS, delim, C, "AST", NumPrecedenceGroups);
-    PRINT_STAT(OS, delim, C, "AST", NumUsedConformances);
-
-    PRINT_STAT(OS, delim, C, "Sema", NumConformancesDeserialized);
-    PRINT_STAT(OS, delim, C, "Sema", NumConstraintScopes);
-    PRINT_STAT(OS, delim, C, "Sema", NumDeclsDeserialized);
-    PRINT_STAT(OS, delim, C, "Sema", NumDeclsValidated);
-    PRINT_STAT(OS, delim, C, "Sema", NumFunctionsTypechecked);
-    PRINT_STAT(OS, delim, C, "Sema", NumGenericSignatureBuilders);
-    PRINT_STAT(OS, delim, C, "Sema", NumLazyGenericEnvironments);
-    PRINT_STAT(OS, delim, C, "Sema", NumLazyGenericEnvironmentsLoaded);
-    PRINT_STAT(OS, delim, C, "Sema", NumLazyIterableDeclContexts);
-    PRINT_STAT(OS, delim, C, "Sema", NominalTypeLookupDirectCount);
-    PRINT_STAT(OS, delim, C, "Sema", NumTypesDeserialized);
-    PRINT_STAT(OS, delim, C, "Sema", NumTypesValidated);
-    PRINT_STAT(OS, delim, C, "Sema", NumUnloadedLazyIterableDeclContexts);
-
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILGenFunctions);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILGenVtables);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILGenWitnessTables);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILGenDefaultWitnessTables);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILGenGlobalVariables);
-
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILOptFunctions);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILOptVtables);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILOptWitnessTables);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILOptDefaultWitnessTables);
-    PRINT_STAT(OS, delim, C, "SILModule", NumSILOptGlobalVariables);
-
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRGlobals);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRFunctions);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRAliases);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRIFuncs);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRNamedMetaData);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRValueSymbols);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRComdatSymbols);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRBasicBlocks);
-    PRINT_STAT(OS, delim, C, "IRModule", NumIRInsts);
-
-    PRINT_STAT(OS, delim, C, "LLVM", NumLLVMBytesOutput);
+#define FRONTEND_STATISTIC(TY, NAME)                        \
+    do {                                                    \
+      OS << delim << "\t\"" #TY "." #NAME "\": " << C.NAME; \
+      delim = ",\n";                                        \
+    } while (0);
+#include "swift/Basic/Statistics.def"
+#undef FRONTEND_STATISTIC
   }
   if (DriverCounters) {
     auto &C = getDriverCounters();
-    PRINT_STAT(OS, delim, C, "Driver", NumDriverJobsRun);
-    PRINT_STAT(OS, delim, C, "Driver", NumDriverJobsSkipped);
-
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepCascadingTopLevel);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepCascadingDynamic);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepCascadingNominal);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepCascadingMember);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepCascadingExternal);
-
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepTopLevel);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepDynamic);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepNominal);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepMember);
-    PRINT_STAT(OS, delim, C, "Driver", DriverDepExternal);
-    PRINT_STAT(OS, delim, C, "Driver", ChildrenMaxRSS);
+#define DRIVER_STATISTIC(NAME)                              \
+    do {                                                    \
+      OS << delim << "\t\"Driver." #NAME "\": " << C.NAME;  \
+      delim = ",\n";                                        \
+    } while (0);
+#include "swift/Basic/Statistics.def"
+#undef DRIVER_STATISTIC
   }
   // Print timers.
   TimerGroup::printAllJSONValues(OS, delim);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -151,6 +151,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
+  inputArgs.AddLastArg(arguments, options::OPT_trace_stats_events);
   inputArgs.AddLastArg(arguments,
                        options::OPT_solver_shrink_unsolved_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_O_Group);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -194,6 +194,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.DebugTimeCompilation |= Args.hasArg(OPT_debug_time_compilation);
   if (const Arg *A = Args.getLastArg(OPT_stats_output_dir)) {
     Opts.StatsOutputDir = A->getValue();
+    if (Args.getLastArg(OPT_trace_stats_events)) {
+      Opts.TraceStats = true;
+    }
   }
 
   if (const Arg *A = Args.getLastArg(OPT_validate_tbd_against_ir_EQ)) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1360,13 +1360,17 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     StringRef OutFile = FEOpts.getSingleOutputFilename();
     StringRef OutputType = llvm::sys::path::extension(OutFile);
     std::string TripleName = LangOpts.Target.normalize();
+    auto &SM = Instance->getSourceMgr();
+    auto Trace = Invocation.getFrontendOptions().TraceStats;
     StatsReporter = llvm::make_unique<UnifiedStatsReporter>("swift-frontend",
                                                             FEOpts.ModuleName,
                                                             InputName,
                                                             TripleName,
                                                             OutputType,
                                                             OptType,
-                                                            StatsOutputDir);
+                                                            StatsOutputDir,
+                                                            &SM,
+                                                            Trace);
   }
 
   const DiagnosticOptions &diagOpts = Invocation.getDiagnosticOptions();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3936,6 +3936,10 @@ public:
       : TC(TC), IsFirstPass(IsFirstPass), IsSecondPass(IsSecondPass) {}
 
   void visit(Decl *decl) {
+    UnifiedStatsReporter::FrontendStatsTracer Tracer;
+    if (TC.Context.Stats)
+      Tracer = TC.Context.Stats->getStatsTracer("type-checking",
+                                                decl->getSourceRange());
     PrettyStackTraceDecl StackTrace("type-checking", decl);
     
     DeclVisitor<DeclChecker>::visit(decl);


### PR DESCRIPTION
This change pulls the UnifiedStatsReporter statistic definitions into an xmacro .def file so we don't have to repeat ourselves quite so much in the reporter, and also adds a new optional, very simple low-overhead counter-change-tracing subsystem that logs changes-to-counters that occur any time a tracing boundary (as defined by the user) is passed. Trace events carry a timestamp and a source range, so we can correlate the compiler's activity a little better with time and source constructs.

Trace files are written to the same dir as stats-output-dir and the files are csv. It's all completely disabled unless the user passes `-trace-stats-dir foo` and `-trace-stats-events`. Nothing terribly fancy or intrusive.

(I'm _likely_ to try to reuse this machinery for a variety of other trace-recording tasks and/or output formats, but this is a good first step and gives easy-to-process output immediately)