### PR TITLE
Run ObjCARCContract when optimizing no matter the IRGenOutputKind.

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -15,11 +15,10 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "irgen"
-#include "swift/Subsystems.h"
+#include "IRGenModule.h"
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/LinkLibrary.h"
-#include "swift/SIL/SILModule.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/Platform.h"
@@ -29,50 +28,56 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/IRGen/IRGenPublic.h"
 #include "swift/IRGen/IRGenSILPasses.h"
-#include "swift/LLVMPasses/PassesFwd.h"
 #include "swift/LLVMPasses/Passes.h"
-#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/LLVMPasses/PassesFwd.h"
+#include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/Subsystems.h"
 #include "clang/Basic/TargetInfo.h"
-#include "llvm/Bitcode/BitcodeWriterPass.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/CodeGen/BasicTTIImpl.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRPrintingPasses.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/MC/SubtargetFeature.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormattedStream.h"
-#include "llvm/Support/TargetRegistry.h"
-#include "llvm/Support/Path.h"
-#include "llvm/Support/Mutex.h"
 #include "llvm/Support/MD5.h"
-#include "llvm/ADT/StringSet.h"
-#include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Support/Mutex.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetSubtargetInfo.h"
-#include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/ObjCARC.h"
-#include "llvm/Object/ObjectFile.h"
-#include "IRGenModule.h"
 
 #include <thread>
 
 using namespace swift;
 using namespace irgen;
 using namespace llvm;
+
+static cl::opt<bool> DisableObjCARCContract(
+    "disable-objc-arc-contract", cl::Hidden,
+    cl::desc("Disable running objc arc contract for testing purposes"));
 
 namespace {
 // We need this to access IRGenOptions from extension functions
@@ -446,6 +451,13 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
 
   legacy::PassManager EmitPasses;
 
+  // Make sure we do ARC contraction under optimization.  We don't
+  // rely on any other LLVM ARC transformations, but we do need ARC
+  // contraction to add the objc_retainAutoreleasedReturnValue
+  // assembly markers and remove clang.arc.used.
+  if (Opts.Optimize && !DisableObjCARCContract)
+    EmitPasses.add(createObjCARCContractPass());
+
   // Set up the final emission passes.
   switch (Opts.OutputKind) {
   case IRGenOutputKind::Module:
@@ -465,13 +477,6 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
 
     EmitPasses.add(createTargetTransformInfoWrapperPass(
         TargetMachine->getTargetIRAnalysis()));
-
-    // Make sure we do ARC contraction under optimization.  We don't
-    // rely on any other LLVM ARC transformations, but we do need ARC
-    // contraction to add the objc_retainAutoreleasedReturnValue
-    // assembly markers.
-    if (Opts.Optimize)
-      EmitPasses.add(createObjCARCContractPass());
 
     bool fail = TargetMachine->addPassesToEmitFile(EmitPasses, *RawOS,
                                                    FileType, !Opts.Verify);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,7 @@ function(get_test_dependencies SDK result_var_name)
       swift-api-digester swift-refactor)
   if(NOT SWIFT_BUILT_STANDALONE)
     list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
-         clang llc llvm-cov llvm-dwarfdump llvm-link llvm-as llvm-profdata not)
+         clang llc llvm-cov llvm-dwarfdump llvm-link llvm-as llvm-dis llvm-profdata not)
   endif()
   if(SWIFT_BUILD_SOURCEKIT)
     list(APPEND deps_binaries sourcekitd-test complete-test)

--- a/test/IRGen/Inputs/StaticInline.h
+++ b/test/IRGen/Inputs/StaticInline.h
@@ -3,3 +3,18 @@
 static inline NSString *staticInlineFun() {
   return [[NSLocale currentLocale] localeIdentifier];
 }
+
+static inline __attribute__((ns_returns_retained))
+NSURL *_Nullable test(NSFileManager *self_, NSURL *originalItemURL,
+                      NSURL *newItemURL, NSString *_Nullable backupItemName,
+                      NSFileManagerItemReplacementOptions options,
+                      NSError **_Nullable error) {
+  NSURL *result = nil;
+  BOOL success = [self_ replaceItemAtURL:originalItemURL
+                           withItemAtURL:newItemURL
+                          backupItemName:backupItemName
+                                 options:options
+                        resultingItemURL:&result
+                                   error:error];
+  return success ? result : nil;
+}

--- a/test/IRGen/objc_arc_contract.swift
+++ b/test/IRGen/objc_arc_contract.swift
@@ -1,0 +1,28 @@
+// Make sure that we run objc arc contract when emitting ir or bc with optimization enabled.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir -Xllvm -disable-objc-arc-contract -parse-as-library -O | %FileCheck --check-prefix=CHECK-WITHOUT-PASS %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-bc -Xllvm -disable-objc-arc-contract -parse-as-library -O -o %t/test1.bc && %llvm-dis -o - %t/test1.bc | %FileCheck --check-prefix=CHECK-WITHOUT-PASS %s
+
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir -parse-as-library -O | %FileCheck --check-prefix=CHECK-WITH-PASS %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-bc -parse-as-library -O -o %t/test2.bc && %llvm-dis -o - %t/test2.bc | %FileCheck --check-prefix=CHECK-WITH-PASS %s
+
+
+// REQUIRES: objc_interop
+// REQUIRES: asserts
+
+// CHECK-WITHOUT-PASS: call void (...) @clang.arc.use
+// CHECK-WITH-PASS-NOT: call void (...) @clang.arc.use
+
+import Foundation
+
+@inline(never)
+public func foo() throws {
+  let x: FileManager! = nil
+  let y = URL(string: "http://swift.org")
+  let z: URL! = nil
+  let w: String = "foo"
+  var e: NSError? = nil
+  test(x, y, z, w, .usingNewMetadataOnly, &e)
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -262,6 +262,7 @@ config.llvm_profdata = inferSwiftBinary('llvm-profdata')
 config.llvm_cov = inferSwiftBinary('llvm-cov')
 config.filecheck = inferSwiftBinary('FileCheck')
 config.llvm_dwarfdump = inferSwiftBinary('llvm-dwarfdump')
+config.llvm_dis = inferSwiftBinary('llvm-dis')
 config.sourcekitd_test = inferSwiftBinary('sourcekitd-test')
 config.complete_test = inferSwiftBinary('complete-test')
 config.swift_api_digester = inferSwiftBinary('swift-api-digester')
@@ -354,6 +355,7 @@ config.substitutions.append( ('%swift-format', config.swift_format) )
 config.substitutions.append( ('%llvm-link', config.llvm_link) )
 config.substitutions.append( ('%swift-llvm-opt', config.swift_llvm_opt) )
 config.substitutions.append( ('%llvm-dwarfdump', config.llvm_dwarfdump) )
+config.substitutions.append( ('%llvm-dis', config.llvm_dis) )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(
@@ -426,6 +428,7 @@ disallow('swift-ide-test')
 disallow('clang')
 disallow('FileCheck')
 disallow('llvm-dwarfdump')
+disallow('llvm-dis')
 
 config.substitutions.insert(0,
     ('%p',


### PR DESCRIPTION
Previously, we were just running ObjCARCContract when codegening. This is out of
character with the rest of the LLVM passes in Swift, namely that after these
have run, an IR pass no longer contains any compiler intrinsics. This can be
seen by SwiftARCContract running in the -O pipeline.

This commit harmonizes the behavior here.

For testing purposes, I added a flag that disables the running of
ObjCARCContract for testing purposes.

rdar://34824507