### PR TITLE
Take parse_stdlib tests from 17 shards to 31 shards.

### DIFF
--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-process_count=17
+process_count=31
 process_id_max=$((process_count - 1))
 
 for id in $(seq 0 $process_id_max); do
@@ -18,9 +18,6 @@ for id in $(seq 0 $process_id_max); do
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
 __EOF__
 
 done

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=0 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=1 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=10 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=12 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=13 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=14 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=15 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=16 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_17.sil
+++ b/validation-test/SIL/parse_stdlib_17.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=17 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_18.sil
+++ b/validation-test/SIL/parse_stdlib_18.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=18 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_19.sil
+++ b/validation-test/SIL/parse_stdlib_19.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=19 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=2 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_20.sil
+++ b/validation-test/SIL/parse_stdlib_20.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=20 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_21.sil
+++ b/validation-test/SIL/parse_stdlib_21.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=21 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_22.sil
+++ b/validation-test/SIL/parse_stdlib_22.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=22 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_23.sil
+++ b/validation-test/SIL/parse_stdlib_23.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=23 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_24.sil
+++ b/validation-test/SIL/parse_stdlib_24.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=24 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_25.sil
+++ b/validation-test/SIL/parse_stdlib_25.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=25 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_26.sil
+++ b/validation-test/SIL/parse_stdlib_26.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=26 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_27.sil
+++ b/validation-test/SIL/parse_stdlib_27.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=27 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_28.sil
+++ b/validation-test/SIL/parse_stdlib_28.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=28 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_29.sil
+++ b/validation-test/SIL/parse_stdlib_29.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=29 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=3 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_30.sil
+++ b/validation-test/SIL/parse_stdlib_30.sil
@@ -7,6 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=11 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=30 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=4 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=5 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=6 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=7 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=8 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -7,9 +7,6 @@
 // FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
 //        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=31 -ast-verifier-process-id=9 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx


### PR DESCRIPTION
Experiment to see if it'll address rdar://problem/34771322, allowing us
to re-enable these tests on Linux CI in the short term.
