### PR TITLE
stubs: fix Windows link

### DIFF
--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -330,7 +330,5 @@ void swift::__swift_stdlib_ubrk_setText(
 // Force an autolink with ICU
 #if defined(__MACH__)
 asm(".linker_option \"-licucore\"\n");
-#elif defined(_WIN32)
-#pragma comment(lib, "icucore.lib")
 #endif // defined(__MACH__)
 


### PR DESCRIPTION
There is no icucore.lib in the official ICU distribution for Windows.
Remove the autolink directive for now.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
