### PR TITLE
 [ClangImporter] Allow setup without RuntimeResourcePath in Linux 

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -123,19 +123,21 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   this->SML = SML.get();
   Context->addModuleLoader(std::move(SML));
 
-  // Wire up the Clang importer. If the user has specified an SDK, use it.
-  // Otherwise, we just keep it around as our interface to Clang's ABI
-  // knowledge.
-  auto clangImporter =
-    ClangImporter::create(*Context, Invocation.getClangImporterOptions(),
-                          Invocation.getPCHHash(),
-                          DepTracker);
-  if (!clangImporter) {
-    Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
-    return true;
-  }
+  if (!Invocation.getSearchPathOptions().RuntimeResourcePath.empty()) {
+    // Wire up the Clang importer. If the user has specified an SDK, use it.
+    // Otherwise, we just keep it around as our interface to Clang's ABI
+    // knowledge.
+    auto clangImporter =
+      ClangImporter::create(*Context, Invocation.getClangImporterOptions(),
+                            Invocation.getPCHHash(),
+                            DepTracker);
+    if (!clangImporter) {
+      Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
+      return true;
+    }
 
-  Context->addModuleLoader(std::move(clangImporter), /*isClang*/true);
+    Context->addModuleLoader(std::move(clangImporter), /*isClang*/true);
+  }
 
   assert(Lexer::isIdentifier(Invocation.getModuleName()));
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift
@@ -7,6 +7,3 @@ func foo() -> Int {
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-func -pos=2:1 -end-pos 4:11 %s -- %s > %t.result/extract-func-default.swift.expected
 // RUN: diff -u %S/extract-func-default.swift.expected %t.result/extract-func-default.swift.expected
-
-// FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed
-// REQUIRES-ANY: OS=macosx

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift
@@ -7,6 +7,3 @@ func foo() -> Int {
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-func -pos=3:1 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-func-with-args.swift.expected
 // RUN: diff -u %S/extract-func-with-args.swift.expected %t.result/extract-func-with-args.swift.expected
-
-// FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed
-// REQUIRES-ANY: OS=macosx

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift
@@ -7,6 +7,3 @@ func foo() -> Int {
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-func -pos=2:1 -end-pos 4:11 -name new_name %s -- %s > %t.result/extract-func.swift.expected
 // RUN: diff -u %S/extract-func.swift.expected %t.result/extract-func.swift.expected
-
-// FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed
-// REQUIRES-ANY: OS=macosx

--- a/test/refactoring/lit.local.cfg
+++ b/test/refactoring/lit.local.cfg
@@ -1,5 +1,1 @@
-if 'OS=macosx' not in config.available_features:
-    config.unsupported = True
-
-else:
-    config.substitutions.append(('%refactor', config.swift_refactor))
+config.substitutions.append(('%refactor', config.swift_refactor))


### PR DESCRIPTION
This is required to enable  refactoring action `ExtractFunction` in Linux: `RefactoringActionExtractFunction::performChange()` setup `CompilerInstance` without `RuntimeResourcePath` for `performParseOnly()`.