### PR TITLE
[AST] Don't try to compute substitutions for a missing generic signature

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -656,12 +656,9 @@ SpecializedProtocolConformance::getTypeWitnessAndDecl(
   }
 
   // Otherwise, perform substitutions to create this witness now.
-  auto *genericSig = GenericConformance->getGenericSignature();
 
-  auto substitutionMap =
-      genericSig->getSubstitutionMap(GenericSubstitutions);
-
-  // Local function to determine whether we will end up
+  // Local function to determine whether we will end up referring to a
+  // tentative witness that may not be chosen.
   auto normal = GenericConformance->getRootNormalConformance();
   auto isTentativeWitness = [&] {
     if (normal->getState() != ProtocolConformanceState::CheckingTypeWitnesses)
@@ -678,6 +675,12 @@ SpecializedProtocolConformance::getTypeWitnessAndDecl(
     return { Type(), nullptr };
 
   auto *typeDecl = genericWitnessAndDecl.second;
+
+  // Form the substitution.
+  auto *genericSig = GenericConformance->getGenericSignature();
+  if (!genericSig) return { Type(), nullptr };
+
+  auto substitutionMap = genericSig->getSubstitutionMap(GenericSubstitutions);
 
   // Apply the substitution we computed above
   auto specializedType

--- a/validation-test/compiler_crashers_2_fixed/0120-rdar34184392.swift
+++ b/validation-test/compiler_crashers_2_fixed/0120-rdar34184392.swift
@@ -1,0 +1,31 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+protocol P {
+  associatedtype A1 : Q where A1.A2 == Self
+
+  var a1: A1? { get set }
+
+  func start()
+}
+
+protocol Q {
+  associatedtype A2 : P where A2.A1 == Self
+
+  func didStart(transport: A2)
+}
+
+class C<D> : P
+  where D : Q, D.A2 == Self
+{
+  typealias A1 = D
+
+  var a1: D? = nil
+}
+
+class C2<D> : P
+  where D : Q, D.A2 == C2<D>
+{
+  typealias A1 = D
+
+  var a1: D? = nil
+}


### PR DESCRIPTION
Eliminates the crash in rdar://problem/34184392, but we still don't handle
this pattern.
