### PR TITLE
[sourcekitd] Add a request to get statistics from the service

### DIFF
--- a/test/SourceKit/Misc/stats.swift
+++ b/test/SourceKit/Misc/stats.swift
@@ -1,0 +1,57 @@
+func foo() {}
+
+// RUN: %sourcekitd-test -req=syntax-map %s == -req=stats | %FileCheck %s -check-prefix=SYNTAX_1
+
+// SYNTAX_1: 2 {{.*}} source.statistic.num-requests
+// SYNTAX_1: 0 {{.*}} source.statistic.num-semantic-requests
+// SYNTAX_1: 0 {{.*}} source.statistic.num-ast-builds
+// SYNTAX_1: 1 {{.*}} source.statistic.num-open-documents
+// SYNTAX_1: 1 {{.*}} source.statistic.max-open-documents
+
+// RUN: %sourcekitd-test -req=syntax-map %s == -req=close %s == -req=stats | %FileCheck %s -check-prefix=SYNTAX_2
+
+// SYNTAX_2: 3 {{.*}} source.statistic.num-requests
+// SYNTAX_2: 0 {{.*}} source.statistic.num-semantic-requests
+// SYNTAX_2: 0 {{.*}} source.statistic.num-ast-builds
+// SYNTAX_2: 0 {{.*}} source.statistic.num-open-documents
+// SYNTAX_2: 1 {{.*}} source.statistic.max-open-documents
+
+// RUN: %sourcekitd-test -req=sema %s -- %s == -req=stats | %FileCheck %s -check-prefix=SEMA_1
+
+// SEMA_1: 3 {{.*}} source.statistic.num-requests
+// SEMA_1: 0 {{.*}} source.statistic.num-semantic-requests
+// SEMA_1: 1 {{.*}} source.statistic.num-ast-builds
+// SEMA_1: 1 {{.*}} source.statistic.num-asts-in-memory
+// SEMA_1: 1 {{.*}} source.statistic.max-asts-in-memory
+// SEMA_1: 0 {{.*}} source.statistic.num-ast-cache-hits
+// SEMA_1: 0 {{.*}} source.statistic.num-ast-snaphost-uses
+
+// RUN: %sourcekitd-test -req=sema %s -- %s == -req=edit -pos=1:1 -replace=" " %s == -req=stats | %FileCheck %s -check-prefix=SEMA_2
+
+// SEMA_2: 5 {{.*}} source.statistic.num-requests
+// SEMA_2: 0 {{.*}} source.statistic.num-semantic-requests
+// SEMA_2: 2 {{.*}} source.statistic.num-ast-builds
+// SEMA_2: 1 {{.*}} source.statistic.num-asts-in-memory
+// SEMA_2: 2 {{.*}} source.statistic.max-asts-in-memory
+// SEMA_2: 0 {{.*}} source.statistic.num-ast-cache-hits
+// SEMA_2: 0 {{.*}} source.statistic.num-ast-snaphost-uses
+
+// RUN: %sourcekitd-test -req=sema %s -- %s == -req=cursor -pos=1:6 %s -- %s == -req=stats | %FileCheck %s -check-prefix=SEMA_3
+
+// SEMA_3: 4 {{.*}} source.statistic.num-requests
+// SEMA_3: 1 {{.*}} source.statistic.num-semantic-requests
+// SEMA_3: 1 {{.*}} source.statistic.num-ast-builds
+// SEMA_3: 1 {{.*}} source.statistic.num-asts-in-memory
+// SEMA_3: 1 {{.*}} source.statistic.max-asts-in-memory
+// SEMA_3: 0 {{.*}} source.statistic.num-ast-cache-hits
+// SEMA_3: 1 {{.*}} source.statistic.num-ast-snaphost-uses
+
+// RUN: %sourcekitd-test -req=sema %s -- %s == -req=related-idents -pos=1:6 %s -- %s == -req=stats | %FileCheck %s -check-prefix=SEMA_4
+
+// SEMA_4: 4 {{.*}} source.statistic.num-requests
+// SEMA_4: 1 {{.*}} source.statistic.num-semantic-requests
+// SEMA_4: 1 {{.*}} source.statistic.num-ast-builds
+// SEMA_4: 1 {{.*}} source.statistic.num-asts-in-memory
+// SEMA_4: 1 {{.*}} source.statistic.max-asts-in-memory
+// SEMA_4: 1 {{.*}} source.statistic.num-ast-cache-hits
+// SEMA_4: 0 {{.*}} source.statistic.num-ast-snaphost-uses

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -251,6 +251,9 @@ public:
   virtual bool valueForOption(UIdent Key, StringRef &Val) = 0;
 };
 
