### PR TITLE
Tabegen dependency cleanup

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -100,6 +100,7 @@ add_swift_library(swiftAST STATIC
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these
 # headers.
+# For more information see the comment at the top of lib/CMakeLists.txt.
 add_dependencies(swiftAST intrinsics_gen clang-tablegen-targets)
 
 set(swift_ast_verifier_flag)

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -99,14 +99,8 @@ add_swift_library(swiftAST STATIC
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these
-# headers. When we build swift out of tree, this is not an issue since LLVM must
-# finish building before we build Swift. But when we are in tree, the build
-# system must be made aware of the dependency between swiftAST and
-# intrinsics_gen.
-if(NOT SWIFT_BUILT_STANDALONE)
-  get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
-  add_dependencies(swiftAST intrinsics_gen ${CLANG_TABLEGEN_TARGETS})
-endif()
+# headers.
+add_dependencies(swiftAST intrinsics_gen clang-tabelgen-targets)
 
 set(swift_ast_verifier_flag)
 if(SWIFT_AST_VERIFIER)

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -100,7 +100,7 @@ add_swift_library(swiftAST STATIC
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these
 # headers.
-add_dependencies(swiftAST intrinsics_gen clang-tabelgen-targets)
+add_dependencies(swiftAST intrinsics_gen clang-tablegen-targets)
 
 set(swift_ast_verifier_flag)
 if(SWIFT_AST_VERIFIER)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,13 @@
-# TODO: Fix the fine grained tabegen dependencies
 # In the absence of fine grained tablegen dependencies we need to ensure that
 # Swift's libraries all build after the LLVM & Clang tablegen-generated headers
-# are generated.
+# are generated. When building out-of-tree (as with build-script) LLVM & Clang's
+# CMake configuration files create these targets as dummies so we can safely
+# depend on them directly here (See: SR-6026)
+# LLVM_COMMON_DEPENDS is a construct from the LLVM build system. It is a special
+# purpose variable that provides common dependencies for all libraries, and
+# executables generated when it is set. CMake's scoping rules enforce that these
+# new dependencies will only be added to targets created under Swift's lib
+# directory.
 list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen clang-tablegen-targets)
 
 add_subdirectory(AST)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,9 @@
+# TODO: Fix the fine grained tabegen dependencies
+# In the absence of fine grained tablegen dependencies we need to ensure that
+# Swift's libraries all build after the LLVM & Clang tablegen-generated headers
+# are generated.
+list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen clang-tablegen-targets)
+
 add_subdirectory(AST)
 add_subdirectory(ASTSectionImporter)
 add_subdirectory(Basic)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -43,4 +43,5 @@ add_swift_library(swiftSIL STATIC
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftSIL depends on these
 # headers.
+# For more information see the comment at the top of lib/CMakeLists.txt.
 add_dependencies(swiftSIL intrinsics_gen clang-tablegen-targets)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -41,9 +41,6 @@ add_swift_library(swiftSIL STATIC
 )
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
-# where intrinsics and attributes are declared. See the comment in lib/AST for
-# more detail.
-if(NOT SWIFT_BUILT_STANDALONE)
-  get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
-  add_dependencies(swiftSIL intrinsics_gen ${CLANG_TABLEGEN_TARGETS})
-endif()
+# where intrinsics and attributes are declared. swiftSIL depends on these
+# headers.
+add_dependencies(swiftSIL intrinsics_gen clang-tablegen-targets)


### PR DESCRIPTION
This is a cleanup of Swift's tablegen dependencies to ensure that both in and out of tree builds work reliably.

This builds off several commits that I made to LLVM & Clang (and are in the swift-4.1 branches) to create wrapper targets for tablegen header generation which are created for both in and out-of-tree builds.