### PR TITLE
[test] Re-enable test/SourceKit/CodeFormat/indent-implicit-getter.swift

### DIFF
--- a/test/SourceKit/CodeFormat/indent-implicit-getter.swift
+++ b/test/SourceKit/CodeFormat/indent-implicit-getter.swift
@@ -24,7 +24,6 @@ class var foo: Int {
   return 1
   }
 }
-// REQUIRES: disabled
 // FIXME: may be crashing non-deterministically
 
 // RUN: %sourcekitd-test -req=format -line=1 -length=1 %s >%t.response


### PR DESCRIPTION
This was disabled a long time ago due to a crash but I cannot reproduce such a crash currently.
rdar://26484736
