### PR TITLE
[ClangImporter] Fix use-after-free in macro importing

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -650,8 +650,9 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
       // If the macro is equal to an existing macro, map down to the same
       // declaration.
       if (macro->isIdenticalTo(*entry.first, clangPP, true)) {
-        known->second.push_back({macro, entry.second});
-        return entry.second;
+        ValueDecl *result = entry.second;
+        known->second.push_back({macro, result});
+        return result;
       }
     }
   }

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/A.h
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/A.h
@@ -1,0 +1,1 @@
+#define REDEFINED 1

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/B.h
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/B.h
@@ -1,0 +1,1 @@
+#define REDEFINED 1

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/C.h
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/C.h
@@ -1,0 +1,1 @@
+#define REDEFINED 1

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/D.h
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/D.h
@@ -1,0 +1,1 @@
+#define REDEFINED 1

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/E.h
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/E.h
@@ -1,0 +1,1 @@
+#define REDEFINED 1

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/F.h
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/F.h
@@ -1,0 +1,1 @@
+#define REDEFINED 1

--- a/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/module.modulemap
+++ b/validation-test/ClangImporter/Inputs/macros-repeatedly-redefined/module.modulemap
@@ -1,0 +1,6 @@
+module A { header "A.h" }
+module B { header "B.h" }
+module C { header "C.h" }
+module D { header "D.h" }
+module E { header "E.h" }
+module F { header "F.h" }

--- a/validation-test/ClangImporter/macros-repeatedly-redefined.swift
+++ b/validation-test/ClangImporter/macros-repeatedly-redefined.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -sdk "" -I %S/Inputs/macros-repeatedly-redefined -typecheck %s -verify
+
+// This used to result in a use-after-free because the SmallVector holding the
+// macros was reallocated.
+import A
+import B
+import C
+import D
+import E
+import F
+
+_ = REDEFINED // no-warning
+_ = x // expected-error {{use of unresolved identifier 'x'}}


### PR DESCRIPTION
This has been showing up as nondeterministic failures on our Linux bots in the clang_builtins.swift test, because that test used to trigger typo correction! Which pulled in macros, which happened to include some redefinitions, which resulted in this.

rdar://problem/34266952