### PR TITLE
[stdlib] Dictionary.Keys, .Values: Implement Custom[Debug]StringConvertible

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1613,40 +1613,20 @@ extension ${Self} : CustomReflectable {
 }
 
 extension ${Self} : CustomStringConvertible, CustomDebugStringConvertible {
-  internal func _makeDescription(isDebug: Bool) -> String {
-%   if Self != 'Array':
-    var result = isDebug ? "${Self}([" : "["
-%   else:
-    // Always show sugared representation for Arrays.
-    var result = "["
-%   end
-    var first = true
-    for item in self {
-      if first {
-        first = false
-      } else {
-        result += ", "
-      }
-      debugPrint(item, terminator: "", to: &result)
-    }
-%   if Self != 'Array':
-    result += isDebug ? "])" : "]"
-%   else:
-    // Always show sugared representation for Arrays.
-    result += "]"
-%   end
-    return result
-  }
-
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeDescription(isDebug: false)
+    return _makeCollectionDescription(for: self, withTypeName: nil)
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeDescription(isDebug: true)
+%   if Self != 'Array':
+    return _makeCollectionDescription(for: self, withTypeName: "${Self}")
+%   else:
+    // Always show sugared representation for Arrays.
+    return _makeCollectionDescription(for: self, withTypeName: nil)
+%   end
   }
 }
 
@@ -1811,6 +1791,32 @@ extension ${Self} {
   }
 }
 %end
+
+// Utility method for collections that wish to implement CustomStringConvertible
+// and CustomDebugStringConvertible using a bracketed list of elements,
+// like an array.
+@_inlineable // FIXME(sil-serialize-all)
+@_versioned // FIXME(sil-serialize-all)
+internal func _makeCollectionDescription<C : Collection>
+  (for items: C, withTypeName type: String?) -> String {
+  var result = ""
+  if let type = type {
+    result += "\(type)(["
+  } else {
+    result += "["
+  }
+  var first = true
+  for item in items {
+    if first {
+      first = false
+    } else {
+      result += ", "
+    }
+    debugPrint(item, terminator: "", to: &result)
+  }
+  result += type != nil ? "])" : "]"
+  return result
+}
 
 @_versioned
 @_fixed_layout

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1322,33 +1322,16 @@ extension Set {
 }
 
 extension Set : CustomStringConvertible, CustomDebugStringConvertible {
-  @_inlineable // FIXME(sil-serialize-all)
-  @_versioned // FIXME(sil-serialize-all)
-  internal func makeDescription(isDebug: Bool) -> String {
-    var result = isDebug ? "Set([" : "["
-    var first = true
-    for member in self {
-      if first {
-        first = false
-      } else {
-        result += ", "
-      }
-      debugPrint(member, terminator: "", to: &result)
-    }
-    result += isDebug ? "])" : "]"
-    return result
-  }
-
   /// A string that represents the contents of the set.
   @_inlineable // FIXME(sil-serialize-all)
   public var description: String {
-    return makeDescription(isDebug: false)
+    return _makeCollectionDescription(for: self, withTypeName: nil)
   }
 
   /// A string that represents the contents of the set, suitable for debugging.
   @_inlineable // FIXME(sil-serialize-all)
   public var debugDescription: String {
-    return makeDescription(isDebug: true)
+    return _makeCollectionDescription(for: self, withTypeName: "Set")
   }
 }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2537,7 +2537,9 @@ extension Dictionary {
 
   /// A view of a dictionary's keys.
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct Keys : Collection, Equatable {
+  public struct Keys
+    : Collection, Equatable,
+      CustomStringConvertible, CustomDebugStringConvertible {
     public typealias Element = Key
 
     @_versioned // FIXME(sil-serialize-all)
@@ -2621,11 +2623,22 @@ extension Dictionary {
 
       return true
     }
+
+    @_inlineable // FIXME(sil-serialize-all)
+    public var description: String {
+      return _makeCollectionDescription(for: self, withTypeName: nil)
+    }
+
+    @_inlineable // FIXME(sil-serialize-all)
+    public var debugDescription: String {
+      return _makeCollectionDescription(for: self, withTypeName: "Dictionary.Keys")
+    }
   }
 
   /// A view of a dictionary's values.
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct Values : MutableCollection {
+  public struct Values
+    : MutableCollection, CustomStringConvertible, CustomDebugStringConvertible {
     public typealias Element = Value
 
     @_versioned // FIXME(sil-serialize-all)
@@ -2681,6 +2694,16 @@ extension Dictionary {
     @_inlineable // FIXME(sil-serialize-all)
     public var isEmpty: Bool {
       return count == 0
+    }
+
+    @_inlineable // FIXME(sil-serialize-all)
+    public var description: String {
+      return _makeCollectionDescription(for: self, withTypeName: nil)
+    }
+
+    @_inlineable // FIXME(sil-serialize-all)
+    public var debugDescription: String {
+      return _makeCollectionDescription(for: self, withTypeName: "Dictionary.Values")
     }
   }
 }


### PR DESCRIPTION
This works around a crash involving `_HashableTypedNativeDictionaryStorage` when printing dictionaries whose keys or values aren't bridged verbatim. (And having nice printouts is a really nice bonus.) 

The `_HTNDS` type doesn't correctly implement the `NSDictionary` API in that case. This is by design, as the implementation is normally only ever used when both `Key` and `Value` are verbatim bridgeable types. However, before this PR, `.Keys` and `.Values` printed using reflection, exposing their underlying native storage. When Foundation was imported, printing the storage object triggered its dormant NSDictionary implementation and that immediately caught on fire.

`.Keys` and `.Values` now print as a bracketed list of elements, like `Set` and the `Array` types.
In fact, all these types now use the same function to construct their descriptions.

Resolves [SR-6003](https://bugs.swift.org/browse/SR-6003) a.k.a rdar://problem/34672149.