### PR TITLE
[swiftc (60 vs. 5600)] Add crasher in swift::ProtocolConformance::getTypeWitnessAndDecl

### DIFF
--- a/validation-test/compiler_crashers/28854-known-typewitnesses-end-didnt-resolve-witness.swift
+++ b/validation-test/compiler_crashers/28854-known-typewitnesses-end-didnt-resolve-witness.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@objc protocol A
+{
+typealias a
+protocol P{{}class a:A{typealias e:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolConformance::getTypeWitnessAndDecl`.

Current number of unresolved compiler crashers: 60 (5600 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `known != TypeWitnesses.end() && "Didn't resolve witness?"` added on 2017-05-03 by you in commit dbb973aa :-)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 474)`](https://github.com/apple/swift/blob/488aa7060061d95be07088ed22244247d5ec89b0/lib/AST/ProtocolConformance.cpp#L474):

```
Assertion `known != TypeWitnesses.end() && "Didn't resolve witness?"' failed.

When executing: std::pair<Type, TypeDecl *> swift::NormalProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl *, swift::LazyResolver *, swift::SubstOptions) const
```

Assertion context:

```c++
  PrettyStackTraceRequirement trace("resolving", this, assocType);
  assert(resolver && "Unable to resolve type witness");
  resolver->resolveTypeWitness(this, assocType);

  known = TypeWitnesses.find(assocType);
  assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
  return known->second;
}

void NormalProtocolConformance::setTypeWitness(AssociatedTypeDecl *assocType,
                                               Type type,
```
Stack trace:

```
0 0x0000000003ea95e4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ea95e4)
1 0x0000000003ea9926 SignalHandler(int) (/path/to/swift/bin/swift+0x3ea9926)
2 0x00007f505d9d9390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f505befe428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f505bf0002a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f505bef6bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f505bef6c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016cdbdb (/path/to/swift/bin/swift+0x16cdbdb)
8 0x00000000016cd7f8 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16cd7f8)
9 0x00000000016cd319 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16cd319)
10 0x00000000016e5fe7 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x16e5fe7)
11 0x00000000016eab4d llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_20>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16eab4d)
12 0x00000000016e6ec6 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16e6ec6)
13 0x00000000016e20e5 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16e20e5)
14 0x00000000013228bb swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x13228bb)
15 0x0000000001322605 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1322605)
16 0x000000000132a3cb resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x132a3cb)
17 0x0000000001329f16 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1329f16)
18 0x00000000013243e6 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13243e6)
19 0x0000000001323d9a swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1323d9a)
20 0x0000000001324b30 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1324b30)
21 0x0000000001324a3c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1324a3c)
22 0x0000000001323335 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1323335)
23 0x00000000012a4ad5 validateTypealiasType(swift::TypeChecker&, swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x12a4ad5)
24 0x00000000012a3828 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a3828)
25 0x00000000012b34af (anonymous namespace)::DeclChecker::visitTypeAliasDecl(swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x12b34af)
26 0x00000000012a19ef (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a19ef)
27 0x00000000012b3bbb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b3bbb)
28 0x00000000012a1b0e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a1b0e)
29 0x00000000012b4efb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b4efb)
30 0x00000000012a1a1f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a1a1f)
31 0x00000000012b4efb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b4efb)
32 0x00000000012a1a1f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a1a1f)
33 0x00000000012a18b3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a18b3)
34 0x0000000001332665 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1332665)
35 0x0000000001055cb4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1055cb4)
36 0x0000000001054d77 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1054d77)
37 0x000000000105469a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105469a)
38 0x00000000004bdc96 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdc96)
39 0x00000000004bca59 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bca59)
40 0x0000000000474d54 main (/path/to/swift/bin/swift+0x474d54)
41 0x00007f505bee9830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
42 0x0000000000472609 _start (/path/to/swift/bin/swift+0x472609)
```