### PR TITLE
[swiftc (58 vs. 5595)] Add crasher in swift::constraints::ConstraintSystem::getTypeOfMemberReference

### DIFF
--- a/validation-test/compiler_crashers/28847-type-hasunboundgenerictype.swift
+++ b/validation-test/compiler_crashers/28847-type-hasunboundgenerictype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension a{protocol P{}}class a<a{var f=a a{}func a:P&


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::getTypeOfMemberReference`.

Current number of unresolved compiler crashers: 58 (5595 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!type->hasUnboundGenericType()` added on 2017-05-21 by you in commit fe419008 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 472)`](https://github.com/apple/swift/blob/64f6b561b52dffdedd5dfa21996b0926b7aebf46/lib/Sema/ConstraintSystem.cpp#L472):

```
Assertion `!type->hasUnboundGenericType()' failed.

When executing: swift::Type swift::constraints::ConstraintSystem::openType(swift::Type, OpenedTypeMap &)
```

Assertion context:

```c++
      return type;
    });
}

Type ConstraintSystem::openType(Type type, OpenedTypeMap &replacements) {
  assert(!type->hasUnboundGenericType());

  if (!type->hasTypeParameter())
    return type;

  return type.transform([&](Type type) -> Type {
```
Stack trace:

```
0 0x0000000003e9c484 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e9c484)
1 0x0000000003e9c7c6 SignalHandler(int) (/path/to/swift/bin/swift+0x3e9c7c6)
2 0x00007fc800eb3390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fc7ff3d8428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc7ff3da02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fc7ff3d0bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fc7ff3d0c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000126c77e (/path/to/swift/bin/swift+0x126c77e)
8 0x000000000126e6f3 swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, swift::DeclContext*, bool, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >*) (/path/to/swift/bin/swift+0x126e6f3)
9 0x000000000126f99d swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x126f99d)
10 0x000000000122edcf (anonymous namespace)::ConstraintGenerator::addMemberRefConstraints(swift::Expr*, swift::Expr*, swift::ValueDecl*, swift::FunctionRefKind) (/path/to/swift/bin/swift+0x122edcf)
11 0x000000000122a15e (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x122a15e)
12 0x0000000001621e8c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1621e8c)
13 0x000000000122080f swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x122080f)
14 0x000000000124e831 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x124e831)
15 0x0000000001282a77 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1282a77)
16 0x000000000128683c swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x128683c)
17 0x0000000001310c19 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1310c19)
18 0x000000000130f6b5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x130f6b5)
19 0x000000000130e886 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0x130e886)
20 0x000000000130daea swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x130daea)
21 0x000000000130d995 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x130d995)
22 0x000000000130e4fd swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x130e4fd)
23 0x000000000132df1c typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x132df1c)
24 0x000000000132eaed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132eaed)
25 0x0000000001052ed4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1052ed4)
26 0x0000000001051f97 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1051f97)
27 0x00000000010518ba swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x10518ba)
28 0x00000000004bdb56 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdb56)
29 0x00000000004bc919 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc919)
30 0x0000000000474c14 main (/path/to/swift/bin/swift+0x474c14)
31 0x00007fc7ff3c3830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x00000000004724c9 _start (/path/to/swift/bin/swift+0x4724c9)
```