### PR TITLE
[GSB] Don't complain about redundant superclass constraints in derived requirements

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1198,6 +1198,14 @@ public:
   /// path.
   bool isDerivedRequirement() const;
 
+  /// Whether we should diagnose a redundant constraint based on this
+  /// requirement source.
+  ///
+  /// \param primary Whether this is the "primary" requirement source, on which
+  /// a "redundant constraint" warning would be emitted vs. the requirement
+  /// source that would be used for the accompanying note.
+  bool shouldDiagnoseRedundancy(bool primary) const;
+
   /// Determine whether the given derived requirement \c source, when rooted at
   /// the potential archetype \c pa, is actually derived from the same
   /// requirement. Such "self-derived" requirements do not make the original

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -203,6 +203,15 @@ public:
     EquivalenceClass &operator=(const EquivalenceClass &) = delete;
     EquivalenceClass &operator=(EquivalenceClass &&) = delete;
 
+    /// Record the conformance of this equivalence class to the given
+    /// protocol as found via the given requirement source.
+    ///
+    /// \returns true if this conformance is new to the equivalence class,
+    /// and false otherwise.
+    bool recordConformanceConstraint(PotentialArchetype *pa,
+                                     ProtocolDecl *proto,
+                                     const RequirementSource *source);
+
     /// Find a source of the same-type constraint that maps a potential
     /// archetype in this equivalence class to a concrete type along with
     /// that concrete type as written.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5996,7 +5996,9 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
                                                     genericParams),
                        equivClass->concreteType, equivClass->superclass);
       }
-    } else if (representativeConstraint.source->getLoc().isValid()) {
+    } else if (representativeConstraint.source->getLoc().isValid() &&
+               !representativeConstraint.source->isDerivedRequirement() &&
+               !representativeConstraint.source->isInferredRequirement()) {
       // It does fulfill the requirement; diagnose the redundancy.
       Diags.diagnose(representativeConstraint.source->getLoc(),
                      diag::redundant_superclass_constraint,

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -333,7 +333,6 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements() {
   // change.)
   assert(canTypeSig.getGenericParams() == canExtensionSig.getGenericParams());
 
-  auto mod = DC->getParentModule();
   // Find the requirements in the extension that aren't proved by the original
   // type, these are the ones that make the conformance conditional.
   SmallVector<Requirement, 4> reqs;

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -179,3 +179,12 @@ class Horse<T>: Rump { }
 func hasRedundantConformanceConstraint<X : Horse<T>, T>(_: X) where X : Rump {}
 // expected-warning@-1 {{redundant conformance constraint 'X': 'Rump'}}
 // expected-note@-2 {{conformance constraint 'X': 'Rump' implied here}}
+
+// SR-5862
+protocol X {
+	associatedtype Y : A
+}
+
+// CHECK-DAG: .noRedundancyWarning@
+// CHECK: Generic signature: <C where C : X, C.Y == B>
+func noRedundancyWarning<C : X>(_ wrapper: C) where C.Y == B {}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -182,7 +182,6 @@ public protocol Proto: class {
 }
 
 @_specialize(where T: _RefCountedObject)
-// expected-warning@-1{{redundant layout constraint 'T' : '_RefCountedObject'}}
 @_specialize(where T: _Trivial)
 // expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial' and '_NativeClass'}}
 @_specialize(where T: _Trivial(64))


### PR DESCRIPTION
<!-- What's in this pull request? -->
Stop warning about redundant constraints in derived requirements. While I'm here, rationalize our logic for when to emit redundant-constraint warnings.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5862](https://bugs.swift.org/browse/SR-5862).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->