### PR TITLE
Implement a few silcombine transformations

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5468,6 +5468,13 @@ public:
   SILValue getValue() const { return Operands[Value].get(); }
   SILValue getBase() const { return Operands[Base].get(); }
 
+  void setValue(SILValue newVal) {
+    Operands[Value].set(newVal);
+  }
+  void setBase(SILValue newVal) {
+    Operands[Base].set(newVal);
+  }
+  
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 };

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -237,6 +237,9 @@ public:
   SILInstruction *visitUnreachableInst(UnreachableInst *UI);
   SILInstruction *visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI);
   SILInstruction *visitEnumInst(EnumInst *EI);
+      
+  SILInstruction *visitMarkDependenceInst(MarkDependenceInst *MDI);
+  SILInstruction *visitInitExistentialRefInst(InitExistentialRefInst *IER);
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
 
   /// Instruction visitor helpers.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1130,6 +1130,15 @@ SILInstruction *SILCombiner::visitStrongReleaseInst(StrongReleaseInst *SRI) {
       isa<ObjCMetatypeToObjectInst>(SRI->getOperand()))
     return eraseInstFromFunction(*SRI);
 
+  // Release of a classbound existential converted from a class is just a
+  // release of the class, squish the conversion.
+  if (auto ier = dyn_cast<InitExistentialRefInst>(SRI->getOperand()))
+    if (ier->hasOneUse()) {
+      SRI->setOperand(ier->getOperand());
+      eraseInstFromFunction(*ier);
+      return SRI;
+    }
+  
   return nullptr;
 }
 
@@ -1401,4 +1410,64 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
 SILInstruction *SILCombiner::visitEnumInst(EnumInst *EI) {
   return nullptr;
 }
+
+SILInstruction *SILCombiner::visitMarkDependenceInst(MarkDependenceInst *MDI) {
+  // Simplify the base operand of a MarkDependenceInst to eliminate unnecessary
+  // instructions that aren't adding value.
+  //
+  // Conversions to Optional.Some(x) often happen here, this isn't important
+  // for us, we can just depend on 'x' directly.
+  if (auto eiBase = dyn_cast<EnumInst>(MDI->getBase())) {
+    if (eiBase->hasOperand() && eiBase->hasOneUse()) {
+      MDI->setBase(eiBase->getOperand());
+      eraseInstFromFunction(*eiBase);
+      return MDI;
+    }
+  }
+  
+  // Conversions from a class to AnyObject also happen a lot, we can just depend
+  // on the class reference.
+  if (auto ier = dyn_cast<InitExistentialRefInst>(MDI->getBase())) {
+    MDI->setBase(ier->getOperand());
+    if (ier->use_empty())
+      eraseInstFromFunction(*ier);
+    return MDI;
+  }
+  
+  return nullptr;
+}
+
+
+SILInstruction *SILCombiner::
+visitInitExistentialRefInst(InitExistentialRefInst *IER) {
+  // Arrays in particular end up with chains of init/open existential refs,
+  // which convert back and forth between a class reference and an existential
+  // reference e.g. like this:
+  //
+  // %a = init_existential_ref %x : $_ContiguousArrayStorageBase :
+  //                                $_ContiguousArrayStorageBase, $_NSArrayCore
+  // %b = open_existential_ref %a : $_NSArrayCore to
+  //                                $@opened("EA85...") _NSArrayCore
+  //
+  // %c = init_existential_ref %b : $@opened("EA85...") _NSArrayCore :
+  //                                $@opened("EA85...") _NSArrayCore, $AnyObject
+  // we can simplify this by having %c initialize itself from the %x reference
+  // directly.
+  if (auto *ORE = dyn_cast<OpenExistentialRefInst>(IER->getOperand())) {
+    if (auto *IER2 = dyn_cast<InitExistentialRefInst>(ORE->getOperand())) {
+      
+      // We create a new instruction, instead of modifying the existing one
+      // in place, because we need the result type of "%c" but the operand list
+      // of "%a", and the number of dependent types could disagree.
+      return Builder.createInitExistentialRef(IER->getLoc(), IER->getType(),
+                                              IER2->getFormalConcreteType(),
+                                              IER2->getOperand(),
+                                              IER->getConformances());
+      
+    }
+  }
+  
+  return nullptr;
+}
+
 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2081,6 +2081,19 @@ bb0(%0 : $B, %1 : $@sil_unowned B, %2 : $AnyObject, %3: $@sil_unmanaged AnyObjec
   return %9999 : $(B, @sil_unowned B, AnyObject, @sil_unmanaged AnyObject)
 }
 
+// CHECK-LABEL: sil @collapse_init_open_init_ref_cast
+// CHECK:       bb0([[Ref:%.*]]: $MyClass):
+// CHECK-NEXT:     init_existential_ref
+// CHECK-NEXT:     return
+sil @collapse_init_open_init_ref_cast : $@convention(thin) (MyClass) -> (AnyObject) {
+bb0(%0: $MyClass):
+  %1 = init_existential_ref %0 : $MyClass : $MyClass, $AnyObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %3 = init_existential_ref %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject, $AnyObject
+  return %3 : $AnyObject
+}
+
+
 // CHECK-LABEL: sil @collapse_existential_pack_unpack_unchecked_ref_cast
 // CHECK:       bb0([[Ref:%.*]]: $MyClass):
 // CHECK-NOT:     init_existential_ref
@@ -3388,5 +3401,23 @@ bb2:                                                // Preds: bb0
 
 bb3(%16 : $Int32):                                  // Preds: bb1 bb2
   return %16 : $Int32                               // id: %17
+}
+
+
+
+// CHECK-LABEL: sil @mark_dependence_base
+// CHECK: bb0(
+// CHECK-NOT: init_existential_ref
+// CHECK-NOT: enum
+// CHECK-NEXT: mark_dependence
+// CHECK-NEXT: load
+// CHECK: return
+sil @mark_dependence_base : $@convention(thin) (@inout Builtin.Int64, @owned B) -> Builtin.Int64 {
+bb0(%0 : $*Builtin.Int64, %1 : $B):
+  %x = init_existential_ref %1 : $B : $B, $AnyObject
+  %2 = enum $Optional<AnyObject>, #Optional.some!enumelt.1, %x : $AnyObject
+  %3 = mark_dependence %0 : $*Builtin.Int64 on %2 : $Optional<AnyObject>
+  %4 = load %3 : $*Builtin.Int64
+  return %4 : $Builtin.Int64
 }
 


### PR DESCRIPTION
 - Useless existential_ref <-> class conversions.
 - mark_dependence_inst depending on uninteresting instructions.
 - release(init_existential_ref(x)) -> release(x) when hasOneUse(x)

these aren't massive performance wins, but do shrink the size of SIL when
dealing with arrays.

@eeckstein LGTY?