### PR TITLE
[swiftc (55 vs. 5595)] Add crasher in swift::ProtocolType::canonicalizeProtocols

### DIFF
--- a/validation-test/compiler_crashers/28844-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28844-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:Self.a&( A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolType::canonicalizeProtocols`.

Current number of unresolved compiler crashers: 55 (5595 resolved)

Stack trace:

```
0 0x0000000003e9c484 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e9c484)
1 0x0000000003e9c7c6 SignalHandler(int) (/path/to/swift/bin/swift+0x3e9c7c6)
2 0x00007fc2aa064390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000016db70e swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16db70e)
4 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
5 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
6 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
7 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
8 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
9 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
10 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
11 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
12 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
13 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
14 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
15 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
16 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
17 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
18 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
19 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
20 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
21 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
22 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
23 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
24 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
25 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
26 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
27 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
28 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
29 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
30 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
31 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
32 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
33 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
34 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
35 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
36 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
37 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
38 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
39 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
40 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
41 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
42 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
43 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
44 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
45 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
46 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
47 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
48 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
49 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
50 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
51 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
52 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
53 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
54 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
55 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
56 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
57 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
58 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
59 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
60 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
61 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
62 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
63 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
64 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
65 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
66 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
67 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
68 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
69 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
70 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
71 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
72 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
73 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
74 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
75 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
76 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
77 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
78 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
79 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
80 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
81 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
82 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
83 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
84 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
85 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
86 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
87 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
88 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
89 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
90 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
91 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
92 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
93 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
94 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
95 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
96 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
97 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
98 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
99 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
100 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
101 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
102 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
103 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
104 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
105 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
106 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
107 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
108 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
109 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
110 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
111 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
112 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
113 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
114 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
115 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
116 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
117 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
118 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
119 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
120 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
121 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
122 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
123 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
124 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
125 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
126 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
127 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
128 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
129 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
130 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
131 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
132 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
133 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
134 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
135 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
136 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
137 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
138 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
139 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
140 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
141 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
142 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
143 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
144 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
145 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
146 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
147 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
148 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
149 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
150 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
151 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
152 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
153 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
154 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
155 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
156 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
157 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
158 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
159 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
160 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
161 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
162 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
163 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
164 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
165 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
166 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
167 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
168 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
169 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
170 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
171 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
172 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
173 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
174 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
175 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
176 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
177 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
178 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
179 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
180 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
181 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
182 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
183 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
184 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
185 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
186 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
187 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
188 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
189 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
190 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
191 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
192 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
193 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
194 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
195 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
196 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
197 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
198 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
199 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
200 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
201 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
202 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
203 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
204 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
205 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
206 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
207 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
208 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
209 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
210 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
211 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
212 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
213 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
214 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
215 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
216 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
217 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
218 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
219 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
220 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
221 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
222 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
223 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
224 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
225 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
226 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
227 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
228 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
229 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
230 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
231 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
232 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
233 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
234 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
235 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
236 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
237 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
238 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
239 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
240 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
241 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
242 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
243 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
244 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
245 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
246 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
247 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
248 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
249 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
250 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
251 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
252 0x00000000016dc47a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16dc47a)
253 0x00000000016d7dbc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16d7dbc)
254 0x00000000016487d5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16487d5)
255 0x00000000016dba90 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16dba90)
```