+struct Statistic;
+typedef std::function<void(ArrayRef<Statistic *> stats)> StatisticsReceiver;
+
 struct RefactoringInfo {
   UIdent Kind;
   StringRef KindName;
@@ -626,6 +629,8 @@ public:
                           StringRef ModuleName,
                           ArrayRef<const char *> Args,
                           DocInfoConsumer &Consumer) = 0;
+
+  virtual void getStatistics(StatisticsReceiver) = 0;
 };
 
 } // namespace SourceKit

--- a/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def
+++ b/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def
@@ -107,6 +107,7 @@ KEY(NameKind, "key.namekind")
 KEY(LocalizationKey, "key.localization_key")
 KEY(IsZeroArgSelector, "key.is_zero_arg_selector")
 KEY(SwiftVersion, "key.swift_version")
+KEY(Value, "key.value")
 
 KEY(EnableDiagnostics, "key.enablediagnostics")
 KEY(GroupName, "key.groupname")
@@ -181,6 +182,7 @@ REQUEST(BuildSettingsRegister, "source.request.buildsettings.register")
 REQUEST(ModuleGroups, "source.request.module.groups")
 REQUEST(NameTranslation, "source.request.name.translation")
 REQUEST(MarkupToXML, "source.request.convert.markup.xml")
+REQUEST(Statistics, "source.request.statistics")
 
 REQUEST(SyntacticRename, "source.request.syntacticrename")
 REQUEST(FindRenameRanges, "source.request.find-syntactic-rename-ranges")
@@ -339,6 +341,9 @@ KIND(Definition, "source.syntacticrename.definition")
 KIND(Reference, "source.syntacticrename.reference")
 KIND(Call, "source.syntacticrename.call")
 KIND(Unknown, "source.syntacticrename.unknown")
+
+KIND(StatNumRequests, "source.statistic.num-requests")
+KIND(StatNumSemaRequests, "source.statistic.num-semantic-requests")
 
 #undef KIND
 #undef REQUEST

--- a/tools/SourceKit/include/SourceKit/Support/Statistic.h
+++ b/tools/SourceKit/include/SourceKit/Support/Statistic.h
@@ -1,0 +1,48 @@
+//===--- Statistic.h - ------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SOURCEKIT_SUPPORT_STATISTIC_H
+#define LLVM_SOURCEKIT_SUPPORT_STATISTIC_H
+
+#include "SourceKit/Support/UIdent.h"
+#include <atomic>
+#include <string>
+
+namespace SourceKit {
+
+struct Statistic {
+  const UIdent name;
+  const std::string description;
+  std::atomic<int64_t> value = {0};
+
+  Statistic(UIdent name, std::string description)
+      : name(name), description(std::move(description)) {}
+
+  int64_t operator++() {
+    return 1 + value.fetch_add(1, std::memory_order_relaxed);
+  }
+  int64_t operator--() {
+    return value.fetch_sub(1, std::memory_order_relaxed) - 1;
+  }
+
+  void updateMax(int64_t newValue) {
+    int64_t prev = value.load(std::memory_order_relaxed);
+    // Note: compare_exchange_weak updates 'prev' if it fails.
+    while (newValue > prev && !value.compare_exchange_weak(
+                                  prev, newValue, std::memory_order_relaxed)) {
+    }
+  }
+};
+
+} // namespace SourceKit
+
+#endif // LLVM_SOURCEKIT_SUPPORT_STATISTIC_H

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -40,6 +40,7 @@ namespace SourceKit {
   class SwiftEditorDocumentFileMap;
   class SwiftLangSupport;
   class SwiftInvocation;
+  struct SwiftStatistics;
   typedef RefPtr<SwiftInvocation> SwiftInvocationRef;
   class EditorDiagConsumer;
 
@@ -48,7 +49,7 @@ public:
   struct Implementation;
   Implementation &Impl;
 
-  explicit ASTUnit(uint64_t Generation);
+  explicit ASTUnit(uint64_t Generation, SwiftStatistics &Statistics);
   ~ASTUnit();
 
   swift::CompilerInstance &getCompilerInstance() const;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2073,6 +2073,8 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
       LOG_WARN_FUNC("Document already exists in editorOpen(..): " << Name);
       Snapshot = nullptr;
     }
