### PR TITLE
stdlib: Fix an assert that triggers after uniqueness hoisting

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1363,7 +1363,17 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   @_versioned
   @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
+    // Due to make_mutable hoisting the situation can arise where we hoist
+    // _makeMutableAndUnique out of loop and use it to replace
+    // _makeUniqueAndReserveCapacityIfNotUnique that preceeds this call. If the
+    // array was empty _makeMutableAndUnique does not replace the empty array
+    // buffer by a unique buffer (it just replaces it by the empty array
+    // singleton).
+    // This specific case is okay because we will make the buffer unique in this
+    // function because we request a capacity > 0 and therefore _copyToNewBuffer
+    // will be called creating a new buffer.
+    _sanityCheck(_buffer.capacity == 0 ||
+                 _buffer.isMutableAndUniquelyReferenced())
 
     if _slowPath(oldCount + 1 > _buffer.capacity) {
       _copyToNewBuffer(oldCount: oldCount)


### PR DESCRIPTION
makeUnique hoisting can create a situation where we hit an assert in
_reserveCapacityAssumingUniqueBuffer that the buffer is not unique if we use
_makeMutableAndUniqueOrPinned to replace
_makeUniqueAndReserveCapacityIfNotUnique.

It is actually fine do to the replacement because we will make the buffer unique
_reserveCapacityAssumingUniqueBuffer if the capacity is zero so adjust the
assert accordingly.

do {
  if (someCond) {
    // array.append(...)
    _makeUniqueAndReserveCapacityIfNotUnique(&array)
    _reserveCapacityAssumingUniqueBuffer(&array)
    _appendElementAssumeUniqueAndCapacity(&array, …)
  } else {
   // array[i] = …
   _makeMutableAndUniqueOrPinned(&array)
   addr = _getElementAddress(&array)
   store 1, addr
  }
} while();

to:

_makeMutableAndUniqueOrPinned(&array) // does not replace empty arrays.
do {
  if (someCond) {
    // array.append(...)
    _reserveCapacityAssumingUniqueBuffer(&array) // hit the assert.
    _appendElementAssumeUniqueAndCapacity(&array, …)
  } else {
   // array[i] = …
   addr = _getElementAddress(&array)
   store 1, addr
  }
} while();

rdar://34149935