### PR TITLE
[Deserialization] Configure protocol before loading requirement signature

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3127,17 +3127,21 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     configureGenericEnvironment(proto, genericEnvID);
 
-    SmallVector<Requirement, 4> requirements;
-    readGenericRequirements(requirements, DeclTypeCursor);
-
     if (isImplicit)
       proto->setImplicit();
     proto->computeType();
 
-    proto->setRequirementSignature(requirements);
+    proto->setCircularityCheck(CircularityCheck::Checked);
+
+    // Establish the requirement signature.
+    {
+      SmallVector<Requirement, 4> requirements;
+      readGenericRequirements(requirements, DeclTypeCursor);
+      proto->setRequirementSignature(requirements);
+    }
 
     proto->setMemberLoader(this, DeclTypeCursor.GetCurrentBitNo());
-    proto->setCircularityCheck(CircularityCheck::Checked);
+
     break;
   }
 

--- a/test/Serialization/Inputs/recursive_protocol_merge_a.swift
+++ b/test/Serialization/Inputs/recursive_protocol_merge_a.swift
@@ -1,0 +1,3 @@
+protocol A {
+  associatedtype T : B
+}

--- a/test/Serialization/Inputs/recursive_protocol_merge_b.swift
+++ b/test/Serialization/Inputs/recursive_protocol_merge_b.swift
@@ -1,0 +1,3 @@
+protocol B {
+  associatedtype T : A
+}

--- a/test/Serialization/recursive_protocol_merge.swift
+++ b/test/Serialization/recursive_protocol_merge.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name rpm -o %t/a.swiftmodule -primary-file %S/Inputs/recursive_protocol_merge_a.swift %S/Inputs/recursive_protocol_merge_b.swift
+// RUN: %target-swift-frontend -emit-module -module-name rpm -o %t/b.swiftmodule %S/Inputs/recursive_protocol_merge_a.swift -primary-file %S/Inputs/recursive_protocol_merge_b.swift
+// RUN: %target-swift-frontend -merge-modules -emit-module -o %t/rpm.swiftmodule %t/a.swiftmodule %t/b.swiftmodule

--- a/validation-test/compiler_crashers_2_fixed/0125-rdar33575781.swift
+++ b/validation-test/compiler_crashers_2_fixed/0125-rdar33575781.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend -typecheck %s 
+
+public class MyCollection : MutableCollection {
+  public var startIndex: MyCollection.Index
+  public var endIndex: MyCollection.Index
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a crash when deserializing recursive protocol conformances,
rdar://problem/34681729.