### PR TITLE
Fix output of function name in crash trace.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -291,11 +291,11 @@ void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
 
   assert(analysesUnlocked() && "Expected all analyses to be unlocked!");
 
-  PrettyStackTraceSILFunctionTransform X(SFT, NumPassesRun);
-  DebugPrintEnabler DebugPrint(NumPassesRun);
-
   SFT->injectPassManager(this);
   SFT->injectFunction(F);
+
+  PrettyStackTraceSILFunctionTransform X(SFT, NumPassesRun);
+  DebugPrintEnabler DebugPrint(NumPassesRun);
 
   // If nothing changed since the last run of this pass, we can skip this
   // pass.
@@ -440,11 +440,11 @@ void SILPassManager::runModulePass(SILModuleTransform *SMT) {
 
   const SILOptions &Options = getOptions();
 
-  PrettyStackTraceSILModuleTransform X(SMT, NumPassesRun);
-  DebugPrintEnabler DebugPrint(NumPassesRun);
-
   SMT->injectPassManager(this);
   SMT->injectModule(Mod);
+
+  PrettyStackTraceSILModuleTransform X(SMT, NumPassesRun);
+  DebugPrintEnabler DebugPrint(NumPassesRun);
 
   updateSILModuleStatsBeforeTransform(*Mod, SMT, *this, NumPassesRun);
 


### PR DESCRIPTION
In the crash output 'While running pass #x SILFunctionTransform "T" on SILFunction "@F".' we printed the previous function which was handled by the pass instead of the current one.
