### PR TITLE
Revert "[GSB] Hack the ordering of adding requirements for a signature."

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6226,22 +6226,8 @@ void GenericSignatureBuilder::addGenericSignature(GenericSignature *sig) {
   for (auto param : sig->getGenericParams())
     addGenericParameter(param);
 
-  // Add the requirements, queuing up same-type requirements until the end.
-  // FIXME: Queuing up same-type requirements is a hack that works around
-  // problems when referencing associated types. These issues primarily
-  // occur when building canonical generic environments
-  SmallVector<Requirement, 4> sameTypeRequirements;
-  for (auto &reqt : sig->getRequirements()) {
-    if (reqt.getKind() == RequirementKind::SameType)
-      sameTypeRequirements.push_back(reqt);
-    else
-      addRequirement(reqt, FloatingRequirementSource::forAbstract(), nullptr);
-  }
-
-  // Handle same-type requirements.
-  for (auto &reqt : sameTypeRequirements) {
+  for (auto &reqt : sig->getRequirements())
     addRequirement(reqt, FloatingRequirementSource::forAbstract(), nullptr);
-  }
 }
 
 /// Collect the set of requirements placed on the given generic parameters and


### PR DESCRIPTION
I don't think this is necessary anymore.

This reverts commit 3e80a616c446822c7710e754a811635aec8545a8.