### PR TITLE
 [GSB] Move a well-formed GenericSignatureBuilder to be the canonical builder

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -857,6 +857,16 @@ public:
   /// not necessarily loaded.
   void getVisibleTopLevelClangModules(SmallVectorImpl<clang::Module*> &Modules) const;
 
+private:
+  /// Register the given generic signature builder to be used as the canonical
+  /// generic signature builder for the given signature, if we don't already
+  /// have one.
+  void registerGenericSignatureBuilder(GenericSignature *sig,
+                                       ModuleDecl &module,
+                                       GenericSignatureBuilder &&builder);
+  friend class GenericSignatureBuilder;
+
+public:
   /// Retrieve or create the stored generic signature builder for the given
   /// canonical generic signature and module.
   GenericSignatureBuilder *getOrCreateGenericSignatureBuilder(CanGenericSignature sig,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -593,8 +593,10 @@ public:
   /// After this point, one cannot introduce new requirements, and the
   /// generic signature builder no longer has valid state.
   GenericSignature *computeGenericSignature(
+                      ModuleDecl &module,
                       SourceLoc loc,
-                      bool allowConcreteGenericParams = false) &&;
+                      bool allowConcreteGenericParams = false,
+                      bool allowBuilderToMove = true) &&;
 
   /// Compute the requirement signature for the given protocol.
   static GenericSignature *computeRequirementSignature(ProtocolDecl *proto);
@@ -1484,6 +1486,12 @@ private:
     while (auto parent = pa->getParent())
       pa = parent;
     return pa->parentOrBuilder.get<GenericSignatureBuilder *>();
+  }
+
+  // Replace the generic signature builder.
+  void replaceBuilder(GenericSignatureBuilder *builder) {
+    assert(parentOrBuilder.is<GenericSignatureBuilder *>());
+    parentOrBuilder = builder;
   }
 
   friend class GenericSignatureBuilder;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1423,6 +1423,18 @@ void ASTContext::getVisibleTopLevelClangModules(
     collectAllModules(Modules);
 }
 
