### PR TITLE
[swiftc (60 vs. 5595)] Add crasher in swift::GenericSignatureBuilder::Constraint

### DIFF
--- a/validation-test/compiler_crashers/28849-hasval.swift
+++ b/validation-test/compiler_crashers/28849-hasval.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:P{}
+protocol P{{}typealias a:A
+class a:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::Constraint`.

Current number of unresolved compiler crashers: 60 (5595 resolved)

Assertion failure in `llvm/include/llvm/ADT/Optional.h (line 128)`:

```
Assertion `hasVal' failed.

When executing: T *llvm::Optional<swift::GenericSignatureBuilder::Constraint<swift::Type> >::getPointer() [T = swift::GenericSignatureBuilder::Constraint<swift::Type>]
```

Assertion context:

```c++
      hasVal = false;
    }
  }

  const T* getPointer() const { assert(hasVal); return reinterpret_cast<const T*>(storage.buffer); }
  T* getPointer() { assert(hasVal); return reinterpret_cast<T*>(storage.buffer); }
  const T& getValue() const LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
  T& getValue() LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }

  explicit operator bool() const { return hasVal; }
  bool hasValue() const { return hasVal; }
```
Stack trace:

```
0 0x0000000003e9c484 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3e9c484)
1 0x0000000003e9c7c6 SignalHandler(int) (/path/to/swift/bin/swift+0x3e9c7c6)
2 0x00007f3fbe08c390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f3fbc5b1428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f3fbc5b302a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f3fbc5a9bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f3fbc5a9c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000169bac2 swift::GenericSignatureBuilder::Constraint<swift::Type> swift::GenericSignatureBuilder::checkConstraintList<swift::Type, swift::Type>(llvm::ArrayRef<swift::GenericTypeParamType*>, std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > >&, llvm::function_ref<bool (swift::GenericSignatureBuilder::Constraint<swift::Type> const&)>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintRelation (swift::GenericSignatureBuilder::Constraint<swift::Type> const&)>, llvm::Optional<swift::Diag<unsigned int, swift::Type, swift::Type, swift::Type> >, swift::Diag<swift::Type, swift::Type>, swift::Diag<unsigned int, swift::Type, swift::Type>, llvm::function_ref<swift::Type (swift::Type const&)>, bool) (/path/to/swift/bin/swift+0x169bac2)
8 0x0000000001686a69 swift::GenericSignatureBuilder::checkConcreteTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x1686a69)
9 0x0000000001684e17 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x1684e17)
10 0x000000000168d713 swift::GenericSignatureBuilder::computeGenericSignature(swift::SourceLoc, bool) && (/path/to/swift/bin/swift+0x168d713)
11 0x000000000168d96d swift::GenericSignatureBuilder::computeRequirementSignature(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x168d96d)
12 0x0000000001649dd6 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x1649dd6)
13 0x00000000012d22a8 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12d22a8)
14 0x00000000012a0208 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a0208)
15 0x00000000012b14ef (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b14ef)
16 0x000000000129e39f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129e39f)
17 0x000000000129e233 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x129e233)
18 0x000000000132e9f5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132e9f5)
19 0x0000000001052ed4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1052ed4)
20 0x0000000001051f97 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1051f97)
21 0x00000000010518ba swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x10518ba)
22 0x00000000004bdb56 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdb56)
23 0x00000000004bc919 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc919)
24 0x0000000000474c14 main (/path/to/swift/bin/swift+0x474c14)
25 0x00007f3fbc59c830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x00000000004724c9 _start (/path/to/swift/bin/swift+0x4724c9)
```