### PR TITLE
AST: Fix a problem with superclass constraints

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2187,10 +2187,12 @@ static void maybeAddSameTypeRequirementForNestedType(
     superConformance->getTypeWitness(assocType, builder.getLazyResolver());
   if (!concreteType) return;
 
+  // We should only have interface types here.
+  assert(!superConformance->getType()->hasArchetype());
+  assert(!concreteType->hasArchetype());
+
   // Add the same-type constraint.
   auto nestedSource = superSource->viaParent(builder, assocType);
-  concreteType = superConformance->getDeclContext()
-      ->mapTypeOutOfContext(concreteType);
 
   builder.addSameTypeRequirement(nestedPA, concreteType, nestedSource,
         GenericSignatureBuilder::UnresolvedHandlingKind::GenerateConstraints);

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -164,3 +164,18 @@ protocol P10 {
 // CHECK: Generic signature: <T where T : P10, T.A : C10>
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0.A : C10>
 func testP10<T>(_: T) where T: P10, T.A: C10 { }
+
+// Nested types of generic class-constrained type parameters.
+protocol Tail {
+  associatedtype E
+}
+
+protocol Rump : Tail {
+  associatedtype E = Self
+}
+
+class Horse<T>: Rump { }
+
+func hasRedundantConformanceConstraint<X : Horse<T>, T>(_: X) where X : Rump {}
+// expected-warning@-1 {{redundant conformance constraint 'X': 'Rump'}}
+// expected-note@-2 {{conformance constraint 'X': 'Rump' implied here}}


### PR DESCRIPTION
If the class itself is generic and we're looking up a nested type
from a conformance, we would pass an interface type to
mapTypeOutOfContext() and crash.