### PR TITLE
[Refactoring] CursorInfoResolver now properly handles cursor placement in OptionalTryExpr and ForceTryExpr

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1968,7 +1968,8 @@ bool RefactoringActionConvertToDoCatch::performChange() {
   OS << "\n} catch {\n" << getCodePlaceholder() << "\n}";
 
   // Delete ! from try! expression
-  auto ExclaimRange = CharSourceRange(TryExpr->getExclaimLoc(), 1);
+  auto ExclaimLen = getKeywordLen(tok::exclaim_postfix);
+  auto ExclaimRange = CharSourceRange(TryExpr->getExclaimLoc(), ExclaimLen);
   EditConsumer.accept(SM, ExclaimRange, "");
   return false;
 }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -195,15 +195,17 @@ bool CursorInfoResolver::walkToExprPre(Expr *E) {
         IsProperCursorLocation = Loc == LocToResolve || IsProperCursorLocation;
       };
       auto TryLoc = ATE->getTryLoc();
-      auto TryEndLoc = TryLoc.getAdvancedLocOrInvalid(3);
+      auto TryEndLoc = TryLoc.getAdvancedLocOrInvalid(getKeywordLen(tok::kw_try));
       CheckLocation(TryEndLoc);
       if (auto *FTE = dyn_cast<ForceTryExpr>(E)) {
         auto ExclaimLoc = FTE->getExclaimLoc();
-        CheckLocation(ExclaimLoc.getAdvancedLocOrInvalid(1));
+        auto ExclaimLen = getKeywordLen(tok::exclaim_postfix);
+        CheckLocation(ExclaimLoc.getAdvancedLocOrInvalid(ExclaimLen));
       }
       if (auto *OTE = dyn_cast<OptionalTryExpr>(E)) {
         auto QuestionLoc = OTE->getQuestionLoc();
-        CheckLocation(QuestionLoc.getAdvancedLocOrInvalid(1));
+        auto QuestionLen = getKeywordLen(tok::question_postfix);
+        CheckLocation(QuestionLoc.getAdvancedLocOrInvalid(QuestionLen));
       }
     }
     // Keep track of trailing expressions.

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -189,24 +189,15 @@ bool CursorInfoResolver::walkToExprPre(Expr *E) {
       }
     }
     auto IsProperCursorLocation = E->getStartLoc() == LocToResolve;
-    // Handle cursor placement after Try, ForceTry and OptionalTry Expr.
-    if (auto *ATE = dyn_cast<AnyTryExpr>(E)) {
-      auto CheckLocation = [&IsProperCursorLocation, this](SourceLoc Loc) {
-        IsProperCursorLocation = Loc == LocToResolve || IsProperCursorLocation;
-      };
-      auto TryLoc = ATE->getTryLoc();
-      auto TryEndLoc = TryLoc.getAdvancedLocOrInvalid(getKeywordLen(tok::kw_try));
-      CheckLocation(TryEndLoc);
-      if (auto *FTE = dyn_cast<ForceTryExpr>(E)) {
-        auto ExclaimLoc = FTE->getExclaimLoc();
-        auto ExclaimLen = getKeywordLen(tok::exclaim_postfix);
-        CheckLocation(ExclaimLoc.getAdvancedLocOrInvalid(ExclaimLen));
-      }
-      if (auto *OTE = dyn_cast<OptionalTryExpr>(E)) {
-        auto QuestionLoc = OTE->getQuestionLoc();
-        auto QuestionLen = getKeywordLen(tok::question_postfix);
-        CheckLocation(QuestionLoc.getAdvancedLocOrInvalid(QuestionLen));
-      }
+    // Handle cursor placement after `try` in ForceTry and OptionalTry Expr.
+    auto CheckLocation = [&IsProperCursorLocation, this](SourceLoc Loc) {
+      IsProperCursorLocation = Loc == LocToResolve || IsProperCursorLocation;
+    };
+    if (auto *FTE = dyn_cast<ForceTryExpr>(E)) {
+      CheckLocation(FTE->getExclaimLoc());
+    }
+    if (auto *OTE = dyn_cast<OptionalTryExpr>(E)) {
+      CheckLocation(OTE->getQuestionLoc());
     }
     // Keep track of trailing expressions.
     if (!E->isImplicit() && IsProperCursorLocation)

--- a/test/refactoring/RefactoringKind/basic.swift
+++ b/test/refactoring/RefactoringKind/basic.swift
@@ -300,6 +300,7 @@ func testForceTry() {
 // RUN: %refactor -source-filename %s -pos=217:12 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
 // RUN: %refactor -source-filename %s -pos=217:13 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
 // RUN: %refactor -source-filename %s -pos=217:14 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
+// RUN: %refactor -source-filename %s -pos=217:15 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
 
 // CHECK1: Action begins
 // CHECK1-NEXT: Extract Method

--- a/test/refactoring/RefactoringKind/basic.swift
+++ b/test/refactoring/RefactoringKind/basic.swift
@@ -300,7 +300,6 @@ func testForceTry() {
 // RUN: %refactor -source-filename %s -pos=217:12 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
 // RUN: %refactor -source-filename %s -pos=217:13 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
 // RUN: %refactor -source-filename %s -pos=217:14 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
-// RUN: %refactor -source-filename %s -pos=217:15 | %FileCheck %s -check-prefix=CHECK-TRY-CATCH
 
 // CHECK1: Action begins
 // CHECK1-NEXT: Extract Method


### PR DESCRIPTION
Small fixes to the resolver which should make recognizing refactoring based on `AnyTryExpr` works properly. Added one test case which is examining this behavior. Also fixed range calculations in one of the refactorings — the number of bytes was hardcoded and now it's computed.

cc: @nkcsgexi @harlanhaskins 