### PR TITLE
benchmarks: replace the Ounchecked build with an Osize build

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -199,7 +199,7 @@ Available configurations: <Optlevel>_SINGLEFILE, <Optlevel>_MULTITHREADED")
 # Syntax for an optset:  <optimization-level>_<configuration>
 #    where "_<configuration>" is optional.
 if(NOT SWIFT_OPTIMIZATION_LEVELS)
-  set(SWIFT_OPTIMIZATION_LEVELS "Onone" "O" "Ounchecked"
+  set(SWIFT_OPTIMIZATION_LEVELS "Onone" "O" "Osize"
                                 ${SWIFT_EXTRA_BENCH_CONFIGS})
 endif()
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -48,7 +48,7 @@ The following build options are available:
       (default: "macosx;iphoneos;appletvos;watchos")
 * `-DSWIFT_OPTIMIZATION_LEVELS`
     * A list of Swift optimization levels to build against
-      (default: "O;Onone;Ounchecked")
+      (default: "O;Onone;Osize")
 * `-DSWIFT_BENCHMARK_EMIT_SIB`
     * A boolean value indicating whether .sib files should be generated
       alongside .o files (default: FALSE)
@@ -92,7 +92,7 @@ Using the Benchmark Driver
 
 * `$ ./Benchmark_O --num-iters=1 --num-samples=1`
 * `$ ./Benchmark_Onone --list`
-* `$ ./Benchmark_Ounchecked Ackermann`
+* `$ ./Benchmark_Osize Ackermann`
 
 ### Note
 As a shortcut, you can also refer to benchmarks by their ordinal numbers.

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -204,7 +204,7 @@ function (swift_benchmark_compile_archopts)
   set(common_swift4_options ${common_options} "-swift-version" "4")
 
   # Always optimize the driver modules.
-  # Note that we compile the driver for Ounchecked also with -Ounchecked
+  # Note that we compile the driver for Osize also with -Osize
   # (and not with -O), because of <rdar://problem/19614516>.
   string(REPLACE "Onone" "O" driver_opt "${optflag}")
 

--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -23,7 +23,7 @@ DTRACE_PATH = os.path.join(DRIVER_LIBRARY_PATH, 'swift_stats.d')
 
 import perf_test_driver  # noqa (E402 module level import not at top of file)
 
-# Regexes for the XFAIL_LIST. Matches against '([Onone|O|Ounchecked],TestName)'
+# Regexes for the XFAIL_LIST. Matches against '([Onone|O|Osize],TestName)'
 XFAIL_LIST = [
 ]
 

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -401,7 +401,7 @@ def main():
         'multiple filters are supported', metavar="PATTERN")
     parent_parser.add_argument(
         '-t', '--tests',
-        help='directory containing Benchmark_O{,none,unchecked} ' +
+        help='directory containing Benchmark_O{,none,size} ' +
         '(default: DRIVER_DIR)',
         default=DRIVER_DIR)
 
@@ -411,8 +411,8 @@ def main():
         parents=[parent_parser])
     submit_parser.add_argument(
         '-o', '--optimization', nargs='+',
-        help='optimization levels to use (default: O Onone Ounchecked)',
-        default=['O', 'Onone', 'Ounchecked'])
+        help='optimization levels to use (default: O Onone Osize)',
+        default=['O', 'Onone', 'Osize'])
     submit_parser.add_argument(
         '-i', '--iterations',
         help='number of times to run each test (default: 10)',
@@ -435,8 +435,8 @@ def main():
     run_parser.add_argument(
         '-o', '--optimization',
         metavar='OPT',
-        choices=['O', 'Onone', 'Ounchecked'],
-        help='optimization level to use: {O,Onone,Ounchecked}, (default: O)',
+        choices=['O', 'Onone', 'Osize'],
+        help='optimization level to use: {O,Onone,Osize}, (default: O)',
         default='O')
     run_parser.add_argument(
         '-i', '--iterations',

--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -20,7 +20,7 @@ sys.path.append("@PATH_TO_DRIVER_LIBRARY@")
 
 import perf_test_driver  # noqa (E402 module level import not at top of file)
 
-# Regexes for the XFAIL_LIST. Matches against '([Onone|O|Ounchecked],TestName)'
+# Regexes for the XFAIL_LIST. Matches against '([Onone|O|Osize],TestName)'
 XFAIL_LIST = [
 ]
 

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -24,7 +24,7 @@ from math import sqrt
 class PerformanceTestResult(object):
     """PerformanceTestResult holds results from executing an individual
     benchmark from the Swift Benchmark Suite as reported by the test driver
-    (Benchmark_O, Benchmark_Onone, Benchmark_Ounchecked or Benchmark_Driver).
+    (Benchmark_O, Benchmark_Onone, Benchmark_Osize or Benchmark_Driver).
 
     It depends on the log format emitted by the test driver in the form:
     #,TEST,SAMPLES,MIN(μs),MAX(μs),MEAN(μs),SD(μs),MEDIAN(μs),MAX_RSS(B)

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -61,7 +61,7 @@ def _unwrap_self(args):
     return type(args[0]).process_input(*args)
 
 
-BenchmarkDriver_OptLevels = ['Onone', 'O', 'Ounchecked']
+BenchmarkDriver_OptLevels = ['Onone', 'O', 'Osize']
 
 
 class BenchmarkDriver(object):

--- a/cmake/modules/SwiftExternalBenchmarkBuild.cmake
+++ b/cmake/modules/SwiftExternalBenchmarkBuild.cmake
@@ -61,7 +61,7 @@ function (add_external_benchmark_suite)
   set(stamp_dir ${SWIFT_BINARY_DIR}/external-benchmark/stamps)
   set(prefix_dir ${SWIFT_BINARY_DIR}/external-benchmark/prefix)
 
-  set(bench_targets Benchmark_O Benchmark_Onone Benchmark_Ounchecked)
+  set(bench_targets Benchmark_O Benchmark_Onone Benchmark_Osize)
   set(library_targets swift-benchmark-macosx-x86_64-external)
 
   set(all_stdlib_dependencies)


### PR DESCRIPTION
We don't measure Ounchecked anymore. On the other hand we want to benchmark the Osize build.

