### PR TITLE
Implementation of "Restrict cross-module struct initializers to be delegating"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3674,19 +3674,16 @@ NOTE(resilience_decl_declared_here,
 NOTE(resilience_decl_declared_here_versioned,
      none, "%0 %1 is not '@_versioned' or public", (DescriptiveDeclKind, DeclName))
 
-ERROR(designated_init_in_extension_resilient,none,
-      "initializer declared in an extension of "
-      "non-'@_fixed_layout' type %0 must delegate to another initializer", (Type))
+ERROR(designated_init_in_cross_module_extension,none,
+      "initializer for %0 %1 must use \"self.init(...)\" or \"self = ...\" "
+      "because it is not in module %2",
+      (DescriptiveDeclKind, Type, Identifier))
 
 ERROR(designated_init_inlineable_resilient,none,
-      "initializer for non-'@_fixed_layout' type %0 is "
-      "'%select{@_transparent|@inline(__always)|@_inlineable|%error}1' and must "
-      "delegate to another initializer", (Type, unsigned))
-
-ERROR(class_designated_init_inlineable_resilient,none,
-      "initializer for class %0 is "
-      "'%select{@_transparent|@inline(__always)|@_inlineable|%error}1' and must "
-      "delegate to another initializer", (Type, unsigned))
+      "initializer for %select{non-'@_fixed_layout' struct|class}0 %1 is "
+      "'%select{@_transparent|@inline(__always)|@_inlineable|%error}2' and must "
+      "delegate to another initializer",
+      (bool, Type, /*FragileFunctionKind*/unsigned))
 
 ERROR(inlineable_stored_property,
       none, "'@_inlineable' attribute cannot be applied to stored properties", ())

--- a/test/decl/init/resilience.swift
+++ b/test/decl/init/resilience.swift
@@ -6,9 +6,10 @@
 import resilient_struct
 import resilient_protocol
 
-// Point is @_fixed_layout -- this is OK
+// Even though Point is @_fixed_layout this is not allowed.
 extension Point {
   init(xx: Int, yy: Int) {
+  // expected-error@-1 {{initializer for struct 'Point' must use "self.init(...)" or "self = ..." because it is not in module 'resilient_struct'}}
     self.x = xx
     self.y = yy
   }
@@ -17,7 +18,7 @@ extension Point {
 // Size is not @_fixed_layout, so we cannot define a new designated initializer
 extension Size {
   init(ww: Int, hh: Int) {
-  // expected-error@-1 {{initializer declared in an extension of non-'@_fixed_layout' type 'Size' must delegate to another initializer}}
+  // expected-error@-1 {{initializer for struct 'Size' must use "self.init(...)" or "self = ..." because it is not in module 'resilient_struct'}}
     self.w = ww
     self.h = hh
   }
@@ -30,7 +31,7 @@ extension Size {
   // FIXME: This should be allowed, but Sema doesn't distinguish this
   // case from memberwise initialization, and DI explodes the value type
   init(other: Size) {
-  // expected-error@-1 {{initializer declared in an extension of non-'@_fixed_layout' type 'Size' must delegate to another initializer}}
+  // expected-error@-1 {{initializer for struct 'Size' must use "self.init(...)" or "self = ..." because it is not in module 'resilient_struct'}}
     self = other
   }
 }
@@ -41,17 +42,17 @@ public struct Animal {
   public let name: String
 
   @_inlineable public init(name: String) {
-  // expected-error@-1 {{initializer for non-'@_fixed_layout' type 'Animal' is '@_inlineable' and must delegate to another initializer}}
+  // expected-error@-1 {{initializer for non-'@_fixed_layout' struct 'Animal' is '@_inlineable' and must delegate to another initializer}}
     self.name = name
   }
 
   @inline(__always) public init(dog: String) {
-  // expected-error@-1 {{initializer for non-'@_fixed_layout' type 'Animal' is '@inline(__always)' and must delegate to another initializer}}
+  // expected-error@-1 {{initializer for non-'@_fixed_layout' struct 'Animal' is '@inline(__always)' and must delegate to another initializer}}
     self.name = dog
   }
 
   @_transparent public init(cat: String) {
-  // expected-error@-1 {{initializer for non-'@_fixed_layout' type 'Animal' is '@_transparent' and must delegate to another initializer}}
+  // expected-error@-1 {{initializer for non-'@_fixed_layout' struct 'Animal' is '@_transparent' and must delegate to another initializer}}
     self.name = cat
   }
 
@@ -63,7 +64,7 @@ public struct Animal {
   // FIXME: This should be allowed, but Sema doesn't distinguish this
   // case from memberwise initialization, and DI explodes the value type
   @_inlineable public init(other: Animal) {
-  // expected-error@-1 {{initializer for non-'@_fixed_layout' type 'Animal' is '@_inlineable' and must delegate to another initializer}}
+  // expected-error@-1 {{initializer for non-'@_fixed_layout' struct 'Animal' is '@_inlineable' and must delegate to another initializer}}
     self = other
   }
 }


### PR DESCRIPTION
Initial implementation of https://github.com/jrose-apple/swift-evolution/blob/restrict-cross-module-struct-initializers/proposals/nnnn-restrict-cross-module-struct-initializers.md, which I plan to submit for swift-evolution review soon. Slava already had most of this in place as a prototype for the restrictions on what's currently spelled `@_fixed_layout`. Tidy it up and make it apply all the time across module boundaries.

This doesn't actually work yet because of the FIXMEs in the test cases; it turns out these very cases come up in the overlays. Slava's working on that separately; once that goes in I'll rebase this.

(The tweak in Serialization is because no one had tested -enable-resilience and -enable-testing at the same time. It's a backwards-compatible change, so no need to bump the module format.)

rdar://problem/34777878