### PR TITLE
SR-5753: Don't warn about constraints redundant with inferred constraints

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -769,16 +769,6 @@ public:
     /// \c TypeRepr.
     Inferred,
 
-    /// A requirement inferred from part of the signature of a declaration
-    /// but for which we don't want to produce warnings, e.g., the result
-    /// type of a generic function:
-    ///
-    /// func f<T>() -> Set<T> { ... } // infers T: Hashable, but don't warn
-    ///
-    /// This is a root requirement source, which can be described by a
-    /// \c TypeRepr.
-    QuietlyInferred,
-
     /// A requirement for the creation of the requirement signature of a
     /// protocol.
     ///
@@ -889,7 +879,6 @@ private:
 
     case Explicit:
     case Inferred:
-    case QuietlyInferred:
     case NestedTypeNameMatch:
     case ConcreteTypeBinding:
     case Superclass:
@@ -930,7 +919,6 @@ private:
     switch (kind) {
     case Explicit:
     case Inferred:
-    case QuietlyInferred:
     case RequirementSignatureSelf:
     case NestedTypeNameMatch:
     case ConcreteTypeBinding:
@@ -1052,8 +1040,7 @@ public:
   /// inferred from some part of a generic declaration's signature, e.g., the
   /// parameter or result type of a generic function.
   static const RequirementSource *forInferred(PotentialArchetype *root,
-                                              const TypeRepr *typeRepr,
-                                              bool quietly);
+                                              const TypeRepr *typeRepr);
 
   /// Retrieve a requirement source representing the requirement signature
   /// computation for a protocol.
@@ -1150,7 +1137,7 @@ public:
 
   /// Whether the requirement is inferred or derived from an inferred
   /// requirement.
-  bool isInferredRequirement(bool includeQuietInferred) const;
+  bool isInferredRequirement() const;
 
   /// Classify the kind of this source for diagnostic purposes.
   unsigned classifyDiagKind() const;
@@ -1272,8 +1259,6 @@ class GenericSignatureBuilder::FloatingRequirementSource {
     Explicit,
     /// An inferred requirement source lacking a root.
     Inferred,
-    /// A quietly inferred requirement source lacking a root.
-    QuietlyInferred,
     /// A requirement source augmented by an abstract protocol requirement
     AbstractProtocol,
     /// A requirement source for a nested-type-name match introduced by
@@ -1319,9 +1304,8 @@ public:
     return { Explicit, requirementRepr };
   }
 
