### PR TITLE
Remove GenericSignatureBuilder::resolveArchetype()

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -596,6 +596,9 @@ public:
                       SourceLoc loc,
                       bool allowConcreteGenericParams = false) &&;
 
+  /// Compute the requirement signature for the given protocol.
+  static GenericSignature *computeRequirementSignature(ProtocolDecl *proto);
+
 private:
   /// Finalize the set of requirements, performing any remaining checking
   /// required before generating archetypes.
@@ -707,6 +710,7 @@ private:
                             ArrayRef<GenericTypeParamType *> genericParams,
                             PotentialArchetype *pa);
 
+public:
   /// \brief Resolve the given type to the potential archetype it names.
   ///
   /// The \c resolutionKind parameter describes how resolution should be
@@ -722,7 +726,6 @@ private:
   resolvePotentialArchetype(Type type,
                             ArchetypeResolutionKind resolutionKind);
 
-public:
   /// \brief Resolve the equivalence class for the given type parameter,
   /// which provides information about that type.
   ///
@@ -737,18 +740,6 @@ public:
   EquivalenceClass *resolveEquivalenceClass(
                       Type type,
                       ArchetypeResolutionKind resolutionKind);
-
-  /// \brief Resolve the given type to the potential archetype it names.
-  ///
-  /// The \c resolutionKind parameter describes how resolution should be
-  /// performed. If the potential archetype named by the given dependent type
-  /// already exists, it will be always returned. If it doesn't exist yet,
-  /// the \c resolutionKind dictates whether the potential archetype will
-  /// be created or whether null will be returned.
-  ///
-  /// For any type that cannot refer to an archetype, this routine returns null.
-  PotentialArchetype *resolveArchetype(Type type,
-                                       ArchetypeResolutionKind resolutionKind);
 
   /// \brief Resolve the given type as far as this Builder knows how.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -234,6 +234,11 @@ public:
     /// class, for use in the canonical type.
     Type getAnchor(ArrayRef<GenericTypeParamType *> genericParams);
 
+    /// \brief Retrieve (or build) the contextual type corresponding to
+    /// this equivalence class within the given generic environment.
+    Type getTypeInContext(GenericSignatureBuilder &builder,
+                          GenericEnvironment *genericEnv);
+
     /// Dump a debugging representation of this equivalence class.
     void dump(llvm::raw_ostream &out) const;
 
@@ -1687,11 +1692,6 @@ public:
                         Identifier name,
                         ProtocolDecl *protocol,
                         ArchetypeResolutionKind kind);
-
-  /// \brief Retrieve (or build) the type corresponding to the potential
-  /// archetype within the given generic environment.
-  Type getTypeInContext(GenericSignatureBuilder &builder,
-                        GenericEnvironment *genericEnv);
 
   /// Retrieve the dependent type that describes this potential
   /// archetype.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -230,6 +230,10 @@ public:
                    Identifier name,
                    SmallVectorImpl<TypeDecl *> *otherConcreteTypes = nullptr);
 
+    /// Retrieve the "anchor" type that canonically describes this equivalence
+    /// class, for use in the canonical type.
+    Type getAnchor(ArrayRef<GenericTypeParamType *> genericParams);
+
     /// Dump a debugging representation of this equivalence class.
     void dump(llvm::raw_ostream &out) const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3399,28 +3399,9 @@ void ProtocolDecl::createGenericParamsIfMissing() {
 void ProtocolDecl::computeRequirementSignature() {
   assert(!RequirementSignature && "already computed requirement signature");
 
-  auto module = getParentModule();
-
-  auto selfType = getSelfInterfaceType()->castTo<GenericTypeParamType>();
-  auto requirement =
-    Requirement(RequirementKind::Conformance, selfType,
-                getDeclaredInterfaceType());
-
-  GenericSignatureBuilder builder(getASTContext(),
-                                  LookUpConformanceInModule(module));
-  builder.addGenericParameter(selfType);
-  auto selfPA =
-      builder.resolveArchetype(selfType, ArchetypeResolutionKind::WellFormed);
-
-  builder.addRequirement(
-         requirement,
-         GenericSignatureBuilder::RequirementSource
-           ::forRequirementSignature(selfPA, this),
-         nullptr);
-
   // Compute and record the signature.
   auto requirementSig =
-    std::move(builder).computeGenericSignature(SourceLoc());
+    GenericSignatureBuilder::computeRequirementSignature(this);
   RequirementSignature = requirementSig->getRequirements().data();
   assert(RequirementSignature != nullptr);
   NumRequirementsInSignature = requirementSig->getRequirements().size();

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -190,15 +190,14 @@ Type GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(
     Type contextType = self->getContextTypes()[index];
     if (!contextType) {
       assert(self->Builder && "Missing generic signature builder for lazy query");
-      auto potentialArchetype =
-        self->Builder->resolveArchetype(
+      auto equivClass =
+        self->Builder->resolveEquivalenceClass(
                                   type,
                                   ArchetypeResolutionKind::CompleteWellFormed);
 
       auto mutableSelf = const_cast<GenericEnvironment *>(self);
-      contextType =
-        potentialArchetype->getTypeInContext(*mutableSelf->Builder,
-                                             mutableSelf);
+      contextType = equivClass->getTypeInContext(*mutableSelf->Builder,
+                                                 mutableSelf);
 
       // FIXME: Redundant mapping from key -> index.
       if (self->getContextTypes()[index].isNull())

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1743,6 +1743,13 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   return populateResult((nestedTypeNameCache[name] = std::move(entry)));
 }
 
+Type EquivalenceClass::getAnchor(
+                            ArrayRef<GenericTypeParamType *> genericParams) {
+  auto anchorPA =
+    members.front()->getArchetypeAnchor(*members.front()->getBuilder());
+  return anchorPA->getDependentType(genericParams);
+}
+
 void EquivalenceClass::dump(llvm::raw_ostream &out) const {
   out << "Equivalence class represented by "
     << members.front()->getRepresentative()->getDebugName() << ":\n";


### PR DESCRIPTION
`GenericSignatureBuilder::resolveArchetype()` was being used by clients in various places throughout the AST and type checker to turn a dependent type into a `PotentialArchetype`. However, we don't want anyone using the `PotentialArchetype` abstraction now, so instead use `EquivalenceClass`-based entry points into the `GenericSignatureBuilder`.

The most interesting client here is the type checker's name lookup facilities, which now perform lookup in the equivalence class.