### PR TITLE
[stdlib] Remove *Subrange methods from algorithms prototype

### DIFF
--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -252,8 +252,7 @@ internal func _gcd(_ m: Int, _ n: Int) -> Int {
   return m
 }
 
-extension MutableCollection where Self: RandomAccessCollection,
-  SubSequence: MutableCollection, SubSequence: RandomAccessCollection {
+extension MutableCollection where Self: RandomAccessCollection {
 
   /// Rotates elements through a cycle, using `sourceForIndex` to generate
   /// the source index for each movement.
@@ -382,7 +381,7 @@ public func == <C1: Collection, C2: Collection>(
 
 /// A concatenation of two collections with the same element type.
 public struct ${Self}<C1 : ${Collection}, C2: ${Collection}>: ${Collection}
-  where C1.Iterator.Element == C2.Iterator.Element {
+  where C1.Element == C2.Element {
 
   init(_base1: C1, base2: C2) {
     self._base1 = _base1
@@ -403,7 +402,7 @@ public struct ${Self}<C1 : ${Collection}, C2: ${Collection}>: ${Collection}
     return ConcatenatedCollectionIndex(second: _base2.endIndex)
   }
 
-  public subscript(i: Index) -> C1.Iterator.Element {
+  public subscript(i: Index) -> C1.Element {
     switch i._position {
     case let .first(i):
       return _base1[i]
@@ -496,7 +495,7 @@ public struct ${Self}<C1 : ${Collection}, C2: ${Collection}>: ${Collection}
 func concatenate<
   C1 : ${Collection}, C2 : ${Collection}
 >(_ first: C1, _ second: C2) -> ${Self}<C1, C2>
-where C1.Iterator.Element == C2.Iterator.Element {
+where C1.Element == C2.Element {
   return ${Self}(_base1: first, base2: second)
 }
 
@@ -506,23 +505,20 @@ where C1.Iterator.Element == C2.Iterator.Element {
 //===----------------------------------------------------------------------===//
 
 /// A position in a rotated collection.
-public struct RotatedCollectionIndex<Base : Collection> : Comparable
-where Base.SubSequence: Collection {
+public struct RotatedCollectionIndex<Base : Collection> : Comparable {
   internal let _index:
     ConcatenatedCollectionIndex<Base.SubSequence, Base.SubSequence>
 }
 
 public func < <Base: Collection>(
   lhs: RotatedCollectionIndex<Base>, rhs: RotatedCollectionIndex<Base>
-) -> Bool
-where Base.SubSequence: Collection {
+) -> Bool {
   return lhs._index < rhs._index
 }
 
 public func == <Base: Collection>(
   lhs: RotatedCollectionIndex<Base>, rhs: RotatedCollectionIndex<Base>
-) -> Bool
-where Base.SubSequence: Collection {
+) -> Bool {
   return lhs._index == rhs._index
 }
 
@@ -533,8 +529,7 @@ where Base.SubSequence: Collection {
 /// A rotated view onto a `${Collection}`.
 public struct ${Self}<
   Base : ${Collection}
-> : ${Collection}
-where Base.SubSequence: ${Collection} {
+> : ${Collection} {
   let _concatenation: Concatenated${Collection}<
     Base.SubSequence, Base.SubSequence>
 
@@ -552,7 +547,7 @@ where Base.SubSequence: ${Collection} {
     return RotatedCollectionIndex(_index: _concatenation.endIndex)
   }
 
-  public subscript(i: Index) -> Base.SubSequence.Iterator.Element {
+  public subscript(i: Index) -> Base.SubSequence.Element {
     return _concatenation[i._index]
   }
 
@@ -581,7 +576,7 @@ where Base.SubSequence: ${Collection} {
   }
 }
 
-extension ${Collection} where SubSequence: ${Collection} {
+extension ${Collection} {
   /// Returns a view of this collection with the elements reordered such the
   /// element at the given position ends up first.
   ///
@@ -609,8 +604,7 @@ extension ${Collection} where SubSequence: ${Collection} {
 
 extension BidirectionalCollection
   where Self : MutableCollectionAlgorithms,
-  SubSequence : BidirectionalCollection,
-  SubSequence.Index == Self.Index {
+  SubSequence: MutableCollectionAlgorithms {
 
   @discardableResult
   mutating func stablePartition(
@@ -675,10 +669,10 @@ extension Collection {
 }
 
 extension LazyCollectionProtocol
-  where Iterator.Element == Elements.Iterator.Element {
+  where Element == Elements.Element {
   func stablyPartitioned(
-    choosingStartGroupBy p: (Iterator.Element) -> Bool
-  ) -> LazyCollection<[Iterator.Element]> {
+    choosingStartGroupBy p: (Element) -> Bool
+  ) -> LazyCollection<[Element]> {
     return elements.stablyPartitioned(choosingStartGroupBy: p).lazy
   }
 }
@@ -691,7 +685,7 @@ extension Collection {
     /// predicate, as if `self.partition(by: predicate)` had already
     /// been called.
     func partitionPoint(
-        where predicate: (Iterator.Element) throws -> Bool
+        where predicate: (Element) throws -> Bool
         ) rethrows -> Index {
         var n = distance(from: startIndex, to: endIndex)
         var r = startIndex..<endIndex

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -45,9 +45,16 @@ public protocol MutableCollectionAlgorithms : MutableCollection {
   mutating func rotate(shiftingToStart middle: Index) -> Index
 }
 
-// In the stdlib, this conformance wouldn't be needed
+// In the stdlib, these conformances wouldn't be needed
 extension Array : MutableCollectionAlgorithms {  }
 extension ArraySlice : MutableCollectionAlgorithms {  }
+
+% for Traversal in TRAVERSALS:
+%   for RangeReplaceable in [ False, True ]:
+%     Slice = sliceTypeName(traversal=Traversal, mutable=True, rangeReplaceable=RangeReplaceable)
+extension ${Slice} : MutableCollectionAlgorithms {  }
+%   end
+% end
 
 /// In the stdlib, this would simply be MutableCollection
 extension MutableCollectionAlgorithms {

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -71,7 +71,7 @@ extension MutableCollectionAlgorithms {
     var p = lhs.lowerBound
     var q = rhs.lowerBound
     repeat {
-      swap(&self[p], &self[q])
+      swapAt(p, q)
       formIndex(after: &p)
       formIndex(after: &q)
     }
@@ -209,7 +209,7 @@ extension MutableCollection where Self: BidirectionalCollection {
     var l = endIndex
     while f != limit && l != limit {
       formIndex(before: &l)
-      swap(&self[f], &self[l])
+      swapAt(f, l)
       formIndex(after: &f)
     }
     return (f, l)
@@ -258,15 +258,19 @@ extension MutableCollection where Self: RandomAccessCollection,
   /// Rotates elements through a cycle, using `sourceForIndex` to generate
   /// the source index for each movement.
   @inline(__always)
-  internal mutating func _rotateCycle(start: Index,
-    transform sourceForIndex: (Index) -> Index)
+  internal mutating func _rotateCycle(
+    start: Index,
+    pivot: Index,
+    plus: IndexDistance,
+    minus: IndexDistance)
   {
     let tmp = self[start]
-    var (i, j) = (start, sourceForIndex(start))
+    var i = start
+    var j = index(start, offsetBy: start < pivot ? plus : minus)
     while j != start {
       self[i] = self[j]
       i = j
-      j = sourceForIndex(j)
+      j = index(j, offsetBy: j < pivot ? plus : minus)
     }
     self[i] = tmp
   }
@@ -297,9 +301,9 @@ extension MutableCollection where Self: RandomAccessCollection,
     let cycles = _gcd(numericCast(plus), -numericCast(minus))
 
     for cycle in 1...cycles {
-      _rotateCycle(start: index(startIndex, offsetBy: numericCast(cycle))) {
-        index($0, offsetBy: $0 < pivot ? plus : minus)
-      }
+      _rotateCycle(
+        start: index(startIndex, offsetBy: numericCast(cycle)),
+        pivot: pivot, plus: plus, minus: minus)
     }
     return pivot
   }

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -602,32 +602,30 @@ extension LazyCollectionProtocol
 }
 
 extension Collection {
-    /// Returns the index of the first element in the collection
-    /// that matches the predicate.
-    ///
-    /// The collection must already be partitioned according to the
-    /// predicate, as if `self.partition(by: predicate)` had already
-    /// been called.
-    func partitionPoint(
-        where predicate: (Element) throws -> Bool
-        ) rethrows -> Index {
-        var n = distance(from: startIndex, to: endIndex)
-        var r = startIndex..<endIndex
+  /// Returns the index of the first element in the collection
+  /// that matches the predicate.
+  ///
+  /// The collection must already be partitioned according to the
+  /// predicate, as if `self.partition(by: predicate)` had already
+  /// been called.
+  func partitionPoint(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var n = distance(from: startIndex, to: endIndex)
+    var l = startIndex
 
-        while n > 0 {
-            let half = n / 2
-            let mid = index(r.lowerBound, offsetBy: half)
-            if try predicate(self[mid]) {
-                r = r.lowerBound..<mid
-                n = half
-            }
-            else {
-                r = index(after: mid)..<r.upperBound
-                n -= half + 1
-            }
-        }
-        return r.lowerBound
+    while n > 0 {
+      let half = n / 2
+      let mid = index(l, offsetBy: half)
+      if try predicate(self[mid]) {
+        n = half
+      } else {
+        l = index(after: mid)
+        n -= half + 1
+      }
     }
+    return l
+  }
 }
 
 //===--- Tests ------------------------------------------------------------===//

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -60,6 +60,25 @@ extension ${Slice} : MutableCollectionAlgorithms {  }
 
 /// In the stdlib, this would simply be MutableCollection
 extension MutableCollectionAlgorithms {
+  /// Swaps the elements of the two given subranges, up to the upper bound of
+  /// the smaller subrange. The returned indices are the ends of the two ranges
+  /// that were actually swapped.
+  ///
+  ///     Input:
+  ///     [a b c d e f g h i j k l m n o p]
+  ///      ^^^^^^^         ^^^^^^^^^^^^^
+  ///      lhs             rhs
+  ///
+  ///     Output:
+  ///     [i j k l e f g h a b c d m n o p]
+  ///             ^               ^
+  ///             p               q
+  ///
+  /// - Precondition: !lhs.isEmpty && !rhs.isEmpty
+  /// - Postcondition: For returned indices `(p, q)`:
+  ///   - distance(from: lhs.lowerBound, to: p) ==
+  ///       distance(from: rhs.lowerBound, to: q)
+  ///   - p == lhs.upperBound || q == rhs.upperBound
   @inline(__always)
   internal mutating func _swapNonemptySubrangePrefixes(
     _ lhs: Range<Index>, _ rhs: Range<Index>
@@ -145,6 +164,21 @@ extension MutableCollectionAlgorithms {
 
 extension MutableCollection where Self: BidirectionalCollection {
 
+  /// Reverses the elements of the collection, moving from each end until
+  /// `limit` is reached from either direction. The returned indices are the
+  /// start and end of the range of unreversed elements.
+  ///
+  ///     Input:
+  ///     [a b c d e f g h i j k l m n o p]
+  ///             ^
+  ///           limit
+  ///     Output:
+  ///     [p o n m e f g h i j k l d c b a]
+  ///             ^               ^
+  ///             f               l
+  ///
+  /// - Postcondition: For returned indices `(f, l)`:
+  ///   `f == limit || l == limit`
   @inline(__always)
   @discardableResult
   internal mutating func _reverseUntil(_ limit: Index) -> (Index, Index) {

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -43,21 +43,11 @@ public protocol MutableCollectionAlgorithms : MutableCollection {
   /// - Complexity: O(*n*)
   @discardableResult
   mutating func rotate(shiftingToStart middle: Index) -> Index
-
-  /// Rotates the elements in `bounds` so that the element
-  /// at `middle` ends up first in `bounds`.
-  ///
-  /// - Returns: The new index of the element that was first
-  ///   pre-rotation.
-  /// - Complexity: O(*n*)
-  @discardableResult
-  mutating func rotateSubrange(
-    _ bounds: Range<Index>, shiftingToStart middle: Index
-  ) -> Index
 }
 
 // In the stdlib, this conformance wouldn't be needed
 extension Array : MutableCollectionAlgorithms {  }
+extension ArraySlice : MutableCollectionAlgorithms {  }
 
 /// In the stdlib, this would simply be MutableCollection
 extension MutableCollectionAlgorithms {
@@ -96,29 +86,8 @@ extension MutableCollectionAlgorithms {
   /// - Complexity: O(*n*)
   @discardableResult
   public mutating func rotate(shiftingToStart middle: Index) -> Index {
-    return rotateSubrange(startIndex..<endIndex, shiftingToStart: middle)
-  }
-
-  /// Rotates the elements in `bounds` so that the element
-  /// at `middle` ends up first.
-  ///
-  /// - Returns: The new index of the element that was first
-  ///   pre-rotation.
-  /// - Complexity: O(*n*)
-  @discardableResult
-  public mutating func rotateSubrange(
-    _ bounds: Range<Index>, shiftingToStart middle: Index
-  ) -> Index {
-    return _rotateSubrangeForward(bounds, shiftingToStart: middle)
-  }
-
-  // Broken out of the method above for testability purposes
-  @discardableResult
-  internal mutating func _rotateSubrangeForward(
-    _ bounds: Range<Index>, shiftingToStart middle: Index
-  ) -> Index {
-    var m = middle, s = bounds.lowerBound
-    let e = bounds.upperBound
+    var m = middle, s = startIndex
+    let e = endIndex
 
     // Handle the trivial cases
     if s == m { return e }
@@ -176,32 +145,6 @@ extension MutableCollectionAlgorithms {
 
 extension MutableCollection where Self: BidirectionalCollection {
 
-  // This could be internal, but until we have pinned accessors for
-  // slices, every mutating algorithm needs a version that takes
-  // indices in order to get performance.
-
-  /// Reverses the elements in the given subrange in place.
-  ///
-  ///     var characters: [Character] = ["^", "C", "a", "f", "é", "$""]
-  ///     let r = characters.index(after: characters.startIndex)
-  ///             ..< characters.index(before: characters.endIndex)
-  ///     characters.reverseSubrange(r)
-  ///     print(cafe.characters)
-  ///     // Prints "["^", "é", "f", "a", "C", "$"]
-  ///
-  /// - Complexity: O(*n*), where *n* is the number of elements in the
-  ///   subrange.
-  public mutating func reverseSubrange(_ bounds: Range<Index>) {
-    if bounds.isEmpty { return }
-    var f = bounds.lowerBound
-    var l = index(before: bounds.upperBound)
-    while f < l {
-      swap(&self[f], &self[l])
-      formIndex(after: &f)
-      formIndex(before: &l)
-    }
-  }
-
   @inline(__always)
   @discardableResult
   internal mutating func _reverseUntil(_ limit: Index) -> (Index, Index) {
@@ -233,10 +176,10 @@ extension MutableCollection where Self: BidirectionalCollection {
     // locality properties than either of the other implementations.
     // Benchmarks should be performed for that algorithm too, just to
     // be sure.
-    reverseSubrange(startIndex..<middle)
-    reverseSubrange(middle..<endIndex)
+    self[startIndex..<middle].reverse()
+    self[middle..<endIndex].reverse()
     let (p, q) = _reverseUntil(middle)
-    reverseSubrange(p..<q)
+    self[p..<q].reverse()
     return middle == p  ? q : p
   }
 }
@@ -608,60 +551,46 @@ extension BidirectionalCollection
 
   @discardableResult
   mutating func stablePartition(
-    choosingStartGroupBy p: (Iterator.Element) -> Bool
+    choosingStartGroupBy p: (Element) -> Bool
   ) -> Index {
-    return stablyPartitionSubrange(
-      startIndex..<endIndex,
+    return _stablePartition(
+      distance: distance(from: startIndex, to: endIndex),
       choosingStartGroupBy: p
     )
   }
 
-  mutating func stablyPartitionSubrange(
-    _ bounds: Range<Index>,
-    choosingStartGroupBy p: (Iterator.Element) -> Bool
-  ) -> Index {
-    return _stablyPartitionSubrange(
-      bounds,
-      distance: distance(from: bounds.lowerBound, to: bounds.upperBound),
-      choosingStartGroupBy: p
-    )
-  }
-
-  mutating func _stablyPartitionSubrange(
-    _ bounds: Range<Index>,
+  mutating func _stablePartition(
     distance n: IndexDistance,
-    choosingStartGroupBy p: (Iterator.Element) -> Bool
+    choosingStartGroupBy p: (Element) -> Bool
   ) -> Index {
     assert(n >= 0)
-    let (start, end) = (bounds.lowerBound, bounds.upperBound)
-    assert(n == distance(from: start, to: end))
-    if n == 0 { return start }
+    assert(n == distance(from: startIndex, to: endIndex))
+    if n == 0 { return startIndex }
     if n == 1 {
-      return p(self[start]) ? index(after: start) : start
+      return p(self[startIndex]) ? endIndex : startIndex
     }
-
 
     // divide and conquer.
     let d = n / numericCast(2)
-    let m = index(start, offsetBy: d)
+    let m = index(startIndex, offsetBy: d)
 
     // TTTTTTTTT s FFFFFFF m ?????????????
-    let s = _stablyPartitionSubrange(
-      start..<m, distance: d, choosingStartGroupBy: p)
+    let s = self[..<m]._stablePartition(
+      distance: numericCast(d), choosingStartGroupBy: p)
 
     // TTTTTTTTT s FFFFFFF m TTTTTTT e FFFFFFFF
-    let e = _stablyPartitionSubrange(
-      m..<end, distance: n - d, choosingStartGroupBy: p)
+    let e = self[m...]._stablePartition(
+      distance: numericCast(n - d), choosingStartGroupBy: p)
 
     // TTTTTTTTT s TTTTTTT m  FFFFFFF e FFFFFFFF
-    return self.rotateSubrange(s..<e, shiftingToStart: m)
+    return self[s..<e].rotate(shiftingToStart: m)
   }
 }
 
 extension Collection {
   func stablyPartitioned(
-    choosingStartGroupBy p: (Iterator.Element) -> Bool
-  ) -> [Iterator.Element] {
+    choosingStartGroupBy p: (Element) -> Bool
+  ) -> [Element] {
     var a = Array(self)
     a.stablePartition(choosingStartGroupBy: p)
     return a
@@ -709,6 +638,8 @@ extension Collection {
 //===--- Tests ------------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
+func address<T>(_ p: UnsafePointer<T>) -> UInt { return UInt(bitPattern: p )}
+
 var suite = TestSuite("Algorithms")
 
 suite.test("reverseSubrange") {
@@ -719,12 +650,17 @@ suite.test("reverseSubrange") {
       let prefix = a.prefix(upTo: p)
       for q in p...l {
         let suffix = a.suffix(from: q)
+
         var b = a
-        b.reverseSubrange(p..<q)
+        b.reserveCapacity(b.count)  // guarantee unique storage
+        let id = address(b)
+
+        b[p..<q].reverse()
         expectEqual(
           b,
           Array([prefix, ArraySlice(a[p..<q].reversed()), suffix].joined()))
-        }
+        expectEqual(address(b), id)
+      }
     }
   }
 }
@@ -740,15 +676,14 @@ suite.test("rotate") {
 
         for m in p...q {
           var b = a
-          let r0 = b._rotateSubrangeForward(p..<q, shiftingToStart: m)
+          b.reserveCapacity(b.count)  // guarantee unique storage
+          let id = address(b)
+
+          let r = b[p..<q].rotate(shiftingToStart: m)
           let rotated = Array([prefix, a[m..<q], a[p..<m], suffix].joined())
           expectEqual(b, rotated)
-          expectEqual(r0, a.index(p, offsetBy: a[m..<q].count))
-
-          b = a
-          let r1 = b.rotateSubrange(p..<q, shiftingToStart: m)
-          expectEqual(b, rotated)
-          expectEqual(r1, r0)
+          expectEqual(r, a.index(p, offsetBy: a[m..<q].count))
+          expectEqual(address(b), id)
         }
       }
       var b = a
@@ -769,15 +704,14 @@ suite.test("rotateRandomAccess") {
 
         for m in p...q {
           var b = a
-          let r0 = b[p..<q].rotateRandomAccess(shiftingToStart: m)
+          b.reserveCapacity(b.count)  // guarantee unique storage
+          let id = address(b)
+
+          let r = b[p..<q].rotateRandomAccess(shiftingToStart: m)
           let rotated = Array([prefix, a[m..<q], a[p..<m], suffix].joined())
           expectEqual(b, rotated)
-          expectEqual(r0, a.index(p, offsetBy: a[m..<q].count))
-
-          b = a
-          let r1 = b[p..<q].rotateRandomAccess(shiftingToStart: m)
-          expectEqual(b, rotated)
-          expectEqual(r1, r0)
+          expectEqual(r, a.index(p, offsetBy: a[m..<q].count))
+          expectEqual(address(b), id)
         }
       }
       var b = a
@@ -803,11 +737,12 @@ suite.test("concatenate") {
 
   let h = "Hello, "
   let w = "world!"
-  let hw = concatenate(h.characters, w.characters)
+  let hw = concatenate(h, w)
   expectEqual("Hello, world!", String(hw))
 }
 
 suite.test("stablePartition") {
+  // FIXME: add test for stability
   for l in 0..<13 {
     let a = Array(0..<l)
 
@@ -823,14 +758,18 @@ suite.test("stablePartition") {
           let notf = { !f($0) }
 
           var b = a
-          var r = b.stablyPartitionSubrange(p..<q, choosingStartGroupBy: f)
+          b.reserveCapacity(b.count)  // guarantee unique storage
+          let id = address(b)
+
+          var r = b[p..<q].stablePartition(choosingStartGroupBy: f)
           expectEqual(b.prefix(upTo:p), prefix)
           expectEqual(b.suffix(from:q), suffix)
           expectEqual(b[p..<r], ArraySlice(subrange.filter(f)))
           expectEqual(b[r..<q], ArraySlice(subrange.filter(notf)))
+          expectEqual(address(b), id)
 
           b = a
-          r = b.stablyPartitionSubrange(p..<q, choosingStartGroupBy: notf)
+          r = b[p..<q].stablePartition(choosingStartGroupBy: notf)
           expectEqual(b.prefix(upTo:p), prefix)
           expectEqual(b.suffix(from:q), suffix)
           expectEqual(b[p..<r], ArraySlice(subrange.filter(notf)))

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -34,7 +34,9 @@ from gyb_stdlib_support import (
 //===----------------------------------------------------------------------===//
 
 // In the stdlib, this would simply be MutableCollection
-public protocol MutableCollectionAlgorithms : MutableCollection {
+public protocol MutableCollectionAlgorithms : MutableCollection
+  where SubSequence : MutableCollectionAlgorithms
+{
   /// Rotates the elements of the collection so that the element
   /// at `middle` ends up first.
   ///
@@ -74,15 +76,6 @@ extension MutableCollectionAlgorithms {
     }
     while p != lhs.upperBound && q != rhs.upperBound
     return (p, q)
-  }
-
-  @inline(__always)
-  internal mutating func _swapSubrangePrefixes(
-    _ lhs: Range<Index>, with rhs: Range<Index>
-  ) -> (Index, Index) {
-    return lhs.isEmpty || rhs.isEmpty
-      ? (lhs.lowerBound, rhs.lowerBound)
-      : _swapNonemptySubrangePrefixes(lhs, rhs)
   }
 
   /// Rotates the elements of the collection so that the element
@@ -183,11 +176,11 @@ extension MutableCollection where Self: BidirectionalCollection {
     // locality properties than either of the other implementations.
     // Benchmarks should be performed for that algorithm too, just to
     // be sure.
-    self[startIndex..<middle].reverse()
-    self[middle..<endIndex].reverse()
+    self[..<middle].reverse()
+    self[middle...].reverse()
     let (p, q) = _reverseUntil(middle)
     self[p..<q].reverse()
-    return middle == p  ? q : p
+    return middle == p ? q : p
   }
 }
 
@@ -209,17 +202,15 @@ extension MutableCollection where Self: RandomAccessCollection {
   @inline(__always)
   internal mutating func _rotateCycle(
     start: Index,
-    pivot: Index,
-    plus: IndexDistance,
-    minus: IndexDistance)
-  {
+    sourceOffsetForIndex: (Index) -> IndexDistance
+  ) {
     let tmp = self[start]
     var i = start
-    var j = index(start, offsetBy: start < pivot ? plus : minus)
+    var j = index(start, offsetBy: sourceOffsetForIndex(start))
     while j != start {
       self[i] = self[j]
       i = j
-      j = index(j, offsetBy: j < pivot ? plus : minus)
+      j = index(j, offsetBy: sourceOffsetForIndex(j))
     }
     self[i] = tmp
   }
@@ -252,7 +243,7 @@ extension MutableCollection where Self: RandomAccessCollection {
     for cycle in 1...cycles {
       _rotateCycle(
         start: index(startIndex, offsetBy: numericCast(cycle)),
-        pivot: pivot, plus: plus, minus: minus)
+        sourceOffsetForIndex: { $0 < pivot ? plus : minus })
     }
     return pivot
   }
@@ -293,35 +284,33 @@ public struct ConcatenatedCollectionIndex<
 
   internal let _position:
     _ConcatenatedCollectionIndexRepresentation<C1.Index, C2.Index>
-}
 
-public func < <C1: Collection, C2: Collection>(
-  lhs: ConcatenatedCollectionIndex<C1, C2>,
-  rhs: ConcatenatedCollectionIndex<C1, C2>
-) -> Bool {
-  switch (lhs._position, rhs._position) {
-  case (.first, .second):
-    return true
-  case (.second, .first):
-    return false
-  case let (.first(l), .first(r)):
-    return l < r
-  case let (.second(l), .second(r)):
-    return l < r
+  public static func < (
+    lhs: ConcatenatedCollectionIndex, rhs: ConcatenatedCollectionIndex
+  ) -> Bool {
+    switch (lhs._position, rhs._position) {
+    case (.first, .second):
+      return true
+    case (.second, .first):
+      return false
+    case let (.first(l), .first(r)):
+      return l < r
+    case let (.second(l), .second(r)):
+      return l < r
+    }
   }
-}
 
-public func == <C1: Collection, C2: Collection>(
-  lhs: ConcatenatedCollectionIndex<C1, C2>,
-  rhs: ConcatenatedCollectionIndex<C1, C2>
-) -> Bool {
-  switch (lhs._position, rhs._position) {
-  case let (.first(l), .first(r)):
-    return l == r
-  case let (.second(l), .second(r)):
-    return l == r
-  default:
-    return false
+  public static func == (
+    lhs: ConcatenatedCollectionIndex, rhs: ConcatenatedCollectionIndex
+  ) -> Bool {
+    switch (lhs._position, rhs._position) {
+    case let (.first(l), .first(r)):
+      return l == r
+    case let (.second(l), .second(r)):
+      return l == r
+    default:
+      return false
+    }
   }
 }
 
@@ -458,18 +447,18 @@ where C1.Element == C2.Element {
 public struct RotatedCollectionIndex<Base : Collection> : Comparable {
   internal let _index:
     ConcatenatedCollectionIndex<Base.SubSequence, Base.SubSequence>
-}
 
-public func < <Base: Collection>(
-  lhs: RotatedCollectionIndex<Base>, rhs: RotatedCollectionIndex<Base>
-) -> Bool {
-  return lhs._index < rhs._index
-}
+  public static func < (
+    lhs: RotatedCollectionIndex, rhs: RotatedCollectionIndex
+  ) -> Bool {
+    return lhs._index < rhs._index
+  }
 
-public func == <Base: Collection>(
-  lhs: RotatedCollectionIndex<Base>, rhs: RotatedCollectionIndex<Base>
-) -> Bool {
-  return lhs._index == rhs._index
+  public static func == (
+    lhs: RotatedCollectionIndex, rhs: RotatedCollectionIndex
+  ) -> Bool {
+    return lhs._index == rhs._index
+  }
 }
 
 % for Traversal in TRAVERSALS:
@@ -484,7 +473,7 @@ public struct ${Self}<
     Base.SubSequence, Base.SubSequence>
 
   init(_base: Base, shiftingToStart i: Base.Index) {
-    _concatenation = concatenate(_base.suffix(from: i), _base.prefix(upTo: i))
+    _concatenation = concatenate(_base[i...], _base[..<i])
   }
 
   public typealias Index = RotatedCollectionIndex<Base>
@@ -553,8 +542,7 @@ extension ${Collection} {
 //===----------------------------------------------------------------------===//
 
 extension BidirectionalCollection
-  where Self : MutableCollectionAlgorithms,
-  SubSequence: MutableCollectionAlgorithms {
+  where Self : MutableCollectionAlgorithms {
 
   @discardableResult
   mutating func stablePartition(
@@ -654,9 +642,9 @@ suite.test("reverseSubrange") {
     let a = Array(0..<l)
 
     for p in a.startIndex...a.endIndex {
-      let prefix = a.prefix(upTo: p)
+      let prefix = a[..<p]
       for q in p...l {
-        let suffix = a.suffix(from: q)
+        let suffix = a[q...]
 
         var b = a
         b.reserveCapacity(b.count)  // guarantee unique storage
@@ -677,9 +665,9 @@ suite.test("rotate") {
     let a = Array(0..<l)
 
     for p in a.startIndex...a.endIndex {
-      let prefix = a.prefix(upTo: p)
+      let prefix = a[..<p]
       for q in p...l {
-        let suffix = a.suffix(from: q)
+        let suffix = a[q...]
 
         for m in p...q {
           var b = a
@@ -705,9 +693,9 @@ suite.test("rotateRandomAccess") {
     let a = Array(0..<l)
 
     for p in a.startIndex...a.endIndex {
-      let prefix = a.prefix(upTo: p)
+      let prefix = a[..<p]
       for q in p...l {
-        let suffix = a.suffix(from: q)
+        let suffix = a[q...]
 
         for m in p...q {
           var b = a
@@ -754,9 +742,9 @@ suite.test("stablePartition") {
     let a = Array(0..<l)
 
     for p in a.startIndex...a.endIndex {
-      let prefix = a.prefix(upTo: p)
+      let prefix = a[..<p]
       for q in p...l {
-        let suffix = a.suffix(from: q)
+        let suffix = a[q...]
 
         let subrange = a[p..<q]
 
@@ -769,7 +757,7 @@ suite.test("stablePartition") {
           let id = address(b)
 
           var r = b[p..<q].stablePartition(choosingStartGroupBy: f)
-          expectEqual(b.prefix(upTo:p), prefix)
+          expectEqual(b[..<p], prefix)
           expectEqual(b.suffix(from:q), suffix)
           expectEqual(b[p..<r], ArraySlice(subrange.filter(f)))
           expectEqual(b[r..<q], ArraySlice(subrange.filter(notf)))
@@ -777,7 +765,7 @@ suite.test("stablePartition") {
 
           b = a
           r = b[p..<q].stablePartition(choosingStartGroupBy: notf)
-          expectEqual(b.prefix(upTo:p), prefix)
+          expectEqual(b[..<p], prefix)
           expectEqual(b.suffix(from:q), suffix)
           expectEqual(b[p..<r], ArraySlice(subrange.filter(notf)))
           expectEqual(b[r..<q], ArraySlice(subrange.filter(f)))
@@ -789,13 +777,13 @@ suite.test("stablePartition") {
         let notf = { !f($0) }
         var b = a
         var r = b.stablePartition(choosingStartGroupBy: f)
-        expectEqual(b.prefix(upTo: r), ArraySlice(a.filter(f)))
-        expectEqual(b.suffix(from: r), ArraySlice(a.filter(notf)))
+        expectEqual(b[..<r], ArraySlice(a.filter(f)))
+        expectEqual(b[r...], ArraySlice(a.filter(notf)))
 
         b = a
         r = b.stablePartition(choosingStartGroupBy: notf)
-        expectEqual(b.prefix(upTo: r), ArraySlice(a.filter(notf)))
-        expectEqual(b.suffix(from: r), ArraySlice(a.filter(f)))
+        expectEqual(b[..<r], ArraySlice(a.filter(notf)))
+        expectEqual(b[r...], ArraySlice(a.filter(f)))
       }
     }
   }

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
 // RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/out.swift
-// RUN: %line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out -Onone
+// RUN: %line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out -Onone -swift-version 4
 // RUN: %line-directive %t/out.swift -- %target-run %t/a.out
 
 // REQUIRES: executable_test


### PR DESCRIPTION
Now that collection slices pin properly, the recursive parts of these algorithms can operate on slices instead of only working on the whole collection and using a `subrange` parameter. 

This change also adds fixes for memory exclusivity, removes newly redundant generic constraints, and adds tests to make sure we’re successfully performing the algorithms without reallocating.
