### PR TITLE
Disable test in resilient build

### DIFF
--- a/test/IRGen/objc_shared_imported_decl.sil
+++ b/test/IRGen/objc_shared_imported_decl.sil
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -primary-file %s -import-objc-header %S/Inputs/usr/include/NSOption.h -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: resilient_stdlib
+
 // REQUIRES: objc_interop
 
 import Swift


### PR DESCRIPTION
In a resilient build we get a lazy protocol witness table cache which is not
what this test is intended to check.

rdar://34742119