### PR TITLE
[Driver] Remove unused input type code (NFCI)

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -167,6 +167,8 @@ public:
                                     const OutputInfo &OI) const;
 
   /// Return the default language type to use for the given extension.
+  /// If the extension is empty or is otherwise not recognized, return
+  /// the invalid type \c TY_INVALID.
   virtual types::ID lookupTypeForExtension(StringRef Ext) const;
 
   /// Check whether a clang library with a given name exists.

--- a/include/swift/Driver/Types.h
+++ b/include/swift/Driver/Types.h
@@ -36,6 +36,8 @@ namespace types {
   StringRef getTypeTempSuffix(ID Id);
 
   /// Lookup the type to use for the file extension \p Ext.
+  /// If the extension is empty or is otherwise not recognized, return
+  /// the invalid type \c TY_INVALID.
   ID lookupTypeForExtension(StringRef Ext);
 
   /// Lookup the type to use for the name \p Name.

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -926,9 +926,6 @@ static bool checkInputExistence(const Driver &D, const DerivedArgList &Args,
 void Driver::buildInputs(const ToolChain &TC,
                          const DerivedArgList &Args,
                          InputFileList &Inputs) const {
-  types::ID InputType = types::TY_Nothing;
-  Arg *InputTypeArg = nullptr;
-
   llvm::StringMap<StringRef> SourceFileNames;
 
   for (Arg *A : Args) {
@@ -936,29 +933,19 @@ void Driver::buildInputs(const ToolChain &TC,
       StringRef Value = A->getValue();
       types::ID Ty = types::TY_INVALID;
 
-      if (InputType == types::TY_Nothing) {
-        // If there was an explicit arg for this, claim it.
-        if (InputTypeArg)
-          InputTypeArg->claim();
-
-        // stdin must be handled specially.
-        if (Value.equals("-")) {
-          // By default, treat stdin as Swift input.
-          // FIXME: should we limit this inference to specific modes?
-          Ty = types::TY_Swift;
-        } else {
-          // Otherwise lookup by extension.
-          Ty = TC.lookupTypeForExtension(llvm::sys::path::extension(Value));
-
-          if (Ty == types::TY_INVALID) {
-            // FIXME: should we adjust this inference in certain modes?
-            Ty = types::TY_Object;
-          }
-        }
+      // stdin must be handled specially.
+      if (Value.equals("-")) {
+        // By default, treat stdin as Swift input.
+        Ty = types::TY_Swift;
       } else {
-        assert(InputTypeArg && "InputType set w/o InputTypeArg");
-        InputTypeArg->claim();
-        Ty = InputType;
+        // Otherwise lookup by extension.
+        Ty = TC.lookupTypeForExtension(llvm::sys::path::extension(Value));
+
+        if (Ty == types::TY_INVALID) {
+          // By default, treat inputs with no extension, or with an
+          // extension that isn't recognized, as object files.
+          Ty = types::TY_Object;
+        }
       }
 
       if (checkInputExistence(*this, Args, Diags, Value))
@@ -973,8 +960,6 @@ void Driver::buildInputs(const ToolChain &TC,
         }
       }
     }
-
-    // FIXME: add -x support (or equivalent)
   }
 }
 


### PR DESCRIPTION
**Summary:**

When the Swift driver executable was first added in https://github.com/apple/swift/commit/ed2038585f0c25bb2dd1cec35da565df2df48c82, the code included a FIXME to support input types, like Clang's `-x <language>` option. Perhaps as a first step in implementing this functionality, it also included dead code that manipulated an input type argument, even though the variable for storing the argument was never written to.

Remove the unused input type code, and update the FIXME with a Swift bug URL, so that a discussion on next steps can be had.

**Test plan:** `utils/build-script --release --test`