### PR TITLE
[Stats] Warn on failure-to-write stats / trace files.

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -361,8 +361,11 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
 
   std::error_code EC;
   raw_fd_ostream ostream(StatsFilename, EC, fs::F_Append | fs::F_Text);
-  if (EC)
+  if (EC) {
+    llvm::errs() << "Error opening -stats-output-dir file '"
+                 << TraceFilename << "' for writing\n";
     return;
+  }
 
   // We change behavior here depending on whether -DLLVM_ENABLE_STATS and/or
   // assertions were on in this build; this is somewhat subtle, but turning on
@@ -387,8 +390,11 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
   if (LastTracedFrontendCounters && SourceMgr) {
     std::error_code EC;
     raw_fd_ostream tstream(TraceFilename, EC, fs::F_Append | fs::F_Text);
-    if (EC)
+    if (EC) {
+      llvm::errs() << "Error opening -trace-stats-events file '"
+                   << TraceFilename << "' for writing\n";
       return;
+    }
     tstream << "Time,Live,IsEntry,EventName,CounterName,"
             << "CounterDelta,CounterValue,SourceRange\n";
     for (auto const &E : FrontendStatsEvents) {

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -23,9 +23,13 @@
 // RUN: %FileCheck -input-file %t/driver.csv %s
 // RUN: %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
 
+// RUN: %target-swiftc_driver -c -o %t/out.o -stats-output-dir %t/this/is/not/a/directory %s 2>&1 | %FileCheck -check-prefix=CHECK-NODIR %s
+
 // CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}
 // CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
 // CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
+
+// CHECK-NODIR: {{Error opening -stats-output-dir file}}
 
 public func foo() {
     print("hello")


### PR DESCRIPTION
Given recent wild goose chase caused by a failure-to-write files in certain circumstances, I'd like to upgrade this path from silent to noisy failure (though still permitting the compiler to continue).

Plumbing a diagnostic consumer through to here seems to me like a bit of overkill, given it's not a standard operating mode at all -- user has to ask for this and it's a rare use-case -- and there's no source location to complain about; decided to do what LLVM's own stats-reporting does on stats-file-open failure and just write to stderr. Hopefully this is acceptable?
