### PR TITLE
[ConstraintSolver] Fix handling of defaultable constraint in `getPotentialBindings`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -624,6 +624,14 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type,
     }
 
     if (auto typeVar = type->getAs<TypeVariableType>()) {
+      bool hasRepresentative = false;
+      if (auto *repr = getRepresentative(typeVar)) {
+        if (typeVar != repr) {
+          hasRepresentative = true;
+          typeVar = repr;
+        }
+      }
+
       if (auto fixed = getFixedType(typeVar)) {
         if (wantRValue)
           fixed = fixed->getRValueType();
@@ -631,6 +639,12 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type,
         type = fixed;
         continue;
       }
+
+      // If type variable has a representative but
+      // no fixed type, reflect that in the type itself.
+      if (hasRepresentative)
+        type = typeVar;
+
       break;
     }
 

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -169,3 +169,6 @@ class SR_5245 {
 
 SR_5245(s: SR_5245.S(f: [.e1, .e2]))
 // expected-error@-1 {{incorrect argument label in call (have 'f:', expected 'e:')}} {{22-23=e}}
+
+// rdar://problem/34670592 - Compiler crash on heterogeneous collection literal
+_ = Array([1, "hello"]) // Ok


### PR DESCRIPTION
While trying to find a fixed type for a given type variable, check if
it has representative and if it does, reflect that in the returned type.

Resolves: rdar://problem/34670592

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
