### PR TITLE
[ConstraintGenerator] Enforce Void result requirement on the empty body closures

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2275,9 +2275,10 @@ namespace {
         // variable for it.
         funcTy = CS.createTypeVariable(locator, TVO_CanBindToInOut);
 
-        // Allow it to default to () if there are no return statements.
+        // Allow result to be bound only to () if there are
+        // no return statements, covers only empty and multi-statement closures.
         if (closureHasNoResult(expr)) {
-          CS.addConstraint(ConstraintKind::Defaultable,
+          CS.addConstraint(ConstraintKind::Equal,
                            funcTy,
                            TupleType::getEmpty(CS.getASTContext()),
                            locator);

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -645,3 +645,14 @@ func rdar33429010_3() {
  let arr = [C_33429010()]
  let _ = arr.map({ ($0.name, $0 as P_33429010) }) // Ok
 }
+
+// rdar://problem/34772225 - failure to disambiguate the type of an overloaded closure argument on a method
+do {
+  struct Foo {
+    func bar(_: (Int) -> ()) {}
+    func bar(_: (Int) -> Bool) {}
+  }
+
+  let foo = Foo()
+  foo.bar { _ in } // Ok
+}


### PR DESCRIPTION
Instead of creating `defaultable` constraint which is very permissive,
let's use `equals` instead, which wouldn't allow unrelated types to
be matched as a closure result type if there are no explicit return
statements in the body.

Resolves: rdar://problem/34772225

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
