### PR TITLE
[CMake] Only build SwiftSyntax if building SDK overlays

### DIFF
--- a/test/SwiftSyntax/LazyCaching.swift
+++ b/test/SwiftSyntax/LazyCaching.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: sdk_overlay
 
 import StdlibUnittest
 import Foundation

--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: sdk_overlay
 
 import Foundation
 import StdlibUnittest

--- a/test/SwiftSyntax/SyntaxFactory.swift
+++ b/test/SwiftSyntax/SyntaxFactory.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: sdk_overlay
 
 import Foundation
 import StdlibUnittest

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -295,6 +295,10 @@ sdk_overlay_linker_opt = ""
 sdk_overlay_dir_opt = ""
 test_sdk_overlay_dir = lit_config.params.get('test_sdk_overlay_dir', None)
 if test_sdk_overlay_dir is not None:
+
+    # TODO: Is this the right place to put this?
+    config.available_features.add('sdk_overlay')
+
     sdk_overlay_dir_opt = ("-I %s" % os.path.join(test_sdk_overlay_dir, run_cpu))
     sdk_overlay_link_path_dir = os.path.join(test_sdk_overlay_dir, run_cpu)
     sdk_overlay_link_path = ("-L %s" % sdk_overlay_link_path_dir)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -295,8 +295,6 @@ sdk_overlay_linker_opt = ""
 sdk_overlay_dir_opt = ""
 test_sdk_overlay_dir = lit_config.params.get('test_sdk_overlay_dir', None)
 if test_sdk_overlay_dir is not None:
-
-    # TODO: Is this the right place to put this?
     config.available_features.add('sdk_overlay')
 
     sdk_overlay_dir_opt = ("-I %s" % os.path.join(test_sdk_overlay_dir, run_cpu))

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -22,7 +22,10 @@ if(SWIFT_HOST_VARIANT STREQUAL "macosx")
   # Only build Darwin-specific tools when deploying to OS X.
   add_swift_tool_subdirectory(swift-stdlib-tool)
 
-  if(SWIFT_BUILD_STDLIB)
+  # SwiftSyntax depends on both the standard library (because it's a
+  # Swift module), and the SDK overlays (because it depends on Foundation).
+  # Ensure we only build SwiftSyntax when we're building both.
+  if(SWIFT_BUILD_STDLIB AND SWIFT_BUILD_SDK_OVERLAY)
     add_subdirectory(SwiftSyntax)
   endif()
 endif()


### PR DESCRIPTION
SwiftSyntax depends on Foundation, which depends on the SDK overlays
being built. However, the existing build configuration tried to build
SwiftSyntax even if the SDK overlays were not built. Ensure we're
building overlays before building SwiftSyntax, and guard tests with an
`sdk_overlay` test.

Resolves [SR-6008](https://bugs.swift.org/browse/SR-6008).
