### PR TITLE
NFC: First step (refactoring) towards speeding up compilation w/ >1 primary file

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -250,16 +250,14 @@ public:
   void addInputBuffer(llvm::MemoryBuffer *Buf) {
     FrontendOpts.Inputs.addInputBuffer(Buf);
   }
-    
+
   void setPrimaryInput(SelectedInput pi) {
     FrontendOpts.Inputs.setPrimaryInput(pi);
   }
 
-  void clearInputs() {
-    FrontendOpts.Inputs.clearInputs();
-  }
+  void clearInputs() { FrontendOpts.Inputs.clearInputs(); }
 
-   StringRef getOutputFilename() const {
+  StringRef getOutputFilename() const {
     return FrontendOpts.getSingleOutputFilename();
   }
 
@@ -357,7 +355,7 @@ class CompilerInstance {
 
   void createSILModule();
   void setPrimarySourceFile(SourceFile *SF);
-  
+
   bool setupForFileAt(unsigned i);
 
 public:
@@ -416,7 +414,9 @@ public:
 
   SerializedModuleLoader *getSerializedModuleLoader() const { return SML; }
 
-  ArrayRef<unsigned> getInputBufferIDs() const { return InputSourceCodeBufferIDs; }
+  ArrayRef<unsigned> getInputBufferIDs() const {
+    return InputSourceCodeBufferIDs;
+  }
 
   ArrayRef<LinkLibrary> getLinkLibraries() const {
     return Invocation.getLinkLibraries();

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -243,27 +243,23 @@ public:
   }
 
   void addInputFilename(StringRef Filename) {
-    FrontendOpts.InputFilenames.push_back(Filename);
+    FrontendOpts.Inputs.addInputFilename(Filename);
   }
 
   /// Does not take ownership of \p Buf.
   void addInputBuffer(llvm::MemoryBuffer *Buf) {
-    FrontendOpts.InputBuffers.push_back(Buf);
+    FrontendOpts.Inputs.addInputBuffer(Buf);
+  }
+    
+  void setPrimaryInput(SelectedInput pi) {
+    FrontendOpts.Inputs.setPrimaryInput(pi);
   }
 
   void clearInputs() {
-    FrontendOpts.InputFilenames.clear();
-    FrontendOpts.InputBuffers.clear();
+    FrontendOpts.Inputs.clearInputs();
   }
 
-  ArrayRef<std::string> getInputFilenames() const {
-    return FrontendOpts.InputFilenames;
-  }
-  ArrayRef<llvm::MemoryBuffer*> getInputBuffers() const {
-    return FrontendOpts.InputBuffers;
-  }
-
-  StringRef getOutputFilename() const {
+   StringRef getOutputFilename() const {
     return FrontendOpts.getSingleOutputFilename();
   }
 
@@ -339,7 +335,7 @@ class CompilerInstance {
   SerializedModuleLoader *SML = nullptr;
 
   /// Contains buffer IDs for input source code files.
-  std::vector<unsigned> BufferIDs;
+  std::vector<unsigned> InputSourceCodeBufferIDs;
 
   struct PartialModuleInputs {
     std::unique_ptr<llvm::MemoryBuffer> ModuleBuffer;
@@ -361,6 +357,8 @@ class CompilerInstance {
 
   void createSILModule();
   void setPrimarySourceFile(SourceFile *SF);
+  
+  bool setupForFileAt(unsigned i);
 
 public:
   SourceManager &getSourceMgr() { return SourceMgr; }
@@ -418,7 +416,7 @@ public:
 
   SerializedModuleLoader *getSerializedModuleLoader() const { return SML; }
 
-  ArrayRef<unsigned> getInputBufferIDs() const { return BufferIDs; }
+  ArrayRef<unsigned> getInputBufferIDs() const { return InputSourceCodeBufferIDs; }
 
   ArrayRef<LinkLibrary> getLinkLibraries() const {
     return Invocation.getLinkLibraries();

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -22,9 +22,9 @@
 namespace llvm {
   class MemoryBuffer;
   namespace opt {
-    class ArgList;
-    class Arg;
-  }
+  class ArgList;
+  class Arg;
+  } // namespace opt
 }
 
 namespace swift {
@@ -70,147 +70,134 @@ enum class InputFileKind {
 class FrontendInputs {
 private:
   // FIXME: (dmu) create a class for the inputs
-  
+
   /// The names of input files to the frontend.
   std::vector<std::string> InputFilenames;
-  
+
   /// Input buffers which may override the file contents of input files.
   std::vector<llvm::MemoryBuffer *> InputBuffers;
-  
+
   /// The input for which output should be generated. If not set, output will
   /// be generated for the whole module.
   Optional<SelectedInput> PrimaryInput;
-  
+
 public:
-  
   // Readers:
-  
+
   // Input filename readers
-  ArrayRef<std::string> getInputFilenames() const {
-    return InputFilenames;
-  }
-  bool hasInputFilenames() const {
-    return !getInputFilenames().empty();
-  }
+  ArrayRef<std::string> getInputFilenames() const { return InputFilenames; }
+  bool hasInputFilenames() const { return !getInputFilenames().empty(); }
   unsigned inputFilenameCount() const { return getInputFilenames().size(); }
-  
-  bool hasUniqueInputFilename() const {
-    return inputFilenameCount() == 1;
-  }
+
+  bool hasUniqueInputFilename() const { return inputFilenameCount() == 1; }
   const std::string &getFilenameOfFirstInput() const {
     assert(hasInputFilenames());
     return getInputFilenames()[0];
   }
-  
+
   bool isReadingFromStdin() {
-    return hasUniqueInputFilename()  &&  getFilenameOfFirstInput() == "-";
+    return hasUniqueInputFilename() && getFilenameOfFirstInput() == "-";
   }
-  
+
   // If we have exactly one input filename, and its extension is "bc" or "ll",
   // treat the input as LLVM_IR.
   bool shouldTreatAsLLVM() const;
-  
+
   // Input buffer readers
-  
-  ArrayRef<llvm::MemoryBuffer*> getInputBuffers() const {
+
+  ArrayRef<llvm::MemoryBuffer *> getInputBuffers() const {
     return InputBuffers;
   }
   unsigned inputBufferCount() const { return getInputBuffers().size(); }
- 
+
   // Primary input readers
 
-  Optional<SelectedInput> getPrimaryInput() const {
-    return PrimaryInput;
-  }
-  bool hasPrimaryInput() const {
-    return getPrimaryInput().hasValue();
-  }
-  
+  Optional<SelectedInput> getPrimaryInput() const { return PrimaryInput; }
+  bool hasPrimaryInput() const { return getPrimaryInput().hasValue(); }
+
   bool isWholeModule() { return !hasPrimaryInput(); }
-  
+
   bool isPrimaryInputAFileAt(unsigned i) {
-    return hasPrimaryInput() &&  getPrimaryInput()->isFilename()  &&  getPrimaryInput()->Index == i;
+    return hasPrimaryInput() && getPrimaryInput()->isFilename() &&
+           getPrimaryInput()->Index == i;
   }
   bool haveAPrimaryInputFile() const {
     return hasPrimaryInput() && getPrimaryInput()->isFilename();
   }
   Optional<unsigned> primaryInputFileIndex() const {
-    return haveAPrimaryInputFile() ? Optional<unsigned>(getPrimaryInput()->Index) : None;
+    return haveAPrimaryInputFile()
+               ? Optional<unsigned>(getPrimaryInput()->Index)
+               : None;
   }
-  
+
   StringRef primaryInputFilenameIfAny() const {
     if (auto Index = primaryInputFileIndex()) {
       return getInputFilenames()[*Index];
     }
     return StringRef();
   }
-  
+
   // Multi-facet readers
-  StringRef baseNameOfOutput(const llvm::opt::ArgList &Args, StringRef ModuleName) const;
+  StringRef baseNameOfOutput(const llvm::opt::ArgList &Args,
+                             StringRef ModuleName) const;
   bool shouldTreatAsSIL() const;
-  
+
   /// Return true for error
-  bool verifyInputs(DiagnosticEngine &Diags, bool TreatAsSIL, bool isREPLRequested, bool isNoneRequested) const;
-  
+  bool verifyInputs(DiagnosticEngine &Diags, bool TreatAsSIL,
+                    bool isREPLRequested, bool isNoneRequested) const;
+
   // Input filename writers
-  
+
   void addInputFilename(StringRef Filename) {
     InputFilenames.push_back(Filename);
   }
-  void transformInputFilenames(const llvm::function_ref<std::string(std::string)> &fn);
-  
+  void transformInputFilenames(
+      const llvm::function_ref<std::string(std::string)> &fn);
+
   // Input buffer writers
-  
-  void addInputBuffer(llvm::MemoryBuffer *Buf) {
-    InputBuffers.push_back(Buf);
+
+  void addInputBuffer(llvm::MemoryBuffer *Buf) { InputBuffers.push_back(Buf); }
+
+  // Primary input writers
+
+  void setPrimaryInput(SelectedInput si) { PrimaryInput = si; }
+  void clearPrimaryInput() { PrimaryInput = 0; }
+  void setPrimaryInputForInputFilename(const std::string &inputFilename) {
+    setPrimaryInput(!inputFilename.empty() && inputFilename != "-"
+                        ? SelectedInput(inputFilenameCount(),
+                                        SelectedInput::InputKind::Filename)
+                        : SelectedInput(inputBufferCount(),
+                                        SelectedInput::InputKind::Buffer));
   }
 
-  
-  // Primary input writers
-  
-  void setPrimaryInput(SelectedInput si) {
-    PrimaryInput = si;
-  }
-  void clearPrimaryInput() {
-    PrimaryInput = 0;
-  }
-  void setPrimaryInputForInputFilename(const std::string &inputFilename) {
-    setPrimaryInput(
-                    !inputFilename.empty() && inputFilename != "-"
-                    ? SelectedInput(inputFilenameCount(), SelectedInput::InputKind::Filename)
-                    : SelectedInput(inputBufferCount(),   SelectedInput::InputKind::Buffer)
-                    );
-  }
-  
   // Multi-faceted writers
-  
+
   void clearInputs() {
     InputFilenames.clear();
     InputBuffers.clear();
   }
-  
-  void setInputFilenamesAndPrimaryInput(DiagnosticEngine &Diags, llvm::opt::ArgList &Args);
-  
-  void readInputFileList(DiagnosticEngine &diags,
-                         llvm::opt::ArgList &Args,
+
+  void setInputFilenamesAndPrimaryInput(DiagnosticEngine &Diags,
+                                        llvm::opt::ArgList &Args);
+
+  void readInputFileList(DiagnosticEngine &diags, llvm::opt::ArgList &Args,
                          const llvm::opt::Arg *filelistPath);
- 
 };
 
 /// Options for controlling the behavior of the frontend.
 class FrontendOptions {
 public:
   FrontendInputs Inputs;
-  
+
   /// The kind of input on which the frontend should operate.
   InputFileKind InputKind = InputFileKind::IFK_Swift;
 
   /// The specified output files. If only a single outputfile is generated,
   /// the name of the last specified file is taken.
   std::vector<std::string> OutputFilenames;
-  
+
   void forAllOutputPaths(std::function<void(const std::string &)> fn) const;
-  
+
   /// Gets the name of the specified output filename.
   /// If multiple files are specified, the last one is returned.
   StringRef getSingleOutputFilename() const {
@@ -223,9 +210,7 @@ public:
     OutputFilenames.clear();
     OutputFilenames.push_back(FileName);
   }
-  void setOutputFilenameToStdout() {
-    setSingleOutputFilename("-");
-  }
+  void setOutputFilenameToStdout() { setSingleOutputFilename("-"); }
   bool isOutputFilenameStdout() const {
     return getSingleOutputFilename() == "-";
   }
@@ -234,7 +219,8 @@ public:
   bool hasNamedOutputFile() const {
     return !OutputFilenames.empty() && !isOutputFilenameStdout();
   }
-  void setOutputFileList(DiagnosticEngine &Diags, const llvm::opt::ArgList &Args );
+  void setOutputFileList(DiagnosticEngine &Diags,
+                         const llvm::opt::ArgList &Args);
 
   /// A list of arbitrary modules to import and make implicitly visible.
   std::vector<std::string> ImplicitImportModuleNames;
@@ -479,25 +465,22 @@ public:
   /// Indicates whether the RequestedAction will immediately run code.
   bool actionIsImmediate() const;
 
-
-
-
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {
     return llvm::hash_value(0);
   }
-  
+
   StringRef originalPath() const;
-  
+
   StringRef determineFallbackModuleName() const;
-  
+
   bool isCompilingExactlyOneSwiftFile() const {
-    return InputKind == InputFileKind::IFK_Swift && Inputs.hasUniqueInputFilename();
+    return InputKind == InputFileKind::IFK_Swift &&
+           Inputs.hasUniqueInputFilename();
   }
-  
+
   void setModuleName(DiagnosticEngine &Diags, const llvm::opt::ArgList &Args);
-  
 };
 
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -325,16 +325,20 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     return true;
   }
 
-  bool TreatAsSIL = Args.hasArg(OPT_parse_sil) || Opts.Inputs.shouldTreatAsSIL();
+  bool TreatAsSIL =
+      Args.hasArg(OPT_parse_sil) || Opts.Inputs.shouldTreatAsSIL();
 
   bool TreatAsLLVM = Opts.Inputs.shouldTreatAsLLVM();
 
-  if (Opts.Inputs.verifyInputs(Diags, TreatAsSIL, Opts.RequestedAction == FrontendOptions::REPL, Opts.RequestedAction == FrontendOptions::NoneAction)) {
+  if (Opts.Inputs.verifyInputs(
+          Diags, TreatAsSIL, Opts.RequestedAction == FrontendOptions::REPL,
+          Opts.RequestedAction == FrontendOptions::NoneAction)) {
     return true;
   }
 
   if (Opts.RequestedAction == FrontendOptions::Immediate) {
-    Opts.ImmediateArgv.push_back(Opts.Inputs.getFilenameOfFirstInput()); // argv[0]
+    Opts.ImmediateArgv.push_back(
+        Opts.Inputs.getFilenameOfFirstInput()); // argv[0]
     if (const Arg *A = Args.getLastArg(OPT__DASH_DASH)) {
       for (unsigned i = 0, e = A->getNumValues(); i != e; ++i) {
         Opts.ImmediateArgv.push_back(A->getValue(i));
@@ -451,11 +455,12 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
       // First, if we're reading from stdin and we don't have a directory,
       // output to stdout.
-      if (Opts.Inputs.isReadingFromStdin() &&  Opts.OutputFilenames.empty())
+      if (Opts.Inputs.isReadingFromStdin() && Opts.OutputFilenames.empty())
         Opts.setOutputFilenameToStdout();
       else {
         // We have a suffix, so determine an appropriate name.
-        StringRef BaseName = Opts.Inputs.baseNameOfOutput(Args, Opts.ModuleName);
+        StringRef BaseName =
+            Opts.Inputs.baseNameOfOutput(Args, Opts.ModuleName);
         llvm::SmallString<128> Path(Opts.getSingleOutputFilename());
         llvm::sys::path::append(Path, BaseName);
         llvm::sys::path::replace_extension(Path, Suffix);
@@ -702,7 +707,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArgNoClaim(OPT_import_objc_header)) {
     Opts.ImplicitObjCHeaderPath = A->getValue();
     Opts.SerializeBridgingHeader |=
-      !Opts.Inputs.getPrimaryInput() && !Opts.ModuleOutputPath.empty();
+        !Opts.Inputs.getPrimaryInput() && !Opts.ModuleOutputPath.empty();
   }
 
   for (const Arg *A : Args.filtered(OPT_import_module)) {
@@ -1432,7 +1437,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // in other classes.
   if (!SILOpts.SILOutputFileNameForDebugging.empty()) {
     Opts.MainInputFilename = SILOpts.SILOutputFileNameForDebugging;
-  } else if (FrontendOpts.Inputs.getPrimaryInput() && FrontendOpts.Inputs.getPrimaryInput()->isFilename()) {
+  } else if (FrontendOpts.Inputs.getPrimaryInput() &&
+             FrontendOpts.Inputs.getPrimaryInput()->isFilename()) {
     unsigned Index = FrontendOpts.Inputs.getPrimaryInput()->Index;
     Opts.MainInputFilename = FrontendOpts.Inputs.getInputFilenames()[Index];
   } else if (FrontendOpts.Inputs.hasUniqueInputFilename()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -27,7 +27,6 @@
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/LineIterator.h"
 #include "llvm/Support/Path.h"
 
 using namespace swift;
@@ -98,47 +97,6 @@ static void debugFailWithCrash() {
   LLVM_BUILTIN_TRAP;
 }
 
-/// Try to read a file list file.
-///
-/// Returns false on error.
-static bool readFileList(DiagnosticEngine &diags,
-                         std::vector<std::string> &inputFiles,
-                         const llvm::opt::Arg *filelistPath,
-                         const llvm::opt::Arg *primaryFileArg = nullptr,
-                         unsigned *primaryFileIndex = nullptr) {
-  assert((primaryFileArg == nullptr) || (primaryFileIndex != nullptr) &&
-         "did not provide argument for primary file index");
-
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
-      llvm::MemoryBuffer::getFile(filelistPath->getValue());
-  if (!buffer) {
-    diags.diagnose(SourceLoc(), diag::cannot_open_file,
-                   filelistPath->getValue(), buffer.getError().message());
-    return false;
-  }
-
-  bool foundPrimaryFile = false;
-  if (primaryFileIndex) *primaryFileIndex = 0;
-
-  for (StringRef line : make_range(llvm::line_iterator(*buffer.get()), {})) {
-    inputFiles.push_back(line);
-
-    if (foundPrimaryFile || primaryFileArg == nullptr)
-      continue;
-    if (line == primaryFileArg->getValue())
-      foundPrimaryFile = true;
-    else
-      ++*primaryFileIndex;
-  }
-
-  if (primaryFileArg && !foundPrimaryFile) {
-    diags.diagnose(SourceLoc(), diag::error_primary_file_not_found,
-                   primaryFileArg->getValue(), filelistPath->getValue());
-    return false;
-  }
-
-  return true;
-}
 
 static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
                               DiagnosticEngine &Diags) {
@@ -267,27 +225,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     }
   }
 
-  if (const Arg *A = Args.getLastArg(OPT_filelist)) {
-    const Arg *primaryFileArg = Args.getLastArg(OPT_primary_file);
-    unsigned primaryFileIndex = 0;
-    if (readFileList(Diags, Opts.InputFilenames, A,
-                     primaryFileArg, &primaryFileIndex)) {
-      if (primaryFileArg)
-        Opts.PrimaryInput = SelectedInput(primaryFileIndex);
-      assert(!Args.hasArg(OPT_INPUT) && "mixing -filelist with inputs");
-    }
-  } else {
-    for (const Arg *A : Args.filtered(OPT_INPUT, OPT_primary_file)) {
-      if (A->getOption().matches(OPT_INPUT)) {
-        Opts.InputFilenames.push_back(A->getValue());
-      } else if (A->getOption().matches(OPT_primary_file)) {
-        Opts.PrimaryInput = SelectedInput(Opts.InputFilenames.size());
-        Opts.InputFilenames.push_back(A->getValue());
-      } else {
-        llvm_unreachable("Unknown input-related argument!");
-      }
-    }
-  }
+  Opts.Inputs.setInputFilenamesAndPrimaryInput(Diags, Args);
 
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);
 
@@ -382,71 +320,21 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   }
 
   if (Opts.RequestedAction == FrontendOptions::Immediate &&
-      Opts.PrimaryInput.hasValue()) {
+      Opts.Inputs.hasPrimaryInput()) {
     Diags.diagnose(SourceLoc(), diag::error_immediate_mode_primary_file);
     return true;
   }
 
-  bool TreatAsSIL = Args.hasArg(OPT_parse_sil);
-  if (!TreatAsSIL && Opts.InputFilenames.size() == 1) {
-    // If we have exactly one input filename, and its extension is "sil",
-    // treat the input as SIL.
-    StringRef Input(Opts.InputFilenames[0]);
-    TreatAsSIL = llvm::sys::path::extension(Input).endswith(SIL_EXTENSION);
-  } else if (!TreatAsSIL && Opts.PrimaryInput.hasValue() &&
-             Opts.PrimaryInput->isFilename()) {
-    // If we have a primary input and it's a filename with extension "sil",
-    // treat the input as SIL.
-    StringRef Input(Opts.InputFilenames[Opts.PrimaryInput->Index]);
-    TreatAsSIL = llvm::sys::path::extension(Input).endswith(SIL_EXTENSION);
-  }
+  bool TreatAsSIL = Args.hasArg(OPT_parse_sil) || Opts.Inputs.shouldTreatAsSIL();
 
-  // If we have exactly one input filename, and its extension is "bc" or "ll",
-  // treat the input as LLVM_IR.
-  bool TreatAsLLVM = false;
-  if (Opts.InputFilenames.size() == 1) {
-    StringRef Input(Opts.InputFilenames[0]);
-    TreatAsLLVM =
-      llvm::sys::path::extension(Input).endswith(LLVM_BC_EXTENSION) ||
-      llvm::sys::path::extension(Input).endswith(LLVM_IR_EXTENSION);
-  }
+  bool TreatAsLLVM = Opts.Inputs.shouldTreatAsLLVM();
 
-  if (Opts.RequestedAction == FrontendOptions::REPL) {
-    if (!Opts.InputFilenames.empty()) {
-      Diags.diagnose(SourceLoc(), diag::error_repl_requires_no_input_files);
-      return true;
-    }
-  } else if (TreatAsSIL && Opts.PrimaryInput.hasValue()) {
-    // If we have the SIL as our primary input, we can waive the one file
-    // requirement as long as all the other inputs are SIBs.
-    if (Opts.PrimaryInput.hasValue()) {
-      for (unsigned i = 0, e = Opts.InputFilenames.size(); i != e; ++i) {
-        if (i == Opts.PrimaryInput->Index)
-          continue;
-
-        StringRef File(Opts.InputFilenames[i]);
-        if (!llvm::sys::path::extension(File).endswith(SIB_EXTENSION)) {
-          Diags.diagnose(SourceLoc(),
-                         diag::error_mode_requires_one_sil_multi_sib);
-          return true;
-        }
-      }
-    }
-  } else if (TreatAsSIL) {
-    if (Opts.InputFilenames.size() != 1) {
-      Diags.diagnose(SourceLoc(), diag::error_mode_requires_one_input_file);
-      return true;
-    }
-  } else if (Opts.RequestedAction != FrontendOptions::NoneAction) {
-    if (Opts.InputFilenames.empty()) {
-      Diags.diagnose(SourceLoc(), diag::error_mode_requires_an_input_file);
-      return true;
-    }
+  if (Opts.Inputs.verifyInputs(Diags, TreatAsSIL, Opts.RequestedAction == FrontendOptions::REPL, Opts.RequestedAction == FrontendOptions::NoneAction)) {
+    return true;
   }
 
   if (Opts.RequestedAction == FrontendOptions::Immediate) {
-    assert(!Opts.InputFilenames.empty());
-    Opts.ImmediateArgv.push_back(Opts.InputFilenames[0]); // argv[0]
+    Opts.ImmediateArgv.push_back(Opts.Inputs.getFilenameOfFirstInput()); // argv[0]
     if (const Arg *A = Args.getLastArg(OPT__DASH_DASH)) {
       for (unsigned i = 0, e = A->getNumValues(); i != e; ++i) {
         Opts.ImmediateArgv.push_back(A->getValue(i));
@@ -465,59 +353,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   else
     Opts.InputKind = InputFileKind::IFK_Swift;
 
-  if (const Arg *A = Args.getLastArg(OPT_output_filelist)) {
-    readFileList(Diags, Opts.OutputFilenames, A);
-    assert(!Args.hasArg(OPT_o) && "don't use -o with -output-filelist");
-  } else {
-    Opts.OutputFilenames = Args.getAllArgValues(OPT_o);
-  }
+  Opts.setOutputFileList(Diags, Args);
 
-  bool UserSpecifiedModuleName = false;
-  {
-    const Arg *A = Args.getLastArg(OPT_module_name);
-    StringRef ModuleName = Opts.ModuleName;
-    if (A) {
-      ModuleName = A->getValue();
-      UserSpecifiedModuleName = true;
-    } else if (ModuleName.empty()) {
-      // The user did not specify a module name, so determine a default fallback
-      // based on other options.
-
-      // Note: this code path will only be taken when running the frontend
-      // directly; the driver should always pass -module-name when invoking the
-      // frontend.
-      if (Opts.RequestedAction == FrontendOptions::REPL) {
-        // Default to a module named "REPL" if we're in REPL mode.
-        ModuleName = "REPL";
-      } else if (!Opts.InputFilenames.empty()) {
-        StringRef OutputFilename = Opts.getSingleOutputFilename();
-        if (OutputFilename.empty() || OutputFilename == "-" ||
-            llvm::sys::fs::is_directory(OutputFilename)) {
-          ModuleName = Opts.InputFilenames[0];
-        } else {
-          ModuleName = OutputFilename;
-        }
-
-        ModuleName = llvm::sys::path::stem(ModuleName);
-      }
-    }
-
-    if (!Lexer::isIdentifier(ModuleName) ||
-        (ModuleName == STDLIB_NAME && !Opts.ParseStdlib)) {
-      if (!Opts.actionHasOutput() ||
-          (Opts.InputKind == InputFileKind::IFK_Swift &&
-           Opts.InputFilenames.size() == 1)) {
-        ModuleName = "main";
-      } else {
-        auto DID = (ModuleName == STDLIB_NAME) ? diag::error_stdlib_module_name
-                                               : diag::error_bad_module_name;
-        Diags.diagnose(SourceLoc(), DID, ModuleName, A == nullptr);
-        ModuleName = "__bad__";
-      }
-    }
-
-    Opts.ModuleName = ModuleName;
-  }
+  Opts.setModuleName(Diags, Args);
 
   if (Opts.OutputFilenames.empty() ||
       llvm::sys::fs::is_directory(Opts.getSingleOutputFilename())) {
@@ -543,7 +381,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
       // Textual modes.
-      Opts.setSingleOutputFilename("-");
+      Opts.setOutputFilenameToStdout();
       break;
 
     case FrontendOptions::EmitPCH:
@@ -553,7 +391,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::EmitSIL: {
       if (Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
+        Opts.setOutputFilenameToStdout();
       else
         Suffix = SIL_EXTENSION;
       break;
@@ -577,7 +415,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
     case FrontendOptions::EmitAssembly: {
       if (Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
+        Opts.setOutputFilenameToStdout();
       else
         Suffix = "s";
       break;
@@ -585,7 +423,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
     case FrontendOptions::EmitIR: {
       if (Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
+        Opts.setOutputFilenameToStdout();
       else
         Suffix = "ll";
       break;
@@ -602,7 +440,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
     case FrontendOptions::EmitImportedModules:
       if (Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
+        Opts.setOutputFilenameToStdout();
       else
         Suffix = "importedmodules";
       break;
@@ -613,24 +451,12 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
       // First, if we're reading from stdin and we don't have a directory,
       // output to stdout.
-      if (Opts.InputFilenames.size() == 1 && Opts.InputFilenames[0] == "-" &&
-          Opts.OutputFilenames.empty())
-        Opts.setSingleOutputFilename("-");
+      if (Opts.Inputs.isReadingFromStdin() &&  Opts.OutputFilenames.empty())
+        Opts.setOutputFilenameToStdout();
       else {
         // We have a suffix, so determine an appropriate name.
+        StringRef BaseName = Opts.Inputs.baseNameOfOutput(Args, Opts.ModuleName);
         llvm::SmallString<128> Path(Opts.getSingleOutputFilename());
-
-        StringRef BaseName;
-        if (Opts.PrimaryInput.hasValue() && Opts.PrimaryInput->isFilename()) {
-          unsigned Index = Opts.PrimaryInput->Index;
-          BaseName = llvm::sys::path::stem(Opts.InputFilenames[Index]);
-        } else if (!UserSpecifiedModuleName &&
-                   Opts.InputFilenames.size() == 1) {
-          BaseName = llvm::sys::path::stem(Opts.InputFilenames[0]);
-        } else {
-          BaseName = Opts.ModuleName;
-        }
-
         llvm::sys::path::append(Path, BaseName);
         llvm::sys::path::replace_extension(Path, Suffix);
 
@@ -645,8 +471,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
         Diags.diagnose(SourceLoc(), diag::error_no_output_filename_specified);
         return true;
       }
-    } else if (Opts.getSingleOutputFilename() != "-" &&
-        llvm::sys::fs::is_directory(Opts.getSingleOutputFilename())) {
+    } else if (Opts.isOutputFileDirectory()) {
       Diags.diagnose(SourceLoc(), diag::error_implicit_output_file_is_directory,
                      Opts.getSingleOutputFilename());
       return true;
@@ -675,21 +500,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     if (!output.empty())
       return;
 
-    StringRef OriginalPath;
-    if (!Opts.OutputFilenames.empty() && Opts.getSingleOutputFilename() != "-")
-      // Put the serialized diagnostics file next to the output file.
-      OriginalPath = Opts.getSingleOutputFilename();
-    else if (Opts.PrimaryInput.hasValue() && Opts.PrimaryInput->isFilename())
-      // We have a primary input, so use that as the basis for the name of the
-      // serialized diagnostics file.
-      OriginalPath = llvm::sys::path::filename(
-        Opts.InputFilenames[Opts.PrimaryInput->Index]);
-    else
-      // We don't have any better indication of name, so fall back on the
-      // module name.
-      OriginalPath = Opts.ModuleName;
-
-    llvm::SmallString<128> Path(OriginalPath);
+    llvm::SmallString<128> Path(Opts.originalPath());
     llvm::sys::path::replace_extension(Path, extension);
     output = Path.str();
   };
@@ -891,7 +702,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArgNoClaim(OPT_import_objc_header)) {
     Opts.ImplicitObjCHeaderPath = A->getValue();
     Opts.SerializeBridgingHeader |=
-      !Opts.PrimaryInput && !Opts.ModuleOutputPath.empty();
+      !Opts.Inputs.getPrimaryInput() && !Opts.ModuleOutputPath.empty();
   }
 
   for (const Arg *A : Args.filtered(OPT_import_module)) {
@@ -1621,11 +1432,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // in other classes.
   if (!SILOpts.SILOutputFileNameForDebugging.empty()) {
     Opts.MainInputFilename = SILOpts.SILOutputFileNameForDebugging;
-  } else if (FrontendOpts.PrimaryInput && FrontendOpts.PrimaryInput->isFilename()) {
-    unsigned Index = FrontendOpts.PrimaryInput->Index;
-    Opts.MainInputFilename = FrontendOpts.InputFilenames[Index];
-  } else if (FrontendOpts.InputFilenames.size() == 1) {
-    Opts.MainInputFilename = FrontendOpts.InputFilenames.front();
+  } else if (FrontendOpts.Inputs.getPrimaryInput() && FrontendOpts.Inputs.getPrimaryInput()->isFilename()) {
+    unsigned Index = FrontendOpts.Inputs.getPrimaryInput()->Index;
+    Opts.MainInputFilename = FrontendOpts.Inputs.getInputFilenames()[Index];
+  } else if (FrontendOpts.Inputs.hasUniqueInputFilename()) {
+    Opts.MainInputFilename = FrontendOpts.Inputs.getFilenameOfFirstInput();
   }
   Opts.OutputFilenames = FrontendOpts.OutputFilenames;
   Opts.ModuleName = FrontendOpts.ModuleName;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -56,9 +56,8 @@ std::string CompilerInvocation::getPCHHash() const {
 void CompilerInstance::createSILModule() {
   assert(MainModule && "main module not created yet");
   // Assume WMO if a -primary-file option was not provided.
-  bool WholeModule = !Invocation.getFrontendOptions().PrimaryInput.hasValue();
   TheSILModule = SILModule::createEmptyModule(
-    getMainModule(), Invocation.getSILOptions(), WholeModule);
+    getMainModule(), Invocation.getSILOptions(), Invocation.getFrontendOptions().Inputs.isWholeModule());
 }
 
 void CompilerInstance::setPrimarySourceFile(SourceFile *SF) {
@@ -145,7 +144,7 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     auto MemBuf = CodeCompletePoint.first;
     // CompilerInvocation doesn't own the buffers, copy to a new buffer.
     CodeCompletionBufferID = SourceMgr.addMemBufferCopy(MemBuf);
-    BufferIDs.push_back(*CodeCompletionBufferID);
+    InputSourceCodeBufferIDs.push_back(*CodeCompletionBufferID);
     SourceMgr.setCodeCompletionPoint(*CodeCompletionBufferID,
                                      CodeCompletePoint.second);
   }
@@ -157,13 +156,13 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     Invocation.getLangOptions().EnableAccessControl = false;
 
   const Optional<SelectedInput> &PrimaryInput =
-    Invocation.getFrontendOptions().PrimaryInput;
+    Invocation.getFrontendOptions().Inputs.getPrimaryInput();
 
   // Add the memory buffers first, these will be associated with a filename
   // and they can replace the contents of an input filename.
-  for (unsigned i = 0, e = Invocation.getInputBuffers().size(); i != e; ++i) {
+  for (unsigned i = 0, e = Invocation.getFrontendOptions().Inputs.inputBufferCount(); i != e; ++i) {
     // CompilerInvocation doesn't own the buffers, copy to a new buffer.
-    auto *InputBuffer = Invocation.getInputBuffers()[i];
+    auto *InputBuffer = Invocation.getFrontendOptions().Inputs.getInputBuffers()[i];
     auto Copy = std::unique_ptr<llvm::MemoryBuffer>(
         llvm::MemoryBuffer::getMemBufferCopy(
             InputBuffer->getBuffer(), InputBuffer->getBufferIdentifier()));
@@ -171,7 +170,7 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
       PartialModules.push_back({ std::move(Copy), nullptr });
     } else {
       unsigned BufferID = SourceMgr.addNewSourceBuffer(std::move(Copy));
-      BufferIDs.push_back(BufferID);
+      InputSourceCodeBufferIDs.push_back(BufferID);
 
       if (SILMode)
         MainBufferID = BufferID;
@@ -181,70 +180,19 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     }
   }
 
-  for (unsigned i = 0, e = Invocation.getInputFilenames().size(); i != e; ++i) {
-    auto &File = Invocation.getInputFilenames()[i];
-
-    // FIXME: Working with filenames is fragile, maybe use the real path
-    // or have some kind of FileManager.
-    using namespace llvm::sys::path;
-    if (Optional<unsigned> ExistingBufferID =
-            SourceMgr.getIDForBufferIdentifier(File)) {
-      if (SILMode || (MainMode && filename(File) == "main.swift"))
-        MainBufferID = ExistingBufferID.getValue();
-
-      if (PrimaryInput && PrimaryInput->isFilename() &&
-          PrimaryInput->Index == i)
-        PrimaryBufferID = ExistingBufferID.getValue();
-
-      continue; // replaced by a memory buffer.
-    }
-
-    // Open the input file.
-    using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
-    FileOrError InputFileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(File);
-    if (!InputFileOrErr) {
-      Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
-                           File, InputFileOrErr.getError().message());
+  for (unsigned i = 0, e = Invocation.getFrontendOptions().Inputs.inputFilenameCount(); i != e; ++i) {
+    bool hasError = setupForFileAt(i);
+    if (hasError) {
       return true;
     }
-
-    if (serialization::isSerializedAST(InputFileOrErr.get()->getBuffer())) {
-      llvm::SmallString<128> ModuleDocFilePath(File);
-      llvm::sys::path::replace_extension(ModuleDocFilePath,
-                                         SERIALIZED_MODULE_DOC_EXTENSION);
-      FileOrError ModuleDocOrErr =
-        llvm::MemoryBuffer::getFileOrSTDIN(ModuleDocFilePath.str());
-      if (!ModuleDocOrErr &&
-          ModuleDocOrErr.getError() != std::errc::no_such_file_or_directory) {
-        Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
-                             File, ModuleDocOrErr.getError().message());
-        return true;
-      }
-      PartialModules.push_back({ std::move(InputFileOrErr.get()),
-                                 ModuleDocOrErr? std::move(ModuleDocOrErr.get())
-                                               : nullptr });
-      continue;
-    }
-
-    // Transfer ownership of the MemoryBuffer to the SourceMgr.
-    unsigned BufferID =
-      SourceMgr.addNewSourceBuffer(std::move(InputFileOrErr.get()));
-
-    BufferIDs.push_back(BufferID);
-
-    if (SILMode || (MainMode && filename(File) == "main.swift"))
-      MainBufferID = BufferID;
-
-    if (PrimaryInput && PrimaryInput->isFilename() && PrimaryInput->Index == i)
-      PrimaryBufferID = BufferID;
   }
 
   // Set the primary file to the code-completion point if one exists.
   if (CodeCompletionBufferID.hasValue())
     PrimaryBufferID = *CodeCompletionBufferID;
 
-  if (MainMode && MainBufferID == NO_SUCH_BUFFER && BufferIDs.size() == 1)
-    MainBufferID = BufferIDs.front();
+  if (MainMode && MainBufferID == NO_SUCH_BUFFER && InputSourceCodeBufferIDs.size() == 1)
+    MainBufferID = InputSourceCodeBufferIDs.front();
 
   return false;
 }
@@ -319,7 +267,7 @@ void CompilerInstance::performSema() {
   Context->LoadedModules[MainModule->getName()] = getMainModule();
 
   if (Invocation.getInputKind() == InputFileKind::IFK_SIL) {
-    assert(BufferIDs.size() == 1);
+    assert(InputSourceCodeBufferIDs.size() == 1);
     assert(MainBufferID != NO_SUCH_BUFFER);
     createSILModule();
   }
@@ -589,7 +537,7 @@ bool CompilerInstance::parsePartialModulesAndLibraryFiles(
   }
 
   // Then parse all the library files.
-  for (auto BufferID : BufferIDs) {
+  for (auto BufferID : InputSourceCodeBufferIDs) {
     if (BufferID != MainBufferID) {
       parseLibraryFile(BufferID, implicitImports, PersistentState,
                        DelayedParseCB);
@@ -713,7 +661,7 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals) {
   PersistentParserState PersistentState;
   PersistentState.PerformConditionEvaluation = EvaluateConditionals;
   // Parse all the library files.
-  for (auto BufferID : BufferIDs) {
+  for (auto BufferID : InputSourceCodeBufferIDs) {
     if (BufferID == MainBufferID)
       continue;
 
@@ -755,4 +703,66 @@ void CompilerInstance::freeContextAndSIL() {
   MainModule = nullptr;
   SML = nullptr;
   PrimarySourceFile = nullptr;
+}
+
+bool CompilerInstance::setupForFileAt(unsigned i) {
+  bool MainMode = (Invocation.getInputKind() == InputFileKind::IFK_Swift);
+  bool SILMode = (Invocation.getInputKind() == InputFileKind::IFK_SIL);
+
+  auto &File = Invocation.getFrontendOptions().Inputs.getInputFilenames()[i];
+  
+  // FIXME: Working with filenames is fragile, maybe use the real path
+  // or have some kind of FileManager.
+  using namespace llvm::sys::path;
+  if (Optional<unsigned> ExistingBufferID =
+      SourceMgr.getIDForBufferIdentifier(File)) {
+    if (SILMode || (MainMode && filename(File) == "main.swift"))
+      MainBufferID = ExistingBufferID.getValue();
+    
+    if (Invocation.getFrontendOptions().Inputs.isPrimaryInputAFileAt(i))
+      PrimaryBufferID = ExistingBufferID.getValue();
+    
+    return false; // replaced by a memory buffer.
+  }
+  
+  // Open the input file.
+  using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
+  FileOrError InputFileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(File);
+  if (!InputFileOrErr) {
+    Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
+                         File, InputFileOrErr.getError().message());
+    return true;
+  }
+  
+  if (serialization::isSerializedAST(InputFileOrErr.get()->getBuffer())) {
+    llvm::SmallString<128> ModuleDocFilePath(File);
+    llvm::sys::path::replace_extension(ModuleDocFilePath,
+                                       SERIALIZED_MODULE_DOC_EXTENSION);
+    FileOrError ModuleDocOrErr =
+    llvm::MemoryBuffer::getFileOrSTDIN(ModuleDocFilePath.str());
+    if (!ModuleDocOrErr &&
+        ModuleDocOrErr.getError() != std::errc::no_such_file_or_directory) {
+      Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
+                           File, ModuleDocOrErr.getError().message());
+      return true;
+    }
+    PartialModules.push_back({ std::move(InputFileOrErr.get()),
+      ModuleDocOrErr? std::move(ModuleDocOrErr.get())
+      : nullptr });
+    return false;
+  }
+  
+  // Transfer ownership of the MemoryBuffer to the SourceMgr.
+  unsigned BufferID =
+  SourceMgr.addNewSourceBuffer(std::move(InputFileOrErr.get()));
+  
+  InputSourceCodeBufferIDs.push_back(BufferID);
+  
+  if (SILMode || (MainMode && filename(File) == "main.swift"))
+    MainBufferID = BufferID;
+  
+  if (Invocation.getFrontendOptions().Inputs.isPrimaryInputAFileAt(i))
+    PrimaryBufferID = BufferID;
+  
+  return false;
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -57,7 +57,8 @@ void CompilerInstance::createSILModule() {
   assert(MainModule && "main module not created yet");
   // Assume WMO if a -primary-file option was not provided.
   TheSILModule = SILModule::createEmptyModule(
-    getMainModule(), Invocation.getSILOptions(), Invocation.getFrontendOptions().Inputs.isWholeModule());
+      getMainModule(), Invocation.getSILOptions(),
+      Invocation.getFrontendOptions().Inputs.isWholeModule());
 }
 
 void CompilerInstance::setPrimarySourceFile(SourceFile *SF) {
@@ -156,13 +157,16 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     Invocation.getLangOptions().EnableAccessControl = false;
 
   const Optional<SelectedInput> &PrimaryInput =
-    Invocation.getFrontendOptions().Inputs.getPrimaryInput();
+      Invocation.getFrontendOptions().Inputs.getPrimaryInput();
 
   // Add the memory buffers first, these will be associated with a filename
   // and they can replace the contents of an input filename.
-  for (unsigned i = 0, e = Invocation.getFrontendOptions().Inputs.inputBufferCount(); i != e; ++i) {
+  for (unsigned i = 0,
+                e = Invocation.getFrontendOptions().Inputs.inputBufferCount();
+       i != e; ++i) {
     // CompilerInvocation doesn't own the buffers, copy to a new buffer.
-    auto *InputBuffer = Invocation.getFrontendOptions().Inputs.getInputBuffers()[i];
+    auto *InputBuffer =
+        Invocation.getFrontendOptions().Inputs.getInputBuffers()[i];
     auto Copy = std::unique_ptr<llvm::MemoryBuffer>(
         llvm::MemoryBuffer::getMemBufferCopy(
             InputBuffer->getBuffer(), InputBuffer->getBufferIdentifier()));
@@ -180,7 +184,9 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     }
   }
 
-  for (unsigned i = 0, e = Invocation.getFrontendOptions().Inputs.inputFilenameCount(); i != e; ++i) {
+  for (unsigned i = 0,
+                e = Invocation.getFrontendOptions().Inputs.inputFilenameCount();
+       i != e; ++i) {
     bool hasError = setupForFileAt(i);
     if (hasError) {
       return true;
@@ -191,7 +197,8 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   if (CodeCompletionBufferID.hasValue())
     PrimaryBufferID = *CodeCompletionBufferID;
 
-  if (MainMode && MainBufferID == NO_SUCH_BUFFER && InputSourceCodeBufferIDs.size() == 1)
+  if (MainMode && MainBufferID == NO_SUCH_BUFFER &&
+      InputSourceCodeBufferIDs.size() == 1)
     MainBufferID = InputSourceCodeBufferIDs.front();
 
   return false;
@@ -710,59 +717,59 @@ bool CompilerInstance::setupForFileAt(unsigned i) {
   bool SILMode = (Invocation.getInputKind() == InputFileKind::IFK_SIL);
 
   auto &File = Invocation.getFrontendOptions().Inputs.getInputFilenames()[i];
-  
+
   // FIXME: Working with filenames is fragile, maybe use the real path
   // or have some kind of FileManager.
   using namespace llvm::sys::path;
   if (Optional<unsigned> ExistingBufferID =
-      SourceMgr.getIDForBufferIdentifier(File)) {
+          SourceMgr.getIDForBufferIdentifier(File)) {
     if (SILMode || (MainMode && filename(File) == "main.swift"))
       MainBufferID = ExistingBufferID.getValue();
-    
+
     if (Invocation.getFrontendOptions().Inputs.isPrimaryInputAFileAt(i))
       PrimaryBufferID = ExistingBufferID.getValue();
-    
+
     return false; // replaced by a memory buffer.
   }
-  
+
   // Open the input file.
   using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
   FileOrError InputFileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(File);
   if (!InputFileOrErr) {
-    Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
-                         File, InputFileOrErr.getError().message());
+    Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file, File,
+                         InputFileOrErr.getError().message());
     return true;
   }
-  
+
   if (serialization::isSerializedAST(InputFileOrErr.get()->getBuffer())) {
     llvm::SmallString<128> ModuleDocFilePath(File);
     llvm::sys::path::replace_extension(ModuleDocFilePath,
                                        SERIALIZED_MODULE_DOC_EXTENSION);
     FileOrError ModuleDocOrErr =
-    llvm::MemoryBuffer::getFileOrSTDIN(ModuleDocFilePath.str());
+        llvm::MemoryBuffer::getFileOrSTDIN(ModuleDocFilePath.str());
     if (!ModuleDocOrErr &&
         ModuleDocOrErr.getError() != std::errc::no_such_file_or_directory) {
-      Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
-                           File, ModuleDocOrErr.getError().message());
+      Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file, File,
+                           ModuleDocOrErr.getError().message());
       return true;
     }
-    PartialModules.push_back({ std::move(InputFileOrErr.get()),
-      ModuleDocOrErr? std::move(ModuleDocOrErr.get())
-      : nullptr });
+    PartialModules.push_back(
+        {std::move(InputFileOrErr.get()),
+         ModuleDocOrErr ? std::move(ModuleDocOrErr.get()) : nullptr});
     return false;
   }
-  
+
   // Transfer ownership of the MemoryBuffer to the SourceMgr.
   unsigned BufferID =
-  SourceMgr.addNewSourceBuffer(std::move(InputFileOrErr.get()));
-  
+      SourceMgr.addNewSourceBuffer(std::move(InputFileOrErr.get()));
+
   InputSourceCodeBufferIDs.push_back(BufferID);
-  
+
   if (SILMode || (MainMode && filename(File) == "main.swift"))
     MainBufferID = BufferID;
-  
+
   if (Invocation.getFrontendOptions().Inputs.isPrimaryInputAFileAt(i))
     PrimaryBufferID = BufferID;
-  
+
   return false;
 }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -12,9 +12,163 @@
 
 #include "swift/Frontend/FrontendOptions.h"
 
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Parse/Lexer.h"
+#include "swift/Option/Options.h"
+#include "swift/Strings.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/Option.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/Path.h"
+
 
 using namespace swift;
+using namespace llvm::opt;
+
+bool FrontendInputs::shouldTreatAsLLVM() const {
+  if (hasUniqueInputFilename()) {
+    StringRef Input(getFilenameOfFirstInput());
+    return
+    llvm::sys::path::extension(Input).endswith(LLVM_BC_EXTENSION) ||
+    llvm::sys::path::extension(Input).endswith(LLVM_IR_EXTENSION);
+  }
+  return false;
+}
+
+StringRef FrontendInputs::baseNameOfOutput(const llvm::opt::ArgList &Args, StringRef ModuleName) const {
+  StringRef pifn = primaryInputFilenameIfAny();
+  if (!pifn.empty()) {
+    return llvm::sys::path::stem(pifn);
+  }
+  bool UserSpecifiedModuleName = Args.getLastArg(options::OPT_module_name);
+  if (!UserSpecifiedModuleName &&  hasUniqueInputFilename()) {
+    return llvm::sys::path::stem(getFilenameOfFirstInput());
+  }
+  return ModuleName;
+}
+
+bool FrontendInputs::shouldTreatAsSIL() const {
+  if (hasUniqueInputFilename()) {
+    // If we have exactly one input filename, and its extension is "sil",
+    // treat the input as SIL.
+    StringRef Input(getFilenameOfFirstInput());
+    return llvm::sys::path::extension(Input).endswith(SIL_EXTENSION);
+  }
+  StringRef Input = primaryInputFilenameIfAny();
+  if (!Input.empty()) {
+    // If we have a primary input and it's a filename with extension "sil",
+    // treat the input as SIL.
+    return llvm::sys::path::extension(Input).endswith(SIL_EXTENSION);
+  }
+  return false;
+}
+
+bool FrontendInputs::verifyInputs(DiagnosticEngine &Diags, bool TreatAsSIL, bool isREPLRequested, bool isNoneRequested) const {
+  if (isREPLRequested) {
+    if (hasInputFilenames()) {
+      Diags.diagnose(SourceLoc(), diag::error_repl_requires_no_input_files);
+      return true;
+    }
+  } else if (TreatAsSIL && hasPrimaryInput()) {
+    // If we have the SIL as our primary input, we can waive the one file
+    // requirement as long as all the other inputs are SIBs.
+    for (unsigned i = 0, e = inputFilenameCount(); i != e; ++i) {
+      if (i == getPrimaryInput()->Index)
+        continue;
+      
+      StringRef File(getInputFilenames()[i]);
+      if (!llvm::sys::path::extension(File).endswith(SIB_EXTENSION)) {
+        Diags.diagnose(SourceLoc(),
+                       diag::error_mode_requires_one_sil_multi_sib);
+        return true;
+      }
+    }
+  } else if (TreatAsSIL) {
+    if (!hasUniqueInputFilename()) {
+      Diags.diagnose(SourceLoc(), diag::error_mode_requires_one_input_file);
+      return true;
+    }
+  } else if (!isNoneRequested) {
+    if (!hasInputFilenames()) {
+      Diags.diagnose(SourceLoc(), diag::error_mode_requires_an_input_file);
+      return true;
+    }
+  }
+  return false;
+}
+
+void FrontendInputs::transformInputFilenames(const llvm::function_ref<std::string(std::string)> &fn) {
+  for (auto &InputFile : InputFilenames) {
+    InputFile = fn(InputFile);
+  }
+}
+
+void FrontendInputs::setInputFilenamesAndPrimaryInput(DiagnosticEngine &Diags, llvm::opt::ArgList &Args) {
+  if (const Arg *filelistPath = Args.getLastArg(options::OPT_filelist)) {
+    readInputFileList(Diags, Args, filelistPath);
+    return;
+  }
+  for (const Arg *A : Args.filtered(options::OPT_INPUT, options::OPT_primary_file)) {
+    if (A->getOption().matches(options::OPT_INPUT)) {
+      addInputFilename(A->getValue());
+    } else if (A->getOption().matches(options::OPT_primary_file)) {
+      setPrimaryInput(SelectedInput(inputFilenameCount()));
+      addInputFilename(A->getValue());
+    } else {
+      llvm_unreachable("Unknown input-related argument!");
+    }
+  }
+}
+
+
+/// Try to read an input file list file.
+///
+/// Returns false on error.
+void FrontendInputs::readInputFileList(DiagnosticEngine &diags,
+                                       llvm::opt::ArgList &Args,
+                                       const llvm::opt::Arg *filelistPath) {
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+  llvm::MemoryBuffer::getFile(filelistPath->getValue());
+  if (!buffer) {
+    diags.diagnose(SourceLoc(), diag::cannot_open_file,
+                   filelistPath->getValue(), buffer.getError().message());
+    return;
+  }
+  
+  const Arg *primaryFileArg = Args.getLastArg(options::OPT_primary_file);
+  unsigned primaryFileIndex = 0;
+  
+  bool foundPrimaryFile = false;
+  
+  for (StringRef line : make_range(llvm::line_iterator(*buffer.get()), {})) {
+    addInputFilename(line);
+    
+    if (foundPrimaryFile || primaryFileArg == nullptr)
+      continue;
+    if (line == primaryFileArg->getValue())
+      foundPrimaryFile = true;
+    else
+      ++primaryFileIndex;
+  }
+  
+  if (primaryFileArg && !foundPrimaryFile) {
+    diags.diagnose(SourceLoc(), diag::error_primary_file_not_found,
+                   primaryFileArg->getValue(), filelistPath->getValue());
+    return;
+  }
+  
+  if (primaryFileArg)
+    setPrimaryInput(SelectedInput(primaryFileIndex));
+  assert(!Args.hasArg(options::OPT_INPUT) && "mixing -filelist with inputs");
+}
+
+
+
+
+
 
 bool FrontendOptions::actionHasOutput() const {
   switch (RequestedAction) {
@@ -100,4 +254,97 @@ void FrontendOptions::forAllOutputPaths(
     if (!next->empty())
       fn(*next);
   }
+}
+
+
+void FrontendOptions::setModuleName(DiagnosticEngine &Diags, const llvm::opt::ArgList &Args) {
+  const Arg *A = Args.getLastArg(options::OPT_module_name);
+  if (A) {
+    ModuleName = A->getValue();
+  }
+  else if (ModuleName.empty()) {
+    // The user did not specify a module name, so determine a default fallback
+    // based on other options.
+    
+    // Note: this code path will only be taken when running the frontend
+    // directly; the driver should always pass -module-name when invoking the
+    // frontend.
+    ModuleName = determineFallbackModuleName();
+  }
+  
+  if (Lexer::isIdentifier(ModuleName) &&
+      (ModuleName != STDLIB_NAME || ParseStdlib)) {
+    return;
+  }
+  if (!actionHasOutput() || isCompilingExactlyOneSwiftFile()) {
+    ModuleName = "main";
+    return;
+  }
+  auto DID = (ModuleName == STDLIB_NAME)
+  ? diag::error_stdlib_module_name
+  : diag::error_bad_module_name;
+  Diags.diagnose(SourceLoc(), DID, ModuleName, A == nullptr);
+  ModuleName = "__bad__";
+}
+
+
+StringRef FrontendOptions::originalPath() const {
+  if (hasNamedOutputFile())
+    // Put the serialized diagnostics file next to the output file.
+    return getSingleOutputFilename();
+  
+  StringRef fn = Inputs.primaryInputFilenameIfAny();
+  // If we have a primary input, so use that as the basis for the name of the
+  // serialized diagnostics file, otherwise fall back on the
+  // module name.
+  return !fn.empty() ? llvm::sys::path::filename(fn) : StringRef(ModuleName);
+}
+
+StringRef FrontendOptions::determineFallbackModuleName() const {
+  // Note: this code path will only be taken when running the frontend
+  // directly; the driver should always pass -module-name when invoking the
+  // frontend.
+  if (RequestedAction == FrontendOptions::REPL) {
+    // Default to a module named "REPL" if we're in REPL mode.
+    return "REPL";
+  }
+  // In order to pass Driver/options.swift test must leave ModuleName empty
+  if (!Inputs.hasInputFilenames()) {
+    return StringRef();
+  }
+  StringRef OutputFilename = getSingleOutputFilename();
+  bool useOutputFilename = isOutputFilePlainFile();
+  return llvm::sys::path::stem(useOutputFilename ? OutputFilename : StringRef(Inputs.getFilenameOfFirstInput()));
+}
+
+/// Try to read an output file list file.
+static void readOutputFileList(DiagnosticEngine &diags,
+                               std::vector<std::string> &outputFiles,
+                               const llvm::opt::Arg *filelistPath) {
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+  llvm::MemoryBuffer::getFile(filelistPath->getValue());
+  if (!buffer) {
+    diags.diagnose(SourceLoc(), diag::cannot_open_file,
+                   filelistPath->getValue(), buffer.getError().message());
+  }
+  for (StringRef line : make_range(llvm::line_iterator(*buffer.get()), {})) {
+    outputFiles.push_back(line);
+  }
+}
+
+void FrontendOptions::setOutputFileList(swift::DiagnosticEngine &Diags, const llvm::opt::ArgList &Args) {
+  if (const Arg *A = Args.getLastArg(options::OPT_output_filelist)) {
+    readOutputFileList(Diags, OutputFilenames, A);
+    assert(!Args.hasArg(options::OPT_o) && "don't use -o with -output-filelist");
+  } else {
+    OutputFilenames = Args.getAllArgValues(options::OPT_o);
+  }
+}
+
+bool FrontendOptions::isOutputFileDirectory() const {
+  return hasNamedOutputFile() && llvm::sys::fs::is_directory(getSingleOutputFilename());
+}
+
+bool FrontendOptions::isOutputFilePlainFile() const {
+  return hasNamedOutputFile() && !llvm::sys::fs::is_directory(getSingleOutputFilename());
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -135,7 +135,8 @@ static bool emitMakeDependencies(DiagnosticEngine &diags,
     out << escape(targetName) << " :";
     // First include all other files in the module. Make-style dependencies
     // need to be conservative!
-    for (auto const &path : reversePathSortedFilenames(opts.Inputs.getInputFilenames()))
+    for (auto const &path :
+         reversePathSortedFilenames(opts.Inputs.getInputFilenames()))
       out << ' ' << escape(path);
     // Then print dependencies we've picked up during compilation.
     for (auto const &path :
@@ -527,15 +528,16 @@ static bool performCompile(CompilerInstance &Instance,
     auto &ImporterOpts = Invocation.getClangImporterOptions();
     auto &PCHOutDir = ImporterOpts.PrecompiledHeaderOutputDir;
     if (!PCHOutDir.empty()) {
-      ImporterOpts.BridgingHeader = Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput();
+      ImporterOpts.BridgingHeader =
+          Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput();
       // Create or validate a persistent PCH.
       auto SwiftPCHHash = Invocation.getPCHHash();
       auto PCH = clangImporter->getOrCreatePCH(ImporterOpts, SwiftPCHHash);
       return !PCH.hasValue();
     }
     return clangImporter->emitBridgingPCH(
-      Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
-      opts.getSingleOutputFilename());
+        Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
+        opts.getSingleOutputFilename());
   }
 
   IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
@@ -548,12 +550,13 @@ static bool performCompile(CompilerInstance &Instance,
     assert(Invocation.getFrontendOptions().Inputs.hasUniqueInputFilename() &&
            "We expect a single input for bitcode input!");
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      llvm::MemoryBuffer::getFileOrSTDIN(Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput());
+        llvm::MemoryBuffer::getFileOrSTDIN(
+            Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput());
     if (!FileBufOrErr) {
-      Instance.getASTContext().Diags.diagnose(SourceLoc(),
-                                              diag::error_open_input_file,
-                                              Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
-                                              FileBufOrErr.getError().message());
+      Instance.getASTContext().Diags.diagnose(
+          SourceLoc(), diag::error_open_input_file,
+          Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
+          FileBufOrErr.getError().message());
       return true;
     }
     llvm::MemoryBuffer *MainFile = FileBufOrErr.get().get();
@@ -565,10 +568,10 @@ static bool performCompile(CompilerInstance &Instance,
     if (!Module) {
       // TODO: Translate from the diagnostic info to the SourceManager location
       // if available.
-      Instance.getASTContext().Diags.diagnose(SourceLoc(),
-                                              diag::error_parse_input_file,
-                                              Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
-                                              Err.getMessage());
+      Instance.getASTContext().Diags.diagnose(
+          SourceLoc(), diag::error_parse_input_file,
+          Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
+          Err.getMessage());
       return true;
     }
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -998,7 +998,7 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
 
   CompilerInvocation Invocation{};
   Invocation.addInputBuffer(InputBuffer.get());
-  Invocation.getFrontendOptions().PrimaryInput = {0, SelectedInput::InputKind::Buffer};
+  Invocation.getFrontendOptions().Inputs.setPrimaryInput( {0, SelectedInput::InputKind::Buffer} );
   Invocation.getFrontendOptions().ModuleName = "extract";
 
   auto Instance = llvm::make_unique<swift::CompilerInstance>();

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -998,7 +998,8 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
 
   CompilerInvocation Invocation{};
   Invocation.addInputBuffer(InputBuffer.get());
-  Invocation.getFrontendOptions().Inputs.setPrimaryInput( {0, SelectedInput::InputKind::Buffer} );
+  Invocation.getFrontendOptions().Inputs.setPrimaryInput(
+      {0, SelectedInput::InputKind::Buffer});
   Invocation.getFrontendOptions().ModuleName = "extract";
 
   auto Instance = llvm::make_unique<swift::CompilerInstance>();

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -156,12 +156,11 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
   }
 
   const unsigned PrimaryIndex =
-    Invocation.getFrontendOptions().Inputs.getInputBuffers().size();
+      Invocation.getFrontendOptions().Inputs.getInputBuffers().size();
 
   Invocation.addInputBuffer(InputBuffer.get());
-  Invocation.getFrontendOptions().Inputs.setPrimaryInput( {
-    PrimaryIndex, SelectedInput::InputKind::Buffer
-  });
+  Invocation.getFrontendOptions().Inputs.setPrimaryInput(
+      {PrimaryIndex, SelectedInput::InputKind::Buffer});
 
   auto Instance = llvm::make_unique<swift::CompilerInstance>();
   if (Instance->setup(Invocation)) {
@@ -449,6 +448,7 @@ const MigratorOptions &Migrator::getMigratorOptions() const {
 
 const StringRef Migrator::getInputFilename() const {
   auto PrimaryInput =
-    StartInvocation.getFrontendOptions().Inputs.getPrimaryInput().getValue();
-  return StartInvocation.getFrontendOptions().Inputs.getInputFilenames()[PrimaryInput.Index];
+      StartInvocation.getFrontendOptions().Inputs.getPrimaryInput().getValue();
+  return StartInvocation.getFrontendOptions()
+      .Inputs.getInputFilenames()[PrimaryInput.Index];
 }

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -144,8 +144,8 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
 
   const auto &OrigFrontendOpts = StartInvocation.getFrontendOptions();
 
-  auto InputBuffers = OrigFrontendOpts.InputBuffers;
-  auto InputFilenames = OrigFrontendOpts.InputFilenames;
+  auto InputBuffers = OrigFrontendOpts.Inputs.getInputBuffers();
+  auto InputFilenames = OrigFrontendOpts.Inputs.getInputFilenames();
 
   for (const auto &Buffer : InputBuffers) {
     Invocation.addInputBuffer(Buffer);
@@ -156,12 +156,12 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
   }
 
   const unsigned PrimaryIndex =
-    Invocation.getFrontendOptions().InputBuffers.size();
+    Invocation.getFrontendOptions().Inputs.getInputBuffers().size();
 
   Invocation.addInputBuffer(InputBuffer.get());
-  Invocation.getFrontendOptions().PrimaryInput = {
+  Invocation.getFrontendOptions().Inputs.setPrimaryInput( {
     PrimaryIndex, SelectedInput::InputKind::Buffer
-  };
+  });
 
   auto Instance = llvm::make_unique<swift::CompilerInstance>();
   if (Instance->setup(Invocation)) {
@@ -449,6 +449,6 @@ const MigratorOptions &Migrator::getMigratorOptions() const {
 
 const StringRef Migrator::getInputFilename() const {
   auto PrimaryInput =
-    StartInvocation.getFrontendOptions().PrimaryInput.getValue();
-  return StartInvocation.getInputFilenames()[PrimaryInput.Index];
+    StartInvocation.getFrontendOptions().Inputs.getPrimaryInput().getValue();
+  return StartInvocation.getFrontendOptions().Inputs.getInputFilenames()[PrimaryInput.Index];
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -399,9 +399,10 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
   // clang's FileManager ?
   std::string PrimaryFile =
     SwiftLangSupport::resolvePathSymlinks(UnresolvedPrimaryFile);
-  Invocation.getFrontendOptions().Inputs.transformInputFilenames( [] (std::string s) -> std::string {
-    return SwiftLangSupport::resolvePathSymlinks(s);
-  });
+  Invocation.getFrontendOptions().Inputs.transformInputFilenames(
+      [](std::string s) -> std::string {
+        return SwiftLangSupport::resolvePathSymlinks(s);
+      });
 
   ClangImporterOptions &ImporterOpts = Invocation.getClangImporterOptions();
   ImporterOpts.DetailedPreprocessingRecord = true;
@@ -426,8 +427,10 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
 
   if (!PrimaryFile.empty()) {
     Optional<unsigned> PrimaryIndex;
-    for (auto i : indices(Invocation.getFrontendOptions().Inputs.getInputFilenames())) {
-      auto &CurFile = Invocation.getFrontendOptions().Inputs.getInputFilenames()[i];
+    for (auto i :
+         indices(Invocation.getFrontendOptions().Inputs.getInputFilenames())) {
+      auto &CurFile =
+          Invocation.getFrontendOptions().Inputs.getInputFilenames()[i];
       if (PrimaryFile == CurFile) {
         PrimaryIndex = i;
         break;
@@ -440,7 +443,8 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
       Error = OS.str();
       return true;
     }
-    Invocation.getFrontendOptions().Inputs.setPrimaryInput(SelectedInput(*PrimaryIndex));
+    Invocation.getFrontendOptions().Inputs.setPrimaryInput(
+        SelectedInput(*PrimaryIndex));
   }
 
   return Err;
@@ -653,8 +657,10 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
 
   // Check if the inputs changed.
   SmallVector<BufferStamp, 8> InputStamps;
-  InputStamps.reserve(Invok.Opts.Invok.getFrontendOptions().Inputs.inputFilenameCount());
-  for (auto &File : Invok.Opts.Invok.getFrontendOptions().Inputs.getInputFilenames()) {
+  InputStamps.reserve(
+      Invok.Opts.Invok.getFrontendOptions().Inputs.inputFilenameCount());
+  for (auto &File :
+       Invok.Opts.Invok.getFrontendOptions().Inputs.getInputFilenames()) {
     bool FoundSnapshot = false;
     for (auto &Snap : Snapshots) {
       if (Snap->getFilename() == File) {
@@ -666,7 +672,8 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
     if (!FoundSnapshot)
       InputStamps.push_back(MgrImpl.getBufferStamp(File));
   }
-  assert(InputStamps.size() == Invok.Opts.Invok.getFrontendOptions().Inputs.inputFilenameCount());
+  assert(InputStamps.size() ==
+         Invok.Opts.Invok.getFrontendOptions().Inputs.inputFilenameCount());
   if (Stamps != InputStamps)
     return true;
 
@@ -738,7 +745,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
   const InvocationOptions &Opts = InvokRef->Impl.Opts;
 
   SmallVector<FileContent, 8> Contents;
-  for (auto &File : Opts.Invok.getFrontendOptions().Inputs.getInputFilenames()) {
+  for (auto &File :
+       Opts.Invok.getFrontendOptions().Inputs.getInputFilenames()) {
     bool FoundSnapshot = false;
     for (auto &Snap : Snapshots) {
       if (Snap->getFilename() == File) {
@@ -758,7 +766,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
     }
     Contents.push_back(std::move(Content));
   }
-  assert(Contents.size() == Opts.Invok.getFrontendOptions().Inputs.inputFilenameCount());
+  assert(Contents.size() ==
+         Opts.Invok.getFrontendOptions().Inputs.inputFilenameCount());
 
   for (auto &Content : Contents)
     Stamps.push_back(Content.Stamp);

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -144,7 +144,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   if (Failed) {
     return false;
   }
-  if (Invocation.getInputFilenames().empty()) {
+  if (!Invocation.getFrontendOptions().Inputs.hasInputFilenames()) {
     Error = "no input filenames specified";
     return false;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1711,14 +1711,14 @@ ImmutableTextSnapshotRef SwiftEditorDocument::replaceText(
       // not update all open documents, since there could be too many of them.
     }
   }
-  
+
   // Update the old syntax map offsets to account for the replaced range.
   // Also set the initial AffectedRange to cover any tokens that
   // the replaced range intersected. This allows for clients that split
   // multi-line tokens at line boundaries, and ensure all parts of these tokens
   // will be cleared.
   Impl.AffectedRange = Impl.SyntaxMap.adjustForReplacement(Offset, Length, Str.size());
-  
+
   return Snapshot;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1705,30 +1705,20 @@ ImmutableTextSnapshotRef SwiftEditorDocument::replaceText(
     if (Length != 0 || Buf->getBufferSize() != 0) {
       updateSemaInfo();
 
-      if (auto Invok = Impl.SemanticInfo->getInvocation()) {
-        // Update semantic info for open editor documents of the same module.
-        // FIXME: Detect edits that don't affect other files, e.g. whitespace,
-        // comments, inside a function body, etc.
-        CompilerInvocation CI;
-        Invok->applyTo(CI);
-        auto &EditorDocs = Impl.LangSupport.getEditorDocuments();
-        for (auto &Input : CI.getInputFilenames()) {
-          if (auto EditorDoc = EditorDocs.findByPath(Input)) {
-            if (EditorDoc.get() != this)
-              EditorDoc->updateSemaInfo();
-          }
-        }
-      }
+      // FIXME: we should also update any "interesting" ASTs that depend on this
+      // document here, e.g. any ASTs for files visible in an editor. However,
+      // because our API conflates this with any file with unsaved changes we do
+      // not update all open documents, since there could be too many of them.
     }
   }
-
+  
   // Update the old syntax map offsets to account for the replaced range.
   // Also set the initial AffectedRange to cover any tokens that
   // the replaced range intersected. This allows for clients that split
   // multi-line tokens at line boundaries, and ensure all parts of these tokens
   // will be cleared.
   Impl.AffectedRange = Impl.SyntaxMap.adjustForReplacement(Offset, Length, Str.size());
-
+  
   return Snapshot;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -279,7 +279,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
     return;
   }
 
-  if (Invocation.getInputFilenames().empty()) {
+  if (!Invocation.getFrontendOptions().Inputs.hasInputFilenames()) {
     IdxConsumer.failed("no input filenames specified");
     return;
   }

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -43,6 +43,9 @@ private:
   std::vector<std::string> InputFilenames;
 
 public:
+  bool hasUniqueInputFilename() const { return InputFilenames.size() == 1; }
+  const std::string &getFilenameOfFirstInput() const { return InputFilenames[0]; }
+  
   void setMainExecutablePath(const std::string &Path) {
     MainExecutablePath = Path;
   }
@@ -126,13 +129,13 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
     return 1;
   }
 
-  if (Invocation.getInputFilenames().size() != 1) {
+  if (!Invocation.hasUniqueInputFilename()) {
     Instance.getDiags().diagnose(SourceLoc(),
                                  diag::error_mode_requires_one_input_file);
     return 1;
   }
 
-  StringRef Filename = Invocation.getInputFilenames()[0];
+  StringRef Filename = Invocation.getFilenameOfFirstInput();
   auto ErrOrBuf = llvm::MemoryBuffer::getFile(Filename);
   if (!ErrOrBuf) {
     Instance.getDiags().diagnose(

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -44,8 +44,10 @@ private:
 
 public:
   bool hasUniqueInputFilename() const { return InputFilenames.size() == 1; }
-  const std::string &getFilenameOfFirstInput() const { return InputFilenames[0]; }
-  
+  const std::string &getFilenameOfFirstInput() const {
+    return InputFilenames[0];
+  }
+
   void setMainExecutablePath(const std::string &Path) {
     MainExecutablePath = Path;
   }

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -201,14 +201,8 @@ int main(int argc, char **argv) {
   CI.addDiagnosticConsumer(&PrintDiags);
 
   if (!PerformWMO) {
-    auto &FrontendOpts = Invocation.getFrontendOptions();
-    if (!InputFilename.empty() && InputFilename != "-") {
-      FrontendOpts.PrimaryInput =
-          SelectedInput(FrontendOpts.InputFilenames.size());
-    } else {
-      FrontendOpts.PrimaryInput = SelectedInput(
-          FrontendOpts.InputBuffers.size(), SelectedInput::InputKind::Buffer);
-    }
+    Invocation.getFrontendOptions().Inputs
+      .setPrimaryInputForInputFilename(InputFilename);
   }
 
   if (CI.setup(Invocation))

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -201,8 +201,8 @@ int main(int argc, char **argv) {
   CI.addDiagnosticConsumer(&PrintDiags);
 
   if (!PerformWMO) {
-    Invocation.getFrontendOptions().Inputs
-      .setPrimaryInputForInputFilename(InputFilename);
+    Invocation.getFrontendOptions().Inputs.setPrimaryInputForInputFilename(
+        InputFilename);
   }
 
   if (CI.setup(Invocation))

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -349,14 +349,7 @@ int main(int argc, char **argv) {
   CI.addDiagnosticConsumer(&PrintDiags);
 
   if (!PerformWMO) {
-    auto &FrontendOpts = Invocation.getFrontendOptions();
-    if (!InputFilename.empty() && InputFilename != "-") {
-      FrontendOpts.PrimaryInput = SelectedInput(
-          FrontendOpts.InputFilenames.size());
-    } else {
-      FrontendOpts.PrimaryInput = SelectedInput(
-          FrontendOpts.InputBuffers.size(), SelectedInput::InputKind::Buffer);
-    }
+    Invocation.getFrontendOptions().Inputs.setPrimaryInputForInputFilename(InputFilename);
   }
 
   if (CI.setup(Invocation))

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -349,7 +349,8 @@ int main(int argc, char **argv) {
   CI.addDiagnosticConsumer(&PrintDiags);
 
   if (!PerformWMO) {
-    Invocation.getFrontendOptions().Inputs.setPrimaryInputForInputFilename(InputFilename);
+    Invocation.getFrontendOptions().Inputs.setPrimaryInputForInputFilename(
+        InputFilename);
   }
 
   if (CI.setup(Invocation))

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1906,7 +1906,7 @@ static int doPrintSwiftFileInterface(const CompilerInvocation &InitInvok,
                                      bool AnnotatePrint) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.addInputFilename(SourceFilename);
-  Invocation.getFrontendOptions().PrimaryInput = 0;
+  Invocation.getFrontendOptions().Inputs.clearPrimaryInput();
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI;
   // Display diagnostics to stderr.
@@ -1937,7 +1937,7 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
                         bool AnnotatePrint) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.addInputFilename(SourceFilename);
-  Invocation.getFrontendOptions().PrimaryInput = 0;
+  Invocation.getFrontendOptions().Inputs.clearPrimaryInput();
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI;
   // Display diagnostics to stderr.


### PR DESCRIPTION
NFC: First step (refactoring) towards speeding up compilation w/ >1 primary file

<!-- What's in this pull request? -->
Creates new class, FrontendInputs, to encapsulate InputFilenames, InputBuffers, and PrimaryInput, which were formerly in FrontendOptions. Add new instance variable, Inputs, to FrontendOptions in order to hold FrontendInputs.

Encapsulate uses of the variables in FrontendInputs with intention-describing functions. Move some code that sets these variables into FrontendInputs and FrontendOptions classes.

Create new FrontendInputs class to encapsulate InputFilenames, InputBuffers and PrimaryInput, which were formerly in Frontend.

Includes one change in SwiftEditor.cpp to resolve a merge conflict.