### PR TITLE
[update_checkout] Add success message to script

### DIFF
--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -485,6 +485,8 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     fail_count += shell.check_parallel_results(update_results, "UPDATE")
     if fail_count > 0:
         print("update-checkout failed, fix errors and try again")
+    else:
+        print("update-checkout succeeded")
     sys.exit(fail_count)
 
 


### PR DESCRIPTION
I think the script for getting sources for Swift should provide not only a failing message but also a success message.