### PR TITLE
[swiftc (56 vs. 5595)] Add crasher in swift::Type::transformRec

### DIFF
--- a/validation-test/compiler_crashers/28845-llvm-optional-swift-type-llvm-function-ref-llvm-optional-swift-type-swift-typeba.swift
+++ b/validation-test/compiler_crashers/28845-llvm-optional-swift-type-llvm-function-ref-llvm-optional-swift-type-swift-typeba.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{extension{class a
+let d=r protocol
+protocol P{}func a{class a<a:A A
+protocol A:a
+class a=
+[(_
+class a=_
+&==
+a{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transformRec`.

Current number of unresolved compiler crashers: 56 (5595 resolved)

Stack trace:

```
0 0x0000000003e9c484 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e9c484)
1 0x0000000003e9c7c6 SignalHandler(int) (/path/to/swift/bin/swift+0x3e9c7c6)
2 0x00007f7e8df65390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000016753a2 swift::GenericSignatureBuilder::EquivalenceClass::getAnchor(llvm::ArrayRef<swift::GenericTypeParamType*>) (/path/to/swift/bin/swift+0x16753a2)
4 0x0000000001675ab9 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675ab9)
5 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
6 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
7 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
8 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
9 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
10 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
11 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
12 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
13 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
14 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
15 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
16 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
17 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
18 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
19 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
20 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
21 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
22 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
23 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
24 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
25 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
26 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
27 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
28 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
29 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
30 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
31 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
32 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
33 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
34 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
35 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
36 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
37 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
38 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
39 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
40 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
41 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
42 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
43 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
44 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
45 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
46 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
47 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
48 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
49 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
50 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
51 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
52 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
53 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
54 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
55 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
56 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
57 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
58 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
59 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
60 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
61 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
62 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
63 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
64 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
65 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
66 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
67 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
68 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
69 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
70 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
71 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
72 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
73 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
74 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
75 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
76 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
77 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
78 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
79 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
80 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
81 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
82 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
83 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
84 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
85 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
86 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
87 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
88 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
89 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
90 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
91 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
92 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
93 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
94 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
95 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
96 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
97 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
98 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
99 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
100 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
101 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
102 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
103 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
104 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
105 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
106 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
107 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
108 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
109 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
110 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
111 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
112 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
113 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
114 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
115 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
116 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
117 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
118 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
119 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
120 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
121 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
122 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
123 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
124 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
125 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
126 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
127 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
128 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
129 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
130 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
131 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
132 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
133 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
134 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
135 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
136 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
137 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
138 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
139 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
140 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
141 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
142 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
143 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
144 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
145 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
146 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
147 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
148 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
149 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
150 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
151 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
152 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
153 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
154 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
155 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
156 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
157 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
158 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
159 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
160 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
161 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
162 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
163 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
164 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
165 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
166 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
167 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
168 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
169 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
170 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
171 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
172 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
173 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
174 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
175 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
176 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
177 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
178 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
179 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
180 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
181 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
182 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
183 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
184 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
185 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
186 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
187 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
188 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
189 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
190 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
191 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
192 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
193 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
194 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
195 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
196 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
197 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
198 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
199 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
200 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
201 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
202 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
203 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
204 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
205 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
206 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
207 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
208 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
209 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
210 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
211 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
212 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
213 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
214 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
215 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
216 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
217 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
218 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
219 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
220 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
221 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
222 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
223 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
224 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
225 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
226 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
227 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
228 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
229 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
230 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
231 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
232 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
233 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
234 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
235 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
236 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
237 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
238 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
239 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
240 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
241 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
242 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
243 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
244 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
245 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
246 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
247 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
248 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
249 0x0000000001675e79 swift::GenericSignatureBuilder::EquivalenceClass::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1675e79)
250 0x000000000166a4a3 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x166a4a3)
251 0x00000000016e5fa9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16e5fa9)
252 0x00000000016e2446 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e2446)
253 0x00000000016e275d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e275d)
254 0x00000000016e0e16 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e0e16)
255 0x000000000166a5da swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x166a5da)
```