### PR TITLE
Executable resilience tests re-build library under a new name now

### DIFF
--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -10,15 +10,15 @@
 
 // RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_class.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/libresilient_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_class_wmo.%target-dylib-extension
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension
+// RUN: %target-run %t/main %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_class_wmo.%target-dylib-extension
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -10,16 +10,15 @@
 
 // RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_enum.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_enum.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/libresilient_enum_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_enum.swift -emit-module -emit-module-path %t/resilient_enum.swiftmodule -module-name resilient_enum -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_enum_wmo.%target-dylib-extension
 
-// RUN: %target-codesign %t/libresilient_enum.%target-dylib-extension
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_enum_wmo -o %t/main -Xlinker -rpath -Xlinker %t
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_enum -o %t/main -Xlinker -rpath -Xlinker %t
-
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_enum.%target-dylib-extension
+// RUN: %target-run %t/main %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_enum_wmo.%target-dylib-extension
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -10,16 +10,15 @@
 
 // RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_global.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_global.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/libresilient_global_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_global.swift -emit-module -emit-module-path %t/resilient_global.swiftmodule -module-name resilient_global -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_global_wmo.%target-dylib-extension
 
-// RUN: %target-codesign %t/libresilient_global.%target-dylib-extension
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_global_wmo -o %t/main -Xlinker -rpath -Xlinker %t
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_global -o %t/main -Xlinker -rpath -Xlinker %t
-
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_global.%target-dylib-extension
+// RUN: %target-run %t/main %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_global_wmo.%target-dylib-extension
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/protocol_resilience.swift
+++ b/test/Interpreter/protocol_resilience.swift
@@ -7,12 +7,12 @@
 
 // RUN: %target-run %t/main %t/libresilient_protocol.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_protocol.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/libresilient_protocol_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_protocol.swift -emit-module -emit-module-path %t/resilient_protocol.swiftmodule -module-name resilient_protocol -whole-module-optimization
 // RUN: %target-codesign %t/libresilient_protocol.%target-dylib-extension
 
-// RUN: %target-build-swift %s -lresilient_protocol -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
+// RUN: %target-build-swift %s -lresilient_protocol_wmo -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 
-// RUN: %target-run %t/main %t/libresilient_protocol.%target-dylib-extension
+// RUN: %target-run %t/main %t/libresilient_protocol_wmo.%target-dylib-extension
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -7,12 +7,12 @@
 
 // RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
-// RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift %s -lresilient_struct -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
+// RUN: %target-build-swift %s -lresilient_struct_wmo -I %t -L %t -o %t/main -Xlinker -rpath -Xlinker %t
 
-// RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension
+// RUN: %target-run %t/main %t/libresilient_struct_wmo.%target-dylib-extension
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Building a new dylib with the same name was breaking some internal bots.

Fixes <rdar://problem/34148403>.