### PR TITLE
Benchmark API Improvements

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -58,13 +58,13 @@ struct Test {
   let index: Int
   let f: (Int) -> ()
   let run: Bool
-  let tags: [BenchmarkCategories]
+  let tags: [BenchmarkCategory]
 }
 
 // Legacy test dictionaries.
-public var precommitTests: [String : ((Int) -> (), [BenchmarkCategories])] = [:]
-public var otherTests: [String : ((Int) -> (), [BenchmarkCategories])] = [:]
-public var stringTests: [String : ((Int) -> (), [BenchmarkCategories])] = [:]
+public var precommitTests: [String : ((Int) -> (), [BenchmarkCategory])] = [:]
+public var otherTests: [String : ((Int) -> (), [BenchmarkCategory])] = [:]
+public var stringTests: [String : ((Int) -> (), [BenchmarkCategory])] = [:]
 
 // We should migrate to a collection of BenchmarkInfo.
 public var registeredBenchmarks = [TestsUtils.BenchmarkInfo]()
@@ -83,7 +83,7 @@ struct TestConfig {
   var filters = [String]()
 
   /// The tag that we want to run
-  var tags = Set<BenchmarkCategories>()
+  var tags = Set<BenchmarkCategory>()
 
   /// The scalar multiple of the amount of times a test should be run. This
   /// enables one to cause tests to run for N iterations longer than they
@@ -158,7 +158,7 @@ struct TestConfig {
 
     if let x = benchArgs.optionalArgsMap["--tags"] {
       if x.isEmpty { return .fail("--tags requires a value") }
-      guard let cat = BenchmarkCategories(rawValue: x) else {
+      guard let cat = BenchmarkCategory(rawValue: x) else {
         return .fail("Unknown benchmark category: '\(x)'")
       }
       tags.insert(cat)
@@ -191,11 +191,11 @@ struct TestConfig {
   }
 
   mutating func findTestsToRun() {
-    var allTests: [(key: String, value: ((Int) -> (), [BenchmarkCategories]))]
+    var allTests: [(key: String, value: ((Int) -> (), [BenchmarkCategory]))]
 
     if onlyRegistered {
       allTests = registeredBenchmarks.map {
-        bench -> (key: String, value: ((Int) -> (), [BenchmarkCategories])) in
+        bench -> (key: String, value: ((Int) -> (), [BenchmarkCategory])) in
         (bench.name, (bench.runFunction, bench.tags))
       }
       // FIXME: for now unstable/extra benchmarks are not registered at all, but
@@ -204,7 +204,7 @@ struct TestConfig {
     }
     else {
       allTests = [precommitTests, otherTests, stringTests]
-        .map { dictionary -> [(key: String, value: ((Int) -> (), [BenchmarkCategories]))] in
+        .map { dictionary -> [(key: String, value: ((Int) -> (), [BenchmarkCategory]))] in
           Array(dictionary).sorted { $0.key < $1.key } } // by name
         .flatMap { $0 }
     }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -158,69 +158,10 @@ struct TestConfig {
 
     if let x = benchArgs.optionalArgsMap["--tags"] {
       if x.isEmpty { return .fail("--tags requires a value") }
-      if x.contains("cpubench") {
-        tags.insert(.cpubench)
+      guard let cat = BenchmarkCategories(rawValue: x) else {
+        return .fail("Unknown benchmark category: '\(x)'")
       }
-      if x.contains("unstable") {
-        tags.insert(.unstable)
-      }
-      if x.contains("validation") {
-        tags.insert(.validation)
-      }
-      if x.contains("api") {
-        tags.insert(.api)
-      }
-      if x.contains("Array") {
-        tags.insert(.Array)
-      }
-      if x.contains("String") {
-        tags.insert(.String)
-      }
-      if x.contains("Dictionary") {
-        tags.insert(.Dictionary)
-      }
-      if x.contains("Codable") {
-        tags.insert(.Codable)
-      }
-      if x.contains("Set") {
-        tags.insert(.Set)
-      }
-      if x.contains("sdk") {
-        tags.insert(.sdk)
-      }
-      if x.contains("runtime") {
-        tags.insert(.runtime)
-      }
-      if x.contains("refcount") {
-        tags.insert(.refcount)
-      }
-      if x.contains("metadata") {
-        tags.insert(.metadata)
-      }
-      if x.contains("abstraction") {
-        tags.insert(.abstraction)
-      }
-      if x.contains("safetychecks") {
-        tags.insert(.safetychecks)
-      }
-      if x.contains("exceptions") {
-        tags.insert(.exceptions)
-      }
-      if x.contains("bridging") {
-        tags.insert(.bridging)
-      }
-      if x.contains("concurrency") {
-        tags.insert(.concurrency)
-      }
-      if x.contains("algorithm") {
-        tags.insert(.algorithm)
-      }
-      if x.contains("miniapplication") {
-        tags.insert(.miniapplication)
-      }
-      if x.contains("regression") {
-        tags.insert(.regression)
-      }
+      tags.insert(cat)
     }
 
     if let _ = benchArgs.optionalArgsMap["--run-all"] {

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -16,7 +16,7 @@ import Glibc
 import Darwin
 #endif
 
-public enum BenchmarkCategories : String {
+public enum BenchmarkCategory : String {
   // Validation "micro" benchmarks test a specific operation or critical path that
   // we know is important to measure.
   case validation
@@ -77,9 +77,9 @@ public struct BenchmarkInfo {
   /// A set of category tags that describe this benchmark. This is used by the
   /// harness to allow for easy slicing of the set of benchmarks along tag
   /// boundaries, e.x.: run all string benchmarks or ref count benchmarks, etc.
-  public var tags: [BenchmarkCategories]
+  public var tags: [BenchmarkCategory]
 
-  public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategories]) {
+  public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategory]) {
     self.name = name
     self.runFunction = runFunction
     self.tags = tags

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -16,7 +16,7 @@ import Glibc
 import Darwin
 #endif
 
-public enum BenchmarkCategories : CustomStringConvertible {
+public enum BenchmarkCategories : String {
   // Validation "micro" benchmarks test a specific operation or critical path that
   // we know is important to measure.
   case validation
@@ -65,32 +65,6 @@ public enum BenchmarkCategories : CustomStringConvertible {
   // reimplementing or call into code paths that have known opportunities for
   // significant optimization.
   case cpubench
-
-  public var description : String {
-    switch self {
-    case .cpubench: return "cpubench"
-    case .unstable: return "unstable"
-    case .validation: return "validation"
-    case .api: return "api"
-    case .Array: return "Array"
-    case .String: return "String"
-    case .Dictionary: return "Dictionary"
-    case .Codable: return "Codable"
-    case .Set: return "Set"
-    case .sdk: return "sdk"
-    case .runtime: return "runtime"
-    case .refcount: return "refcount"
-    case .metadata: return "metadata"
-    case .abstraction: return "abstraction"
-    case .safetychecks: return "safetychecks"
-    case .exceptions: return "exceptions"
-    case .bridging: return "bridging"
-    case .concurrency: return "concurrency"
-    case .algorithm: return "algorithm"
-    case .miniapplication: return "miniapplication"
-    case .regression: return "regression"
-    }
-  }
 }
 
 public struct BenchmarkInfo {

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -94,8 +94,15 @@ public enum BenchmarkCategories : CustomStringConvertible {
 }
 
 public struct BenchmarkInfo {
+  /// The name of the benchmark that should be displayed by the harness.
   public var name: String
+
+  /// A function that invokes the specific benchmark routine.
   public var runFunction: (Int) -> ()
+
+  /// A set of category tags that describe this benchmark. This is used by the
+  /// harness to allow for easy slicing of the set of benchmarks along tag
+  /// boundaries, e.x.: run all string benchmarks or ref count benchmarks, etc.
   public var tags: [BenchmarkCategories]
 
   public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategories]) {

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -142,10 +142,10 @@ registerBenchmark(SevenBoom)
 
 @inline(__always)
 private func addTo(
-  _ testSuite: inout [String : ((Int) -> (), [BenchmarkCategories])],
+  _ testSuite: inout [String : ((Int) -> (), [BenchmarkCategory])],
   _ name: String,
   _ function: @escaping (Int) -> (),
-  _ tags: [BenchmarkCategories] = []
+  _ tags: [BenchmarkCategory] = []
   ) {
   testSuite[name] = (function, tags)
 }


### PR DESCRIPTION
This PR updates parts of the benchmark harness to match the API guidelines closer. That includes using a String enum for BenchmarkCategories and renaming BenchmarkCategories to BenchmarkCategory (since it is an enum that represents a single benchmark category after all).