### PR TITLE
[stdlib] Implement slice Indices using their base Indices

### DIFF
--- a/stdlib/public/core/Indices.swift.gyb
+++ b/stdlib/public/core/Indices.swift.gyb
@@ -34,8 +34,8 @@ public struct ${Self}<
   Elements : ${collectionForTraversal(Traversal)}
 > : ${collectionForTraversal(Traversal)} {
 
-  // FIXME(compiler limitation): this typealias should be inferred.
   public typealias Index = Elements.Index
+  public typealias Indices = ${Self}<Elements>
 
   @_inlineable
   @_versioned
@@ -50,12 +50,12 @@ public struct ${Self}<
   }
 
   @_inlineable
-  public var startIndex: Elements.Index {
+  public var startIndex: Index {
     return _startIndex
   }
 
   @_inlineable
-  public var endIndex: Elements.Index {
+  public var endIndex: Index {
     return _endIndex
   }
 
@@ -65,7 +65,6 @@ public struct ${Self}<
     return i
   }
 
-  // FIXME(compiler limitation): this typealias should be inferred.
   public typealias SubSequence = ${Self}<Elements>
 
   @_inlineable
@@ -103,9 +102,6 @@ public struct ${Self}<
   }
 %     end
 
-  // FIXME(compiler limitation): this typealias should be inferred.
-  public typealias Indices = ${Self}<Elements>
-
   @_inlineable
   public var indices: Indices {
     return self
@@ -120,10 +116,7 @@ public struct ${Self}<
 }
 
 extension ${collectionForTraversal(Traversal)}
-%     if Traversal != 'RandomAccess':
-  where Indices == ${Self}<Self>
-%     end
-{
+where Indices == ${Self}<Self> {
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
   ///

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -116,8 +116,7 @@ public struct ${Self}<Base : ${BaseRequirements}>
   : ${SelfProtocols} {
 
   public typealias Index = Base.Index
-  public typealias IndexDistance = Base.IndexDistance
-  public typealias Indices = ${Indices}<${Self}<Base>>
+  public typealias IndexDistance = Base.IndexDistance  
 
   public var _startIndex: Index
   public var _endIndex: Index
@@ -164,13 +163,10 @@ public struct ${Self}<Base : ${BaseRequirements}>
 %     end
   }
 
-  // FIXME(ABI)#67 (Associated Types with where clauses):
-  //
-  //   public typealias Indices = Base.Indices
-  //   public var indices: Indices { ... }
-  //
-  // We can't do it right now because we don't have enough
-  // constraints on the Base.Indices type in this context.
+  public typealias Indices = Base.Indices
+  public var indices: Indices { 
+    return _base.indices[_startIndex..<_endIndex]
+  }
 
   @_inlineable // FIXME(sil-serialize-all)
   public func index(after i: Index) -> Index {

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -62,7 +62,7 @@ SliceTests.test("${Slice}/AssociatedTypes") {
       subSequenceType: CollectionSlice.self,
       indexType: MinimalIndex.self,
       indexDistanceType: Int.self,
-      indicesType: ${defaultIndicesForTraversal(Traversal)}<CollectionSlice>.self)
+      indicesType: Collection.Indices.self)
   }
 
   func checkStaticTypealiases1<Base : Collection>(_: Base) {


### PR DESCRIPTION
Resolves this issue:

```
// FIXME(ABI)#67 (Associated Types with where clauses):
//
//   public typealias Indices = Base.Indices
//   public var indices: Indices { ... }
//
// We can't do it right now because we don't have enough
// constraints on the Base.Indices type in this context.
```

Now that we are constraining `Collection.Indices` to be its own slice type we can implement a slice's `Indices` in terms of it.