+void ASTContext::registerGenericSignatureBuilder(
+                                       GenericSignature *sig,
+                                       ModuleDecl &module,
+                                       GenericSignatureBuilder &&builder) {
+  auto canSig = sig->getCanonicalSignature();
+  auto known = Impl.GenericSignatureBuilders.find({canSig, &module});
+  if (known != Impl.GenericSignatureBuilders.end()) return;
+
+  Impl.GenericSignatureBuilders[{canSig, &module}] =
+    llvm::make_unique<GenericSignatureBuilder>(std::move(builder));
+}
+
 GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
                                                       CanGenericSignature sig,
                                                       ModuleDecl *mod) {
@@ -4591,7 +4603,7 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   builder.addRequirement(requirement, source, nullptr);
 
-  CanGenericSignature genericSig(std::move(builder).computeGenericSignature(SourceLoc()));
+  CanGenericSignature genericSig(std::move(builder).computeGenericSignature(*mod, SourceLoc()));
 
   auto result = Impl.ExistentialSignatures.insert(
     std::make_pair(existential, genericSig));

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -43,6 +43,7 @@
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Allocator.h"
@@ -51,6 +52,12 @@
 #include <memory>
 
 using namespace swift;
+
+#define DEBUG_TYPE "ASTContext"
+STATISTIC(NumRegisteredGenericSignatureBuilders,
+          "# of generic signature builders successfully registered");
+STATISTIC(NumRegisteredGenericSignatureBuildersAlready,
+          "# of generic signature builders already registered");
 
 /// Define this to 1 to enable expensive assertions of the
 /// GenericSignatureBuilder.
@@ -1429,8 +1436,12 @@ void ASTContext::registerGenericSignatureBuilder(
                                        GenericSignatureBuilder &&builder) {
   auto canSig = sig->getCanonicalSignature();
   auto known = Impl.GenericSignatureBuilders.find({canSig, &module});
-  if (known != Impl.GenericSignatureBuilders.end()) return;
+  if (known != Impl.GenericSignatureBuilders.end()) {
+    ++NumRegisteredGenericSignatureBuildersAlready;
+    return;
+  }
 
+  ++NumRegisteredGenericSignatureBuilders;
   Impl.GenericSignatureBuilders[{canSig, &module}] =
     llvm::make_unique<GenericSignatureBuilder>(std::move(builder));
 }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -492,7 +492,8 @@ namespace {
       }
 
       auto GenericSig =
-        std::move(Builder).computeGenericSignature(SourceLoc());
+        std::move(Builder).computeGenericSignature(*ctx.TheBuiltinModule,
+                                                   SourceLoc());
       GenericEnv = GenericSig->createGenericEnvironment(*ctx.TheBuiltinModule);
     }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -144,6 +144,12 @@ struct GenericSignatureBuilder::Implementation {
   /// Deallocate the given equivalence class, returning it to the free list.
   void deallocateEquivalenceClass(EquivalenceClass *equivClass);
 
+  /// Whether there were any errors.
+  bool HadAnyError = false;
+
+  /// FIXME: Hack to work around a small number of minimization bugs.
+  bool HadAnyRedundantConstraints = false;
+
 #ifndef NDEBUG
   /// Whether we've already finalized the builder.
   bool finalized = false;
@@ -2048,11 +2054,14 @@ GenericSignatureBuilder::resolveConcreteConformance(PotentialArchetype *pa,
                               ->castTo<ProtocolType>());
   if (!conformance) {
     if (!concrete->hasError() && concreteSource->getLoc().isValid()) {
+      Impl->HadAnyError = true;
+
       Diags.diagnose(concreteSource->getLoc(),
                      diag::requires_generic_param_same_type_does_not_conform,
                      concrete, proto->getName());
     }
 
+    Impl->HadAnyError = true;
     paEquivClass->invalidConcreteType = true;
     return nullptr;
   }
@@ -2854,7 +2863,23 @@ GenericSignatureBuilder::GenericSignatureBuilder(
     Context.Stats->getFrontendCounters().NumGenericSignatureBuilders++;
 }
 
-GenericSignatureBuilder::GenericSignatureBuilder(GenericSignatureBuilder &&) = default;
+GenericSignatureBuilder::GenericSignatureBuilder(
+                                         GenericSignatureBuilder &&other)
+  : Context(other.Context), Diags(other.Diags), Impl(std::move(other.Impl))
+{
+  other.Impl.reset();
+
+  if (Impl) {
+    // Update the generic parameters to their canonical types.
+    for (auto &gp : Impl->GenericParams) {
+      gp = gp->getCanonicalType()->castTo<GenericTypeParamType>();
+    }
+
+    // Point each root potential archetype at this generic signature builder.
+    for (auto pa : Impl->PotentialArchetypes)
+      pa->replaceBuilder(this);
+  }
+}
 
 GenericSignatureBuilder::~GenericSignatureBuilder() = default;
 
@@ -3380,6 +3405,8 @@ ConstraintResult GenericSignatureBuilder::addLayoutRequirement(
     // If a layout requirement was explicitly written on a concrete type,
     // complain.
     if (source.isExplicit() && source.getLoc().isValid()) {
+      Impl->HadAnyError = true;
+
       Diags.diagnose(source.getLoc(), diag::requires_not_suitable_archetype,
                      TypeLoc::withoutLoc(resolvedSubject->getType()));
       return ConstraintResult::Concrete;
@@ -3523,6 +3550,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
         subjectType = subject.get<PotentialArchetype *>()
                         ->getDependentType(Impl->GenericParams);
 
+      Impl->HadAnyError = true;
       Diags.diagnose(source.getLoc(), diag::requires_conformance_nonprotocol,
                      TypeLoc::withoutLoc(subjectType),
                      TypeLoc::withoutLoc(constraintType));
@@ -3551,6 +3579,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
     // One cannot explicitly write a constraint on a concrete type.
     if (source.isExplicit()) {
       if (source.getLoc().isValid()) {
+        Impl->HadAnyError = true;
         Diags.diagnose(source.getLoc(), diag::requires_not_suitable_archetype,
                        TypeLoc::withoutLoc(resolvedSubject->getType()));
       }
@@ -3896,6 +3925,7 @@ ConstraintResult GenericSignatureBuilder::addSameTypeRequirement(
                                  UnresolvedHandlingKind unresolvedHandling) {
   return addSameTypeRequirement(paOrT1, paOrT2, source, unresolvedHandling,
                                 [&](Type type1, Type type2) {
+      Impl->HadAnyError = true;
       if (source.getLoc().isValid()) {
         Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,
                        type1, type2);
@@ -4075,6 +4105,8 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
         !Req->getSecondType()->hasTypeParameter()) {
       if (!Req->getFirstType()->hasError() &&
           !Req->getSecondType()->hasError()) {
+        Impl->HadAnyError = true;
+
         Diags.diagnose(Req->getEqualLoc(),
                        diag::requires_no_same_type_archetype)
           .highlight(Req->getFirstTypeLoc().getSourceRange())
@@ -4173,6 +4205,7 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
         firstType, secondType, source,
         UnresolvedHandlingKind::GenerateConstraints,
         [&](Type type1, Type type2) {
+          Impl->HadAnyError = true;
           if (source.getLoc().isValid()) {
             Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,
                            type1, type2);
@@ -4514,6 +4547,8 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
       if (isRecursiveConcreteType(&equivClass, /*isSuperclass=*/false)) {
         if (auto constraint =
               equivClass.findAnyConcreteConstraintAsWritten()) {
+          Impl->HadAnyError = true;
+
           Diags.diagnose(constraint->source->getLoc(),
                          diag::recursive_same_type_constraint,
                          archetype->getDependentType(genericParams),
@@ -4530,6 +4565,8 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
     if (equivClass.superclass) {
       if (isRecursiveConcreteType(&equivClass, /*isSuperclass=*/true)) {
         if (auto source = equivClass.findAnySuperclassConstraintAsWritten()) {
+          Impl->HadAnyError = true;
+
           Diags.diagnose(source->source->getLoc(),
                          diag::recursive_superclass_constraint,
                          source->archetype->getDependentType(genericParams),
@@ -4589,10 +4626,13 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
       // because then we don't actually have a parameter.
       auto equivClass = rep->getOrCreateEquivalenceClass();
       if (equivClass->concreteType) {
-        if (auto constraint = equivClass->findAnyConcreteConstraintAsWritten())
+        if (auto constraint = equivClass->findAnyConcreteConstraintAsWritten()){
+          Impl->HadAnyError = true;
+
           Diags.diagnose(constraint->source->getLoc(),
                          diag::requires_generic_param_made_equal_to_concrete,
                          rep->getDependentType(genericParams));
+        }
         continue;
       }
 
@@ -4622,6 +4662,8 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
         }
 
         if (repConstraint && repConstraint->source->getLoc().isValid()) {
+          Impl->HadAnyError = true;
+
           Diags.diagnose(repConstraint->source->getLoc(),
                          diag::requires_generic_params_made_equal,
                          pa->getDependentType(genericParams),
@@ -4902,6 +4944,8 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
       // The requirement conflicts. If this constraint has a location, complain
       // about it.
       if (constraint.source->getLoc().isValid()) {
+        Impl->HadAnyError = true;
+
         auto subject = getSubjectType(constraint.archetype);
         Diags.diagnose(constraint.source->getLoc(), *conflictingDiag,
                        subject.first, subject.second,
@@ -4916,6 +4960,8 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
       // do so now.
       if (!diagnosedConflictingRepresentative &&
           representativeConstraint->source->getLoc().isValid()) {
+        Impl->HadAnyError = true;
+
         auto subject = getSubjectType(representativeConstraint->archetype);
         Diags.diagnose(representativeConstraint->source->getLoc(),
                        *conflictingDiag,
@@ -4932,6 +4978,7 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
     case ConstraintRelation::Redundant:
       // If this requirement is not derived or inferred (but has a useful
       // location) complain that it is redundant.
+      Impl->HadAnyRedundantConstraints = true;
       if (!constraint.source->isDerivedRequirement() &&
           !constraint.source->isInferredRequirement() &&
           constraint.source->getLoc().isValid() &&
@@ -5907,6 +5954,8 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
     if (!equivClass->superclass->isExactSuperclassOf(equivClass->concreteType)) {
       if (auto existing = equivClass->findAnyConcreteConstraintAsWritten(
                             representativeConstraint.archetype)) {
+        Impl->HadAnyError = true;
+
         Diags.diagnose(existing->source->getLoc(), diag::type_does_not_inherit,
                        existing->archetype->getDependentType(
                                                    genericParams),
@@ -5914,6 +5963,8 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
 
         // FIXME: Note the representative constraint.
       } else if (representativeConstraint.source->getLoc().isValid()) {
+        Impl->HadAnyError = true;
+
         Diags.diagnose(representativeConstraint.source->getLoc(),
                        diag::type_does_not_inherit,
                        representativeConstraint.archetype->getDependentType(
@@ -6286,8 +6337,10 @@ static void collectRequirements(GenericSignatureBuilder &builder,
 }
 
 GenericSignature *GenericSignatureBuilder::computeGenericSignature(
+                                          ModuleDecl &module,
                                           SourceLoc loc,
-                                          bool allowConcreteGenericParams) && {
+                                          bool allowConcreteGenericParams,
+                                          bool allowBuilderToMove) && {
   // Finalize the builder, producing any necessary diagnostics.
   finalize(loc, Impl->GenericParams, allowConcreteGenericParams);
 
@@ -6297,6 +6350,23 @@ GenericSignature *GenericSignatureBuilder::computeGenericSignature(
 
   // Form the generic signature.
   auto sig = GenericSignature::get(Impl->GenericParams, requirements);
+
+  // When we can, move this generic signature builder to make it the canonical
+  // builder, rather than constructing a new generic signature builder that
+  // will produce the same thing.
+  //
+  // We cannot do this when there were errors.
+  // FIXME: The HadAnyRedundantConstraints bit is a hack because we are
+  // over-minimizing.
+  if (allowBuilderToMove && !Impl->HadAnyError &&
+      !Impl->HadAnyRedundantConstraints) {
+    // Set the conformance lookup function to something that works canonically.
+    Impl->LookupConformance = LookUpConformanceInModule(&module);
+
+    // Register this generic signature builer as the canonical builder for the
+    // given signature.
+    Context.registerGenericSignatureBuilder(sig, module, std::move(*this));
+  }
 
   // Wipe out the internal state, ensuring that nobody uses this builder for
   // anything more.
@@ -6330,6 +6400,9 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
                  RequirementSource::forRequirementSignature(selfPA, proto),
                  nullptr);
 
-  return std::move(builder).computeGenericSignature(SourceLoc());
+  return std::move(builder).computeGenericSignature(
+           *module, SourceLoc(),
+           /*allowConcreteGenericPArams=*/false,
+           /*allowBuilderToMove=*/false);
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7654,7 +7654,8 @@ GenericSignature *ClangImporter::Implementation::buildGenericSignature(
     (void) result;
   }
 
-  return std::move(builder).computeGenericSignature(SourceLoc());
+  return std::move(builder).computeGenericSignature(*dc->getParentModule(),
+                                                    SourceLoc());
 }
 
 // Calculate the generic environment from an imported generic param list.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2695,7 +2695,7 @@ buildThunkSignature(SILGenFunction &SGF,
   builder.addRequirement(newRequirement, source, nullptr);
 
   GenericSignature *genericSig =
-    std::move(builder).computeGenericSignature(SourceLoc(),
+    std::move(builder).computeGenericSignature(*mod, SourceLoc(),
                                     /*allowConcreteGenericParams=*/true);
   genericEnv = genericSig->createGenericEnvironment(*mod);
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -800,7 +800,8 @@ getGenericEnvironmentAndSignatureWithRequirements(
   }
 
   auto NewGenSig =
-    std::move(Builder).computeGenericSignature(SourceLoc(),
+    std::move(Builder).computeGenericSignature(*M.getSwiftModule(),
+                                   SourceLoc(),
                                    /*allowConcreteGenericParams=*/true);
   auto NewGenEnv = NewGenSig->createGenericEnvironment(*M.getSwiftModule());
   return { NewGenEnv, NewGenSig };
@@ -1490,7 +1491,8 @@ FunctionSignaturePartialSpecializer::
 
   // Finalize the archetype builder.
   auto GenSig =
-      std::move(Builder).computeGenericSignature(SourceLoc(),
+      std::move(Builder).computeGenericSignature(*M.getSwiftModule(),
+                                      SourceLoc(),
                                       /*allowConcreteGenericParams=*/true);
   auto GenEnv = GenSig->createGenericEnvironment(*M.getSwiftModule());
   return { GenEnv, GenSig };

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1852,6 +1852,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Check the result.
   (void)std::move(Builder).computeGenericSignature(
+                                        *DC->getParentModule(),
                                         attr->getLocation(),
                                         /*allowConcreteGenericParams=*/true);
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -755,7 +755,8 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
 
     // The generic function signature is complete and well-formed. Determine
     // the type of the generic function.
-    sig = std::move(builder).computeGenericSignature(func->getLoc());
+    sig = std::move(builder).computeGenericSignature(*func->getParentModule(),
+                                                     func->getLoc());
 
     // The generic signature builder now has all of the requirements, although
     // there might still be errors that have not yet been diagnosed. Revert the
@@ -979,7 +980,9 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
 
     // The generic subscript signature is complete and well-formed. Determine
     // the type of the generic subscript.
-    sig = std::move(builder).computeGenericSignature(subscript->getLoc());
+    sig =
+      std::move(builder).computeGenericSignature(*subscript->getParentModule(),
+                                                 subscript->getLoc());
 
     // The generic signature builder now has all of the requirements, although
     // there might still be errors that have not yet been diagnosed. Revert the
@@ -1118,6 +1121,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
     // Record the generic type parameter types and the requirements.
     sig = std::move(builder).computeGenericSignature(
+                                         *dc->getParentModule(),
                                          genericParams->getSourceRange().Start,
                                          allowConcreteGenericParams);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1157,7 +1157,9 @@ RequirementEnvironment::RequirementEnvironment(
   // FIXME: Pass in a source location for the conformance, perhaps? It seems
   // like this could fail.
   syntheticSignature =
-    std::move(builder).computeGenericSignature(SourceLoc());
+    std::move(builder).computeGenericSignature(
+                                           *conformanceDC->getParentModule(),
+                                           SourceLoc());
   syntheticEnvironment = syntheticSignature->createGenericEnvironment(
                                              *conformanceDC->getParentModule());
 }

--- a/validation-test/compiler_crashers_fixed/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
+++ b/validation-test/compiler_crashers_fixed/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a:A
 protocol A:a{
 protocol A{struct a{var f:A


### PR DESCRIPTION
Once we compute a generic signature from a generic signature builder,
all queries involving that generic signature will go through a separate
(canonicalized) builder, and the original builder can no longer be used.
The canonicalization process then creates a new, effectively identical
generic signature builder. How silly.

Once we’ve computed the signature of a generic signature builder, “register”
it with the `ASTContext`, allowing us to move the existing generic signature
builder into place as the canonical generic signature builder. The builder
requires minimal patching but is otherwise fully usable.

Thanks to Slava Pestov for the idea!