### PR TITLE
[Parse] Fix crash case in parseStmtForeach

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1770,15 +1770,17 @@ static bool isStmtForCStyle(Parser &P) {
   auto HasLParen = P.consumeIf(tok::l_paren);
 
   // Skip until we see ';', or something that ends control part.
-  while (P.Tok.isNot(tok::eof, tok::kw_in, tok::semi, tok::l_brace,
-                     tok::r_brace, tok::r_paren) && !P.isStartOfStmt()) {
+  while (true) {
+    if (P.Tok.isAny(tok::eof, tok::kw_in, tok::l_brace, tok::r_brace,
+                    tok::r_paren) || P.isStartOfStmt())
+      return false;
     // If we saw newline before ';', consider it is a foreach statement.
     if (!HasLParen && P.Tok.isAtStartOfLine())
       return false;
+    if (P.Tok.is(tok::semi))
+      return true;
     P.skipSingle();
   }
-
-  return P.Tok.is(tok::semi);
 }
 
 /// 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -224,6 +224,9 @@ func missingControllingExprInForEach() {
       let key = "\(name)"
     }
   }
+
+  for // expected-error {{expected pattern}} expected-error {{Sequence expression for for-each loop}}
+  ; // expected-error {{expected '{' to start the body of for-each loop}}
 }
 
 func missingControllingExprInSwitch() {

--- a/validation-test/compiler_crashers_fixed/28843-startofcontrol-tok-getloc.swift
+++ b/validation-test/compiler_crashers_fixed/28843-startofcontrol-tok-getloc.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {for
 ;


### PR DESCRIPTION
Don't treat
```
for
;
```
as removed C-style for statement.