### PR TITLE
Added in missing imports to Accelerate and CoreFoundation overlays.

### DIFF
--- a/stdlib/public/SDK/Accelerate/CMakeLists.txt
+++ b/stdlib/public/SDK/Accelerate/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.4.3)
+include("../../../../cmake/modules/StandaloneOverlay.cmake")
+
 add_swift_library(swiftAccelerate ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   BNNS.swift.gyb
 

--- a/stdlib/public/SDK/CoreFoundation/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreFoundation/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.4.3)
+include("../../../../cmake/modules/StandaloneOverlay.cmake")
+
 add_swift_library(swiftCoreFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreFoundation.swift
 


### PR DESCRIPTION
# Purpose

This PR adds the missing `cmake_minimum_required` and `import` calls to both the Accelerate and CoreFoundation overlays.

rdar://34662423