### PR TITLE
Stats output dir filename issues

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -101,7 +101,7 @@ auxName(StringRef ModuleName,
     InputName = "all";
   }
   if (OptType.empty()) {
-    InputName = "Onone";
+    OptType = "Onone";
   }
   if (!OutputType.empty() && OutputType.front() == '.') {
     OutputType = OutputType.substr(1);

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -100,6 +100,8 @@ auxName(StringRef ModuleName,
   if (InputName.empty()) {
     InputName = "all";
   }
+  // Dispose of path prefix, which might make composite name too long.
+  InputName = path::filename(InputName);
   if (OptType.empty()) {
     OptType = "Onone";
   }


### PR DESCRIPTION
Principal fix here is to only use the basename of a path when mangling input names into stats-dir
output filenames, so that we are much less likely to hit a path-name limit and drop a stats output
on the floor (this was happening in practice in CI).

Secondary fix is just a harmless-but-silly typo I noticed while in there.
