### PR TITLE
Autorelease to close files and not leak memory after invoking swiftc in SwiftSyntax tool.

### DIFF
--- a/tools/SwiftSyntax/SwiftcInvocation.swift
+++ b/tools/SwiftSyntax/SwiftcInvocation.swift
@@ -72,6 +72,9 @@ func run(_ executable: URL, arguments: [String] = []) -> ProcessResult {
   process.terminationHandler = { process in
     stdoutPipe.fileHandleForReading.readabilityHandler = nil
     stderrPipe.fileHandleForReading.readabilityHandler = nil
+    
+    stdoutPipe.fileHandleForReading.closeFile()
+    stderrPipe.fileHandleForReading.closeFile()
   }
 
   process.launchPath = executable.path

--- a/tools/SwiftSyntax/SwiftcInvocation.swift
+++ b/tools/SwiftSyntax/SwiftcInvocation.swift
@@ -55,37 +55,39 @@ struct ProcessResult {
 ///   - arguments: A list of strings to pass to the process as arguments.
 /// - Returns: A ProcessResult containing stdout, stderr, and the exit code.
 func run(_ executable: URL, arguments: [String] = []) -> ProcessResult {
-  let stdoutPipe = Pipe()
-  var stdoutData = Data()
-  stdoutPipe.fileHandleForReading.readabilityHandler = { file in
-    stdoutData.append(file.availableData)
-  }
-
-  let stderrPipe = Pipe()
-  var stderrData = Data()
-  stderrPipe.fileHandleForReading.readabilityHandler = { file in
-    stderrData.append(file.availableData)
-  }
-
-  let process = Process()
-
-  process.terminationHandler = { process in
-    stdoutPipe.fileHandleForReading.readabilityHandler = nil
-    stderrPipe.fileHandleForReading.readabilityHandler = nil
+  // Use an autoreleasepool to prevent memory- and file-descriptor leaks.
+  return autoreleasepool {
+    () -> ProcessResult in
     
-    stdoutPipe.fileHandleForReading.closeFile()
-    stderrPipe.fileHandleForReading.closeFile()
+    let stdoutPipe = Pipe()
+    var stdoutData = Data()
+    stdoutPipe.fileHandleForReading.readabilityHandler = { file in
+      stdoutData.append(file.availableData)
+    }
+    
+    let stderrPipe = Pipe()
+    var stderrData = Data()
+    stderrPipe.fileHandleForReading.readabilityHandler = { file in
+      stderrData.append(file.availableData)
+    }
+    
+    let process = Process()
+    
+    process.terminationHandler = { process in
+      stdoutPipe.fileHandleForReading.readabilityHandler = nil
+      stderrPipe.fileHandleForReading.readabilityHandler = nil
+    }
+    
+    process.launchPath = executable.path
+    process.arguments = arguments
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    process.launch()
+    process.waitUntilExit()
+    return ProcessResult(exitCode: Int(process.terminationStatus),
+                         stdoutData: stdoutData,
+                         stderrData: stderrData)
   }
-
-  process.launchPath = executable.path
-  process.arguments = arguments
-  process.standardOutput = stdoutPipe
-  process.standardError = stderrPipe
-  process.launch()
-  process.waitUntilExit()
-  return ProcessResult(exitCode: Int(process.terminationStatus),
-                       stdoutData: stdoutData,
-                       stderrData: stderrData)
 }
 
 /// Finds the dylib or executable which the provided address falls in.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Close the output file descriptors after the swiftc invocation. I have testing this code in a different program, but have not tested this in situ. (I don't know how to test this particular tool.)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
