### PR TITLE
Truly disable thumb emission

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -532,7 +532,9 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
   if (!targetFeaturesArray.empty()) {
     llvm::SubtargetFeatures features;
     for (const std::string &feature : targetFeaturesArray)
-      features.AddFeature(feature);
+      if (!shouldRemoveTargetFeature(feature)) {
+        features.AddFeature(feature);
+      }
     targetFeatures = features.getString();
   }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -803,6 +803,11 @@ llvm::AttributeList IRGenModule::getAllocAttrs() {
   return AllocAttrs;
 }
 
+/// Disable thumb-mode until debugger support is there.
+bool swift::irgen::shouldRemoveTargetFeature(const std::string &feature) {
+  return feature == "+thumb-mode";
+}
+
 /// Construct initial function attributes from options.
 void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs) {
   // Add DisableFPElim. 
@@ -821,7 +826,11 @@ void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs) {
   if (CPU != "")
     Attrs.addAttribute("target-cpu", CPU);
 
-  std::vector<std::string> Features = ClangOpts.Features;
+  std::vector<std::string> Features;
+  for (auto &F : ClangOpts.Features)
+    if (!shouldRemoveTargetFeature(F))
+        Features.push_back(F);
+
   if (!Features.empty()) {
     SmallString<64> allFeatures;
     // Sort so that the target features string is canonical.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -804,7 +804,7 @@ llvm::AttributeList IRGenModule::getAllocAttrs() {
 }
 
 /// Disable thumb-mode until debugger support is there.
-bool swift::irgen::shouldRemoveTargetFeature(const std::string &feature) {
+bool swift::irgen::shouldRemoveTargetFeature(StringRef feature) {
   return feature == "+thumb-mode";
 }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1120,6 +1120,9 @@ public:
   IRGenModule *operator->() const { return IGM; }
 };
 
+/// Workaround to disable thumb-mode until debugger support is there.
+bool shouldRemoveTargetFeature(const std::string &);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1121,7 +1121,7 @@ public:
 };
 
 /// Workaround to disable thumb-mode until debugger support is there.
-bool shouldRemoveTargetFeature(const std::string &);
+bool shouldRemoveTargetFeature(StringRef);
 
 } // end namespace irgen
 } // end namespace swift

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -338,16 +338,42 @@ func minMax3(x : Int, y : Int) -> Ret? {
 // Passing struct: Int8, MyPoint x 10, MySize * 10
 // CHECK-LABEL: define hidden swiftcc double @_T08test_v7k0A4Ret5{{.*}}(%T8test_v7k7MyRect3V* noalias nocapture dereferenceable(328))
 // V7K-LABEL: __T08test_v7k0A4Ret5
-// V7K:   ldrb    r1, [r0]
-// V7K:   vldr    d16, [r0, #8]
-// V7K:   add     r0, r0, #296
-// V7K:   vldr    d18, [r0]
-// V7K:   sxtb    r0, r1
-// V7K:   vmov    s0, r0
-// V7K:   vcvt.f64.s32    d20, s0
-// V7K:   vadd.f64        d16, d20, d16
-// V7K:   vadd.f64        d0, d16, d18
-// V7K:   bx      lr
+// V7K:  sub     sp, sp, #56
+// V7K:  ldrb    r1, [r0]
+// V7K:  strb    r1, [sp, #52]
+// V7K:  ldrsb   r1, [sp, #52]
+// V7K:  vmov    s0, r1
+// V7K:  vcvt.f64.s32    d16, s0
+// V7K:  ldr     r1, [r0, #8]
+// V7K:  str     r1, [sp, #24]
+// V7K:  ldr     r1, [r0, #12]
+// V7K:  str     r1, [sp, #28]
+// V7K:  ldr     r1, [r0, #16]
+// V7K:  str     r1, [sp, #32]
+// V7K:  ldr     r1, [r0, #20]
+// V7K:  str     r1, [sp, #36]
+// V7K:  ldr     r1, [sp, #24]
+// V7K:  str     r1, [sp, #40]
+// V7K:  ldr     r1, [sp, #28]
+// V7K:  str     r1, [sp, #44]
+// V7K:  vldr    d18, [sp, #40]
+// V7K:  vadd.f64        d16, d16, d18
+// V7K:  ldr     r1, [r0, #296]
+// V7K:  str     r1, [sp]
+// V7K:  ldr     r1, [r0, #300]
+// V7K:  str     r1, [sp, #4]
+// V7K:  ldr     r1, [r0, #304]
+// V7K:  str     r1, [sp, #8]
+// V7K:  ldr     r0, [r0, #308]
+// V7K:  str     r0, [sp, #12]
+// V7K:  ldr     r0, [sp]
+// V7K:  str     r0, [sp, #16]
+// V7K:  ldr     r0, [sp, #4]
+// V7K:  str     r0, [sp, #20]
+// V7K:  vldr    d18, [sp, #16]
+// V7K:  vadd.f64        d0, d16, d18
+// V7K:  add     sp, sp, #56
+// V7K:  bx      lr
 
 struct MyRect3 {
   var t: Int8

--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -23,24 +23,24 @@ public func use_global() -> Int {
 // Check for the runtime memory enforcement call. The global address may be
 // materialized in a different register prior to that call.
 // armv7:         bl _swift_beginAccess
-// armv7:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSivp-([[PIC_0:L.*]]+4))
-// armv7:         movt [[R_ADR]], :upper16:(__T04main6globalSivp-([[PIC_0]]+4))
+// armv7:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSivp-([[PIC_0:L.*]]+8))
+// armv7:         movt [[R_ADR]], :upper16:(__T04main6globalSivp-([[PIC_0]]+8))
 // armv7:       [[PIC_0]]:{{$}}
 // armv7:         add [[R_ADR]], pc
 // armv7:         ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
 // armv7s-LABEL: __T04main10use_globalSiyF:
 // armv7s:         bl _swift_beginAccess
-// armv7s:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSivp-([[PIC_0:L.*]]+4))
-// armv7s:         movt [[R_ADR]], :upper16:(__T04main6globalSivp-([[PIC_0]]+4))
+// armv7s:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSivp-([[PIC_0:L.*]]+8))
+// armv7s:         movt [[R_ADR]], :upper16:(__T04main6globalSivp-([[PIC_0]]+8))
 // armv7s:       [[PIC_0]]:{{$}}
 // armv7s:         add [[R_ADR]], pc
 // armv7s:         ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
 // armv7k-LABEL: __T04main10use_globalSiyF:
 // armv7k:         bl _swift_beginAccess
-// armv7k:        movw [[R_ADR:r.*]], :lower16:(__T04main6globalSivp-([[PIC_0:L.*]]+4))
-// armv7k:        movt [[R_ADR]], :upper16:(__T04main6globalSivp-([[PIC_0]]+4))
+// armv7k:        movw [[R_ADR:r.*]], :lower16:(__T04main6globalSivp-([[PIC_0:L.*]]+8))
+// armv7k:        movt [[R_ADR]], :upper16:(__T04main6globalSivp-([[PIC_0]]+8))
 // armv7k:      [[PIC_0]]:{{$}}
 // armv7k:        add [[R_ADR]], pc
 // armv7k:        ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}


### PR DESCRIPTION
Interpreter support for thumb is not yet properly implemented/tested.
Disable thumb emission.

This change is necessary because LLVM now uses the features string in the
metadata. This features string contains '+thumb'.

This is a follow-up to 034241e440ec6b4782eba22d3f12a41e47b0b8cb.

rdar://32599805
rdar://34781037 (tests that expect non-thumb instructions are failing)