### PR TITLE
[SourceKit] Disable automatic rebuilding of dependent-ASTs

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1590,20 +1590,10 @@ ImmutableTextSnapshotRef SwiftEditorDocument::replaceText(
     if (Length != 0 || Buf->getBufferSize() != 0) {
       updateSemaInfo();
 
-      if (auto Invok = Impl.SemanticInfo->getInvocation()) {
-        // Update semantic info for open editor documents of the same module.
-        // FIXME: Detect edits that don't affect other files, e.g. whitespace,
-        // comments, inside a function body, etc.
-        CompilerInvocation CI;
-        Invok->applyTo(CI);
-        auto &EditorDocs = Impl.LangSupport.getEditorDocuments();
-        for (auto &Input : CI.getInputFilenames()) {
-          if (auto EditorDoc = EditorDocs.findByPath(Input)) {
-            if (EditorDoc.get() != this)
-              EditorDoc->updateSemaInfo();
-          }
-        }
-      }
+      // FIXME: we should also update any "interesting" ASTs that depend on this
+      // document here, e.g. any ASTs for files visible in an editor. However,
+      // because our API conflates this with any file with unsaved changes we do
+      // not update all open documents, since there could be too many of them.
     }
   }
 


### PR DESCRIPTION
* Explanation: Previously, after a change to one open document sourcekitd would attempt to rebuild all ASTs that might be affected by that change (e.g. to update diagnostics).  While this can be useful, it create a big performance problem (both memory and time) when there are many open documents - e.g. change one file and rebuild 50 ASTs.  This behaviour assumed there would only be a few open documents corresponding to e.g. files visible at the same time in an editor, but our API forces you to keep an open document for any unsaved file changes, so that assumption doesn't hold.  While removing the automatic AST builds creates a functionality regression if any clients of sourcekitd knew about this behaviour, it seems worthwhile to avoid the huge performance issue.
* Scope: Affects clients of sourcekitd that use multiple open documents.
* Radar: rdar://problem/34415818
* Risk: Very low; just removes a call to rebuild ASTs.
* Testing: Tested manually in Xcode. We plan to introduce new API to make this more testable in the future.
