### PR TITLE
[Diagnostics] Suggest 'self.' in method when name of the property matches parameter label.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -216,6 +216,10 @@ ERROR(cannot_pass_rvalue_inout,none,
 ERROR(cannot_assign_to_literal,none,
       "cannot assign to a literal value", ())
 
+ERROR(property_use_in_init_without_explicit_self,none,
+"reference to property %0 in initialiser requires explicit 'self.' to make"
+" capture semantics explicit", (Identifier))
+
 ERROR(cannot_call_with_no_params,none,
       "cannot invoke %select{|initializer for type }1'%0' with no arguments",
       (StringRef, bool))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7046,6 +7046,8 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   return true;
 }
 
+
+// Start work here:
 bool FailureDiagnosis::visitAssignExpr(AssignExpr *assignExpr) {
   // Diagnose obvious assignments to literals.
   if (isa<LiteralExpr>(assignExpr->getDest()->getValueProvidingExpr())) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
**This PR is still under development.**

This PR aims to reduce the overhead developers require in explicitly writing `self.` in front of property names in initialisers if the initialiser has a parameter whose label has the same name as the property.
Additional discussion, ad an example, can be found in the [bug report](https://bugs.swift.org/browse/SR-5996)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5996](https://bugs.swift.org/browse/SR-5996).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->