### PR TITLE
[SourceKit] Disable automatic rebuilding of dependent-ASTs

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1705,20 +1705,10 @@ ImmutableTextSnapshotRef SwiftEditorDocument::replaceText(
     if (Length != 0 || Buf->getBufferSize() != 0) {
       updateSemaInfo();
 
-      if (auto Invok = Impl.SemanticInfo->getInvocation()) {
-        // Update semantic info for open editor documents of the same module.
-        // FIXME: Detect edits that don't affect other files, e.g. whitespace,
-        // comments, inside a function body, etc.
-        CompilerInvocation CI;
-        Invok->applyTo(CI);
-        auto &EditorDocs = Impl.LangSupport.getEditorDocuments();
-        for (auto &Input : CI.getInputFilenames()) {
-          if (auto EditorDoc = EditorDocs.findByPath(Input)) {
-            if (EditorDoc.get() != this)
-              EditorDoc->updateSemaInfo();
-          }
-        }
-      }
+      // FIXME: we should also update any "interesting" ASTs that depend on this
+      // document here, e.g. any ASTs for files visible in an editor. However,
+      // because our API conflates this with any file with unsaved changes we do
+      // not update all open documents, since there could be too many of them.
     }
   }
 


### PR DESCRIPTION
After modifying a file, don't rebuild the ASTs for every file that
(might) depend on it.  This is very expensive if there are a lot of open
documents and we don't yet provide a way for clients to distinguish
documents that they want to update from any other documents that e.g.
are just open because they haven't been saved yet.

rdar://problem/34415818