### PR TITLE
Return back the '-report-errors-to-debugger' frontend flag to support custom toolchains from master in Xcode

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -298,6 +298,9 @@ def disable_tsan_inout_instrumentation : Flag<["-"],
   "disable-tsan-inout-instrumentation">,
   HelpText<"Disable treatment of inout parameters as Thread Sanitizer accesses">;
 
+def report_errors_to_debugger : Flag<["-"], "report-errors-to-debugger">,
+  HelpText<"Deprecated, will be removed in future versions.">;
+
 def enable_infer_import_as_member :
   Flag<["-"], "enable-infer-import-as-member">,
   HelpText<"Infer when a global could be imported as a member">;


### PR DESCRIPTION
The '-report-errors-to-debugger' should be eventually removed, but we can't do that just yet because Xcode uses this flag, and we want to support using custom toolchains in Xcode.