### PR TITLE
[Type checker] Drop parameter 'inout' types in a few more places.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2075,7 +2075,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
         classDecl->getGenericEnvironment());
 
     for (auto *decl : *bodyParams) {
-      auto paramTy = decl->getInterfaceType();
+      auto paramTy = decl->getInterfaceType()->getInOutObjectType();
 
       // Apply the superclass substitutions to produce a contextual
       // type in terms of the derived class archetypes.
@@ -2089,7 +2089,9 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   } else {
     for (auto *decl : *bodyParams) {
       if (!decl->hasType())
-        decl->setType(classDecl->mapTypeIntoContext(decl->getInterfaceType()));
+        decl->setType(
+          classDecl->mapTypeIntoContext(
+            decl->getInterfaceType()->getInOutObjectType()));
     }
   }
 

--- a/test/decl/inherit/initializer.swift
+++ b/test/decl/inherit/initializer.swift
@@ -168,7 +168,7 @@ public class Node {
  }
 }
 
-final class SubNode : Node {
+class SubNode : Node {
   var a: Int
 
   required init(node: Node) {
@@ -179,5 +179,30 @@ final class SubNode : Node {
   init(data: inout Data, additionalParam: Int) {
     a = additionalParam
     super.init(data: &data)
+  }
+}
+
+class GenericSubNode<T> : SubNode {
+  required init(node: Node) {
+    super.init(node: node)
+  }
+
+  init(data: inout Data, value: T) {
+    super.init(data: &data, additionalParam: 1)
+  }
+}
+
+protocol HasValue {
+  associatedtype Value
+  func getValue() -> Value
+}
+
+class GenericWrapperNode<T : HasValue> : GenericSubNode<T.Value> {
+  required init(node: Node) {
+    super.init(node: node)
+  }
+
+  init(data: inout Data, otherValue: T) {
+    super.init(data: &data, value: otherValue.getValue())
   }
 }


### PR DESCRIPTION
Follow-up to my earlier changes to drop 'inout' types when cloning parameter
lists, we also need to deal with substitutions into those parameter types.
This is an artifact of us having mostly---but not entirely---removed
InOutType from the AST. Fixes rdar://problem/34818336.
