### PR TITLE
[stdlib] Skip inconsistent ArrayNew tests

### DIFF
--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -447,8 +447,8 @@ ArrayTestSuite.test("BridgedFromObjC.Verbatim.ImmutableArrayIsRetained") {
 }
 
 ArrayTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableArrayIsCopied")
-  .xfail(.iOSAny("<rdar://problem/33926468>"))
-  .xfail(.tvOSAny("<rdar://problem/33926468>"))
+  .skip(.iOSAny("<rdar://problem/33926468>"))
+  .skip(.tvOSAny("<rdar://problem/33926468>"))
   .code {
   let nsa: NSArray = CustomImmutableNSArray(_privateInit: ())
 


### PR DESCRIPTION
The "BridgedFromObjC.Nonverbatim.ImmutableArrayIsCopied" ArrayNew test is failing occasionally, so we can't xfail it. Skipping for now.

rdar://problem/33926468