### PR TITLE
[GSB] Eliminate dependence on specific modules

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -862,22 +862,20 @@ private:
   /// generic signature builder for the given signature, if we don't already
   /// have one.
   void registerGenericSignatureBuilder(GenericSignature *sig,
-                                       ModuleDecl &module,
                                        GenericSignatureBuilder &&builder);
   friend class GenericSignatureBuilder;
 
 public:
   /// Retrieve or create the stored generic signature builder for the given
   /// canonical generic signature and module.
-  GenericSignatureBuilder *getOrCreateGenericSignatureBuilder(CanGenericSignature sig,
-                                                ModuleDecl *mod);
+  GenericSignatureBuilder *getOrCreateGenericSignatureBuilder(
+                                                     CanGenericSignature sig);
 
   /// Retrieve or create the canonical generic environment of a canonical
   /// generic signature builder.
   GenericEnvironment *getOrCreateCanonicalGenericEnvironment(
                                        GenericSignatureBuilder *builder,
-                                       GenericSignature *sig,
-                                       ModuleDecl &module);
+                                       GenericSignature *sig);
 
   /// Retrieve the inherited name set for the given class.
   const InheritedNameSet *getAllPropertyNames(ClassDecl *classDecl,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -27,7 +27,6 @@
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/LayoutConstraint.h"
-#include "swift/AST/LazyResolver.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Witness.h"
@@ -62,6 +61,7 @@ namespace swift {
   class GenericSignature;
   class GenericTypeParamDecl;
   class GenericTypeParamType;
+  class LazyResolver;
   class ModuleDecl;
   class NameAliasType;
   class EnumCaseDecl;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -132,7 +132,7 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
                                    ArrayRef<Requirement> requirements);
 
   /// Retrieve the generic signature builder for the given generic signature.
-  GenericSignatureBuilder *getGenericSignatureBuilder(ModuleDecl &mod);
+  GenericSignatureBuilder *getGenericSignatureBuilder();
 
   friend class ArchetypeType;
 
@@ -256,7 +256,7 @@ public:
   /// Create a new generic environment that provides fresh contextual types
   /// (archetypes) that correspond to the interface types in this generic
   /// signature.
-  GenericEnvironment *createGenericEnvironment(ModuleDecl &mod);
+  GenericEnvironment *createGenericEnvironment();
 
   /// Uniquing for the ASTContext.
   void Profile(llvm::FoldingSetNodeID &ID) {

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -264,46 +264,47 @@ public:
   }
   
   /// Determine whether the given dependent type is required to be a class.
-  bool requiresClass(Type type, ModuleDecl &mod);
+  bool requiresClass(Type type);
 
   /// Determine the superclass bound on the given dependent type.
-  Type getSuperclassBound(Type type, ModuleDecl &mod);
+  Type getSuperclassBound(Type type);
 
   using ConformsToArray = SmallVector<ProtocolDecl *, 2>;
   /// Determine the set of protocols to which the given dependent type
   /// must conform.
-  ConformsToArray getConformsTo(Type type, ModuleDecl &mod);
+  ConformsToArray getConformsTo(Type type);
 
   /// Determine whether the given dependent type conforms to this protocol.
-  bool conformsToProtocol(Type type, ProtocolDecl *proto, ModuleDecl &mod);
+  bool conformsToProtocol(Type type, ProtocolDecl *proto);
 
   /// Determine whether the given dependent type is equal to a concrete type.
-  bool isConcreteType(Type type, ModuleDecl &mod);
+  bool isConcreteType(Type type);
 
   /// Return the concrete type that the given dependent type is constrained to,
   /// or the null Type if it is not the subject of a concrete same-type
   /// constraint.
-  Type getConcreteType(Type type, ModuleDecl &mod);
+  Type getConcreteType(Type type);
 
   /// Return the layout constraint that the given dependent type is constrained
   /// to, or the null LayoutConstraint if it is not the subject of layout
   /// constraint.
-  LayoutConstraint getLayoutConstraint(Type type, ModuleDecl &mod);
+  LayoutConstraint getLayoutConstraint(Type type);
 
   /// Return whether two type parameters represent the same type under this
   /// generic signature.
   ///
   /// The type parameters must be known to not be concrete within the context.
-  bool areSameTypeParameterInContext(Type type1, Type type2, ModuleDecl &mod);
+  bool areSameTypeParameterInContext(Type type1, Type type2);
 
   /// Return the canonical version of the given type under this generic
   /// signature.
-  CanType getCanonicalTypeInContext(Type type, ModuleDecl &mod);
-  bool isCanonicalTypeInContext(Type type, ModuleDecl &mod);
+  CanType getCanonicalTypeInContext(Type type);
+  bool isCanonicalTypeInContext(Type type);
 
   /// Return the canonical version of the given type under this generic
   /// signature.
-  CanType getCanonicalTypeInContext(Type type, GenericSignatureBuilder &builder);
+  CanType getCanonicalTypeInContext(Type type,
+                                    GenericSignatureBuilder &builder);
   bool isCanonicalTypeInContext(Type type, GenericSignatureBuilder &builder);
 
   /// Retrieve the conformance access path used to extract the conformance of
@@ -319,8 +320,7 @@ public:
   ///
   /// \seealso ConformanceAccessPath
   ConformanceAccessPath getConformanceAccessPath(Type type,
-                                                 ProtocolDecl *protocol,
-                                                 ModuleDecl &mod);
+                                                 ProtocolDecl *protocol);
 
   static void Profile(llvm::FoldingSetNodeID &ID,
                       ArrayRef<GenericTypeParamType *> genericParams,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -613,7 +613,6 @@ public:
   /// After this point, one cannot introduce new requirements, and the
   /// generic signature builder no longer has valid state.
   GenericSignature *computeGenericSignature(
-                      ModuleDecl &module,
                       SourceLoc loc,
                       bool allowConcreteGenericParams = false,
                       bool allowBuilderToMove = true) &&;

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_LAZYRESOLVER_H
 #define SWIFT_AST_LAZYRESOLVER_H
 
+#include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/TypeLoc.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
 
@@ -102,6 +103,10 @@ public:
   /// is usable for the given type.
   virtual bool isProtocolExtensionUsable(DeclContext *dc, Type type,
                                          ExtensionDecl *protocolExtension) = 0;
+
+  /// Mark the given conformance as "used" from the given declaration context.
+  virtual void markConformanceUsed(ProtocolConformanceRef conformance,
+                                   DeclContext *dc) = 0;
 };
 
 /// An implementation of LazyResolver that delegates to another.
@@ -170,6 +175,11 @@ public:
   bool isProtocolExtensionUsable(DeclContext *dc, Type type,
                                  ExtensionDecl *protocolExtension) override {
     return Principal.isProtocolExtensionUsable(dc, type, protocolExtension);
+  }
+
+  void markConformanceUsed(ProtocolConformanceRef conformance,
+                           DeclContext *dc) override {
+    return Principal.markConformanceUsed(conformance, dc);
   }
 };
 

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -577,7 +577,7 @@ public:
 
   /// Retrieve the canonical generic environment associated with this
   /// generic signature.
