### PR TITLE
[benchmark] Update perf_test_driver for benchmark driver updates.

### DIFF
--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -47,10 +47,13 @@ class GuardMallocBenchmarkDriver(perf_test_driver.BenchmarkDriver):
         test_name = '({},{})'.format(data['opt'], data['test_name'])
         print("Running {}...".format(test_name))
         sys.stdout.flush()
-        status = subprocess.call(
+
+        p = subprocess.Popen(
             [data['path'], data['test_name'], '--num-iters=2'],
             env=data['env'], stderr=open('/dev/null', 'w'),
             stdout=open('/dev/null', 'w'))
+        status = p.wait()
+
         return GuardMallocResult(test_name, status)
 
 

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -21,6 +21,9 @@ import re
 import subprocess
 
 
+BENCHMARK_OUTPUT_RE = re.compile('([^,]+),')
+
+
 class Result(object):
 
     def __init__(self, name, status, output, xfail_list):
@@ -83,8 +86,12 @@ class BenchmarkDriver(object):
 
     def run_for_opt_level(self, binary, opt_level, test_filter):
         print("testing driver at path: %s" % binary)
-        names = [n.strip() for n in subprocess.check_output(
-            [binary, "--list"]).split()[2:]]
+        names = []
+        for l in subprocess.check_output([binary, "--list"]).split("\n")[1:]:
+            m = BENCHMARK_OUTPUT_RE.match(l)
+            if m is None:
+                continue
+            names.append(m.group(1))
         if test_filter:
             regex = re.compile(test_filter)
             names = [n for n in names if regex.match(n)]


### PR DESCRIPTION
This ensures that Benchmark_GuardMalloc, Benchmark_RuntimeLeaksRunner, etc. all
support the new way benchmark --list outputs benchmark names.

rdar://34781144