### PR TITLE
Fix runtime metadata unit test even harder

### DIFF
--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -165,13 +165,14 @@ uint32_t Global2 = 0;
 uint32_t Global3 = 0;
 
 /// The general structure of a generic metadata.
-template <typename Instance>
+template <typename Instance, unsigned NumArguments>
 struct GenericMetadataTest {
   GenericMetadata Header;
   Instance Template;
+  void *Storage[NumArguments];
 };
 
-GenericMetadataTest<StructMetadata> MetadataTest1 = {
+GenericMetadataTest<StructMetadata, 1> MetadataTest1 = {
   // Header
   {
     // allocation function
@@ -182,7 +183,7 @@ GenericMetadataTest<StructMetadata> MetadataTest1 = {
       metadataWords[2] = argsWords[0];
       return metadata;
     },
-    2 * sizeof(void*), // metadata size
+    3 * sizeof(void*), // metadata size
     1, // num arguments
     0, // address point
     {} // private data
@@ -192,7 +193,10 @@ GenericMetadataTest<StructMetadata> MetadataTest1 = {
   {
     MetadataKind::Struct,
     reinterpret_cast<const NominalTypeDescriptor*>(&Global1)
-  }
+  },
+
+  // Arguments
+  {nullptr}
 };
 
 struct TestObjContainer {


### PR DESCRIPTION
StructMetadata is now two words that the parent pointer is gone.
We need to add our own storage for the generic arguments, instead
of smashing the location where the parent pointer used to be.

My previous fix was incorrect because it would set the template
size to two words (thus we no longer read past the end of the
template) but in turn we would write past the end of the
instantiated metadata.