-  static FloatingRequirementSource forInferred(const TypeRepr *typeRepr,
-                                               bool quietly) {
-    return { quietly? QuietlyInferred : Inferred, typeRepr };
+  static FloatingRequirementSource forInferred(const TypeRepr *typeRepr) {
+    return { Inferred, typeRepr };
   }
 
   static FloatingRequirementSource viaProtocolRequirement(

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -912,8 +912,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
 
     // We are at an explicit or inferred requirement.
     assert(source->kind == RequirementSource::Explicit ||
-           source->kind == RequirementSource::Inferred ||
-           source->kind == RequirementSource::QuietlyInferred);
+           source->kind == RequirementSource::Inferred);
 
     // Skip trivial path elements. These occur when querying a requirement
     // signature.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -8030,8 +8030,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](GenericSignatureBuilder &builder) {
     auto source =
-      GenericSignatureBuilder::FloatingRequirementSource::forInferred(
-                                          nullptr, /*quietly=*/false);
+      GenericSignatureBuilder::FloatingRequirementSource::forInferred(nullptr);
 
     builder.inferRequirements(*ext->getModuleContext(),
                               TypeLoc::withoutLoc(extInterfaceType),

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -480,8 +480,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
           fn->getBodyResultTypeLoc().getTypeRepr()) {
         auto source =
           GenericSignatureBuilder::FloatingRequirementSource::forInferred(
-              fn->getBodyResultTypeLoc().getTypeRepr(),
-              /*quietly=*/true);
+              fn->getBodyResultTypeLoc().getTypeRepr());
         builder->inferRequirements(*func->getParentModule(),
                                    fn->getBodyResultTypeLoc(),
                                    source);
@@ -497,8 +496,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
         if (auto *subscriptDecl = dyn_cast<SubscriptDecl>(storage)) {
           auto source =
             GenericSignatureBuilder::FloatingRequirementSource::forInferred(
-                subscriptDecl->getElementTypeLoc().getTypeRepr(),
-                /*quietly=*/true);
+                subscriptDecl->getElementTypeLoc().getTypeRepr());
 
           TypeLoc type(nullptr, subscriptDecl->getElementInterfaceType());
           assert(type.getType());
@@ -945,8 +943,7 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   if (genericParams && builder) {
     auto source =
       GenericSignatureBuilder::FloatingRequirementSource::forInferred(
-          subscript->getElementTypeLoc().getTypeRepr(),
-          /*quietly=*/true);
+          subscript->getElementTypeLoc().getTypeRepr());
 
     builder->inferRequirements(*subscript->getParentModule(),
                                subscript->getElementTypeLoc(),

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -76,8 +76,6 @@ struct V<T : Canidae> {}
 // CHECK-NEXT:   τ_0_0 : Canidae
 func inferSuperclassRequirement1<T : Carnivora>(
 	_ v: V<T>) {}
-// expected-warning@-2{{redundant superclass constraint 'T' : 'Carnivora'}}
-// expected-note@-2{{superclass constraint 'T' : 'Canidae' inferred from type here}}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
 // CHECK-NEXT: Requirements:
@@ -307,8 +305,8 @@ struct X21<T, U> {
 }
 
 struct X22<T, U> {
-  func g<V>(_: V) where T: P20, // expected-warning{{redundant conformance constraint 'T': 'P20'}}
-                  U == X20<T> { } // expected-note{{conformance constraint 'T': 'P20' inferred from type here}}
+  func g<V>(_: V) where T: P20,
+                  U == X20<T> { }
 }
 
 // CHECK: Generic signature: <Self where Self : P22>
@@ -330,8 +328,8 @@ protocol P22 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X20<τ_0_0.B>>
 protocol P23 {
   associatedtype A
-  associatedtype B: P20 // expected-warning{{redundant conformance constraint 'Self.B': 'P20'}}
-    where A == X20<B> // expected-note{{conformance constraint 'Self.B': 'P20' inferred from type here}}
+  associatedtype B: P20
+    where A == X20<B>
 }
 
 protocol P24 {

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -363,8 +363,8 @@ func trivialRedundancy<T: P10>(_: T) where T.A == T.A { } // expected-warning{{r
 
 struct X11<T: P10> where T.A == T.B { }
 
-func intracomponentInferred<T>(_: X11<T>) // expected-note{{previous same-type constraint 'T.A' == 'T.B' inferred from type here}}
-  where T.A == T.B { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.B'}}
+func intracomponentInferred<T>(_: X11<T>)
+  where T.A == T.B { }
 
 // Suppress redundant same-type constraint warnings from result types.
 struct StructTakingP1<T: P1> { }

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -97,12 +97,7 @@ struct SI<A: PI> : I where A : I, A.T == SI<A> {
 struct S4<A: PI> : I where A : I {
 }
 
-struct S5<A: PI> : I where A : I, A.T == S4<A> {
-// expected-warning@-1{{redundant conformance constraint 'A': 'I'}}
-// expected-warning@-2{{redundant conformance constraint 'A': 'PI'}}
-// expected-note@-3{{conformance constraint 'A': 'PI' inferred from type here}}
-// expected-note@-4{{conformance constraint 'A': 'I' inferred from type here}}
-}
+struct S5<A: PI> : I where A : I, A.T == S4<A> { }
 
 // Used to hit ArchetypeBuilder assertions
 struct SU<A: P> where A.T == SU {


### PR DESCRIPTION
Stop warning about constraints made redundant due to inferred constraints, e.g., don't warn on this:

    struct S<T: Hashable> {}
    fun f<T: Equatable>(s: S<T>) {}

because `T: Hashable` was inferred from `S: T`. Addresses https://bugs.swift.org/browse/SR-5753.