### PR TITLE
[Type checker] When type resolution fails, don't check bridgeable conformances

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -612,7 +612,7 @@ Type TypeChecker::applyUnboundGenericArguments(
                                 LookUpConformance(*this, dc),
                                 SubstFlags::UseErrorType);
 
-  if (isa<NominalTypeDecl>(decl)) {
+  if (isa<NominalTypeDecl>(decl) && resultType) {
     if (useObjectiveCBridgeableConformancesOfArgs(
           dc, resultType->castTo<BoundGenericType>(),
           unsatisfiedDependency))


### PR DESCRIPTION
Should address rdar://problem/34760012, although there isn't enough detail
there to be certain.
