### PR TITLE
Re-apply "Fix issue with 'Self' metadata when class conforms to protocol with default implementations"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1452,6 +1452,11 @@ ERROR(witness_requires_dynamic_self,none,
       "method %0 in non-final class %1 must return `Self` to conform to "
       "protocol %2",
       (DeclName, Type, Type))
+ERROR(witness_requires_class_implementation,none,
+      "method %0 in non-final class %1 cannot be implemented in a "
+      "protocol extension because it returns `Self` and has associated type "
+      "requirements",
+      (DeclName, Type))
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3520,9 +3520,15 @@ public:
 
   CanType getSelfInstanceType() const;
 
-  /// If this a @convention(witness_method) function with an abstract
-  /// self parameter, return the protocol constraint for the Self type.
+  /// If this is a @convention(witness_method) function with a protocol
+  /// constrained self parameter, return the protocol constraint for
+  /// the Self type.
   ProtocolDecl *getDefaultWitnessMethodProtocol(ModuleDecl &M) const;
+
+  /// If this is a @convention(witness_method) function with a class
+  /// constrained self parameter, return the class constraint for the
+  /// Self type.
+  ClassDecl *getWitnessMethodClass(ModuleDecl &M) const;
 
   ExtInfo getExtInfo() const { return ExtInfo(SILFunctionTypeBits.ExtInfo); }
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -100,13 +100,27 @@ SILFunctionType::getDefaultWitnessMethodProtocol(ModuleDecl &M) const {
   assert(getRepresentation() == SILFunctionTypeRepresentation::WitnessMethod);
   auto selfTy = getSelfInstanceType();
   if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {
+    assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
     auto superclass = GenericSig->getSuperclassBound(paramTy, M);
     if (superclass)
       return nullptr;
-    assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
     auto protos = GenericSig->getConformsTo(paramTy, M);
     assert(protos.size() == 1);
     return protos[0];
+  }
+
+  return nullptr;
+}
+
+ClassDecl *
+SILFunctionType::getWitnessMethodClass(ModuleDecl &M) const {
+  auto selfTy = getSelfInstanceType();
+  auto genericSig = getGenericSignature();
+  if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {
+    assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
+    auto superclass = genericSig->getSuperclassBound(paramTy, M);
+    if (superclass)
+      return superclass->getClassOrBoundGenericClass();
   }
 
   return nullptr;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -135,6 +135,7 @@ namespace {
                            DeclContext *conformanceDC,
                            GenericSignature *reqSig,
                            ProtocolDecl *proto,
+                           ClassDecl *covariantSelf,
                            ProtocolConformance *conformance);
 
     /// Retrieve the synthetic generic environment.
@@ -1027,6 +1028,7 @@ RequirementEnvironment::RequirementEnvironment(
                                            DeclContext *conformanceDC,
                                            GenericSignature *reqSig,
                                            ProtocolDecl *proto,
+                                           ClassDecl *covariantSelf,
                                            ProtocolConformance *conformance)
     : reqSig(reqSig) {
   ASTContext &ctx = tc.Context;
@@ -1167,8 +1169,64 @@ matchWitness(TypeChecker &tc,
   Type reqType, openedFullReqType;
 
   auto *reqSig = req->getInnermostDeclContext()->getGenericSignatureOfContext();
+
+  ClassDecl *covariantSelf = nullptr;
+  if (witness->getDeclContext()->getAsProtocolExtensionContext()) {
+    if (auto *classDecl = dc->getAsClassOrClassExtensionContext()) {
+      if (!classDecl->isFinal()) {
+        // If the requirement's type does not involve any associated types,
+        // we use a class-constrained generic parameter as the 'Self' type
+        // in the witness thunk.
+        //
+        // This allows the following code to type check:
+        //
+        // protocol P {
+        //   func f() -> Self
+        // }
+        //
+        // extension P {
+        //   func f() { return self }
+        // }
+        //
+        // class C : P {}
+        //
+        // When we call (C() as P).f(), we want to pass the 'Self' type
+        // from the call site, not the static 'Self' type of the conformance.
+        //
+        // On the other hand, if the requirement's type contains associated
+        // types, we use the static 'Self' type, to preserve backward
+        // compatibility with code that uses this pattern:
+        //
+        // protocol P {
+        //   associatedtype T = Self
+        //   func f() -> T
+        // }
+        //
+        // extension P where Self.T == Self {
+        //   func f() -> Self { return self }
+        // }
+        //
+        // class C : P {}
+        //
+        // It would have been much nicer to just ban this completely if
+        // the class 'C' is not final, but there is a great deal of existing
+        // code out there that relies on this behavior, most commonly by
+        // defining a non-final class conforming to 'Collection' which uses
+        // the default witness for 'Collection.Iterator', which is defined
+        // as 'IndexingIterator<Self>'.
+        auto selfKind = proto->findProtocolSelfReferences(req,
+                                             /*allowCovariantParameters=*/false,
+                                             /*skipAssocTypes=*/false);
+        if (!selfKind.other) {
+          covariantSelf = classDecl;
+        }
+      }
+    }
+  }
+
   Optional<RequirementEnvironment> reqEnvironment(
-      RequirementEnvironment(tc, dc, reqSig, proto, conformance));
+      RequirementEnvironment(tc, dc, reqSig, proto, covariantSelf,
+                             conformance));
 
   // Set up the constraint system for matching.
   auto setup = [&]() -> std::tuple<Optional<RequirementMatch>, Type, Type> {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1207,6 +1207,13 @@ RequirementEnvironment::RequirementEnvironment(
   // Next, add each of the requirements (mapped from the requirement's
   // interface types into the abstract type parameters).
   for (auto &req : reqSig->getRequirements()) {
+    // FIXME: This should not be necessary, since the constraint is redundant,
+    // but we need it to work around some crashes for now.
+    if (req.getKind() == RequirementKind::Conformance &&
+        req.getFirstType()->isEqual(selfType) &&
+        req.getSecondType()->isEqual(proto->getDeclaredType()))
+      continue;
+
     builder.addRequirement(req, source, /*inferModule=*/nullptr,
                            &reqToSyntheticEnvMap);
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3153,6 +3153,8 @@ ResolveWitnessResult
 ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
 
+  auto *nominal = Adoptee->getAnyNominal();
+
   // Resolve all associated types before trying to resolve this witness.
   resolveTypeWitnesses();
 
@@ -3166,23 +3168,21 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
 
   // Determine whether we can derive a witness for this requirement.
   bool canDerive = false;
-  if (auto *nominal = Adoptee->getAnyNominal()) {
-    // Can a witness for this requirement be derived for this nominal type?
-    if (auto derivable = DerivedConformance::getDerivableRequirement(
-                           nominal,
-                           requirement)) {
-      if (derivable == requirement) {
-        // If it's the same requirement, we can derive it here.
-        canDerive = true;
-      } else {
-        // Otherwise, go satisfy the derivable requirement, which can introduce
-        // a member that could in turn satisfy *this* requirement.
-        auto derivableProto = cast<ProtocolDecl>(derivable->getDeclContext());
-        if (auto conformance =
-              TC.conformsToProtocol(Adoptee, derivableProto, DC, None)) {
-          if (conformance->isConcrete())
-            (void)conformance->getConcrete()->getWitnessDecl(derivable, &TC);
-        }
+  // Can a witness for this requirement be derived for this nominal type?
+  if (auto derivable = DerivedConformance::getDerivableRequirement(
+                         nominal,
+                         requirement)) {
+    if (derivable == requirement) {
+      // If it's the same requirement, we can derive it here.
+      canDerive = true;
+    } else {
+      // Otherwise, go satisfy the derivable requirement, which can introduce
+      // a member that could in turn satisfy *this* requirement.
+      auto derivableProto = cast<ProtocolDecl>(derivable->getDeclContext());
+      if (auto conformance =
+            TC.conformsToProtocol(Adoptee, derivableProto, DC, None)) {
+        if (conformance->isConcrete())
+          (void)conformance->getConcrete()->getWitnessDecl(derivable, &TC);
       }
     }
   }
@@ -3229,8 +3229,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         });
     }
 
-    AccessScope nominalAccessScope =
-        Adoptee->getAnyNominal()->getFormalAccessScope(DC);
+    auto nominalAccessScope = nominal->getFormalAccessScope(DC);
     auto check = checkWitness(nominalAccessScope, requirement, best);
 
     switch (check.Kind) {
@@ -3446,10 +3445,9 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
 
   // Find the declaration that derives the protocol conformance.
   NominalTypeDecl *derivingTypeDecl = nullptr;
-  if (auto *nominal = Adoptee->getAnyNominal()) {
-    if (nominal->derivesProtocolConformance(Proto))
-      derivingTypeDecl = nominal;
-  }
+  auto *nominal = Adoptee->getAnyNominal();
+  if (nominal->derivesProtocolConformance(Proto))
+    derivingTypeDecl = nominal;
 
   if (!derivingTypeDecl) {
     return ResolveWitnessResult::Missing;
@@ -5621,14 +5619,13 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   // Note that we check the module name to smooth over the difference
   // between an imported Objective-C module and its overlay.
   if (Proto->isSpecificProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
-    if (auto nominal = Adoptee->getAnyNominal()) {
-      if (!TC.Context.isTypeBridgedInExternalModule(nominal)) {
-        if (nominal->getParentModule() != DC->getParentModule() &&
-            !isInOverlayModuleForImportedModule(DC, nominal)) {
-          auto nominalModule = nominal->getParentModule();
-          TC.diagnose(Loc, diag::nonlocal_bridged_to_objc, nominal->getName(),
-                      Proto->getName(), nominalModule->getName());
-        }
+    auto nominal = Adoptee->getAnyNominal();
+    if (!TC.Context.isTypeBridgedInExternalModule(nominal)) {
+      if (nominal->getParentModule() != DC->getParentModule() &&
+          !isInOverlayModuleForImportedModule(DC, nominal)) {
+        auto nominalModule = nominal->getParentModule();
+        TC.diagnose(Loc, diag::nonlocal_bridged_to_objc, nominal->getName(),
+                    Proto->getName(), nominalModule->getName());
       }
     }
   }

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -100,3 +100,36 @@ entry(%ret : $*T.GrowthHack, %self : $*T):
   %z = apply %m<T>(%ret, %self) : $@convention(witness_method) <U: Strategy> (@in_guaranteed U) -> @out U.GrowthHack
   return %z : $()
 }
+
+// Class-constrained archetype witness method.
+struct ToVideo : Pivot {}
+
+class TPSReport<CoverSheet> : Strategy {
+  typealias GrowthHack = ToVideo
+
+  func disrupt() -> GrowthHack
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(%swift.type* %CoverSheet, %T14witness_method9TPSReportC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type* %Self, i8** %SelfWitnessTable)
+
+sil @classArchetypeWitnessMethod : $@convention(witness_method) <T><CoverSheet where T : TPSReport<CoverSheet>> (@in_guaranteed T) -> () {
+entry(%self : $*T):
+  %z = tuple ()
+  return %z : $()
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @testClassArchetypeWitnessMethod(%T14witness_method7ToVideoV* noalias nocapture sret, %T14witness_method9TPSReportC** noalias nocapture dereferenceable({{4|8}}), %swift.type* %T, %swift.type* %CoverSheet)
+// CHECK: entry:
+// CHECK:  [[WITNESS_FN:%.*]] = load i8*, i8** getelementptr inbounds (i8*, i8** @_T014witness_method9TPSReportCyxGAA8StrategyAAlWP, i32 2)
+// CHECK:  [[WITNESS:%.*]] = bitcast i8* [[WITNESS_FN]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, i8**)*
+// CHECK: call swiftcc void [[WITNESS]](%swift.opaque* noalias nocapture sret %4, %swift.opaque* noalias nocapture swiftself %5, %swift.type* %T, i8** @_T014witness_method9TPSReportCyxGAA8StrategyAAlWP)
+// CHECK: ret void
+
+sil @testClassArchetypeWitnessMethod : $@convention(thin) <T><CoverSheet where T : TPSReport<CoverSheet>> (@in_guaranteed T) -> (@out T.GrowthHack) {
+entry(%ret : $*T.GrowthHack, %self : $*T):
+  %m = witness_method $T, #Strategy.disrupt!1 : $@convention(witness_method) <U: Strategy> (@in_guaranteed U) -> @out U.GrowthHack
+  %z = apply %m<T>(%ret, %self) : $@convention(witness_method) <U: Strategy> (@in_guaranteed U) -> @out U.GrowthHack
+  return %z : $()
+}
+
+sil_vtable TPSReport {}

--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -263,5 +263,68 @@ _ = sup.init()
 sup = Sub.self
 _ = sup.init()
 
+// https://bugs.swift.org/browse/SR-617
+protocol SelfMetadataTest {
+  associatedtype T = Int
+
+  func staticTypeOfSelf() -> Any
+  func staticTypeOfSelfTakesT(_: T) -> Any
+  func staticTypeOfSelfCallsWitness() -> Any
+}
+
+extension SelfMetadataTest {
+  func staticTypeOfSelf() -> Any {
+    return Self.self
+  }
+
+  func staticTypeOfSelfTakesT(_: T) -> Any {
+    return Self.self
+  }
+
+  func staticTypeOfSelfNotAWitness() -> Any {
+    return Self.self
+  }
+
+  func staticTypeOfSelfCallsWitness() -> Any {
+    return staticTypeOfSelf()
+  }
+}
+
+class SelfMetadataBase : SelfMetadataTest {}
+
+class SelfMetadataDerived : SelfMetadataBase {}
+
+func testSelfMetadata<T : SelfMetadataTest>(_ x: T, _ t: T.T) {
+  print("testSelfMetadata()")
+  print(x.staticTypeOfSelf())
+  print(x.staticTypeOfSelfTakesT(t))
+  print(x.staticTypeOfSelfNotAWitness())
+  print(x.staticTypeOfSelfCallsWitness())
+}
+
+// CHECK: testSelfMetadata()
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataBase
+testSelfMetadata(SelfMetadataBase(), 0)
+
+// CHECK: testSelfMetadata()
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataBase
+testSelfMetadata(SelfMetadataDerived() as SelfMetadataBase, 0)
+
+// This is the interesting case -- make sure the static type of 'Self'
+// is correctly passed on from the call site to the extension method
+
+// CHECK: testSelfMetadata()
+// CHECK-NEXT: SelfMetadataDerived
+// CHECK-NEXT: SelfMetadataBase
+// CHECK-NEXT: SelfMetadataDerived
+// CHECK-NEXT: SelfMetadataDerived
+testSelfMetadata(SelfMetadataDerived(), 0)
+
 // CHECK: DONE
 print("DONE")

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -70,7 +70,7 @@ class C : P1 {
 
 //   (materializeForSet test from above)
 // CHECK-LABEL: sil private [transparent] [thunk] @_T019protocol_extensions1CCAA2P1A2aDPS2icimTW
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $Int, %3 : $*C):
+// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $Int, %3 : $*τ_0_0):
 // CHECK: function_ref @_T019protocol_extensions2P1PAAES2icig
 // CHECK: return
 

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen %s | %FileCheck %s
 
 protocol Fooable: class {
   func foo()
@@ -24,8 +24,8 @@ class Foo: Fooable {
   // CHECK:         class_method
 }
 
-// CHECK-LABEL: sil hidden @_T015witnesses_class3gen{{[_0-9a-zA-Z]*}}F
-// CHECK:         bb0([[SELF:%.*]] : $T)
+// CHECK-LABEL: sil hidden @_T015witnesses_class3genyxAA7FooableRzlF
+// CHECK:         bb0([[SELF:%.*]] : @owned $T)
 // CHECK:         [[METHOD:%.*]] = witness_method $T
 // CHECK-NOT:     copy_value [[SELF]]
 // CHECK:         [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
@@ -40,7 +40,7 @@ func gen<T: Fooable>(_ foo: T) {
 }
 
 // CHECK-LABEL: sil hidden @_T015witnesses_class2exyAA7Fooable_pF
-// CHECK: bb0([[SELF:%[0-0]+]] : $Fooable):
+// CHECK: bb0([[SELF:%[0-0]+]] : @owned $Fooable):
 // CHECK:         [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK:         [[SELF_PROJ:%.*]] = open_existential_ref [[BORROWED_SELF]]
 // CHECK:         [[METHOD:%.*]] = witness_method $[[OPENED:@opened(.*) Fooable]],
@@ -53,3 +53,58 @@ func gen<T: Fooable>(_ foo: T) {
 func ex(_ foo: Fooable) {
   foo.foo()
 }
+
+// Default implementations in a protocol extension
+protocol HasDefaults {
+  associatedtype T = Self
+
+  func hasDefault()
+
+  func hasDefaultTakesT(_: T)
+
+  func hasDefaultGeneric<U : Fooable>(_: U)
+
+  func hasDefaultGenericTakesT<U : Fooable>(_: T, _: U)
+}
+
+extension HasDefaults {
+  func hasDefault() {}
+
+  func hasDefaultTakesT(_: T) {}
+
+  func hasDefaultGeneric<U : Fooable>(_: U) {}
+
+  func hasDefaultGenericTakesT<U : Fooable>(_: T, _: U) {}
+}
+
+protocol Barable {}
+
+class UsesDefaults<X : Barable> : HasDefaults {}
+
+// Covariant Self:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP10hasDefaultyyFTW : $@convention(witness_method) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed τ_0_0) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE10hasDefaultyyF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<τ_0_0>(
+// CHECK: return
+
+// Invariant Self, since type signature contains an associated type:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP16hasDefaultTakesTy1TQzFTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : Barable> (@in UsesDefaults<τ_0_0>, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE16hasDefaultTakesTy1TQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in τ_0_0.T, @in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>>(
+// CHECK: return
+
+// Covariant Self:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP17hasDefaultGenericyqd__AA7FooableRd__lFTW : $@convention(witness_method) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@owned τ_2_0, @in_guaranteed τ_0_0) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE17hasDefaultGenericyqd__AA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@owned τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<τ_0_0, τ_2_0>(
+// CHECK: return
+
+// Invariant Self, since type signature contains an associated type:
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T015witnesses_class12UsesDefaultsCyxGAA03HasD0A2A7BarableRzlAaEP23hasDefaultGenericTakesTy1TQz_qd__tAA7FooableRd__lFTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : Barable><τ_1_0 where τ_1_0 : Fooable> (@in UsesDefaults<τ_0_0>, @owned τ_1_0, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_T015witnesses_class11HasDefaultsPAAE23hasDefaultGenericTakesTy1TQz_qd__tAA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@in τ_0_0.T, @owned τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>, τ_1_0>(
+// CHECK: return

--- a/test/SILOptimizer/devirt_class_witness_method.sil
+++ b/test/SILOptimizer/devirt_class_witness_method.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer -sil-combine -enable-resilience | tee /tmp/xxx | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+
+protocol P {
+  func f()
+}
+
+extension P {
+  func f()
+}
+
+class C<T, U> : P {}
+
+sil hidden_external [transparent] [thunk] @witness_thunk : $@convention(witness_method) <τ_0_0><τ_1_0, τ_1_1 where τ_0_0 : C<τ_1_0, τ_1_1>> (@in_guaranteed τ_0_0) -> ()
+
+// CHECK-LABEL: sil hidden @caller : $@convention(thin) <T, U> (@owned C<T, U>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @witness_thunk
+// CHECK: apply [[FN]]<C<T, U>, T, U>(
+// CHECK: return
+sil hidden @caller : $@convention(thin) <T, U> (@owned C<T, U>) -> () {
+bb0(%0 : $C<T, U>):
+  strong_retain %0 : $C<T, U>
+  %4 = alloc_stack $C<T, U>
+  store %0 to %4 : $*C<T, U>
+  %6 = witness_method $C<T, U>, #P.f!1 : <Self where Self : P> (Self) -> () -> () : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %7 = apply %6<C<T, U>>(%4) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %4 : $*C<T, U>
+  strong_release %0 : $C<T, U>
+  %9 = tuple ()
+  return %9 : $()
+}
+
+sil_vtable C {}
+
+sil_witness_table hidden <T, U> C<T, U>: P module clsx {
+  method #P.f!1: <Self where Self : P> (Self) -> () -> () : @witness_thunk
+}
+
+sil_default_witness_table hidden P {
+}

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype T = Int
+
+  func hasDefault()
+  func returnsSelf() -> Self
+  func hasDefaultTakesT(_: T)
+  func returnsSelfTakesT(_: T) -> Self
+}
+
+extension P {
+  func hasDefault() {}
+
+  func returnsSelf() -> Self {
+    return self
+  }
+
+  func hasDefaultTakesT(_: T) {}
+
+  func returnsSelfTakesT(_: T) -> Self { // expected-error {{method 'returnsSelfTakesT' in non-final class 'Class' cannot be implemented in a protocol extension because it returns `Self` and has associated type requirements}}
+    return self
+  }
+}
+
+// This fails
+class Class : P {}
+
+// This succeeds, because the class is final
+final class FinalClass : P {}
+
+// This succeeds, because we're not using the default implementation
+class NonFinalClass : P {
+  func returnsSelfTakesT(_: T) -> Self {
+    return self
+  }
+}

--- a/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// This test fails in the AST verifier, which can be turned off.
-// REQUIRES: swift_ast_verifier
+// REQUIRES: asserts
 class a<T where g:d{class A{class A<T>:A{init(){T{


### PR DESCRIPTION
My PR https://github.com/apple/swift/pull/12174 got reverted because it broke 32-bit x86 targets. This was a legitimate IRGen bug that was being masked by the use of swiftcc, which meant that passing a redundant second-to-last argument prior to the self argument was not detectable on x86-64. Fix this and re-apply the other changes verbatim, except for a small refactoring in the devirtualizer part to use the new utility method on SILFunctionType.

Fixes <rdar://problem/34889823>.