### PR TITLE
Fixes (another) IRGen compiler crash caused by the new large types ABI

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -275,7 +275,8 @@ static bool modResultType(GenericEnvironment *genEnv,
   }
   auto singleResult = loweredTy->getSingleResult();
   auto resultStorageType = singleResult.getSILStorageType();
-  if (isLargeLoadableType(genEnv, resultStorageType, Mod)) {
+  auto newResultStorageType = getNewSILType(genEnv, resultStorageType, Mod);
+  if (resultStorageType != newResultStorageType) {
     return true;
   }
   return false;
@@ -406,7 +407,7 @@ struct StructLoweringState {
   SmallVector<SILInstruction *, 16> instsToMod;
   // All function-exiting terminators (return or throw instructions).
   SmallVector<TermInst *, 8> returnInsts;
-  // All return instructions that are modified
+  // All (large type) return instructions that are modified
   SmallVector<ReturnInst *, 8> modReturnInsts;
   // All destroy_value instrs should be replaced with _addr version
   SmallVector<SILInstruction *, 16> destroyValueInstsToMod;
@@ -799,12 +800,39 @@ void LargeValueVisitor::visitPointerToAddressInst(PointerToAddressInst *instr) {
   }
 }
 
+static bool modNonFuncTypeResultType(GenericEnvironment *genEnv,
+                                     CanSILFunctionType loweredTy,
+                                     irgen::IRGenModule &Mod) {
+  if (!modifiableFunction(loweredTy)) {
+    return false;
+  }
+  if (loweredTy->getNumResults() != 1) {
+    return false;
+  }
+  auto singleResult = loweredTy->getSingleResult();
+  auto resultStorageType = singleResult.getSILStorageType();
+  if (isLargeLoadableType(genEnv, resultStorageType, Mod)) {
+    return true;
+  }
+  return false;
+}
+
+static bool modNonFuncTypeResultType(SILFunction *F, irgen::IRGenModule &Mod) {
+  GenericEnvironment *genEnv = F->getGenericEnvironment();
+  auto loweredTy = F->getLoweredFunctionType();
+  if (!genEnv && loweredTy->isPolymorphic()) {
+    genEnv = getGenericEnvironment(F->getModule(), loweredTy);
+  }
+
+  return modNonFuncTypeResultType(genEnv, loweredTy, Mod);
+}
+
 void LargeValueVisitor::visitReturnInst(ReturnInst *instr) {
   if (!modResultType(pass.F, pass.Mod)) {
     visitInstr(instr);
-  } else {
+  } else if (modNonFuncTypeResultType(pass.F, pass.Mod)) {
     pass.modReturnInsts.push_back(instr);
-  }
+  } // else: function signature return instructions remain as-is
 }
 
 void LargeValueVisitor::visitDeallocInst(DeallocStackInst *instr) {
@@ -1207,7 +1235,7 @@ void LoadableStorageAllocation::convertIndirectFunctionArgs() {
   }
 
   // Convert the result type to indirect if necessary:
-  if (modResultType(pass.F, pass.Mod)) {
+  if (modNonFuncTypeResultType(pass.F, pass.Mod)) {
     insertIndirectReturnArgs();
   }
 }
@@ -1257,8 +1285,15 @@ void LoadableStorageAllocation::convertApplyResults() {
       if (!isLargeLoadableType(genEnv, resultStorageType, pass.Mod)) {
         // Make sure it is a function type
         auto canType = resultStorageType.getSwiftRValueType();
-        assert(dyn_cast<SILFunctionType>(canType.getPointer()) &&
-               "Expected SILFunctionType for the result type");
+        if (!dyn_cast<SILFunctionType>(canType.getPointer())) {
+          // Check if it is an optional funciton type
+          OptionalTypeKind optKind;
+          auto optionalType = canType.getAnyOptionalObjectType(optKind);
+          assert(optionalType &&
+                 "Expected SILFunctionType or Optional for the result type");
+          assert(dyn_cast<SILFunctionType>(optionalType.getPointer()) &&
+                 "Expected a SILFunctionType inside the optional Type");
+        }
         continue;
       }
       auto newSILType = getNewSILType(genEnv, resultStorageType, pass.Mod);
@@ -2030,6 +2065,8 @@ static void rewriteFunction(StructLoweringState &pass,
     auto loc = instr->getLoc(); // SILLocation::RegularKind
     auto regLoc = RegularLocation(loc.getSourceLoc());
     SILBuilder retBuilder(instr);
+    assert(modNonFuncTypeResultType(pass.F, pass.Mod) &&
+           "Expected a regular type");
     // Before we return an empty tuple, init return arg:
     auto *entry = pass.F->getEntryBlock();
     auto *retArg = entry->getArgument(0);
@@ -2247,7 +2284,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
   // Find the new alloc we created earlier.
   // and pass it as first parameter:
   if (applyInst->getKind() != SILInstructionKind::PartialApplyInst &&
-      modResultType(genEnv, origCanType, *currIRMod) &&
+      modNonFuncTypeResultType(genEnv, origCanType, *currIRMod) &&
       modifiableApply(applySite, *getIRGenModule())) {
     assert(allApplyRetToAllocMap.find(applyInst) !=
            allApplyRetToAllocMap.end());

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -140,6 +140,28 @@ bb0(%0 : $Builtin.Int64, %1 : $() -> @owned BigStruct):
   return undef : $BigStruct
 }
 
+// CHECK-LABEL: define swiftcc void @poninter_to_mod_ret(i8*, %swift.refcounted*) #0 {
+// CHECK: [[BITCAST:%.*]] = bitcast i8* %0 to { i8*, %swift.refcounted* } (%swift.refcounted*)*
+// CHECK: [[CALL:%.*]] = call swiftcc { i8*, %swift.refcounted* } [[BITCAST]](%swift.refcounted* swiftself %1)
+// CHECK: extractvalue { i8*, %swift.refcounted* } [[CALL]], 0
+// CHECK: extractvalue { i8*, %swift.refcounted* } [[CALL]], 1
+// CHECK: ret void
+sil @poninter_to_mod_ret : $@convention(thin) (@owned @callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct) -> () {
+bb0(%funcpointer : $@callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct):
+  %papply = apply %funcpointer() : $@callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: define swiftcc { i64, i64 } @ret_pointer_to_mod() #0 {
+// CHECK-NEXT: entry
+// CHECK-NEXT: ret { i64, i64 } zeroinitializer
+sil @ret_pointer_to_mod : $@convention(thin) () -> @owned Optional<@callee_owned () -> @owned Optional<BigStruct>> {
+bb0:
+  %0 = enum $Optional<@callee_owned () -> @owned Optional<BigStruct>>, #Optional.none!enumelt // user: %1
+  return %0 : $Optional<@callee_owned () -> @owned Optional<BigStruct>> // id: %1
+}
+
 //////////////////////
 // Autoclosure Test //
 //////////////////////


### PR DESCRIPTION
radar rdar://problem/34277023

Fixes a corner-case when getting a function ref as an argument and/or returning a function ref. In some cases wherein the signature of the referenced function was modified, we did not propagate that change correctly.