### PR TITLE
Runtime: avoid an assertion in lldb

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -690,6 +690,8 @@ public:
 
     switch (Meta->getKind()) {
     case MetadataKind::Class:
+      if (!cast<TargetClassMetadata<Runtime>>(Meta)->isTypeMetadata())
+        return BuiltType();
       return readNominalTypeFromMetadata(Meta, skipArtificialSubclasses);
     case MetadataKind::Struct:
       return readNominalTypeFromMetadata(Meta);


### PR DESCRIPTION
When lldb is running the testsuite, it can result in this assertion triggering.
However, since we now have an absolute pointer, we do not do any pointer
tagging, so remove the assertion.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
