### PR TITLE
Add test case that uses metadata of 'import as nested types' Objective-C types

### DIFF
--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -137,3 +137,10 @@ struct StructOfNSStrings {
 };
 
 struct StructOfNSStrings useStructOfNSStringsInObjC(struct StructOfNSStrings);
+
+@interface OuterType : NSObject
+@end
+
+__attribute__((swift_name("OuterType.InnerType")))
+@interface OuterTypeInnerType : NSObject
+@end

--- a/test/IRGen/objc_types_as_member.sil
+++ b/test/IRGen/objc_types_as_member.sil
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import gizmo
+
+sil @use_metatype : $@convention(thin) <T> (@thin T.Type) -> ()
+
+// CHECK-LABEL: define swiftcc void @test(%TSo9InnerTypeC* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK:   [[TMP:%.*]] = call %swift.type* @_T0So9OuterTypeCMa()
+// CHECK:   call swiftcc void @use_metatype(%swift.type* [[TMP]])
+// CHECK:   ret void
+
+sil @test : $@convention(witness_method) (@guaranteed OuterType.InnerType) -> () {
+bb0(%0 : $OuterType.InnerType):
+  %1 = function_ref @use_metatype : $@convention(thin) <τ_0_0> (@thin τ_0_0.Type) -> ()
+  %2 = metatype $@thin OuterType.Type
+  %3 = apply %1<OuterType>(%2) : $@convention(thin) <τ_0_0> (@thin τ_0_0.Type) -> ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: define {{.*}}%swift.type* @_T0So9OuterTypeCMa()
+// CHECK:  [[TMP:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(
+// CHECK:  call %swift.type* @swift_getObjCClassMetadata(%objc_class* [[TMP]])
+// CHECK:  ret

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
@@ -109,6 +109,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) shouldBeTrueCBool: (_Bool)value;
 @end
 
+@interface OuterType : NSObject
+@end
+
+__attribute__((swift_name("OuterType.InnerType")))
+@interface OuterTypeInnerType : NSObject
+@property NSArray<OuterType *> *things;
+@end
+
 NS_ASSUME_NONNULL_END
 
 #endif

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.m
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.m
@@ -170,3 +170,24 @@ static unsigned counter = 0;
 }
 
 @end
+
+@implementation OuterType
+
+- (id)init {
+  if ((self = [super init]) != nil) {
+  }
+  return self;
+}
+
+@end
+
+@implementation OuterTypeInnerType
+
+- (id)init {
+  if ((self = [super init]) != nil) {
+    self.things = [NSArray array];
+  }
+  return self;
+}
+
+@end

--- a/test/Interpreter/objc_types_as_members.swift
+++ b/test/Interpreter/objc_types_as_members.swift
@@ -1,0 +1,45 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+// RUN: %target-build-swift -O -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o %s -o %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import ObjCClasses
+import Foundation
+
+protocol OuterProto:class {
+}
+
+protocol InnerProto : class {
+    var outerthings:[OuterProto] { get }
+}
+
+extension OuterType : OuterProto {
+}
+
+extension OuterType.InnerType: InnerProto {
+    var outerthings:[OuterProto] {
+        return self.things
+    }
+}
+
+var innerthing:InnerProto = OuterType.InnerType()
+
+@inline(never)
+func getInnerThing() -> InnerProto {
+  return innerthing
+}
+
+@inline(never)
+func dontCrash() {
+  let thing = getInnerThing()
+  let devices = thing.outerthings
+  print("Got devices: \(devices)")
+}
+
+// CHECK: Got devices: []
+dontCrash()


### PR DESCRIPTION
This used to crash before we removed parent metadata references.

rdar://34846458