### PR TITLE
 [refactoring] Implement "Convert to Trailing Closure" refactoring action

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2712,6 +2712,12 @@ public:
   Expr *getSubExpr() const { return SubExpr; }
   void setSubExpr(Expr *e) { SubExpr = e; }
 
+  Expr *getSyntacticSubExpr() const {
+    if (auto *ICE = dyn_cast<ImplicitConversionExpr>(SubExpr))
+      return ICE->getSyntacticSubExpr();
+    return SubExpr;
+  }
+
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_ImplicitConversionExpr &&
            E->getKind() <= ExprKind::Last_ImplicitConversionExpr;

--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -44,6 +44,8 @@ CURSOR_REFACTORING(CollapseNestedIfExpr, "Collapse Nested If Expression", collap
 
 CURSOR_REFACTORING(ConvertToDoCatch, "Convert To Do/Catch", convert.do.catch)
 
+CURSOR_REFACTORING(TrailingClosure, "Convert To Trailing Closure", trailingclosure)
+
 RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr)
 
 RANGE_REFACTORING(ExtractFunction, "Extract Method", extract.function)

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -80,7 +80,7 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
     return false;
 
   if (Loc == LocToResolve) {
-    CursorInfo = { D, CtorTyRef, ExtTyRef, &SrcFile, Loc, IsRef, Ty, ContainerType };
+    CursorInfo.setValueRef(D, CtorTyRef, ExtTyRef, IsRef, Ty, ContainerType);
     return true;
   }
   return false;
@@ -88,7 +88,7 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
 
 bool CursorInfoResolver::tryResolve(ModuleEntity Mod, SourceLoc Loc) {
   if (Loc == LocToResolve) {
-    CursorInfo = { Mod, &SrcFile, Loc };
+    CursorInfo.setModuleRef(Mod);
     return true;
   }
   return false;
@@ -97,13 +97,13 @@ bool CursorInfoResolver::tryResolve(ModuleEntity Mod, SourceLoc Loc) {
 bool CursorInfoResolver::tryResolve(Stmt *St) {
   if (auto *LST = dyn_cast<LabeledStmt>(St)) {
     if (LST->getStartLoc() == LocToResolve) {
-      CursorInfo = { St, &SrcFile };
+      CursorInfo.setTrailingStmt(St);
       return true;
     }
   }
   if (auto *CS = dyn_cast<CaseStmt>(St)) {
     if (CS->getStartLoc() == LocToResolve) {
-      CursorInfo = { St, &SrcFile };
+      CursorInfo.setTrailingStmt(St);
       return true;
     }
   }
@@ -120,7 +120,7 @@ bool CursorInfoResolver::visitSubscriptReference(ValueDecl *D, CharSourceRange R
 ResolvedCursorInfo CursorInfoResolver::resolve(SourceLoc Loc) {
   assert(Loc.isValid());
   LocToResolve = Loc;
-  CursorInfo = ResolvedCursorInfo();
+  CursorInfo.Loc = Loc;
   walk(SrcFile);
   return CursorInfo;
 }
@@ -211,7 +211,7 @@ bool CursorInfoResolver::walkToExprPost(Expr *E) {
     return false;
   if (!TrailingExprStack.empty() && TrailingExprStack.back() == E) {
     // We return the outtermost expression in the token info.
-    CursorInfo = { TrailingExprStack.front(), &SrcFile };
+    CursorInfo.setTrailingExpr(TrailingExprStack.front());
     return false;
   }
   return true;

--- a/test/refactoring/RefactoringKind/trailingclosure.swift
+++ b/test/refactoring/RefactoringKind/trailingclosure.swift
@@ -1,0 +1,46 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map({ $0 + 1 })
+}
+
+// RUN: %refactor -source-filename %s -pos=7:3 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:6 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:7 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:10 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:11 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:12 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:14 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:16 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:18 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=7:19 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+
+// RUN: %refactor -source-filename %s -pos=8:3 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=8:11 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+
+// RUN: %refactor -source-filename %s -pos=9:3 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=9:8 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+
+// RUN: %refactor -source-filename %s -pos=10:3 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=10:9 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=10:17 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+
+// RUN: %refactor -source-filename %s -pos=12:4 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=13:5 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=14:5 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+
+// CHECK-TRAILING-CLOSURE: Convert To Trailing Closure
+
+// CHECK-NO-TRAILING-CLOSURE: Action begins
+// CHECK-NO-TRAILING-CLOSURE-NOT: Convert To Trailing Closure
+// CHECK-NO-TRAILING-CLOSURE: Action ends

--- a/test/refactoring/TrailingClosure/Outputs/basic/L10.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L10.swift.expected
@@ -1,0 +1,21 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1) { 1 }
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map({ $0 + 1 })
+}
+
+
+
+
+
+

--- a/test/refactoring/TrailingClosure/Outputs/basic/L13.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L13.swift.expected
@@ -1,0 +1,21 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter { $0 % 2 == 0 }
+    .map({ $0 + 1 })
+}
+
+
+
+
+
+

--- a/test/refactoring/TrailingClosure/Outputs/basic/L14.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L14.swift.expected
@@ -1,0 +1,21 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map { $0 + 1 }
+}
+
+
+
+
+
+

