### PR TITLE
[ProtocolDecl] Avoid getMembers(), imported ObjC protocols can always be existential.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3310,6 +3310,10 @@ bool ProtocolDecl::existentialTypeSupportedSlow(LazyResolver *resolver) {
   ProtocolDeclBits.ExistentialTypeSupportedValid = true;
   ProtocolDeclBits.ExistentialTypeSupported = true;
 
+  // ObjC protocols can always be existential.
+  if (isObjC())
+    return true;
+
   // Resolve the protocol's type.
   if (resolver && !hasInterfaceType())
     resolver->resolveDeclSignature(this);


### PR DESCRIPTION
Bypass calling getMembers() in an obvious case.

(We also ought to encode this as a bit in the .swiftmodule, but one thing at a time)