### PR TITLE
Revamped argument parsing unit-tests

### DIFF
--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -7,6 +7,9 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import argparse
+import multiprocessing
+
+from build_swift import defaults
 
 
 __all__ = [
@@ -54,7 +57,7 @@ EXPECTED_DEFAULTS = {
     'build_ios': True,
     'build_ios_device': False,
     'build_ios_simulator': False,
-    'build_jobs': 4,
+    'build_jobs': multiprocessing.cpu_count(),
     'build_libdispatch': False,
     'build_libicu': False,
     'build_linux': True,
@@ -83,20 +86,25 @@ EXPECTED_DEFAULTS = {
     'build_xctest': False,
     'clang_compiler_version': None,
     'clang_profile_instr_use': None,
-    'clang_user_visible_version': '5.0.0',
+    'clang_user_visible_version': defaults.CLANG_USER_VISIBLE_VERSION,
     'clean': False,
     'cmake': None,
     'cmake_generator': 'Ninja',
     'cmark_assertions': True,
     'cmark_build_variant': 'Debug',
-    'compiler_vendor': 'none',
+    'compiler_vendor': defaults.COMPILER_VENDOR,
     'coverage_db': None,
     'cross_compile_hosts': [],
-    'darwin_deployment_version_ios': '7.0',
-    'darwin_deployment_version_osx': '10.9',
-    'darwin_deployment_version_tvos': '9.0',
-    'darwin_deployment_version_watchos': '2.0',
-    'darwin_xcrun_toolchain': 'default',
+    'darwin_deployment_version_ios':
+        defaults.DARWIN_DEPLOYMENT_VERSION_IOS,
+    'darwin_deployment_version_osx':
+        defaults.DARWIN_DEPLOYMENT_VERSION_OSX,
+    'darwin_deployment_version_tvos':
+        defaults.DARWIN_DEPLOYMENT_VERSION_TVOS,
+    'darwin_deployment_version_watchos':
+        defaults.DARWIN_DEPLOYMENT_VERSION_WATCHOS,
+    'darwin_xcrun_toolchain':
+        defaults.DARWIN_XCRUN_TOOLCHAIN,
     'distcc': False,
     'dry_run': False,
     'enable_asan': False,
@@ -114,8 +122,10 @@ EXPECTED_DEFAULTS = {
     'host_cxx': None,
     'host_libtool': None,
     'host_lipo': None,
+    # FIXME: determine actual default value rather than hardcode
     'host_target': 'macosx-x86_64',
     'host_test': False,
+    # FIXME: determine actual default value rather than hardcode
     'install_prefix': '/Applications/Xcode.app/Contents/Developer/Toolchains/'
                       'XcodeDefault.xctoolchain/usr',
     'install_symroot': None,
@@ -147,14 +157,14 @@ EXPECTED_DEFAULTS = {
         'appletvos-arm64',
         'watchos-armv7k'
     ],
-    'swift_analyze_code_coverage': 'false',
+    'swift_analyze_code_coverage': defaults.SWIFT_ANALYZE_CODE_COVERAGE,
     'swift_assertions': True,
     'swift_build_variant': 'Debug',
     'swift_compiler_version': None,
     'swift_stdlib_assertions': True,
     'swift_stdlib_build_variant': 'Debug',
     'swift_tools_max_parallel_lto_link_jobs': 0,
-    'swift_user_visible_version': '4.1',
+    'swift_user_visible_version': defaults.SWIFT_USER_VISIBLE_VERSION,
     'symbols_package': None,
     'test': None,
     'test_android_host': False,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -10,16 +10,19 @@ import argparse
 
 
 __all__ = [
-    'Option',
-    'AppendOption',
-    'ChoicesOption',
     'HelpOption',
-    'IgnoreOption',
+    'SetOption',
+    'SetTrueOption',
+    'SetFalseOption',
+    'DisableOption',
+    'EnableOption',
+    'ChoicesOption',
     'IntOption',
-    'PathOption',
     'StrOption',
-    'ToggleOption',
+    'PathOption',
+    'AppendOption',
     'UnsupportedOption',
+    'IgnoreOption',
     'EXPECTED_OPTIONS',
     'EXPECTED_DEFAULTS',
 ]
@@ -183,33 +186,31 @@ EXPECTED_DEFAULTS = {
 
 # -----------------------------------------------------------------------------
 
+def _sanitize_option_string(option_string):
+    if option_string.startswith('--'):
+        return option_string[2:].replace('-', '_')
+
+    if len(option_string) == 2 and option_string[0] == '-':
+        return option_string[1]
+
+    raise ValueError('invalid option_string format: ' + option_string)
+
+
 class _BaseOption(object):
 
-    def __init__(self, option_string, dest, default=None):
-        self.option_string = option_string
-        self.dest = dest
+    def __init__(self, option_string, dest=None, default=None):
+        if dest is None:
+            dest = _sanitize_option_string(option_string)
 
         if default is None:
             default = EXPECTED_DEFAULTS.get(dest, None)
 
+        self.option_string = option_string
+        self.dest = dest
         self.default = default
 
-    def sanitized_str(self):
-        if self.option_string.startswith('--'):
-            return self.option_string[2:].replace('-', '_')
-
-        if len(self.option_string) == 2 and self.option_string[0] == '-':
-            return self.option_string[1]
-
-        raise ValueError('invalid option_string format: ' + self.option_string)
-
-
-class Option(_BaseOption):
-    """Option that accepts no arguments."""
-
-    def __init__(self, *args, **kwargs):
-        self.value = kwargs.pop('value', None)
-        super(Option, self).__init__(*args, **kwargs)
+    def sanitized_string(self):
+        return _sanitize_option_string(self.option_string)
 
 
 class HelpOption(_BaseOption):
@@ -218,8 +219,46 @@ class HelpOption(_BaseOption):
     pass
 
 
-class ToggleOption(_BaseOption):
-    """Option that accepts no argument or an optional bool argument."""
+class SetOption(_BaseOption):
+    """Option that accepts no arguments, setting the destination to a
+    hard-coded value or None.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.value = kwargs.pop('value', None)
+        super(SetOption, self).__init__(*args, **kwargs)
+
+
+class SetTrueOption(_BaseOption):
+    """Option that accepts no arguments, setting the destination value to True
+    if parsed and defaulting to False otherwise.
+    """
+
+    pass
+
+
+class SetFalseOption(_BaseOption):
+    """Option that accepts no arguments, setting the destination value to False
+    if parsed and defaulting to True otherwise.
+    """
+
+    pass
+
+
+class EnableOption(_BaseOption):
+    """Option that sets the destination to True when parsed and False by default.
+    Can be toggled True or False with an optional bool argument.
+    """
+
+    pass
+
+
+class DisableOption(_BaseOption):
+    """Option that sets the destination to False when parsed and True by default.
+    Can be toggled True or False with an optional bool argument, which is then
+    negated. Thus if an option is passed the value 'True' it will set the
+    destination to False and vice versa.
+    """
 
     pass
 
@@ -261,9 +300,7 @@ class AppendOption(_BaseOption):
 class UnsupportedOption(_BaseOption):
     """Option that is not supported."""
 
-    def __init__(self, *args, **kwargs):
-        kwargs['dest'] = kwargs.pop('dest', None)
-        super(UnsupportedOption, self).__init__(*args, **kwargs)
+    pass
 
 
 class IgnoreOption(_BaseOption):
@@ -282,235 +319,218 @@ EXPECTED_OPTIONS = [
     HelpOption('-h', dest='help', default=argparse.SUPPRESS),
     HelpOption('--help', dest='help', default=argparse.SUPPRESS),
 
-    Option('--assertions', dest='assertions', value=True),
-    Option('--benchmark', dest='benchmark', value=True),
-    Option('--clean', dest='clean', value=True),
-    Option('--cmark-assertions', dest='cmark_assertions', value=True),
-    Option('--debug', dest='build_variant', value='Debug'),
-    Option('--debug-cmark', dest='cmark_build_variant', value='Debug'),
-    Option('--debug-foundation',
-           dest='foundation_build_variant', value='Debug'),
-    Option('--debug-libdispatch',
-           dest='libdispatch_build_variant', value='Debug'),
-    Option('--debug-libicu', dest='libicu_build_variant', value='Debug'),
-    Option('--debug-lldb', dest='lldb_build_variant', value='Debug'),
-    Option('--debug-llvm', dest='llvm_build_variant', value='Debug'),
-    Option('--debug-swift', dest='swift_build_variant', value='Debug'),
-    Option('--debug-swift-stdlib',
-           dest='swift_stdlib_build_variant', value='Debug'),
-    Option('--dry-run', dest='dry_run', value=True),
-    Option('--eclipse', dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
-    Option('--enable-sil-ownership', dest='enable_sil_ownership', value=True),
-    Option('--force-optimized-typechecker',
-           dest='force_optimized_typechecker', value=True),
-    Option('--ios', dest='ios', value=True),
-    Option('--llbuild', dest='build_llbuild', value=True),
-    Option('--lldb', dest='build_lldb', value=True),
-    Option('--lldb-assertions', dest='lldb_assertions', value=True),
-    Option('--llvm-assertions', dest='llvm_assertions', value=True),
-    Option('--make', dest='cmake_generator', value='Unix Makefiles'),
-    Option('--no-assertions', dest='assertions', value=False),
-    Option('--no-legacy-impl', dest='legacy_impl', value=False),
-    Option('--no-lldb-assertions', dest='lldb_assertions', value=False),
-    Option('--no-llvm-assertions', dest='llvm_assertions', value=False),
-    Option('--no-swift-assertions', dest='swift_assertions', value=False),
-    Option('--no-swift-stdlib-assertions',
-           dest='swift_stdlib_assertions', value=False),
-    Option('--playgroundlogger', dest='build_playgroundlogger', value=True),
-    Option('--playgroundsupport', dest='build_playgroundsupport', value=True),
-    Option('--release', dest='build_variant', value='Release'),
-    Option('--release-debuginfo',
-           dest='build_variant', value='RelWithDebInfo'),
-    Option('--skip-build', dest='skip_build', value=True),
-    Option('--skip-ios', dest='ios', value=False),
-    Option('--skip-tvos', dest='tvos', value=False),
-    Option('--skip-watchos', dest='watchos', value=False),
-    Option('--swift-assertions', dest='swift_assertions', value=True),
-    Option('--swift-stdlib-assertions',
-           dest='swift_stdlib_assertions', value=True),
-    Option('--swiftpm', dest='build_swiftpm', value=True),
-    Option('--xcode', dest='cmake_generator', value='Xcode'),
-    Option('-B', dest='benchmark', value=True),
-    Option('-R', dest='build_variant', value='Release'),
-    Option('-S', dest='skip_build', value=True),
-    Option('-T', dest='validation_test', value=True),
-    Option('-b', dest='build_llbuild', value=True),
-    Option('-c', dest='clean', value=True),
-    Option('-d', dest='build_variant', value='Debug'),
-    Option('-e', dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
-    Option('-i', dest='ios', value=True),
-    Option('-l', dest='build_lldb', value=True),
-    Option('-m', dest='cmake_generator', value='Unix Makefiles'),
-    Option('-n', dest='dry_run', value=True),
-    Option('-o', dest='test_optimized', value=True),
-    Option('-p', dest='build_swiftpm', value=True),
-    Option('-r', dest='build_variant', value='RelWithDebInfo'),
-    Option('-s', dest='test_optimize_for_size', value=True),
-    Option('-t', dest='test', value=True),
-    Option('-x', dest='cmake_generator', value='Xcode'),
+    SetOption('--debug', dest='build_variant', value='Debug'),
+    SetOption('--debug-cmark', dest='cmark_build_variant', value='Debug'),
+    SetOption('--debug-foundation',
+              dest='foundation_build_variant', value='Debug'),
+    SetOption('--debug-libdispatch',
+              dest='libdispatch_build_variant', value='Debug'),
+    SetOption('--debug-libicu', dest='libicu_build_variant', value='Debug'),
+    SetOption('--debug-lldb', dest='lldb_build_variant', value='Debug'),
+    SetOption('--debug-llvm', dest='llvm_build_variant', value='Debug'),
+    SetOption('--debug-swift', dest='swift_build_variant', value='Debug'),
+    SetOption('--debug-swift-stdlib',
+              dest='swift_stdlib_build_variant', value='Debug'),
+    SetOption('--eclipse',
+              dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
+    SetOption('--make', dest='cmake_generator', value='Unix Makefiles'),
+    SetOption('--release', dest='build_variant', value='Release'),
+    SetOption('--release-debuginfo',
+              dest='build_variant', value='RelWithDebInfo'),
+    SetOption('--xcode', dest='cmake_generator', value='Xcode'),
+    SetOption('-R', dest='build_variant', value='Release'),
+    SetOption('-d', dest='build_variant', value='Debug'),
+    SetOption('-e', dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
+    SetOption('-m', dest='cmake_generator', value='Unix Makefiles'),
+    SetOption('-r', dest='build_variant', value='RelWithDebInfo'),
+    SetOption('-x', dest='cmake_generator', value='Xcode'),
 
-    ToggleOption('--android', dest='android'),
-    ToggleOption('--build-external-benchmarks',
-                 dest='build_external_benchmarks'),
-    ToggleOption('--build-ninja', dest='build_ninja'),
-    ToggleOption('--build-runtime-with-host-compiler',
-                 dest='build_runtime_with_host_compiler'),
-    ToggleOption('--build-swift-dynamic-sdk-overlay',
-                 dest='build_swift_dynamic_sdk_overlay'),
-    ToggleOption('--build-swift-dynamic-stdlib',
-                 dest='build_swift_dynamic_stdlib'),
-    ToggleOption('--build-swift-static-sdk-overlay',
-                 dest='build_swift_static_sdk_overlay'),
-    ToggleOption('--build-swift-static-stdlib',
-                 dest='build_swift_static_stdlib'),
-    ToggleOption('--build-swift-stdlib-unittest-extra',
-                 dest='build_swift_stdlib_unittest_extra'),
-    ToggleOption('--distcc', dest='distcc'),
-    ToggleOption('--enable-asan', dest='enable_asan'),
-    ToggleOption('--enable-lsan', dest='enable_lsan'),
-    ToggleOption('--enable-tsan', dest='enable_tsan'),
-    ToggleOption('--enable-ubsan', dest='enable_ubsan'),
-    ToggleOption('--export-compile-commands', dest='export_compile_commands'),
-    ToggleOption('--foundation', dest='build_foundation'),
-    ToggleOption('--host-test', dest='host_test'),
-    ToggleOption('--libdispatch', dest='build_libdispatch'),
-    ToggleOption('--libicu', dest='build_libicu'),
-    ToggleOption('--long-test', dest='long_test'),
-    ToggleOption('--show-sdks', dest='show_sdks'),
-    ToggleOption('--skip-build-android', dest='build_android'),
-    ToggleOption('--skip-build-benchmarks', dest='build_benchmarks'),
-    ToggleOption('--skip-build-cygwin', dest='build_cygwin'),
-    ToggleOption('--skip-build-freebsd', dest='build_freebsd'),
-    ToggleOption('--skip-build-ios', dest='build_ios'),
-    ToggleOption('--skip-build-ios-device', dest='build_ios_device'),
-    ToggleOption('--skip-build-ios-simulator',
-                 dest='build_ios_simulator'),
-    ToggleOption('--skip-build-linux', dest='build_linux'),
-    ToggleOption('--skip-build-osx', dest='build_osx'),
-    ToggleOption('--skip-build-tvos', dest='build_tvos'),
-    ToggleOption('--skip-build-tvos-device', dest='build_tvos_device'),
-    ToggleOption('--skip-build-tvos-simulator',
-                 dest='build_tvos_simulator'),
-    ToggleOption('--skip-build-watchos', dest='build_watchos'),
-    ToggleOption('--skip-build-watchos-device',
-                 dest='build_watchos_device'),
-    ToggleOption('--skip-build-watchos-simulator',
-                 dest='build_watchos_simulator'),
-    ToggleOption('--skip-test-android-host', dest='test_android_host'),
-    ToggleOption('--skip-test-cygwin', dest='test_cygwin'),
-    ToggleOption('--skip-test-freebsd', dest='test_freebsd'),
-    ToggleOption('--skip-test-ios', dest='test_ios'),
-    ToggleOption('--skip-test-ios-32bit-simulator',
-                 dest='test_ios_32bit_simulator'),
-    ToggleOption('--skip-test-ios-host', dest='test_ios_host'),
-    ToggleOption('--skip-test-ios-simulator', dest='test_ios_simulator'),
-    ToggleOption('--skip-test-linux', dest='test_linux'),
-    ToggleOption('--skip-test-osx', dest='test_osx'),
-    ToggleOption('--skip-test-tvos', dest='test_tvos'),
-    ToggleOption('--skip-test-tvos-host', dest='test_tvos_host'),
-    ToggleOption('--skip-test-tvos-simulator',
-                 dest='test_tvos_simulator'),
-    ToggleOption('--skip-test-watchos', dest='test_watchos'),
-    ToggleOption('--skip-test-watchos-host', dest='test_watchos_host'),
-    ToggleOption('--skip-test-watchos-simulator',
-                 dest='test_watchos_simulator'),
-    ToggleOption('--test', dest='test'),
-    ToggleOption('--test-optimize-for-size', dest='test_optimize_for_size'),
-    ToggleOption('--test-optimized', dest='test_optimized'),
-    ToggleOption('--tvos', dest='tvos'),
-    ToggleOption('--validation-test', dest='validation_test'),
-    ToggleOption('--verbose-build', dest='verbose_build'),
-    ToggleOption('--watchos', dest='watchos'),
-    ToggleOption('--xctest', dest='build_xctest'),
+    # FIXME: Convert these options to set_true actions
+    SetOption('--assertions', value=True),
+    SetOption('--cmark-assertions', value=True),
+    SetOption('--lldb-assertions', value=True),
+    SetOption('--llvm-assertions', value=True),
+    SetOption('--swift-assertions', value=True),
+    SetOption('--swift-stdlib-assertions', value=True),
+    SetOption('-T', dest='validation_test', value=True),
+    SetOption('-o', dest='test_optimized', value=True),
+    SetOption('-s', dest='test_optimize_for_size', value=True),
+    SetOption('-t', dest='test', value=True),
+
+    # FIXME: Convert these options to set_false actions
+    SetOption('--no-assertions', dest='assertions', value=False),
+    SetOption('--no-lldb-assertions', dest='lldb_assertions', value=False),
+    SetOption('--no-llvm-assertions', dest='llvm_assertions', value=False),
+    SetOption('--no-swift-assertions', dest='swift_assertions', value=False),
+    SetOption('--no-swift-stdlib-assertions',
+              dest='swift_stdlib_assertions', value=False),
+    SetOption('--skip-ios', dest='ios', value=False),
+    SetOption('--skip-tvos', dest='tvos', value=False),
+    SetOption('--skip-watchos', dest='watchos', value=False),
+
+    SetTrueOption('--benchmark'),
+    SetTrueOption('--clean'),
+    SetTrueOption('--dry-run'),
+    SetTrueOption('--enable-sil-ownership'),
+    SetTrueOption('--force-optimized-typechecker'),
+    SetTrueOption('--ios'),
+    SetTrueOption('--llbuild', dest='build_llbuild'),
+    SetTrueOption('--lldb', dest='build_lldb'),
+    SetTrueOption('--playgroundlogger', dest='build_playgroundlogger'),
+    SetTrueOption('--playgroundsupport', dest='build_playgroundsupport'),
+    SetTrueOption('--skip-build'),
+    SetTrueOption('--swiftpm', dest='build_swiftpm'),
+    SetTrueOption('-B', dest='benchmark'),
+    SetTrueOption('-S', dest='skip_build'),
+    SetTrueOption('-b', dest='build_llbuild'),
+    SetTrueOption('-c', dest='clean'),
+    SetTrueOption('-i', dest='ios'),
+    SetTrueOption('-l', dest='build_lldb'),
+    SetTrueOption('-n', dest='dry_run'),
+    SetTrueOption('-p', dest='build_swiftpm'),
+
+    SetFalseOption('--no-legacy-impl', dest='legacy_impl'),
+
+    EnableOption('--android'),
+    EnableOption('--build-external-benchmarks'),
+    EnableOption('--build-ninja'),
+    EnableOption('--build-runtime-with-host-compiler'),
+    EnableOption('--build-swift-dynamic-sdk-overlay'),
+    EnableOption('--build-swift-dynamic-stdlib'),
+    EnableOption('--build-swift-static-sdk-overlay'),
+    EnableOption('--build-swift-static-stdlib'),
+    EnableOption('--build-swift-stdlib-unittest-extra'),
+    EnableOption('--distcc'),
+    EnableOption('--enable-asan'),
+    EnableOption('--enable-lsan'),
+    EnableOption('--enable-tsan'),
+    EnableOption('--enable-ubsan'),
+    EnableOption('--export-compile-commands'),
+    EnableOption('--foundation', dest='build_foundation'),
+    EnableOption('--host-test'),
+    EnableOption('--libdispatch', dest='build_libdispatch'),
+    EnableOption('--libicu', dest='build_libicu'),
+    EnableOption('--long-test'),
+    EnableOption('--show-sdks'),
+    EnableOption('--test'),
+    EnableOption('--test-optimize-for-size'),
+    EnableOption('--test-optimized'),
+    EnableOption('--tvos'),
+    EnableOption('--validation-test'),
+    EnableOption('--verbose-build'),
+    EnableOption('--watchos'),
+    EnableOption('--xctest', dest='build_xctest'),
+
+    DisableOption('--skip-build-android', dest='build_android'),
+    DisableOption('--skip-build-benchmarks', dest='build_benchmarks'),
+    DisableOption('--skip-build-cygwin', dest='build_cygwin'),
+    DisableOption('--skip-build-freebsd', dest='build_freebsd'),
+    DisableOption('--skip-build-ios', dest='build_ios'),
+    DisableOption('--skip-build-ios-device', dest='build_ios_device'),
+    DisableOption('--skip-build-ios-simulator',
+                  dest='build_ios_simulator'),
+    DisableOption('--skip-build-linux', dest='build_linux'),
+    DisableOption('--skip-build-osx', dest='build_osx'),
+    DisableOption('--skip-build-tvos', dest='build_tvos'),
+    DisableOption('--skip-build-tvos-device', dest='build_tvos_device'),
+    DisableOption('--skip-build-tvos-simulator',
+                  dest='build_tvos_simulator'),
+    DisableOption('--skip-build-watchos', dest='build_watchos'),
+    DisableOption('--skip-build-watchos-device',
+                  dest='build_watchos_device'),
+    DisableOption('--skip-build-watchos-simulator',
+                  dest='build_watchos_simulator'),
+    DisableOption('--skip-test-android-host', dest='test_android_host'),
+    DisableOption('--skip-test-cygwin', dest='test_cygwin'),
+    DisableOption('--skip-test-freebsd', dest='test_freebsd'),
+    DisableOption('--skip-test-ios', dest='test_ios'),
+    DisableOption('--skip-test-ios-32bit-simulator',
+                  dest='test_ios_32bit_simulator'),
+    DisableOption('--skip-test-ios-host', dest='test_ios_host'),
+    DisableOption('--skip-test-ios-simulator', dest='test_ios_simulator'),
+    DisableOption('--skip-test-linux', dest='test_linux'),
+    DisableOption('--skip-test-osx', dest='test_osx'),
+    DisableOption('--skip-test-tvos', dest='test_tvos'),
+    DisableOption('--skip-test-tvos-host', dest='test_tvos_host'),
+    DisableOption('--skip-test-tvos-simulator',
+                  dest='test_tvos_simulator'),
+    DisableOption('--skip-test-watchos', dest='test_watchos'),
+    DisableOption('--skip-test-watchos-host', dest='test_watchos_host'),
+    DisableOption('--skip-test-watchos-simulator',
+                  dest='test_watchos_simulator'),
 
     ChoicesOption('--android-ndk-gcc-version',
-                  dest='android_ndk_gcc_version',
                   choices=['4.8', '4.9']),
     ChoicesOption('--compiler-vendor',
-                  dest='compiler_vendor',
                   choices=['none', 'apple']),
     ChoicesOption('--swift-analyze-code-coverage',
-                  dest='swift_analyze_code_coverage',
                   choices=['false', 'not-merged', 'merged']),
 
-    StrOption('--android-api-level', dest='android_api_level'),
-    StrOption('--build-args', dest='build_args'),
-    StrOption('--build-stdlib-deployment-targets',
-              dest='build_stdlib_deployment_targets'),
-    StrOption('--darwin-deployment-version-ios',
-              dest='darwin_deployment_version_ios'),
-    StrOption('--darwin-deployment-version-osx',
-              dest='darwin_deployment_version_osx'),
-    StrOption('--darwin-deployment-version-tvos',
-              dest='darwin_deployment_version_tvos'),
-    StrOption('--darwin-deployment-version-watchos',
-              dest='darwin_deployment_version_watchos'),
-    StrOption('--darwin-xcrun-toolchain', dest='darwin_xcrun_toolchain'),
-    StrOption('--enable-tsan-runtime', dest='enable_tsan_runtime'),
-    StrOption('--host-target', dest='host_target'),
-    StrOption('--lit-args', dest='lit_args'),
-    StrOption('--llvm-targets-to-build', dest='llvm_targets_to_build'),
+    StrOption('--android-api-level'),
+    StrOption('--build-args'),
+    StrOption('--build-stdlib-deployment-targets'),
+    StrOption('--darwin-deployment-version-ios'),
+    StrOption('--darwin-deployment-version-osx'),
+    StrOption('--darwin-deployment-version-tvos'),
+    StrOption('--darwin-deployment-version-watchos'),
+    StrOption('--darwin-xcrun-toolchain'),
+    StrOption('--enable-tsan-runtime'),
+    StrOption('--host-target'),
+    StrOption('--lit-args'),
+    StrOption('--llvm-targets-to-build'),
 
-    PathOption('--android-deploy-device-path',
-               dest='android_deploy_device_path'),
-    PathOption('--android-icu-i18n', dest='android_icu_i18n'),
-    PathOption('--android-icu-i18n-include', dest='android_icu_i18n_include'),
-    PathOption('--android-icu-uc', dest='android_icu_uc'),
-    PathOption('--android-icu-uc-include', dest='android_icu_uc_include'),
-    PathOption('--android-ndk', dest='android_ndk'),
-    PathOption('--build-subdir', dest='build_subdir'),
-    PathOption('--clang-profile-instr-use', dest='clang_profile_instr_use'),
-    PathOption('--cmake', dest='cmake'),
-    PathOption('--coverage-db', dest='coverage_db'),
-    PathOption('--host-cc', dest='host_cc'),
-    PathOption('--host-cxx', dest='host_cxx'),
-    PathOption('--host-libtool', dest='host_libtool'),
-    PathOption('--host-lipo', dest='host_lipo'),
-    PathOption('--install-prefix', dest='install_prefix'),
-    PathOption('--install-symroot', dest='install_symroot'),
-    PathOption('--symbols-package', dest='symbols_package'),
+    PathOption('--android-deploy-device-path'),
+    PathOption('--android-icu-i18n'),
+    PathOption('--android-icu-i18n-include'),
+    PathOption('--android-icu-uc'),
+    PathOption('--android-icu-uc-include'),
+    PathOption('--android-ndk'),
+    PathOption('--build-subdir'),
+    PathOption('--clang-profile-instr-use'),
+    PathOption('--cmake'),
+    PathOption('--coverage-db'),
+    PathOption('--host-cc'),
+    PathOption('--host-cxx'),
+    PathOption('--host-libtool'),
+    PathOption('--host-lipo'),
+    PathOption('--install-prefix'),
+    PathOption('--install-symroot'),
+    PathOption('--symbols-package'),
 
-    IntOption('--benchmark-num-o-iterations',
-              dest='benchmark_num_o_iterations'),
-    IntOption('--benchmark-num-onone-iterations',
-              dest='benchmark_num_onone_iterations'),
+    IntOption('--benchmark-num-o-iterations'),
+    IntOption('--benchmark-num-onone-iterations'),
     IntOption('--jobs', dest='build_jobs'),
-    IntOption('--llvm-max-parallel-lto-link-jobs',
-              dest='llvm_max_parallel_lto_link_jobs'),
-    IntOption('--swift-tools-max-parallel-lto-link-jobs',
-              dest='swift_tools_max_parallel_lto_link_jobs'),
+    IntOption('--llvm-max-parallel-lto-link-jobs'),
+    IntOption('--swift-tools-max-parallel-lto-link-jobs'),
     IntOption('-j', dest='build_jobs'),
 
-    AppendOption('--cross-compile-hosts', dest='cross_compile_hosts'),
-    AppendOption('--extra-cmake-options', dest='extra_cmake_options'),
-    AppendOption('--extra-swift-args', dest='extra_swift_args'),
-    AppendOption('--stdlib-deployment-targets',
-                 dest='stdlib_deployment_targets'),
-    AppendOption('--test-paths', dest='test_paths'),
+    AppendOption('--cross-compile-hosts'),
+    AppendOption('--extra-cmake-options'),
+    AppendOption('--extra-swift-args'),
+    AppendOption('--stdlib-deployment-targets'),
+    AppendOption('--test-paths'),
 
     UnsupportedOption('--build-jobs'),
     UnsupportedOption('--common-cmake-options'),
-    UnsupportedOption('--ios-all'),
     UnsupportedOption('--only-execute'),
     UnsupportedOption('--skip-test-optimize-for-size'),
     UnsupportedOption('--skip-test-optimized'),
-    UnsupportedOption('--tvos-all'),
-    UnsupportedOption('--watchos-all'),
-    UnsupportedOption('-I'),
 
     # NOTE: LTO flag is a special case that acts both as an option and has
     # valid choices
-    Option('--lto', dest='lto_type'),
+    SetOption('--lto', dest='lto_type'),
     ChoicesOption('--lto', dest='lto_type', choices=['thin', 'full']),
 
     # NOTE: We'll need to manually test the behavior of these since they
     # validate compiler version strings.
-    IgnoreOption('--clang-compiler-version',
-                 dest='clang_compiler_version'),
-    IgnoreOption('--clang-user-visible-version',
-                 dest='clang_user_visible_version'),
-    IgnoreOption('--swift-compiler-version',
-                 dest='swift_compiler_version'),
-    IgnoreOption('--swift-user-visible-version',
-                 dest='swift_user_visible_version'),
+    IgnoreOption('--clang-compiler-version'),
+    IgnoreOption('--clang-user-visible-version'),
+    IgnoreOption('--swift-compiler-version'),
+    IgnoreOption('--swift-user-visible-version'),
+
+    # TODO: Migrate to unavailable options once new parser is in place
+    IgnoreOption('-I'),
+    IgnoreOption('--ios-all'),
+    IgnoreOption('--tvos-all'),
+    IgnoreOption('--watchos-all'),
 ]

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -8,6 +8,7 @@
 
 from __future__ import print_function
 
+import argparse
 import os
 import sys
 import unittest
@@ -16,7 +17,7 @@ from contextlib import contextmanager
 from io import StringIO
 
 from build_swift import driver_arguments
-from build_swift.tests import expected_options
+from build_swift.tests import expected_options as eo
 
 from swift_build_support.swift_build_support import migration
 from swift_build_support.swift_build_support.SwiftBuildSupport import (
@@ -92,13 +93,13 @@ class TestDriverArgumentParserMeta(type):
 
     def __new__(cls, name, bases, attrs):
         # Generate tests for each default value
-        for dest, value in expected_options.EXPECTED_DEFAULTS.items():
+        for dest, value in eo.EXPECTED_DEFAULTS.items():
             test_name = 'test_default_value_' + dest
             attrs[test_name] = cls.generate_default_value_test(dest, value)
 
         # Generate tests for each expected option
-        for option in expected_options.EXPECTED_OPTIONS:
-            test_name = 'test_option_' + option.sanitized_str()
+        for option in eo.EXPECTED_OPTIONS:
+            test_name = 'test_option_' + option.sanitized_string()
             attrs[test_name] = cls.generate_option_test(option)
 
         # Generate tests for each preset
@@ -115,7 +116,7 @@ class TestDriverArgumentParserMeta(type):
     def generate_default_value_test(cls, dest, default_value):
         def test(self):
             with self.assertNotRaises(ParserError):
-                parsed_values = self.parse_args([])
+                parsed_values = self.parse_default_args([])
 
             parsed_value = getattr(parsed_values, dest)
             if default_value.__class__ is str:
@@ -124,42 +125,6 @@ class TestDriverArgumentParserMeta(type):
             self.assertEqual(default_value, parsed_value,
                              'Invalid default value for "{}": {} != {}'
                              .format(dest, default_value, parsed_value))
-
-        return test
-
-    @classmethod
-    def _generate_option_test(cls, option):
-        def test(self):
-            with self.assertNotRaises(ParserError):
-                args = self.parse_args([option.option_string])
-                self.assertEqual(getattr(args, option.dest), option.value)
-
-            with self.assertRaises(ParserError):
-                self.parse_args([option.option_string, 'foo'])
-
-        return test
-
-    @classmethod
-    def _generate_append_option_test(cls, option):
-        def test(self):
-            with self.assertNotRaises(ParserError):
-                # Range size is arbitrary, just needs to be more than once
-                for i in range(1, 4):
-                    args = self.parse_args([option.option_string, 'ARG'] * i)
-                    self.assertEqual(getattr(args, option.dest), ['ARG'] * i)
-
-        return test
-
-    @classmethod
-    def _generate_choices_option_test(cls, option):
-        def test(self):
-            with self.assertNotRaises(ParserError):
-                for choice in option.choices:
-                    args = self.parse_args([option.option_string, str(choice)])
-                    self.assertEqual(getattr(args, option.dest), choice)
-
-            with self.assertRaises(ParserError):
-                self.parse_args([option.option_string, 'INVALID'])
 
         return test
 
@@ -173,12 +138,130 @@ class TestDriverArgumentParserMeta(type):
         return test
 
     @classmethod
+    def _generate_set_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                namespace = self.parse_args([option.option_string])
+                self.assertEqual(getattr(namespace, option.dest), option.value)
+
+            with self.assertRaises(ParserError):
+                self.parse_args([option.option_string, 'foo'])
+
+        return test
+
+    @classmethod
+    def _generate_set_true_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                # TODO: Move to unit-tests for the action class
+                namespace = self.parse_args([])
+                self.assertFalse(getattr(namespace, option.dest))
+
+                namespace = self.parse_args([option.option_string])
+                self.assertTrue(getattr(namespace, option.dest))
+
+        return test
+
+    @classmethod
+    def _generate_set_false_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                # TODO: Move to unit-tests for the action class
+                namespace = self.parse_args([])
+                self.assertTrue(getattr(namespace, option.dest))
+
+                namespace = self.parse_args([option.option_string])
+                self.assertFalse(getattr(namespace, option.dest))
+
+        return test
+
+    @classmethod
+    def _generate_enable_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                # TODO: Move to unit-tests for the action class
+                # Test parsing True values
+                self.parse_args([option.option_string, '1'])
+                self.parse_args([option.option_string, 'true'])
+                self.parse_args([option.option_string, 'True'])
+                self.parse_args([option.option_string, 'TRUE'])
+
+                # TODO: Move to unit-tests for the action class
+                # Test parsing False values
+                self.parse_args([option.option_string, '0'])
+                self.parse_args([option.option_string, 'false'])
+                self.parse_args([option.option_string, 'False'])
+                self.parse_args([option.option_string, 'FALSE'])
+
+                # TODO: Move to unit-tests for the action class
+                # Test default value
+                namespace = self.parse_args([option.option_string])
+                self.assertTrue(getattr(namespace, option.dest))
+
+                # Test setting value to True
+                namespace = self.parse_args([option.option_string, 'True'])
+                self.assertTrue(getattr(namespace, option.dest))
+
+                # Test setting value to False
+                namespace = self.parse_args([option.option_string, 'False'])
+                self.assertFalse(getattr(namespace, option.dest))
+
+        return test
+
+    @classmethod
+    def _generate_disable_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                # TODO: Move to unit-tests for the action class
+                # Test parsing True values
+                self.parse_args([option.option_string, '1'])
+                self.parse_args([option.option_string, 'true'])
+                self.parse_args([option.option_string, 'True'])
+                self.parse_args([option.option_string, 'TRUE'])
+
+                # TODO: Move to unit-tests for the action class
+                # Test parsing False values
+                self.parse_args([option.option_string, '0'])
+                self.parse_args([option.option_string, 'false'])
+                self.parse_args([option.option_string, 'False'])
+                self.parse_args([option.option_string, 'FALSE'])
+
+                # TODO: Move to unit-tests for the action class
+                # Test default value
+                namespace = self.parse_args([option.option_string])
+                self.assertFalse(getattr(namespace, option.dest))
+
+                # Test setting value to True resulting in False
+                namespace = self.parse_args([option.option_string, 'True'])
+                self.assertFalse(getattr(namespace, option.dest))
+
+                # Test setting value to False resulting in True
+                namespace = self.parse_args([option.option_string, 'False'])
+                self.assertTrue(getattr(namespace, option.dest))
+
+        return test
+
+    @classmethod
+    def _generate_choices_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                for choice in option.choices:
+                    namespace = self.parse_args(
+                        [option.option_string, str(choice)])
+                    self.assertEqual(getattr(namespace, option.dest), choice)
+
+            with self.assertRaises(ParserError):
+                self.parse_args([option.option_string, 'INVALID'])
+
+        return test
+
+    @classmethod
     def _generate_int_option_test(cls, option):
         def test(self):
             with self.assertNotRaises(ParserError):
                 for i in [0, 1, 42]:
-                    args = self.parse_args([option.option_string, str(i)])
-                    self.assertEqual(int(getattr(args, option.dest)), i)
+                    namespace = self.parse_args([option.option_string, str(i)])
+                    self.assertEqual(int(getattr(namespace, option.dest)), i)
 
             # FIXME: int-type options should not accept non-int strings
             # with self.assertRaises(ParserError):
@@ -186,6 +269,14 @@ class TestDriverArgumentParserMeta(type):
             #     self.parse_args([option.option_string, str(1.0)])
             #     self.parse_args([option.option_string, str(3.14)])
             #     self.parse_args([option.option_string, 'NaN'])
+
+        return test
+
+    @classmethod
+    def _generate_str_option_test(cls, option):
+        def test(self):
+            with self.assertNotRaises(ParserError):
+                self.parse_args([option.option_string, 'foo'])
 
         return test
 
@@ -202,35 +293,15 @@ class TestDriverArgumentParserMeta(type):
         return test
 
     @classmethod
-    def _generate_str_option_test(cls, option):
+    def _generate_append_option_test(cls, option):
         def test(self):
             with self.assertNotRaises(ParserError):
-                self.parse_args([option.option_string, 'foo'])
-
-        return test
-
-    @classmethod
-    def _generate_toggle_option_test(cls, option):
-        def test(self):
-            with self.assertNotRaises(ParserError):
-                # Standalone argument
-                self.parse_args([option.option_string])
-
-                # True values
-                # self.parse_args([option.option_string, True])
-                # self.parse_args([option.option_string, 1])
-                self.parse_args([option.option_string, '1'])
-                self.parse_args([option.option_string, 'true'])
-                self.parse_args([option.option_string, 'True'])
-                # self.parse_args([option.option_string, 'TRUE'])
-
-                # False values
-                # self.parse_args([option.option_string, False])
-                # self.parse_args([option.option_string, 0])
-                self.parse_args([option.option_string, '0'])
-                self.parse_args([option.option_string, 'false'])
-                self.parse_args([option.option_string, 'False'])
-                # self.parse_args([option.option_string, 'FALSE'])
+                # Range size is arbitrary, just needs to be more than once
+                for i in range(1, 4):
+                    namespace = self.parse_args(
+                        [option.option_string, 'ARG'] * i)
+                    self.assertEqual(getattr(namespace, option.dest),
+                                     ['ARG'] * i)
 
         return test
 
@@ -244,40 +315,39 @@ class TestDriverArgumentParserMeta(type):
 
     @classmethod
     def generate_option_test(cls, option):
-        if option.__class__ is expected_options.Option:
-            return cls._generate_option_test(option)
-        elif option.__class__ is expected_options.AppendOption:
-            return cls._generate_append_option_test(option)
-        elif option.__class__ is expected_options.ChoicesOption:
-            return cls._generate_choices_option_test(option)
-        elif option.__class__ is expected_options.HelpOption:
-            return cls._generate_help_option_test(option)
-        elif option.__class__ is expected_options.IntOption:
-            return cls._generate_int_option_test(option)
-        elif option.__class__ is expected_options.PathOption:
-            return cls._generate_path_option_test(option)
-        elif option.__class__ is expected_options.StrOption:
-            return cls._generate_str_option_test(option)
-        elif option.__class__ is expected_options.ToggleOption:
-            return cls._generate_toggle_option_test(option)
-        elif option.__class__ is expected_options.UnsupportedOption:
-            return cls._generate_unsupported_option_test(option)
+        generate_test_funcs = {
+            eo.HelpOption: cls._generate_help_option_test,
+            eo.SetOption: cls._generate_set_option_test,
+            eo.SetTrueOption: cls._generate_set_true_option_test,
+            eo.SetFalseOption: cls._generate_set_false_option_test,
+            eo.EnableOption: cls._generate_enable_option_test,
+            eo.DisableOption: cls._generate_disable_option_test,
+            eo.ChoicesOption: cls._generate_choices_option_test,
+            eo.IntOption: cls._generate_int_option_test,
+            eo.StrOption: cls._generate_str_option_test,
+            eo.PathOption: cls._generate_path_option_test,
+            eo.AppendOption: cls._generate_append_option_test,
+            eo.UnsupportedOption: cls._generate_unsupported_option_test,
 
-        # Ignore all IgnoreOption tests since they should be manually tested
-        elif option.__class__ is expected_options.IgnoreOption:
-            return lambda self: None
+            # IgnoreOptions should be manually tested
+            eo.IgnoreOption: lambda self: None,
+        }
+
+        test_func = generate_test_funcs.get(option.__class__, None)
+        if test_func is not None:
+            return test_func(option)
 
         # Catch-all meaningless test
         return lambda self: \
-            self.fail('Unexpected option "{}"'.format(option.option_string))
+            self.fail('unexpected option "{}"'.format(option.option_string))
 
     @classmethod
     def generate_preset_test(cls, preset_name, preset_args):
         def test(self):
             try:
-                self.parse_args(preset_args, check_impl_args=True)
+                self.parse_default_args(preset_args, check_impl_args=True)
             except ParserError as e:
-                self.fail('Failed to parse preset "{}": {}'.format(
+                self.fail('failed to parse preset "{}": {}'.format(
                     preset_name, e))
 
         return test
@@ -287,28 +357,54 @@ class TestDriverArgumentParser(unittest.TestCase):
 
     __metaclass__ = TestDriverArgumentParserMeta
 
-    def parse_args(self, args, error_message=None, check_impl_args=False):
-        if error_message is None:
-            error_message = 'failed to parse arguments: ' + str(args)
-
+    @contextmanager
+    def _quiet_output(self):
         with open(os.devnull, 'w') as devnull:
-            try:
-                with redirect_stderr(devnull), redirect_stdout(devnull):
-                    namespace = migration.parse_args(self.parser, args)
-            except (SystemExit, ValueError) as e:
-                raise ParserError(error_message, e)
+            with redirect_stderr(devnull), redirect_stdout(devnull):
+                yield
 
-            if not namespace.build_script_impl_args and not check_impl_args:
-                return namespace
+    def _parse_args(self, args):
+        try:
+            return migration.parse_args(self.parser, args)
+        except (SystemExit, ValueError) as e:
+            raise ParserError('failed to parse arguments: ' +
+                              str(args), e)
 
+    def _check_impl_args(self, namespace):
+        assert hasattr(namespace, 'build_script_impl_args')
+
+        try:
+            migration.check_impl_args(BUILD_SCRIPT_IMPL,
+                                      namespace.build_script_impl_args)
+        except (SystemExit, ValueError) as e:
+            raise ParserError('failed to parse impl arguments: ' +
+                              str(namespace.build_script_impl_args), e)
+
+    def parse_args(self, args, namespace=None):
+        if namespace is None:
+            namespace = argparse.Namespace()
+
+        with self._quiet_output():
             try:
-                with redirect_stderr(devnull), redirect_stdout(devnull):
-                    migration.check_impl_args(BUILD_SCRIPT_IMPL,
-                                              namespace.build_script_impl_args)
-            except (SystemExit, ValueError) as e:
-                raise ParserError(error_message, e)
+                namespace, unknown_args =\
+                    super(self.parser.__class__, self.parser)\
+                    .parse_known_args(args, namespace)
+            except (SystemExit, argparse.ArgumentError) as e:
+                raise ParserError('failed to parse arguments: ' + str(args), e)
+
+        if unknown_args:
+            raise ParserError('unknown arguments: ' + str(unknown_args))
 
         return namespace
+
+    def parse_default_args(self, args, check_impl_args=False):
+        with self._quiet_output():
+            namespace = self._parse_args(args)
+
+            if check_impl_args:
+                self._check_impl_args(namespace)
+
+            return namespace
 
     @contextmanager
     def assertNotRaises(self, exception):
@@ -323,217 +419,255 @@ class TestDriverArgumentParser(unittest.TestCase):
         self.parser = driver_arguments.create_argument_parser()
 
     # -------------------------------------------------------------------------
+
+    def test_expected_options_exhaustive(self):
+        """Test that we are exhaustively testing all options accepted by the
+        parser. If this test if failing then the parser accepts more options
+        than currently being tested, meaning the EXPECTED_OPTIONS list in
+        build_swift/tests/expected_options.py should be updated to include
+        the missing options.
+        """
+
+        expected_options = {o.option_string for o in eo.EXPECTED_OPTIONS}
+
+        # aggregate and flatten the options_strings accepted by the parser
+        actual_options = [a.option_strings for a in self.parser._actions]
+        actual_options = set(sum(actual_options, []))
+
+        diff = actual_options - expected_options
+
+        if len(diff) > 0:
+            self.fail('non-exhaustive expected options, missing: {}'
+                      .format(diff))
+
+    # -------------------------------------------------------------------------
     # Manual option tests
 
     def test_option_clang_compiler_version(self):
         option_string = '--clang-compiler-version'
 
         with self.assertNotRaises(ParserError):
-            self.parse_args([option_string, '5.0.0'])
-            self.parse_args([option_string, '5.0.1'])
-            self.parse_args([option_string, '5.0.0.1'])
+            self.parse_default_args([option_string, '5.0.0'])
+            self.parse_default_args([option_string, '5.0.1'])
+            self.parse_default_args([option_string, '5.0.0.1'])
 
         with self.assertRaises(ParserError):
-            self.parse_args([option_string, '1'])
-            self.parse_args([option_string, '1.2'])
-            self.parse_args([option_string, '0.0.0.0.1'])
+            self.parse_default_args([option_string, '1'])
+            self.parse_default_args([option_string, '1.2'])
+            self.parse_default_args([option_string, '0.0.0.0.1'])
 
     def test_option_clang_user_visible_version(self):
         option_string = '--clang-user-visible-version'
 
         with self.assertNotRaises(ParserError):
-            self.parse_args([option_string, '5.0.0'])
-            self.parse_args([option_string, '5.0.1'])
-            self.parse_args([option_string, '5.0.0.1'])
+            self.parse_default_args([option_string, '5.0.0'])
+            self.parse_default_args([option_string, '5.0.1'])
+            self.parse_default_args([option_string, '5.0.0.1'])
 
         with self.assertRaises(ParserError):
-            self.parse_args([option_string, '1'])
-            self.parse_args([option_string, '1.2'])
-            self.parse_args([option_string, '0.0.0.0.1'])
+            self.parse_default_args([option_string, '1'])
+            self.parse_default_args([option_string, '1.2'])
+            self.parse_default_args([option_string, '0.0.0.0.1'])
 
     def test_option_swift_compiler_version(self):
         option_string = '--swift-compiler-version'
 
         with self.assertNotRaises(ParserError):
-            self.parse_args([option_string, '4.1'])
-            self.parse_args([option_string, '4.0.1'])
-            self.parse_args([option_string, '200.99.1'])
+            self.parse_default_args([option_string, '4.1'])
+            self.parse_default_args([option_string, '4.0.1'])
+            self.parse_default_args([option_string, '200.99.1'])
 
         with self.assertRaises(ParserError):
-            self.parse_args([option_string, '1'])
-            self.parse_args([option_string, '0.0.0.1'])
+            self.parse_default_args([option_string, '1'])
+            self.parse_default_args([option_string, '0.0.0.1'])
 
     def test_option_swift_user_visible_version(self):
         option_string = '--swift-user-visible-version'
 
         with self.assertNotRaises(ParserError):
-            self.parse_args([option_string, '4.1'])
-            self.parse_args([option_string, '4.0.1'])
-            self.parse_args([option_string, '200.99.1'])
+            self.parse_default_args([option_string, '4.1'])
+            self.parse_default_args([option_string, '4.0.1'])
+            self.parse_default_args([option_string, '200.99.1'])
 
         with self.assertRaises(ParserError):
-            self.parse_args([option_string, '1'])
-            self.parse_args([option_string, '0.0.0.1'])
+            self.parse_default_args([option_string, '1'])
+            self.parse_default_args([option_string, '0.0.0.1'])
+
+    def test_option_I(self):
+        with self.assertRaises(ValueError):
+            self.parse_default_args(['-I'])
+
+    def test_option_ios_all(self):
+        with self.assertRaises(ValueError):
+            self.parse_default_args(['--ios-all'])
+
+    def test_option_tvos_all(self):
+        with self.assertRaises(ValueError):
+            self.parse_default_args(['--tvos-all'])
+
+    def test_option_watchos_all(self):
+        with self.assertRaises(ValueError):
+            self.parse_default_args(['--watchos-all'])
 
     # -------------------------------------------------------------------------
     # Implied defaults tests
 
     def test_implied_defaults_assertions(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--assertions'])
+            namespace = self.parse_default_args(['--assertions'])
 
-            self.assertTrue(args.cmark_assertions)
-            self.assertTrue(args.llvm_assertions)
-            self.assertTrue(args.swift_assertions)
-            self.assertTrue(args.swift_stdlib_assertions)
+            self.assertTrue(namespace.cmark_assertions)
+            self.assertTrue(namespace.llvm_assertions)
+            self.assertTrue(namespace.swift_assertions)
+            self.assertTrue(namespace.swift_stdlib_assertions)
 
     def test_implied_defaults_cmark_build_variant(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--debug-cmark'])
-            self.assertTrue(args.build_cmark)
+            namespace = self.parse_default_args(['--debug-cmark'])
+            self.assertTrue(namespace.build_cmark)
 
     def test_implied_defaults_lldb_build_variant(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--debug-lldb'])
-            self.assertTrue(args.build_lldb)
+            namespace = self.parse_default_args(['--debug-lldb'])
+            self.assertTrue(namespace.build_lldb)
 
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--lldb-assertions'])
-            self.assertTrue(args.build_lldb)
+            namespace = self.parse_default_args(['--lldb-assertions'])
+            self.assertTrue(namespace.build_lldb)
 
     def test_implied_defaults_build_variant(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--debug'])
+            namespace = self.parse_default_args(['--debug'])
 
-            self.assertEquals(args.cmark_build_variant, 'Debug')
-            self.assertEquals(args.foundation_build_variant, 'Debug')
-            self.assertEquals(args.libdispatch_build_variant, 'Debug')
-            self.assertEquals(args.libicu_build_variant, 'Debug')
-            self.assertEquals(args.lldb_build_variant, 'Debug')
-            self.assertEquals(args.llvm_build_variant, 'Debug')
-            self.assertEquals(args.swift_build_variant, 'Debug')
-            self.assertEquals(args.swift_stdlib_build_variant, 'Debug')
+            self.assertEquals(namespace.cmark_build_variant, 'Debug')
+            self.assertEquals(namespace.foundation_build_variant, 'Debug')
+            self.assertEquals(namespace.libdispatch_build_variant, 'Debug')
+            self.assertEquals(namespace.libicu_build_variant, 'Debug')
+            self.assertEquals(namespace.lldb_build_variant, 'Debug')
+            self.assertEquals(namespace.llvm_build_variant, 'Debug')
+            self.assertEquals(namespace.swift_build_variant, 'Debug')
+            self.assertEquals(namespace.swift_stdlib_build_variant, 'Debug')
 
     def test_implied_defaults_skip_build(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-build'])
+            namespace = self.parse_default_args(['--skip-build'])
 
-            self.assertFalse(args.build_benchmarks)
+            self.assertFalse(namespace.build_benchmarks)
 
-            self.assertFalse(args.build_linux)
-            self.assertFalse(args.build_android)
-            self.assertFalse(args.build_freebsd)
-            self.assertFalse(args.build_cygwin)
-            self.assertFalse(args.build_osx)
-            self.assertFalse(args.build_ios)
-            self.assertFalse(args.build_tvos)
-            self.assertFalse(args.build_watchos)
+            self.assertFalse(namespace.build_linux)
+            self.assertFalse(namespace.build_android)
+            self.assertFalse(namespace.build_freebsd)
+            self.assertFalse(namespace.build_cygwin)
+            self.assertFalse(namespace.build_osx)
+            self.assertFalse(namespace.build_ios)
+            self.assertFalse(namespace.build_tvos)
+            self.assertFalse(namespace.build_watchos)
 
-            self.assertFalse(args.build_foundation)
-            self.assertFalse(args.build_libdispatch)
-            self.assertFalse(args.build_libicu)
-            self.assertFalse(args.build_lldb)
-            self.assertFalse(args.build_llbuild)
-            self.assertFalse(args.build_playgroundlogger)
-            self.assertFalse(args.build_playgroundsupport)
-            self.assertFalse(args.build_swiftpm)
-            self.assertFalse(args.build_xctest)
+            self.assertFalse(namespace.build_foundation)
+            self.assertFalse(namespace.build_libdispatch)
+            self.assertFalse(namespace.build_libicu)
+            self.assertFalse(namespace.build_lldb)
+            self.assertFalse(namespace.build_llbuild)
+            self.assertFalse(namespace.build_playgroundlogger)
+            self.assertFalse(namespace.build_playgroundsupport)
+            self.assertFalse(namespace.build_swiftpm)
+            self.assertFalse(namespace.build_xctest)
 
     def test_implied_defaults_skip_build_ios(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-build-ios'])
-            self.assertFalse(args.build_ios_device)
-            self.assertFalse(args.build_ios_simulator)
+            namespace = self.parse_default_args(['--skip-build-ios'])
+            self.assertFalse(namespace.build_ios_device)
+            self.assertFalse(namespace.build_ios_simulator)
 
             # Also implies that the tests should be skipped
-            self.assertFalse(args.test_ios_host)
-            self.assertFalse(args.test_ios_simulator)
+            self.assertFalse(namespace.test_ios_host)
+            self.assertFalse(namespace.test_ios_simulator)
 
     def test_implied_defaults_skip_build_tvos(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-build-tvos'])
-            self.assertFalse(args.build_tvos_device)
-            self.assertFalse(args.build_tvos_simulator)
+            namespace = self.parse_default_args(['--skip-build-tvos'])
+            self.assertFalse(namespace.build_tvos_device)
+            self.assertFalse(namespace.build_tvos_simulator)
 
             # Also implies that the tests should be skipped
-            self.assertFalse(args.test_tvos_host)
-            self.assertFalse(args.test_tvos_simulator)
+            self.assertFalse(namespace.test_tvos_host)
+            self.assertFalse(namespace.test_tvos_simulator)
 
     def test_implied_defaults_skip_build_watchos(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-build-watchos'])
-            self.assertFalse(args.build_watchos_device)
-            self.assertFalse(args.build_watchos_simulator)
+            namespace = self.parse_default_args(['--skip-build-watchos'])
+            self.assertFalse(namespace.build_watchos_device)
+            self.assertFalse(namespace.build_watchos_simulator)
 
             # Also implies that the tests should be skipped
-            self.assertFalse(args.test_watchos_host)
-            self.assertFalse(args.test_watchos_simulator)
+            self.assertFalse(namespace.test_watchos_host)
+            self.assertFalse(namespace.test_watchos_simulator)
 
     def test_implied_defaults_validation_test(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--validation-test'])
-            self.assertTrue(args.test)
+            namespace = self.parse_default_args(['--validation-test'])
+            self.assertTrue(namespace.test)
 
     def test_implied_defaults_test_optimized(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--test-optimized'])
-            self.assertTrue(args.test)
+            namespace = self.parse_default_args(['--test-optimized'])
+            self.assertTrue(namespace.test)
 
     def test_implied_defaults_test_optimize_for_size(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--test-optimize-for-size'])
-            self.assertTrue(args.test)
+            namespace = self.parse_default_args(['--test-optimize-for-size'])
+            self.assertTrue(namespace.test)
 
     def test_implied_defaults_skip_all_tests(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args([
+            namespace = self.parse_default_args([
                 '--test', '0',
                 '--validation-test', '0',
                 '--long-test', '0',
             ])
 
-            self.assertFalse(args.test_linux)
-            self.assertFalse(args.test_freebsd)
-            self.assertFalse(args.test_cygwin)
-            self.assertFalse(args.test_osx)
-            self.assertFalse(args.test_ios)
-            self.assertFalse(args.test_tvos)
-            self.assertFalse(args.test_watchos)
+            self.assertFalse(namespace.test_linux)
+            self.assertFalse(namespace.test_freebsd)
+            self.assertFalse(namespace.test_cygwin)
+            self.assertFalse(namespace.test_osx)
+            self.assertFalse(namespace.test_ios)
+            self.assertFalse(namespace.test_tvos)
+            self.assertFalse(namespace.test_watchos)
 
     def test_implied_defaults_skip_test_ios(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-test-ios'])
-            self.assertFalse(args.test_ios_host)
-            self.assertFalse(args.test_ios_simulator)
+            namespace = self.parse_default_args(['--skip-test-ios'])
+            self.assertFalse(namespace.test_ios_host)
+            self.assertFalse(namespace.test_ios_simulator)
 
     def test_implied_defaults_skip_test_tvos(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-test-tvos'])
-            self.assertFalse(args.test_tvos_host)
-            self.assertFalse(args.test_tvos_simulator)
+            namespace = self.parse_default_args(['--skip-test-tvos'])
+            self.assertFalse(namespace.test_tvos_host)
+            self.assertFalse(namespace.test_tvos_simulator)
 
     def test_implied_defaults_skip_test_watchos(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-test-watchos'])
-            self.assertFalse(args.test_watchos_host)
-            self.assertFalse(args.test_watchos_simulator)
+            namespace = self.parse_default_args(['--skip-test-watchos'])
+            self.assertFalse(namespace.test_watchos_host)
+            self.assertFalse(namespace.test_watchos_simulator)
 
     def test_implied_defaults_skip_build_android(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--android', '0'])
-            self.assertFalse(args.test_android_host)
+            namespace = self.parse_default_args(['--android', '0'])
+            self.assertFalse(namespace.test_android_host)
 
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--skip-build-android'])
-            self.assertFalse(args.test_android_host)
+            namespace = self.parse_default_args(['--skip-build-android'])
+            self.assertFalse(namespace.test_android_host)
 
     def test_implied_defaults_host_test(self):
         with self.assertNotRaises(ParserError):
-            args = self.parse_args(['--host-test', '0'])
-            self.assertFalse(args.test_ios_host)
-            self.assertFalse(args.test_tvos_host)
-            self.assertFalse(args.test_watchos_host)
-            self.assertFalse(args.test_android_host)
+            namespace = self.parse_default_args(['--host-test', '0'])
+            self.assertFalse(namespace.test_ios_host)
+            self.assertFalse(namespace.test_tvos_host)
+            self.assertFalse(namespace.test_watchos_host)
+            self.assertFalse(namespace.test_android_host)
 
 
 if __name__ == '__main__':

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -440,6 +440,29 @@ class TestDriverArgumentParser(unittest.TestCase):
             self.fail('non-exhaustive expected options, missing: {}'
                       .format(diff))
 
+    def test_expected_options_have_default_values(self):
+        """Test that all the options in EXPECTED_OPTIONS have an associated
+        default value.
+        """
+
+        skip_option_classes = [
+            eo.HelpOption,
+            eo.IgnoreOption,
+            eo.UnsupportedOption,
+        ]
+
+        missing_defaults = set()
+        for option in eo.EXPECTED_OPTIONS:
+            if option.__class__ in skip_option_classes:
+                continue
+
+            if option.dest not in eo.EXPECTED_DEFAULTS:
+                missing_defaults.add(option.dest)
+
+        if len(missing_defaults) > 0:
+            self.fail('non-exhaustive default values for options, missing: {}'
+                      .format(missing_defaults))
+
     # -------------------------------------------------------------------------
     # Manual option tests
 


### PR DESCRIPTION
# Purpose

This PR revamps the current argument parsing test suite to use a more declarative (and concise) set of `*Option` classes in addition to better refining the current behavior of each flag. I've also taken the liberty to add two new test cases that check the exhaustiveness of the generated option unit-tests. The first will ensure that the suite has a test case for *every* option supported by the argument parser, while the second test ensures that every option has an associated default value.

A note for reviewers the first commit does move some classes and definitions around which makes the changes a little noisy.