### PR TITLE
master-next: Update DomTreeBuilder template declarations.

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -30,10 +30,8 @@ namespace DomTreeBuilder {
 using SILDomTree = llvm::DomTreeBase<swift::SILBasicBlock>;
 using SILPostDomTree = llvm::PostDomTreeBase<swift::SILBasicBlock>;
 
-extern template void Calculate<SILDomTree, swift::SILFunction>(
-    SILDomTree &DT, swift::SILFunction &F);
-extern template void Calculate<SILPostDomTree, swift::SILFunction>(
-    SILPostDomTree &DT, swift::SILFunction &F);
+extern template void Calculate<SILDomTree>(SILDomTree &DT);
+extern template void Calculate<SILPostDomTree>(SILPostDomTree &DT);
 } // namespace DomTreeBuilder
 } // namespace llvm
 


### PR DESCRIPTION
The declarations that I moved into the header on master do not
match the versions for master-next. This just updates the header
to match the template instantiations in lib/SIL/Dominance.cpp.