### PR TITLE
Moves formerly statically-allocated RecursiveSharedTimer(s) effectively into ASTContext

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -176,6 +176,16 @@ typedef llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *>
   TypeOrExtensionDecl;
 
 /// ASTContext - This object creates and owns the AST objects.
+/// However, this class does more than just maintain context within an AST.
+/// It is the closest thing to thread-local or compile-local storage in this code base.
+/// Why? SourceKit uses this code with multiple threads per Unix process.
+/// Each thread processes a different source file. Each thread has its own instance
+/// of ASTContext, and that instance persists for the duration of the thread, throughout all
+/// phases of the compilation. (The name "ASTContext" is a bit of a misnomer here.)
+/// Why not use thread-local storage? This code may use DispatchQueues and pthread-style TLS
+/// won't work with code that uses DispatchQueues.
+/// Summary: if you think you need a global or static variable, you probably need to put it here instead.
+
 class ASTContext {
   ASTContext(const ASTContext&) = delete;
   void operator=(const ASTContext&) = delete;

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -177,14 +177,15 @@ typedef llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *>
 
 /// ASTContext - This object creates and owns the AST objects.
 /// However, this class does more than just maintain context within an AST.
-/// It is the closest thing to thread-local or compile-local storage in this code base.
-/// Why? SourceKit uses this code with multiple threads per Unix process.
-/// Each thread processes a different source file. Each thread has its own instance
-/// of ASTContext, and that instance persists for the duration of the thread, throughout all
-/// phases of the compilation. (The name "ASTContext" is a bit of a misnomer here.)
-/// Why not use thread-local storage? This code may use DispatchQueues and pthread-style TLS
-/// won't work with code that uses DispatchQueues.
-/// Summary: if you think you need a global or static variable, you probably need to put it here instead.
+/// It is the closest thing to thread-local or compile-local storage in this
+/// code base. Why? SourceKit uses this code with multiple threads per Unix
+/// process. Each thread processes a different source file. Each thread has its
+/// own instance of ASTContext, and that instance persists for the duration of
+/// the thread, throughout all phases of the compilation. (The name "ASTContext"
+/// is a bit of a misnomer here.) Why not use thread-local storage? This code
+/// may use DispatchQueues and pthread-style TLS won't work with code that uses
+/// DispatchQueues. Summary: if you think you need a global or static variable,
+/// you probably need to put it here instead.
 
 class ASTContext {
   ASTContext(const ASTContext&) = delete;

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -65,6 +65,16 @@ public:
 #include "Statistics.def"
 #undef FRONTEND_STATISTIC
   };
+  
+  
+  struct AlwaysOnFrontendRecursiveSharedTimers {
+    AlwaysOnFrontendRecursiveSharedTimers();
+#define FRONTEND_RECURSIVE_SHARED_TIMER(ID)   RecursiveSharedTimer ID;
+#include "Statistics.def"
+#undef FRONTEND_RECURSIVE_SHARED_TIMER
+    
+    int dummyInstanceVariableToGetConstructorToParse;
+  };
 
   struct FrontendStatsTracer
   {
@@ -82,6 +92,8 @@ public:
     FrontendStatsTracer(const FrontendStatsTracer&) = delete;
     FrontendStatsTracer& operator=(const FrontendStatsTracer&) = delete;
   };
+  
+  
 
   struct FrontendStatsEvent
   {
@@ -95,6 +107,7 @@ public:
     SourceRange SourceRange;
   };
 
+
 private:
   SmallString<128> StatsFilename;
   SmallString<128> TraceFilename;
@@ -105,6 +118,7 @@ private:
   std::unique_ptr<AlwaysOnFrontendCounters> FrontendCounters;
   std::unique_ptr<AlwaysOnFrontendCounters> LastTracedFrontendCounters;
   std::vector<FrontendStatsEvent> FrontendStatsEvents;
+  std::unique_ptr<AlwaysOnFrontendRecursiveSharedTimers> FrontendRecursiveSharedTimers;
 
   void publishAlwaysOnStatsToLLVM();
   void printAlwaysOnStatsAndTimers(llvm::raw_ostream &OS);
@@ -128,6 +142,7 @@ public:
 
   AlwaysOnDriverCounters &getDriverCounters();
   AlwaysOnFrontendCounters &getFrontendCounters();
+  AlwaysOnFrontendRecursiveSharedTimers &getFrontendRecursiveSharedTimers();
   FrontendStatsTracer getStatsTracer(StringRef N,
                                      SourceRange const &R);
   void saveAnyFrontendStatsEvents(FrontendStatsTracer const& T,

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -65,14 +65,13 @@ public:
 #include "Statistics.def"
 #undef FRONTEND_STATISTIC
   };
-  
-  
+
   struct AlwaysOnFrontendRecursiveSharedTimers {
     AlwaysOnFrontendRecursiveSharedTimers();
-#define FRONTEND_RECURSIVE_SHARED_TIMER(ID)   RecursiveSharedTimer ID;
+#define FRONTEND_RECURSIVE_SHARED_TIMER(ID) RecursiveSharedTimer ID;
 #include "Statistics.def"
 #undef FRONTEND_RECURSIVE_SHARED_TIMER
-    
+
     int dummyInstanceVariableToGetConstructorToParse;
   };
 
@@ -92,8 +91,6 @@ public:
     FrontendStatsTracer(const FrontendStatsTracer&) = delete;
     FrontendStatsTracer& operator=(const FrontendStatsTracer&) = delete;
   };
