### PR TITLE
[GSB] Use bump pointer allocation for permanent data structures

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -30,6 +30,7 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/ilist.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/MapVector.h"
@@ -117,7 +118,7 @@ public:
   typedef Constraint<Type> ConcreteConstraint;
 
   /// Describes an equivalence class of potential archetypes.
-  struct EquivalenceClass {
+  struct EquivalenceClass : llvm::ilist_node<EquivalenceClass> {
     /// The list of protocols to which this equivalence class conforms.
     ///
     /// The keys form the (semantic) list of protocols to which this type
@@ -196,6 +197,11 @@ public:
 
     /// Note that this equivalence class has been modified.
     void modified(GenericSignatureBuilder &builder);
+
+    EquivalenceClass(const EquivalenceClass &) = delete;
+    EquivalenceClass(EquivalenceClass &&) = delete;
+    EquivalenceClass &operator=(const EquivalenceClass &) = delete;
+    EquivalenceClass &operator=(EquivalenceClass &&) = delete;
 
     /// Find a source of the same-type constraint that maps a potential
     /// archetype in this equivalence class to a concrete type along with

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -62,6 +62,13 @@ namespace {
 
 } // end anonymous namespace
 
+namespace llvm {
+  // Equivalence classes are bump-ptr-allocated.
+  template <> struct ilist_alloc_traits<EquivalenceClass> {
+    static void deleteNode(EquivalenceClass *ptr) { ptr->~EquivalenceClass(); }
+  };
+}
+
 #define DEBUG_TYPE "Generic signature builder"
 STATISTIC(NumPotentialArchetypes, "# of potential archetypes");
 STATISTIC(NumConformances, "# of conformances tracked");
@@ -88,6 +95,9 @@ STATISTIC(NumDelayedRequirementUnresolved,
           "Delayed requirements left unresolved");
 
 struct GenericSignatureBuilder::Implementation {
+  /// Allocator.
+  llvm::BumpPtrAllocator Allocator;
+
   /// Function used to look up conformances.
   std::function<GenericFunction> LookupConformance;
 
@@ -107,6 +117,9 @@ struct GenericSignatureBuilder::Implementation {
   /// The set of equivalence classes.
   llvm::iplist<EquivalenceClass> EquivalenceClasses;
 
+  /// Equivalence classes that are not currently being used.
+  std::vector<void *> FreeEquivalenceClasses;
+
   /// The generation number, which is incremented whenever we successfully
   /// introduce a new constraint.
   unsigned Generation = 0;
@@ -116,6 +129,9 @@ struct GenericSignatureBuilder::Implementation {
 
   /// Whether we are currently processing delayed requirements.
   bool ProcessingDelayedRequirements = false;
+
+  /// Tear down an implementation.
+  ~Implementation();
 
   /// Allocate a new equivalence class with the given representative.
   EquivalenceClass *allocateEquivalenceClass(
@@ -131,10 +147,25 @@ struct GenericSignatureBuilder::Implementation {
 };
 
 #pragma mark Memory management
+GenericSignatureBuilder::Implementation::~Implementation() {
+  for (auto pa : PotentialArchetypes)
+    pa->~PotentialArchetype();
+}
+
 EquivalenceClass *
 GenericSignatureBuilder::Implementation::allocateEquivalenceClass(
                                           PotentialArchetype *representative) {
-  auto equivClass = new EquivalenceClass(representative);
+  void *mem;
+  if (FreeEquivalenceClasses.empty()) {
+    // Allocate a new equivalence class.
+    mem = Allocator.Allocate<EquivalenceClass>();
+  } else {
+    // Take an equivalence class from the free list.
+    mem = FreeEquivalenceClasses.back();
+    FreeEquivalenceClasses.pop_back();
+  }
+
+  auto equivClass = new (mem) EquivalenceClass(representative);
   EquivalenceClasses.push_back(equivClass);
   return equivClass;
 }
@@ -142,6 +173,7 @@ GenericSignatureBuilder::Implementation::allocateEquivalenceClass(
 void GenericSignatureBuilder::Implementation::deallocateEquivalenceClass(
                                                EquivalenceClass *equivClass) {
   EquivalenceClasses.erase(equivClass);
+  FreeEquivalenceClasses.push_back(equivClass);
 }
 
 #pragma mark GraphViz visualization
@@ -776,7 +808,8 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
     totalSizeToAlloc<ProtocolDecl *, WrittenRequirementLoc>(               \
                                            NumProtocolDecls,               \
                                            WrittenReq.isNull()? 0 : 1);    \
-  void *mem = ::operator new(size);                                        \
+  void *mem =                                                              \
+    builder.Impl->Allocator.Allocate(size, alignof(RequirementSource));    \
   auto result = new (mem) RequirementSource ConstructorArgs;               \
   builder.Impl->RequirementSources.InsertNode(result, insertPos);          \
   return result
@@ -1474,7 +1507,7 @@ GenericSignatureBuilder::PotentialArchetype::~PotentialArchetype() {
 
   for (const auto &nested : NestedTypes) {
     for (auto pa : nested.second) {
-      delete pa;
+      pa->~PotentialArchetype();
     }
   }
 }
@@ -2430,10 +2463,11 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
       // modification.
       getOrCreateEquivalenceClass()->modified(builder);
 
+      void *mem = builder.Impl->Allocator.Allocate<PotentialArchetype>();
       if (assocType)
-        resultPA = new PotentialArchetype(this, assocType);
+        resultPA = new (mem) PotentialArchetype(this, assocType);
       else
-        resultPA = new PotentialArchetype(this, concreteDecl);
+        resultPA = new (mem) PotentialArchetype(this, concreteDecl);
 
       NestedTypes[name].push_back(resultPA);
       builder.addedNestedType(resultPA);
@@ -2846,20 +2880,7 @@ GenericSignatureBuilder::GenericSignatureBuilder(
 
 GenericSignatureBuilder::GenericSignatureBuilder(GenericSignatureBuilder &&) = default;
 
-GenericSignatureBuilder::~GenericSignatureBuilder() {
-  if (!Impl)
-    return;
-
-  SmallVector<RequirementSource *, 4> requirementSources;
-  for (auto &reqSource : Impl->RequirementSources)
-    requirementSources.push_back(&reqSource);
-  Impl->RequirementSources.clear();
-  for (auto reqSource : requirementSources)
-    delete reqSource;
-
-  for (auto PA : Impl->PotentialArchetypes)
-    delete PA;
-}
+GenericSignatureBuilder::~GenericSignatureBuilder() = default;
 
 std::function<GenericFunction>
 GenericSignatureBuilder::getLookupConformanceFn() const {
@@ -2986,7 +3007,8 @@ void GenericSignatureBuilder::addGenericParameter(GenericTypeParamType *GenericP
            Key.Index == 0)));
 
   // Create a potential archetype for this type parameter.
-  auto PA = new PotentialArchetype(this, GenericParam);
+  void *mem = Impl->Allocator.Allocate<PotentialArchetype>();
+  auto PA = new (mem) PotentialArchetype(this, GenericParam);
   Impl->GenericParams.push_back(GenericParam);
   Impl->PotentialArchetypes.push_back(PA);
 }
@@ -3707,7 +3729,7 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
   for (auto equiv : equivClass2Members)
     equivClass->members.push_back(equiv);
 
-  // Grab the old equivalence class, if present. We'll delete it at the end.
+  // Grab the old equivalence class, if present. We'll deallocate it at the end.
   auto equivClass2 = T2->getEquivalenceClassIfPresent();
   SWIFT_DEFER {
     Impl->deallocateEquivalenceClass(equivClass2);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -104,6 +104,9 @@ struct GenericSignatureBuilder::Implementation {
   /// The set of requirements that have been delayed for some reason.
   SmallVector<DelayedRequirement, 4> DelayedRequirements;
 
+  /// The set of equivalence classes.
+  llvm::iplist<EquivalenceClass> EquivalenceClasses;
+
   /// The generation number, which is incremented whenever we successfully
   /// introduce a new constraint.
   unsigned Generation = 0;
@@ -114,11 +117,32 @@ struct GenericSignatureBuilder::Implementation {
   /// Whether we are currently processing delayed requirements.
   bool ProcessingDelayedRequirements = false;
 
+  /// Allocate a new equivalence class with the given representative.
+  EquivalenceClass *allocateEquivalenceClass(
+                                       PotentialArchetype *representative);
+
+  /// Deallocate the given equivalence class, returning it to the free list.
+  void deallocateEquivalenceClass(EquivalenceClass *equivClass);
+
 #ifndef NDEBUG
   /// Whether we've already finalized the builder.
   bool finalized = false;
 #endif
 };
+
+#pragma mark Memory management
+EquivalenceClass *
+GenericSignatureBuilder::Implementation::allocateEquivalenceClass(
+                                          PotentialArchetype *representative) {
+  auto equivClass = new EquivalenceClass(representative);
+  EquivalenceClasses.push_back(equivClass);
+  return equivClass;
+}
+
+void GenericSignatureBuilder::Implementation::deallocateEquivalenceClass(
+                                               EquivalenceClass *equivClass) {
+  EquivalenceClasses.erase(equivClass);
+}
 
 #pragma mark GraphViz visualization
 static int compareDependentTypes(PotentialArchetype * const* pa,
@@ -1450,12 +1474,9 @@ GenericSignatureBuilder::PotentialArchetype::~PotentialArchetype() {
 
   for (const auto &nested : NestedTypes) {
     for (auto pa : nested.second) {
-      if (pa != this)
-        delete pa;
+      delete pa;
     }
   }
-
-  delete representativeOrEquivClass.dyn_cast<EquivalenceClass *>();
 }
 
 std::string GenericSignatureBuilder::PotentialArchetype::getDebugName() const {
@@ -1933,7 +1954,8 @@ auto PotentialArchetype::getOrCreateEquivalenceClass() const -> EquivalenceClass
 
   // Create a new equivalence class.
   auto equivClass =
-    new EquivalenceClass(const_cast<PotentialArchetype *>(this));
+    getBuilder()->Impl->allocateEquivalenceClass(
+      const_cast<PotentialArchetype *>(this));
   representativeOrEquivClass = equivClass;
   return equivClass;
 }
@@ -3688,7 +3710,7 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
   // Grab the old equivalence class, if present. We'll delete it at the end.
   auto equivClass2 = T2->getEquivalenceClassIfPresent();
   SWIFT_DEFER {
-    delete equivClass2;
+    Impl->deallocateEquivalenceClass(equivClass2);
   };
 
   // Consider the second equivalence class to be modified.
@@ -4508,38 +4530,37 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
 
   // Check for recursive or conflicting same-type bindings and superclass
   // constraints.
-  visitPotentialArchetypes([&](PotentialArchetype *archetype) {
-    if (archetype != archetype->getRepresentative()) return;
+  for (auto &equivClass : Impl->EquivalenceClasses) {
+    auto archetype = equivClass.members.front()->getRepresentative();
 
-    auto equivClass = archetype->getOrCreateEquivalenceClass();
-    if (equivClass->concreteType) {
+    if (equivClass.concreteType) {
       // Check for recursive same-type bindings.
       if (isRecursiveConcreteType(archetype, /*isSuperclass=*/false)) {
         if (auto constraint =
-              equivClass->findAnyConcreteConstraintAsWritten()) {
+              equivClass.findAnyConcreteConstraintAsWritten()) {
           Diags.diagnose(constraint->source->getLoc(),
                          diag::recursive_same_type_constraint,
                          archetype->getDependentType(genericParams),
                          constraint->value);
         }
 
-        equivClass->recursiveConcreteType = true;
+        equivClass.recursiveConcreteType = true;
       } else {
         checkConcreteTypeConstraints(genericParams, archetype);
       }
     }
 
     // Check for recursive superclass bindings.
-    if (equivClass->superclass) {
+    if (equivClass.superclass) {
       if (isRecursiveConcreteType(archetype, /*isSuperclass=*/true)) {
-        if (auto source = equivClass->findAnySuperclassConstraintAsWritten()) {
+        if (auto source = equivClass.findAnySuperclassConstraintAsWritten()) {
           Diags.diagnose(source->source->getLoc(),
                          diag::recursive_superclass_constraint,
                          source->archetype->getDependentType(genericParams),
-                         equivClass->superclass);
+                         equivClass.superclass);
         }
 
-        equivClass->recursiveSuperclassType = true;
+        equivClass.recursiveSuperclassType = true;
       } else {
         checkSuperclassConstraints(genericParams, archetype);
       }
@@ -4547,7 +4568,7 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
 
     checkConformanceConstraints(genericParams, archetype);
     checkLayoutConstraints(genericParams, archetype);
-  });
+  };
 
   // FIXME: Expand all conformance requirements. This is expensive :(
   visitPotentialArchetypes([&](PotentialArchetype *archetype) {
@@ -4565,12 +4586,10 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
   });
 
   // Check same-type constraints.
-  visitPotentialArchetypes([&](PotentialArchetype *archetype) {
-    if (archetype != archetype->getRepresentative()) return;
-
-    if (archetype->getEquivalenceClassIfPresent())
-      checkSameTypeConstraints(genericParams, archetype);
-  });
+  for (const auto &equivClass : Impl->EquivalenceClasses) {
+    checkSameTypeConstraints(genericParams,
+                             equivClass.members[0]->getRepresentative());
+  };
 
   // Check for generic parameters which have been made concrete or equated
   // with each other.

--- a/validation-test/compiler_crashers_fixed/28842-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28842-hasval.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{{}typealias a:A{}class a
 protocol a protocol A:P{typealias a


### PR DESCRIPTION
Introduce bump pointer allocation for permanent parts of the `GenericSignatureBuilder`:

* `RequirementSource` and `PotentialArchetype` are permanent once allocated
* `EquivalenceClass` is *almost* permanent; they get combined occasionally by same-type constraints. Add a free list to re-use dead ones.

Track equivalence classes in an list, so we can iterate over the list of equivalence classes rather than walking all of the potential archetypes to find equivalence classes.