+    auto numOpen = ++Stats.numOpenDocs;
+    Stats.maxOpenDocs.updateMax(numOpen);
   }
 
   if (!Snapshot) {
@@ -2095,8 +2097,12 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
 
 void SwiftLangSupport::editorClose(StringRef Name, bool RemoveCache) {
   auto Removed = EditorDocuments.remove(Name);
-  if (!Removed)
+  if (Removed) {
+    --Stats.numOpenDocs;
+  } else {
     IFaceGenContexts.remove(Name);
+  }
+
   if (Removed && RemoveCache)
     Removed->removeCachedAST();
   // FIXME: Report error if Name did not apply to anything ?

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -715,6 +715,14 @@ std::string SwiftLangSupport::resolvePathSymlinks(StringRef FilePath) {
 #endif
 }
 
+void SwiftLangSupport::getStatistics(StatisticsReceiver receiver) {
+  std::vector<Statistic *> stats = {
+#define SWIFT_STATISTIC(VAR, UID, DESC) &Stats.VAR,
+#include "SwiftStatistics.def"
+  };
+  receiver(stats);
+}
+
 CloseClangModuleFiles::~CloseClangModuleFiles() {
   clang::Preprocessor &PP = loader.getClangPreprocessor();
   clang::ModuleMap &ModMap = PP.getHeaderSearchInfo().getModuleMap();

--- a/tools/SourceKit/lib/SwiftLang/SwiftStatistics.def
+++ b/tools/SourceKit/lib/SwiftLang/SwiftStatistics.def
@@ -1,0 +1,28 @@
+//===--- SwiftStatistics.def - ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STATISTIC
+#error "must define SWIFT_STATISTIC to use"
+#endif
+
+/// SWIFT_STATISTIC(VAR_NAME, UNIQUE_ID, DESCRIPTION)
+
+SWIFT_STATISTIC(numASTBuilds, num-ast-builds, "# of ASTs built or rebuilt")
+SWIFT_STATISTIC(numASTsInMem, num-asts-in-memory, "# of ASTs currently in memory")
+SWIFT_STATISTIC(maxASTsInMem, max-asts-in-memory, "maximum # of ASTs ever in memory at once")
+SWIFT_STATISTIC(numASTCacheHits, num-ast-cache-hits, "# of ASTs found in the cache without rebuilding")
+SWIFT_STATISTIC(numASTsUsedWithSnaphots, num-ast-snaphost-uses, "# of ASTs used with snaphots without rebuilding")
+
+SWIFT_STATISTIC(numOpenDocs, num-open-documents, "# of editor documents currently open")
+SWIFT_STATISTIC(maxOpenDocs, max-open-documents, "maximum # of editor documents ever open at once")
+
+#undef SWIFT_STATISTIC

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -127,6 +127,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("find-usr", SourceKitRequest::FindUSR)
         .Case("find-interface", SourceKitRequest::FindInterfaceDoc)
         .Case("open", SourceKitRequest::Open)
+        .Case("close", SourceKitRequest::Close)
         .Case("edit", SourceKitRequest::Edit)
         .Case("print-annotations", SourceKitRequest::PrintAnnotations)
         .Case("print-diags", SourceKitRequest::PrintDiags)
@@ -145,6 +146,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("expand-default", SourceKitRequest::ExpandDefault)
         .Case("localize-string", SourceKitRequest::LocalizeString)
         .Case("markup-xml", SourceKitRequest::MarkupToXML)
+        .Case("stats", SourceKitRequest::Statistics)
         .Default(SourceKitRequest::None);
 
       if (Request == SourceKitRequest::None) {
@@ -153,8 +155,8 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/"
                "cursor/related-idents/syntax-map/structure/format/expand-placeholder/"
                "doc-info/sema/interface-gen/interface-gen-openfind-usr/find-interface/"
-               "open/edit/print-annotations/print-diags/extract-comment/module-groups/"
-               "range/syntactic-rename/find-rename-ranges/translate/markup-xml\n";
+               "open/close/edit/print-annotations/print-diags/extract-comment/module-groups/"
+               "range/syntactic-rename/find-rename-ranges/translate/markup-xml/stats\n";
         return true;
       }
       break;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -45,6 +45,7 @@ enum class SourceKitRequest {
   FindUSR,
   FindInterfaceDoc,
   Open,
+  Close,
   Edit,
   PrintAnnotations,
   PrintDiags,
@@ -55,6 +56,7 @@ enum class SourceKitRequest {
   FindLocalRenameRanges,
   NameTranslation,
   MarkupToXML,
+  Statistics,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/IDE/RefactoringKinds.def"
 };


### PR DESCRIPTION
... and add a few basic statistics about the number of requests, ASTs
built, etc.  The Statistic type is loosely based on the one from LLVM,
but suitable for using without DEBUG macros and using SourceKit UIdents
to identify the statistic.  The easiest way to add a new statistic is to
add it to SwiftStatistics.def in the SwiftLangSupport.