### PR TITLE
[SourceKit] Include AccessLevel attributes in structure (SR-5978)

### DIFF
--- a/test/SourceKit/DocumentStructure/access_parse.swift.response
+++ b/test/SourceKit/DocumentStructure/access_parse.swift.response
@@ -590,7 +590,14 @@
       key.length: 28,
       key.typename: "Int",
       key.nameoffset: 953,
-      key.namelength: 14
+      key.namelength: 14,
+      key.attributes: [
+        {
+          key.offset: 936,
+          key.length: 12,
+          key.attribute: source.decl.attribute.setter_access.private
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -605,6 +612,11 @@
       key.bodyoffset: 1026,
       key.bodylength: 31,
       key.attributes: [
+        {
+          key.offset: 987,
+          key.length: 12,
+          key.attribute: source.decl.attribute.setter_access.private
+        },
         {
           key.offset: 980,
           key.length: 6,
@@ -626,6 +638,11 @@
       key.bodylength: 31,
       key.attributes: [
         {
+          key.offset: 1066,
+          key.length: 16,
+          key.attribute: source.decl.attribute.setter_access.fileprivate
+        },
+        {
           key.offset: 1059,
           key.length: 6,
           key.attribute: source.decl.attribute.public
@@ -645,6 +662,11 @@
       key.bodyoffset: 1186,
       key.bodylength: 31,
       key.attributes: [
+        {
+          key.offset: 1147,
+          key.length: 13,
+          key.attribute: source.decl.attribute.setter_access.internal
+        },
         {
           key.offset: 1140,
           key.length: 6,

--- a/test/SourceKit/DocumentStructure/access_parse.swift.response
+++ b/test/SourceKit/DocumentStructure/access_parse.swift.response
@@ -35,7 +35,14 @@
           key.length: 21,
           key.typename: "Int",
           key.nameoffset: 55,
-          key.namelength: 7
+          key.namelength: 7,
+          key.attributes: [
+            {
+              key.offset: 44,
+              key.length: 6,
+              key.attribute: source.decl.attribute.public
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -46,7 +53,14 @@
           key.length: 22,
           key.typename: "Int",
           key.nameoffset: 87,
-          key.namelength: 8
+          key.namelength: 8,
+          key.attributes: [
+            {
+              key.offset: 75,
+              key.length: 7,
+              key.attribute: source.decl.attribute.private
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -57,7 +71,14 @@
           key.nameoffset: 122,
           key.namelength: 9,
           key.bodyoffset: 133,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 108,
+              key.length: 8,
+              key.attribute: source.decl.attribute.internal
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -68,7 +89,14 @@
           key.nameoffset: 154,
           key.namelength: 8,
           key.bodyoffset: 164,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 137,
+              key.length: 11,
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ]
         }
       ]
     },
@@ -83,6 +111,13 @@
       key.namelength: 9,
       key.bodyoffset: 193,
       key.bodylength: 193,
+      key.attributes: [
+        {
+          key.offset: 169,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -104,7 +139,14 @@
           key.length: 21,
           key.typename: "Int",
           key.nameoffset: 231,
-          key.namelength: 7
+          key.namelength: 7,
+          key.attributes: [
+            {
+              key.offset: 220,
+              key.length: 6,
+              key.attribute: source.decl.attribute.public
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -115,7 +157,14 @@
           key.length: 22,
           key.typename: "Int",
           key.nameoffset: 263,
-          key.namelength: 8
+          key.namelength: 8,
+          key.attributes: [
+            {
+              key.offset: 251,
+              key.length: 7,
+              key.attribute: source.decl.attribute.private
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -126,7 +175,14 @@
           key.nameoffset: 298,
           key.namelength: 9,
           key.bodyoffset: 309,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 284,
+              key.length: 8,
+              key.attribute: source.decl.attribute.internal
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -137,7 +193,14 @@
           key.nameoffset: 330,
           key.namelength: 8,
           key.bodyoffset: 340,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 313,
+              key.length: 11,
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.class,
@@ -176,6 +239,13 @@
       key.namelength: 9,
       key.bodyoffset: 415,
       key.bodylength: 149,
+      key.attributes: [
+        {
+          key.offset: 389,
+          key.length: 8,
+          key.attribute: source.decl.attribute.internal
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -197,7 +267,14 @@
           key.length: 21,
           key.typename: "Int",
           key.nameoffset: 453,
-          key.namelength: 7
+          key.namelength: 7,
+          key.attributes: [
+            {
+              key.offset: 442,
+              key.length: 6,
+              key.attribute: source.decl.attribute.public
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -208,7 +285,14 @@
           key.length: 22,
           key.typename: "Int",
           key.nameoffset: 485,
-          key.namelength: 8
+          key.namelength: 8,
+          key.attributes: [
+            {
+              key.offset: 473,
+              key.length: 7,
+              key.attribute: source.decl.attribute.private
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -219,7 +303,14 @@
           key.nameoffset: 520,
           key.namelength: 9,
           key.bodyoffset: 531,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 506,
+              key.length: 8,
+              key.attribute: source.decl.attribute.internal
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -230,7 +321,14 @@
           key.nameoffset: 552,
           key.namelength: 8,
           key.bodyoffset: 562,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 535,
+              key.length: 11,
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ]
         }
       ]
     },
@@ -245,6 +343,13 @@
       key.namelength: 10,
       key.bodyoffset: 593,
       key.bodylength: 193,
+      key.attributes: [
+        {
+          key.offset: 567,
+          key.length: 7,
+          key.attribute: source.decl.attribute.private
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -266,7 +371,14 @@
           key.length: 21,
           key.typename: "Int",
           key.nameoffset: 631,
-          key.namelength: 7
+          key.namelength: 7,
+          key.attributes: [
+            {
+              key.offset: 620,
+              key.length: 6,
+              key.attribute: source.decl.attribute.public
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -277,7 +389,14 @@
           key.length: 22,
           key.typename: "Int",
           key.nameoffset: 663,
-          key.namelength: 8
+          key.namelength: 8,
+          key.attributes: [
+            {
+              key.offset: 651,
+              key.length: 7,
+              key.attribute: source.decl.attribute.private
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -288,7 +407,14 @@
           key.nameoffset: 698,
           key.namelength: 9,
           key.bodyoffset: 709,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 684,
+              key.length: 8,
+              key.attribute: source.decl.attribute.internal
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -299,7 +425,14 @@
           key.nameoffset: 730,
           key.namelength: 8,
           key.bodyoffset: 740,
-          key.bodylength: 0
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 713,
+              key.length: 11,
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.class,
@@ -347,7 +480,14 @@
       key.nameoffset: 819,
       key.namelength: 9,
       key.bodyoffset: 830,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 807,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -358,7 +498,14 @@
       key.nameoffset: 845,
       key.namelength: 10,
       key.bodyoffset: 857,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 832,
+          key.length: 7,
+          key.attribute: source.decl.attribute.private
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -369,7 +516,14 @@
       key.nameoffset: 873,
       key.namelength: 9,
       key.bodyoffset: 884,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 859,
+          key.length: 8,
+          key.attribute: source.decl.attribute.internal
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.enum,
@@ -381,6 +535,13 @@
       key.namelength: 7,
       key.bodyoffset: 908,
       key.bodylength: 25,
+      key.attributes: [
+        {
+          key.offset: 887,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.enumcase,
@@ -442,7 +603,14 @@
       key.nameoffset: 1004,
       key.namelength: 14,
       key.bodyoffset: 1026,
-      key.bodylength: 31
+      key.bodylength: 31,
+      key.attributes: [
+        {
+          key.offset: 980,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -455,7 +623,14 @@
       key.nameoffset: 1087,
       key.namelength: 12,
       key.bodyoffset: 1107,
-      key.bodylength: 31
+      key.bodylength: 31,
+      key.attributes: [
+        {
+          key.offset: 1059,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -468,7 +643,14 @@
       key.nameoffset: 1165,
       key.namelength: 13,
       key.bodyoffset: 1186,
-      key.bodylength: 31
+      key.bodylength: 31,
+      key.attributes: [
+        {
+          key.offset: 1140,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -480,7 +662,14 @@
       key.nameoffset: 1231,
       key.namelength: 10,
       key.bodyoffset: 1249,
-      key.bodylength: 21
+      key.bodylength: 21,
+      key.attributes: [
+        {
+          key.offset: 1220,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -490,7 +679,14 @@
       key.length: 19,
       key.typename: "Int",
       key.nameoffset: 1284,
-      key.namelength: 9
+      key.namelength: 9,
+      key.attributes: [
+        {
+          key.offset: 1273,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -512,7 +708,14 @@
       key.nameoffset: 1331,
       key.namelength: 9,
       key.bodyoffset: 1342,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 1319,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -523,7 +726,14 @@
       key.nameoffset: 1357,
       key.namelength: 10,
       key.bodyoffset: 1369,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 1344,
+          key.length: 7,
+          key.attribute: source.decl.attribute.private
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -534,7 +744,14 @@
       key.nameoffset: 1385,
       key.namelength: 9,
       key.bodyoffset: 1396,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.attributes: [
+        {
+          key.offset: 1371,
+          key.length: 8,
+          key.attribute: source.decl.attribute.internal
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.extension,
@@ -638,6 +855,13 @@
       key.namelength: 9,
       key.bodyoffset: 1605,
       key.bodylength: 25,
+      key.attributes: [
+        {
+          key.offset: 1576,
+          key.length: 7,
+          key.attribute: source.decl.attribute.private
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -662,6 +886,13 @@
       key.namelength: 9,
       key.bodyoffset: 1662,
       key.bodylength: 29,
+      key.attributes: [
+        {
+          key.offset: 1632,
+          key.length: 8,
+          key.attribute: source.decl.attribute.internal
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -686,6 +917,13 @@
       key.namelength: 9,
       key.bodyoffset: 1721,
       key.bodylength: 27,
+      key.attributes: [
+        {
+          key.offset: 1693,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -716,7 +954,14 @@
       key.offset: 1783,
       key.length: 24,
       key.nameoffset: 1793,
-      key.namelength: 8
+      key.namelength: 8,
+      key.attributes: [
+        {
+          key.offset: 1776,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.typealias,
@@ -725,7 +970,14 @@
       key.offset: 1816,
       key.length: 25,
       key.nameoffset: 1826,
-      key.namelength: 9
+      key.namelength: 9,
+      key.attributes: [
+        {
+          key.offset: 1808,
+          key.length: 7,
+          key.attribute: source.decl.attribute.private
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.typealias,
@@ -734,7 +986,14 @@
       key.offset: 1851,
       key.length: 24,
       key.nameoffset: 1861,
-      key.namelength: 8
+      key.namelength: 8,
+      key.attributes: [
+        {
+          key.offset: 1842,
+          key.length: 8,
+          key.attribute: source.decl.attribute.internal
+        }
+      ]
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -65,6 +65,9 @@
           key.is_dynamic: 1,
           key.attributes: [
             {
+              key.attribute: source.decl.attribute.public
+            },
+            {
               key.attribute: source.decl.attribute.objc
             }
           ]

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -93,6 +93,11 @@
           key.line: 8,
           key.column: 15
         }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
       ]
     },
     {

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift.response
@@ -104,6 +104,11 @@
           ]
         }
       ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ],
       key.is_test_candidate: 1
     },
     {
@@ -177,7 +182,12 @@
           key.usr: "s:23index_is_test_candidate7MyClassC0C57_startsWithTest_takesNoParams_andReturnsVoid_butIsPrivate33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B9LLyyF",
           key.line: 24,
           key.column: 16,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ]
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -214,6 +224,11 @@
               key.attribute: source.decl.attribute.override
             }
           ]
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
         }
       ],
       key.is_test_candidate: 1

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
@@ -105,6 +105,11 @@
           ]
         }
       ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ],
       key.is_test_candidate: 1
     },
     {
@@ -179,6 +184,11 @@
           key.line: 23,
           key.column: 16,
           key.is_dynamic: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
           key.is_test_candidate: 1
         },
         {
@@ -216,6 +226,11 @@
               key.attribute: source.decl.attribute.override
             }
           ]
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
         }
       ],
       key.is_test_candidate: 1

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
@@ -62,6 +62,13 @@ public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
     key.typename: "Int32",
     key.nameoffset: 13,
     key.namelength: 43,
+    key.attributes: [
+      {
+        key.offset: 1,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -180,6 +180,13 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.typename: "Int32",
     key.nameoffset: 79,
     key.namelength: 26,
+    key.attributes: [
+      {
+        key.offset: 67,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -201,7 +208,14 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.length: 45,
     key.typename: "Int",
     key.nameoffset: 127,
-    key.namelength: 28
+    key.namelength: 28,
+    key.attributes: [
+      {
+        key.offset: 116,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -212,6 +226,13 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.length: 45,
     key.typename: "Int",
     key.nameoffset: 180,
-    key.namelength: 28
+    key.namelength: 28,
+    key.attributes: [
+      {
+        key.offset: 169,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   }
 ]

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -4270,6 +4270,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "RawRepresentable"
       }
     ],
+    key.attributes: [
+      {
+        key.offset: 208,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
@@ -4291,6 +4298,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 24,
         key.nameoffset: 275,
         key.namelength: 24,
+        key.attributes: [
+          {
+            key.offset: 268,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4311,6 +4325,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 22,
         key.nameoffset: 312,
         key.namelength: 22,
+        key.attributes: [
+          {
+            key.offset: 305,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4332,7 +4353,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 20,
         key.typename: "UInt32",
         key.nameoffset: 351,
-        key.namelength: 8
+        key.namelength: 8,
+        key.attributes: [
+          {
+            key.offset: 340,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -4347,7 +4375,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 409,
     key.namelength: 9,
     key.docoffset: 371,
-    key.doclength: 27
+    key.doclength: 27,
+    key.attributes: [
+      {
+        key.offset: 398,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.struct,
@@ -4365,6 +4400,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.name: "RawRepresentable"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 438,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
       }
     ],
     key.elements: [
@@ -4388,6 +4430,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 24,
         key.nameoffset: 505,
         key.namelength: 24,
+        key.attributes: [
+          {
+            key.offset: 498,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4408,6 +4457,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 22,
         key.nameoffset: 542,
         key.namelength: 22,
+        key.attributes: [
+          {
+            key.offset: 535,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4429,7 +4485,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 20,
         key.typename: "UInt32",
         key.nameoffset: 581,
-        key.namelength: 8
+        key.namelength: 8,
+        key.attributes: [
+          {
+            key.offset: 570,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -4442,7 +4505,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "FooEnum2",
     key.nameoffset: 611,
-    key.namelength: 9
+    key.namelength: 9,
+    key.attributes: [
+      {
+        key.offset: 600,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -4453,7 +4523,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "FooEnum2",
     key.nameoffset: 650,
-    key.namelength: 9
+    key.namelength: 9,
+    key.attributes: [
+      {
+        key.offset: 639,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.struct,
@@ -4471,6 +4548,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.name: "RawRepresentable"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 678,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
       }
     ],
     key.elements: [
@@ -4494,6 +4578,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 24,
         key.nameoffset: 745,
         key.namelength: 24,
+        key.attributes: [
+          {
+            key.offset: 738,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4514,6 +4605,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 22,
         key.nameoffset: 782,
         key.namelength: 22,
+        key.attributes: [
+          {
+            key.offset: 775,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4535,7 +4633,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 20,
         key.typename: "UInt32",
         key.nameoffset: 821,
-        key.namelength: 8
+        key.namelength: 8,
+        key.attributes: [
+          {
+            key.offset: 810,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -4548,7 +4653,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "FooEnum3",
     key.nameoffset: 851,
-    key.namelength: 9
+    key.namelength: 9,
+    key.attributes: [
+      {
+        key.offset: 840,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -4559,7 +4671,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "FooEnum3",
     key.nameoffset: 890,
-    key.namelength: 9
+    key.namelength: 9,
+    key.attributes: [
+      {
+        key.offset: 879,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.enum,
@@ -4576,6 +4695,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.inheritedtypes: [
       {
         key.name: "Int"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 956,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
       }
     ],
     key.elements: [
@@ -4659,6 +4785,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "OptionSet"
       }
     ],
+    key.attributes: [
+      {
+        key.offset: 1166,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
@@ -4675,6 +4808,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 19,
         key.nameoffset: 1224,
         key.namelength: 19,
+        key.attributes: [
+          {
+            key.offset: 1217,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4696,7 +4836,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 49,
         key.typename: "FooRuncingOptions",
         key.nameoffset: 1294,
-        key.namelength: 11
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 1276,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.static,
@@ -4707,7 +4854,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 50,
         key.typename: "FooRuncingOptions",
         key.nameoffset: 1356,
-        key.namelength: 12
+        key.namelength: 12,
+        key.attributes: [
+          {
+            key.offset: 1338,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -4721,6 +4875,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 10,
     key.bodyoffset: 1450,
     key.bodylength: 109,
+    key.attributes: [
+      {
+        key.offset: 1424,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -4731,7 +4892,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 12,
         key.typename: "Int32",
         key.nameoffset: 1467,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 1456,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -4742,7 +4910,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 13,
         key.typename: "Double",
         key.nameoffset: 1492,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 1481,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -4751,7 +4926,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 1514,
         key.length: 6,
         key.nameoffset: 1514,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 1507,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -4761,6 +4943,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 25,
         key.nameoffset: 1533,
         key.namelength: 25,
+        key.attributes: [
+          {
+            key.offset: 1526,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4791,7 +4980,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.offset: 1568,
     key.length: 62,
     key.nameoffset: 1578,
-    key.namelength: 17
+    key.namelength: 17,
+    key.attributes: [
+      {
+        key.offset: 1561,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.struct,
@@ -4803,6 +4999,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 10,
     key.bodyoffset: 1658,
     key.bodylength: 109,
+    key.attributes: [
+      {
+        key.offset: 1632,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -4813,7 +5016,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 12,
         key.typename: "Int32",
         key.nameoffset: 1675,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 1664,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -4824,7 +5034,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 13,
         key.typename: "Double",
         key.nameoffset: 1700,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 1689,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -4833,7 +5050,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 1722,
         key.length: 6,
         key.nameoffset: 1722,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 1715,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -4843,6 +5067,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 25,
         key.nameoffset: 1741,
         key.namelength: 25,
+        key.attributes: [
+          {
+            key.offset: 1734,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4873,7 +5104,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.offset: 1776,
     key.length: 40,
     key.nameoffset: 1786,
-    key.namelength: 17
+    key.namelength: 17,
+    key.attributes: [
+      {
+        key.offset: 1769,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.struct,
@@ -4885,6 +5123,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 17,
     key.bodyoffset: 1851,
     key.bodylength: 109,
+    key.attributes: [
+      {
+        key.offset: 1818,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -4895,7 +5140,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 12,
         key.typename: "Int32",
         key.nameoffset: 1868,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 1857,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -4906,7 +5158,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 13,
         key.typename: "Double",
         key.nameoffset: 1893,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 1882,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -4915,7 +5174,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 1915,
         key.length: 6,
         key.nameoffset: 1915,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 1908,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -4925,6 +5191,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 25,
         key.nameoffset: 1934,
         key.namelength: 25,
+        key.attributes: [
+          {
+            key.offset: 1927,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -4957,7 +5230,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 2009,
     key.namelength: 11,
     key.docoffset: 1963,
-    key.doclength: 29
+    key.doclength: 29,
+    key.attributes: [
+      {
+        key.offset: 1992,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -4970,7 +5250,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 2068,
     key.namelength: 9,
     key.docoffset: 2030,
-    key.doclength: 27
+    key.doclength: 27,
+    key.attributes: [
+      {
+        key.offset: 2057,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -4983,6 +5270,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 20,
     key.docoffset: 2086,
     key.doclength: 26,
+    key.attributes: [
+      {
+        key.offset: 2112,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -5004,6 +5298,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.typename: "Int32",
     key.nameoffset: 2167,
     key.namelength: 32,
+    key.attributes: [
+      {
+        key.offset: 2155,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -5024,6 +5325,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.typename: "Int32",
     key.nameoffset: 2221,
     key.namelength: 80,
+    key.attributes: [
+      {
+        key.offset: 2209,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -5071,6 +5379,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 49,
     key.nameoffset: 2371,
     key.namelength: 44,
+    key.attributes: [
+      {
+        key.offset: 2359,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -5091,6 +5406,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 75,
     key.nameoffset: 2429,
     key.namelength: 70,
+    key.attributes: [
+      {
+        key.offset: 2417,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -5111,7 +5433,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 32,
     key.typename: "Never",
     key.nameoffset: 2513,
-    key.namelength: 18
+    key.namelength: 18,
+    key.attributes: [
+      {
+        key.offset: 2501,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5121,7 +5450,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 32,
     key.typename: "Never",
     key.nameoffset: 2553,
-    key.namelength: 18
+    key.namelength: 18,
+    key.attributes: [
+      {
+        key.offset: 2541,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5132,7 +5468,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 2657,
     key.namelength: 21,
     key.docoffset: 2582,
-    key.doclength: 62
+    key.doclength: 62,
+    key.attributes: [
+      {
+        key.offset: 2645,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5141,7 +5484,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.offset: 2730,
     key.length: 26,
     key.nameoffset: 2735,
-    key.namelength: 21
+    key.namelength: 21,
+    key.attributes: [
+      {
+        key.offset: 2723,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5152,7 +5502,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 2830,
     key.namelength: 21,
     key.docoffset: 2758,
-    key.doclength: 59
+    key.doclength: 59,
+    key.attributes: [
+      {
+        key.offset: 2818,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5163,7 +5520,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 2918,
     key.namelength: 21,
     key.docoffset: 2853,
-    key.doclength: 53
+    key.doclength: 53,
+    key.attributes: [
+      {
+        key.offset: 2906,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5174,7 +5538,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 3012,
     key.namelength: 21,
     key.docoffset: 2941,
-    key.doclength: 59
+    key.doclength: 59,
+    key.attributes: [
+      {
+        key.offset: 3000,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5187,6 +5558,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 44,
     key.docoffset: 3035,
     key.doclength: 50,
+    key.attributes: [
+      {
+        key.offset: 3085,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -5212,6 +5590,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.bodylength: 545,
     key.docoffset: 3152,
     key.doclength: 33,
+    key.attributes: [
+      {
+        key.offset: 3185,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5222,7 +5607,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 3288,
         key.namelength: 14,
         key.docoffset: 3229,
-        key.doclength: 43
+        key.doclength: 43,
+        key.attributes: [
+          {
+            key.offset: 3276,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5233,7 +5625,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 3393,
         key.namelength: 35,
         key.docoffset: 3313,
-        key.doclength: 64
+        key.doclength: 64,
+        key.attributes: [
+          {
+            key.offset: 3381,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5244,7 +5643,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 3533,
         key.namelength: 35,
         key.docoffset: 3439,
-        key.doclength: 77
+        key.doclength: 77,
+        key.attributes: [
+          {
+            key.offset: 3521,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
@@ -5253,7 +5659,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 3586,
         key.length: 31,
         key.nameoffset: 3598,
-        key.namelength: 19
+        key.namelength: 19,
+        key.attributes: [
+          {
+            key.offset: 3579,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -5266,7 +5679,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 3639,
         key.namelength: 12,
         key.bodyoffset: 3660,
-        key.bodylength: 9
+        key.bodylength: 9,
+        key.attributes: [
+          {
+            key.offset: 3628,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -5279,7 +5699,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 3687,
         key.namelength: 12,
         key.bodyoffset: 3708,
-        key.bodylength: 9
+        key.bodylength: 9,
+        key.attributes: [
+          {
+            key.offset: 3676,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -5291,7 +5718,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 3735,
         key.namelength: 12,
         key.bodyoffset: 3756,
-        key.bodylength: 5
+        key.bodylength: 5,
+        key.attributes: [
+          {
+            key.offset: 3724,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -5309,6 +5743,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.inheritedtypes: [
       {
         key.name: "FooProtocolBase"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 3766,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
       }
     ],
     key.elements: [
@@ -5330,6 +5771,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 12,
     key.bodyoffset: 3849,
     key.bodylength: 269,
+    key.attributes: [
+      {
+        key.offset: 3824,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5338,7 +5786,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 3860,
         key.length: 27,
         key.nameoffset: 3865,
-        key.namelength: 22
+        key.namelength: 22,
+        key.attributes: [
+          {
+            key.offset: 3855,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5349,6 +5804,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.typename: "FooClassBase!",
         key.nameoffset: 3903,
         key.namelength: 38,
+        key.attributes: [
+          {
+            key.offset: 3893,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -5368,7 +5830,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 3971,
         key.length: 7,
         key.nameoffset: 3971,
-        key.namelength: 7
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 3964,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5383,6 +5852,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.offset: 3991,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
+          },
+          {
+            key.offset: 3984,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
           }
         ],
         key.substructure: [
@@ -5404,7 +5878,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 4035,
         key.length: 36,
         key.nameoffset: 4040,
-        key.namelength: 31
+        key.namelength: 31,
+        key.attributes: [
+          {
+            key.offset: 4030,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.class,
@@ -5413,7 +5894,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 4087,
         key.length: 30,
         key.nameoffset: 4098,
-        key.namelength: 19
+        key.namelength: 19,
+        key.attributes: [
+          {
+            key.offset: 4082,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       }
     ]
   },
@@ -5438,6 +5926,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "FooProtocolDerived"
       }
     ],
+    key.attributes: [
+      {
+        key.offset: 4154,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
@@ -5460,7 +5955,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 23,
         key.typename: "Int32",
         key.nameoffset: 4237,
-        key.namelength: 12
+        key.namelength: 12,
+        key.attributes: [
+          {
+            key.offset: 4228,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -5471,7 +5973,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 23,
         key.typename: "Int32",
         key.nameoffset: 4271,
-        key.namelength: 12
+        key.namelength: 12,
+        key.attributes: [
+          {
+            key.offset: 4262,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -5482,7 +5991,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 31,
         key.typename: "Int32",
         key.nameoffset: 4305,
-        key.namelength: 12
+        key.namelength: 12,
+        key.attributes: [
+          {
+            key.offset: 4296,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5491,7 +6007,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 4417,
         key.length: 23,
         key.nameoffset: 4422,
-        key.namelength: 18
+        key.namelength: 18,
+        key.attributes: [
+          {
+            key.offset: 4412,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5501,6 +6024,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 33,
         key.nameoffset: 4456,
         key.namelength: 28,
+        key.attributes: [
+          {
+            key.offset: 4446,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -5521,6 +6051,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 49,
         key.nameoffset: 4500,
         key.namelength: 44,
+        key.attributes: [
+          {
+            key.offset: 4490,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -5549,7 +6086,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 4560,
         key.length: 36,
         key.nameoffset: 4565,
-        key.namelength: 31
+        key.namelength: 31,
+        key.attributes: [
+          {
+            key.offset: 4555,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.class,
@@ -5558,7 +6102,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 4612,
         key.length: 26,
         key.nameoffset: 4623,
-        key.namelength: 15
+        key.namelength: 15,
+        key.attributes: [
+          {
+            key.offset: 4607,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       }
     ]
   },
@@ -5569,7 +6120,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.offset: 4649,
     key.length: 31,
     key.nameoffset: 4659,
-    key.namelength: 13
+    key.namelength: 13,
+    key.attributes: [
+      {
+        key.offset: 4642,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5580,7 +6138,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 4725,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4714,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5591,7 +6156,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 4763,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4752,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5602,7 +6174,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 4801,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4790,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5613,7 +6192,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "UInt32",
     key.nameoffset: 4878,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4867,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5624,7 +6210,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "UInt64",
     key.nameoffset: 4917,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4906,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5635,7 +6228,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 38,
     key.typename: "typedef_int_t",
     key.nameoffset: 4956,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4945,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5646,7 +6246,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 38,
     key.typename: "typedef_int_t",
     key.nameoffset: 5002,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 4991,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5657,7 +6264,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 29,
     key.typename: "Int8",
     key.nameoffset: 5048,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 5037,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5668,7 +6282,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 5085,
-    key.namelength: 11
+    key.namelength: 11,
+    key.attributes: [
+      {
+        key.offset: 5074,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5679,7 +6300,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "Int16",
     key.nameoffset: 5123,
-    key.namelength: 12
+    key.namelength: 12,
+    key.attributes: [
+      {
+        key.offset: 5112,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5690,7 +6318,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 29,
     key.typename: "Int",
     key.nameoffset: 5162,
-    key.namelength: 12
+    key.namelength: 12,
+    key.attributes: [
+      {
+        key.offset: 5151,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5701,7 +6336,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 31,
     key.typename: "Int32",
     key.nameoffset: 5199,
-    key.namelength: 12
+    key.namelength: 12,
+    key.attributes: [
+      {
+        key.offset: 5188,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5712,7 +6354,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 32,
     key.typename: "Int32",
     key.nameoffset: 5238,
-    key.namelength: 13
+    key.namelength: 13,
+    key.attributes: [
+      {
+        key.offset: 5227,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5723,7 +6372,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 38,
     key.typename: "UInt64",
     key.nameoffset: 5278,
-    key.namelength: 18
+    key.namelength: 18,
+    key.attributes: [
+      {
+        key.offset: 5267,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5734,7 +6390,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 36,
     key.typename: "UInt32",
     key.nameoffset: 5324,
-    key.namelength: 16
+    key.namelength: 16,
+    key.attributes: [
+      {
+        key.offset: 5313,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5745,7 +6408,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 36,
     key.typename: "Int32",
     key.nameoffset: 5369,
-    key.namelength: 17
+    key.namelength: 17,
+    key.attributes: [
+      {
+        key.offset: 5358,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5756,7 +6426,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 36,
     key.typename: "Int32",
     key.nameoffset: 5414,
-    key.namelength: 17
+    key.namelength: 17,
+    key.attributes: [
+      {
+        key.offset: 5403,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5765,7 +6442,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.offset: 5455,
     key.length: 23,
     key.nameoffset: 5460,
-    key.namelength: 18
+    key.namelength: 18,
+    key.attributes: [
+      {
+        key.offset: 5448,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.function.free,
@@ -5774,7 +6458,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.offset: 5487,
     key.length: 28,
     key.nameoffset: 5492,
-    key.namelength: 23
+    key.namelength: 23,
+    key.attributes: [
+      {
+        key.offset: 5480,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.struct,
@@ -5786,6 +6477,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 15,
     key.bodyoffset: 5548,
     key.bodylength: 72,
+    key.attributes: [
+      {
+        key.offset: 5517,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -5796,7 +6494,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 12,
         key.typename: "Int32",
         key.nameoffset: 5565,
-        key.namelength: 1
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 5554,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5805,7 +6510,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 5586,
         key.length: 6,
         key.nameoffset: 5586,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 5579,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5815,6 +6527,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 14,
         key.nameoffset: 5605,
         key.namelength: 14,
+        key.attributes: [
+          {
+            key.offset: 5598,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -5847,7 +6566,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 29,
         key.typename: "Any!",
         key.nameoffset: 5663,
-        key.namelength: 16
+        key.namelength: 16,
+        key.attributes: [
+          {
+            key.offset: 5653,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       }
     ]
   },
@@ -5869,7 +6595,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 29,
         key.typename: "Any!",
         key.nameoffset: 5776,
-        key.namelength: 16
+        key.namelength: 16,
+        key.attributes: [
+          {
+            key.offset: 5766,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -5879,7 +6612,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 30,
         key.typename: "Any!",
         key.nameoffset: 5816,
-        key.namelength: 17
+        key.namelength: 17,
+        key.attributes: [
+          {
+            key.offset: 5806,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       }
     ]
   },
@@ -5901,7 +6641,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 29,
         key.typename: "Any!",
         key.nameoffset: 5885,
-        key.namelength: 16
+        key.namelength: 16,
+        key.attributes: [
+          {
+            key.offset: 5875,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       }
     ]
   },
@@ -5915,7 +6662,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 5929,
     key.namelength: 13,
     key.bodyoffset: 5944,
-    key.bodylength: 1
+    key.bodylength: 1,
+    key.attributes: [
+      {
+        key.offset: 5913,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.class,
@@ -5931,6 +6685,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.inheritedtypes: [
       {
         key.name: "_InternalProt"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 5948,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
       }
     ],
     key.elements: [
@@ -5957,6 +6718,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "FooClassBase"
       }
     ],
+    key.attributes: [
+      {
+        key.offset: 6002,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
@@ -5977,6 +6745,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 10,
         key.attributes: [
           {
+            key.offset: 6077,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          },
+          {
             key.offset: 6061,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
@@ -5995,6 +6768,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 16,
         key.attributes: [
           {
+            key.offset: 6130,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          },
+          {
             key.offset: 6114,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
@@ -6010,7 +6788,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 20,
         key.typename: "Any!",
         key.nameoffset: 6182,
-        key.namelength: 10
+        key.namelength: 10,
+        key.attributes: [
+          {
+            key.offset: 6173,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -6021,7 +6806,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 19,
         key.typename: "Any!",
         key.nameoffset: 6213,
-        key.namelength: 9
+        key.namelength: 9,
+        key.attributes: [
+          {
+            key.offset: 6204,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -6032,7 +6824,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 18,
         key.typename: "Any!",
         key.nameoffset: 6243,
-        key.namelength: 8
+        key.namelength: 8,
+        key.attributes: [
+          {
+            key.offset: 6234,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -6045,6 +6844,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 6277,
         key.namelength: 7,
         key.attributes: [
+          {
+            key.offset: 6268,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          },
           {
             key.offset: 6263,
             key.length: 4,
@@ -6061,7 +6865,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.length: 17,
         key.typename: "Int32",
         key.nameoffset: 6311,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 6302,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ]
       }
     ]
   },
@@ -6079,6 +6890,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.inheritedtypes: [
       {
         key.name: "FooClassBase"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 6328,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
       }
     ],
     key.elements: [
@@ -6102,6 +6920,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.offset: 6390,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
+          },
+          {
+            key.offset: 6383,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
           }
         ],
         key.substructure: [
@@ -6126,6 +6949,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 12,
         key.attributes: [
           {
+            key.offset: 6476,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          },
+          {
             key.offset: 6432,
             key.length: 39,
             key.attribute: source.decl.attribute.available
@@ -6142,6 +6970,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 24,
         key.attributes: [
           {
+            key.offset: 6537,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          },
+          {
             key.offset: 6509,
             key.length: 23,
             key.attribute: source.decl.attribute.available
@@ -6157,6 +6990,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 6644,
         key.namelength: 27,
         key.attributes: [
+          {
+            key.offset: 6634,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          },
           {
             key.offset: 6582,
             key.length: 47,
@@ -6176,7 +7014,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.nameoffset: 6688,
     key.namelength: 9,
     key.bodyoffset: 6699,
-    key.bodylength: 1
+    key.bodylength: 1,
+    key.attributes: [
+      {
+        key.offset: 6675,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.enum,
@@ -6194,6 +7039,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       }
     ],
     key.attributes: [
+      {
+        key.offset: 6767,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      },
       {
         key.offset: 6703,
         key.length: 63,
@@ -6257,6 +7107,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.namelength: 19,
     key.bodyoffset: 7000,
     key.bodylength: 22,
+    key.attributes: [
+      {
+        key.offset: 6966,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -6265,7 +7122,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.offset: 7013,
         key.length: 8,
         key.nameoffset: 7018,
-        key.namelength: 3
+        key.namelength: 3,
+        key.attributes: [
+          {
+            key.offset: 7006,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -6285,6 +7149,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "Foo.FooOverlayClassBase"
       }
     ],
+    key.attributes: [
+      {
+        key.offset: 7025,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
@@ -6302,6 +7173,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.nameoffset: 7115,
         key.namelength: 3,
         key.attributes: [
+          {
+            key.offset: 7103,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          },
           {
             key.offset: 7094,
             key.length: 8,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -335,6 +335,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.typename: "Int32",
     key.nameoffset: 67,
     key.namelength: 23,
+    key.attributes: [
+      {
+        key.offset: 55,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -365,6 +372,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "RawRepresentable"
       }
     ],
+    key.attributes: [
+      {
+        key.offset: 101,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
@@ -386,6 +400,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.length: 24,
         key.nameoffset: 171,
         key.namelength: 24,
+        key.attributes: [
+          {
+            key.offset: 164,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -406,6 +427,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.length: 22,
         key.nameoffset: 208,
         key.namelength: 22,
+        key.attributes: [
+          {
+            key.offset: 201,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -427,7 +455,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.length: 20,
         key.typename: "UInt32",
         key.nameoffset: 247,
-        key.namelength: 8
+        key.namelength: 8,
+        key.attributes: [
+          {
+            key.offset: 236,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -440,7 +475,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 37,
     key.typename: "FooSubEnum1",
     key.nameoffset: 277,
-    key.namelength: 12
+    key.namelength: 12,
+    key.attributes: [
+      {
+        key.offset: 266,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -451,7 +493,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 37,
     key.typename: "FooSubEnum1",
     key.nameoffset: 322,
-    key.namelength: 12
+    key.namelength: 12,
+    key.attributes: [
+      {
+        key.offset: 311,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -462,6 +511,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 42,
     key.typename: "Int",
     key.nameoffset: 368,
-    key.namelength: 25
+    key.namelength: 25,
+    key.attributes: [
+      {
+        key.offset: 357,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   }
 ]

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -144,6 +144,13 @@ public struct NUPixelSize {
     key.namelength: 11,
     key.bodyoffset: 28,
     key.bodylength: 117,
+    key.attributes: [
+      {
+        key.offset: 1,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -154,7 +161,14 @@ public struct NUPixelSize {
         key.length: 14,
         key.typename: "Int",
         key.nameoffset: 45,
-        key.namelength: 5
+        key.namelength: 5,
+        key.attributes: [
+          {
+            key.offset: 34,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -165,7 +179,14 @@ public struct NUPixelSize {
         key.length: 15,
         key.typename: "Int",
         key.nameoffset: 72,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 61,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -174,7 +195,14 @@ public struct NUPixelSize {
         key.offset: 96,
         key.length: 6,
         key.nameoffset: 96,
-        key.namelength: 6
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 89,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -184,6 +212,13 @@ public struct NUPixelSize {
         key.length: 29,
         key.nameoffset: 115,
         key.namelength: 29,
+        key.attributes: [
+          {
+            key.offset: 108,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,

--- a/test/SourceKit/InterfaceGen/gen_header.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.response
@@ -166,6 +166,13 @@ public protocol SameNameProtocol {
     key.length: 36,
     key.nameoffset: 12,
     key.namelength: 31,
+    key.attributes: [
+      {
+        key.offset: 0,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -189,6 +196,13 @@ public protocol SameNameProtocol {
     key.namelength: 10,
     key.bodyoffset: 68,
     key.bodylength: 35,
+    key.attributes: [
+      {
+        key.offset: 45,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -198,6 +212,13 @@ public protocol SameNameProtocol {
         key.length: 23,
         key.nameoffset: 84,
         key.namelength: 18,
+        key.attributes: [
+          {
+            key.offset: 74,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -224,7 +245,14 @@ public protocol SameNameProtocol {
     key.bodyoffset: 189,
     key.bodylength: 1,
     key.docoffset: 106,
-    key.doclength: 62
+    key.doclength: 62,
+    key.attributes: [
+      {
+        key.offset: 168,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.protocol,
@@ -236,6 +264,13 @@ public protocol SameNameProtocol {
     key.nameoffset: 229,
     key.namelength: 16,
     key.bodyoffset: 247,
-    key.bodylength: 1
+    key.bodylength: 1,
+    key.attributes: [
+      {
+        key.offset: 213,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   }
 ]

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
@@ -84,6 +84,13 @@ public func pub_function()
     key.namelength: 7,
     key.bodyoffset: 48,
     key.bodylength: 31,
+    key.attributes: [
+      {
+        key.offset: 26,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -92,7 +99,14 @@ public func pub_function()
         key.offset: 61,
         key.length: 17,
         key.nameoffset: 66,
-        key.namelength: 12
+        key.namelength: 12,
+        key.attributes: [
+          {
+            key.offset: 54,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       }
     ]
   },
@@ -103,6 +117,13 @@ public func pub_function()
     key.offset: 89,
     key.length: 19,
     key.nameoffset: 94,
-    key.namelength: 14
+    key.namelength: 14,
+    key.attributes: [
+      {
+        key.offset: 82,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   }
 ]

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -377,7 +377,14 @@ internal enum Colors {
     key.nameoffset: 115,
     key.namelength: 18,
     key.bodyoffset: 135,
-    key.bodylength: 1
+    key.bodylength: 1,
+    key.attributes: [
+      {
+        key.offset: 102,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.class,
@@ -392,6 +399,13 @@ internal enum Colors {
     key.bodylength: 51,
     key.docoffset: 139,
     key.doclength: 27,
+    key.attributes: [
+      {
+        key.offset: 166,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -400,7 +414,14 @@ internal enum Colors {
         key.offset: 213,
         key.length: 8,
         key.nameoffset: 218,
-        key.namelength: 3
+        key.namelength: 3,
+        key.attributes: [
+          {
+            key.offset: 206,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -411,7 +432,14 @@ internal enum Colors {
         key.length: 14,
         key.typename: "Int",
         key.nameoffset: 240,
-        key.namelength: 5
+        key.namelength: 5,
+        key.attributes: [
+          {
+            key.offset: 227,
+            key.length: 8,
+            key.attribute: source.decl.attribute.internal
+          }
+        ]
       }
     ]
   },
@@ -429,6 +457,13 @@ internal enum Colors {
     key.inheritedtypes: [
       {
         key.name: "FooOverlayClassBase"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 254,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
       }
     ],
     key.elements: [
@@ -449,6 +484,11 @@ internal enum Colors {
         key.namelength: 3,
         key.attributes: [
           {
+            key.offset: 328,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          },
+          {
             key.offset: 319,
             key.length: 8,
             key.attribute: source.decl.attribute.override
@@ -467,7 +507,14 @@ internal enum Colors {
     key.nameoffset: 363,
     key.namelength: 20,
     key.bodyoffset: 385,
-    key.bodylength: 1
+    key.bodylength: 1,
+    key.attributes: [
+      {
+        key.offset: 348,
+        key.length: 8,
+        key.attribute: source.decl.attribute.internal
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.class,
@@ -479,7 +526,14 @@ internal enum Colors {
     key.nameoffset: 404,
     key.namelength: 22,
     key.bodyoffset: 428,
-    key.bodylength: 1
+    key.bodylength: 1,
+    key.attributes: [
+      {
+        key.offset: 389,
+        key.length: 8,
+        key.attribute: source.decl.attribute.internal
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.class,
@@ -492,6 +546,13 @@ internal enum Colors {
     key.namelength: 18,
     key.bodyoffset: 467,
     key.bodylength: 117,
+    key.attributes: [
+      {
+        key.offset: 432,
+        key.length: 8,
+        key.attribute: source.decl.attribute.internal
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -504,7 +565,14 @@ internal enum Colors {
         key.nameoffset: 512,
         key.namelength: 4,
         key.docoffset: 473,
-        key.doclength: 22
+        key.doclength: 22,
+        key.attributes: [
+          {
+            key.offset: 499,
+            key.length: 8,
+            key.attribute: source.decl.attribute.internal
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -517,7 +585,14 @@ internal enum Colors {
         key.nameoffset: 564,
         key.namelength: 2,
         key.docoffset: 527,
-        key.doclength: 19
+        key.doclength: 19,
+        key.attributes: [
+          {
+            key.offset: 550,
+            key.length: 8,
+            key.attribute: source.decl.attribute.internal
+          }
+        ]
       }
     ]
   },
@@ -531,6 +606,13 @@ internal enum Colors {
     key.namelength: 6,
     key.bodyoffset: 609,
     key.bodylength: 30,
+    key.attributes: [
+      {
+        key.offset: 587,
+        key.length: 8,
+        key.attribute: source.decl.attribute.internal
+      }
+    ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -643,9 +643,28 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
           return Attr_Open;
       }
     }
+    case DAK_SetterAccess: {
+      static UIdent Attr_Private("source.decl.attribute.setter_access.private");
+      static UIdent Attr_FilePrivate("source.decl.attribute.setter_access.fileprivate");
+      static UIdent Attr_Internal("source.decl.attribute.setter_access.internal");
+      static UIdent Attr_Public("source.decl.attribute.setter_access.public");
+      static UIdent Attr_Open("source.decl.attribute.setter_access.open");
+
+      switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
+        case AccessLevel::Private:
+          return Attr_Private;
+        case AccessLevel::FilePrivate:
+          return Attr_FilePrivate;
+        case AccessLevel::Internal:
+          return Attr_Internal;
+        case AccessLevel::Public:
+          return Attr_Public;
+        case AccessLevel::Open:
+          return Attr_Open;
+      }
+    }
 
     // Ignore these.
-    case DAK_SetterAccess:
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
     case DAK_DowngradeExhaustivityCheck:

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -623,11 +623,29 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
         return Attr_Objc;
       }
     }
+    case DAK_AccessControl: {
+      static UIdent Attr_Private("source.decl.attribute.private");
+      static UIdent Attr_FilePrivate("source.decl.attribute.fileprivate");
+      static UIdent Attr_Internal("source.decl.attribute.internal");
+      static UIdent Attr_Public("source.decl.attribute.public");
+      static UIdent Attr_Open("source.decl.attribute.open");
 
-    // We handle access control explicitly.
-    case DAK_AccessControl:
-    case DAK_SetterAccess:
+      switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
+        case AccessLevel::Private:
+          return Attr_Private;
+        case AccessLevel::FilePrivate:
+          return Attr_FilePrivate;
+        case AccessLevel::Internal:
+          return Attr_Internal;
+        case AccessLevel::Public:
+          return Attr_Public;
+        case AccessLevel::Open:
+          return Attr_Open;
+      }
+    }
+
     // Ignore these.
+    case DAK_SetterAccess:
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
     case DAK_DowngradeExhaustivityCheck:


### PR DESCRIPTION
This PR includes AccessLevel attributes inside `key.attributes` in structures.

This would make possible for tools like [SwiftLint](https://github.com/realm/SwiftLint) to get the ranges of these attributes, which can be useful for several rules:

* Enforcing that every top level declaration has an explicit AccessLevel
* Enforcing that all declarations have explicit AccessLevels
* Enforcing that an AccessLevel is omitted when it can be inferred
* Validating the order of "modifiers" (`private`, `mutating`, `final`, etc) of declarations
* Enforcing that the setter AccessLevel is not the same as the general one (e.g. `private(set) private foo: Int`)

This PR also adds attributes for setter AccessLevel in 472fd78c43203a6c746db720373c79352a066a29. I'm not sure if this is the best way to do it, creating attributes like `source.decl.attribute.setter_access.private`, so feedbacks are welcome!

Resolves [SR-5978](https://bugs.swift.org/browse/SR-5978).

// cc @nkcsgexi 
