### PR TITLE
[Stats] Add a test for long input-path bug (0e5b982d)

### DIFF
--- a/test/Misc/stats_dir_long_path_name.swift
+++ b/test/Misc/stats_dir_long_path_name.swift
@@ -1,0 +1,16 @@
+// REQUIRES: OS=macosx
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: mkdir -p %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents
+// RUN: cp %s %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
+// RUN: touch %t/main.swift
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %t/main.swift %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
+// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %FileCheck -input-file %t/frontend.csv %s
+
+// CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}
+// CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
+// CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
+
+public func foo() {
+    print("hello")
+}


### PR DESCRIPTION
Add a testcase for the bug in 0e5b982d where we were forming over-long stats-dir output filenames.