### PR TITLE
stdlib: fix build for non-ObjC targets

### DIFF
--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -91,8 +91,13 @@ internal func _collectAllReferencesInsideObjectImpl(
 // of runtime function counters.
 public // @testable
 struct _RuntimeFunctionCounters {
+#if os(Windows) && arch(x86_64)
   public typealias RuntimeFunctionCountersUpdateHandler =
-   @convention(c) (_ object: UnsafeRawPointer, _ functionId: Int64) -> Void
+    @convention(c) (_ object: UnsafeRawPointer, _ functionId: Int) -> Void
+#else
+  public typealias RuntimeFunctionCountersUpdateHandler =
+    @convention(c) (_ object: UnsafeRawPointer, _ functionId: Int64) -> Void
+#endif
 
   public static let runtimeFunctionNames =
     getRuntimeFunctionNames()


### PR DESCRIPTION
When building the stdlib for Windows, we would see the following error:

  swift/stdlib/public/core/RuntimeFunctionCounters.swift:95:19: error: '(UnsafeRawPointer, Int64) -> Void' is not representable in Objective-C, so it cannot be used with '@convention(c)'
     @convention(c) (_ object: UnsafeRawPointer, _ functionId: Int64) -> Void
                    ^

Add a case around it to permit building the stdlib.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
