### PR TITLE
[CMake] Default to Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,13 @@ option(SWIFT_INCLUDE_DOCS
 # TODO: Please categorize these!
 #
 
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
+      "Build type for Swift [Debug, RelWithDebInfo, Release, MinSizeRel]"
+      FORCE)
+  message(STATUS "No build type was specified, will default to ${CMAKE_BUILD_TYPE}")
+endif()
+
 set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
     "Build type for the Swift standard library and SDK overlays [Debug, RelWithDebInfo, Release, MinSizeRel]")
 set_property(CACHE SWIFT_STDLIB_BUILD_TYPE PROPERTY


### PR DESCRIPTION
When CMake is invoked manually to configure a Swift build, it fails
because no default value is specified for the build type:

    CMake Error at cmake/modules/SwiftUtils.cmake:94 (message):
      Unknown build type:
    Call Stack (most recent call first):
      CMakeLists.txt:98 (is_build_type_optimized)

Instead we take a cue from LLVM, and default to "Debug" if the
CMAKE_BUILD_TYPE is unspecified.

The changes are essentially a copy of the relevant stanza from
'llvm/CMakeLists.txt'. There is one deviation: we use "NOT DEFINED" in
the conditional instead of relying on the empty string being false-y.
