### PR TITLE
[stdlib] Fix for initFromArray test on big endian (4.0)

### DIFF
--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -66,7 +66,11 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   array1.withUnsafeBytes { bytes1 in
     expectEqual(bytes1.count, 16)
     for (i, b) in bytes1.enumerated() {
-      if i % 4 == 0 {
+      var num = i
+#if _endian(big)
+      num = num + 1
+#endif
+      if num % 4 == 0 {
         expectEqual(Int(b), i / 4)
       }
       else {


### PR DESCRIPTION
Account for byte order in initFromArray test. This will allow the test to pass on s390x

Same fix as #9458 but this is for the swift-4.0-branch

Tagging @moiseev for his attention.  Thanks.
