### PR TITLE
[swiftc (59 vs. 5595)] Add crasher in swift::GenericSignature::getCanonicalTypeInContext

### DIFF
--- a/validation-test/compiler_crashers/28848-iscanonicaltypeincontext-result-builder.swift
+++ b/validation-test/compiler_crashers/28848-iscanonicaltypeincontext-result-builder.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a{}func a:a.a{}class a{{}protocol 0


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getCanonicalTypeInContext`.

Current number of unresolved compiler crashers: 59 (5595 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `isCanonicalTypeInContext(result, builder)` added on 2017-02-02 by you in commit ded7e83a :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 713)`](https://github.com/apple/swift/blob/d98d7c4fe5252a9fd53851a2bae067693a21eac1/lib/AST/GenericSignature.cpp#L713):

```
Assertion `isCanonicalTypeInContext(result, builder)' failed.

When executing: swift::CanType swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::GenericSignatureBuilder &)
```

Assertion context:

```c++
    return equivClass->getAnchor(getGenericParams());
  });

  auto result = type->getCanonicalType();

  assert(isCanonicalTypeInContext(result, builder));
  return result;
}

CanType GenericSignature::getCanonicalTypeInContext(Type type,
                                                    ModuleDecl &mod) {
```
Stack trace:

```
0 0x0000000003e9c484 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e9c484)
1 0x0000000003e9c7c6 SignalHandler(int) (/path/to/swift/bin/swift+0x3e9c7c6)
2 0x00007fb47be4e390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fb47a373428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb47a37502a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb47a36bbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fb47a36bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000166d645 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x166d645)
8 0x000000000166d6c3 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x166d6c3)
9 0x00000000012ce6d8 swift::CompleteGenericTypeResolver::areSameType(swift::Type, swift::Type) (/path/to/swift/bin/swift+0x12ce6d8)
10 0x00000000013263cb resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13263cb)
11 0x0000000001320856 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1320856)
12 0x000000000132062f resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x132062f)
13 0x00000000013201da swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13201da)
14 0x0000000001320fa0 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1320fa0)
15 0x0000000001320eac swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1320eac)
16 0x000000000131f785 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131f785)
17 0x00000000012cf556 checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x12cf556)
18 0x00000000012cf325 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x12cf325)
19 0x00000000012b3fa7 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x12b3fa7)
20 0x000000000129e3bf (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129e3bf)
21 0x000000000129fdaf swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x129fdaf)
22 0x000000000129ee67 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129ee67)
23 0x00000000012b181b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b181b)
24 0x000000000129e39f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129e39f)
25 0x000000000129e233 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x129e233)
26 0x000000000132e9f5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132e9f5)
27 0x0000000001052ed4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1052ed4)
28 0x0000000001051f97 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1051f97)
29 0x00000000010518ba swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x10518ba)
30 0x00000000004bdb56 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdb56)
31 0x00000000004bc919 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc919)
32 0x0000000000474c14 main (/path/to/swift/bin/swift+0x474c14)
33 0x00007fb47a35e830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x00000000004724c9 _start (/path/to/swift/bin/swift+0x4724c9)
```