### PR TITLE
[Diagnostics] Restore `inout` ParamDecl types properly after type-check

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0119-rdar33613329.swift
+++ b/validation-test/compiler_crashers_2_fixed/0119-rdar33613329.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift %s
+
+precedencegroup BindingPrecedence {
+  higherThan: DefaultPrecedence
+}
+
+infix operator ~>
+infix operator ≈> : BindingPrecedence
+
+struct M<L : P, R> {
+  let f: L
+  let b: (inout L.B) -> R
+
+  init(f: L, b: @escaping (inout L.B) -> R) {
+    self.f = f
+    self.b = b
+  }
+}
+
+protocol P {
+  associatedtype A
+  associatedtype B
+
+  func `in`<R>(_ a: inout A, apply body: (inout B) -> R) -> R
+
+  static func ~> (_: A, _: Self) -> B
+}
+
+extension P {
+  static func ≈> <R>(f: Self,  b: @escaping (inout B) -> R) -> M<Self, R> {}
+}
+
+extension WritableKeyPath : P {
+  typealias A = Root
+  typealias B = Value
+
+  func `in`<R>(_ a: inout A, apply body: (inout B) -> R) -> R {}
+
+  static func ~> (a: A, path: WritableKeyPath) -> B {}
+}
+
+struct X { var y: Int = 0 }
+var x = X()
+x ~> \X.y ≈> { a in a += 1; return 3 }
+// expected-error@-1 {{cannot convert call result type 'M<WritableKeyPath<X, Int>, _>' to expected type 'WritableKeyPath<_, _>'}}


### PR DESCRIPTION
We are currently in process of removing `InOutType`
so `VarDecl::get{Interface}Type` is going to wrap base
type into `InOutType` if its flag indicates that it's
an `inout` parameter declaration. But such type can't
be restored directly using `VarDecl::set{Interface}Type`
caller needs additional logic to extract base type.

Resolves: rdar://problem/33613329

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
