### PR TITLE
Remove generic metadata pattern from nominal type descriptors.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1283,9 +1283,7 @@ struct TargetNominalTypeDescriptor {
     } Enum;
   };
   
-  RelativeDirectPointerIntPair<TargetGenericMetadata<Runtime>,
-                               NominalTypeKind, /*Nullable*/ true>
-    SadnessAndKind;
+  NominalTypeKind Kind;
 
   using NonGenericMetadataAccessFunction = const Metadata *();
 
@@ -1305,7 +1303,7 @@ struct TargetNominalTypeDescriptor {
   }
 
   NominalTypeKind getKind() const {
-    return SadnessAndKind.getInt();
+    return Kind;
   }
 
   int32_t offsetToNameOffset() const {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1285,7 +1285,7 @@ struct TargetNominalTypeDescriptor {
   
   RelativeDirectPointerIntPair<TargetGenericMetadata<Runtime>,
                                NominalTypeKind, /*Nullable*/ true>
-    GenericMetadataPatternAndKind;
+    SadnessAndKind;
 
   using NonGenericMetadataAccessFunction = const Metadata *();
 
@@ -1300,19 +1300,12 @@ struct TargetNominalTypeDescriptor {
   TargetRelativeDirectPointer<Runtime, NonGenericMetadataAccessFunction,
                               /*Nullable*/ true> AccessFunction;
 
-  /// A pointer to the generic metadata pattern that is used to instantiate
-  /// instances of this type. Zero if the type is not generic.
-  TargetGenericMetadata<Runtime> *getGenericMetadataPattern() const {
-    return const_cast<TargetGenericMetadata<Runtime>*>(
-                                    GenericMetadataPatternAndKind.getPointer());
-  }
-
   NonGenericMetadataAccessFunction *getAccessFunction() const {
     return AccessFunction.get();
   }
 
   NominalTypeKind getKind() const {
-    return GenericMetadataPatternAndKind.getInt();
+    return SadnessAndKind.getInt();
   }
 
   int32_t offsetToNameOffset() const {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2116,7 +2116,7 @@ namespace {
     void layout() {
       asImpl().addName();
       asImpl().addKindDependentFields();
-      asImpl().addGenericMetadataPatternAndKind();
+      asImpl().addKind();
       asImpl().addAccessFunction();
       asImpl().addGenericParams();
     }
@@ -2130,19 +2130,9 @@ namespace {
                                  /*willBeRelativelyAddressed*/ true));
     }
     
-    void addGenericMetadataPatternAndKind() {
-      NominalTypeDecl *ntd = asImpl().getTarget();
+    void addKind() {
       auto kind = asImpl().getKind();
-      if (!ntd->isGenericContext()) {
-        // There's no pattern to link.
-        B.addInt32(kind);
-        return;
-      }
-
-      B.addTaggedRelativeOffset(
-        IGM.RelativeAddressTy,
-        IGM.getAddrOfTypeMetadata(getAbstractType(), /*pattern*/ true),
-        kind);
+      B.addInt32(kind);
     }
 
     void addAccessFunction() {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1471,11 +1471,6 @@ swift::swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
   // even if Swift doesn't, because of SwiftObject.)
   rodata->InstanceStart = size;
 
-  auto genericPattern = self->getDescription()->getGenericMetadataPattern();
-  auto &allocator =
-    genericPattern ? unsafeGetInitializedCache(genericPattern).getAllocator()
-                   : getResilientMetadataAllocator();
-
   // Always clone the ivar descriptors.
   if (numFields) {
     const ClassIvarList *dependentIvars = rodata->IvarList;
@@ -1484,8 +1479,8 @@ swift::swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
 
     auto ivarListSize = sizeof(ClassIvarList) +
                         numFields * sizeof(ClassIvarEntry);
-    auto ivars = (ClassIvarList*) allocator.Allocate(ivarListSize,
-                                                     alignof(ClassIvarList));
+    auto ivars = (ClassIvarList*) getResilientMetadataAllocator()
+      .Allocate(ivarListSize, alignof(ClassIvarList));
     memcpy(ivars, dependentIvars, ivarListSize);
     rodata->IvarList = ivars;
 

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -21,8 +21,8 @@ import Swift
 // CHECK-SAME:   i32 15,
 // --       field names
 // CHECK-SAME:   [7 x i8]* [[ROOTGENERIC_FIELDS]]
-// --       generic metadata pattern
-// CHECK-SAME:   @_T015generic_classes11RootGenericCMP
+// --       kind 0 (class)
+// CHECK-SAME:   i32 0,
 // --       generic parameter vector offset
 // CHECK-SAME:   i32 10,
 // --       generic parameter count, primary count

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -19,8 +19,8 @@ import Builtin
 // CHECK-SAME:   i32 2,
 // --       field names
 // CHECK-SAME:   [3 x i8]* [[SINGLEDYNAMIC_FIELDS]]
-// --       generic metadata pattern, kind 1 (struct)
-// CHECK-SAME:   i32 add ({{.*}}@_T015generic_structs13SingleDynamicVMP{{.*}}, i32 1)
+// --       kind 1 (struct)
+// CHECK-SAME:   i32 1
 // --       generic parameter vector offset
 // CHECK-SAME:   i32 3,
 // --       generic parameter count, primary count
@@ -66,8 +66,8 @@ import Builtin
 // CHECK-SAME: i32 2,
 // --       field names
 // CHECK-SAME: [5 x i8]* [[DYNAMICWITHREQUIREMENTS_FIELDS]]
-// --       generic metadata pattern
-// CHECK-SAME: i32 add ({{.*}}@_T015generic_structs23DynamicWithRequirementsVMP{{.*}}, i32 1)
+// --       kind 1 (struct)
+// CHECK-SAME: i32 1,
 // --       generic parameter vector offset
 // CHECK-SAME: i32 4,
 // --       generic requirements count; generic arguments count


### PR DESCRIPTION
The NTD now references the metadata accessor function for the type, which is a better interface for most things one would want to do with type metadata from a nominal type. The only remaining use in the runtime self really has no requirement to do so. For now, don't disturb the rest of the binary layout to prevent breaking downstream clients too much at a time.