### PR TITLE
DefiniteInitialization: fixed crash for wrong super call with inout instance variable

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1094,7 +1094,7 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
           if (auto *DSCE = dyn_cast<SelfApplyExpr>(CE->getFn()))
             // Normal method calls are curried, so they are:
             // (call_expr (dot_syntax_call_expr (decl_ref_expr METHOD)))
-            FD = dyn_cast<FuncDecl>(DSCE->getCalledValue());
+            FD = dyn_cast_or_null<FuncDecl>(DSCE->getCalledValue());
           else
             // Operators and normal function calls are just (CallExpr DRE)
             FD = dyn_cast_or_null<FuncDecl>(CE->getCalledValue());

--- a/test/SILOptimizer/definite_init_inout_super_init.swift
+++ b/test/SILOptimizer/definite_init_inout_super_init.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null
+
+class B {
+  init(x: inout Int) {}
+}
+
+class A : B {
+  let x: Int
+
+  init() {
+    self.x = 12
+    super.init(x: &x) // expected-error {{immutable value 'self.x' must not be passed inout}}
+  } // expected-error {{super.init isn't called on all paths before returning from initializer}}
+}
+


### PR DESCRIPTION
Fixes rdar://problem/22960985
