### PR TITLE
[Driver] Remove obsolete "APPLE-ONLY" comments

### DIFF
--- a/include/swift/Driver/Types.def
+++ b/include/swift/Driver/Types.def
@@ -60,10 +60,7 @@ TYPE("remap",           Remapping,          "remap",           "")
 TYPE("imported-modules", ImportedModules,   "importedmodules", "")
 TYPE("tbd",             TBD,                "tbd",             "")
 TYPE("module-trace",    ModuleTrace,        "trace.json",      "")
-
-// BEGIN APPLE-ONLY OUTPUT TYPES
 TYPE("index-data",      IndexData,          "",                "")
-// END APPLE-ONLY OUTPUT TYPES
 
 // Misc types
 TYPE("pcm",             ClangModuleFile,    "pcm",             "")

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1158,12 +1158,10 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerMode = OutputInfo::Mode::SingleCompile;
       break;
 
-    // BEGIN APPLE-ONLY OUTPUT ACTIONS
     case options::OPT_index_file:
       OI.CompilerMode = OutputInfo::Mode::SingleCompile;
       OI.CompilerOutputType = types::TY_IndexData;
       break;
-    // END APPLE-ONLY OUTPUT ACTIONS
 
     case options::OPT_update_code:
       OI.CompilerOutputType = types::TY_Remapping;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -234,13 +234,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_ImportedModules:
       FrontendModeOption = "-emit-imported-modules";
       break;
-
-    // BEGIN APPLE-ONLY OUTPUT TYPES
     case types::TY_IndexData:
       FrontendModeOption = "-typecheck";
       break;
-    // END APPLE-ONLY OUTPUT TYPES
-
     case types::TY_Remapping:
       FrontendModeOption = "-update-code";
       break;


### PR DESCRIPTION
A post-commit reviewer on https://github.com/apple/swift/pull/10716 asked that the comments be removed. Remove them, as they're no longer demarcating code that is internal to Apple.