-  
-  
 
   struct FrontendStatsEvent
   {
@@ -107,7 +104,6 @@ public:
     SourceRange SourceRange;
   };
 
-
 private:
   SmallString<128> StatsFilename;
   SmallString<128> TraceFilename;
@@ -118,7 +114,8 @@ private:
   std::unique_ptr<AlwaysOnFrontendCounters> FrontendCounters;
   std::unique_ptr<AlwaysOnFrontendCounters> LastTracedFrontendCounters;
   std::vector<FrontendStatsEvent> FrontendStatsEvents;
-  std::unique_ptr<AlwaysOnFrontendRecursiveSharedTimers> FrontendRecursiveSharedTimers;
+  std::unique_ptr<AlwaysOnFrontendRecursiveSharedTimers>
+      FrontendRecursiveSharedTimers;
 
   void publishAlwaysOnStatsToLLVM();
   void printAlwaysOnStatsAndTimers(llvm::raw_ostream &OS);

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -101,3 +101,9 @@ FRONTEND_STATISTIC(IRModule, NumIRInsts)
 
 FRONTEND_STATISTIC(LLVM, NumLLVMBytesOutput)
 #endif
+
+/// Frontend timers for recursive routines
+#ifdef FRONTEND_RECURSIVE_SHARED_TIMER
+FRONTEND_RECURSIVE_SHARED_TIMER(NominalTypeDecl__lookupDirect)
+FRONTEND_RECURSIVE_SHARED_TIMER(ClangImporter__Implementation__loadAllMembers)
+#endif

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -49,8 +49,7 @@ namespace swift {
   /// A SharedTimer for recursive routines.
   /// void example() {
   ///  RecursiveSharedTimer::Guard guard; // MUST BE AT TOP SCOPE of function to work right!
-  ///  ASTContext &ctx = getASTContext();
-  ///  if (ctx.Stats) {
+  ///  if (auto s = getASTContext().Stats) {
   ///    guard = ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
 //  }
   ///   ...

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -48,10 +48,11 @@ namespace swift {
 
   /// A SharedTimer for recursive routines.
   /// void example() {
-  ///  RecursiveSharedTimer::Guard guard; // MUST BE AT TOP SCOPE of function to work right!
-  ///  if (auto s = getASTContext().Stats) {
-  ///    guard = ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
-//  }
+  ///  RecursiveSharedTimer::Guard guard; // MUST BE AT TOP SCOPE of function to
+  ///  work right! if (auto s = getASTContext().Stats) {
+  ///    guard =
+  ///    ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
+  //  }
   ///   ...
   /// }
 
@@ -73,28 +74,35 @@ namespace swift {
     }
 
   public:
-    RecursiveSharedTimer(StringRef name) : name(name) {}    
+    RecursiveSharedTimer(StringRef name) : name(name) {}
 
     struct Guard {
       RecursiveSharedTimer *recursiveTimerOrNull;
- 
+
       Guard(RecursiveSharedTimer *rst) : recursiveTimerOrNull(rst) {
-        if (recursiveTimerOrNull) recursiveTimerOrNull->enterRecursiveFunction();
+        if (recursiveTimerOrNull)
+          recursiveTimerOrNull->enterRecursiveFunction();
       }
-      ~Guard() {  if (recursiveTimerOrNull) recursiveTimerOrNull->exitRecursiveFunction(); }
+      ~Guard() {
+        if (recursiveTimerOrNull)
+          recursiveTimerOrNull->exitRecursiveFunction();
+      }
 
       // All this stuff is to do an RAII object that be moved.
       Guard() : recursiveTimerOrNull(nullptr) {}
-      Guard(Guard &&other) { recursiveTimerOrNull = other.recursiveTimerOrNull; other.recursiveTimerOrNull = nullptr; }
-      Guard& operator=(Guard&& other) {
+      Guard(Guard &&other) {
+        recursiveTimerOrNull = other.recursiveTimerOrNull;
+        other.recursiveTimerOrNull = nullptr;
+      }
+      Guard &operator=(Guard &&other) {
         recursiveTimerOrNull = other.recursiveTimerOrNull;
         other.recursiveTimerOrNull = nullptr;
         return *this;
       }
-      Guard(const Guard&) = delete;
-      Guard& operator=(const Guard&) = delete;
+      Guard(const Guard &) = delete;
+      Guard &operator=(const Guard &) = delete;
     };
-    
+
     Guard getGuard() { return Guard(this); }
   };
 } // end namespace swift

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -76,13 +76,14 @@ namespace swift {
     RecursiveSharedTimer(StringRef name) : name(name) {}    
 
     struct Guard {
-      // FIXME OPTIONAL??
       RecursiveSharedTimer *recursiveTimerOrNull;
  
-      // All this stuff is to do an RAII object that be moved.
       Guard(RecursiveSharedTimer *rst) : recursiveTimerOrNull(rst) {
         if (recursiveTimerOrNull) recursiveTimerOrNull->enterRecursiveFunction();
       }
+      ~Guard() {  if (recursiveTimerOrNull) recursiveTimerOrNull->exitRecursiveFunction(); }
+
+      // All this stuff is to do an RAII object that be moved.
       Guard() : recursiveTimerOrNull(nullptr) {}
       Guard(Guard &&other) { recursiveTimerOrNull = other.recursiveTimerOrNull; other.recursiveTimerOrNull = nullptr; }
       Guard& operator=(Guard&& other) {
@@ -90,7 +91,6 @@ namespace swift {
         other.recursiveTimerOrNull = nullptr;
         return *this;
       }
-      ~Guard() {  if (recursiveTimerOrNull) recursiveTimerOrNull->exitRecursiveFunction(); }
       Guard(const Guard&) = delete;
       Guard& operator=(const Guard&) = delete;
     };

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -47,11 +47,9 @@ namespace swift {
   };
 
   /// A SharedTimer for recursive routines.
-  /// Declare as a static, and use as below:
   /// void example() {
-  ///     static RecursiveSharedTimer timer("lookupDirect");
-  ///     auto guard = RecursiveSharedTimer::Guard(timer);
-  ///     (void)guard;
+  /// ASTContext &ctx = getASTContext();
+  ///   auto guard = RecursiveSharedTimer::Guard(ctx.Stats ? ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect : nullptr); (void)guard;
   ///   ...
   /// }
 
@@ -74,14 +72,16 @@ namespace swift {
 
   public:
     RecursiveSharedTimer(StringRef name) : name(name) {}
+    
+    // IMPLICIT TO OPTIONAL??
 
     struct Guard {
-      RecursiveSharedTimer &recursiveTimer;
+      RecursiveSharedTimer *recursiveTimerOrNull;
       Guard &operator=(Guard &) = delete;
-      Guard(RecursiveSharedTimer &rst) : recursiveTimer(rst) {
-        recursiveTimer.enterRecursiveFunction();
+      Guard(RecursiveSharedTimer *rst) : recursiveTimerOrNull(rst) {
+        if (recursiveTimerOrNull) recursiveTimerOrNull->enterRecursiveFunction();
       }
-      ~Guard() { recursiveTimer.exitRecursiveFunction(); }
+      ~Guard() {  if (recursiveTimerOrNull) recursiveTimerOrNull->exitRecursiveFunction(); }
     };
   };
 } // end namespace swift

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -942,9 +942,9 @@ void IterableDeclContext::setMemberLoader(LazyMemberLoader *loader,
   ++NumLazyIterableDeclContexts;
   ++NumUnloadedLazyIterableDeclContexts;
   // FIXME: (transitional) increment the redundant "always-on" counter.
-  if (ctx.Stats) {
-    ++ctx.Stats->getFrontendCounters().NumLazyIterableDeclContexts;
-    ++ctx.Stats->getFrontendCounters().NumUnloadedLazyIterableDeclContexts;
+  if (auto s = ctx.Stats) {
+    ++s->getFrontendCounters().NumLazyIterableDeclContexts;
+    ++s->getFrontendCounters().NumUnloadedLazyIterableDeclContexts;
   }
 }
 
@@ -974,8 +974,8 @@ void IterableDeclContext::loadAllMembers() const {
 
   --NumUnloadedLazyIterableDeclContexts;
   // FIXME: (transitional) decrement the redundant "always-on" counter.
-  if (ctx.Stats)
-    ctx.Stats->getFrontendCounters().NumUnloadedLazyIterableDeclContexts--;
+  if (auto s = ctx.Stats)
+    s->getFrontendCounters().NumUnloadedLazyIterableDeclContexts--;
 }
 
 bool IterableDeclContext::classof(const Decl *D) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1194,11 +1194,8 @@ void NominalTypeDecl::makeMemberVisible(ValueDecl *member) {
 TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
-  static RecursiveSharedTimer timer("lookupDirect");
-  auto guard = RecursiveSharedTimer::Guard(timer);
-  (void)guard;
-
   ASTContext &ctx = getASTContext();
+  auto guard = RecursiveSharedTimer::Guard(ctx.Stats ? &ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect : nullptr); (void)guard;
   if (ctx.Stats)
     ++ctx.Stats->getFrontendCounters().NominalTypeLookupDirectCount;
   

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1195,11 +1195,12 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
   RecursiveSharedTimer::Guard guard;
-    if (auto s = getASTContext().Stats) {
-      ++s->getFrontendCounters().NominalTypeLookupDirectCount;
-      guard = s->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
-    }
-  
+  if (auto s = getASTContext().Stats) {
+    ++s->getFrontendCounters().NominalTypeLookupDirectCount;
+    guard = s->getFrontendRecursiveSharedTimers()
+                .NominalTypeDecl__lookupDirect.getGuard();
+  }
+
   (void)getMembers();
 
   // Make sure we have the complete list of members (in this nominal and in all

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1195,13 +1195,10 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
   RecursiveSharedTimer::Guard guard;
-  {
-    ASTContext &ctx = getASTContext();
-    if (ctx.Stats) {
-      ++ctx.Stats->getFrontendCounters().NominalTypeLookupDirectCount;
-      guard = ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
+    if (auto s = getASTContext().Stats) {
+      ++s->getFrontendCounters().NominalTypeLookupDirectCount;
+      guard = s->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
     }
-  }
   
   (void)getMembers();
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1194,10 +1194,14 @@ void NominalTypeDecl::makeMemberVisible(ValueDecl *member) {
 TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
-  ASTContext &ctx = getASTContext();
-  auto guard = RecursiveSharedTimer::Guard(ctx.Stats ? &ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect : nullptr); (void)guard;
-  if (ctx.Stats)
-    ++ctx.Stats->getFrontendCounters().NominalTypeLookupDirectCount;
+  RecursiveSharedTimer::Guard guard;
+  {
+    ASTContext &ctx = getASTContext();
+    if (ctx.Stats) {
+      ++ctx.Stats->getFrontendCounters().NominalTypeLookupDirectCount;
+      guard = ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
+    }
+  }
   
   (void)getMembers();
 

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -172,6 +172,14 @@ UnifiedStatsReporter::getFrontendCounters()
     FrontendCounters = make_unique<AlwaysOnFrontendCounters>();
   return *FrontendCounters;
 }
+  
+UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers &
+UnifiedStatsReporter::getFrontendRecursiveSharedTimers()
+{
+  if (!FrontendRecursiveSharedTimers)
+    FrontendRecursiveSharedTimers = make_unique<AlwaysOnFrontendRecursiveSharedTimers>();
+  return *FrontendRecursiveSharedTimers;
+}
 
 void
 UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
@@ -312,6 +320,13 @@ UnifiedStatsReporter::saveAnyFrontendStatsEvents(
 #include "swift/Basic/Statistics.def"
 #undef FRONTEND_STATISTIC
 }
+  
+UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers::AlwaysOnFrontendRecursiveSharedTimers() :
+#define FRONTEND_RECURSIVE_SHARED_TIMER(ID) ID(#ID),
+#include "swift/Basic/Statistics.def"
+#undef FRONTEND_RECURSIVE_SHARED_TIMER
+  dummyInstanceVariableToGetConstructorToParse(0)
+{}
 
 UnifiedStatsReporter::~UnifiedStatsReporter()
 {

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -172,12 +172,12 @@ UnifiedStatsReporter::getFrontendCounters()
     FrontendCounters = make_unique<AlwaysOnFrontendCounters>();
   return *FrontendCounters;
 }
-  
+
 UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers &
-UnifiedStatsReporter::getFrontendRecursiveSharedTimers()
-{
+UnifiedStatsReporter::getFrontendRecursiveSharedTimers() {
   if (!FrontendRecursiveSharedTimers)
-    FrontendRecursiveSharedTimers = make_unique<AlwaysOnFrontendRecursiveSharedTimers>();
+    FrontendRecursiveSharedTimers =
+        make_unique<AlwaysOnFrontendRecursiveSharedTimers>();
   return *FrontendRecursiveSharedTimers;
 }
 
@@ -320,13 +320,15 @@ UnifiedStatsReporter::saveAnyFrontendStatsEvents(
 #include "swift/Basic/Statistics.def"
 #undef FRONTEND_STATISTIC
 }
-  
-UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers::AlwaysOnFrontendRecursiveSharedTimers() :
+
+UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers::
+    AlwaysOnFrontendRecursiveSharedTimers()
+    :
 #define FRONTEND_RECURSIVE_SHARED_TIMER(ID) ID(#ID),
 #include "swift/Basic/Statistics.def"
 #undef FRONTEND_RECURSIVE_SHARED_TIMER
-  dummyInstanceVariableToGetConstructorToParse(0)
-{}
+      dummyInstanceVariableToGetConstructorToParse(0) {
+}
 
 UnifiedStatsReporter::~UnifiedStatsReporter()
 {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7978,9 +7978,8 @@ createUnavailableDecl(Identifier name, DeclContext *dc, Type type,
 
 void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
-  static RecursiveSharedTimer timer("ClangImporterLoadAllMembers");
-  auto guard = RecursiveSharedTimer::Guard(timer);
-  (void)guard;
+  ASTContext &ctx = D->getASTContext();
+  auto guard = RecursiveSharedTimer::Guard(ctx.Stats ? &ctx.Stats->getFrontendRecursiveSharedTimers().ClangImporter__Implementation__loadAllMembers : nullptr); (void)guard;
 
   assert(D);
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7980,7 +7980,8 @@ void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   RecursiveSharedTimer::Guard guard;
   if (auto s = D->getASTContext().Stats) {
-    guard = s->getFrontendRecursiveSharedTimers().ClangImporter__Implementation__loadAllMembers.getGuard();
+    guard = s->getFrontendRecursiveSharedTimers()
+                .ClangImporter__Implementation__loadAllMembers.getGuard();
   }
 
   assert(D);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7979,11 +7979,8 @@ createUnavailableDecl(Identifier name, DeclContext *dc, Type type,
 void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   RecursiveSharedTimer::Guard guard;
-  {
-    ASTContext &ctx = D->getASTContext();
-    if (ctx.Stats) {
-      guard = ctx.Stats->getFrontendRecursiveSharedTimers().ClangImporter__Implementation__loadAllMembers.getGuard();
-    }
+  if (auto s = D->getASTContext().Stats) {
+    guard = s->getFrontendRecursiveSharedTimers().ClangImporter__Implementation__loadAllMembers.getGuard();
   }
 
   assert(D);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7978,8 +7978,13 @@ createUnavailableDecl(Identifier name, DeclContext *dc, Type type,
 
 void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
-  ASTContext &ctx = D->getASTContext();
-  auto guard = RecursiveSharedTimer::Guard(ctx.Stats ? &ctx.Stats->getFrontendRecursiveSharedTimers().ClangImporter__Implementation__loadAllMembers : nullptr); (void)guard;
+  RecursiveSharedTimer::Guard guard;
+  {
+    ASTContext &ctx = D->getASTContext();
+    if (ctx.Stats) {
+      guard = ctx.Stats->getFrontendRecursiveSharedTimers().ClangImporter__Implementation__loadAllMembers.getGuard();
+    }
+  }
 
   assert(D);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2128,8 +2128,8 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   SmallVector<uint64_t, 64> scratch;
   StringRef blobData;
 
-  if (ctx.Stats)
-    ctx.Stats->getFrontendCounters().NumDeclsDeserialized++;
+  if (auto s = ctx.Stats)
+    s->getFrontendCounters().NumDeclsDeserialized++;
 
   // Read the attributes (if any).
   // This isn't just using DeclAttributes because that would result in the
@@ -3816,8 +3816,8 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
   StringRef blobData;
   unsigned recordID = DeclTypeCursor.readRecord(entry.ID, scratch, &blobData);
 
-  if (ctx.Stats)
-    ctx.Stats->getFrontendCounters().NumTypesDeserialized++;
+  if (auto s = ctx.Stats)
+    s->getFrontendCounters().NumTypesDeserialized++;
 
   switch (recordID) {
   case decls_block::NAME_ALIAS_TYPE: {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Moves RecursiveSharedTimer into statistics structure pointed-to by ASTContext, instead of being statically-allocated.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://34475709.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
