### PR TITLE
IRGen: Fix linkage for shared declarations

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1415,7 +1415,8 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
 
   case SILLinkage::Shared:
   case SILLinkage::SharedExternal:
-    return RESULT(LinkOnceODR, Hidden, Default);
+    return isDefinition ? RESULT(LinkOnceODR, Hidden, Default)
+                        : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
     return RESULT(External, Hidden, Default);

--- a/test/IRGen/Inputs/usr/include/NSOption.h
+++ b/test/IRGen/Inputs/usr/include/NSOption.h
@@ -1,0 +1,7 @@
+#define CF_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
+#define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
+
+typedef NS_OPTIONS(int, SomeOptions) {
+  SomeOptionsFoo = 1,
+  SomeOptionsBar = 2,
+};

--- a/test/IRGen/objc_shared_imported_decl.sil
+++ b/test/IRGen/objc_shared_imported_decl.sil
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -primary-file %s -import-objc-header %S/Inputs/usr/include/NSOption.h -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Swift
+
+sil public @use_witness : $@convention(thin) () -> () {
+  %0 = witness_method $SomeOptions, #Equatable."=="!1 : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool
+  %1 = tuple ()
+  return %1: $()
+}
+
+// We used to emit linkonce_odr llvm linkage for this declaration.
+sil_witness_table shared SomeOptions : Equatable module __ObjC
+
+// CHECK: @_T0SC11SomeOptionsVs9EquatableSoWP = external hidden global


### PR DESCRIPTION
They need external linkage not linkonce_odr which can only be used by defintions
not declarations.
This got exposed by clang imported protocol witness table declarations.
They get assigned shared linkage since they are potentially not unique.

rdar://26563441