### PR TITLE
[swiftc (58 vs. 5600)] Add crasher in swift::GenericSignatureBuilder::addRequirement

### DIFF
--- a/validation-test/compiler_crashers/28852-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
+++ b/validation-test/compiler_crashers/28852-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension P{}
+protocol P{{}typealias e:A
+protocol A{{}typealias e where f=a
+{}class a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::addRequirement`.

Current number of unresolved compiler crashers: 58 (5600 resolved)

Stack trace:

```
0 0x0000000003ea2314 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ea2314)
1 0x0000000003ea2656 SignalHandler(int) (/path/to/swift/bin/swift+0x3ea2656)
2 0x00007fcbc7c11390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x0000000001682dd4 swift::GenericSignatureBuilder::addRequirement(swift::RequirementRepr const*, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::SubstitutionMap const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1682dd4)
4 0x0000000001680f62 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x1680f62)
5 0x000000000168511a swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x168511a)
6 0x000000000169bfe3 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x169bfe3)
7 0x0000000001692ac2 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1692ac2)
8 0x000000000168084e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x168084e)
9 0x0000000001680e49 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x1680e49)
10 0x000000000168511a swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x168511a)
11 0x0000000001682a5b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x1682a5b)
12 0x0000000001690d82 swift::GenericSignatureBuilder::computeRequirementSignature(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1690d82)
13 0x000000000164ce56 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x164ce56)
14 0x00000000012d4b38 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12d4b38)
15 0x00000000012a2798 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a2798)
16 0x00000000012a2289 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a2289)
17 0x00000000012a2289 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a2289)
18 0x00000000016c17eb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0x16c17eb)
19 0x00000000016bf7b4 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0x16bf7b4)
20 0x00000000012d6f68 swift::TypeChecker::lookupUnqualifiedType(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12d6f68)
21 0x0000000001328af6 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1328af6)
22 0x00000000013230a6 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13230a6)
23 0x0000000001322a5a swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1322a5a)
24 0x00000000013237f0 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13237f0)
25 0x00000000013236fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13236fc)
26 0x0000000001321ff5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1321ff5)
27 0x00000000012d1060 swift::TypeChecker::validateRequirement(swift::SourceLoc, swift::RequirementRepr&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12d1060)
28 0x00000000012d0ef6 swift::TypeChecker::validateRequirements(swift::SourceLoc, llvm::MutableArrayRef<swift::RequirementRepr>, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::GenericSignatureBuilder*) (/path/to/swift/bin/swift+0x12d0ef6)
29 0x0000000001298496 swift::TypeChecker::validateWhereClauses(swift::ProtocolDecl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1298496)
30 0x000000000129b850 swift::TypeChecker::validateDeclForNameLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0x129b850)
31 0x00000000016c17eb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0x16c17eb)
32 0x00000000016bf7b4 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0x16bf7b4)
33 0x00000000012d6f68 swift::TypeChecker::lookupUnqualifiedType(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12d6f68)
34 0x0000000001328af6 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1328af6)
35 0x00000000013230a6 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13230a6)
36 0x0000000001322a5a swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1322a5a)
37 0x00000000013237f0 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13237f0)
38 0x00000000013236fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13236fc)
39 0x0000000001321ff5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1321ff5)
40 0x00000000013e9801 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x13e9801)
41 0x00000000013b27a6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x13b27a6)
42 0x00000000012985f9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12985f9)
43 0x0000000001680764 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1680764)
44 0x0000000001680e49 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x1680e49)
45 0x000000000168511a swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x168511a)
46 0x0000000001682a5b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x1682a5b)
47 0x0000000001690a1d swift::GenericSignatureBuilder::addGenericSignature(swift::GenericSignature*) (/path/to/swift/bin/swift+0x1690a1d)
48 0x000000000159f106 swift::ASTContext::getOrCreateGenericSignatureBuilder(swift::CanGenericSignature, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x159f106)
49 0x00000000012d4965 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, swift::ExtensionDecl*, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x12d4965)
50 0x00000000012a7b74 checkExtensionGenericParams(swift::TypeChecker&, swift::ExtensionDecl*, swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x12a7b74)
51 0x000000000129a90f swift::TypeChecker::validateExtension(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x129a90f)
52 0x00000000012b1eab (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12b1eab)
53 0x00000000012a095f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a095f)
54 0x00000000012a07c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a07c3)
55 0x0000000001331325 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1331325)
56 0x0000000001054ae4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1054ae4)
57 0x0000000001053ba7 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1053ba7)
58 0x00000000010534ca swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x10534ca)
59 0x00000000004bdb56 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdb56)
60 0x00000000004bc919 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc919)
61 0x0000000000474c14 main (/path/to/swift/bin/swift+0x474c14)
62 0x00007fcbc6121830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
63 0x00000000004724c9 _start (/path/to/swift/bin/swift+0x4724c9)
```