### PR TITLE
IRGen: fix DLL storage for runtime functions

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -472,7 +472,8 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     fn->setCallingConv(cc);
 
     if (::useDllStorage(llvm::Triple(Module.getTargetTriple())) &&
-        (fn->getLinkage() == llvm::GlobalValue::ExternalLinkage ||
+        ((fn->getLinkage() == llvm::GlobalValue::ExternalLinkage &&
+          fn->isDeclaration()) ||
          fn->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage))
       fn->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
 


### PR DESCRIPTION
The runtime functions should not have DLLImport storage for the runtime
functions.  Without this change, we would see `swift_unexpectedError` be
given DLL Import DLL Storage.  It should probably be given DLLExport DLL
Storage.  This is needed to repair the Windows build.  The problem is
that the ExternalLinkage does not indicate whether the function is
internally available or externally available, merely that it
participates in linkage resolution.  Ensure that we only give import
storage to declarations with ExternalLinkage.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
