### PR TITLE
[benchmark][cmake] Implement IS_SWIFT_BUILD correctly and rename it to SWIFT_BENCHMARK_BUILT_STANDALONE.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,6 +11,11 @@ cmake_minimum_required(VERSION 2.8.12)
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+set(SWIFT_BENCHMARK_BUILT_STANDALONE FALSE)
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(SWIFT_BENCHMARK_BUILT_STANDALONE TRUE)
+endif()
+
 include(AddSwiftBenchmarkSuite)
 
 set(SWIFT_BENCH_MODULES
@@ -240,16 +245,12 @@ endforeach()
 
 set(executable_targets)
 
-if(SWIFT_SDKS)
-  set(IS_SWIFT_BUILD true)
-endif()
-
 set(srcdir "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if(IS_SWIFT_BUILD)
-  get_filename_component(swift-bin-dir "${SWIFT_EXEC}" DIRECTORY)
-else()
+if(SWIFT_BENCHMARK_BUILT_STANDALONE)
   set(swift-bin-dir "${CMAKE_BINARY_DIR}/bin")
+else()
+  get_filename_component(swift-bin-dir "${SWIFT_EXEC}" DIRECTORY)
 endif()
 
 set(benchmark-bin-dir "${CMAKE_CURRENT_BINARY_DIR}/bin")

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -415,7 +415,7 @@ endfunction()
 function(swift_benchmark_compile)
   cmake_parse_arguments(SWIFT_BENCHMARK_COMPILE "" "PLATFORM" "" ${ARGN})
 
-  if(IS_SWIFT_BUILD)
+  if(NOT SWIFT_BENCHMARK_BUILT_STANDALONE)
     set(stdlib_dependencies "swift")
     foreach(stdlib_dependency ${UNIVERSAL_LIBRARY_NAMES_${SWIFT_BENCHMARK_COMPILE_PLATFORM}})
       string(FIND "${stdlib_dependency}" "Unittest" find_output)
@@ -441,7 +441,7 @@ function(swift_benchmark_compile)
     add_custom_target("${executable_target}"
         DEPENDS ${platform_executables})
 
-    if(IS_SWIFT_BUILD AND "${SWIFT_BENCHMARK_COMPILE_PLATFORM}" STREQUAL "macosx")
+    if(NOT SWIFT_BENCHMARK_BUILT_STANDALONE AND "${SWIFT_BENCHMARK_COMPILE_PLATFORM}" STREQUAL "macosx")
       add_custom_command(
           TARGET "${executable_target}"
           POST_BUILD


### PR DESCRIPTION
[benchmark][cmake] Implement IS_SWIFT_BUILD correctly and rename it to SWIFT_BENCHMARK_BUILT_STANDALONE.