-  GenericEnvironment *getGenericEnvironment(ModuleDecl &module) const;
+  GenericEnvironment *getGenericEnvironment() const;
 
   GenericSignature *operator->() const {
     return Signature;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3523,7 +3523,7 @@ public:
   /// If this is a @convention(witness_method) function with a protocol
   /// constrained self parameter, return the protocol constraint for
   /// the Self type.
-  ProtocolDecl *getDefaultWitnessMethodProtocol(ModuleDecl &M) const;
+  ProtocolDecl *getDefaultWitnessMethodProtocol() const;
 
   /// If this is a @convention(witness_method) function with a class
   /// constrained self parameter, return the class constraint for the

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -393,7 +393,7 @@ public:
 
   /// getCanonicalType - Stronger canonicalization which folds away equivalent
   /// associated types, or type parameters that have been made concrete.
-  CanType getCanonicalType(GenericSignature *sig, ModuleDecl &mod);
+  CanType getCanonicalType(GenericSignature *sig);
 
   /// Reconstitute type sugar, e.g., for array types, dictionary
   /// types, optionals, etc.

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -705,14 +705,14 @@ public:
 
   /// Is this an interface type that is subject to a concrete
   /// same-type constraint?
-  bool isConcreteType(ModuleDecl &module) const {
+  bool isConcreteType() const {
     assert(isTypeParameter());
     return (getKind() != Kind::Opaque &&
             GenericSig != nullptr &&
-            GenericSig->isConcreteType(getType(), module));
+            GenericSig->isConcreteType(getType()));
   }
 
-  bool requiresClass(ModuleDecl &module) {
+  bool requiresClass() {
     switch (getKind()) {
     case Kind::Opaque:
       return false;
@@ -725,7 +725,7 @@ public:
                isa<GenericTypeParamType>(type)) {
         assert(GenericSig &&
                "Dependent type in pattern without generic signature?");
-        return GenericSig->requiresClass(type, module);
+        return GenericSig->requiresClass(type);
       }
       return false;
     }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1460,8 +1460,7 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
     return known->second.get();
 
   // Create a new generic signature builder with the given signature.
-  auto builder =
-    new GenericSignatureBuilder(*this, LookUpConformanceInModule(mod));
+  auto builder = new GenericSignatureBuilder(*this);
 
   // Store this generic signature builder (no generic environment yet).
   Impl.GenericSignatureBuilders[{sig, mod}] =
@@ -4725,7 +4724,7 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
 
   assert(existential.isExistentialType());
 
-  GenericSignatureBuilder builder(*this, LookUpConformanceInModule(mod));
+  GenericSignatureBuilder builder(*this);
 
   auto genericParam = GenericTypeParamType::get(0, 0, *this);
   builder.addGenericParameter(genericParam);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -252,8 +252,7 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   llvm::DenseMap<const DeclContext *, LazyContextData *> LazyContexts;
 
   /// Stored generic signature builders for canonical generic signatures.
-  llvm::DenseMap<std::pair<GenericSignature *, ModuleDecl *>,
-                 std::unique_ptr<GenericSignatureBuilder>>
+  llvm::DenseMap<GenericSignature *, std::unique_ptr<GenericSignatureBuilder>>
     GenericSignatureBuilders;
 
   /// Canonical generic environments for canonical generic signatures.
@@ -1436,26 +1435,24 @@ void ASTContext::getVisibleTopLevelClangModules(
 
 void ASTContext::registerGenericSignatureBuilder(
                                        GenericSignature *sig,
-                                       ModuleDecl &module,
                                        GenericSignatureBuilder &&builder) {
   auto canSig = sig->getCanonicalSignature();
-  auto known = Impl.GenericSignatureBuilders.find({canSig, &module});
+  auto known = Impl.GenericSignatureBuilders.find(canSig);
   if (known != Impl.GenericSignatureBuilders.end()) {
     ++NumRegisteredGenericSignatureBuildersAlready;
     return;
   }
 
   ++NumRegisteredGenericSignatureBuilders;
-  Impl.GenericSignatureBuilders[{canSig, &module}] =
+  Impl.GenericSignatureBuilders[canSig] =
     llvm::make_unique<GenericSignatureBuilder>(std::move(builder));
 }
 
 GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
-                                                      CanGenericSignature sig,
-                                                      ModuleDecl *mod) {
+                                                      CanGenericSignature sig) {
   // Check whether we already have a generic signature builder for this
   // signature and module.
-  auto known = Impl.GenericSignatureBuilders.find({sig, mod});
+  auto known = Impl.GenericSignatureBuilders.find(sig);
   if (known != Impl.GenericSignatureBuilders.end())
     return known->second.get();
 
@@ -1463,7 +1460,7 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
   auto builder = new GenericSignatureBuilder(*this);
 
   // Store this generic signature builder (no generic environment yet).
-  Impl.GenericSignatureBuilders[{sig, mod}] =
+  Impl.GenericSignatureBuilders[sig] =
     std::unique_ptr<GenericSignatureBuilder>(builder);
 
   builder->addGenericSignature(sig);
@@ -1533,13 +1530,12 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
 
 GenericEnvironment *ASTContext::getOrCreateCanonicalGenericEnvironment(
                                               GenericSignatureBuilder *builder,
-                                              GenericSignature *sig,
-                                              ModuleDecl &module) {
+                                              GenericSignature *sig) {
   auto known = Impl.CanonicalGenericEnvironments.find(builder);
   if (known != Impl.CanonicalGenericEnvironments.end())
     return known->second;
 
-  auto env = sig->createGenericEnvironment(module);
+  auto env = sig->createGenericEnvironment();
   Impl.CanonicalGenericEnvironments[builder] = env;
   return env;
 }
@@ -4735,7 +4731,7 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   builder.addRequirement(requirement, source, nullptr);
 
-  CanGenericSignature genericSig(std::move(builder).computeGenericSignature(*mod, SourceLoc()));
+  CanGenericSignature genericSig(std::move(builder).computeGenericSignature(SourceLoc()));
 
   auto result = Impl.ExistentialSignatures.insert(
     std::make_pair(existential, genericSig));

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3632,12 +3632,10 @@ GenericFunctionType::get(GenericSignature *sig,
   // it's canonical.  Unfortunately, isCanonicalTypeInContext can cause
   // new GenericFunctionTypes to be created and thus invalidate our insertion
   // point.
-  auto &moduleForCanonicality = *ctx.TheBuiltinModule;
   bool isCanonical = sig->isCanonical()
     && isCanonicalFunctionInputType(input)
-    && sig->isCanonicalTypeInContext(unwrapParenType(input),
-                                     moduleForCanonicality)
-    && sig->isCanonicalTypeInContext(output, moduleForCanonicality);
+    && sig->isCanonicalTypeInContext(unwrapParenType(input))
+    && sig->isCanonicalTypeInContext(output);
 
   if (auto result
         = ctx.Impl.GenericFunctionTypes.FindNodeOrInsertPos(id, insertPos)) {

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1680,8 +1680,8 @@ void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt) {
   // dependent type, but can't yet. Shouldn't need this side channel.
 
   appendIdentifier(assocTy->getName().str());
-  if (!OptimizeProtocolNames || !CurGenericSignature || !Mod
-      || CurGenericSignature->getConformsTo(dmt->getBase(), *Mod).size() > 1) {
+  if (!OptimizeProtocolNames || !CurGenericSignature
+      || CurGenericSignature->getConformsTo(dmt->getBase()).size() > 1) {
     appendAnyGenericType(assocTy->getProtocol());
   }
 }

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -491,9 +491,8 @@ namespace {
       }
 
       auto GenericSig =
-        std::move(Builder).computeGenericSignature(*ctx.TheBuiltinModule,
-                                                   SourceLoc());
-      GenericEnv = GenericSig->createGenericEnvironment(*ctx.TheBuiltinModule);
+        std::move(Builder).computeGenericSignature(SourceLoc());
+      GenericEnv = GenericSig->createGenericEnvironment();
     }
 
     template <class G>

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -485,8 +485,7 @@ namespace {
       TheGenericParamList = getGenericParams(ctx, numGenericParams,
                                              GenericTypeParams);
 
-      GenericSignatureBuilder Builder(ctx,
-                               LookUpConformanceInModule(ctx.TheBuiltinModule));
+      GenericSignatureBuilder Builder(ctx);
       for (auto gp : GenericTypeParams) {
         Builder.addGenericParameter(gp);
       }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceManager.h"

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6323,7 +6323,6 @@ static void collectRequirements(GenericSignatureBuilder &builder,
 }
 
 GenericSignature *GenericSignatureBuilder::computeGenericSignature(
-                                          ModuleDecl &module,
                                           SourceLoc loc,
                                           bool allowConcreteGenericParams,
                                           bool allowBuilderToMove) && {
@@ -6348,7 +6347,7 @@ GenericSignature *GenericSignatureBuilder::computeGenericSignature(
       !Impl->HadAnyRedundantConstraints) {
     // Register this generic signature builer as the canonical builder for the
     // given signature.
-    Context.registerGenericSignatureBuilder(sig, module, std::move(*this));
+    Context.registerGenericSignatureBuilder(sig, std::move(*this));
   }
 
   // Wipe out the internal state, ensuring that nobody uses this builder for
@@ -6360,7 +6359,6 @@ GenericSignature *GenericSignatureBuilder::computeGenericSignature(
 
 GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
                                                      ProtocolDecl *proto) {
-  auto module = proto->getParentModule();
   GenericSignatureBuilder builder(proto->getASTContext());
 
   // Add the 'self' parameter.
@@ -6383,7 +6381,7 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
                  nullptr);
 
   return std::move(builder).computeGenericSignature(
-           *module, SourceLoc(),
+           SourceLoc(),
            /*allowConcreteGenericPArams=*/false,
            /*allowBuilderToMove=*/false);
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2919,8 +2919,12 @@ GenericSignatureBuilder::lookupConformance(CanType dependentType,
   // FIXME: When lookupConformance() starts respecting modules, we'll need
   // to do some filtering here.
   ModuleDecl *searchModule = conformedProtocol->getDecl()->getParentModule();
-  return searchModule->lookupConformance(conformingReplacementType,
-                                         conformedProtocol->getDecl());
+  auto result = searchModule->lookupConformance(conformingReplacementType,
+                                                conformedProtocol->getDecl());
+  if (result && getLazyResolver())
+    getLazyResolver()->markConformanceUsed(*result, searchModule);
+
+  return result;
 }
 
 LazyResolver *GenericSignatureBuilder::getLazyResolver() const { 

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -133,8 +133,7 @@ Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
 
   // The generic parameter may have been made concrete by the generic signature,
   // substitute into the concrete type.
-  ModuleDecl &anyModule = *genericParam->getASTContext().getStdlibModule();
-  if (auto concreteType = genericSig->getConcreteType(genericParam, anyModule)){
+  if (auto concreteType = genericSig->getConcreteType(genericParam)){
     // Set the replacement type to an error, to block infinite recursion.
     replacementType = ErrorType::get(concreteType);
 
@@ -191,14 +190,13 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
     };
 
   auto genericSig = getGenericSignature();
-  auto &mod = *proto->getModuleContext();
 
   // If the type doesn't conform to this protocol, fail.
-  if (!genericSig->conformsToProtocol(type, proto, mod))
+  if (!genericSig->conformsToProtocol(type, proto))
     return None;
 
   auto accessPath =
-    genericSig->getConformanceAccessPath(type, proto, mod);
+    genericSig->getConformanceAccessPath(type, proto);
 
   // Fall through because we cannot yet evaluate an access path.
   Optional<ProtocolConformanceRef> conformance;

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1239,7 +1239,7 @@ CanType TypeBase::getCanonicalType(GenericSignature *sig,
   if (!sig)
     return getCanonicalType();
 
-  return sig->getCanonicalTypeInContext(this, mod);
+  return sig->getCanonicalTypeInContext(this);
 }
 
 TypeBase *TypeBase::reconstituteSugar(bool Recursive) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1143,12 +1143,10 @@ CanType TypeBase::getCanonicalType() {
       ->getCanonicalSignature();
     
     // Transform the input and result types.
-    auto &ctx = function->getInput()->getASTContext();
-    auto &mod = *ctx.TheBuiltinModule;
     auto inputTy = getCanonicalInputType(function, [&](Type type) -> CanType {
-      return type->getCanonicalType(sig, mod);
+      return type->getCanonicalType(sig);
     });
-    auto resultTy = function->getResult()->getCanonicalType(sig, mod);
+    auto resultTy = function->getResult()->getCanonicalType(sig);
     Result = GenericFunctionType::get(sig, inputTy, resultTy,
                                       function->getExtInfo());
     assert(Result->isCanonical());
@@ -1234,8 +1232,7 @@ CanType TypeBase::getCanonicalType() {
   return CanType(Result);
 }
 
-CanType TypeBase::getCanonicalType(GenericSignature *sig,
-                                   ModuleDecl &mod) {
+CanType TypeBase::getCanonicalType(GenericSignature *sig) {
   if (!sig)
     return getCanonicalType();
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7651,15 +7651,13 @@ GenericSignature *ClangImporter::Implementation::buildGenericSignature(
     (void) result;
   }
 
-  return std::move(builder).computeGenericSignature(*dc->getParentModule(),
-                                                    SourceLoc());
+  return std::move(builder).computeGenericSignature(SourceLoc());
 }
 
 // Calculate the generic environment from an imported generic param list.
 GenericEnvironment *ClangImporter::Implementation::buildGenericEnvironment(
     GenericParamList *genericParams, DeclContext *dc) {
-  return buildGenericSignature(genericParams, dc)->createGenericEnvironment(
-                                                       *dc->getParentModule());
+  return buildGenericSignature(genericParams, dc)->createGenericEnvironment();
 }
 
 DeclContext *

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7638,8 +7638,7 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
 
 GenericSignature *ClangImporter::Implementation::buildGenericSignature(
     GenericParamList *genericParams, DeclContext *dc) {
-  GenericSignatureBuilder builder(SwiftContext,
-                           LookUpConformanceInModule(dc->getParentModule()));
+  GenericSignatureBuilder builder(SwiftContext);
   SmallVector<GenericTypeParamType *, 4> allGenericParams;
   for (auto param : *genericParams) {
     builder.addGenericParameter(param);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1956,7 +1956,7 @@ public:
       }
 
       if (t->isTypeParameter()) {
-        auto protos = genericSig->getConformsTo(t, *M);
+        auto protos = genericSig->getConformsTo(t);
         if (!protos.empty())
           return buildProtocolComposition(protos);
       }

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -210,8 +210,8 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
   auto signature = environment->getGenericSignature()->getCanonicalSignature();
   auto archetypeDepType = archetype->getInterfaceType();
 
-  auto astPath = signature->getConformanceAccessPath(archetypeDepType, protocol,
-                                                     *IGF.IGM.getSwiftModule());
+  auto astPath = signature->getConformanceAccessPath(archetypeDepType,
+                                                     protocol);
 
   auto i = astPath.begin(), e = astPath.end();
   assert(i != e && "empty path!");

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -642,7 +642,7 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   
   GenericEnvironment *genericEnv = nullptr;
   if (auto sig = pattern->getGenericSignature()) {
-    genericEnv = sig->createGenericEnvironment(*getSwiftModule());
+    genericEnv = sig->createGenericEnvironment();
     enumerateGenericSignatureRequirements(pattern->getGenericSignature(),
       [&](GenericRequirement reqt) { requirements.push_back(reqt); });
   }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -92,11 +92,11 @@ protected:
   FulfillmentMap Fulfillments;
 
   GenericSignature::ConformsToArray getConformsTo(Type t) {
-    return Generics->getConformsTo(t, M);
+    return Generics->getConformsTo(t);
   }
 
   CanType getSuperclassBound(Type t) {
-    if (auto superclassTy = Generics->getSuperclassBound(t, M))
+    if (auto superclassTy = Generics->getSuperclassBound(t))
       return superclassTy->getCanonicalType();
     return CanType();
   }
@@ -313,7 +313,7 @@ void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
                        MetadataSource::InvalidSourceIndex,
                        selfTy);
 
-  if (auto *proto = fnType->getDefaultWitnessMethodProtocol(M)) {
+  if (auto *proto = fnType->getDefaultWitnessMethodProtocol()) {
     // The Self type is abstract, so we can fulfill its metadata from
     // the Self metadata parameter.
     addSelfMetadataFulfillment(selfTy);
@@ -554,7 +554,7 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
 
       // Mark this as the cached witness table for Self.
 
-      if (auto *proto = FnType->getDefaultWitnessMethodProtocol(M)) {
+      if (auto *proto = FnType->getDefaultWitnessMethodProtocol()) {
         auto selfTy = FnType->getSelfInstanceType();
         CanType argTy = getTypeInContext(selfTy);
         auto archetype = cast<ArchetypeType>(argTy);
@@ -2602,8 +2602,7 @@ GenericTypeRequirements::GenericTypeRequirements(IRGenModule &IGM,
   // Figure out what we're actually still required to pass 
   PolymorphicConvention convention(IGM, fnType);
   convention.enumerateUnfulfilledRequirements([&](GenericRequirement reqt) {
-    assert(generics->isCanonicalTypeInContext(reqt.TypeParameter,
-                                              *IGM.getSwiftModule()));
+    assert(generics->isCanonicalTypeInContext(reqt.TypeParameter));
     Requirements.push_back(reqt);
   });
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -689,9 +689,8 @@ void TypeConverter::popGenericContext(CanGenericSignature signature) {
 }
 
 GenericEnvironment *TypeConverter::getGenericEnvironment() {
-  auto moduleDecl = IGM.getSwiftModule();
   auto genericSig = IGM.getSILTypes().getCurGenericContext();
-  return genericSig->getCanonicalSignature().getGenericEnvironment(*moduleDecl);
+  return genericSig->getCanonicalSignature().getGenericEnvironment();
 }
 
 GenericEnvironment *IRGenModule::getGenericEnvironment() {
@@ -962,8 +961,7 @@ ArchetypeType *TypeConverter::getExemplarArchetype(ArchetypeType *t) {
   // Dig out the canonical generic environment.
   auto genericSig = genericEnv->getGenericSignature();
   auto canGenericSig = genericSig->getCanonicalSignature();
-  auto module = IGM.getSwiftModule();
-  auto canGenericEnv = canGenericSig.getGenericEnvironment(*module);
+  auto canGenericEnv = canGenericSig.getGenericEnvironment();
   if (canGenericEnv == genericEnv) return t;
 
   // Map the archetype out of its own generic environment and into the
@@ -1711,8 +1709,7 @@ bool TypeConverter::isExemplarArchetype(ArchetypeType *arch) const {
   // Dig out the canonical generic environment.
   auto genericSig = genericEnv->getGenericSignature();
   auto canGenericSig = genericSig->getCanonicalSignature();
-  auto module = IGM.getSwiftModule();
-  auto canGenericEnv = canGenericSig.getGenericEnvironment(*module);
+  auto canGenericEnv = canGenericSig.getGenericEnvironment();
 
   // If this archetype is in the canonical generic environment, it's an
   // exemplar archetype.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1953,10 +1953,9 @@ static llvm::Value *getObjCClassForValue(IRGenFunction &IGF,
 static llvm::Value *emitWitnessTableForLoweredCallee(IRGenSILFunction &IGF,
                                               CanSILFunctionType origCalleeType,
                                               SubstitutionList subs) {
-  auto &M = *IGF.getSwiftModule();
   llvm::Value *wtable;
 
-  if (auto *proto = origCalleeType->getDefaultWitnessMethodProtocol(M)) {
+  if (auto *proto = origCalleeType->getDefaultWitnessMethodProtocol()) {
     // The generic signature for a witness method with abstract Self must
     // have exactly one protocol requirement.
     //

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -54,8 +54,7 @@ static SILLocation getLocForValue(SILValue value) {
 
 static GenericEnvironment *getGenericEnvironment(SILModule &Mod,
                                                  CanSILFunctionType loweredTy) {
-  return loweredTy->getGenericSignature()->createGenericEnvironment(
-                                                         *Mod.getSwiftModule());
+  return loweredTy->getGenericSignature()->createGenericEnvironment();
 }
 
 /// Utility to determine if this is a large loadable type

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1944,13 +1944,12 @@ class ReferencedTypeFinder : public TypeVisitor<ReferencedTypeFinder> {
 
   /// Returns true if \p paramTy has any constraints other than being
   /// class-bound ("conforms to" AnyObject).
-  static bool isConstrained(ModuleDecl &mod,
-                            GenericSignature *sig,
+  static bool isConstrained(GenericSignature *sig,
                             GenericTypeParamType *paramTy) {
-    if (sig->getSuperclassBound(paramTy, mod))
+    if (sig->getSuperclassBound(paramTy))
       return true;
 
-    auto conformsTo = sig->getConformsTo(paramTy, mod);
+    auto conformsTo = sig->getConformsTo(paramTy);
     return conformsTo.size() > 0;
   }
 
@@ -1967,7 +1966,7 @@ class ReferencedTypeFinder : public TypeVisitor<ReferencedTypeFinder> {
     for_each(boundGeneric->getGenericArgs(),
              sig->getInnermostGenericParams(),
              [&](Type argTy, GenericTypeParamType *paramTy) {
-      if (isObjCGeneric && isConstrained(M, sig, paramTy))
+      if (isObjCGeneric && isConstrained(sig, paramTy))
         NeedsDefinition = true;
       visit(argTy);
       NeedsDefinition = false;

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -53,8 +53,7 @@ TypeConverter::getIndicesAbstractionPattern(SubscriptDecl *decl) {
   if (auto sig = decl->getGenericSignatureOfContext())
     genericSig = sig->getCanonicalSignature();
   auto indicesTy = decl->getIndicesInterfaceType();
-  auto indicesCanTy = indicesTy->getCanonicalType(genericSig,
-                                                  *decl->getParentModule());
+  auto indicesCanTy = indicesTy->getCanonicalType(genericSig);
   return AbstractionPattern(genericSig, indicesCanTy);
 }
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -870,7 +870,7 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
     auto origGenericSig
       = function->getGenericSignature();
     auto getCanonicalType = [origGenericSig, &M](Type t) -> CanType {
-      return t->getCanonicalType(origGenericSig, *M.getSwiftModule());
+      return t->getCanonicalType(origGenericSig);
     };
 
     auto &Types = M.Types;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -869,9 +869,6 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
     // signature from the AST for that.
     auto origGenericSig
       = function->getGenericSignature();
-    auto getCanonicalType = [origGenericSig, &M](Type t) -> CanType {
-      return t->getCanonicalType(origGenericSig);
-    };
 
     auto &Types = M.Types;
     auto loweredCaptures = Types.getLoweredLocalCaptures(*function);
@@ -887,7 +884,8 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
             dynamicSelfInterfaceType,
             MetatypeRepresentation::Thick);
         
-        auto canSelfMetatype = getCanonicalType(selfMetatype);
+        auto canSelfMetatype =
+          selfMetatype->getCanonicalType(origGenericSig);
         SILParameterInfo param(canSelfMetatype, convention);
         inputs.push_back(param);
 
@@ -896,7 +894,7 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
 
       auto *VD = capture.getDecl();
       auto type = VD->getInterfaceType();
-      auto canType = getCanonicalType(type);
+      auto canType = type->getCanonicalType(origGenericSig);
 
       auto &loweredTL = Types.getTypeLowering(
                               AbstractionPattern(genericSig, canType), canType);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2115,8 +2115,7 @@ public:
     require(selfRequirement &&
             selfRequirement->getKind() == RequirementKind::Conformance,
             "first non-same-typerequirement should be conformance requirement");
-    auto conformsTo = genericSig->getConformsTo(selfGenericParam,
-                                                *F.getModule().getSwiftModule());
+    auto conformsTo = genericSig->getConformsTo(selfGenericParam);
     require(conformsTo.size() == 1,
             "requirement Self parameter must conform to exactly one protocol");
     require(conformsTo[0] == protocol,
@@ -4490,7 +4489,7 @@ void SILWitnessTable::verify(const SILModule &M) const {
                SILFunctionTypeRepresentation::WitnessMethod &&
                "Witnesses must have witness_method representation.");
         auto *witnessSelfProtocol = F->getLoweredFunctionType()
-            ->getDefaultWitnessMethodProtocol(*M.getSwiftModule());
+            ->getDefaultWitnessMethodProtocol();
         assert((witnessSelfProtocol == nullptr ||
                 witnessSelfProtocol == protocol) &&
                "Witnesses must either have a concrete Self, or an "
@@ -4518,7 +4517,7 @@ void SILDefaultWitnessTable::verify(const SILModule &M) const {
            SILFunctionTypeRepresentation::WitnessMethod &&
            "Default witnesses must have witness_method representation.");
     auto *witnessSelfProtocol = F->getLoweredFunctionType()
-        ->getDefaultWitnessMethodProtocol(*M.getSwiftModule());
+        ->getDefaultWitnessMethodProtocol();
     assert(witnessSelfProtocol == getProtocol() &&
            "Default witnesses must have an abstract Self parameter "
            "constrained to their protocol.");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1735,9 +1735,7 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
 
   // The result type might be written in terms of type parameters
   // that have been made fully concrete.
-  CanType canResultTy = resultTy->getCanonicalType(
-      AFD->getGenericSignature(),
-      *TC.M.getSwiftModule());
+  CanType canResultTy = resultTy->getCanonicalType(AFD->getGenericSignature());
 
   // Get the generic signature from the surrounding context.
   auto funcInfo = TC.getConstantInfo(SILDeclRef(AFD));
@@ -1766,8 +1764,7 @@ static CanAnyFunctionType getDestructorInterfaceType(TypeConverter &TC,
                                                      bool isDeallocating,
                                                      bool isForeign) {
   auto classType = dd->getDeclContext()->getDeclaredInterfaceType()
-    ->getCanonicalType(dd->getGenericSignatureOfContext(),
-                       *TC.M.getSwiftModule());
+    ->getCanonicalType(dd->getGenericSignatureOfContext());
 
   assert((!isForeign || isDeallocating)
          && "There are no foreign destroying destructors");
@@ -1797,8 +1794,7 @@ static CanAnyFunctionType getIVarInitDestroyerInterfaceType(TypeConverter &TC,
                                                             bool isObjC,
                                                             bool isDestroyer) {
   auto classType = cd->getDeclaredInterfaceType()
-    ->getCanonicalType(cd->getGenericSignatureOfContext(),
-                       *TC.M.getSwiftModule());
+    ->getCanonicalType(cd->getGenericSignatureOfContext());
 
   CanType emptyTupleTy = TupleType::getEmpty(TC.Context);
   auto resultType = (isDestroyer ? emptyTupleTy : classType);
@@ -2095,10 +2091,8 @@ getMaterializeForSetCallbackType(AbstractStorageDecl *storage,
     }
   }
 
-  auto canSelfType = selfType->getCanonicalType(
-    genericSig, *M.getSwiftModule());
-  auto canSelfMetatypeType = selfMetatypeType->getCanonicalType(
-    genericSig, *M.getSwiftModule());
+  auto canSelfType = selfType->getCanonicalType(genericSig);
+  auto canSelfMetatypeType = selfMetatypeType->getCanonicalType(genericSig);
 
   // Create the SILFunctionType for the callback.
   SILParameterInfo params[] = {
@@ -2508,7 +2502,7 @@ TypeConverter::getContextBoxTypeForCapture(ValueDecl *captured,
         ->getGenericSignatureOfContext();
     loweredInterfaceType =
       env->mapTypeOutOfContext(loweredInterfaceType)
-        ->getCanonicalType(homeSig, *M.getSwiftModule());
+        ->getCanonicalType(homeSig);
   }
   
   auto boxType = getInterfaceBoxTypeForCapture(captured,

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -256,11 +256,10 @@ namespace {
 
     RetTy visitAbstractTypeParamType(CanType type) {
       if (auto genericSig = getGenericSignature()) {
-        auto &mod = *M.getSwiftModule();
-        if (genericSig->requiresClass(type, mod)) {
+        if (genericSig->requiresClass(type)) {
           return asImpl().handleReference(type);
-        } else if (genericSig->isConcreteType(type, mod)) {
-          return asImpl().visit(genericSig->getConcreteType(type, mod)
+        } else if (genericSig->isConcreteType(type)) {
+          return asImpl().visit(genericSig->getConcreteType(type)
                                     ->getCanonicalType());
         } else {
           return asImpl().handleAddressOnly(type);
@@ -284,20 +283,19 @@ namespace {
 
     bool hasNativeReferenceCounting(CanType type) {
       if (type->isTypeParameter()) {
-        auto &mod = *M.getSwiftModule();
         auto signature = getGenericSignature();
         assert(signature && "dependent type without generic signature?!");
 
-        if (auto concreteType = signature->getConcreteType(type, mod))
+        if (auto concreteType = signature->getConcreteType(type))
           return hasNativeReferenceCounting(concreteType->getCanonicalType());
 
-        assert(signature->requiresClass(type, mod));
+        assert(signature->requiresClass(type));
 
         // If we have a superclass bound, recurse on that.  This should
         // always terminate: even if we allow
         //   <T, U: T, V: U, ...>
         // at some point the type-checker should prove acyclic-ness.
-        auto bound = signature->getSuperclassBound(type, mod);
+        auto bound = signature->getSuperclassBound(type);
         if (bound) {
           return hasNativeReferenceCounting(bound->getCanonicalType());
         }
@@ -492,7 +490,7 @@ namespace {
       // signature plumbed through.
       if (Sig && type->hasTypeParameter()) {
         type = Sig->getCanonicalSignature()
-          .getGenericEnvironment(*M.getSwiftModule())
+          .getGenericEnvironment()
           ->mapTypeIntoContext(type)
           ->getCanonicalType();
       }
@@ -2468,8 +2466,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
   // Instantiate the layout with identity substitutions.
   auto subMap = signature->getSubstitutionMap(
     [&](SubstitutableType *type) -> Type {
-      return signature->getCanonicalTypeInContext(type,
-                                                  *M.getSwiftModule());
+      return signature->getCanonicalTypeInContext(type);
     },
     [](Type depTy, Type replacementTy, ProtocolType *conformedTy)
     -> ProtocolConformanceRef {
@@ -2485,7 +2482,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
   auto loweredContextType = loweredInterfaceType;
   auto contextBoxTy = boxTy;
   if (signature) {
-    auto env = signature.getGenericEnvironment(*M.getSwiftModule());
+    auto env = signature.getGenericEnvironment();
     loweredContextType = env->mapTypeIntoContext(loweredContextType)
                             ->getCanonicalType();
     contextBoxTy = cast<SILBoxType>(

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -434,8 +434,7 @@ public:
     }
 
     CanType witnessSelfType =
-      computeSelfParam(Witness).getType()->getCanonicalType(
-        GenericSig, *SGM.M.getSwiftModule());
+      computeSelfParam(Witness).getType()->getCanonicalType(GenericSig);
     witnessSelfType = getSubstWitnessInterfaceType(witnessSelfType);
 
     // Get the inout object type, but remember whether we needed to.
@@ -661,8 +660,7 @@ collectIndicesFromParameters(SILGenFunction &SGF, SILLocation loc,
   auto witnessSubscript = cast<SubscriptDecl>(WitnessStorage);
   CanType witnessIndicesType =
     witnessSubscript->getIndicesInterfaceType()
-      ->getCanonicalType(GenericSig,
-                         *SGM.M.getSwiftModule());
+      ->getCanonicalType(GenericSig);
   CanType substIndicesType =
     getSubstWitnessInterfaceType(witnessIndicesType);
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2822,9 +2822,8 @@ CanSILFunctionType SILGenFunction::buildThunkType(
                       ? DefaultThickCalleeConvention
                       : ParameterConvention::Direct_Unowned});
 
-  auto &mod = *F.getModule().getSwiftModule();
   auto getCanonicalType = [&](Type t) -> CanType {
-    return t->getCanonicalType(genericSig, mod);
+    return t->getCanonicalType(genericSig);
   };
 
   // Map the parameter and expected types out of context to get the interface

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2822,10 +2822,6 @@ CanSILFunctionType SILGenFunction::buildThunkType(
                       ? DefaultThickCalleeConvention
                       : ParameterConvention::Direct_Unowned});
 
-  auto getCanonicalType = [&](Type t) -> CanType {
-    return t->getCanonicalType(genericSig);
-  };
-
   // Map the parameter and expected types out of context to get the interface
   // type of the thunk.
   SmallVector<SILParameterInfo, 4> interfaceParams;
@@ -2834,7 +2830,7 @@ CanSILFunctionType SILGenFunction::buildThunkType(
     auto paramIfaceTy = GenericEnvironment::mapTypeOutOfContext(
         genericEnv, param.getType());
     interfaceParams.push_back(
-      SILParameterInfo(getCanonicalType(paramIfaceTy),
+      SILParameterInfo(paramIfaceTy->getCanonicalType(genericSig),
                        param.getConvention()));
   }
 
@@ -2842,7 +2838,8 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   for (auto &result : expectedType->getResults()) {
     auto resultIfaceTy = GenericEnvironment::mapTypeOutOfContext(
         genericEnv, result.getType());
-    auto interfaceResult = result.getWithType(getCanonicalType(resultIfaceTy));
+    auto interfaceResult =
+      result.getWithType(resultIfaceTy->getCanonicalType(genericSig));
     interfaceResults.push_back(interfaceResult);
   }
 
@@ -2852,7 +2849,7 @@ CanSILFunctionType SILGenFunction::buildThunkType(
     auto errorIfaceTy = GenericEnvironment::mapTypeOutOfContext(
         genericEnv, errorResult.getType());
     interfaceErrorResult = SILResultInfo(
-        getCanonicalType(errorIfaceTy),
+        errorIfaceTy->getCanonicalType(genericSig),
         expectedType->getErrorResult().getConvention());
   }
   

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2695,9 +2695,9 @@ buildThunkSignature(SILGenFunction &SGF,
   builder.addRequirement(newRequirement, source, nullptr);
 
   GenericSignature *genericSig =
-    std::move(builder).computeGenericSignature(*mod, SourceLoc(),
+    std::move(builder).computeGenericSignature(SourceLoc(),
                                     /*allowConcreteGenericParams=*/true);
-  genericEnv = genericSig->createGenericEnvironment(*mod);
+  genericEnv = genericSig->createGenericEnvironment();
 
   newArchetype = genericEnv->mapTypeIntoContext(newGenericParam)
     ->castTo<ArchetypeType>();

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2673,7 +2673,7 @@ buildThunkSignature(SILGenFunction &SGF,
     return genericSig;
   }
 
-  GenericSignatureBuilder builder(ctx, LookUpConformanceInModule(mod));
+  GenericSignatureBuilder builder(ctx);
 
   // Add the existing generic signature.
   int depth = 0;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -501,8 +501,7 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,
                                     bool throws) {
   // Create the indirect result parameters.
   auto *genericSig = DC->getGenericSignatureOfContext();
-  resultType = resultType->getCanonicalType(genericSig,
-                                            *SGM.M.getSwiftModule());
+  resultType = resultType->getCanonicalType(genericSig);
 
   emitIndirectResultParameters(*this, resultType, DC);
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -876,7 +876,7 @@ getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI, SILFunction *F,
 
   auto *mod = Module.getSwiftModule();
   bool isDefaultWitness =
-    (witnessFnTy->getDefaultWitnessMethodProtocol(*mod)
+    (witnessFnTy->getDefaultWitnessMethodProtocol()
       == CRef.getRequirement());
   auto *classWitness = witnessFnTy->getWitnessMethodClass(*mod);
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -785,8 +785,7 @@ getGenericEnvironmentAndSignatureWithRequirements(
     GenericSignature *OrigGenSig, GenericEnvironment *OrigGenericEnv,
     ArrayRef<Requirement> Requirements, SILModule &M) {
   // Form a new generic signature based on the old one.
-  GenericSignatureBuilder Builder(M.getASTContext(),
-                           LookUpConformanceInModule(M.getSwiftModule()));
+  GenericSignatureBuilder Builder(M.getASTContext());
 
   // First, add the old generic signature.
   Builder.addGenericSignature(OrigGenSig);
@@ -1150,7 +1149,7 @@ public:
       : CallerGenericSig(CallerGenericSig), CallerGenericEnv(CallerGenericEnv),
         CalleeGenericSig(CalleeGenericSig), CalleeGenericEnv(CalleeGenericEnv),
         M(M), SM(M.getSwiftModule()), Ctx(M.getASTContext()),
-        Builder(Ctx, LookUpConformanceInModule(SM)) {
+        Builder(Ctx) {
     SpecializedGenericSig = nullptr;
     SpecializedGenericEnv = nullptr;
     CalleeInterfaceToCallerArchetypeMap =
@@ -1166,7 +1165,7 @@ public:
       : CallerGenericSig(CalleeGenericSig), CallerGenericEnv(CalleeGenericEnv),
         CalleeGenericSig(CalleeGenericSig), CalleeGenericEnv(CalleeGenericEnv),
         M(M), SM(M.getSwiftModule()), Ctx(M.getASTContext()),
-        Builder(Ctx, LookUpConformanceInModule(SM)) {
+        Builder(Ctx) {
 
     // Create the new generic signature using provided requirements.
     std::tie(SpecializedGenericEnv, SpecializedGenericSig) =

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -715,8 +715,7 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
     // account by the substGenericArgs. So, canonicalize in the context of the
     // specialized signature.
     FnTy = cast<SILFunctionType>(
-        CanSpecializedGenericSig->getCanonicalTypeInContext(
-            FnTy, *M.getSwiftModule()));
+        CanSpecializedGenericSig->getCanonicalTypeInContext(FnTy));
   }
   assert(FnTy);
 
@@ -1345,7 +1344,7 @@ void FunctionSignaturePartialSpecializer::
   for (auto GP : CalleeGenericSig->getGenericParams()) {
     auto CanTy = GP->getCanonicalType();
     auto CanTyInContext =
-        CalleeGenericSig->getCanonicalTypeInContext(CanTy, *SM);
+        CalleeGenericSig->getCanonicalTypeInContext(CanTy);
     auto Replacement = CanTyInContext.subst(CalleeInterfaceToCallerArchetypeMap);
     DEBUG(llvm::dbgs() << "\n\nChecking callee generic parameter:\n";
           CanTy->dump());

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -799,10 +799,10 @@ getGenericEnvironmentAndSignatureWithRequirements(
   }
 
   auto NewGenSig =
-    std::move(Builder).computeGenericSignature(*M.getSwiftModule(),
+    std::move(Builder).computeGenericSignature(
                                    SourceLoc(),
                                    /*allowConcreteGenericParams=*/true);
-  auto NewGenEnv = NewGenSig->createGenericEnvironment(*M.getSwiftModule());
+  auto NewGenEnv = NewGenSig->createGenericEnvironment();
   return { NewGenEnv, NewGenSig };
 }
 
@@ -1489,10 +1489,10 @@ FunctionSignaturePartialSpecializer::
 
   // Finalize the archetype builder.
   auto GenSig =
-      std::move(Builder).computeGenericSignature(*M.getSwiftModule(),
+      std::move(Builder).computeGenericSignature(
                                       SourceLoc(),
                                       /*allowConcreteGenericParams=*/true);
-  auto GenEnv = GenSig->createGenericEnvironment(*M.getSwiftModule());
+  auto GenEnv = GenSig->createGenericEnvironment();
   return { GenEnv, GenSig };
 }
 

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -132,12 +132,10 @@ public:
 class CompleteGenericTypeResolver : public GenericTypeResolver {
   TypeChecker &tc;
   GenericSignature *genericSig;
-  ModuleDecl &module;
   GenericSignatureBuilder &builder;
 
 public:
-  CompleteGenericTypeResolver(TypeChecker &tc, GenericSignature *genericSig,
-                              ModuleDecl &module);
+  CompleteGenericTypeResolver(TypeChecker &tc, GenericSignature *genericSig);
 
   virtual Type mapTypeIntoContext(Type type);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1689,7 +1689,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Form a new generic signature based on the old one.
   GenericSignatureBuilder Builder(D->getASTContext(),
-                                  TypeChecker::LookUpConformance(TC, DC));
+                            LookUpConformanceInModule(DC->getParentModule()));
 
   // First, add the old generic signature.
   Builder.addGenericSignature(genericSig);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1688,8 +1688,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   }
 
   // Form a new generic signature based on the old one.
-  GenericSignatureBuilder Builder(D->getASTContext(),
-                            LookUpConformanceInModule(DC->getParentModule()));
+  GenericSignatureBuilder Builder(D->getASTContext());
 
   // First, add the old generic signature.
   Builder.addGenericSignature(genericSig);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1851,7 +1851,6 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Check the result.
   (void)std::move(Builder).computeGenericSignature(
-                                        *DC->getParentModule(),
                                         attr->getLocation(),
                                         /*allowConcreteGenericParams=*/true);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4239,7 +4239,7 @@ public:
       gp->setOuterParameters(dc->getGenericParamsOfContext());
 
       auto *sig = TC.validateGenericSubscriptSignature(SD);
-      auto *env = sig->createGenericEnvironment(*SD->getModuleContext());
+      auto *env = sig->createGenericEnvironment();
       SD->setGenericEnvironment(env);
 
       // Revert the types within the signature so it can be type-checked with
@@ -5219,7 +5219,7 @@ public:
         env = cast<SubscriptDecl>(storage)->getGenericEnvironment();
         assert(env && "accessor has generics but subscript is not generic");
       } else {
-        env = sig->createGenericEnvironment(*FD->getModuleContext());
+        env = sig->createGenericEnvironment();
       }
       FD->setGenericEnvironment(env);
 
@@ -6970,7 +6970,7 @@ public:
       gp->setOuterParameters(CD->getDeclContext()->getGenericParamsOfContext());
 
       auto *sig = TC.validateGenericFuncSignature(CD);
-      auto *env = sig->createGenericEnvironment(*CD->getModuleContext());
+      auto *env = sig->createGenericEnvironment();
       CD->setGenericEnvironment(env);
 
       // Revert the types within the signature so it can be type-checked with

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5978,12 +5978,9 @@ public:
         // Canonicalize with respect to the override's generic signature, if any.
         auto *genericSig = decl->getInnermostDeclContext()
           ->getGenericSignatureOfContext();
-        auto *module = dc->getParentModule();
 
-        auto canDeclTy =
-          declTy->getCanonicalType(genericSig, *module);
-        auto canParentDeclTy =
-          parentDeclTy->getCanonicalType(genericSig, *module);
+        auto canDeclTy = declTy->getCanonicalType(genericSig);
+        auto canParentDeclTy = parentDeclTy->getCanonicalType(genericSig);
 
         if (canDeclTy == canParentDeclTy) {
           matches.push_back({parentDecl, true, parentDeclTy});

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -118,9 +118,8 @@ void ProtocolRequirementTypeResolver::recordParamType(ParamDecl *decl,
 
 CompleteGenericTypeResolver::CompleteGenericTypeResolver(
                                               TypeChecker &tc,
-                                              GenericSignature *genericSig,
-                                              ModuleDecl &module)
-  : tc(tc), genericSig(genericSig), module(module),
+                                              GenericSignature *genericSig)
+  : tc(tc), genericSig(genericSig),
     builder(*tc.Context.getOrCreateGenericSignatureBuilder(
                                genericSig->getCanonicalSignature()))
 {
@@ -223,8 +222,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 }
 
 bool CompleteGenericTypeResolver::areSameType(Type type1, Type type2) {
-  return genericSig->getCanonicalTypeInContext(type1, module)
-           == genericSig->getCanonicalTypeInContext(type2, module);
+  return genericSig->getCanonicalTypeInContext(type1)
+           == genericSig->getCanonicalTypeInContext(type2);
 }
 
 void
@@ -792,8 +791,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
     sig = func->getDeclContext()->getGenericSignatureOfContext();
   }
 
-  CompleteGenericTypeResolver completeResolver(*this, sig,
-                                               *func->getModuleContext());
+  CompleteGenericTypeResolver completeResolver(*this, sig);
   if (checkGenericFuncSignature(*this, nullptr, func, completeResolver))
     invalid = true;
 
@@ -1019,8 +1017,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
     sig = subscript->getDeclContext()->getGenericSignatureOfContext();
   }
 
-  CompleteGenericTypeResolver completeResolver(*this, sig,
-                                               *subscript->getModuleContext());
+  CompleteGenericTypeResolver completeResolver(*this, sig);
   if (checkGenericSubscriptSignature(*this, nullptr, subscript, completeResolver))
     invalid = true;
 
@@ -1167,8 +1164,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
             ->getGenericSignatureOfContext();
   }
 
-  CompleteGenericTypeResolver completeResolver(*this, sig,
-                                               *dc->getParentModule());
+  CompleteGenericTypeResolver completeResolver(*this, sig);
   if (recursivelyVisitGenericParams) {
     visitOuterToInner(genericParams,
                       [&](GenericParamList *gpList) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -758,7 +758,8 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
     prepareGenericParamList(gp, func);
 
     // Create the generic signature builder.
-    GenericSignatureBuilder builder(Context, LookUpConformance(*this, func));
+    GenericSignatureBuilder builder(Context,
+                          LookUpConformanceInModule(func->getParentModule()));
 
     // Type check the function declaration, treating all generic type
     // parameters as dependent, unresolved.
@@ -986,7 +987,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
 
     // Create the generic signature builder.
     GenericSignatureBuilder builder(Context,
-                                    LookUpConformance(*this, subscript));
+        LookUpConformanceInModule(subscript->getParentModule()));
 
     // Type check the function declaration, treating all generic type
     // parameters as dependent, unresolved.
@@ -1118,7 +1119,8 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     }
 
     // Create the generic signature builder.
-    GenericSignatureBuilder builder(Context, LookUpConformance(*this, dc));
+    GenericSignatureBuilder builder(Context,
+                             LookUpConformanceInModule(dc->getParentModule()));
 
     // Type check the generic parameters, treating all generic type
     // parameters as dependent, unresolved.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -122,8 +122,7 @@ CompleteGenericTypeResolver::CompleteGenericTypeResolver(
                                               ModuleDecl &module)
   : tc(tc), genericSig(genericSig), module(module),
     builder(*tc.Context.getOrCreateGenericSignatureBuilder(
-                               genericSig->getCanonicalSignature(),
-                               &module))
+                               genericSig->getCanonicalSignature()))
 {
 }
 
@@ -768,8 +767,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
 
     // The generic function signature is complete and well-formed. Determine
     // the type of the generic function.
-    sig = std::move(builder).computeGenericSignature(*func->getParentModule(),
-                                                     func->getLoc());
+    sig = std::move(builder).computeGenericSignature(func->getLoc());
 
     // The generic signature builder now has all of the requirements, although
     // there might still be errors that have not yet been diagnosed. Revert the
@@ -997,8 +995,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
     // The generic subscript signature is complete and well-formed. Determine
     // the type of the generic subscript.
     sig =
-      std::move(builder).computeGenericSignature(*subscript->getParentModule(),
-                                                 subscript->getLoc());
+      std::move(builder).computeGenericSignature(subscript->getLoc());
 
     // The generic signature builder now has all of the requirements, although
     // there might still be errors that have not yet been diagnosed. Revert the
@@ -1137,7 +1134,6 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
     // Record the generic type parameter types and the requirements.
     sig = std::move(builder).computeGenericSignature(
-                                         *dc->getParentModule(),
                                          genericParams->getSourceRange().Start,
                                          allowConcreteGenericParams);
 
@@ -1184,8 +1180,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
   }
 
   // Form the generic environment.
-  ModuleDecl *module = dc->getParentModule();
-  return sig->createGenericEnvironment(*module);
+  return sig->createGenericEnvironment();
 }
 
 void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -758,8 +758,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
     prepareGenericParamList(gp, func);
 
     // Create the generic signature builder.
-    GenericSignatureBuilder builder(Context,
-                          LookUpConformanceInModule(func->getParentModule()));
+    GenericSignatureBuilder builder(Context);
 
     // Type check the function declaration, treating all generic type
     // parameters as dependent, unresolved.
@@ -986,8 +985,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
     prepareGenericParamList(gp, subscript);
 
     // Create the generic signature builder.
-    GenericSignatureBuilder builder(Context,
-        LookUpConformanceInModule(subscript->getParentModule()));
+    GenericSignatureBuilder builder(Context);
 
     // Type check the function declaration, treating all generic type
     // parameters as dependent, unresolved.
@@ -1119,8 +1117,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     }
 
     // Create the generic signature builder.
-    GenericSignatureBuilder builder(Context,
-                             LookUpConformanceInModule(dc->getParentModule()));
+    GenericSignatureBuilder builder(Context);
 
     // Type check the generic parameters, treating all generic type
     // parameters as dependent, unresolved.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3531,18 +3531,17 @@ static CheckTypeWitnessResult checkTypeWitness(TypeChecker &tc, DeclContext *dc,
                                                ProtocolDecl *proto,
                                                AssociatedTypeDecl *assocType, 
                                                Type type) {
-  auto *moduleDecl = dc->getParentModule();
   auto *genericSig = proto->getGenericSignature();
   auto *depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                          assocType);
 
-  if (auto superclass = genericSig->getSuperclassBound(depTy, *moduleDecl)) {
+  if (auto superclass = genericSig->getSuperclassBound(depTy)) {
     if (!superclass->isExactSuperclassOf(type))
       return superclass->getAnyNominal();
   }
 
   // Check protocol conformances.
-  for (auto reqProto : genericSig->getConformsTo(depTy, *moduleDecl)) {
+  for (auto reqProto : genericSig->getConformsTo(depTy)) {
     if (!tc.conformsToProtocol(type, reqProto, dc, None))
       return reqProto;
 
@@ -5843,8 +5842,7 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
     auto interfaceType = DC->mapTypeOutOfContext(T);
     if (interfaceType->isTypeParameter()) {
       auto genericSig = DC->getGenericSignatureOfContext();
-      auto path = genericSig->getConformanceAccessPath(interfaceType, Proto,
-                                                       *DC->getParentModule());
+      auto path = genericSig->getConformanceAccessPath(interfaceType, Proto);
 
       // Debugging aid: display the conformance access path for archetype
       // conformances.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1152,7 +1152,7 @@ RequirementEnvironment::RequirementEnvironment(
   // because both define the capabilities of the requirement.
   GenericSignatureBuilder builder(
            ctx,
-           TypeChecker::LookUpConformance(tc, conformanceDC));
+           LookUpConformanceInModule(conformanceDC->getParentModule()));
 
   auto source =
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1140,8 +1140,7 @@ RequirementEnvironment::RequirementEnvironment(
     if (syntheticSignature) {
       syntheticSignature = syntheticSignature->getCanonicalSignature();
       syntheticEnvironment =
-        syntheticSignature->createGenericEnvironment(
-                                     *conformanceDC->getParentModule());
+        syntheticSignature->createGenericEnvironment();
     }
 
     return;
@@ -1220,11 +1219,8 @@ RequirementEnvironment::RequirementEnvironment(
   // FIXME: Pass in a source location for the conformance, perhaps? It seems
   // like this could fail.
   syntheticSignature =
-    std::move(builder).computeGenericSignature(
-                                           *conformanceDC->getParentModule(),
-                                           SourceLoc());
-  syntheticEnvironment = syntheticSignature->createGenericEnvironment(
-                                             *conformanceDC->getParentModule());
+    std::move(builder).computeGenericSignature(SourceLoc());
+  syntheticEnvironment = syntheticSignature->createGenericEnvironment();
 }
 
 static RequirementMatch

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1150,9 +1150,7 @@ RequirementEnvironment::RequirementEnvironment(
   // Construct a generic signature builder by collecting the constraints
   // from the requirement and the context of the conformance together,
   // because both define the capabilities of the requirement.
-  GenericSignatureBuilder builder(
-           ctx,
-           LookUpConformanceInModule(conformanceDC->getParentModule()));
+  GenericSignatureBuilder builder(ctx);
 
   auto source =
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -342,8 +342,7 @@ Type TypeChecker::resolveTypeInContext(
       //
       // Get the superclass of the 'Self' type parameter.
       auto *sig = foundDC->getGenericSignatureOfContext();
-      auto superclassType = sig->getSuperclassBound(
-        selfType, *foundDC->getParentModule());
+      auto superclassType = sig->getSuperclassBound(selfType);
       assert(superclassType);
       selfType = superclassType;
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1961,7 +1961,7 @@ public:
   /// Mark the given protocol conformance as "used" from the given declaration
   /// context.
   void markConformanceUsed(ProtocolConformanceRef conformance,
-                           DeclContext *dc);
+                           DeclContext *dc) override final;
 
   /// Functor class suitable for use as a \c LookupConformanceFn to look up a
   /// conformance through a particular declaration context using the given

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1034,7 +1034,7 @@ ModuleFile::getGenericSignatureOrEnvironment(
 
   // Form the generic environment. Record it now so that deserialization of
   // the archetypes in the environment can refer to this environment.
-  auto genericEnv = signature->createGenericEnvironment(*getAssociatedModule());
+  auto genericEnv = signature->createGenericEnvironment();
   envOrOffset = genericEnv;
 
   return genericEnv;
@@ -4878,8 +4878,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       syntheticSig = GenericSignature::get(genericParams, requirements);
 
       // Create the synthetic environment.
-      syntheticEnv =
-        syntheticSig->createGenericEnvironment(*getAssociatedModule());
+      syntheticEnv = syntheticSig->createGenericEnvironment();
 
       // Requirement -> synthetic substitutions.
       if (unsigned numReqSubstitutions = *rawIDIter++) {


### PR DESCRIPTION
Eliminate the `GenericSignatureBuilder` 's dependencies on specific modules:

* The GSB gets its own module-agnostic conformance lookup function (which is the only remaining dependency)
* The module is no longer used to unique canonical generic signature builders (so we only build one canonical GSB per generic signature)
* All of the `ModuleDecl` parameters go away from `GenericSignature`