### PR TITLE
Rdar 25802399 change may to must

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -363,9 +363,9 @@ ERROR(expected_rbrace_protocol,none,
 ERROR(protocol_setter_name,none,
       "setter in a protocol cannot have a name", ())
 ERROR(protocol_method_with_body,none,
-      "protocol methods may not have bodies", ())
+      "protocol methods must not have bodies", ())
 ERROR(protocol_init_with_body,none,
-      "protocol initializers may not have bodies", ())
+      "protocol initializers must not have bodies", ())
 
 // Subscripting
 ERROR(subscript_decl_wrong_scope,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -316,7 +316,7 @@ ERROR(expected_type_in_typealias,PointsToFirstBadToken,
 ERROR(expected_type_in_associatedtype,PointsToFirstBadToken,
       "expected type in associated type declaration", ())
 ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
-      "associated types may not have a generic parameter list", ())
+      "associated types must not have a generic parameter list", ())
 
 
 // Func

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -269,7 +269,7 @@ ERROR(expected_accessor_kw,none,
 ERROR(var_set_without_get,none,
       "variable with a setter must also have a getter", ())
 ERROR(observingproperty_with_getset,none,
-      "%select{willSet|didSet}0 variable may not also have a "
+      "%select{willSet|didSet}0 variable must not also have a "
       "%select{get|set}1 specifier", (unsigned, unsigned))
 ERROR(observingproperty_without_mutableaddress,none,
       "%select{willSet|didSet}0 variable with addressor must provide a "

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -844,7 +844,7 @@ ERROR(inout_as_attr_disallowed,none,
       "%0 before a parameter name is not allowed, place it before the parameter type instead",
       (StringRef))
 ERROR(parameter_specifier_repeated,none,
-      "parameter may not have multiple '__owned', 'inout', '__shared',"
+      "parameter must not have multiple '__owned', 'inout', '__shared',"
       " 'var', or 'let' specifiers", ())
 ERROR(parameter_let_var_as_attr,none,
       "'%0' as a parameter attribute is not allowed",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -202,7 +202,7 @@ ERROR(mutating_method_called_on_immutable_value,none,
       " be used on immutable value '%2'",
       (DeclBaseName, unsigned, StringRef))
 ERROR(immutable_value_passed_inout,none,
-      "immutable value '%0' may not be passed inout",
+      "immutable value '%0' must not be passed inout",
       (StringRef))
 ERROR(assignment_to_immutable_value,none,
       "immutable value '%0' may not be assigned to",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -205,7 +205,7 @@ ERROR(immutable_value_passed_inout,none,
       "immutable value '%0' must not be passed inout",
       (StringRef))
 ERROR(assignment_to_immutable_value,none,
-      "immutable value '%0' may not be assigned to",
+      "immutable value '%0' must not be assigned to",
       (StringRef))
 ERROR(mutating_protocol_witness_method_on_let_constant,none,
       "cannot perform mutating operation: '%0' is a 'let' constant",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -221,7 +221,7 @@ ERROR(missing_never_call,none,
       "call to another never-returning function on all paths",
       (Type, unsigned))
 ERROR(guard_body_must_not_fallthrough,none,
-      "'guard' body may not fall through, consider using a 'return' or 'throw'"
+      "'guard' body must not fall through, consider using a 'return' or 'throw'"
       " to exit the scope", ())
 WARNING(unreachable_code,none, "will never be executed", ())
 NOTE(unreachable_code_branch,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1017,7 +1017,7 @@ ERROR(mutating_invalid_classes,none,
       "classes or class-bound protocols", (bool))
 
 ERROR(functions_mutating_and_not,none,
-      "method may not be declared both "
+      "method must not be declared both "
       "%select{nonmutating|mutating|__consuming}0 and "
       "%select{nonmutating|mutating|__consuming}1",
       (unsigned, unsigned))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2294,7 +2294,7 @@ NOTE(attr_ApplicationMain_script_here,none,
 ERROR(lazy_not_on_let,none,
       "'lazy' cannot be used on a let", ())
 ERROR(lazy_not_on_computed,none,
-      "'lazy' may not be used on a computed property", ())
+      "'lazy' must not be used on a computed property", ())
 
 ERROR(lazy_on_already_lazy_global,none,
       "'lazy' may not be used on an already-lazy global", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1347,7 +1347,7 @@ ERROR(extension_specialization,none,
       "constrained extension must be declared on the unspecialized generic "
       "type %0 with constraints specified by a 'where' clause", (Identifier))
 ERROR(extension_stored_property,none,
-      "extensions may not contain stored properties", ())
+      "extensions must not contain stored properties", ())
 ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0", (Type))
 ERROR(extension_constrained_inheritance,none,
@@ -1993,7 +1993,7 @@ WARNING(enum_case_access_warn,none,
         "uses %select{a private|a fileprivate|an internal|%error|%error}1 type",
         (AccessLevel, AccessLevel))
 ERROR(enum_stored_property,none,
-      "enums may not contain stored properties", ())
+      "enums must not contain stored properties", ())
 
 // Enum raw types
 ERROR(multiple_enum_raw_types,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1022,7 +1022,7 @@ ERROR(functions_mutating_and_not,none,
       "%select{nonmutating|mutating|__consuming}1",
       (unsigned, unsigned))
 ERROR(static_functions_not_mutating,none,
-      "static functions may not be declared mutating", ())
+      "static functions must not be declared mutating", ())
 
 ERROR(transparent_stored_property,none,
       "@_transparent cannot be applied to stored properties", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3206,7 +3206,7 @@ ERROR(objc_in_generic_extension,none,
 ERROR(objc_operator, none,
       "operator methods cannot be declared @objc", ())
 ERROR(objc_operator_proto, none,
-      "@objc protocols may not have operator requirements", ())
+      "@objc protocols must not have operator requirements", ())
 WARNING(objc_inference_swift3_dynamic,none,
         "inference of '@objc' for 'dynamic' members is deprecated", ())
 WARNING(objc_inference_swift3_objc_derived,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2309,7 +2309,7 @@ ERROR(lazy_requires_single_var,none,
 ERROR(lazy_must_be_property,none,
       "lazy is only valid for members of a struct or class", ())
 ERROR(lazy_not_observable,none,
-      "lazy properties may not have observers", ())
+      "lazy properties must not have observers", ())
 
 // Debugger function attribute.
 ERROR(attr_for_debugger_support_only,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2192,7 +2192,7 @@ ERROR(attr_only_on_parameters,none,
 ERROR(attr_not_on_variadic_parameters,none,
       "%0 must not be used on variadic parameters", (StringRef))
 ERROR(attr_not_on_subscript_parameters,none,
-      "%0 may not be used on subscript parameters", (StringRef))
+      "%0 must not be used on subscript parameters", (StringRef))
 
 ERROR(override_final,none,
       "%0 overrides a 'final' %1", (DescriptiveDeclKind, DescriptiveDeclKind))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -603,7 +603,7 @@ NOTE(serialization_compatibility_version_mismatch,none,
      (StringRef, StringRef, StringRef))
 
 ERROR(reserved_member_name,none,
-      "type member may not be named %0, since it would conflict with the"
+      "type member must not be named %0, since it would conflict with the"
       " 'foo.%1' expression", (DeclName, StringRef))
 
 ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -961,7 +961,7 @@ NOTE(unbound_generic_parameter_explicit_fix,none,
 
 
 ERROR(string_index_not_integer,none,
-      "String may not be indexed with %0, it has variable size elements",
+      "String must not be indexed with %0, it has variable size elements",
       (Type))
 NOTE(string_index_not_integer_note,none,
      "consider using an existing high level algorithm, "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3108,7 +3108,7 @@ ERROR(invalid_ownership_type,none,
       "class and class-bound protocol types, not %1",
       (/*Ownership*/unsigned, Type))
 ERROR(invalid_ownership_protocol_type,none,
-      "'%select{strong|weak|unowned|unowned}0' may not be applied to "
+      "'%select{strong|weak|unowned|unowned}0' must not be applied to "
       "non-class-bound %1; consider adding a protocol conformance that has a class bound",
       (/*Ownership*/unsigned, Type))
 ERROR(invalid_weak_ownership_not_optional,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2190,7 +2190,7 @@ ERROR(attr_only_one_decl_kind,none,
 ERROR(attr_only_on_parameters,none,
       "%0 may only be used on parameters", (StringRef))
 ERROR(attr_not_on_variadic_parameters,none,
-      "%0 may not be used on variadic parameters", (StringRef))
+      "%0 must not be used on variadic parameters", (StringRef))
 ERROR(attr_not_on_subscript_parameters,none,
       "%0 may not be used on subscript parameters", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -641,7 +641,7 @@ NOTE(unspaced_binary_operators_candidate,none,
      "could be %select{binary|postfix}2 %0 and %select{prefix|binary}2 %1",
      (Identifier, Identifier, bool))
 ERROR(unspaced_unary_operator,none,
-      "unary operators may not be juxtaposed; parenthesize inner expression",
+      "unary operators must not be juxtaposed; parenthesize inner expression",
       ())
 
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2297,7 +2297,7 @@ ERROR(lazy_not_on_computed,none,
       "'lazy' must not be used on a computed property", ())
 
 ERROR(lazy_on_already_lazy_global,none,
-      "'lazy' may not be used on an already-lazy global", ())
+      "'lazy' must not be used on an already-lazy global", ())
 ERROR(lazy_not_in_protocol,none,
       "'lazy' isn't allowed on a protocol requirement", ())
 ERROR(lazy_requires_initializer,none,

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -351,7 +351,7 @@ extension ThisBase1 {
 
   func baseExtFunc0() {}
 
-  var baseExtStaticVar: Int // expected-error {{extensions may not contain stored properties}} // expected-note 2 {{did you mean 'baseExtStaticVar'?}}
+  var baseExtStaticVar: Int // expected-error {{extensions must not contain stored properties}} // expected-note 2 {{did you mean 'baseExtStaticVar'?}}
 
   var baseExtStaticProp: Int { // expected-note 2 {{did you mean 'baseExtStaticProp'?}}
     get {
@@ -383,7 +383,7 @@ extension ThisDerived1 {
 
   func derivedExtFunc0() {}
 
-  var derivedExtStaticVar: Int // expected-error {{extensions may not contain stored properties}}
+  var derivedExtStaticVar: Int // expected-error {{extensions must not contain stored properties}}
 
   var derivedExtStaticProp: Int {
     get {

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -93,7 +93,7 @@ enum ImproperlyHasIVars {
   case Flopsy
   case Mopsy
 
-  var ivar : Int // expected-error{{enums may not contain stored properties}}
+  var ivar : Int // expected-error{{enums must not contain stored properties}}
 }
 
 // We used to crash on this.  rdar://14678675

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -79,7 +79,7 @@ extension BarClass {
 }
 
 protocol BarProtocol {
-  init() {} // expected-error {{protocol initializers may not have bodies}}
+  init() {} // expected-error {{protocol initializers must not have bodies}}
   deinit {} // expected-error {{deinitializers may only be declared within a class}}
 }
 

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -1,20 +1,20 @@
 // RUN: %target-typecheck-verify-swift
 
 // rdar://15946844
-func test1(inout var x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{18-22=}}
+func test1(inout var x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{18-22=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}
-func test2(inout let x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{18-22=}}
+func test2(inout let x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{18-22=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}
 func test3(f : (inout _ x : Int) -> Void) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
 
-func test1s(__shared var x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{22-26=}}
+func test1s(__shared var x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{22-26=}}
 // expected-error @-1 {{'__shared' before a parameter name is not allowed, place it before the parameter type instead}} {{13-21=}} {{30-30=__shared }}
-func test2s(__shared let x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{22-26=}}
+func test2s(__shared let x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{22-26=}}
 // expected-error @-1 {{'__shared' before a parameter name is not allowed, place it before the parameter type instead}} {{13-21=}} {{30-30=__shared }}
 
-func test1o(__owned var x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{21-25=}}
+func test1o(__owned var x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{21-25=}}
 // expected-error @-1 {{'__owned' as a parameter attribute is not allowed}} {{13-20=}}
-func test2o(__owned let x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{21-25=}}
+func test2o(__owned let x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{21-25=}}
 // expected-error @-1 {{'__owned' as a parameter attribute is not allowed}} {{13-20=}}
 
 func test3() {
@@ -84,19 +84,19 @@ func SR698(_ a: Int, b: Int) {}
 SR698(1, b: 2,) // expected-error {{unexpected ',' separator}}
 
 // SR-979 - Two inout crash compiler
-func SR979a(a : inout inout Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-23=}}
+func SR979a(a : inout inout Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-23=}}
 func SR979b(inout inout b: Int) {} // expected-error {{inout' before a parameter name is not allowed, place it before the parameter type instead}} {{13-18=}} {{28-28=inout }} 
-// expected-error@-1 {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{19-25=}}
+// expected-error@-1 {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{19-25=}}
 func SR979c(let a: inout Int) {} // expected-error {{'let' as a parameter attribute is not allowed}} {{13-16=}}
 func SR979d(let let a: Int) {}  // expected-error {{'let' as a parameter attribute is not allowed}} {{13-16=}} 
-// expected-error @-1 {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-21=}}
-func SR979e(inout x: inout String) {} // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{13-18=}}
-func SR979f(var inout x : Int) { // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-23=}}
+// expected-error @-1 {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-21=}}
+func SR979e(inout x: inout String) {} // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{13-18=}}
+func SR979f(var inout x : Int) { // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-23=}}
 // expected-error @-1 {{'var' as a parameter attribute is not allowed}}
   x += 10     // expected-error {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
 }
-func SR979g(inout i: inout Int) {} // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{13-18=}}
-func SR979h(let inout x : Int) {}  // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-23=}}
+func SR979g(inout i: inout Int) {} // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{13-18=}}
+func SR979h(let inout x : Int) {}  // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{17-23=}}
 // expected-error @-1 {{'let' as a parameter attribute is not allowed}}
 class VarTester {
   init(var a: Int, var b: Int) {} // expected-error {{'var' as a parameter attribute is not allowed}}

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -136,7 +136,7 @@ prefix func %<T>(x: T) -> T { return x } // No error expected - the < is conside
 
 struct Weak<T: class> { // expected-error {{'class' constraint can only appear on protocol declarations}}
   // expected-note@-1 {{did you mean to write an 'AnyObject' constraint?}} {{16-21=AnyObject}}
-  weak let value: T // expected-error {{'weak' must be a mutable variable, because it may change at runtime}} expected-error {{'weak' variable should have optional type 'T?'}} expected-error {{'weak' may not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound}}
+  weak let value: T // expected-error {{'weak' must be a mutable variable, because it may change at runtime}} expected-error {{'weak' variable should have optional type 'T?'}} expected-error {{'weak' must not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound}}
 }
 
 let x: () = ()

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -22,12 +22,12 @@ protocol Zim {
 
   init()
   // TODO class var prop: Int { get }
-  static func meth() {} // expected-error{{protocol methods may not have bodies}}
-  func instMeth() {} // expected-error{{protocol methods may not have bodies}}
+  static func meth() {} // expected-error{{protocol methods must not have bodies}}
+  func instMeth() {} // expected-error{{protocol methods must not have bodies}}
 }
 
 protocol Bad {
-  init() {} // expected-error{{protocol initializers may not have bodies}}
+  init() {} // expected-error{{protocol initializers must not have bodies}}
 }
 
 struct Gen<T> {

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -85,8 +85,8 @@ func test2() {
   
   let b5: Any
   b5 = "x"   
-  { takes_inout_any(&b5) }()   // expected-error {{immutable value 'b5' may not be passed inout}}
-  ({ takes_inout_any(&b5) })()   // expected-error {{immutable value 'b5' may not be passed inout}}
+  { takes_inout_any(&b5) }()   // expected-error {{immutable value 'b5' must not be passed inout}}
+  ({ takes_inout_any(&b5) })()   // expected-error {{immutable value 'b5' must not be passed inout}}
 
   // Structs
   var s1 : SomeStruct
@@ -874,7 +874,7 @@ struct LetProperties {
     u = 1; v = 13; w = (1,2); y = 1 ; z = u
 
     var variable = 42
-    swap(&u, &variable)  // expected-error {{immutable value 'self.u' may not be passed inout}}
+    swap(&u, &variable)  // expected-error {{immutable value 'self.u' must not be passed inout}}
     
     u.inspect()  // ok, non mutating.
     u.mutate()  // expected-error {{mutating method 'mutate' may not be used on immutable value 'self.u'}}
@@ -945,7 +945,7 @@ func testAddressOnlyProperty<T>(_ b : T) -> T {
   x = b   // expected-error {{immutable value 'x' may only be initialized once}}
 
   var tmp = b
-  swap(&x, &tmp)   // expected-error {{immutable value 'x' may not be passed inout}}
+  swap(&x, &tmp)   // expected-error {{immutable value 'x' must not be passed inout}}
   return y
 }
 
@@ -996,7 +996,7 @@ struct StructMutatingMethodTest {
     x += 1     // expected-error {{mutating operator '+=' may not be used on immutable value 'self.x'}}
 
     y = 12
-    myTransparentFunction(&y)  // expected-error {{immutable value 'self.y' may not be passed inout}}
+    myTransparentFunction(&y)  // expected-error {{immutable value 'self.y' must not be passed inout}}
   }
 }
 
@@ -1135,7 +1135,7 @@ func bug22436880(_ x: UnsafeMutablePointer<Int>) {}
 func test22436880() {
   let x: Int
   x = 1
-  bug22436880(&x) // expected-error {{immutable value 'x' may not be passed inout}}
+  bug22436880(&x) // expected-error {{immutable value 'x' must not be passed inout}}
 }
 
 // sr-184

--- a/test/SILOptimizer/unreachable_code.swift
+++ b/test/SILOptimizer/unreachable_code.swift
@@ -218,7 +218,7 @@ class r20097963MyClass {
 func die() -> Never { die() }
 
 func testGuard(_ a : Int) {
-  guard case 4 = a else {  }  // expected-error {{'guard' body may not fall through, consider using a 'return' or 'throw'}}
+  guard case 4 = a else {  }  // expected-error {{'guard' body must not fall through, consider using a 'return' or 'throw'}}
 
   guard case 4 = a else { return }  // ok
   guard case 4 = a else { die() }  // ok

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -488,11 +488,11 @@ struct F { // expected-note 1 {{in declaration of 'F'}}
   mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{expected declaration}}
   }
   
-  mutating nonmutating func g() {}  // expected-error {{method may not be declared both mutating and nonmutating}}
-  __consuming nonmutating func h() {}  // expected-error {{method may not be declared both __consuming and nonmutating}}
-  __consuming mutating func i() {}  // expected-error {{method may not be declared both __consuming and mutating}}
-  nonmutating mutating func j() {}  // expected-error {{method may not be declared both nonmutating and mutating}}
-  __consuming nonmutating mutating func k() {}  // expected-error {{method may not be declared both __consuming and mutating}} expected-error {{method may not be declared both nonmutating and mutating}}
+  mutating nonmutating func g() {}  // expected-error {{method must not be declared both mutating and nonmutating}}
+  __consuming nonmutating func h() {}  // expected-error {{method must not be declared both __consuming and nonmutating}}
+  __consuming mutating func i() {}  // expected-error {{method must not be declared both __consuming and mutating}}
+  nonmutating mutating func j() {}  // expected-error {{method must not be declared both nonmutating and mutating}}
+  __consuming nonmutating mutating func k() {}  // expected-error {{method must not be declared both __consuming and mutating}} expected-error {{method must not be declared both nonmutating and mutating}}
 }
 
 protocol SingleIntProperty {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -119,7 +119,7 @@ struct SomeStruct {
   
   static let type_let = 5  // expected-note {{change 'let' to 'var' to make it mutable}} {{10-13=var}}
 
-  mutating static func f() {  // expected-error {{static functions may not be declared mutating}} {{3-12=}}
+  mutating static func f() {  // expected-error {{static functions must not be declared mutating}} {{3-12=}}
   }
   
   mutating func g() {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -610,8 +610,8 @@ func f(a : FooClass, b : LetStructMembers) {
 class MutableSubscripts {
   var x : Int = 0
 
-  subscript(x: inout Int) -> () { x += 1 } // expected-error {{'inout' may not be used on subscript parameters}}
-  subscript<T>(x: inout T) -> () { // expected-error {{'inout' may not be used on subscript parameters}}
+  subscript(x: inout Int) -> () { x += 1 } // expected-error {{'inout' must not be used on subscript parameters}}
+  subscript<T>(x: inout T) -> () { // expected-error {{'inout' must not be used on subscript parameters}}
     fatalError()
   }
 

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -374,7 +374,7 @@ func testSelectorStyleArguments3(_ x: Int, bar y: Int) {
   ++y  // expected-error {{cannot pass immutable value to mutating operator: 'y' is a 'let' constant}}
 }
 
-func invalid_inout(inout var x : Int) { // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{26-30=}}
+func invalid_inout(inout var x : Int) { // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{26-30=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{20-25=}}{{34-34=inout }}
 }
 func invalid_var(var x: Int) { // expected-error {{'var' as a parameter attribute is not allowed}}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -155,7 +155,7 @@ func callAutoclosureWithNoEscape_3(_ fn: @autoclosure () -> Int) {
   takesAutoclosure(fn()) // ok
 }
 
-// expected-error @+1 {{@autoclosure may not be used on variadic parameters}}
+// expected-error @+1 {{@autoclosure must not be used on variadic parameters}}
 func variadicAutoclosure(_ fn: @autoclosure () -> ()...) {
   for _ in fn {}
 }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2193,7 +2193,7 @@ func ==(lhs: ObjC_Class1, rhs: ObjC_Class1) -> Bool {
 } // CHECK: {{^}$}}
 
 @objc protocol OperatorInProtocol {
-  static func +(lhs: Self, rhs: Self) -> Self // expected-error {{@objc protocols may not have operator requirements}}
+  static func +(lhs: Self, rhs: Self) -> Self // expected-error {{@objc protocols must not have operator requirements}}
 }
 
 class AdoptsOperatorInProtocol : OperatorInProtocol {

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -161,14 +161,14 @@ weak
 var weak8 : Class? = Ty0()
 unowned var weak9 : Class = Ty0()
 weak
-var weak10 : NonClass? = Ty0() // expected-error {{'weak' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak10 : NonClass? = Ty0() // expected-error {{'weak' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 unowned
-var weak11 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak11 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 
 unowned
-var weak12 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak12 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 unowned
-var weak13 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak13 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 
 weak
 var weak14 : Ty0 // expected-error {{'weak' variable should have optional type 'Ty0?'}}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -47,8 +47,8 @@ extension S1.Type {} // expected-error {{cannot extend a metatype 'S1.Type'}}
 extension S1.NestedStruct {} // no-error
 
 struct S1_2 {
-  // expected-error @+4 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
-  // expected-error @+3 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+4 {{type member must not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+3 {{type member must not be named 'Type', since it would conflict with the 'foo.Type' expression}}
   // expected-note @+2 {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Type`}}
   // expected-note @+1 {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Type`}}
   enum Type {}

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -123,7 +123,7 @@ func testObjCMethodCurry(_ a : ClassWithObjCMethod) -> (Int) -> () {
 }
 
 // We used to crash on this.
-func rdar16786220(inout let c: Int) -> () { // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{25-29=}}
+func rdar16786220(inout let c: Int) -> () { // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{25-29=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{19-24=}}{{32-32=inout }}
 
   c = 42
@@ -139,7 +139,7 @@ _ = [1] !!! [1]   // unambiguously picking the array overload.
 
 
 // <rdar://problem/16786168> Functions currently permit 'var inout' parameters
-func var_inout_error(inout var x : Int) {} // expected-error {{parameter may not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{28-32=}}
+func var_inout_error(inout var x : Int) {} // expected-error {{parameter must not have multiple '__owned', 'inout', '__shared', 'var', or 'let' specifiers}} {{28-32=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{22-27=}}{{36-36=inout }}
 
 // Unnamed parameters require the name "_":

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -190,10 +190,10 @@ _ = n☃⃠☃⃠n     // expected-error {{ambiguous missing whitespace between 
 // expected-note @-1 {{could be binary '☃⃠' and prefix '☃⃠'}} {{12-12= }} {{18-18= }}
 // expected-note @-2 {{could be postfix '☃⃠' and binary '☃⃠'}} {{6-6= }} {{12-12= }}
 
-_ = n☃⃠☃⃠ // expected-error {{unary operators may not be juxtaposed; parenthesize inner expression}}
-_ = ~!n  // expected-error {{unary operators may not be juxtaposed; parenthesize inner expression}}
-_ = -+n  // expected-error {{unary operators may not be juxtaposed; parenthesize inner expression}}
-_ = -++n // expected-error {{unary operators may not be juxtaposed; parenthesize inner expression}}
+_ = n☃⃠☃⃠ // expected-error {{unary operators must not be juxtaposed; parenthesize inner expression}}
+_ = ~!n  // expected-error {{unary operators must not be juxtaposed; parenthesize inner expression}}
+_ = -+n  // expected-error {{unary operators must not be juxtaposed; parenthesize inner expression}}
+_ = -++n // expected-error {{unary operators must not be juxtaposed; parenthesize inner expression}}
 
 // <rdar://problem/16230507> Cannot use a negative constant as the second operator of ... operator
 _ = 3...-5  // expected-error {{ambiguous missing whitespace between unary and binary operators}} expected-note {{could be postfix '...' and binary '-'}} expected-note {{could be binary '...' and prefix '-'}}

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -108,7 +108,7 @@ extension C_Derived {
 protocol P {
   static func f1()
   static func f2()
-  static func f3() {} // expected-error {{protocol methods may not have bodies}}
+  static func f3() {} // expected-error {{protocol methods must not have bodies}}
   static final func f4() // expected-error {{only classes and class members may be marked with 'final'}}
 }
 

--- a/test/decl/func/vararg.swift
+++ b/test/decl/func/vararg.swift
@@ -19,7 +19,7 @@ f3({ print($0) })
 func f4(_ a: Int..., b: Int) { }
 
 // rdar://16008564
-func inoutVariadic(_ i: inout Int...) {  // expected-error {{'inout' may not be used on variadic parameters}}
+func inoutVariadic(_ i: inout Int...) {  // expected-error {{'inout' must not be used on variadic parameters}}
 }
 
 // rdar://19722429

--- a/test/decl/nested/reserved_name.swift
+++ b/test/decl/nested/reserved_name.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
 struct S1 {
-  // expected-error @+4 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
-  // expected-error @+3 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+4 {{type member must not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+3 {{type member must not be named 'Type', since it would conflict with the 'foo.Type' expression}}
   // expected-note @+2 {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Type`}}
   // expected-note @+1 {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Type`}}
   enum Type {

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -295,11 +295,11 @@ enum EnumWithMutating {
 // <rdar://problem/21783216> Ban members named Type and Protocol without backticks
 // https://twitter.com/jadengeller/status/619989059046240256
 protocol r21783216a {
-  // expected-error @+2 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+2 {{type member must not be named 'Type', since it would conflict with the 'foo.Type' expression}}
   // expected-note @+1 {{if this name is unavoidable, use backticks to escape it}} {{18-22=`Type`}}
   associatedtype Type
   
-  // expected-error @+2 {{type member may not be named 'Protocol', since it would conflict with the 'foo.Protocol' expression}}
+  // expected-error @+2 {{type member must not be named 'Protocol', since it would conflict with the 'foo.Protocol' expression}}
   // expected-note @+1 {{if this name is unavoidable, use backticks to escape it}} {{18-26=`Protocol`}}
   associatedtype Protocol
 }

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -275,7 +275,7 @@ protocol ProtocolWithMutating {
   mutating func test2(_ a: Int?) // expected-note {{previously declared}}
   func test2(_ a: Int!) // expected-error{{invalid redeclaration of 'test2'}}
 
-  mutating static func classTest1() // expected-error {{static functions may not be declared mutating}} {{3-12=}} expected-note {{previously declared}}
+  mutating static func classTest1() // expected-error {{static functions must not be declared mutating}} {{3-12=}} expected-note {{previously declared}}
   static func classTest1() // expected-error{{invalid redeclaration of 'classTest1()'}}
 }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -2,7 +2,7 @@
 protocol EmptyProtocol { }
 
 protocol DefinitionsInProtocols {
-  init() {} // expected-error {{protocol initializers may not have bodies}}
+  init() {} // expected-error {{protocol initializers must not have bodies}}
   deinit {} // expected-error {{deinitializers may only be declared within a class}}
 }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -466,7 +466,7 @@ protocol ShouldntCrash {
 
 // rdar://problem/18168866
 protocol FirstProtocol {
-    weak var delegate : SecondProtocol? { get } // expected-error{{'weak' may not be applied to non-class-bound 'SecondProtocol'; consider adding a protocol conformance that has a class bound}}
+    weak var delegate : SecondProtocol? { get } // expected-error{{'weak' must not be applied to non-class-bound 'SecondProtocol'; consider adding a protocol conformance that has a class bound}}
 }
 
 protocol SecondProtocol {

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -30,7 +30,7 @@ typealias DS<T> = MyType<String, T>
 
 typealias BadA<T : Int> = MyType<String, T>  // expected-error {{inheritance from non-protocol, non-class type 'Int'}}
 
-typealias BadB<T where T == Int> = MyType<String, T>  // expected-error {{associated types may not have a generic parameter list}}
+typealias BadB<T where T == Int> = MyType<String, T>  // expected-error {{associated types must not have a generic parameter list}}
 // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
 
 typealias BadC<T,T> = MyType<String, T>  // expected-error {{definition conflicts with previous value}}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -3,7 +3,7 @@
 // Tests for typealias inside protocols
 
 protocol Bad {
-  associatedtype X<T>  // expected-error {{associated types may not have a generic parameter list}}
+  associatedtype X<T>  // expected-error {{associated types must not have a generic parameter list}}
   typealias Y<T>       // expected-error {{expected '=' in type alias declaration}}
 }
 

--- a/test/decl/var/behaviors.swift
+++ b/test/decl/var/behaviors.swift
@@ -155,7 +155,7 @@ struct Foo2<T> {
 
 extension Foo {
   static var y: T __behavior hasStorage // expected-error{{static stored properties not supported in generic types}}
-  var y: T __behavior hasStorage // expected-error {{extensions may not contain stored properties}}
+  var y: T __behavior hasStorage // expected-error {{extensions must not contain stored properties}}
 }
 
 protocol storageWithoutInit {

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -37,7 +37,7 @@ class TestClass {
 
   lazy var k : Int = { () -> Int in return 0 }()+1  // multi-stmt closure
 
-  lazy var l : Int = 42 {  // expected-error {{lazy properties may not have observers}} {{3-8=}}
+  lazy var l : Int = 42 {  // expected-error {{lazy properties must not have observers}} {{3-8=}}
     didSet {
     }
   }

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -21,7 +21,7 @@ class TestClass {
 
   lazy let b = 42  // expected-error {{'lazy' cannot be used on a let}} {{3-8=}}
 
-  lazy var c : Int { return 42 } // expected-error {{'lazy' may not be used on a computed property}} {{3-8=}}
+  lazy var c : Int { return 42 } // expected-error {{'lazy' must not be used on a computed property}} {{3-8=}}
 
   lazy var d : Int  // expected-error {{lazy properties must have an initializer}} {{3-8=}}
 

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -2,10 +2,10 @@
 
 lazy func lazy_func() {} // expected-error {{'lazy' may only be used on 'var' declarations}} {{1-6=}}
 
-lazy var b = 42  // expected-error {{'lazy' may not be used on an already-lazy global}} {{1-6=}}
+lazy var b = 42  // expected-error {{'lazy' must not be used on an already-lazy global}} {{1-6=}}
 
 struct S {
-  lazy static var lazy_global = 42 // expected-error {{'lazy' may not be used on an already-lazy global}} {{3-8=}}
+  lazy static var lazy_global = 42 // expected-error {{'lazy' must not be used on an already-lazy global}} {{3-8=}}
 }
 
 protocol SomeProtocol {

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -441,7 +441,7 @@ struct StructWithExtension1 {
   static var fooStatic = 4
 }
 extension StructWithExtension1 {
-  var fooExt: Int // expected-error {{extensions may not contain stored properties}}
+  var fooExt: Int // expected-error {{extensions must not contain stored properties}}
   static var fooExtStatic = 4
 }
 
@@ -450,16 +450,16 @@ class ClassWithExtension1 {
   class var fooStatic = 4 // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
 }
 extension ClassWithExtension1 {
-  var fooExt: Int // expected-error {{extensions may not contain stored properties}}
+  var fooExt: Int // expected-error {{extensions must not contain stored properties}}
   class var fooExtStatic = 4 // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
 }
 
 enum EnumWithExtension1 {
-  var foo: Int // expected-error {{enums may not contain stored properties}}
+  var foo: Int // expected-error {{enums must not contain stored properties}}
   static var fooStatic  = 4
 }
 extension EnumWithExtension1 {
-  var fooExt: Int // expected-error {{extensions may not contain stored properties}}
+  var fooExt: Int // expected-error {{extensions must not contain stored properties}}
   static var fooExtStatic = 4
 }
 
@@ -468,7 +468,7 @@ protocol ProtocolWithExtension1 {
   static var fooStatic : Int { get }
 }
 extension ProtocolWithExtension1 {
-  var fooExt: Int // expected-error{{extensions may not contain stored properties}}
+  var fooExt: Int // expected-error{{extensions must not contain stored properties}}
   static var fooExtStatic = 4 // expected-error{{static stored properties not supported in protocol extensions}}
 }
 
@@ -1113,8 +1113,8 @@ class rdar17391625 {
 }
 
 extension rdar17391625 {
-  var someStoredVar: Int       // expected-error {{extensions may not contain stored properties}}
-  var someObservedVar: Int {   // expected-error {{extensions may not contain stored properties}}
+  var someStoredVar: Int       // expected-error {{extensions must not contain stored properties}}
+  var someObservedVar: Int {   // expected-error {{extensions must not contain stored properties}}
   didSet {
   }
   }
@@ -1135,7 +1135,7 @@ extension rdar17391625derived {
 public protocol rdar27671033P {}
 struct rdar27671033S<Key, Value> {}
 extension rdar27671033S : rdar27671033P where Key == String { // expected-error {{extension of type 'rdar27671033S' with constraints cannot have an inheritance clause}}
-  let d = rdar27671033S<Int, Int>() // expected-error {{extensions may not contain stored properties}}
+  let d = rdar27671033S<Int, Int>() // expected-error {{extensions must not contain stored properties}}
 }
 
 // <rdar://problem/19874152> struct memberwise initializer violates new sanctity of previously set `let` property

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -712,7 +712,7 @@ struct WillSetDidSetProperties {
     didSet {
       markUsed("woot")
     }
-    get { // expected-error {{didSet variable may not also have a get specifier}}
+    get { // expected-error {{didSet variable must not also have a get specifier}}
       return 4
     }
   }
@@ -721,7 +721,7 @@ struct WillSetDidSetProperties {
     willSet {
       markUsed("woot")
     }
-    set { // expected-error {{willSet variable may not also have a set specifier}}
+    set { // expected-error {{willSet variable must not also have a set specifier}}
       return 4
     }
   }


### PR DESCRIPTION
Minor diagnostic fix for clarity: user was unsure whether "foo may not be bar" meant that the state of affairs was indeterminate (may be? may not be?) or whether the compiler was saying that foo is prohibited from being bar.

(with helpful link to RFC 2119)

rdar://25802399