### PR TITLE
Temporarily disable parse_stdlib tests on Linux.

### DIFF
--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -18,6 +18,9 @@ for id in $(seq 0 $process_id_max); do
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx
 __EOF__
 
 done

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_11.sil
+++ b/validation-test/SIL/parse_stdlib_11.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable on Linux when we're no long running out of memory.
+// REQUIRES: OS=macosx


### PR DESCRIPTION
They're breaking CI because we seem to be running out of memory (?).
Need to investigate.
