### PR TITLE
Fix AST dump generation for `enum_is_case_expr` Node

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2343,7 +2343,7 @@ public:
     printCommon(E, "enum_is_case_expr") << ' ' <<
       E->getEnumElement()->getName() << "\n";
     printRec(E->getSubExpr());
-    
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitUnresolvedPatternExpr(UnresolvedPatternExpr *E) {
     printCommon(E, "unresolved_pattern_expr") << '\n';


### PR DESCRIPTION
AST Dumper at the moment generates invalid AST dump output for `enum_is_case_expr`
Currently it `forgets` to add a closing bracket, which leads to unparsable AST dump output.
```
(if_stmt implicit\
  (call_expr implicit type='Int1' nothrow arg_labels=\
    (dot_syntax_call_expr implicit type='() -> Int1' nothrow\
      (declref_expr implicit type='(Bool) -> () -> Int1' decl=Swift.(file).Bool._getBuiltinLogicValue() function_ref=double)\
      (enum_is_case_expr implicit type='Bool' some\
        (declref_expr implicit type='UIBarButtonItem?' decl=The.(file).Controller.<anonymous>.tmp1 direct_to_storage function_ref=unapplied))\                   # <--- One Bracked is missing here
    (tuple_expr implicit type='()'))\
  (return_stmt implicit\
    (force_value_expr implicit type='UIBarButtonItem'\
      (declref_expr implicit type='UIBarButtonItem?' decl=The.(file).Controller.<anonymous>.tmp1 direct_to_storage function_ref=unapplied))))\
```

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
