### PR TITLE
[swiftc (62 vs. 5600)] Add crasher in swift::constraints::ConstraintGraph::lookupNode(...)

### DIFF
--- a/validation-test/compiler_crashers/28856-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28856-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{[Int?as?ManagedBuffer}{


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraph::lookupNode(...)`.

Current number of unresolved compiler crashers: 62 (5600 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `TypeVariables[impl.getGraphIndex()] == typeVar && "Type variable mismatch"` added on 2013-12-09 by you in commit 11794095 :-)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 52)`](https://github.com/apple/swift/blob/9fdf08ac98616a9f0a427d0896752ca5eee4e8aa/lib/Sema/ConstraintGraph.cpp#L52):

```
Assertion `TypeVariables[impl.getGraphIndex()] == typeVar && "Type variable mismatch"' failed.

When executing: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *)
```

Assertion context:

```c++
  // Check whether we've already created a node for this type variable.
  auto &impl = typeVar->getImpl();
  if (auto nodePtr = impl.getGraphNode()) {
    assert(impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index");
    assert(TypeVariables[impl.getGraphIndex()] == typeVar &&
           "Type variable mismatch");
    return { *nodePtr, impl.getGraphIndex() };
  }

  // Allocate the new node.
  auto nodePtr = new ConstraintGraphNode(typeVar);
```
Stack trace:

```
0 0x0000000003ea95e4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ea95e4)
1 0x0000000003ea9926 SignalHandler(int) (/path/to/swift/bin/swift+0x3ea9926)
2 0x00007f2e21ca6390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f2e201cb428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f2e201cd02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f2e201c3bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f2e201c3c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012609ed swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType*) (/path/to/swift/bin/swift+0x12609ed)
8 0x00000000012624ef swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0x12624ef)
9 0x0000000001230239 swift::constraints::ConstraintSystem::addUnsolvedConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0x1230239)
10 0x000000000123a2bc swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x123a2bc)
11 0x0000000001246778 swift::constraints::ConstraintSystem::addConstraintImpl(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x1246778)
12 0x000000000123d8ad swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x123d8ad)
13 0x0000000001229025 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1229025)
14 0x000000000122d6be (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x122d6be)
15 0x00000000016299df swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x16299df)
16 0x000000000162655b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x162655b)
17 0x0000000001223d9f swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x1223d9f)
18 0x0000000001251da1 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1251da1)
19 0x0000000001286057 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1286057)
20 0x000000000128a6da swift::TypeChecker::getPossibleTypesOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, llvm::SmallVectorImpl<swift::Type>&, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0x128a6da)
21 0x0000000001383d6b (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1383d6b)
22 0x00000000013657d2 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13657d2)
23 0x000000000135f162 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x135f162)
24 0x00000000013651d9 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13651d9)
25 0x0000000001286098 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1286098)
26 0x0000000001289e1c swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1289e1c)
27 0x0000000001313335 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1313335)
28 0x0000000001312b46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1312b46)
29 0x00000000013326d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13326d0)
30 0x0000000001055cb4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1055cb4)
31 0x0000000001054d77 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1054d77)
32 0x000000000105469a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105469a)
33 0x00000000004bdc96 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bdc96)
34 0x00000000004bca59 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bca59)
35 0x0000000000474d54 main (/path/to/swift/bin/swift+0x474d54)
36 0x00007f2e201b6830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
37 0x0000000000472609 _start (/path/to/swift/bin/swift+0x472609)
```