### PR TITLE
[sil] Instead of returning an ArrayRef<SILValue> for SILInstruction::getResults(), use SILInstructionResultArray.

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -613,6 +613,8 @@ NON_VALUE_INST(AllocGlobalInst, alloc_global,
 NON_VALUE_INST(CondFailInst, cond_fail,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 
+NODE_RANGE(NonValueInstruction, UnreachableInst, CondFailInst)
+
 NODE_RANGE(SILInstruction, AllocStackInst, CondFailInst)
 NODE_RANGE(SILNode, SILPHIArgument, CondFailInst)
 

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -172,19 +172,20 @@ void SILInstruction::dropAllReferences() {
   }
 }
 
-ArrayRef<ValueBase> SILInstruction::getResultsImpl() const {
+SILInstructionResultArray SILInstruction::getResultsImpl() const {
   switch (getKind()) {
 #define NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   case SILInstructionKind::ID:
 #include "swift/SIL/SILNodes.def"
-    return {};
+    return SILInstructionResultArray();
 
 #define SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   case SILInstructionKind::ID:
 #include "swift/SIL/SILNodes.def"
-    return static_cast<const SingleValueInstruction *>(this)->getResultsImpl();
+    return SILInstructionResultArray(
+        static_cast<const SingleValueInstruction *>(this));
 
-  // add any multi-result instructions here...
+    // add any multi-result instructions here...
   }
   llvm_unreachable("bad kind");
 }
@@ -1173,4 +1174,102 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
   }
 
   llvm_unreachable("Unhandled ReleasingBehavior in switch.");
+}
+
+//===----------------------------------------------------------------------===//
+//                         SILInstructionResultArray
+//===----------------------------------------------------------------------===//
+
+SILInstructionResultArray::SILInstructionResultArray(
+    const SingleValueInstruction *SVI)
+    : Pointer(), Size(1) {
+  // Make sure that even though we are munging things, we are able to get back
+  // the original value, types, and operands.
+  SILValue originalValue(SVI);
+  SILType originalType = SVI->getType();
+  (void)originalValue;
+  (void)originalType;
+
+  // *PLEASE READ BEFORE CHANGING*
+  //
+  // Since SingleValueInstruction is both a ValueBase and a SILInstruction, but
+  // SILInstruction is the first parent, we need to ensure that our ValueBase *
+  // pointer is properly offset. by first static casting to ValueBase and then
+  // going back to a uint8_t *.
+  auto *Value = static_cast<const ValueBase *>(SVI);
+  assert(uintptr_t(Value) != uintptr_t(SVI) &&
+         "Expected value to be offset from SVI since it is not the first "
+         "multi-inheritence parent");
+  Pointer = reinterpret_cast<const uint8_t *>(Value);
+
+  assert(originalValue == (*this)[0] &&
+         "Wrong value returned for single result");
+  assert(originalType == (*this)[0]->getType());
+
+  auto ValueRange = getValues();
+  (void)ValueRange;
+  assert(1 == std::distance(ValueRange.begin(), ValueRange.end()));
+  assert(originalValue == *ValueRange.begin());
+
+  auto TypedRange = getTypes();
+  (void)TypedRange;
+  assert(1 == std::distance(TypedRange.begin(), TypedRange.end()));
+  assert(originalType == *TypedRange.begin());
+
+  SILInstructionResultArray Copy = *this;
+  (void)Copy;
+  assert(Copy.hasSameTypes(*this));
+  assert(Copy == *this);
+}
+
+SILValue SILInstructionResultArray::operator[](size_t Index) const {
+  assert(Index < Size && "Index out of bounds");
+  // Today we only have single instruction results so offset will always be
+  // zero. Once we have multiple instruction results, this will be equal to
+  // sizeof(MultipleValueInstructionResult)*Index. This is safe even to do with
+  // SingleValueInstruction since index will always be zero for the offset.
+  size_t Offset = 0;
+  return SILValue(reinterpret_cast<const ValueBase *>(&Pointer[Offset]));
+}
+
+bool SILInstructionResultArray::hasSameTypes(
+    const SILInstructionResultArray &rhs) {
+  auto &lhs = *this;
+  if (lhs.size() != rhs.size())
+    return false;
+  for (unsigned i : indices(lhs)) {
+    if (lhs[i]->getType() != rhs[i]->getType())
+      return false;
+  }
+  return true;
+}
+
+bool SILInstructionResultArray::
+operator==(const SILInstructionResultArray &other) {
+  if (size() != other.size())
+    return false;
+  for (auto i : indices(*this))
+    if ((*this)[i] != other[i])
+      return false;
+  return true;
+}
+
+SILInstructionResultArray::type_range
+SILInstructionResultArray::getTypes() const {
+  std::function<SILType(SILValue)> F = [](SILValue V) -> SILType {
+    return V->getType();
+  };
+  return {llvm::map_iterator(begin(), F), llvm::map_iterator(end(), F)};
+}
+
+SILInstructionResultArray::iterator SILInstructionResultArray::begin() const {
+  return iterator(*this, getStartOffset());
+}
+
+SILInstructionResultArray::iterator SILInstructionResultArray::end() const {
+  return iterator(*this, getEndOffset());
+}
+
+SILInstructionResultArray::range SILInstructionResultArray::getValues() const {
+  return {begin(), end()};
 }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -660,13 +660,13 @@ public:
   /// Print out the users of the SILValue \p V. Return true if we printed out
   /// either an id or a use list. Return false otherwise.
   bool printUsersOfSILNode(const SILNode *node, bool printedSlashes) {
-    SILInstruction::ResultArrayRef values;
+    TinyPtrVector<SILValue> values;
     if (auto value = dyn_cast<ValueBase>(node)) {
       // The base pointer of the ultimate ArrayRef here is just the
       // ValueBase; we aren't forming a reference to a temporary array.
-      values = ArrayRef<ValueBase>(value, 1);
-    } else if (auto inst = dyn_cast<SILInstruction>(node)) {
-      values = inst->getResults();
+      values.push_back(value);
+    } else if (auto *inst = dyn_cast<SILInstruction>(node)) {
+      copy(inst->getResults(), std::back_inserter(values));
     }
 
     // If the set of values is empty, we need to print the ID of


### PR DESCRIPTION
[sil] Instead of returning an ArrayRef<SILValue> for SILInstruction::getResults(), use SILInstructionResultArray.

The reason that I am doing this is in preparation for adding support for
MultipleValueInstruction. This enables us to avoid type issues and also ensures
that we do not increase the size of SingleValueInstruction while we are doing
it.

The MultipleValueInstruction commit will come soon.

rdar://31521023
