### PR TITLE
[ClangImporter] Don't add duplicate search paths

### DIFF
--- a/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/Test.framework/Headers/Test.h
+++ b/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/Test.framework/Headers/Test.h
@@ -1,0 +1,3 @@
+#warning "Test.h found in override"
+
+extern int TestFrameworkFromOverride;

--- a/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/Test.framework/Modules/module.modulemap
+++ b/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/Test.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+framework module Test {
+  umbrella header "Test.h"
+}

--- a/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/TestUser.framework/Headers/TestUser.h
+++ b/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/TestUser.framework/Headers/TestUser.h
@@ -1,0 +1,3 @@
+#warning "TestUser found in override"
+
+@import Test;

--- a/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/TestUser.framework/Modules/module.modulemap
+++ b/validation-test/ClangImporter/Inputs/explicit-system-framework-path/override/TestUser.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module TestUser {
+  umbrella header "TestUser.h"
+  export *
+}

--- a/validation-test/ClangImporter/Inputs/explicit-system-framework-path/sdkroot/Library/Frameworks/Test.framework/Headers/Test.h
+++ b/validation-test/ClangImporter/Inputs/explicit-system-framework-path/sdkroot/Library/Frameworks/Test.framework/Headers/Test.h
@@ -1,0 +1,3 @@
+#warning "Test.h found in SDK"
+
+extern int TestFrameworkFromSDK;

--- a/validation-test/ClangImporter/Inputs/explicit-system-framework-path/sdkroot/Library/Frameworks/Test.framework/Modules/module.modulemap
+++ b/validation-test/ClangImporter/Inputs/explicit-system-framework-path/sdkroot/Library/Frameworks/Test.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+framework module Test {
+  umbrella header "Test.h"
+}

--- a/validation-test/ClangImporter/explicit-system-framework-path.swift
+++ b/validation-test/ClangImporter/explicit-system-framework-path.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -F %S/Inputs/explicit-system-framework-path/sdkroot/Library/Frameworks -F %S/Inputs/explicit-system-framework-path/override -typecheck -sdk %S/Inputs/explicit-system-framework-path/sdkroot %s 2>&1 | %FileCheck %s
+
+// Make sure we're matching Clang's behavior on this.
+// RUN: echo '@import TestUser;' | %clang -F %S/Inputs/explicit-system-framework-path/sdkroot/Library/Frameworks -F %S/Inputs/explicit-system-framework-path/override -isysroot %S/Inputs/explicit-system-framework-path/sdkroot -x objective-c -fmodules -fsyntax-only - 2>&1 | %FileCheck %s
+
+// This only works with framework search paths because normal include paths
+// will pop up a "redefinition of module 'X'" error. Only Apple platforms have
+// default framework search paths, so just limit this to macOS.
+// REQUIRES: OS=macosx
+
+import TestUser
+
+// CHECK: TestUser found in override
+// CHECK: Test.h found in override


### PR DESCRIPTION
Besides saving some calls to `stat()`, this also causes problems when the user specifies a search path that Clang already adds by default, like $SDKROOT/Library/Frameworks/. Why? Because Swift adds its search paths after Clang has already configured its defaults, but Clang reconfigures its search paths from scratch when compiling a module to a PCM file to cache. This led to system search paths being found sooner in the primary Clang instance than in the PCM files, which in turn resulted in the PCM files being considered out of date.

This isn't likely to affect people much in practice, but it's better to get right. (We ran into this during Doug's experiments in making /System/Library/PrivateFrameworks a default search path in Clang r313317; turns out that's problematic for other reasons as well.)

While here, tweak the filtering for Clang diagnostics so that next time something like this breaks we'll actually see it in the build log.

rdar://problem/34664596