### PR TITLE
[stdlib] Add overloads for elementsEqual for unordered collections [WIP]

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -6636,3 +6636,65 @@ extension Set {
     }
   }
 }
+
+extension Set {
+  @available(*, deprecated,
+    message: "Set is unordered. Define some order by, for example, sorting it first.")
+  public func elementsEqual<
+    Other : Sequence
+  >(_ other: Other) -> Bool where Other.Element == Element {
+    return self._elementsEqual(other)
+  }
+
+  @available(*, deprecated,
+    message: "Set is unordered. Define some order by, for example, sorting it first.")
+  public func elementsEqual<Other : Sequence>(
+    _ other: Other,
+    by areEquivalent: (Element, Element) throws -> Bool
+  ) rethrows -> Bool where Other.Element == Element {
+    return try self._elementsEqual(other, by: areEquivalent)
+  }
+}
+
+extension Sequence where Element : Hashable {
+  @available(*, deprecated,
+    message: "Set is unordered. Define some order by, for example, sorting it first.")
+  public func elementsEqual(
+    _ other: Set<Element>
+  ) -> Bool {
+    return self._elementsEqual(other)
+  }
+
+  @available(*, deprecated,
+    message: "Set is unordered. Define some order by, for example, sorting it first.")
+  public func elementsEqual(
+    _ other: Set<Element>,
+    by areEquivalent: (Element, Element) throws -> Bool
+  ) rethrows -> Bool {
+    return try self._elementsEqual(other, by: areEquivalent)
+  }
+}
+
+extension Dictionary {
+  @available(*, deprecated,
+    message: "Dictionary is unordered. Define some order by, for example, sorting it first.")
+  public func elementsEqual<Other : Sequence>(
+    _ other: Other,
+    by areEquivalent: (Element, Element) throws -> Bool
+  ) rethrows -> Bool where Other.Element == Element {
+    return try self._elementsEqual(other, by: areEquivalent)
+  }
+}
+
+extension Sequence {
+  @available(*, deprecated,
+    message: "Dictionary is unordered. Define some order by, for example, sorting it first.")
+  public func elementsEqual<
+    Key : Hashable, Value
+  >(
+    _ other: Dictionary<Key, Value>,
+    by areEquivalent: (Element, Element) throws -> Bool
+  ) rethrows -> Bool where Element == Dictionary<Key, Value>.Element {
+    return try self._elementsEqual(other, by: areEquivalent)
+  }
+}

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -334,8 +334,23 @@ ${equivalenceExplanation}
   /// - Returns: `true` if this sequence and `other` contain the same elements
   ///   in the same order.
 %   end
-  @_inlineable
+  @inline(__always)
   public func elementsEqual<OtherSequence>(
+    _ other: OtherSequence${"," if preds else ""}
+%   if preds:
+    by areEquivalent: (Element, Element) throws -> Bool
+%   end
+  ) ${rethrows_}-> Bool
+    where
+    OtherSequence: Sequence,
+    OtherSequence.Element == Element {
+    return ${"try " if preds else ""}_elementsEqual(
+      other${", by: areEquivalent" if preds else ""})
+  }
+
+  @_versioned // FIXME(sil-serialize-all)
+  @_inlineable
+  internal func _elementsEqual<OtherSequence>(
     _ other: OtherSequence${"," if preds else ""}
 %   if preds:
     by areEquivalent: (Element, Element) throws -> Bool

--- a/test/stdlib/ElementsEqual.swift
+++ b/test/stdlib/ElementsEqual.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -typecheck -verify -DVERIFY %s
+// RUN: %target-run-stdlib-swift
+// REQUIRES: executable_test
+
+#if !VERIFY
+
+import StdlibUnittest
+
+var tests = TestSuite("ElementsEqual")
+
+tests.test("Set.elementsEqual(_:)/OtherSet") {
+  let s = Set([1, 2, 3])
+  let r = Set(s.reversed())
+  _ = s.elementsEqual(r) // result can be anything, but it should not trap
+}
+
+tests.test("Set.elementsEqual(_:)/Sequence") {
+  let xs = [1,2,3]
+  let s = Set(xs)
+  _ = s.elementsEqual(xs) // result can be anything, but it should not trap
+  expectFalse(s.elementsEqual(xs + [4]))
+}
+
+tests.test("Set.elementsEqual(_:by:)/Sequence") {
+  let xs = [1,2,3]
+  let s = Set(xs)
+  _ = s.elementsEqual(xs, by: { $0 == $1 })
+  // result can be anything, but it should not trap
+}
+
+tests.test("Sequence.elementsEqual(_:)/Set") {
+  let xs = [1,2,3]
+  let s = Set(xs)
+  _ = xs.elementsEqual(s) // result can be anything, but it should not trap
+  expectFalse((xs + [4]).elementsEqual(s))
+}
+
+tests.test("Sequence.elementsEqual(_:by:)/Seq") {
+  let xs = [1,2,3]
+  let s = Set(xs)
+  _ = xs.elementsEqual(s, by: { $0 == $1 })
+  // result can be anything, but it should not trap
+}
+
+tests.test("Dictionary.elementsEqual(_:, by:)/Sequence") {
+  let d = [1 : "foo", 2 : "bar"]
+  let kvs = [(key: 1, value: "foo"), (key: 2, value: "bar")]
+  _ = (d.elementsEqual(kvs, by: { _ in true }))
+  // result can be anything, but it should not trap
+}
+
+tests.test("Sequence.elementsEqual(_:, by:)/Dictionary") {
+  let d = [1 : "foo", 2 : "bar"]
+  let kvs = [(key: 1, value: "foo"), (key: 2, value: "bar")]
+  _ = (kvs.elementsEqual(d, by: { _ in true }))
+  // result can be anything, but it should not trap
+}
+
+runAllTests()
+
+#else
+
+let s = Set([1, 2, 3])
+let r = Set(s.reversed())
+
+_ = s.elementsEqual(r) // expected-warning {{unordered}}
+_ = s.elementsEqual(r, by: { _ in true }) // expected-warning {{unordered}}
+_ = [1,2,3].elementsEqual(s) // expected-warning {{unordered}}
+_ = [1,2,3].elementsEqual(s, by: { _ in true }) // expected-warning {{unordered}}
+
+let d = [1 : "foo"]
+let kvs = [(key: 1, value: "foo")]
+_ = d.elementsEqual(kvs, by: { _ in true }) // expected-warning {{unordered}}
+_ = kvs.elementsEqual(d, by: { _ in true }) // expected-warning {{unordered}}
+
+#endif


### PR DESCRIPTION
Behavior of Sequence.elementsEqual can be unexpected when applied to
unordered collections, such as Set or Dictionary.

This commit introduces a few more overloads to this function to:
1) Make behavior for Set consistent with ==
2) Mark cases that produce unexpected results as deprecated with a
useful message.