### PR TITLE
stdlib: introduce new CIntPtr, CUIntPtr types

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -80,6 +80,14 @@ public typealias CChar32 = Unicode.Scalar
 /// The C '_Bool' and C++ 'bool' type.
 public typealias CBool = Bool
 
+#if arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(x86_64)
+public typealias CIntPtr = Int64
+public typealias CUIntPtr = UInt64
+#else
+public typealias CIntPtr = Int32
+public typealias CUIntPtr = UInt32
+#endif
+
 /// A wrapper around an opaque C pointer.
 ///
 /// Opaque pointers are used to represent C pointers to types that


### PR DESCRIPTION
Some 64-bit targets are LLP64 rather than LP64.  Introduce two new
types:
  - CIntPtr
  - CUIntPtr
to represent the C integral pointer type.  These are effectively
`intptr_t` and `uintptr_t`.  This allows us to break the assumption that
`Long` is pointer-width.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
