### PR TITLE
Sema: Fix a failure to emit a diagnostic

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6214,11 +6214,15 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
 
   auto result = TC.checkGenericArguments(
       dc, callExpr->getLoc(), fnExpr->getLoc(), AFD->getInterfaceType(),
-      env->getGenericSignature(), QueryTypeSubstitutionMap{substitutions},
+      env->getGenericSignature(), substitutionFn,
       LookUpConformanceInModule{dc->getParentModule()}, nullptr,
       ConformanceCheckFlags::SuppressDependencyTracking, &genericReqListener);
 
-  return result != RequirementCheckResult::Success;
+  assert(result != RequirementCheckResult::UnsatisfiedDependency);
+
+  // Note: If result is RequirementCheckResult::SubstitutionFailure, we did
+  // not emit a diagnostic, so we must return false in that case.
+  return result == RequirementCheckResult::Failure;
 }
 
 /// When initializing Unsafe[Mutable]Pointer<T> from Unsafe[Mutable]RawPointer,

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1102,3 +1102,12 @@ func rdar17170728() {
     // expected-error@-1 {{type of expression is ambiguous without more context}}
   }
 }
+
+// https://bugs.swift.org/browse/SR-5934 - failure to emit diagnostic for bad
+// generic constraints
+func elephant<T, U>(_: T) where T : Collection, T.Element == U, T.Element : Hashable {}
+// expected-note@-1 {{in call to function 'elephant'}}
+
+func platypus<T>(a: [T]) {
+    _ = elephant(a) // expected-error {{generic parameter 'U' could not be inferred}}
+}

--- a/validation-test/compiler_crashers_2_fixed/sr-5836.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr-5836.swift
@@ -1,5 +1,4 @@
-// RUN: not --crash %target-typecheck-verify-swift
-// REQUIRES: asserts
+// RUN: not %target-typecheck-verify-swift
 
 extension Dictionary {
   func doSomething<T>() -> [T : Value] {


### PR DESCRIPTION
CSDiag was misinterpreting the result of checkGenericArguments().

A result of SubstitutionFailure does not mean a diagnostic was
emitted, only a result of Failure means that. This fixes a case
where we did not emit a diagnostic, result in a crash on invalid.

The diagnostic is still poor, but that's better than crashing.

Fixes <https://bugs.swift.org/browse/SR-5932>,
<rdar://problem/34522739>.