### PR TITLE
[Type checker] Diagnose failed attempts to resolve associated type witnesses

### DIFF
--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -149,7 +149,7 @@ struct XSubP0b : SubscriptP0 {
 
 struct XSubP0c : SubscriptP0 {
 // expected-error@-1 {{type 'XSubP0c' does not conform to protocol 'SubscriptP0'}}
-  subscript (i: Index) -> Element { get { } }
+  subscript (i: Index) -> Element { get { } } // expected-error{{reference to invalid associated type 'Element' of type 'XSubP0c'}}
 }
 
 struct XSubP0d : SubscriptP0 {

--- a/validation-test/compiler_crashers_2_fixed/0124-sr5825.swift
+++ b/validation-test/compiler_crashers_2_fixed/0124-sr5825.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 
 struct DefaultAssociatedType {
 }


### PR DESCRIPTION
If unqualified name lookup finds an associated type, but resolution to
the type witness fails, produce a diagnostic rather than silently
failing. Fixes the crash in SR-5825, SR-5881, and SR-5905.

It's conceivable that we could resolve this with suitably global
associated type inference... but that's far off and it's best not to
crash until then.
