### PR TITLE
[AST] Strip InOutType when cloning a parameter.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4197,12 +4197,20 @@ ParamDecl::ParamDecl(Specifier specifier,
            "'var' cannot appear on parameters; you meant 'inout'");
 }
 
+// Remove the top-level inout type, if there is one.
+static Type removeInOutType(Type type) {
+  if (auto inOutType = type->getAs<InOutType>())
+    return inOutType->getObjectType();
+
+  return type;
+}
+
 /// Clone constructor, allocates a new ParamDecl identical to the first.
 /// Intentionally not defined as a copy constructor to avoid accidental copies.
 ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
   : VarDecl(DeclKind::Param, /*IsStatic*/false, PD->getSpecifier(),
             /*IsCaptureList*/false, PD->getNameLoc(), PD->getName(),
-            PD->hasType() && withTypes? PD->getType() : Type(),
+            PD->hasType() && withTypes? removeInOutType(PD->getType()) : Type(),
             PD->getDeclContext()),
     ArgumentName(PD->getArgumentName()),
     ArgumentNameLoc(PD->getArgumentNameLoc()),
@@ -4215,7 +4223,7 @@ ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
     typeLoc.setType(Type());
 
   if (withTypes && PD->hasInterfaceType())
-    setInterfaceType(PD->getInterfaceType());
+    setInterfaceType(removeInOutType(PD->getInterfaceType()));
 }
 
 

--- a/test/decl/inherit/initializer.swift
+++ b/test/decl/inherit/initializer.swift
@@ -150,3 +150,34 @@ func testClassInGenericFunc<T>(t: T) {
 
   _ = B(t: t)
 }
+
+// rdar://problem/34789779
+public class Node {
+  var data : Data
+
+  public struct Data {
+    var index: Int32 = 0// for helpers
+  }
+
+ init(data: inout Data/*, context: Context*/) {
+   self.data = data
+ }
+
+ public required init(node: Node) {
+   data = node.data
+ }
+}
+
+final class SubNode : Node {
+  var a: Int
+
+  required init(node: Node) {
+    a = 1
+    super.init(node: node)
+  }
+
+  init(data: inout Data, additionalParam: Int) {
+    a = additionalParam
+    super.init(data: &data)
+  }
+}

--- a/validation-test/compiler_crashers_2/0127-sr5546.swift
+++ b/validation-test/compiler_crashers_2/0127-sr5546.swift
@@ -1,0 +1,36 @@
+// RUN: not --crash %target-swift-frontend %s -typecheck
+public struct Foo<A, B, C> {}
+
+public protocol P {
+    associatedtype PA
+    associatedtype PB = Never
+    associatedtype PC = Never
+
+    typealias Context = Foo<PA, PB, PC>
+
+    func f1(_ x: Context, _ y: PA)
+    func f2(_ x: Context, _ y: PB)
+    func f3(_ x: Context, _ y: PC)
+    func f4(_ x: Context)
+}
+
+public extension P {
+    public func f1(_ x: Context, _ y: PA) {
+    }
+    public func f2(_ x: Context, _ y: PB) {
+    }
+    public func f3(_ x: Context, _ y: PC) {
+    }
+    public func f4(_ x: Context) {
+    }
+}
+
+public struct S: P {
+    public typealias PA = String
+    public typealias PB = Int
+
+    public func f1(_ x: Context, _ y: PA) {
+    }
+    public func f2(_ x: Context, _ y: PB) {
+    }
+}


### PR DESCRIPTION
Fixes rdar://problem/34789779, where initializer inheritance was breaking
in the presence of 'inout' parameters.