### PR TITLE
Add optimization remarks

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -32,6 +32,7 @@ namespace swift {
 enum class DiagnosticKind : uint8_t {
   Error,
   Warning,
+  Remark,
   Note
 };
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -435,6 +435,7 @@ namespace swift {
       Unspecified,
       Ignore,
       Note,
+      Remark,
       Warning,
       Error,
       Fatal,

--- a/include/swift/AST/DiagnosticsAll.def
+++ b/include/swift/AST/DiagnosticsAll.def
@@ -33,6 +33,11 @@
   DIAG(NOTE,ID,Options,Text,Signature)
 #endif
 
+#ifndef REMARK
+#  define REMARK(ID,Options,Text,Signature) \
+  DIAG(REMARK,ID,Options,Text,Signature)
+#endif
+
 #define DIAG_NO_UNDEF
 
 #include "DiagnosticsCommon.def"
@@ -53,3 +58,4 @@
 #undef NOTE
 #undef WARNING
 #undef ERROR
+#undef REMARK

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -202,6 +202,9 @@ WARNING(cannot_assign_value_to_conditional_compilation_flag,none,
         "conditional compilation flags do not have values in Swift; they are "
         "either present or absent (rather than '%0')", (StringRef))
 
+ERROR(error_optimization_remark_pattern, none, "%0 in '%1'",
+      (StringRef, StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !(defined(DIAG) || (defined(ERROR) && defined(WARNING) && defined(NOTE)))
-#  error Must define either DIAG or the set {ERROR,WARNING,NOTE}
+#if !(defined(DIAG) || (defined(ERROR) && defined(WARNING) && defined(NOTE) && defined(REMARK)))
+#  error Must define either DIAG or the set {ERROR,WARNING,NOTE,REMARK}
 #endif
 
 #ifndef ERROR
@@ -34,6 +34,11 @@
 #ifndef NOTE
 #  define NOTE(ID,Options,Text,Signature) \
   DIAG(NOTE,ID,Options,Text,Signature)
+#endif
+
+#ifndef REMARK
+#  define REMARK(ID,Options,Text,Signature) \
+  DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
 
@@ -291,11 +296,14 @@ ERROR(shifting_all_significant_bits,none,
 ERROR(static_report_error, none,
       "static report error", ())
 
+REMARK(opt_remark_passed, none, "%0", (StringRef))
+REMARK(opt_remark_missed, none, "%0", (StringRef))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG
 # endif
+# undef REMARK
 # undef NOTE
 # undef WARNING
 # undef ERROR

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Triple.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
 #include <vector>
@@ -235,7 +236,13 @@ namespace swift {
 
     /// Diagnose uses of NSCoding with classes that have unstable mangled names.
     bool EnableNSKeyedArchiverDiagnostics = true;
-    
+
+    /// Regex for the passes that should report passed and missed optimizations.
+    ///
+    /// These are shared_ptrs so that this class remains copyable.
+    std::shared_ptr<llvm::Regex> OptimizationRemarkPassedPattern;
+    std::shared_ptr<llvm::Regex> OptimizationRemarkMissedPattern;
+
     /// When a conversion from String to Substring fails, emit a fix-it to append
     /// the void subscript '[]'.
     /// FIXME: Remove this flag when void subscripts are implemented.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -321,6 +321,16 @@ def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
   Alias<warn_swift3_objc_inference_complete>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
+def Rpass_EQ : Joined<["-"], "Rpass=">,
+  Flags<[FrontendOption]>,
+  HelpText<"Report performed transformations by optimization passes whose "
+           "name matches the given POSIX regular expression">;
+
+def Rpass_missed_EQ : Joined<["-"], "Rpass-missed=">,
+  Flags<[FrontendOption]>,
+  HelpText<"Report missed transformations by optimization passes whose "
+           "name matches the given POSIX regular expression">;
+
 // Platform options.
 def enable_app_extension : Flag<["-"], "application-extension">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -1,0 +1,137 @@
+//===--- OptimizationRemark.h - Optimization diagnostics --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// This file defines the remark type and the emitter class that passes can use
+/// to emit optimization diagnostics.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_OPTIMIZATIONREMARKEMITTER_H
+#define SWIFT_SIL_OPTIMIZATIONREMARKEMITTER_H
+
+#include "swift/Basic/SourceLoc.h"
+#include "swift/SIL/SILInstruction.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+
+class ASTContext;
+class SILFunction;
+
+namespace OptRemark {
+
+/// \brief Used in the streaming interface as the general argument type.  It
+/// internally converts everything into a key-value pair.
+struct Argument {
+  std::string Key;
+  std::string Val;
+  /// If set, the debug location corresponding to the value.
+  SourceLoc Loc;
+
+  explicit Argument(StringRef Str = "") : Key("String"), Val(Str) {}
+
+  Argument(StringRef Key, int N);
+  Argument(StringRef Key, long N);
+  Argument(StringRef Key, long long N);
+  Argument(StringRef Key, unsigned N);
+  Argument(StringRef Key, unsigned long N);
+  Argument(StringRef Key, unsigned long long N);
+
+  Argument(StringRef Key, SILFunction *F);
+};
+
+/// Shorthand to insert named-value pairs.
+using NV = Argument;
+
+/// The base class for remarks.  This can be created by optimization passed to
+/// report successful and unsuccessful optimizations. CRTP is used to preserve
+/// the underlying type encoding the remark kind in the insertion operator.
+template <typename DerivedT> class Remark {
+  /// Arguments collected via the streaming interface.
+  SmallVector<Argument, 4> Args;
+
+  /// Textual identifier for the remark (single-word, camel-case). Can be used
+  /// by external tools reading the YAML output file for optimization remarks to
+  /// identify the remark.
+  StringRef Identifier;
+
+  /// Source location for the diagnostics.
+  SourceLoc Location;
+
+protected:
+  Remark(StringRef Identifier, SILInstruction &I)
+      : Identifier(Identifier), Location(I.getLoc().getSourceLoc()) {}
+
+public:
+  DerivedT &operator<<(StringRef S) {
+    Args.emplace_back(S);
+    return *static_cast<DerivedT *>(this);
+  }
+
+  DerivedT &operator<<(Argument A) {
+    Args.push_back(std::move(A));
+    return *static_cast<DerivedT *>(this);
+  }
+
+  SourceLoc getLocation() const { return Location; }
+  std::string getMsg() const;
+};
+
+/// Remark to report a successful optimization.
+struct RemarkPassed : public Remark<RemarkPassed> {
+  RemarkPassed(StringRef Id, SILInstruction &I) : Remark(Id, I) {}
+};
+/// Remark to report a unsuccessful optimization.
+struct RemarkMissed : public Remark<RemarkMissed> {
+  RemarkMissed(StringRef Id, SILInstruction &I) : Remark(Id, I) {}
+};
+
+/// Used to emit the remarks.  Passes reporting remarks should create an
+/// instance of this.
+class Emitter {
+  ASTContext &Ctx;
+  std::string PassName;
+  bool PassedEnabled;
+  bool MissedEnabled;
+
+  void emit(const RemarkPassed &R);
+  void emit(const RemarkMissed &R);
+
+  template <typename RemarkT> bool isEnabled();
+
+public:
+  Emitter(StringRef PassName, ASTContext &Ctx);
+
+  /// \brief Take a lambda that returns a remark which will be emitted.  The
+  /// lambda is not evaluated unless remarks are enabled.  Second argument is
+  /// only used to restrict this to functions.
+  template <typename T>
+  void emit(T RemarkBuilder, decltype(RemarkBuilder()) * = nullptr) {
+    using RemarkT = decltype(RemarkBuilder());
+    // Avoid building the remark unless remarks are enabled.
+    if (isEnabled<RemarkT>()) {
+      auto R = RemarkBuilder();
+      emit(R);
+    }
+  }
+};
+
+template <> inline bool Emitter::isEnabled<RemarkMissed>() {
+  return MissedEnabled;
+}
+template <> inline bool Emitter::isEnabled<RemarkPassed>() {
+  return PassedEnabled;
+}
+} // namespace OptRemark
+} // namespace swift
+#endif

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -79,6 +79,8 @@ static StoredDiagnosticInfo storedDiagnosticInfos[] = {
   StoredDiagnosticInfo(DiagnosticKind::Warning, DiagnosticOptions::Options),
 #define NOTE(ID, Options, Text, Signature)                                     \
   StoredDiagnosticInfo(DiagnosticKind::Note, DiagnosticOptions::Options),
+#define REMARK(ID, Options, Text, Signature)                                   \
+  StoredDiagnosticInfo(DiagnosticKind::Remark, DiagnosticOptions::Options),
 #include "swift/AST/DiagnosticsAll.def"
 };
 static_assert(sizeof(storedDiagnosticInfos) / sizeof(StoredDiagnosticInfo) ==
@@ -89,6 +91,7 @@ static const char *diagnosticStrings[] = {
 #define ERROR(ID, Options, Text, Signature) Text,
 #define WARNING(ID, Options, Text, Signature) Text,
 #define NOTE(ID, Options, Text, Signature) Text,
+#define REMARK(ID, Options, Text, Signature) Text,
 #include "swift/AST/DiagnosticsAll.def"
     "<not a diagnostic>",
 };
@@ -578,6 +581,8 @@ static DiagnosticKind toDiagnosticKind(DiagnosticState::Behavior behavior) {
     return DiagnosticKind::Note;
   case DiagnosticState::Behavior::Warning:
     return DiagnosticKind::Warning;
+  case DiagnosticState::Behavior::Remark:
+    return DiagnosticKind::Remark;
   }
 
   llvm_unreachable("Unhandled DiagnosticKind in switch.");
@@ -641,6 +646,8 @@ DiagnosticState::Behavior DiagnosticState::determineBehavior(DiagID id) {
     return set(diagInfo.isFatal ? Behavior::Fatal : Behavior::Error);
   case DiagnosticKind::Warning:
     return set(Behavior::Warning);
+  case DiagnosticKind::Remark:
+    return set(Behavior::Remark);
   }
 
   llvm_unreachable("Unhandled DiagnosticKind in switch.");

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -142,6 +142,8 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_solver_memory_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_value_recursion_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_warn_swift3_objc_inference);
+  inputArgs.AddLastArg(arguments, options::OPT_Rpass_EQ);
+  inputArgs.AddLastArg(arguments, options::OPT_Rpass_missed_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_warnings);
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -67,6 +67,7 @@ static std::string getDiagKindString(llvm::SourceMgr::DiagKind Kind) {
   case llvm::SourceMgr::DK_Error: return "error";
   case llvm::SourceMgr::DK_Warning: return "warning";
   case llvm::SourceMgr::DK_Note: return "note";
+  case llvm::SourceMgr::DK_Remark: return "remark";
   }
 
   llvm_unreachable("Unhandled DiagKind in switch.");

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -80,9 +80,13 @@ void PrintingDiagnosticConsumer::handleDiagnostic(
     case DiagnosticKind::Warning: 
       SMKind = llvm::SourceMgr::DK_Warning; 
       break;
-      
-    case DiagnosticKind::Note: 
-      SMKind = llvm::SourceMgr::DK_Note; 
+
+    case DiagnosticKind::Note:
+      SMKind = llvm::SourceMgr::DK_Note;
+      break;
+
+    case DiagnosticKind::Remark:
+      SMKind = llvm::SourceMgr::DK_Remark;
       break;
   }
 

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -295,6 +295,8 @@ static clang::serialized_diags::Level getDiagnosticLevel(DiagnosticKind Kind) {
     return clang::serialized_diags::Note;
   case DiagnosticKind::Warning:
     return clang::serialized_diags::Warning;
+  case DiagnosticKind::Remark:
+    return clang::serialized_diags::Remark;
   }
 
   llvm_unreachable("Unhandled DiagnosticKind in switch.");

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -7,6 +7,7 @@ add_swift_library(swiftSIL STATIC
   InstructionUtils.cpp
   Linker.cpp
   LoopInfo.cpp
+  OptimizationRemark.cpp
   PrettyStackTrace.cpp
   Projection.cpp
   SIL.cpp

--- a/lib/SIL/OptimizationRemark.cpp
+++ b/lib/SIL/OptimizationRemark.cpp
@@ -1,0 +1,81 @@
+//===--- OptimizationRemark.cpp - Optimization diagnostics ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// This file defines the remark type and the emitter class that passes can use
+/// to emit optimization diagnostics.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/OptimizationRemark.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/SIL/SILFunction.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+using namespace OptRemark;
+
+Argument::Argument(StringRef Key, int N) : Key(Key), Val(llvm::itostr(N)) {}
+
+Argument::Argument(StringRef Key, long N) : Key(Key), Val(llvm::itostr(N)) {}
+
+Argument::Argument(StringRef Key, long long N)
+    : Key(Key), Val(llvm::itostr(N)) {}
+
+Argument::Argument(StringRef Key, unsigned N)
+    : Key(Key), Val(llvm::utostr(N)) {}
+
+Argument::Argument(StringRef Key, unsigned long N)
+    : Key(Key), Val(llvm::utostr(N)) {}
+
+Argument::Argument(StringRef Key, unsigned long long N)
+    : Key(Key), Val(llvm::utostr(N)) {}
+
+Argument::Argument(StringRef Key, SILFunction *F)
+    : Key(Key), Val(F->getName()) {
+  if (F->hasLocation())
+    Loc = F->getLocation().getSourceLoc();
+}
+
+template <typename DerivedT> std::string Remark<DerivedT>::getMsg() const {
+  std::string Str;
+  llvm::raw_string_ostream OS(Str);
+  for (const Argument &Arg : Args)
+    OS << Arg.Val;
+  return OS.str();
+}
+
+Emitter::Emitter(StringRef PassName, ASTContext &Ctx)
+    : Ctx(Ctx), PassName(PassName),
+      PassedEnabled(
+          Ctx.LangOpts.OptimizationRemarkPassedPattern &&
+          Ctx.LangOpts.OptimizationRemarkPassedPattern->match(PassName)),
+      MissedEnabled(
+          Ctx.LangOpts.OptimizationRemarkMissedPattern &&
+          Ctx.LangOpts.OptimizationRemarkMissedPattern->match(PassName)) {}
+
+template <typename RemarkT, typename... ArgTypes>
+static void emitRemark(ASTContext &Ctx, const RemarkT &R,
+                       Diag<ArgTypes...> ID) {
+  Ctx.Diags.diagnose(R.getLocation(), ID, R.getMsg());
+}
+
+void Emitter::emit(const RemarkPassed &R) {
+  emitRemark(Ctx, R, diag::opt_remark_passed);
+}
+
+void Emitter::emit(const RemarkMissed &R) {
+  emitRemark(Ctx, R, diag::opt_remark_missed);
+}

--- a/test/Driver/opt-remark.swift
+++ b/test/Driver/opt-remark.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swiftc_driver -O %s -o /dev/null 2>&1 | %FileCheck -allow-empty -check-prefix=DEFAULT %s
+// RUN: %target-swiftc_driver -O -Rpass=sil-inliner %s -o /dev/null 2>&1 | %FileCheck -check-prefix=REMARK_PASSED %s
+// RUN: %target-swiftc_driver -O -Rpass-missed=sil-inliner %s -o /dev/null 2>&1 | %FileCheck -check-prefix=REMARK_MISSED %s
+
+// DEFAULT-NOT: remark
+
+func big() {
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+  print("hello")
+}
+
+func small() {
+  print("hello")
+}
+
+func foo() {
+  // REMARK_MISSED-NOT: remark: {{.*}} inlined
+  // REMARK_MISSED: opt-remark.swift:43:2: remark: Not profitable to inline (cost = {{.*}}, benefit = {{.*}})
+  // REMARK_MISSED-NOT: remark: {{.*}} inlined
+	big()
+  // REMARK_PASSED-NOT: remark: Not profitable
+  // REMARK_PASSED: opt-remark.swift:47:3: remark: _T04null5smallyyF inlined into _T04null3fooyyF (cost = {{.*}}, benefit = {{.*}})
+  // REMARK_PASSED-NOT: remark: Not profitable
+  small()
+}

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -1,5 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-remarks=sil-inliner -o %t.sil 2>&1 | %FileCheck -check-prefix=REMARKS_PASSED %s
+// RUN: %FileCheck %s < %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-remarks-missed=sil-inliner -o /dev/null 2>&1 | %FileCheck -check-prefix=REMARKS_MISSED %s
+
+// REMARKS_PASSED-NOT: remark:
+// REMARKS_MISSED-NOT: remark:
 
 sil_stage canonical
 
@@ -185,6 +190,7 @@ bb0:
   %c30 = builtin "assert_configuration"() : $Builtin.Int32
 
   %f = function_ref @update_global: $@convention(thin) () -> ()
+  // REMARKS_PASSED: inliner_coldblocks.sil:194:3: remark: update_global inlined into regular_large_callee (cost = {{.*}}, benefit = {{.*}})
   apply %f() : $@convention(thin) () -> ()
 
   %r = tuple ()
@@ -198,6 +204,7 @@ bb0:
 sil @dont_inline_regular_large_callee : $@convention(thin) () -> () {
 bb0:
   %f = function_ref @regular_large_callee : $@convention(thin) () -> ()
+  // REMARKS_MISSED: inliner_coldblocks.sil:208:8: remark: Not profitable to inline (cost = {{.*}}, benefit = {{.*}})
   %a = apply %f() : $@convention(thin) () -> ()
   %r = tuple ()
   return %r : $()
@@ -252,3 +259,5 @@ bb0:
   return %r : $()
 }
 
+// REMARKS_PASSED-NOT: remark:
+// REMARKS_MISSED-NOT: remark:

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -55,6 +55,7 @@ public:
       case DiagnosticKind::Error: OS << "error: "; break;
       case DiagnosticKind::Warning: OS << "warning: "; break;
       case DiagnosticKind::Note: OS << "note: "; break;
+      case DiagnosticKind::Remark: OS << "remark: "; break;
     }
     DiagnosticEngine::formatDiagnosticText(OS, FormatString, FormatArgs);
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -69,6 +69,12 @@ void EditorDiagConsumer::handleDiagnostic(
     // Is this possible?
     return;
 
+  if (Kind == DiagnosticKind::Remark) {
+    // FIXME: we may want to handle optimization remarks in sourcekitd.
+    LOG_WARN_FUNC("unhandled optimization remark");
+    return;
+  }
+
   DiagnosticEntryInfo SKInfo;
 
   // Actually substitute the diagnostic arguments into the diagnostic text.
@@ -150,6 +156,7 @@ void EditorDiagConsumer::handleDiagnostic(
       SKInfo.Severity = DiagnosticSeverityKind::Warning;
       break;
     case DiagnosticKind::Note:
+    case DiagnosticKind::Remark:
       llvm_unreachable("already covered");
   }
 


### PR DESCRIPTION
This allows reporting successful and unsuccessful optimizations similar to
clang/llvm (http://llvm.org/devmtg/2016-11/#talk15).

This first patch adds support for the
options -Rpass=<pass-name-regex> -Rpass-missed=<pass-name-regex>.  These allow
reporting successful/unsuccessful optimization on the compiler output for passes
specified by the regex.  I've also added one missed and one passed remark type
to the inliner to test the infrastructure.

Clang also has the option of collecting these records in an external YAML data
file to be displayed by an external tool called the opt-viewer.  Support for this will be added in a later patch.

A few notes:
* The goal is to use this facility for both user-lever "performance" warnings
and expert-level performance analysis.  There will probably be a flag in the
future differentiating these two modes.

* The intent is match clang/llvm as much as it makes sense.  On the other hand I
did make some changes.  Unlike in llvm, the emitter is not a pass which
simplifies things.  Also the remark class hierarchy is greatly simplified since
we don't derive from DiagnosticInfo.  We also don't derive from Diagnostic to
support the streaming API for arbitrary named-value pairs.

* The -Rpass options imply -gline-tables in order to have source location for
the remarks.

* There is also a small llvm patch required that adds the remark kind to
SMDiagnostics.

* Currently function names are printed mangled which should be fixed.
