### PR TITLE
SR-6032 fix private class printing with String(describing:)

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -100,6 +100,8 @@ static void _buildNameForMetadata(const Metadata *type,
 
   Demangle::DemangleOptions options;
   options.QualifyEntities = qualified;
+  if (!qualified)
+    options.ShowPrivateDiscriminators = false;
   result = Demangle::nodeToString(demangling, options);
 }
 

--- a/test/stdlib/StringDescribing.swift
+++ b/test/stdlib/StringDescribing.swift
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+private class Foo {}
+class Bar {}
+
+var StringDescribingTestSuite = TestSuite("StringDescribing")
+
+StringDescribingTestSuite.test("String(describing:) shouldn't include extra stuff if the class is private") {
+  expectEqual(String(describing: Foo.self), "Foo")
+  expectEqual(String(describing: Bar.self), "Bar")
+}
+
+StringDescribingTestSuite.test("String(reflecting:) should include extra stuff if the class is private") {
+  expectEqual(String(reflecting: Bar.self), "main.Bar")
+  expectEqual(String(reflecting: Foo.self), "main.(Foo in _AE29BC3E71CF180B9604AA0071CCE6E8)")
+}
+
+runAllTests()


### PR DESCRIPTION
Private classes doesn't add extra stuff when passed to String(describing:)

I'm not at all sure if the test done in this way is correct, launched with:
```
./llvm/utils/lit/lit.py -sv ./build/Ninja-DebugAssert/swift-macosx-x86_64/test-macosx-x86_64/stdlib/StringDescribing.swift
```
will end with a success, but I haven't found how to launch all the tests for sodlib without launching all 3000. 
Resolves [SR-6032](https://bugs.swift.org/browse/SR-6032).