### PR TITLE
[stdlib] Constrain SubSequence.IndexDistance == IndexDistance

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -404,7 +404,8 @@ public protocol Collection : Sequence
   /// protocol, but it is restated here with stricter constraints. In a
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence : Collection = Slice<Self>
-    where SubSequence.Index == Index
+    where SubSequence.Index == Index,
+          SubSequence.IndexDistance == IndexDistance
 
   /// Accesses the element at the specified position.
   ///


### PR DESCRIPTION
Ran into this limitation when working on #12333 that got in the way passing an `IndexDistance` in a recursive method — what do you think @airspeedswift?