### PR TITLE
[CMake] Fix status message when not building stdlib/runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,7 +823,7 @@ message(STATUS "")
 
 if (SWIFT_BULID_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
 
-  message(STATUS "Building Swift standard library and SDK overlays for SDKs: ${SWIFT_SDKS}")
+  message(STATUS "Building Swift standard library and overlays for SDKs: ${SWIFT_SDKS}")
   message(STATUS "  Build type: ${SWIFT_STDLIB_BUILD_TYPE}")
   message(STATUS "  Assertions: ${SWIFT_STDLIB_ASSERTIONS}")
   message(STATUS "")
@@ -834,7 +834,7 @@ if (SWIFT_BULID_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
 
 else()
 
-  message(STATUS "Not building Swift standard library and runtime")
+  message(STATUS "Not building Swift standard library, SDK overlays, and runtime")
   message(STATUS "")
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -821,14 +821,23 @@ message(STATUS "  Assertions: ${LLVM_ENABLE_ASSERTIONS}")
 message(STATUS "  LTO:        ${SWIFT_TOOLS_ENABLE_LTO}")
 message(STATUS "")
 
-message(STATUS "Building Swift standard library and SDK overlays for SDKs: ${SWIFT_SDKS}")
-message(STATUS "  Build type: ${SWIFT_STDLIB_BUILD_TYPE}")
-message(STATUS "  Assertions: ${SWIFT_STDLIB_ASSERTIONS}")
-message(STATUS "")
+if (SWIFT_BULID_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
 
-message(STATUS "Building Swift runtime with:")
-message(STATUS "  Leak Detection Checker Entrypoints: ${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")
-message(STATUS "")
+  message(STATUS "Building Swift standard library and SDK overlays for SDKs: ${SWIFT_SDKS}")
+  message(STATUS "  Build type: ${SWIFT_STDLIB_BUILD_TYPE}")
+  message(STATUS "  Assertions: ${SWIFT_STDLIB_ASSERTIONS}")
+  message(STATUS "")
+
+  message(STATUS "Building Swift runtime with:")
+  message(STATUS "  Leak Detection Checker Entrypoints: ${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")
+  message(STATUS "")
+
+else()
+
+  message(STATUS "Not building Swift standard library and runtime")
+  message(STATUS "")
+
+endif()
 
 #
 # Find required dependencies.


### PR DESCRIPTION
Fixes: [SR-5817](https://bugs.swift.org/browse/SR-5817)

>    Swift CMake prints "Building Swift standard library and SDK
    overlays" and "Building Swift runtime", even when those are *not*
    being built

Test Cases:

These depend on the path on the particular machine, so including these
inline instead of adding them somewhere to the source tree.

- Reproduction of Issue ("Should not Print"):

```
    export SWFT=~/Desktop/Swift
    mkdir /tmp/swift-build
    cd /tmp/swift-build

    cmake \
        -G 'Unix Makefiles' \
        -DCMAKE_BUILD_TYPE=Release \
        -DSWIFT_PATH_TO_LLVM_SOURCE=$SWFT/llvm \
        -DSWIFT_PATH_TO_LLVM_BUILD=$SWFT/build/llvm \
        -DSWIFT_PATH_TO_CMARK_SOURCE=$SWFT/cmark \
        -DSWIFT_PATH_TO_CMARK_BUILD=$SWFT/build/cmark \
        -DSWIFT_BUILD_REMOTE_MIRROR=FALSE \
        -DSWIFT_BUILD_DYNAMIC_STDLIB=FALSE \
        -DSWIFT_BUILD_STATIC_STDLIB=FALSE \
        -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=FALSE \
        -DSWIFT_BUILD_STATIC_SDK_OVERLAY=FALSE \
        $SWFT/swift
```

- Verification of Fix ("Should Print"):

```
    cmake \
        -G 'Unix Makefiles' \
        -DCMAKE_BUILD_TYPE=Release \
        -DSWIFT_PATH_TO_LLVM_SOURCE=$SWFT/llvm \
        -DSWIFT_PATH_TO_LLVM_BUILD=$SWFT/build/llvm \
        -DSWIFT_PATH_TO_CMARK_SOURCE=$SWFT/cmark \
        -DSWIFT_PATH_TO_CMARK_BUILD=$SWFT/build/cmark \
        -DSWIFT_BUILD_REMOTE_MIRROR=FALSE \
        $SWFT/swift
```

Reported-by: Brian Ivan Gesiak (@modocache)