### PR TITLE
[Parse] Error recovery improvement

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -579,7 +579,12 @@ ParserResult<Stmt> Parser::parseStmt() {
 ParserResult<BraceStmt> Parser::parseBraceItemList(Diag<> ID) {
   if (Tok.isNot(tok::l_brace)) {
     diagnose(Tok, ID);
-    return nullptr;
+
+    // Attempt to recover by looking for a left brace on the same line
+    while (Tok.isNot(tok::eof, tok::l_brace) && !Tok.isAtStartOfLine())
+      skipSingle();
+    if (Tok.isNot(tok::l_brace))
+      return nullptr;
   }
   SourceLoc LBLoc = consumeToken(tok::l_brace);
 

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -104,8 +104,7 @@ func illformed() throws {
     do {
       _ = try genError()
 
-    // TODO: this recovery is terrible
-    } catch MSV.CarriesInt(let i) where i == genError()) { // expected-error {{call can throw, but errors cannot be thrown out of a catch guard expression}} expected-error {{expected '{'}} expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}} {{58-58=do }}
+    } catch MSV.CarriesInt(let i) where i == genError()) { // expected-error {{call can throw, but errors cannot be thrown out of a catch guard expression}} expected-error {{expected '{'}}
     }
 }
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -194,7 +194,7 @@ func missingControllingExprInForEach() {
   // expected-error @+3 {{expected pattern}}
   // expected-error @+2 {{expected Sequence expression for for-each loop}}
   // expected-error @+1 {{expected '{' to start the body of for-each loop}}
-  for for in { // expected-error {{expected pattern}} expected-error {{expected Sequence expression for for-each loop}}
+  for for in {
   }
 
   for i in { // expected-error {{expected Sequence expression for for-each loop}}
@@ -215,6 +215,15 @@ func missingControllingExprInForEach() {
     var x = 42
   }
 #endif
+  
+  // SR-5943
+  struct User { let name: String? }
+  let users = [User]()
+  for user in users whe { // expected-error {{expected '{' to start the body of for-each loop}}
+    if let name = user.name {
+      let key = "\(name)"
+    }
+  }
 }
 
 func missingControllingExprInSwitch() {

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -94,7 +94,7 @@ if 1 != 2, 4 == 57 {}
 if 1 != 2, 4 == 57, let x = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 
 // Test that these don't cause the parser to crash.
-if true { if a == 0; {} }   // expected-error {{expected '{' after 'if' condition}} expected-error 2{{}} expected-note 1{{}}
+if true { if a == 0; {} }   // expected-error {{use of unresolved identifier 'a'}} expected-error {{expected '{' after 'if' condition}}
 if a == 0, where b == 0 {}  // expected-error 3{{}} expected-note {{}} {{25-25=do }}
 
 


### PR DESCRIPTION
When parsing a statement that expects a brace item list and the "{" isn't where we expect, try to recover by skipping tokens on the same line until we find an open brace, and use that as the item list if we find it. (While still erroring that we expected a brace on the first bad token.) Improves recovery in general and in SR-5943 in particular.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5943](https://bugs.swift.org/browse/SR-5943).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->