### PR TITLE
Rdar 34818636 backport pr 12257 stats output dir filename issues to swift 4.0 branch

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -88,7 +88,7 @@ auxName(StringRef ModuleName,
     InputName = "all";
   }
   if (OptType.empty()) {
-    InputName = "Onone";
+    OptType = "Onone";
   }
   if (!OutputType.empty() && OutputType.front() == '.') {
     OutputType = OutputType.substr(1);

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -87,6 +87,8 @@ auxName(StringRef ModuleName,
   if (InputName.empty()) {
     InputName = "all";
   }
+  // Dispose of path prefix, which might make composite name too long.
+  InputName = path::filename(InputName);
   if (OptType.empty()) {
     OptType = "Onone";
   }

--- a/test/Misc/stats_dir_long_path_name.swift
+++ b/test/Misc/stats_dir_long_path_name.swift
@@ -1,0 +1,16 @@
+// REQUIRES: OS=macosx
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: mkdir -p %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents
+// RUN: cp %s %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
+// RUN: touch %t/main.swift
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %t/main.swift %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
+// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %FileCheck -input-file %t/frontend.csv %s
+
+// CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}
+// CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
+// CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
+
+public func foo() {
+    print("hello")
+}


### PR DESCRIPTION
This is a backport of #12257 and #12279 to swift-4.0-branch to more-accurately gather stats there (in particular: dodge a data-loss issue when writing stats files to deeply-nested directories).

rdar://34818636