### PR TITLE
stubs: fix architecture check for Windows

### DIFF
--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -109,7 +109,7 @@ SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_destroyTLS(void *);
 
 static void
-#if defined(_M_X86)
+#if defined(_M_IX86)
 __stdcall
 #endif
 _swift_stdlib_destroyTLS_CCAdjustmentThunk(void *ptr) {


### PR DESCRIPTION
Fix a typo in the architecture check.  The missing `I` in the x86 check
prevented the x86 build from succeeding.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
