### PR TITLE
build: improve SourceKit handling of libdispatch

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -98,25 +98,52 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                         CMAKE_ARGS
                           -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
                           -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
+                          -DCMAKE_SWIFT_COMPILER=$<TARGET_FILE:swift>c
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                          -DENABLE_SWIFT=YES
                         BUILD_BYPRODUCTS
-                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX})
+                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
+                        STEP_TARGETS
+                          configure)
 
+    # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
+    # the directory existing.  Just create the location which will be populated
+    # during the installation.
+    ExternalProject_Get_Property(libdispatch install_dir)
+    file(MAKE_DIRECTORY ${install_dir}/include)
+
+    # TODO(compnerd) this should be taken care of by the
+    # INTERFACE_INCLUDE_DIRECTORIES below
     include_directories(AFTER
-                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
-    link_directories(${SWIFT_PATH_TO_LIBDISPATCH_BUILD})
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
+    add_dependencies(libdispatch-configure
+                       swift
+                       swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
+                       swiftSwiftOnoneSupport-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
+                       swiftCore-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
+                       swiftSwiftOnoneSupport-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
   endif()
 
-  include_directories(AFTER ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
-
-  add_library(dispatch UNKNOWN IMPORTED)
+  ExternalProject_Get_Property(libdispatch install_dir)
+  add_library(dispatch SHARED IMPORTED)
   set_target_properties(dispatch
                         PROPERTIES
-                          IMPORTED_LOCATION ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX})
+                          IMPORTED_LOCATION
+                            ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                          INTERFACE_INCLUDE_DIRECTORIES
+                            ${install_dir}/include
+                          IMPORTED_LINK_INTERFACE_LIBRARIES
+                            swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
 
-  add_library(swiftCore SHARED IMPORTED)
-  set_target_properties(swiftCore PROPERTIES
-                        IMPORTED_LOCATION ${SOURCEKIT_BINARY_DIR}/lib/swift/linux/libswiftCore.so)
+  add_library(BlocksRuntime STATIC IMPORTED)
+  set_target_properties(BlocksRuntime
+                        PROPERTIES
+                          IMPORTED_LOCATION
+                            ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
+                          INTERFACE_INCLUDE_DIRECTORIES
+                            ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 
   set(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH TRUE)
 endif()

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -118,7 +118,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     include_directories(AFTER
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
-    add_dependencies(libdispatch-configure
+    add_dependencies(libdispatch
                        swift
                        swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
                        swiftSwiftOnoneSupport-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -67,8 +67,18 @@ function(add_sourcekit_default_compiler_flags target)
     RESULT_VAR_NAME link_flags)
 
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    # TODO(compnerd) this should really use target_compile_options but the use
+    # of keyword and non-keyword flags prevents this
     list(APPEND c_compile_flags "-fblocks")
+    # TODO(compnerd) this should really use target_link_libraries but the use of
+    # explicit_llvm_config using target_link_libraries without keywords on
+    # executables causes conflicts here
+    list(APPEND link_flags "-L${SWIFT_PATH_TO_LIBDISPATCH_BUILD}")
     list(APPEND link_flags "-lBlocksRuntime")
+    # NOTE(compnerd) since we do not use target_link_libraries, we do not get
+    # the implicit dependency tracking.  Add an explicit dependency until we can
+    # use target_link_libraries.
+    add_dependencies(${target} BlocksRuntime)
   endif()
 
   # Convert variables to space-separated strings.

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
 endif()
 
 if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch swiftCore)
+  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch)
 endif()
 
 add_sourcekit_executable(complete-test

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -9,7 +9,7 @@ if(HAVE_UNICODE_LIBEDIT)
   endif()
 
   if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-    set(SOURCEKITD_REPL_LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} dispatch swiftCore)
+    set(SOURCEKITD_REPL_LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} dispatch)
   endif()
 
   add_sourcekit_executable(sourcekitd-repl

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
 endif()
 
 if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch swiftCore)
+  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch)
 endif()
 
 add_sourcekit_executable(sourcekitd-test

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -42,10 +42,6 @@ if (SOURCEKITD_BUILD_STATIC_INPROC)
   )
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-  target_link_libraries(sourcekitdInProc PUBLIC BlocksRuntime)
-endif()
-
 if (SOURCEKIT_BUILT_STANDALONE)
   # Create the symlinks necessary to find the swift runtime.
   add_custom_command(TARGET sourcekitdInProc PRE_BUILD


### PR DESCRIPTION
Avoid overwriting the `swiftCore` target in the SourceKit build.
Instead, link to the explicit variant of the swiftCore.  This tracks the
dependency better and enables multiple parallel cross-compilations of
the stdlib.

Implicitly link against swiftCore when linking against libdispatch.
Remove the extraneous link against the Blocks runtime on Linux.  The
`add_sourcekit_executable` call already handles this.  Ensure that we
enable the swift SDK overlay for libdispatch by sending it the path to
the swift compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
