### PR TITLE
Fix memory leaks in ThreadBarriers.swift

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -162,10 +162,7 @@ public class _stdlib_Barrier {
   }
 
   deinit {
-    let ret = _stdlib_thread_barrier_destroy(_threadBarrierPtr)
-    if ret != 0 {
-      fatalError("_stdlib_thread_barrier_destroy() failed")
-    }
+    _stdlib_thread_barrier_destroy(_threadBarrierPtr)
   }
 
   public func wait() {

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -82,10 +82,10 @@ public func _stdlib_thread_barrier_init(
 }
 
 private func _stdlib_thread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>) -> CInt {
-  guard pthread_mutex_init(barrier.pointee.mutex!) == 0 else {
+  guard pthread_mutex_init(barrier.pointee.mutex!, nil) == 0 else {
     return -1
   }
-  guard pthread_cond_init(barrier.pointee.cond!) == 0 else {
+  guard pthread_cond_init(barrier.pointee.cond!, nil) == 0 else {
     pthread_mutex_destroy(barrier.pointee.mutex!)
     return -1
   }

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -70,7 +70,7 @@ public func _stdlib_thread_barrier_init(
 #else
   barrier.pointee.mutex = UnsafeMutablePointer.allocate(capacity: 1)
   barrier.pointee.cond = UnsafeMutablePointer.allocate(capacity: 1)
-  guard _stdlib_pthread_barrier_mutex_and_cond_init(barrier) == 0 else {
+  guard _stdlib_thread_barrier_mutex_and_cond_init(barrier) == 0 else {
     barrier.pointee.mutex!.deinitialize(count: 1)
     barrier.pointee.mutex!.deallocate()
     barrier.pointee.cond!.deinitialize(count: 1)
@@ -81,7 +81,7 @@ public func _stdlib_thread_barrier_init(
   return 0
 }
 
-private func _stdlib_pthread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutablePointer<_stdlib_pthread_barrier_t>) -> CInt {
+private func _stdlib_thread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>) -> CInt {
   guard pthread_mutex_init(barrier.pointee.mutex!) == 0 else {
     return -1
   }

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -75,6 +75,7 @@ public func _stdlib_thread_barrier_init(
     barrier.pointee.mutex!.deallocate()
     barrier.pointee.cond!.deinitialize(count: 1)
     barrier.pointee.cond!.deallocate()
+    return -1
   }
 #endif
   barrier.pointee.count = count

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -94,14 +94,14 @@ private func _stdlib_pthread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutabl
 
 public func _stdlib_thread_barrier_destroy(
   _ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>
-) -> CInt {
+) {
 #if os(Windows)
   // Condition Variables do not need to be explicitly destroyed
   // Mutexes do not need to be explicitly destroyed
 #else
   guard pthread_cond_destroy(barrier.pointee.cond!) == 0 &&
     pthread_mutex_destroy(barrier.pointee.mutex!) == 0 else {
-    return -1
+    fatalError("_stdlib_thread_barrier_destroy() failed")
   }
 #endif
   barrier.pointee.cond!.deinitialize(count: 1)
@@ -110,7 +110,7 @@ public func _stdlib_thread_barrier_destroy(
   barrier.pointee.mutex!.deinitialize(count: 1)
   barrier.pointee.mutex!.deallocate()
 
-  return 0
+  return
 }
 
 public func _stdlib_thread_barrier_wait(

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -111,8 +111,7 @@ StringTestSuite.test("SliceConcurrentAppend") {
   expectEqual(0, joinRet1)
   expectEqual(0, joinRet2)
 
-  ret = _stdlib_thread_barrier_destroy(barrierVar!)
-  expectEqual(0, ret)
+  _stdlib_thread_barrier_destroy(barrierVar!)
 
   barrierVar!.deinitialize(count: 1)
   barrierVar!.deallocate()


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix memory leaks in PthreadBarriers.swift as indicated by `FIXME`s.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
