### PR TITLE
[swiftc (61 vs. 5600)] Add crasher in swift::GenericSignatureBuilder::addRequirement

### DIFF
--- a/validation-test/compiler_crashers/28855-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
+++ b/validation-test/compiler_crashers/28855-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@objc protocol P{typealias e where f=a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::addRequirement`.

Current number of unresolved compiler crashers: 61 (5600 resolved)

Stack trace:

```
0 0x0000000003ea95e4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ea95e4)
1 0x0000000003ea9926 SignalHandler(int) (/path/to/swift/bin/swift+0x3ea9926)
2 0x00007f6f711e2390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000016842f0 swift::GenericSignatureBuilder::addRequirement(swift::RequirementRepr const*, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::SubstitutionMap const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x16842f0)
4 0x00000000016824b7 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x16824b7)
5 0x000000000168669a swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x168669a)
6 0x0000000001683f8b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x1683f8b)
7 0x0000000001692302 swift::GenericSignatureBuilder::computeRequirementSignature(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1692302)
8 0x000000000164e6f6 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x164e6f6)
9 0x00000000012d5c58 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12d5c58)
10 0x00000000012a3888 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a3888)
11 0x00000000012b4b94 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b4b94)
12 0x00000000012a1a1f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a1a1f)
13 0x00000000012a18b3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a18b3)
14 0x0000000001332665 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1332665)
15 0x0000000001055cb4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1055cb4)
16 0x0000000001054d77 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1054d77)
17 0x000000000105469a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105469a)
18 0x00000000004bdc96 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdc96)
19 0x00000000004bca59 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bca59)
20 0x0000000000474d54 main (/path/to/swift/bin/swift+0x474d54)
21 0x00007f6f6f6f2830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000472609 _start (/path/to/swift/bin/swift+0x472609)
```