### PR TITLE
Eliminate some uses of uninitialized memory found by valgrind

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -63,7 +63,7 @@ public:
     ParentTy(Expr *E) : Kind(ParentKind::Expr), Ptr(E) {}
     ParentTy(Pattern *P) : Kind(ParentKind::Pattern), Ptr(P) {}
     ParentTy(TypeRepr *T) : Kind(ParentKind::TypeRepr), Ptr(T) {}
-    ParentTy() = default;
+    ParentTy() : Kind(ParentKind::Module), Ptr(nullptr) { }
 
     bool isNull() const { return Ptr == nullptr; }
     ParentKind getKind() const {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1314,6 +1314,7 @@ public:
                                      bool inferred) {
     FloatingRequirementSource result{ AbstractProtocol, base };
     result.protocolReq.protocol = inProtocol;
+    result.protocolReq.written = WrittenRequirementLoc();
     result.protocolReq.inferred = inferred;
     return result;
   }


### PR DESCRIPTION
Valgrind found two places where we were using uninitialized memory:

* In the generic signature builder, `FloatingRequirementSource` was failing to zero-initialize one of its fields when adding protocol requirements.
* In the `ASTWalker`, the "null" state of `ParentTy` wasn't fully initialized.