### PR TITLE
[test] XFAIL stdlib/Dispatch.swift on all ARM CPUs pending rdar://34751238.

### DIFF
--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -10,7 +10,7 @@
 // REQUIRES: objc_interop
 
 // FIXME: rdar://34751238 DispatchTime.addSubtract test traps
-// XFAIL: CPU=armv7 || CPU=armv7k || CPU=armv7s
+// XFAIL: CPU=armv7 || CPU=armv7k || CPU=armv7s || CPU=arm64
 
 
 import Dispatch


### PR DESCRIPTION
Previous XFAIL (#12259) was only for 32-bit ARM, but 64-bit ARM is also affected.