### PR TITLE
Make Type::join return Any by default.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2644,10 +2644,15 @@ private:
           auto &lastBinding = Bindings[*lastSupertypeIndex];
           auto lastType = lastBinding.BindingType->getWithoutSpecifierType();
           auto bindingType = binding.BindingType->getWithoutSpecifierType();
-          if (auto join = Type::join(lastType, bindingType)) {
-            // Replace the last supertype binding with the join. We're done.
-            lastBinding.BindingType = join;
-            return;
+          auto join = Type::join(lastType, bindingType);
+          if (join) {
+            auto anyType = join->getASTContext().TheAnyType;
+            if (!join->isEqual(anyType) || lastType->isEqual(anyType) ||
+                bindingType->isEqual(anyType)) {
+              // Replace the last supertype binding with the join. We're done.
+              lastBinding.BindingType = join;
+              return;
+            }
           }
         }
 

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -304,8 +304,6 @@ struct Beef : Pear {}
 
 let routerFruit = Company(
   routes: [
-    // FIXME: implement join() for existentials
-    // expected-error@+1 {{cannot convert value of type '() -> Tomato.Type' to expected element type '() -> _'}}
     { () -> Tomato.Type in
       _ = ()
       return Chicken.self


### PR DESCRIPTION
For the moment, update the sole caller to not infer `Any` in cases where
neither argument was `Any`. This is in part because not all the cases are
handled here and the result of inferring `Any` will be to miss appropriate
bindings in certain cases. It is also in part because by inferring `Any`
we may end up deferring diagnostics until later in a function, which may
result in very hard to understand diagnostics for users.

This will be revisted once all the cases are properly handled here.
