### PR TITLE
Revert "SIL: Remove special meaning for @_semantics("stdlib_binary_only")"

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -117,13 +117,15 @@ Cloning code from the standard library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Swift compiler can copy code from the standard library into the
-application for functions marked @_inlineable. This allows the optimizer to
-inline calls from the stdlib and improve the performance of code that uses
-common operators such as '+=' or basic containers such as Array. However,
-importing code from the standard library can increase the binary size.
+application. This allows the optimizer to inline calls from stdlib and improve
+the performance of code that uses common operators such as '++' or basic
+containers such as Array. However, importing code from the standard library can
+increase the binary size. Marking functions with @_semantics("stdlib_binary_only")
+will prevent the copying of the marked function from the standard library into the
+user program.
 
-To prevent copying of functions from the standard library into the user
-program, make sure the function in question is not marked @_inlineable.
+Notice that this annotation is similar to the resilient annotation that will
+disallow the cloning of code into the user application.
 
 Array
 ~~~~~

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -1353,9 +1353,11 @@ void SILGlobalOpt::replaceFindStringCall(ApplyInst *FindStringCall) {
   if (!FD)
     return;
 
-  SILDeclRef declRef(FD, SILDeclRef::Kind::Func);
-  SILFunction *replacementFunc = Module->getOrCreateFunction(
-      FindStringCall->getLoc(), declRef, NotForDefinition);
+  std::string Mangled = SILDeclRef(FD, SILDeclRef::Kind::Func).mangle();
+  SILFunction *replacementFunc = Module->findFunction(Mangled,
+                                                    SILLinkage::PublicExternal);
+  if (!replacementFunc)
+    return;
 
   SILFunctionType *FTy = replacementFunc->getLoweredFunctionType();
   if (FTy->getNumParameters() != 3)
@@ -1365,7 +1367,6 @@ void SILGlobalOpt::replaceFindStringCall(ApplyInst *FindStringCall) {
   NominalTypeDecl *cacheDecl = cacheType.getNominalOrBoundGenericNominal();
   if (!cacheDecl)
     return;
-
   SILType wordTy = cacheType.getFieldType(
                             cacheDecl->getStoredProperties().front(), *Module);
 

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -423,7 +423,11 @@ SILLinkage swift::getSpecializedLinkage(SILFunction *F, SILLinkage L) {
     return SILLinkage::Private;
   }
 
-  return SILLinkage::Shared;
+  // Treat stdlib_binary_only specially. We don't serialize the body of
+  // stdlib_binary_only functions so we can't mark them as Shared (making
+  // their visibility in the dylib hidden).
+  return F->hasSemanticsAttr("stdlib_binary_only") ? SILLinkage::Public
+                                                   : SILLinkage::Shared;
 }
 
 /// Remove all instructions in the body of \p BB in safe manner by using

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -627,7 +627,7 @@ func _stdlib_installTrapInterceptor()
 #endif
 
 // Avoid serializing references to objc_setUncaughtExceptionHandler in SIL.
-@inline(never)
+@inline(never) @_semantics("stdlib_binary_only")
 func _childProcess() {
   _stdlib_installTrapInterceptor()
 

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -82,8 +82,10 @@ func _fatalErrorFlags() -> UInt32 {
 ///
 /// This function should not be inlined because it is cold and inlining just
 /// bloats code.
-@_versioned // FIXME(sil-serialize-all)
+@_inlineable // FIXME(sil-serialize-all)
+@_versioned
 @inline(never)
+@_semantics("stdlib_binary_only")
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
   file: StaticString, line: UInt,
@@ -112,8 +114,10 @@ internal func _assertionFailure(
 ///
 /// This function should not be inlined because it is cold and inlining just
 /// bloats code.
-@_versioned // FIXME(sil-serialize-all)
+@_inlineable // FIXME(sil-serialize-all)
+@_versioned
 @inline(never)
+@_semantics("stdlib_binary_only")
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: String,
   file: StaticString, line: UInt,
@@ -142,8 +146,10 @@ internal func _assertionFailure(
 ///
 /// This function should not be inlined because it is cold and it inlining just
 /// bloats code.
-@_versioned // FIXME(sil-serialize-all)
+@_inlineable // FIXME(sil-serialize-all)
+@_versioned
 @inline(never)
+@_semantics("stdlib_binary_only")
 @_semantics("arc.programtermination_point")
 internal func _fatalErrorMessage(
   _ prefix: StaticString, _ message: StaticString,

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -305,8 +305,10 @@ public enum _DebuggerSupport {
   }
 
   // LLDB uses this function in expressions, and if it is inlined the resulting
-  // LLVM IR is enormous.  As a result, to improve LLDB performance we are not
-  // making it @_inlineable.
+  // LLVM IR is enormous.  As a result, to improve LLDB performance we have made
+  // this stdlib_binary_only, which prevents inlining.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_semantics("stdlib_binary_only")
   public static func stringForPrintObject(_ value: Any) -> String {
     var maxItemCounter = Int.max
     var refs = Set<ObjectIdentifier>()

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2862,7 +2862,9 @@ public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
 ///
 /// - Precondition: `SwiftKey` and `SwiftValue` are bridged to Objective-C,
 ///   and at least one of them requires non-trivial bridging.
+@_inlineable // FIXME(sil-serialize-all)
 @inline(never)
+@_semantics("stdlib_binary_only")
 public func _dictionaryBridgeToObjectiveC<
   SwiftKey, SwiftValue, ObjCKey, ObjCValue
 >(

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -343,9 +343,11 @@ internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
   }
 }
 
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned
 @inline(never)
 @_semantics("optimize.sil.specialize.generic.never")
+@_semantics("stdlib_binary_only")
 internal func _print_unlocked<T, TargetStream : TextOutputStream>(
   _ value: T, _ target: inout TargetStream
 ) {

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -49,7 +49,9 @@
 ///     space (`" "`).
 ///   - terminator: The string to print after all items have been printed. The
 ///     default is a newline (`"\n"`).
+@_inlineable // FIXME(sil-serialize-all)
 @inline(never)
+@_semantics("stdlib_binary_only")
 public func print(
   _ items: Any...,
   separator: String = " ",
@@ -108,7 +110,9 @@ public func print(
 ///     space (`" "`).
 ///   - terminator: The string to print after all items have been printed. The
 ///     default is a newline (`"\n"`).
+@_inlineable // FIXME(sil-serialize-all)
 @inline(never)
+@_semantics("stdlib_binary_only")
 public func debugPrint(
   _ items: Any...,
   separator: String = " ",
@@ -224,8 +228,10 @@ public func debugPrint<Target : TextOutputStream>(
     items, separator: separator, terminator: terminator, to: &output)
 }
 
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned
 @inline(never)
+@_semantics("stdlib_binary_only")
 internal func _print<Target : TextOutputStream>(
   _ items: [Any],
   separator: String = " ",
@@ -243,8 +249,10 @@ internal func _print<Target : TextOutputStream>(
   output.write(terminator)
 }
 
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned
 @inline(never)
+@_semantics("stdlib_binary_only")
 internal func _debugPrint<Target : TextOutputStream>(
   _ items: [Any],
   separator: String = " ",

--- a/stdlib/public/core/REPL.swift
+++ b/stdlib/public/core/REPL.swift
@@ -18,7 +18,9 @@ func _replPrintLiteralString(_ text: String) {
 }
 
 /// Print the debug representation of `value`, followed by a newline.
+@_inlineable // FIXME(sil-serialize-all)
 @inline(never)
+@_semantics("stdlib_binary_only")
 public // COMPILER_INTRINSIC
 func _replDebugPrintln<T>(_ value: T) {
   debugPrint(value)

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -47,8 +47,9 @@ func _stdlib_binary_CFStringGetCharactersPtr(
 
 /// Bridges `source` to `Swift.String`, assuming that `source` has non-ASCII
 /// characters (does not apply ASCII optimizations).
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
-@inline(never) // Hide the CF dependency
+@inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
 func _cocoaStringToSwiftString_NonASCII(
   _ source: _CocoaString
 ) -> String {
@@ -69,8 +70,9 @@ func _cocoaStringToSwiftString_NonASCII(
 
 /// Produces a `_StringBuffer` from a given subrange of a source
 /// `_CocoaString`, having the given minimum capacity.
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
-@inline(never) // Hide the CF dependency
+@inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
 internal func _cocoaStringToContiguous(
   source: _CocoaString, range: Range<Int>, minimumCapacity: Int
 ) -> _StringBuffer {
@@ -92,8 +94,9 @@ internal func _cocoaStringToContiguous(
 
 /// Reads the entire contents of a _CocoaString into contiguous
 /// storage of sufficient capacity.
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
-@inline(never) // Hide the CF dependency
+@inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
 internal func _cocoaStringReadAll(
   _ source: _CocoaString, _ destination: UnsafeMutablePointer<UTF16.CodeUnit>
 ) {
@@ -102,8 +105,9 @@ internal func _cocoaStringReadAll(
       location: 0, length: _swift_stdlib_CFStringGetLength(source)), destination)
 }
 
+@_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
-@inline(never) // Hide the CF dependency
+@inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
 internal func _cocoaStringSlice(
   _ target: _StringCore, _ bounds: Range<Int>
 ) -> _StringCore {
@@ -122,8 +126,9 @@ internal func _cocoaStringSlice(
   return String(_cocoaString: cfResult)._core
 }
 
-@_versioned // FIXME(sil-serialize-all)
-@inline(never) // Hide the CF dependency
+@_inlineable // FIXME(sil-serialize-all)
+@_versioned
+@inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
 internal func _cocoaStringSubscript(
   _ target: _StringCore, _ position: Int
 ) -> UTF16.CodeUnit {
@@ -146,7 +151,8 @@ internal var kCFStringEncodingASCII : _swift_shims_CFStringEncoding {
 }
 
 extension String {
-  @inline(never) // Hide the CF dependency
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
   public // SPI(Foundation)
   init(_cocoaString: AnyObject) {
     if let wrapped = _cocoaString as? _NSContiguousString {
@@ -368,7 +374,8 @@ extension String {
     return _NSContiguousString(_core)
   }
 
-  @inline(never) // Hide the CF dependency
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
   public func _bridgeToObjectiveCImpl() -> AnyObject {
     return _stdlib_binary_bridgeToObjectiveCImpl()
   }

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -77,7 +77,9 @@ extension String {
 #endif
 
   /// Compares two strings with the Unicode Collation Algorithm.
-  @inline(never) // Hide the CF/ICU dependency
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(never)
+  @_semantics("stdlib_binary_only") // Hide the CF/ICU dependency
   public  // @testable
   func _compareDeterministicUnicodeCollation(_ rhs: String) -> Int {
     // Note: this operation should be consistent with equality comparison of

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -82,8 +82,10 @@ extension Unicode {
   }
 }
 
+// FIXME: cannot be marked @_inlineable. See <rdar://problem/34438258>
+// @_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
-@inline(never) // Hide the CF dependency
+@inline(never) @_semantics("stdlib_binary_only") // Hide the CF dependency
 internal func _hashString(_ string: String) -> Int {
   let core = string._core
 #if _runtime(_ObjC)

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -16,6 +16,8 @@
 
 /// The compiler intrinsic which is called to lookup a string in a table
 /// of static string case values.
+@_inlineable // FIXME(sil-serialize-all)
+@_semantics("stdlib_binary_only")
 @_semantics("findStringSwitchCase")
 public // COMPILER_INTRINSIC
 func _findStringSwitchCase(
@@ -66,6 +68,8 @@ internal struct _StringSwitchContext {
 /// in \p cache. Consecutive calls use the cache for faster lookup.
 /// The \p cases array must not change between subsequent calls with the
 /// same \p cache.
+@_inlineable // FIXME(sil-serialize-all)
+@_semantics("stdlib_binary_only")
 @_semantics("findStringSwitchCaseWithCache")
 public // COMPILER_INTRINSIC
 func _findStringSwitchCaseWithCache(

--- a/test/SILOptimizer/Inputs/linker_pass_input.swift
+++ b/test/SILOptimizer/Inputs/linker_pass_input.swift
@@ -2,26 +2,23 @@
 @_silgen_name("unknown")
 public func unknown() -> ()
 
-@_inlineable
 public func doSomething() {
   unknown()
 }
 
+@_semantics("stdlib_binary_only")
 public func doSomething2() {
   unknown()
 }
 
 @inline(never)
+@_semantics("stdlib_binary_only")
 public func doSomething3<T>(_ a:T) {
   unknown()
 }
 
-@_versioned struct A {
-  @_versioned init() {}
-}
-
+struct A {}
 @inline(never)
-@_inlineable
 public func callDoSomething3() {
   doSomething3(A())
 }

--- a/test/SILOptimizer/linker.swift
+++ b/test/SILOptimizer/linker.swift
@@ -1,21 +1,23 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/Inputs/linker_pass_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
+// RUN: %target-swift-frontend -emit-module %S/Inputs/linker_pass_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -sil-serialize-all -module-link-name swiftCore
 // RUN: %target-swift-frontend %s -O -I %t -sil-debug-serialization -o - -emit-sil | %FileCheck %s
 
 // CHECK: sil public_external [serialized] @_T0s11doSomethingyyF : $@convention(thin) () -> () {
 doSomething()
 
-// CHECK: sil @_T0s12doSomething2yyF : $@convention(thin) () -> ()
+// Make sure we are not linking doSomething2 because it is marked with 'noimport'
+
+// CHECK: sil [_semantics "stdlib_binary_only"] @_T0s12doSomething2yyF : $@convention(thin) () -> ()
 // CHECK-NOT: return
 doSomething2()
 
-// CHECK: sil public_external [serialized] [noinline] @_T0s16callDoSomething3yyF
+// CHECK: sil public_external [serialized] [noinline] @{{.*}}callDoSomething3{{.*}}
 
 // CHECK: sil @unknown
 
-// CHECK: sil [noinline] @_T0s12doSomething3yxlF
+// CHECK: sil [serialized] [noinline] [_semantics "stdlib_binary_only"] @{{.*}}doSomething3{{.*}}
 // CHECK-NOT: return
 
-// CHECK: sil @_T0s1AVABycfC
+// CHECK: sil {{.*}} @_T0s1AV{{[_0-9a-zA-Z]*}}fC
 
 callDoSomething3()

--- a/test/SILOptimizer/specialization_of_stdlib_binary_only.swift
+++ b/test/SILOptimizer/specialization_of_stdlib_binary_only.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -sil-serialize-all -O -parse-stdlib -parse-as-library -emit-sil %s | %FileCheck %s
+
+// Make sure specialization of stdlib_binary_only functions are not marked
+// shared. Marking them shared would make their visibility hidden. Because
+// stdlib_binary_only implies public external linkage in other modules we would
+// get linking errors.
+
+@_silgen_name("unknown")
+public func unknown() -> ()
+
+@inline(never)
+@_semantics("stdlib_binary_only")
+public func doSomething3<T>(_ a:T) {
+    unknown()
+}
+
+struct A {}
+@inline(never)
+public func callDoSomething3() {
+    doSomething3(A())
+}
+
+// CHECK-NOT: sil {{.*}}shared{{.*}} {{.*}}12doSomething3

--- a/test/SILOptimizer/string_switch.swift
+++ b/test/SILOptimizer/string_switch.swift
@@ -2,6 +2,7 @@
 // RUN: %target-build-swift -O %s -module-name=test -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil | %FileCheck %s
 // RUN: %target-run %t.out
 // UNSUPPORTED: nonatomic_rc
+// UNSUPPORTED: resilient_stdlib
 
 import StdlibUnittest
 


### PR DESCRIPTION
Reverts apple/swift#12237. It still affects StdlibUnittest, which is still using -sil-serialize-all.