### PR TITLE
[test] Disable parse_stdlib tests on Mac too

### DIFF
--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -19,8 +19,8 @@ for id in $(seq 0 $process_id_max); do
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322
 __EOF__
 
 done

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_11.sil
+++ b/validation-test/SIL/parse_stdlib_11.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -11,5 +11,5 @@
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 
-// FIXME: Re-enable on Linux when we're no long running out of memory.
-// REQUIRES: OS=macosx
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322


### PR DESCRIPTION
We're running out of memory there as well. Fixing this is tracked by rdar://problem/34771322.
