### PR TITLE
[stdlib] Implement -retainCount in _SwiftNativeNS*Base

### DIFF
--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -24,9 +24,9 @@
 // To trick Swift into using its fast refcounting and allocation
 // directly (rather than going through objc_msgSend to arrive at the
 // implementations defined here), we define subclasses on the Swift
-// side but hide the inheritance relationship from the Swift compiler
-// and only establish it dynamically, in the '+ load' method of each
-// class defined here.
+// side but we establish the inheritance relationship with
+// the special @_swift_native_objc_runtime_base attribute rather
+// than directly subclassing the classes defined here.
 //
 //===----------------------------------------------------------------------===//
 
@@ -71,6 +71,10 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 }
 - (id)autorelease {
   return _objc_rootAutorelease(self);
+}
+- (NSUInteger)retainCount {
+  auto SELF = reinterpret_cast<HeapObject *>(self);
+  return swift_retainCount(SELF);
 }
 
 - (BOOL)_tryRetain {

--- a/test/stdlib/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m
+++ b/test/stdlib/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m
@@ -40,8 +40,23 @@ static int Errors;
   } while (0)
 
 
-void TestSwiftNativeNSBase(void)
+BOOL TestSwiftNativeNSBase_RetainCount(id object)
 {
+  Errors = 0;
+  NSUInteger rc1 = [object retainCount];
+  id object2 = [object retain];
+  expectTrue(object == object2);
+  NSUInteger rc2 = [object retainCount];
+  expectTrue(rc2 > rc1);
+  [object release];
+  NSUInteger rc3 = [object retainCount];
+  expectTrue(rc3 < rc2);
+  return Errors == 0;
+}
+
+BOOL TestSwiftNativeNSBase_UnwantedCdtors()
+{
+  Errors = 0;
   printf("TestSwiftNativeNSBase\n");
 
   unsigned int classCount;
@@ -82,5 +97,5 @@ void TestSwiftNativeNSBase(void)
 
   printf("TestSwiftNativeNSBase: %d error%s\n",
          Errors, Errors == 1 ? "" : "s");
-  exit(Errors ? 1 : 0);
+  return Errors == 0;
 }

--- a/validation-test/stdlib/SwiftNativeNSBase.swift
+++ b/validation-test/stdlib/SwiftNativeNSBase.swift
@@ -13,16 +13,71 @@
 // RUN: %empty-directory(%t)
 // 
 // RUN: %target-clang %S/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m -c -o %t/SwiftNativeNSBase.o -g
-// RUN: %target-build-swift %s -I %S/Inputs/SwiftNativeNSBase/ -Xlinker %t/SwiftNativeNSBase.o -o %t/SwiftNativeNSBase
+// RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
+// RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"
+// RUN: %target-build-swift -Xfrontend -disable-access-control  %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -I %S/Inputs/SwiftNativeNSBase/ -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -Xlinker %t/SwiftNativeNSBase.o -o %t/SwiftNativeNSBase
 // RUN: %target-run %t/SwiftNativeNSBase
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
 
 import Foundation
+import StdlibUnittest
 
-@_silgen_name("TestSwiftNativeNSBase") 
-func TestSwiftNativeNSBase()
+@_silgen_name("TestSwiftNativeNSBase_UnwantedCdtors") 
+func TestSwiftNativeNSBase_UnwantedCdtors() -> Bool
+@_silgen_name("TestSwiftNativeNSBase_RetainCount") 
+func TestSwiftNativeNSBase_RetainCount(_: UnsafeMutableRawPointer) -> Bool
 
-TestSwiftNativeNSBase()
-// does not return
+func classChain(of cls: AnyClass) -> [String] {
+  var chain: [String] = []
+  var cls: AnyClass? = cls
+  while cls != nil {
+    chain.append(NSStringFromClass(cls!))
+    cls = class_getSuperclass(cls)
+  }
+  return chain
+}
+
+var SwiftNativeNSBaseTestSuite = TestSuite("SwiftNativeNSBase")
+
+SwiftNativeNSBaseTestSuite.test("UnwantedCdtors") {
+  expectTrue(TestSwiftNativeNSBase_UnwantedCdtors())
+}
+
+SwiftNativeNSBaseTestSuite.test("_SwiftNativeNSArrayBase.retainCount") {
+  let bridged = getBridgedNSArrayOfRefTypeVerbatimBridged()
+  assert(classChain(of: type(of: bridged)).contains("_SwiftNativeNSArrayBase"))
+  expectTrue(TestSwiftNativeNSBase_RetainCount(
+      Unmanaged.passUnretained(bridged).toOpaque()))
+  _fixLifetime(bridged)
+}
+
+SwiftNativeNSBaseTestSuite.test("_SwiftNativeNSDictionaryBase.retainCount") {
+  let bridged = getBridgedNSDictionaryOfRefTypesBridgedVerbatim()
+  assert(classChain(of: type(of: bridged))
+    .contains("_SwiftNativeNSDictionaryBase"))
+  expectTrue(TestSwiftNativeNSBase_RetainCount(
+      Unmanaged.passUnretained(bridged).toOpaque()))
+  _fixLifetime(bridged)
+}
+
+SwiftNativeNSBaseTestSuite.test("_SwiftNativeNSSetBase.retainCount") {
+  let bridged = Set([10, 20, 30].map{ TestObjCKeyTy($0) })._bridgeToObjectiveC()
+  assert(classChain(of: type(of: bridged)).contains("_SwiftNativeNSSetBase"))
+  expectTrue(TestSwiftNativeNSBase_RetainCount(
+      Unmanaged.passUnretained(bridged).toOpaque()))
+  _fixLifetime(bridged)
+}
+
+SwiftNativeNSBaseTestSuite.setUp {
+  resetLeaksOfDictionaryKeysValues()
+  resetLeaksOfObjCDictionaryKeysValues()
+}
+
+SwiftNativeNSBaseTestSuite.tearDown {
+  expectNoLeaksOfDictionaryKeysValues()
+  expectNoLeaksOfObjCDictionaryKeysValues()
+}
+
+runAllTests()


### PR DESCRIPTION

<!-- What's in this pull request? -->
Adds overrides for `-retainCount` on `_SwiftNativeNSArrayBase`, `_SwiftNativeNSDictionaryBase`, etc., to go along with the existing `-retain`, `-release`, `-autorelease` overrides. It also updates tests to verify the new implementations on bridged arrays, dictionaries and sets.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes rdar://problem/28002554.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
