### PR TITLE
[Demangler] Eliminate a read-past-the-end-of-a-buffer misuse of StringRef.

### DIFF
--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -36,7 +36,7 @@ void Context::clear() {
 }
 
 NodePointer Context::demangleSymbolAsNode(llvm::StringRef MangledName) {
-  if (isMangledName(MangledName.data())) {
+  if (isMangledName(MangledName)) {
     return D->demangleSymbol(MangledName);
   }
   return demangleOldSymbolAsNode(MangledName, *D);


### PR DESCRIPTION
Putting the results of `StringRef::data()` back into a `StringRef` scans for the
null character at the end, which won’t always be there. Caught by ASan.
