### PR TITLE
[4.0] SIL: Substitute DynamicSelfType out of context when synthesizing a capture parameter for it.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -765,9 +765,14 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
     for (auto capture : loweredCaptures.getCaptures()) {
       if (capture.isDynamicSelfMetadata()) {
         ParameterConvention convention = ParameterConvention::Direct_Unowned;
+        auto dynamicSelfInterfaceType = GenericEnvironment::mapTypeOutOfContext(
+          function->getGenericEnvironment(),
+          loweredCaptures.getDynamicSelfType());
+        
         auto selfMetatype = MetatypeType::get(
-            loweredCaptures.getDynamicSelfType(),
+            dynamicSelfInterfaceType,
             MetatypeRepresentation::Thick);
+        
         auto canSelfMetatype = getCanonicalType(selfMetatype);
         SILParameterInfo param(canSelfMetatype, convention);
         inputs.push_back(param);

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -363,6 +363,28 @@ class Derived : Base {
   }
 }
 
+class Generic<T> {
+  // Examples where we have to add a special argument to capture Self's metadata
+  func t1() -> Self {
+    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t1ACyxGXDyFAEXDSgycfU_ : $@convention(thin) <T> (@owned <τ_0_0> { var @sil_weak Optional<Generic<τ_0_0>> } <T>, @thick @dynamic_self Generic<T>.Type) -> @owned Optional<Generic<T>>
+    _ = {[weak self] in self }
+    return self
+  }
+
+  func t2() -> Self {
+    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t2ACyxGXDyFAEXD_AEXDtycfU_ : $@convention(thin) <T> (@owned (Generic<T>, Generic<T>), @thick @dynamic_self Generic<T>.Type) -> (@owned Generic<T>, @owned Generic<T>)
+    let selves = (self, self)
+    _ = { selves }
+    return self
+  }
+
+  func t3() -> Self {
+    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t3ACyxGXDyFAEXDycfU_ : $@convention(thin) <T> (@owned @sil_unowned Generic<T>, @thick @dynamic_self Generic<T>.Type) -> @owned Generic<T> 
+    _ = {[unowned self] in self }
+    return self
+  }
+}
+
 // CHECK-LABEL: sil_witness_table hidden X: P module dynamic_self {
 // CHECK: method #P.f!1: {{.*}} : @_T012dynamic_self1XCAA1PA2aDP1f{{[_0-9a-zA-Z]*}}FTW
 


### PR DESCRIPTION
Explanation: The compiler would crash in situations where code captured `[weak self]` in a closure inside a class method returning dynamic `Self`.

Scope of issue: Regression from Swift 3.x

Issue:  rdar://problem/34563466.

Risk: Low. Small, targeted bug fix.

Testing: Swift CI, compatibility suite, project from Radar