### PR TITLE
[4.0][migrator] When renaming a function decl, we should use underscore to represent empty external argument label. rdar://34569243

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -684,14 +684,19 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
           StringRef NewArg = View.args()[Index++];
           auto ArgLoc = PD->getArgumentNameLoc();
 
+          // Represent empty label with underscore.
+          if (NewArg.empty())
+            NewArg = "_";
+
           // If the argument name is not specified, add the argument name before
           // the parameter name.
           if (ArgLoc.isInvalid())
             Editor.insertBefore(PD->getNameLoc(),
                                 (llvm::Twine(NewArg) + " ").str());
-          else
+          else {
             // Otherwise, replace the argument name directly.
             Editor.replaceToken(ArgLoc, NewArg);
+          }
         }
       }
     }

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -449,6 +449,17 @@
   {
     "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities04MoreA0P8addZooAtySi_Si1ySi1ztF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "addNewZooAt(_:newY:newZ:)",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
     "NodeAnnotation": "TypeRewritten",
     "ChildIndex": "1:0",
     "LeftUsr": "s:6CitiesAAC8maroochyySiSg1x_AD1ytF",

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -22,6 +22,7 @@ public protocol ExtraCities {
 
 public protocol MoreCities {
   func setZooLocation(x: Int, y: Int, z: Int)
+  func addZooAt(_ x: Int, y: Int, z: Int)
 }
 
 public func setCityProperty1(_ c : Cities, _ p : Int) {}

--- a/test/Migrator/rename-func-decl.swift
+++ b/test/Migrator/rename-func-decl.swift
@@ -8,4 +8,5 @@ import Cities
 
 class MyCities : MoreCities {
   func setZooLocation(x ix: Int, y iy: Int, z iz: Int) {}
+  func addZooAt(_ x: Int, y: Int, z: Int) {}
 }

--- a/test/Migrator/rename-func-decl.swift.expected
+++ b/test/Migrator/rename-func-decl.swift.expected
@@ -8,4 +8,5 @@ import Cities
 
 class MyCities : MoreCities {
   func setZooLocationNew(newX ix: Int, newY iy: Int, newZ iz: Int) {}
+  func addNewZooAt(_ x: Int, newY y: Int, newZ z: Int) {}
 }


### PR DESCRIPTION
Explanation: We recently changed DeclNameView to return an empty string instead of an underscore to represent an empty argument label. This leads to migration errors when we use the representation literally. This fix teaches migrator to use underscore when emitting rename changes.
Scope: Swift 4.0 Migrator
Radar: rdar://problem/34569243
Risk: Very low
Testing: Regression test added