### PR TITLE
[benchmark] Only add -external suffix to targets in standalone builds where SWIFT_BENCHMARK_SUBCMAKE_BUILD is set.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,9 +11,17 @@ cmake_minimum_required(VERSION 2.8.12)
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+# Load utility modules.
+include(SwiftBenchmarkUtils)
+
 set(SWIFT_BENCHMARK_BUILT_STANDALONE FALSE)
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   set(SWIFT_BENCHMARK_BUILT_STANDALONE TRUE)
+endif()
+
+if(SWIFT_BENCHMARK_SUBCMAKE_BUILD)
+  precondition(SWIFT_BENCHMARK_BUILD_STANDALONE
+    MESSAGE "If we are a subcmake build, we must be built standalone")
 endif()
 
 include(AddSwiftBenchmarkSuite)

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -488,15 +488,15 @@ function(swift_benchmark_compile)
       list(APPEND platform_executables ${new_output_exec})
     endforeach()
 
-    # If we are building standalone, we add the -external suffix to all of our
-    # cmake target names. This enables the main swift build to simple create
-    # -external targets and forward them via AddExternalProject to the
-    # standalone benchmark project. The reason why this is necessary is that we
-    # want to be able to support in-tree and out-of-tree benchmark builds at the
-    # same time implying that we need some sort of way to distinguish the
-    # in-tree (which don't have the suffix) from the out of tree target (which
-    # do).
-    translate_flag(SWIFT_BENCHMARK_BUILT_STANDALONE "-external" external)
+    # If we are building standalone as part of a subcmake build, we add the
+    # -external suffix to all of our cmake target names. This enables the main
+    # swift build to simple create -external targets and forward them via
+    # AddExternalProject to the standalone benchmark project. The reason why
+    # this is necessary is that we want to be able to support in-tree and
+    # out-of-tree benchmark builds at the same time implying that we need some
+    # sort of way to distinguish the in-tree (which don't have the suffix) from
+    # the out of tree target (which do).
+    translate_flag(SWIFT_BENCHMARK_SUBCMAKE_BUILD "-external" external)
     set(executable_target "swift-benchmark-${SWIFT_BENCHMARK_COMPILE_PLATFORM}-${arch}${external}")
 
     add_custom_target("${executable_target}"

--- a/cmake/modules/SwiftExternalBenchmarkBuild.cmake
+++ b/cmake/modules/SwiftExternalBenchmarkBuild.cmake
@@ -84,6 +84,7 @@ function (add_external_benchmark_suite)
       -DSWIFT_LIBRARY_PATH=${SWIFT_BINARY_DIR}/lib/swift
       -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
       -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
+      -DSWIFT_BENCHMARK_SUBCMAKE_BUILD=TRUE
     PASSTHROUGH_PREFIXES SWIFT_BENCHMARK
     )
 endfunction()


### PR DESCRIPTION
[benchmark] Only add -external suffix to targets in standalone builds where SWIFT_BENCHMARK_SUBCMAKE_BUILD is set.

This enables us to distinguish in between builds which are triggered by a
subcmake call from the main swift cmake file and one from a user who is trying
to compile the swift benchmark suite against a misc swift installation/use the
ninja file by hand.
