### PR TITLE
[di] DI assumes that all structs it analyzes will have /1/ property... this is not always true =><=.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -79,6 +79,8 @@ static SILType getElementTypeRec(SILModule &Module, SILType T, unsigned EltNo) {
         return getElementTypeRec(Module, FieldType, EltNo);
       EltNo -= NumFieldElements;
     }
+    // This can only happen if we look at a symbolic element number of an empty
+    // tuple.
     llvm::report_fatal_error("invalid element number");
   }
 

--- a/test/SILOptimizer/definite_init_nsmanagedvalue.swift
+++ b/test/SILOptimizer/definite_init_nsmanagedvalue.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../ClangImporter/Inputs/custom-modules %s -emit-sil -enable-sil-ownership
+
+// REQUIRES: objc_interop
+
+// Make sure if we have an NSManagedObject without stored properties that DI
+// does not crash or emit an error.
+
+import Foundation
+import CoreData
+
+class Person : NSManagedObject {
+  enum MyError : Error {
+  case error
+  }
+
+  static func myThrow() throws {}
+  static func myBool() -> Bool { return false }
+  public required init(_ x: Int) throws {
+    if Person.myBool() {
+      throw MyError.error
+    }
+    super.init()
+    try Person.myThrow()
+  }
+}
+
+extension Person {
+  @NSManaged var name: String
+}


### PR DESCRIPTION
[di] DI assumes that all structs it analyzes will have /1/ property... this is not always true =><=.

The culprit here is NSManagedObject subclasses that only have @NSManaged
attributes.

This doesn't affect predictable mem opts since this issue is in the
DIMemoryUseCollector that only affects DI and that I have removed.

rdar://34589327