### PR TITLE
Build fix for LLDB: resolve ambiguity with operator delete

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -524,6 +524,8 @@ public:
   // Redeclare because lldb currently doesn't know about using-declarations
   void dump() const;
 
+  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
+
   ValueKind getValueKind() const {
     return ValueBase::getKind();
   }


### PR DESCRIPTION
This is required to allow uses of the `new` operator to compile when you're building with exceptions enabled.