### PR TITLE
Fix issue with 'Self' metadata when class conforms to protocol with default implementations

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1452,6 +1452,11 @@ ERROR(witness_requires_dynamic_self,none,
       "method %0 in non-final class %1 must return `Self` to conform to "
       "protocol %2",
       (DeclName, Type, Type))
+ERROR(witness_requires_class_implementation,none,
+      "method %0 in non-final class %1 cannot be implemented in a "
+      "protocol extension because it returns `Self` and has associated type "
+      "requirements",
+      (DeclName, Type))
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -712,7 +712,8 @@ DevirtualizationResult swift::tryDevirtualizeClassMethod(FullApplySite AI,
 //===----------------------------------------------------------------------===//
 
 static SubstitutionMap
-getSubstitutionsForProtocolConformance(ProtocolConformanceRef CRef) {
+getSubstitutionsForProtocolConformance(ModuleDecl *M,
+                                       ProtocolConformanceRef CRef) {
   auto C = CRef.getConcrete();
 
   // Walk down to the base NormalProtocolConformance.
@@ -746,8 +747,7 @@ getSubstitutionsForProtocolConformance(ProtocolConformanceRef CRef) {
 
   if (Subs.empty()) {
     auto *DC = NormalC->getDeclContext();
-    return NormalC->getType()
-      ->getContextSubstitutionMap(DC->getParentModule(), DC);
+    return NormalC->getType()->getContextSubstitutionMap(M, DC);
   }
 
   return NormalC->getGenericSignature()->getSubstitutionMap(Subs);
@@ -764,17 +764,50 @@ getSubstitutionsForProtocolConformance(ProtocolConformanceRef CRef) {
 /// are written in terms of the requirement's generic signature need
 /// to be remapped to substitutions suitable for the witness signature.
 ///
+/// Supported remappings are:
+///
+/// - (Concrete witness thunk) Original substitutions:
+///   [Self := ConcreteType, R0 := X0, R1 := X1, ...]
+/// - Requirement generic signature:
+///   <Self : P, R0, R1, ...>
+/// - Witness thunk generic signature:
+///   <W0, W1, ...>
+/// - Remapped substitutions:
+///   [W0 := X0, W1 := X1, ...]
+///
+/// - (Class witness thunk) Original substitutions:
+///   [Self := C<A0, A1>, T0 := X0, T1 := X1, ...]
+/// - Requirement generic signature:
+///   <Self : P, R0, R1, ...>
+/// - Witness thunk generic signature:
+///   <Self : C<B0, B1>, B0, B1, W0, W1, ...>
+/// - Remapped substitutions:
+///   [Self := C<B0, B1>, B0 := A0, B1 := A1, W0 := X0, W1 := X1]
+///
+/// - (Default witness thunk) Original substitutions:
+///   [Self := ConcreteType, R0 := X0, R1 := X1, ...]
+/// - Requirement generic signature:
+///   <Self : P, R0, R1, ...>
+/// - Witness thunk generic signature:
+///   <Self : P, W0, W1, ...>
+/// - Remapped substitutions:
+///   [Self := ConcreteType, W0 := X0, W1 := X1, ...]
+///
 /// \param conformanceRef The (possibly-specialized) conformance
 /// \param requirementSig The generic signature of the requirement
 /// \param witnessThunkSig The generic signature of the witness method
 /// \param origSubs The substitutions from the call instruction
+/// \param isDefaultWitness True if this is a default witness method
+/// \param classWitness The ClassDecl if this is a class witness method
 static SubstitutionMap
 getWitnessMethodSubstitutions(
+    ModuleDecl *mod,
     ProtocolConformanceRef conformanceRef,
     GenericSignature *requirementSig,
     GenericSignature *witnessThunkSig,
     SubstitutionList origSubs,
-    bool isDefaultWitness) {
+    bool isDefaultWitness,
+    ClassDecl *classWitness) {
 
   if (witnessThunkSig == nullptr)
     return SubstitutionMap();
@@ -789,7 +822,7 @@ getWitnessMethodSubstitutions(
 
   // If `Self` maps to a bound generic type, this gives us the
   // substitutions for the concrete type's generic parameters.
-  auto baseSubMap = getSubstitutionsForProtocolConformance(conformanceRef);
+  auto baseSubMap = getSubstitutionsForProtocolConformance(mod, conformanceRef);
 
   unsigned baseDepth = 0;
   auto *rootConformance = conformance->getRootNormalConformance();
@@ -797,6 +830,39 @@ getWitnessMethodSubstitutions(
     baseDepth = witnessSig->getGenericParams().back()->getDepth() + 1;
 
   auto origDepth = 1;
+
+  // If the witness has a class-constrained 'Self' generic parameter,
+  // we have to build a new substitution map that shifts all generic
+  // parameters down by one.
+  if (classWitness != nullptr) {
+    baseDepth += 1;
+
+    auto &ctx = mod->getASTContext();
+    auto *proto = conformance->getProtocol();
+    auto selfType = proto->getSelfInterfaceType();
+
+    auto witnessThunkToWitnessMap = witnessThunkSig->getSubstitutionMap(
+        [&](SubstitutableType *type) -> Type {
+          if (type->isEqual(selfType))
+            return classWitness->getSelfInterfaceType();
+
+          auto *origParamTy = cast<GenericTypeParamType>(type);
+          auto *substParamTy = GenericTypeParamType::get(
+              origParamTy->getDepth() - 1,
+              origParamTy->getIndex(),
+              ctx);
+
+          return substParamTy;
+        },
+        [&](CanType origType, Type replacementType, ProtocolType *protoType)
+            -> Optional<ProtocolConformanceRef> {
+          assert(!origType->isEqual(selfType));
+
+          return ProtocolConformanceRef(protoType->getDecl());
+        });
+
+    baseSubMap = witnessThunkToWitnessMap.subst(baseSubMap);
+  }
 
   return SubstitutionMap::combineSubstitutionMaps(
       baseSubMap,
@@ -807,24 +873,40 @@ getWitnessMethodSubstitutions(
       witnessThunkSig);
 }
 
+static ClassDecl *
+getWitnessMethodClass(SILFunctionType *witnessFnTy, ModuleDecl &M) {
+  auto selfTy = witnessFnTy->getSelfInstanceType();
+  auto genericSig = witnessFnTy->getGenericSignature();
+  if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {
+    auto superclass = genericSig->getSuperclassBound(paramTy, M);
+    if (superclass)
+      return superclass->getClassOrBoundGenericClass();
+  }
+
+  return nullptr;
+}
+
 static SubstitutionMap
 getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI, SILFunction *F,
                               ProtocolConformanceRef CRef) {
+  auto witnessFnTy = F->getLoweredFunctionType();
+  assert(witnessFnTy->getRepresentation() ==
+         SILFunctionTypeRepresentation::WitnessMethod);
+
   auto requirementSig = AI.getOrigCalleeType()->getGenericSignature();
-  auto witnessThunkSig = F->getLoweredFunctionType()->getGenericSignature();
+  auto witnessThunkSig = witnessFnTy->getGenericSignature();
 
   SubstitutionList origSubs = AI.getSubstitutions();
 
+  auto *mod = Module.getSwiftModule();
   bool isDefaultWitness =
-    F->getLoweredFunctionType()->getRepresentation()
-      == SILFunctionTypeRepresentation::WitnessMethod &&
-    F->getLoweredFunctionType()->getDefaultWitnessMethodProtocol(
-                                                     *Module.getSwiftModule())
-      == CRef.getRequirement();
+    (witnessFnTy->getDefaultWitnessMethodProtocol(*mod)
+      == CRef.getRequirement());
+  auto *classWitness = getWitnessMethodClass(witnessFnTy, *mod);
 
   return getWitnessMethodSubstitutions(
-      CRef, requirementSig, witnessThunkSig,
-      origSubs, isDefaultWitness);
+      mod, CRef, requirementSig, witnessThunkSig,
+      origSubs, isDefaultWitness, classWitness);
 }
 
 /// Generate a new apply of a function_ref to replace an apply of a

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3095,7 +3095,8 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
 
     // If the function has a dynamic Self, it's okay.
     if (auto func = dyn_cast<FuncDecl>(witness)) {
-      if (!func->hasDynamicSelf()) {
+      if (func->getDeclContext()->getAsClassOrClassExtensionContext() &&
+          !func->hasDynamicSelf()) {
         diagnoseOrDefer(requirement, false,
           [witness, requirement](NormalProtocolConformance *conformance) {
             auto proto = conformance->getProtocol();
@@ -3149,6 +3150,31 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   // A non-final class can model a protocol requirement with a
   // contravariant Self, because here the witness will always have
   // a more general type than the requirement.
+
+  // If the witness is in a protocol extension, there's an additional
+  // constraint that either the requirement not produce 'Self' in a
+  // covariant position, or the type of the requirement does not involve
+  // associated types.
+  if (auto func = dyn_cast<FuncDecl>(witness)) {
+    if (func->getDeclContext()->getAsProtocolExtensionContext()) {
+      auto selfKindWithAssocTypes = Proto->findProtocolSelfReferences(
+          requirement,
+          /*allowCovariantParameters=*/false,
+          /*skipAssocTypes=*/false);
+      if (selfKindWithAssocTypes.other &&
+          selfKindWithAssocTypes.result) {
+        diagnoseOrDefer(requirement, false,
+          [witness, requirement](NormalProtocolConformance *conformance) {
+            auto proto = conformance->getProtocol();
+            auto &diags = proto->getASTContext().Diags;
+            diags.diagnose(witness->getLoc(),
+                           diag::witness_requires_class_implementation,
+                           requirement->getFullName(),
+                           conformance->getType());
+          });
+      }
+    }
+  }
 }
 
 ResolveWitnessResult

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1943,6 +1943,11 @@ namespace {
     void recordTypeWitness(AssociatedTypeDecl *assocType, Type type,
                            TypeDecl *typeDecl, bool performRedeclarationCheck);
 
+    /// Enforce restrictions on non-final classes witnessing requirements
+    /// involving the protocol 'Self' type.
+    void checkNonFinalClassWitness(ValueDecl *requirement,
+                                   ValueDecl *witness);
+
     /// Resolve a (non-type) witness via name lookup.
     ResolveWitnessResult resolveWitnessViaLookup(ValueDecl *requirement);
 
@@ -3037,6 +3042,115 @@ getAdopteeSelfSameTypeConstraint(ClassDecl *selfClass, ValueDecl *witness) {
   return None;
 }
 
+void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
+                                                   ValueDecl *witness) {
+  auto *classDecl = Adoptee->getClassOrBoundGenericClass();
+
+  // If we have an initializer requirement and the conforming type
+  // is a non-final class, the witness must be 'required'.
+  // We exempt Objective-C initializers from this requirement
+  // because there is no equivalent to 'required' in Objective-C.
+  if (auto ctor = dyn_cast<ConstructorDecl>(witness)) {
+    if (!ctor->isRequired() &&
+        !ctor->getDeclContext()->getAsProtocolOrProtocolExtensionContext() &&
+        !ctor->hasClangNode()) {
+      // FIXME: We're not recovering (in the AST), so the Fix-It
+      // should move.
+      diagnoseOrDefer(requirement, false,
+        [ctor, requirement](NormalProtocolConformance *conformance) {
+          bool inExtension = isa<ExtensionDecl>(ctor->getDeclContext());
+          auto &diags = ctor->getASTContext().Diags;
+          auto diag = diags.diagnose(ctor->getLoc(),
+                                     diag::witness_initializer_not_required,
+                                     requirement->getFullName(),
+                                     inExtension,
+                                     conformance->getType());
+          if (!ctor->isImplicit() && !inExtension)
+            diag.fixItInsert(ctor->getStartLoc(), "required ");
+        });
+    }
+  }
+
+  // Check whether this requirement uses Self in a way that might
+  // prevent conformance from succeeding.
+  auto selfKind = Proto->findProtocolSelfReferences(requirement,
+                                       /*allowCovariantParameters=*/false,
+                                       /*skipAssocTypes=*/true);
+
+  if (selfKind.other) {
+    // References to Self in a position where subclasses cannot do
+    // the right thing. Complain if the adoptee is a non-final
+    // class.
+    diagnoseOrDefer(requirement, false,
+      [witness, requirement](NormalProtocolConformance *conformance) {
+        auto proto = conformance->getProtocol();
+        auto &diags = proto->getASTContext().Diags;
+        diags.diagnose(witness->getLoc(), diag::witness_self_non_subtype,
+                       proto->getDeclaredType(), requirement->getFullName(),
+                       conformance->getType());
+      });
+  } else if (selfKind.result) {
+    // The reference to Self occurs in the result type. A non-final class
+    // can satisfy this requirement with a method that returns Self.
+
+    // If the function has a dynamic Self, it's okay.
+    if (auto func = dyn_cast<FuncDecl>(witness)) {
+      if (!func->hasDynamicSelf()) {
+        diagnoseOrDefer(requirement, false,
+          [witness, requirement](NormalProtocolConformance *conformance) {
+            auto proto = conformance->getProtocol();
+            auto &diags = proto->getASTContext().Diags;
+            diags.diagnose(witness->getLoc(),
+                           diag::witness_requires_dynamic_self,
+                           requirement->getFullName(),
+                           conformance->getType(),
+                           proto->getDeclaredType());
+          });
+      }
+
+    // Constructors conceptually also have a dynamic Self
+    // return type, so they're okay.
+    } else if (!isa<ConstructorDecl>(witness)) {
+      diagnoseOrDefer(requirement, false,
+        [witness, requirement](NormalProtocolConformance *conformance) {
+          auto proto = conformance->getProtocol();
+          auto &diags = proto->getASTContext().Diags;
+          diags.diagnose(witness->getLoc(), diag::witness_self_non_subtype,
+                         proto->getDeclaredType(),
+                         requirement->getFullName(),
+                         conformance->getType());
+        });
+    }
+  } else if (selfKind.requirement) {
+    if (auto constraint = getAdopteeSelfSameTypeConstraint(classDecl,
+                                                           witness)) {
+      // A "Self ==" constraint works incorrectly with subclasses. Complain.
+      auto proto = Conformance->getProtocol();
+      auto &diags = proto->getASTContext().Diags;
+      diags.diagnose(witness->getLoc(),
+                     diag::witness_self_same_type,
+                     witness->getDescriptiveKind(),
+                     witness->getFullName(),
+                     Conformance->getType(),
+                     requirement->getDescriptiveKind(),
+                     requirement->getFullName(),
+                     proto->getDeclaredType());
+
+      if (auto requirementRepr = *constraint) {
+        diags.diagnose(requirementRepr->getEqualLoc(),
+                       diag::witness_self_weaken_same_type,
+                       requirementRepr->getFirstType(),
+                       requirementRepr->getSecondType())
+          .fixItReplace(requirementRepr->getEqualLoc(), ":");
+      }
+    }
+  }
+
+  // A non-final class can model a protocol requirement with a
+  // contravariant Self, because here the witness will always have
+  // a more general type than the requirement.
+}
+
 ResolveWitnessResult
 ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
@@ -3247,112 +3361,10 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
     }
 
-    ClassDecl *classDecl = Adoptee->getClassOrBoundGenericClass();
-
-    if (classDecl && !classDecl->isFinal()) {
-      // If we have an initializer requirement and the conforming type
-      // is a non-final class, the witness must be 'required'.
-      // We exempt Objective-C initializers from this requirement
-      // because there is no equivalent to 'required' in Objective-C.
-      if (auto ctor = dyn_cast<ConstructorDecl>(best.Witness)) {
-        if (!ctor->isRequired() &&
-            !ctor->getDeclContext()->getAsProtocolOrProtocolExtensionContext() &&
-            !ctor->hasClangNode()) {
-          // FIXME: We're not recovering (in the AST), so the Fix-It
-          // should move.
-          diagnoseOrDefer(requirement, false,
-            [ctor, requirement](NormalProtocolConformance *conformance) {
-              bool inExtension = isa<ExtensionDecl>(ctor->getDeclContext());
-              auto &diags = ctor->getASTContext().Diags;
-              auto diag = diags.diagnose(ctor->getLoc(),
-                                         diag::witness_initializer_not_required,
-                                         requirement->getFullName(), 
-                                         inExtension,
-                                         conformance->getType());
-              if (!ctor->isImplicit() && !inExtension)
-                diag.fixItInsert(ctor->getStartLoc(), "required ");
-            });
-        }
+    if (auto *classDecl = Adoptee->getClassOrBoundGenericClass()) {
+      if (!classDecl->isFinal()) {
+        checkNonFinalClassWitness(requirement, witness);
       }
-
-      // Check whether this requirement uses Self in a way that might
-      // prevent conformance from succeeding.
-      auto selfKind = Proto->findProtocolSelfReferences(requirement,
-                                           /*allowCovariantParameters=*/false,
-                                           /*skipAssocTypes=*/true);
-
-      if (selfKind.other) {
-        // References to Self in a position where subclasses cannot do
-        // the right thing. Complain if the adoptee is a non-final
-        // class.
-        diagnoseOrDefer(requirement, false,
-          [witness, requirement](NormalProtocolConformance *conformance) {
-            auto proto = conformance->getProtocol();
-            auto &diags = proto->getASTContext().Diags;
-            diags.diagnose(witness->getLoc(), diag::witness_self_non_subtype,
-                           proto->getDeclaredType(), requirement->getFullName(),
-                           conformance->getType());
-          });
-      } else if (selfKind.result) {
-        // The reference to Self occurs in the result type. A non-final class 
-        // can satisfy this requirement with a method that returns Self.
-
-        // If the function has a dynamic Self, it's okay.
-        if (auto func = dyn_cast<FuncDecl>(best.Witness)) {
-          if (!func->hasDynamicSelf()) {
-            diagnoseOrDefer(requirement, false,
-              [witness, requirement](NormalProtocolConformance *conformance) {
-                auto proto = conformance->getProtocol();
-                auto &diags = proto->getASTContext().Diags;
-                diags.diagnose(witness->getLoc(),
-                               diag::witness_requires_dynamic_self,
-                               requirement->getFullName(),
-                               conformance->getType(),
-                               proto->getDeclaredType());
-              });
-          }
-
-        // Constructors conceptually also have a dynamic Self
-        // return type, so they're okay.
-        } else if (!isa<ConstructorDecl>(best.Witness)) {
-          diagnoseOrDefer(requirement, false,
-            [witness, requirement](NormalProtocolConformance *conformance) {
-              auto proto = conformance->getProtocol();
-              auto &diags = proto->getASTContext().Diags;
-              diags.diagnose(witness->getLoc(), diag::witness_self_non_subtype,
-                             proto->getDeclaredType(),
-                             requirement->getFullName(),
-                             conformance->getType());
-            });
-        }
-      } else if (selfKind.requirement) {
-        if (auto constraint = getAdopteeSelfSameTypeConstraint(classDecl,
-                                                               witness)) {
-          // A "Self ==" constraint works incorrectly with subclasses. Complain.
-          auto proto = Conformance->getProtocol();
-          auto &diags = proto->getASTContext().Diags;
-          diags.diagnose(witness->getLoc(),
-                         diag::witness_self_same_type,
-                         witness->getDescriptiveKind(),
-                         witness->getFullName(),
-                         Conformance->getType(),
-                         requirement->getDescriptiveKind(),
-                         requirement->getFullName(),
-                         proto->getDeclaredType());
-
-          if (auto requirementRepr = *constraint) {
-            diags.diagnose(requirementRepr->getEqualLoc(),
-                           diag::witness_self_weaken_same_type,
-                           requirementRepr->getFirstType(),
-                           requirementRepr->getSecondType())
-              .fixItReplace(requirementRepr->getEqualLoc(), ":");
-          }
-        }
-      }
-
-      // A non-final class can model a protocol requirement with a
-      // contravariant Self, because here the witness will always have
-      // a more general type than the requirement.
     }
 
     // Record the match.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -124,14 +124,17 @@ namespace {
     /// \param conformanceDC The \c DeclContext to which the protocol
     /// conformance is ascribed, which provides additional constraints.
     ///
-    /// \param req The requirement for which we are creating a generic
-    /// environment.
+    /// \param reqSig The generic signature of the requirement for which we
+    /// are creating a generic environment.
+    ///
+    /// \param proto The protocol containing the requirement.
     ///
     /// \param conformance The protocol conformance, or null if there is no
     /// conformance (because we're finding default implementations).
     RequirementEnvironment(TypeChecker &tc,
                            DeclContext *conformanceDC,
-                           ValueDecl *req,
+                           GenericSignature *reqSig,
+                           ProtocolDecl *proto,
                            ProtocolConformance *conformance);
 
     /// Retrieve the synthetic generic environment.
@@ -195,7 +198,6 @@ namespace {
     bool findBestWitness(ValueDecl *requirement,
                          bool *ignoringNames,
                          NormalProtocolConformance *conformance,
-                         const RequirementEnvironment &reqEnvironment,
                          SmallVectorImpl<RequirementMatch> &matches,
                          unsigned &numViable,
                          unsigned &bestIdx,
@@ -212,7 +214,7 @@ namespace {
 
     RequirementCheck checkWitness(AccessScope requiredAccessScope,
                                   ValueDecl *requirement,
-                                  RequirementMatch match);
+                                  const RequirementMatch &match);
   };
 
   /// \brief The result of matching a particular declaration to a given
@@ -412,15 +414,18 @@ namespace {
 
   /// \brief Describes a match between a requirement and a witness.
   struct RequirementMatch {
-    RequirementMatch(ValueDecl *witness, MatchKind kind)
-      : Witness(witness), Kind(kind), WitnessType() {
+    RequirementMatch(ValueDecl *witness, MatchKind kind,
+                     Optional<RequirementEnvironment> &&env = None)
+      : Witness(witness), Kind(kind), WitnessType(), ReqEnv(std::move(env)) {
       assert(!hasWitnessType() && "Should have witness type");
     }
 
     RequirementMatch(ValueDecl *witness, MatchKind kind,
                      Type witnessType,
+                     Optional<RequirementEnvironment> &&env = None,
                      ArrayRef<OptionalAdjustment> optionalAdjustments = {})
       : Witness(witness), Kind(kind), WitnessType(witnessType),
+        ReqEnv(std::move(env)),
         OptionalAdjustments(optionalAdjustments.begin(),
                             optionalAdjustments.end())
     {
@@ -436,6 +441,9 @@ namespace {
 
     /// \brief The type of the witness when it is referenced.
     Type WitnessType;
+
+    /// \brief The requirement environment to use for the witness thunk.
+    Optional<RequirementEnvironment> ReqEnv;
 
     /// The set of optional adjustments performed on the witness.
     SmallVector<OptionalAdjustment, 2> OptionalAdjustments;
@@ -496,51 +504,15 @@ namespace {
 
     SmallVector<Substitution, 2> WitnessSubstitutions;
 
-    swift::Witness getWitness(ASTContext &ctx,
-                              RequirementEnvironment &&reqEnvironment) const {
+    swift::Witness getWitness(ASTContext &ctx) const {
       SmallVector<Substitution, 2> syntheticSubs;
-      auto syntheticEnv = reqEnvironment.getSyntheticEnvironment();
-      reqEnvironment.getRequirementSignature()->getSubstitutions(
-          reqEnvironment.getRequirementToSyntheticMap(),
+      auto syntheticEnv = ReqEnv->getSyntheticEnvironment();
+      ReqEnv->getRequirementSignature()->getSubstitutions(
+          ReqEnv->getRequirementToSyntheticMap(),
           syntheticSubs);
       return swift::Witness(this->Witness, WitnessSubstitutions,
                             syntheticEnv, syntheticSubs);
     }
-
-    /// Classify the provided optionality issues for use in diagnostics.
-    /// FIXME: Enumify this
-    unsigned classifyOptionalityIssues(ValueDecl *requirement) const {
-      unsigned numParameterAdjustments = 0;
-      bool hasNonParameterAdjustment = false;
-      for (const auto &adjustment : OptionalAdjustments) {
-        if (adjustment.isParameterAdjustment())
-          ++numParameterAdjustments;
-        else
-          hasNonParameterAdjustment = true;
-      }
-
-      if (hasNonParameterAdjustment) {
-        // Both return and parameter adjustments.
-        if (numParameterAdjustments > 0)
-          return 4;
-
-        // The type of a variable.
-        if (isa<VarDecl>(requirement))
-          return 0;
-
-        // The result type of something.
-        return 1;
-      }
-
-      // Only parameter adjustments.
-      assert(numParameterAdjustments > 0 && "No adjustments?");
-      return numParameterAdjustments == 1 ? 2 : 3;
-    }
-
-    /// Add Fix-Its that correct the optionality in the witness.
-    void addOptionalityFixIts(const ASTContext &ctx,
-                              ValueDecl *witness, 
-                              InFlightDiagnostic &diag) const;
   };
 
   /// \brief Describes the suitability of the chosen witness for
@@ -949,7 +921,7 @@ matchWitness(TypeChecker &tc,
     Optional<RequirementMatch> result;
     std::tie(result, reqType, witnessType) = setup();
     if (result) {
-      return *result;
+      return std::move(result.getValue());
     }
   }
 
@@ -977,7 +949,7 @@ matchWitness(TypeChecker &tc,
 
       if (auto result = matchTypes(std::get<0>(types), 
                                    std::get<1>(types))) {
-        return *result;
+        return std::move(result.getValue());
       }
     }
 
@@ -1020,7 +992,7 @@ matchWitness(TypeChecker &tc,
       // Check whether the parameter types match.
       if (auto result = matchTypes(std::get<0>(types), 
                                    std::get<1>(types))) {
-        return *result;
+        return std::move(result.getValue());
       }
 
       // FIXME: Consider default arguments here?
@@ -1044,7 +1016,7 @@ matchWitness(TypeChecker &tc,
     }
 
     if (auto result = matchTypes(std::get<0>(types), std::get<1>(types))) {
-      return *result;
+      return std::move(result.getValue());
     }
   }
 
@@ -1055,14 +1027,11 @@ matchWitness(TypeChecker &tc,
 RequirementEnvironment::RequirementEnvironment(
                                            TypeChecker &tc,
                                            DeclContext *conformanceDC,
-                                           ValueDecl *req,
-                                           ProtocolConformance *conformance) {
-
-  auto reqDC = req->getInnermostDeclContext();
-  reqSig = reqDC->getGenericSignatureOfContext();
-
+                                           GenericSignature *reqSig,
+                                           ProtocolDecl *proto,
+                                           ProtocolConformance *conformance)
+    : reqSig(reqSig) {
   ASTContext &ctx = tc.Context;
-  auto proto = cast<ProtocolDecl>(req->getDeclContext());
 
   // Build a substitution map to replace the protocol's \c Self and the type
   // parameters of the requirement into a combined context that provides the
@@ -1187,8 +1156,7 @@ static RequirementMatch
 matchWitness(TypeChecker &tc,
              ProtocolDecl *proto,
              ProtocolConformance *conformance,
-             DeclContext *dc, ValueDecl *req, ValueDecl *witness,
-             const RequirementEnvironment &reqEnvironment) {
+             DeclContext *dc, ValueDecl *req, ValueDecl *witness) {
   using namespace constraints;
 
   // Initialized by the setup operation.
@@ -1200,14 +1168,18 @@ matchWitness(TypeChecker &tc,
   Type openedFullWitnessType;
   Type reqType, openedFullReqType;
 
+  auto *reqSig = req->getInnermostDeclContext()->getGenericSignatureOfContext();
+  Optional<RequirementEnvironment> reqEnvironment(
+      RequirementEnvironment(tc, dc, reqSig, proto, conformance));
+
   // Set up the constraint system for matching.
   auto setup = [&]() -> std::tuple<Optional<RequirementMatch>, Type, Type> {
     // Construct a constraint system to use to solve the equality between
     // the required type and the witness type.
     cs.emplace(tc, dc, ConstraintSystemOptions());
 
-    auto reqGenericEnv = reqEnvironment.getSyntheticEnvironment();
-    auto &reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
+    auto reqGenericEnv = reqEnvironment->getSyntheticEnvironment();
+    auto &reqSubMap = reqEnvironment->getRequirementToSyntheticMap();
 
     Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
     if (reqGenericEnv)
@@ -1298,6 +1270,7 @@ matchWitness(TypeChecker &tc,
                               : anyRenaming ? MatchKind::RenamedMatch
                                             : MatchKind::ExactMatch,
                             witnessType,
+                            std::move(reqEnvironment),
                             optionalAdjustments);
 
     // Compute the set of substitutions we'll need for the witness.
@@ -1412,7 +1385,6 @@ bool WitnessChecker::findBestWitness(
                                ValueDecl *requirement,
                                bool *ignoringNames,
                                NormalProtocolConformance *conformance,
-                               const RequirementEnvironment &reqEnvironment,
                                SmallVectorImpl<RequirementMatch> &matches,
                                unsigned &numViable,
                                unsigned &bestIdx,
@@ -1477,7 +1449,7 @@ bool WitnessChecker::findBestWitness(
         TC.validateDecl(witness);
 
       auto match = matchWitness(TC, Proto, conformance, DC,
-                                requirement, witness, reqEnvironment);
+                                requirement, witness);
       if (match.isViable()) {
         ++numViable;
         bestIdx = matches.size();
@@ -1593,7 +1565,7 @@ checkWitnessAvailability(ValueDecl *requirement,
 RequirementCheck WitnessChecker::
 checkWitness(AccessScope requiredAccessScope,
              ValueDecl *requirement,
-             RequirementMatch match) {
+             const RequirementMatch &match) {
   if (!match.OptionalAdjustments.empty())
     return CheckKind::OptionalityConflict;
 
@@ -1825,8 +1797,7 @@ namespace {
     ArrayRef<AssociatedTypeDecl *> getReferencedAssociatedTypes(ValueDecl *req);
 
     /// Record a (non-type) witness for the given requirement.
-    void recordWitness(ValueDecl *requirement, const RequirementMatch &match,
-                       RequirementEnvironment &&reqEnvironment);
+    void recordWitness(ValueDecl *requirement, const RequirementMatch &match);
 
     /// Record that the given optional requirement has no witness.
     void recordOptionalWitness(ValueDecl *requirement);
@@ -2332,11 +2303,44 @@ SourceLoc OptionalAdjustment::getOptionalityLoc(TypeRepr *tyR) const {
   return SourceLoc();
 }
 
-void RequirementMatch::addOptionalityFixIts(
-      const ASTContext &ctx,
-       ValueDecl *witness, 
-       InFlightDiagnostic &diag) const {
-  for (const auto &adjustment : OptionalAdjustments) {
+/// Classify the provided optionality issues for use in diagnostics.
+/// FIXME: Enumify this
+static unsigned classifyOptionalityIssues(
+    const SmallVectorImpl<OptionalAdjustment> &adjustments,
+    ValueDecl *requirement) {
+  unsigned numParameterAdjustments = 0;
+  bool hasNonParameterAdjustment = false;
+  for (const auto &adjustment : adjustments) {
+    if (adjustment.isParameterAdjustment())
+      ++numParameterAdjustments;
+    else
+      hasNonParameterAdjustment = true;
+  }
+
+  if (hasNonParameterAdjustment) {
+    // Both return and parameter adjustments.
+    if (numParameterAdjustments > 0)
+      return 4;
+
+    // The type of a variable.
+    if (isa<VarDecl>(requirement))
+      return 0;
+
+    // The result type of something.
+    return 1;
+  }
+
+  // Only parameter adjustments.
+  assert(numParameterAdjustments > 0 && "No adjustments?");
+  return numParameterAdjustments == 1 ? 2 : 3;
+}
+
+static void addOptionalityFixIts(
+    const SmallVectorImpl<OptionalAdjustment> &adjustments,
+    const ASTContext &ctx,
+    ValueDecl *witness, 
+    InFlightDiagnostic &diag) {
+  for (const auto &adjustment : adjustments) {
     SourceLoc adjustmentLoc = adjustment.getOptionalityLoc(witness);
     if (adjustmentLoc.isInvalid())
       continue;
@@ -2425,12 +2429,15 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     break;
 
   case MatchKind::OptionalityConflict: {
+    auto &adjustments = match.OptionalAdjustments;
     auto diag = diags.diagnose(match.Witness, 
                                diag::protocol_witness_optionality_conflict,
-                               match.classifyOptionalityIssues(req),
+                               classifyOptionalityIssues(adjustments, req),
                                withAssocTypes);
-    match.addOptionalityFixIts(match.Witness->getASTContext(), match.Witness,
-                               diag);
+    addOptionalityFixIts(adjustments,
+                         match.Witness->getASTContext(),
+                         match.Witness,
+                         diag);
     break;
   }
 
@@ -2510,8 +2517,7 @@ ConformanceChecker::getReferencedAssociatedTypes(ValueDecl *req) {
 }
 
 void ConformanceChecker::recordWitness(ValueDecl *requirement,
-                                       const RequirementMatch &match,
-                                       RequirementEnvironment &&reqEnvironment){
+                                       const RequirementMatch &match) {
   // If we already recorded this witness, don't do so again.
   if (Conformance->hasWitness(requirement)) {
     assert(Conformance->getWitness(requirement, nullptr).getDecl() ==
@@ -2520,7 +2526,7 @@ void ConformanceChecker::recordWitness(ValueDecl *requirement,
   }
 
   // Record this witness in the conformance.
-  auto witness = match.getWitness(TC.Context, std::move(reqEnvironment));
+  auto witness = match.getWitness(TC.Context);
   Conformance->setWitness(requirement, witness);
 
   // Synthesize accessors for the protocol witness table to use.
@@ -2950,14 +2956,12 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   bool considerRenames =
     !canDerive && !requirement->getAttrs().hasAttribute<OptionalAttr>() &&
     !requirement->getAttrs().isUnavailable(TC.Context);
-  RequirementEnvironment reqEnvironment(TC, DC, requirement, Conformance);
   if (findBestWitness(requirement,
                       considerRenames ? &ignoringNames : nullptr,
                       Conformance,
-                      reqEnvironment,
                       /* out parameters: */
                       matches, numViable, bestIdx, doNotDiagnoseMatches)) {
-    auto &best = matches[bestIdx];
+    const auto &best = matches[bestIdx];
     auto witness = best.Witness;
 
     // If the name didn't actually line up, complain.
@@ -3054,28 +3058,31 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       break;
     }
 
-    case CheckKind::OptionalityConflict:
+    case CheckKind::OptionalityConflict: {
+      auto adjustments = best.OptionalAdjustments;
+
       diagnoseOrDefer(requirement, false,
-        [witness, best, requirement](NormalProtocolConformance *conformance) {
+        [witness, adjustments, requirement](NormalProtocolConformance *conformance) {
           auto proto = conformance->getProtocol();
           auto &ctx = witness->getASTContext();
           auto &diags = ctx.Diags;
           {
             auto diag = diags.diagnose(
                           witness,
-                          hasAnyError(best.OptionalAdjustments)
+                          hasAnyError(adjustments)
                             ? diag::err_protocol_witness_optionality
                             : diag::warn_protocol_witness_optionality,
-                          best.classifyOptionalityIssues(requirement),
+                          classifyOptionalityIssues(adjustments, requirement),
                           witness->getFullName(),
                           proto->getFullName());
-            best.addOptionalityFixIts(ctx, witness, diag);
+            addOptionalityFixIts(adjustments, ctx, witness, diag);
           }
 
           diags.diagnose(requirement, diag::protocol_requirement_here,
                          requirement->getFullName());
       });
       break;
+    }
 
     case CheckKind::ConstructorFailability:
       diagnoseOrDefer(requirement, false,
@@ -3221,7 +3228,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
 
     // Record the match.
-    recordWitness(requirement, best, std::move(reqEnvironment));
+    recordWitness(requirement, best);
     return ResolveWitnessResult::Success;
 
     // We have an ambiguity; diagnose it below.
@@ -3316,11 +3323,9 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
     return ResolveWitnessResult::ExplicitFailed;
 
   // Try to match the derived requirement.
-  RequirementEnvironment reqEnvironment(TC, DC, requirement, Conformance);
-  auto match = matchWitness(TC, Proto, Conformance, DC, requirement, derived,
-                            reqEnvironment);
+  auto match = matchWitness(TC, Proto, Conformance, DC, requirement, derived);
   if (match.isViable()) {
-    recordWitness(requirement, match, std::move(reqEnvironment));
+    recordWitness(requirement, match);
     return ResolveWitnessResult::Success;
   }
 
@@ -6173,9 +6178,8 @@ static void diagnosePotentialWitness(TypeChecker &tc,
 
   // Describe why the witness didn't satisfy the requirement.
   auto dc = conformance->getDeclContext();
-  RequirementEnvironment reqEnvironment(tc, dc, req, conformance);
   auto match = matchWitness(tc, conformance->getProtocol(), conformance,
-                            dc, req, witness, reqEnvironment);
+                            dc, req, witness);
   if (match.Kind == MatchKind::ExactMatch &&
       req->isObjC() && !witness->isObjC()) {
     // Special case: note to add @objc.
@@ -6666,11 +6670,10 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
         if (accessorKind != AccessorKind::NotAccessor)
           witnessToMatch = cast<FuncDecl>(witness)->getAccessorStorageDecl();
 
-        RequirementEnvironment reqEnvironment(*this, dc, req, *conformance);
         if (matchWitness(*this, proto, *conformance,
                          witnessToMatch->getDeclContext(), req,
-                         const_cast<ValueDecl *>(witnessToMatch),
-                         reqEnvironment).Kind == MatchKind::ExactMatch) {
+                         const_cast<ValueDecl *>(witnessToMatch))
+              .Kind == MatchKind::ExactMatch) {
           if (accessorKind != AccessorKind::NotAccessor) {
             auto *storageReq = dyn_cast<AbstractStorageDecl>(req);
             if (!storageReq)
@@ -6822,8 +6825,7 @@ namespace {
       : WitnessChecker(tc, proto, proto->getDeclaredType(), proto) { }
 
     ResolveWitnessResult resolveWitnessViaLookup(ValueDecl *requirement);
-    void recordWitness(ValueDecl *requirement, const RequirementMatch &match,
-                       RequirementEnvironment &&reqEnvironment);
+    void recordWitness(ValueDecl *requirement, const RequirementMatch &match);
   };
 } // end anonymous namespace
 
@@ -6837,10 +6839,8 @@ DefaultWitnessChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   unsigned bestIdx = 0;
   bool doNotDiagnoseMatches = false;
 
-  RequirementEnvironment reqEnvironment(TC, DC, requirement,
-                                        /*conformance=*/nullptr);
   if (findBestWitness(
-                 requirement, nullptr, nullptr, reqEnvironment,
+                 requirement, nullptr, nullptr,
                  /* out parameters: */
                  matches, numViable, bestIdx, doNotDiagnoseMatches)) {
 
@@ -6853,7 +6853,7 @@ DefaultWitnessChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       return ResolveWitnessResult::ExplicitFailed;
 
     // Record the match.
-    recordWitness(requirement, best, std::move(reqEnvironment));
+    recordWitness(requirement, best);
     return ResolveWitnessResult::Success;
   }
 
@@ -6863,11 +6863,9 @@ DefaultWitnessChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
 
 void DefaultWitnessChecker::recordWitness(
                                   ValueDecl *requirement,
-                                  const RequirementMatch &match,
-                                  RequirementEnvironment &&reqEnvironment) {
+                                  const RequirementMatch &match) {
   Proto->setDefaultWitness(requirement,
-                           match.getWitness(TC.Context,
-                                            std::move(reqEnvironment)));
+                           match.getWitness(TC.Context));
 
   // Synthesize accessors for the protocol witness table to use.
   if (auto storage = dyn_cast<AbstractStorageDecl>(match.Witness))
@@ -6945,9 +6943,8 @@ void TypeChecker::recordKnownWitness(NormalProtocolConformance *conformance,
   // (because property behaviors rely on renaming).
   validateDecl(witness);
   auto dc = conformance->getDeclContext();
-  RequirementEnvironment reqEnvironment(*this, dc, req, conformance);
   auto match = matchWitness(*this, conformance->getProtocol(), conformance,
-                            dc, req, witness, reqEnvironment);
+                            dc, req, witness);
   if (match.Kind != MatchKind::ExactMatch &&
       match.Kind != MatchKind::RenamedMatch) {
     diagnose(witness, diag::property_behavior_conformance_broken,
@@ -6955,8 +6952,7 @@ void TypeChecker::recordKnownWitness(NormalProtocolConformance *conformance,
     return;
   }
 
-  conformance->setWitness(req,
-                          match.getWitness(Context, std::move(reqEnvironment)));
+  conformance->setWitness(req, match.getWitness(Context));
 }
 
 Type TypeChecker::getWitnessType(Type type, ProtocolDecl *protocol,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1035,52 +1035,92 @@ RequirementEnvironment::RequirementEnvironment(
     : reqSig(reqSig) {
   ASTContext &ctx = tc.Context;
 
+  auto concreteType = conformanceDC->getSelfInterfaceType();
+  auto *conformanceSig = conformanceDC->getGenericSignatureOfContext();
+
+  // Build a substitution map from the generic parameters of the conforming
+  // type to the synthetic environment.
+  //
+  // For structs, enums and protocols, this is a 1:1 mapping; for classes,
+  // we increase the depth of each generic parameter by 1 so that we can
+  // introduce a class-bound 'Self' parameter.
+  auto substConcreteType = concreteType;
+  SubstitutionMap conformanceToSyntheticEnvMap;
+  if (conformanceSig) {
+    conformanceToSyntheticEnvMap = conformanceSig->getSubstitutionMap(
+      [&](SubstitutableType *type) {
+        auto *genericParam = cast<GenericTypeParamType>(type);
+        if (covariantSelf) {
+          return GenericTypeParamType::get(
+              genericParam->getDepth() + 1,
+              genericParam->getIndex(),
+              ctx);
+        }
+
+        return GenericTypeParamType::get(
+            genericParam->getDepth(),
+            genericParam->getIndex(),
+            ctx);
+      },
+      MakeAbstractConformanceForGenericType());
+
+    substConcreteType = concreteType.subst(conformanceToSyntheticEnvMap);
+  }
+
+  // Calculate the depth at which the requirement's generic parameters
+  // appear in the synthetic signature.
+  unsigned depth = 0;
+  if (covariantSelf) {
+    depth++;
+  }
+  if (conformanceSig) {
+    depth += conformanceSig->getGenericParams().back()->getDepth() + 1;
+  }
+
   // Build a substitution map to replace the protocol's \c Self and the type
   // parameters of the requirement into a combined context that provides the
   // type parameters of the conformance context and the parameters of the
   // requirement.
   auto selfType = cast<GenericTypeParamType>(
-                            proto->getSelfInterfaceType()->getCanonicalType());
-
-  // Add the generic signature of the context of the conformance. This includes
-  // the generic parameters from the conforming type as well as any additional
-  // constraints that might occur on the extension that declares the
-  // conformance (i.e., if the conformance is conditional).
-  GenericSignature *conformanceSig;
-  unsigned depth = 0;
-  if ((conformanceSig = conformanceDC->getGenericSignatureOfContext())) {
-    // Use the canonical signature here.
-    conformanceSig = conformanceSig->getCanonicalSignature();
-    depth = conformanceSig->getGenericParams().back()->getDepth() + 1;
-  }
-
-  // Add the generic signature of the requirement, substituting our concrete
-  // type for 'Self'. We don't need the 'Self' requirement or parameter.
-  auto concreteType = conformanceDC->getSelfInterfaceType();
+      proto->getSelfInterfaceType()->getCanonicalType());
 
   reqToSyntheticEnvMap = reqSig->getSubstitutionMap(
-    [selfType, concreteType, depth, &ctx](SubstitutableType *type) -> Type {
-      if (type->isEqual(selfType))
-        return concreteType;
+    [selfType, substConcreteType, depth, covariantSelf, &ctx]
+    (SubstitutableType *type) -> Type {
+      // If the conforming type is a class, the protocol 'Self' maps to
+      // the class-constrained 'Self'. Otherwise, it maps to the concrete
+      // type.
+      if (type->isEqual(selfType)) {
+        if (covariantSelf)
+          return GenericTypeParamType::get(/*depth=*/0, /*index=*/0, ctx);
+        return substConcreteType;
+      }
+      // Other requirement generic parameters map 1:1 with their depth
+      // increased appropriately.
       auto *genericParam = cast<GenericTypeParamType>(type);
+      // In a protocol requirement, the only generic parameter at depth 0
+      // should be 'Self', and all others at depth 1. Anything else is
+      // invalid code.
       if (genericParam->getDepth() != 1)
         return Type();
       auto substGenericParam =
         GenericTypeParamType::get(depth, genericParam->getIndex(), ctx);
       return substGenericParam;
     },
-    [selfType, concreteType, conformance, conformanceDC, &ctx](
+    [selfType, substConcreteType, conformance, conformanceDC, &ctx](
         CanType type, Type replacement, ProtocolType *protoType)
           -> Optional<ProtocolConformanceRef> {
       auto proto = protoType->getDecl();
+
+      // The protocol 'Self' conforms concretely to the conforming type.
       if (type->isEqual(selfType)) {
         ProtocolConformance *specialized = conformance;
         if (conformance && conformance->getGenericSignature()) {
           auto concreteSubs =
-            concreteType->getContextSubstitutionMap(
+            substConcreteType->getContextSubstitutionMap(
               conformanceDC->getParentModule(), conformanceDC);
           specialized =
-            ctx.getSpecializedConformance(concreteType, conformance,
+            ctx.getSpecializedConformance(substConcreteType, conformance,
                                           concreteSubs);
         }
 
@@ -1088,12 +1128,15 @@ RequirementEnvironment::RequirementEnvironment(
           return ProtocolConformanceRef(specialized);
       }
 
+      // All other generic parameters come from the requirement itself
+      // and conform abstractly.
       return ProtocolConformanceRef(proto);
     });
 
   // If the requirement itself is non-generic, the synthetic signature
   // is that of the conformance context.
-  if (reqSig->getGenericParams().size() == 1 &&
+  if (!covariantSelf &&
+      reqSig->getGenericParams().size() == 1 &&
       reqSig->getRequirements().size() == 1) {
     syntheticSignature = conformanceDC->getGenericSignatureOfContext();
     if (syntheticSignature) {
@@ -1113,11 +1156,40 @@ RequirementEnvironment::RequirementEnvironment(
            ctx,
            TypeChecker::LookUpConformance(tc, conformanceDC));
 
-  if (conformanceSig) {
-    builder.addGenericSignature(conformanceSig);
+  auto source =
+    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
+
+  // If the conforming type is a class, add a class-constrained 'Self'
+  // parameter.
+  if (covariantSelf) {
+    auto paramTy = GenericTypeParamType::get(/*depth=*/0, /*index=*/0, ctx);
+    builder.addGenericParameter(paramTy);
   }
 
-  // First, add the generic parameters from the requirement.
+  // Now, add all generic parameters from the conforming type.
+  if (conformanceSig) {
+    for (auto param : conformanceSig->getGenericParams()) {
+      builder.addGenericParameter(
+          Type(param).subst(conformanceToSyntheticEnvMap)
+              ->castTo<GenericTypeParamType>());
+    }
+  }
+
+  // Next, add requirements.
+  if (covariantSelf) {
+    auto paramTy = GenericTypeParamType::get(/*depth=*/0, /*index=*/0, ctx);
+    Requirement reqt(RequirementKind::Superclass, paramTy, substConcreteType);
+    builder.addRequirement(reqt, source, nullptr);
+  }
+
+  if (conformanceSig) {
+    for (auto &reqt : conformanceSig->getRequirements()) {
+      builder.addRequirement(reqt, source, nullptr,
+                             &conformanceToSyntheticEnvMap);
+    }
+  }
+
+  // Finally, add the generic parameters from the requirement.
   for (auto genericParam : reqSig->getGenericParams().slice(1)) {
     // The only depth that makes sense is depth == 1, the generic parameters
     // of the requirement itself. Anything else is from invalid code.
@@ -1136,10 +1208,8 @@ RequirementEnvironment::RequirementEnvironment(
 
   // Next, add each of the requirements (mapped from the requirement's
   // interface types into the abstract type parameters).
-  auto source =
-    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   for (auto &req : reqSig->getRequirements()) {
-    builder.addRequirement(req, source, conformanceDC->getParentModule(),
+    builder.addRequirement(req, source, /*inferModule=*/nullptr,
                            &reqToSyntheticEnvMap);
   }
 

--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -263,5 +263,55 @@ _ = sup.init()
 sup = Sub.self
 _ = sup.init()
 
+// https://bugs.swift.org/browse/SR-617
+protocol SelfMetadataTest {
+  associatedtype T = Int
+
+  func staticTypeOfSelf() -> Any
+  func staticTypeOfSelfTakesT(_: T) -> Any
+}
+
+extension SelfMetadataTest {
+  func staticTypeOfSelf() -> Any {
+    return Self.self
+  }
+
+  func staticTypeOfSelfTakesT(_: T) -> Any {
+    return Self.self
+  }
+
+  func staticTypeOfSelfNotAWitness() -> Any {
+    return Self.self
+  }
+}
+
+class SelfMetadataBase : SelfMetadataTest {}
+
+class SelfMetadataDerived : SelfMetadataBase {}
+
+func testSelfMetadata<T : SelfMetadataTest>(_ x: T, _ t: T.T) {
+  print(x.staticTypeOfSelf())
+  print(x.staticTypeOfSelfTakesT(t))
+  print(x.staticTypeOfSelfNotAWitness())
+}
+
+// CHECK: SelfMetadataBase
+// CHECK: SelfMetadataBase
+// CHECK: SelfMetadataBase
+testSelfMetadata(SelfMetadataBase(), 0)
+
+// CHECK: SelfMetadataBase
+// CHECK: SelfMetadataBase
+// CHECK: SelfMetadataBase
+testSelfMetadata(SelfMetadataDerived() as SelfMetadataBase, 0)
+
+// This is the interesting case -- make sure the static type of 'Self'
+// is correctly passed on from the call site to the extension method
+
+// CHECK: SelfMetadataDerived
+// CHECK: SelfMetadataBase
+// CHECK: SelfMetadataDerived
+testSelfMetadata(SelfMetadataDerived(), 0)
+
 // CHECK: DONE
 print("DONE")

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -70,7 +70,7 @@ class C : P1 {
 
 //   (materializeForSet test from above)
 // CHECK-LABEL: sil private [transparent] [thunk] @_T019protocol_extensions1CCAA2P1A2aDPS2icimTW
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $Int, %3 : $*C):
+// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $Int, %3 : $*τ_0_0):
 // CHECK: function_ref @_T019protocol_extensions2P1PAAES2icig
 // CHECK: return
 

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen %s | %FileCheck %s
 
 protocol Fooable: class {
   func foo()
@@ -24,8 +24,8 @@ class Foo: Fooable {
   // CHECK:         class_method
 }
 
-// CHECK-LABEL: sil hidden @_T015witnesses_class3gen{{[_0-9a-zA-Z]*}}F
-// CHECK:         bb0([[SELF:%.*]] : $T)
+// CHECK-LABEL: sil hidden @_T015witnesses_class3genyxAA7FooableRzlF
+// CHECK:         bb0([[SELF:%.*]] : @owned $T)
 // CHECK:         [[METHOD:%.*]] = witness_method $T
 // CHECK-NOT:     copy_value [[SELF]]
 // CHECK:         [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
@@ -40,7 +40,7 @@ func gen<T: Fooable>(_ foo: T) {
 }
 
 // CHECK-LABEL: sil hidden @_T015witnesses_class2exyAA7Fooable_pF
-// CHECK: bb0([[SELF:%[0-0]+]] : $Fooable):
+// CHECK: bb0([[SELF:%[0-0]+]] : @owned $Fooable):
 // CHECK:         [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK:         [[SELF_PROJ:%.*]] = open_existential_ref [[BORROWED_SELF]]
 // CHECK:         [[METHOD:%.*]] = witness_method $[[OPENED:@opened(.*) Fooable]],
@@ -53,3 +53,58 @@ func gen<T: Fooable>(_ foo: T) {
 func ex(_ foo: Fooable) {
   foo.foo()
 }
+
+// Default implementations in a protocol extension
+protocol HasDefaults {
+  associatedtype T = Self
+
+  func hasDefault()
+
+  func hasDefaultTakesT(_: T)
+
+  func hasDefaultGeneric<U : Fooable>(_: U)
+
+  func hasDefaultGenericTakesT<U : Fooable>(_: T, _: U)
+}
+
+extension HasDefaults {
+  func hasDefault() {}
+
+  func hasDefaultTakesT(_: T) {}
+
+  func hasDefaultGeneric<U : Fooable>(_: U) {}
+
+  func hasDefaultGenericTakesT<U : Fooable>(_: T, _: U) {}
+}
+
+protocol Barable {}
+
+class UsesDefaults<X : Barable> : HasDefaults {}
+
+// Covariant Self:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP10hasDefaultyyFTW : $@convention(witness_method) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed τ_0_0) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE10hasDefaultyyF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<τ_0_0>(
+// CHECK: return
+
+// Invariant Self, since type signature contains an associated type:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP16hasDefaultTakesTy1TQzFTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : Barable> (@in UsesDefaults<τ_0_0>, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE16hasDefaultTakesTy1TQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in τ_0_0.T, @in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>>(
+// CHECK: return
+
+// Covariant Self:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP17hasDefaultGenericyqd__AA7FooableRd__lFTW : $@convention(witness_method) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@owned τ_2_0, @in_guaranteed τ_0_0) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE17hasDefaultGenericyqd__AA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@owned τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<τ_0_0, τ_2_0>(
+// CHECK: return
+
+// Invariant Self, since type signature contains an associated type:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP23hasDefaultGenericTakesTy1TQz_qd__tAA7FooableRd__lFTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : Barable><τ_1_0 where τ_1_0 : Fooable> (@in UsesDefaults<τ_0_0>, @owned τ_1_0, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE23hasDefaultGenericTakesTy1TQz_qd__tAA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@in τ_0_0.T, @owned τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>, τ_1_0>(
+// CHECK: return

--- a/test/SILOptimizer/devirt_class_witness_method.sil
+++ b/test/SILOptimizer/devirt_class_witness_method.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -sil-combine -enable-resilience | tee /tmp/xxx | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+
+protocol P {
+  func f()
+}
+
+extension P {
+  func f()
+}
+
+class C<T, U> : P {}
+
+sil hidden_external [transparent] [thunk] @witness_thunk : $@convention(witness_method) <τ_0_0><τ_1_0, τ_1_1 where τ_0_0 : C<τ_1_0, τ_1_1>> (@in_guaranteed τ_0_0) -> ()
+
+// CHECK-LABEL: sil hidden @caller : $@convention(thin) <T, U> (@owned C<T, U>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @witness_thunk
+// CHECK: apply [[FN]]<C<T, U>, T, U>(
+// CHECK: return
+sil hidden @caller : $@convention(thin) <T, U> (@owned C<T, U>) -> () {
+bb0(%0 : $C<T, U>):
+  strong_retain %0 : $C<T, U>
+  %4 = alloc_stack $C<T, U>
+  store %0 to %4 : $*C<T, U>
+  %6 = witness_method $C<T, U>, #P.f!1 : <Self where Self : P> (Self) -> () -> () : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %7 = apply %6<C<T, U>>(%4) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %4 : $*C<T, U>
+  strong_release %0 : $C<T, U>
+  %9 = tuple ()
+  return %9 : $()
+}
+
+sil_vtable C {}
+
+sil_witness_table hidden <T, U> C<T, U>: P module clsx {
+  method #P.f!1: <Self where Self : P> (Self) -> () -> () : @witness_thunk
+}
+
+sil_default_witness_table hidden P {
+}

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype T = Int
+
+  func hasDefault()
+  func returnsSelf() -> Self
+  func hasDefaultTakesT(_: T)
+  func returnsSelfTakesT(_: T) -> Self
+}
+
+extension P {
+  func hasDefault() {}
+
+  func returnsSelf() -> Self {
+    return self
+  }
+
+  func hasDefaultTakesT(_: T) {}
+
+  func returnsSelfTakesT(_: T) -> Self { // expected-error {{method 'returnsSelfTakesT' in non-final class 'Class' cannot be implemented in a protocol extension because it returns `Self` and has associated type requirements}}
+    return self
+  }
+}
+
+// This fails
+class Class : P {}
+
+// This succeeds, because the class is final
+final class FinalClass : P {}
+
+// This succeeds, because we're not using the default implementation
+class NonFinalClass : P {
+  func returnsSelfTakesT(_: T) -> Self {
+    return self
+  }
+}

--- a/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// This test fails in the AST verifier, which can be turned off.
-// REQUIRES: swift_ast_verifier
+// REQUIRES: asserts
 class a<T where g:d{class A{class A<T>:A{init(){T{


### PR DESCRIPTION
This builds upon <https://github.com/apple/swift/pull/12118>. Witness thunks for conformances of classes now have a generic parameter for `Self`, constrained to the class. If the witness is defined in a protocol extension, we pass through the `Self` parameter instead of using the static conforming type.

This means we now allow the following:

```
protocol P {
  init()
  static func f() -> Self
}

extension P {
  static func f() -> Self {
    return self.init()
  }
}

class C : P {
  required init() {}
}
```

Previously, we rejected this, to paper over the problem with passing `Self` metadata. However this was an unsatisfactory fix, because not only does it ban a useful pattern, it also means adding a new protocol requirement is source breaking, even when there is a default implementation.

Furthermore, even if your default implementation does not return `Self`, it was possible to observe the incorrect `Self` metadata, as was shown in https://bugs.swift.org/browse/SR-617.

Fixes <rdar://problem/23671426>, <rdar://problem/33690383>, <https://bugs.swift.org/browse/SR-617>.