### PR TITLE
Add support for init function

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -54,11 +54,21 @@ extension BenchResults : CustomStringConvertible {
 }
 
 struct Test {
-  let name: String
+  let benchInfo: BenchmarkInfo
   let index: Int
-  let f: (Int) -> ()
   let run: Bool
-  let tags: [BenchmarkCategory]
+
+  var name: String {
+    return benchInfo.name
+  }
+
+  var runFunction: (Int) -> () {
+    return benchInfo.runFunction
+  }
+
+  var tags: [BenchmarkCategory] {
+    return benchInfo.tags
+  }
 }
 
 // Legacy test dictionaries.
@@ -232,10 +242,9 @@ struct TestConfig {
     tests = zip(1...filteredTests.count, filteredTests).map {
       t -> Test in
       let (ordinal, benchInfo) = t
-      return Test(name: benchInfo.name, index: ordinal, f: benchInfo.runFunction,
+      return Test(benchInfo: benchInfo, index: ordinal,
                   run: includedBenchmarks.contains(benchInfo.name)
-                    || includedBenchmarks.contains(String(ordinal)),
-                  tags: benchInfo.tags)
+                  || includedBenchmarks.contains(String(ordinal)))
     }
   }
 }
@@ -426,10 +435,10 @@ func runBenchmarks(_ c: TestConfig) {
     if !t.run {
       continue
     }
+
     let benchIndex = t.index
     let benchName = t.name
-    let benchFunc = t.f
-    let results = runBench(benchName, benchFunc, c)
+    let results = runBench(benchName, t.runFunction, c)
     print("\(benchIndex)\(c.delim)\(benchName)\(c.delim)\(results.description)")
     fflush(stdout)
 

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -214,17 +214,24 @@ struct TestConfig {
       return;
     }
 
-    let included =
-      !filters.isEmpty ? Set(filters)
-      : onlyPrecommit ? Set(precommitTests.keys)
-      : Set(filteredTests.map { $0.key })
+    let includedBenchmarks: Set<String> = {
+      if !filters.isEmpty {
+        return Set(filters)
+      }
+
+      if onlyPrecommit {
+        return Set(precommitTests.keys)
+      }
+
+      return Set(filteredTests.map { $0.key })
+    }()
 
     tests = zip(1...filteredTests.count, filteredTests).map {
       t -> Test in
       let (ordinal, (key: name, value: funcAndTags)) = t
       return Test(name: name, index: ordinal, f: funcAndTags.0,
-                  run: included.contains(name)
-                    || included.contains(String(ordinal)),
+                  run: includedBenchmarks.contains(name)
+                    || includedBenchmarks.contains(String(ordinal)),
                   tags: funcAndTags.1)
     }
   }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -79,10 +79,30 @@ public struct BenchmarkInfo {
   /// boundaries, e.x.: run all string benchmarks or ref count benchmarks, etc.
   public var tags: [BenchmarkCategory]
 
+  /// An optional function that if non-null is run before benchmark samples
+  /// are timed.
+  public var setUpFunction: (() -> ())?
+
+  /// An optional function that if non-null is run immediately after a sample is
+  /// taken.
+  public var tearDownFunction: (() -> ())?
+
   public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategory]) {
     self.name = name
     self.runFunction = runFunction
     self.tags = tags
+    self.setUpFunction = nil
+    self.tearDownFunction = nil
+  }
+
+  public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategory],
+              setUpFunction: (() -> ())?,
+              tearDownFunction: (() -> ())?) {
+    self.name = name
+    self.runFunction = runFunction
+    self.tags = tags
+    self.setUpFunction = setUpFunction
+    self.tearDownFunction = tearDownFunction
   }
 }
 

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -86,6 +86,21 @@ public struct BenchmarkInfo {
   }
 }
 
+extension BenchmarkInfo : Comparable {
+  public static func < (lhs: BenchmarkInfo, rhs: BenchmarkInfo) -> Bool {
+    return lhs.name < rhs.name
+  }
+  public static func == (lhs: BenchmarkInfo, rhs: BenchmarkInfo) -> Bool {
+    return lhs.name == rhs.name
+  }
+}
+
+extension BenchmarkInfo : Hashable {
+  public var hashValue: Int {
+    return name.hashValue
+  }
+}
+
 // Linear function shift register.
 //
 // This is just to drive benchmarks. I don't make any claim about its

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -142,12 +142,12 @@ registerBenchmark(SevenBoom)
 
 @inline(__always)
 private func addTo(
-  _ testSuite: inout [String : ((Int) -> (), [BenchmarkCategory])],
+  _ testSuite: inout [BenchmarkInfo],
   _ name: String,
   _ function: @escaping (Int) -> (),
   _ tags: [BenchmarkCategory] = []
   ) {
-  testSuite[name] = (function, tags)
+  testSuite.append(BenchmarkInfo(name: name, runFunction: function, tags: tags))
 }
 
 // The main test suite: precommit tests


### PR DESCRIPTION
This series of commits performs a few tasks that culminate in the addition of the ability to initialize data before timing a benchmark.

Specifically:

1. Instead of creating a tuple containing data, legacy tests just now create a BenchmarkInfo struct. We still store them in the precommitTest, otherTests, stringTests variables.

2. Now that all tests use BenchmarkInfo, we no longer have to choose running either the legacy tests or use the new registered tests. Instead, we start with the registered list of benchmarks and any benchmarks that have not been registered yet are added later to that same list. This ensures that even when running in legacy mode, we get the advantage of being able to initialize global data.

3. Since we are always using BenchmarkInfo now, I pushed BenchmarkInfo all the way through the driver into Test. This is important since we are iterating over tests when we want to run the initialization closure.

3. An optional closure field called initFunction is added to BenchmarkInfo. If it is non-nil, the harness will invoke it right /before/ sampling has begun. Since the initFunction is specified in the benchmark file one to access all of the types/functions of the benchmark file in the closure.

rdar://34556274