--- a/test/refactoring/TrailingClosure/Outputs/basic/L7.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L7.swift.expected
@@ -1,0 +1,21 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo { 1 }
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map({ $0 + 1 })
+}
+
+
+
+
+
+

--- a/test/refactoring/TrailingClosure/Outputs/basic/L8.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L8.swift.expected
@@ -1,0 +1,21 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar { print(3); return 1 }
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map({ $0 + 1 })
+}
+
+
+
+
+
+

--- a/test/refactoring/TrailingClosure/Outputs/basic/L9.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L9.swift.expected
@@ -1,0 +1,21 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1) { 1 }
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map({ $0 + 1 })
+}
+
+
+
+
+
+

--- a/test/refactoring/TrailingClosure/basic.swift
+++ b/test/refactoring/TrailingClosure/basic.swift
@@ -1,0 +1,34 @@
+struct Foo {
+  static func foo(a: () -> Int) {}
+  func qux(x: Int, y: () -> Int ) {}
+}
+
+func testTrailingClosure() -> String {
+  Foo.foo(a: { 1 })
+  Foo.bar(a: { print(3); return 1 })
+  Foo().qux(x: 1, y: { 1 })
+  let _ = Foo().quux(x: 1, y: { 1 })
+
+  [1,2,3]
+    .filter({ $0 % 2 == 0 })
+    .map({ $0 + 1 })
+}
+// RUN: rm -rf %t.result && mkdir -p %t.result
+
+// RUN: %refactor -trailingclosure -source-filename %s -pos=7:3 > %t.result/L7.swift
+// RUN: diff -u %S/Outputs/basic/L7.swift.expected %t.result/L7.swift
+
+// RUN: %refactor -trailingclosure -source-filename %s -pos=8:11 > %t.result/L8.swift
+// RUN: diff -u %S/Outputs/basic/L8.swift.expected %t.result/L8.swift
+
+// RUN: %refactor -trailingclosure -source-filename %s -pos=9:8 > %t.result/L9.swift
+// RUN: diff -u %S/Outputs/basic/L9.swift.expected %t.result/L9.swift
+
+// RUN: %refactor -trailingclosure -source-filename %s -pos=10:17 > %t.result/L10.swift
+// RUN: diff -u %S/Outputs/basic/L10.swift.expected %t.result/L10.swift
+
+// RUN: %refactor -trailingclosure -source-filename %s -pos=13:5 > %t.result/L13.swift
+// RUN: diff -u %S/Outputs/basic/L13.swift.expected %t.result/L13.swift
+// RUN: %refactor -trailingclosure -source-filename %s -pos=14:5 > %t.result/L14.swift
+// RUN: diff -u %S/Outputs/basic/L14.swift.expected %t.result/L14.swift
+

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -55,7 +55,9 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::FindGlobalRenameRanges,
                       "find-rename-ranges", "Find detailed ranges for syntactic rename"),
            clEnumValN(RefactoringKind::FindLocalRenameRanges,
-                      "find-local-rename-ranges", "Find detailed ranges for local rename")));
+                      "find-local-rename-ranges", "Find detailed ranges for local rename"),
+           clEnumValN(RefactoringKind::TrailingClosure,
+                      "trailingclosure", "Perform trailing closure refactoring")));
 
 
 static llvm::cl::opt<std::string>


### PR DESCRIPTION
Implement [SR-5738](https://bugs.swift.org/browse/SR-5738)

~As a groundwork, I modified  `CursorInfoResolver` and `ResolvedCursorInfo` so that it preserves surrounding `ASTNode` (direct child of `BraceStmt`).
Also, introduced `CursorInfoKind::Middle` (naming TBD) which means the cursor is at middle of someting, like:~
```swift
do {
  foo(x: bar, y: baz)
       ↑ here
}
```

As a ground work, added `SourceFile` to `ResolvedCursorInfo` struct. Also, let `CursorInfoResolver ` always set `Loc` to `ResolvedCursorInfo` so that we can manually resolve the surrounding context later.

This refactoring action searches *innermost* `CallExpr` from the cursor position. If found, it's applicable if that `CallExpr` has `ClosureExpr` as the last argument.