### PR TITLE
[ConstraintSolver] Prioritize certain type variables while looking for bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -361,6 +361,10 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
                ConstraintClassification::Relational &&
            "only relational constraints handled here");
 
+    // Record constraint which contributes to the
+    // finding of pontential bindings.
+    result.Sources.insert(constraint);
+
     auto first = simplifyType(constraint->getFirstType());
     auto second = simplifyType(constraint->getSecondType());
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1695,13 +1695,14 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         }
 
         // If we have a binding for the right-hand side
-        // (argument type) don't try to bind it to the left-hand
-        // side (parameter type) directly, because their
-        // relationship is contravariant and the actual
-        // binding can only come from the left-hand side.
+        // (argument type used in the body) don't try
+        // to bind it to the left-hand side (parameter type)
+        // directly, because there could be an implicit
+        // conversion between them, and actual binding
+        // can only come from the left-hand side.
         addUnsolvedConstraint(
-            Constraint::create(*this, ConstraintKind::ArgumentConversion, type2,
-                               typeVar1, getConstraintLocator(locator)));
+            Constraint::create(*this, ConstraintKind::Equal, typeVar1, type2,
+                               getConstraintLocator(locator)));
         return SolutionKind::Solved;
       }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -504,3 +504,27 @@ func rdar27700622<E: Comparable>(_ input: [E]) -> [E] {
 
   return rdar27700622(lhs) + [pivot] + rdar27700622(rhs) // Ok
 }
+
+// rdar://problem/22898292 - Type inference failure with constrained subclass
+protocol P_22898292 {}
+
+do {
+  func construct_generic<T: P_22898292>(_ construct: () -> T) -> T { return construct() }
+
+  class A {}
+  class B : A, P_22898292 {}
+
+  func foo() -> B { return B() }
+  func bar(_ value: A) {}
+  func baz<T: A>(_ value: T) {}
+
+  func rdar_22898292_1() {
+    let x = construct_generic { foo() } // returns A
+    bar(x) // Ok
+    bar(construct_generic { foo() }) // Ok
+  }
+
+  func rdar22898292_2<T: B>(_ d: T) {
+    _ = { baz($0) }(construct_generic { d }) // Ok
+  }
+}


### PR DESCRIPTION
Presence of some constraints (Subtype at least) requires a certain
contextual ranking of the type variables associated with them when
it comes to picking bindings, otherwise it might lead to no or
invalid solutions, because only a set of the bindings for the best
type variable is attempted.

Resolves: rdar://problem/22898292

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
