### PR TITLE
[swiftc (57 vs. 5600)] Add crasher in swift::GenericSignature::getConformanceAccessPath

### DIFF
--- a/validation-test/compiler_crashers/28851-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
+++ b/validation-test/compiler_crashers/28851-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:a{{}typealias a=a{}func a{}typealias a}class a:A{func a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getConformanceAccessPath`.

Current number of unresolved compiler crashers: 57 (5600 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasConformanceInSignature(inProtocol->getRequirementSignature(), subjectType, conformingProto) && "missing explicit conformance in requirement signature"` added on 2017-03-08 by you in commit 1f8b0f9b :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 854)`](https://github.com/apple/swift/blob/38bf97bacb7aa9304cf22fdc4c261e7ed70499b7/lib/AST/GenericSignature.cpp#L854):

```
Assertion `hasConformanceInSignature(inProtocol->getRequirementSignature(), subjectType, conformingProto) && "missing explicit conformance in requirement signature"' failed.

When executing: auto swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl *, swift::ModuleDecl &)::(anonymous class)::operator()(ArrayRef<swift::Requirement>, const RequirementSource *, swift::ProtocolDecl *, swift::Type, swift::ProtocolDecl *) const
```

Assertion context:

```c++
          ->getCanonicalTypeInContext(subjectType,
                                      *inProtocol->getParentModule());

        assert(hasConformanceInSignature(inProtocol->getRequirementSignature(),
                                         subjectType, conformingProto) &&
               "missing explicit conformance in requirement signature");

        // Record this step.
        path.path.push_back({subjectType, conformingProto});
        return;
      }
```
Stack trace:

```
0 0x0000000003ea2314 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ea2314)
1 0x0000000003ea2656 SignalHandler(int) (/path/to/swift/bin/swift+0x3ea2656)
2 0x00007f052cd8f390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f052b2b4428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f052b2b602a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f052b2acbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f052b2acc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001671e89 std::_Function_handler<void (llvm::ArrayRef<swift::Requirement>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type, swift::ProtocolDecl*), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, llvm::ArrayRef<swift::Requirement>&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&, swift::ProtocolDecl*&&) (/path/to/swift/bin/swift+0x1671e89)
8 0x00000000016721ca std::_Function_handler<void (llvm::ArrayRef<swift::Requirement>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type, swift::ProtocolDecl*), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, llvm::ArrayRef<swift::Requirement>&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&, swift::ProtocolDecl*&&) (/path/to/swift/bin/swift+0x16721ca)
9 0x0000000001670b39 swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x1670b39)
10 0x00000000016d72f5 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x16d72f5)
11 0x00000000016717ae bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const::$_8>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0x16717ae)
12 0x000000000166e677 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0x166e677)
13 0x000000000166fc52 swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x166fc52)
14 0x00000000012eb8bb (anonymous namespace)::RequirementMatch::getWitness(swift::ASTContext&, (anonymous namespace)::RequirementEnvironment&&) const (/path/to/swift/bin/swift+0x12eb8bb)
15 0x00000000012f0556 (anonymous namespace)::ConformanceChecker::recordWitness(swift::ValueDecl*, (anonymous namespace)::RequirementMatch const&, (anonymous namespace)::RequirementEnvironment&&) (/path/to/swift/bin/swift+0x12f0556)
16 0x00000000012ee269 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12ee269)
17 0x00000000012e3eae (anonymous namespace)::MultiConformanceChecker::checkAllConformances() (/path/to/swift/bin/swift+0x12e3eae)
18 0x00000000012e542a swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x12e542a)
19 0x00000000012b2a9d (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b2a9d)
20 0x00000000012a0a1e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a0a1e)
21 0x00000000012a07c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a07c3)
22 0x00000000013313aa swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13313aa)
23 0x0000000001054ae4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1054ae4)
24 0x0000000001053ba7 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1053ba7)
25 0x00000000010534ca swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x10534ca)
26 0x00000000004bdb56 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdb56)
27 0x00000000004bc919 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc919)
28 0x0000000000474c14 main (/path/to/swift/bin/swift+0x474c14)
29 0x00007f052b29f830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x00000000004724c9 _start (/path/to/swift/bin/swift+0x4724c9)
```