### PR TITLE
[swiftc (59 vs. 5600)] Add crasher in swift::TypeBase::getContextSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28853-result-second.swift
+++ b/validation-test/compiler_crashers/28853-result-second.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func a<a{
+extension{{}
+{
+}
+class a<a{
+class a{protocol
+protocol{protocol A typealias e:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getContextSubstitutions`.

Current number of unresolved compiler crashers: 59 (5600 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `result.second` added on 2017-03-07 by you in commit 3d4503a9 :-)

Assertion failure in [`lib/AST/Type.cpp (line 3322)`](https://github.com/apple/swift/blob/ae41fa9dc38ca3547574bf212329b5792493cff5/lib/AST/Type.cpp#L3322):

```
Assertion `result.second' failed.

When executing: TypeSubstitutionMap swift::TypeBase::getContextSubstitutions(const swift::DeclContext *, swift::GenericEnvironment *)
```

Assertion context:

```c++
    if (auto *outerSig = parentDC->getGenericSignatureOfContext()) {
      for (auto gp : outerSig->getGenericParams()) {
        auto result = substitutions.insert(
          {gp->getCanonicalType()->castTo<GenericTypeParamType>(),
           genericEnv->mapTypeIntoContext(gp)});
        assert(result.second);
        (void) result;
      }
    }
  }

```
Stack trace:

```
0 0x0000000003ea2314 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ea2314)
1 0x0000000003ea2656 SignalHandler(int) (/path/to/swift/bin/swift+0x3ea2656)
2 0x00007feafa6c7390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007feaf8bec428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007feaf8bee02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007feaf8be4bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007feaf8be4c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016e5304 swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x16e5304)
8 0x00000000016e0af0 swift::TypeBase::getContextSubstitutionMap(swift::ModuleDecl*, swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x16e0af0)
9 0x0000000001692c22 swift::GenericSignatureBuilder::InferRequirementsWalker::walkToTypePost(swift::Type) (/path/to/swift/bin/swift+0x1692c22)
10 0x00000000016f317d swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x16f317d)
11 0x00000000016f31a0 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x16f31a0)
12 0x00000000016f31a0 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x16f31a0)
13 0x00000000016f2114 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x16f2114)
14 0x000000000169bf91 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x169bf91)
15 0x0000000001692ac2 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1692ac2)
16 0x000000000168084e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x168084e)
17 0x0000000001680e49 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x1680e49)
18 0x000000000168511a swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x168511a)
19 0x0000000001682a5b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x1682a5b)
20 0x0000000001690d82 swift::GenericSignatureBuilder::computeRequirementSignature(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1690d82)
21 0x000000000164ce56 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x164ce56)
22 0x00000000012d4b38 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12d4b38)
23 0x00000000012a2798 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a2798)
24 0x00000000012b3aa4 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b3aa4)
25 0x00000000012a092f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a092f)
26 0x00000000012b2acb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b2acb)
27 0x00000000012a0a1e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a0a1e)
28 0x00000000012b2acb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b2acb)
29 0x00000000012a0a1e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a0a1e)
30 0x00000000012b211b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12b211b)
31 0x00000000012a095f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a095f)
32 0x00000000012a07c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a07c3)
33 0x0000000001311f95 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1311f95)
34 0x00000000013110f6 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0x13110f6)
35 0x000000000131035a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x131035a)
36 0x0000000001310205 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1310205)
37 0x0000000001310d6d swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1310d6d)
38 0x000000000133084c typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x133084c)
39 0x000000000133141d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x133141d)
40 0x0000000001054ae4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1054ae4)
41 0x0000000001053ba7 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1053ba7)
42 0x00000000010534ca swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x10534ca)
43 0x00000000004bdb56 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdb56)
44 0x00000000004bc919 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bc919)
45 0x0000000000474c14 main (/path/to/swift/bin/swift+0x474c14)
46 0x00007feaf8bd7830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
47 0x00000000004724c9 _start (/path/to/swift/bin/swift+0x4724c9)
```