### PR TITLE
[Constraint system] Move addPotentialBinding implementation back to CSBdinings.cpp.

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -123,6 +123,40 @@ static bool shouldBindToValueType(Constraint *constraint) {
   llvm_unreachable("Unhandled ConstraintKind in switch.");
 }
 
+void ConstraintSystem::PotentialBindings::addPotentialBinding(
+    PotentialBinding binding, bool allowJoinMeet) {
+  assert(!binding.BindingType->is<ErrorType>());
+
+  // If this is a non-defaulted supertype binding,
+  // check whether we can combine it with another
+  // supertype binding by computing the 'join' of the types.
+  if (binding.Kind == AllowedBindingKind::Supertypes &&
+      !binding.BindingType->hasTypeVariable() && !binding.DefaultedProtocol &&
+      !binding.isDefaultableBinding() && allowJoinMeet) {
+    if (lastSupertypeIndex) {
+      // Can we compute a join?
+      auto &lastBinding = Bindings[*lastSupertypeIndex];
+      auto lastType = lastBinding.BindingType->getWithoutSpecifierType();
+      auto bindingType = binding.BindingType->getWithoutSpecifierType();
+      auto join = Type::join(lastType, bindingType);
+      if (join) {
+        auto anyType = join->getASTContext().TheAnyType;
+        if (!join->isEqual(anyType) || lastType->isEqual(anyType) ||
+            bindingType->isEqual(anyType)) {
+          // Replace the last supertype binding with the join. We're done.
+          lastBinding.BindingType = join;
+          return;
+        }
+      }
+    }
+
+    // Record this as the most recent supertype index.
+    lastSupertypeIndex = Bindings.size();
+  }
+
+  Bindings.push_back(std::move(binding));
+}
+
 /// \brief Retrieve the set of potential type bindings for the given
 /// representative type variable, along with flags indicating whether
 /// those types should be opened.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2629,39 +2629,7 @@ private:
     /// \brief Add a potential binding to the list of bindings,
     /// coalescing supertype bounds when we are able to compute the meet.
     void addPotentialBinding(PotentialBinding binding,
-                             bool allowJoinMeet = true) {
-      assert(!binding.BindingType->is<ErrorType>());
-
-      // If this is a non-defaulted supertype binding,
-      // check whether we can combine it with another
-      // supertype binding by computing the 'join' of the types.
-      if (binding.Kind == AllowedBindingKind::Supertypes &&
-          !binding.BindingType->hasTypeVariable() &&
-          !binding.DefaultedProtocol && !binding.isDefaultableBinding() &&
-          allowJoinMeet) {
-        if (lastSupertypeIndex) {
-          // Can we compute a join?
-          auto &lastBinding = Bindings[*lastSupertypeIndex];
-          auto lastType = lastBinding.BindingType->getWithoutSpecifierType();
-          auto bindingType = binding.BindingType->getWithoutSpecifierType();
-          auto join = Type::join(lastType, bindingType);
-          if (join) {
-            auto anyType = join->getASTContext().TheAnyType;
-            if (!join->isEqual(anyType) || lastType->isEqual(anyType) ||
-                bindingType->isEqual(anyType)) {
-              // Replace the last supertype binding with the join. We're done.
-              lastBinding.BindingType = join;
-              return;
-            }
-          }
-        }
-
-        // Record this as the most recent supertype index.
-        lastSupertypeIndex = Bindings.size();
-      }
-
-      Bindings.push_back(std::move(binding));
-    }
+                             bool allowJoinMeet = true);
 
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {


### PR DESCRIPTION
The method is logically part of PotentialBindings, but the
implementation doesn't need to live in the header.
