### PR TITLE
[long test] Enable verify_all_overlays test

### DIFF
--- a/validation-test/SIL/verify_all_overlays.sil
+++ b/validation-test/SIL/verify_all_overlays.sil
@@ -2,6 +2,5 @@
 
 // CHECK-NOT: Unknown
 
-// REQUIRES: rdar31683781
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test


### PR DESCRIPTION
The test was originally disabled but to timeouts that were supposedly caused by the new integer protocols. A few improvements have been implemented in the compiler as well as in the standard library since them, so it might no longer be a problem.