### PR TITLE
[test] XFAIL stdlib/Dispatch.swift on 32-bit ARM pending rdar://34751238.

### DIFF
--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -10,7 +10,7 @@
 // REQUIRES: objc_interop
 
 // FIXME: rdar://34751238 DispatchTime.addSubtract test traps
-// XFAIL: CPU=armv7 || CPU=armv7k
+// XFAIL: CPU=armv7 || CPU=armv7k || CPU=armv7s
 
 
 import Dispatch


### PR DESCRIPTION
Previous attempt to XFAIL (#12231) missed armv7s.