### PR TITLE
[RemoteAST] Fix function generation to form type from multiple params

### DIFF
--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -342,6 +342,7 @@ public:
         if (inOutArgs[i]) arg = InOutType::get(arg);
         elts.push_back(arg);
       }
+      input = TupleType::get(elts, Ctx);
     }
 
     return FunctionType::get(input, output, einfo);


### PR DESCRIPTION
If function type has multiple parameters make sure that correct
tuple type is formed before constructing function type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
