### PR TITLE
[4.0] IRGen: An @objc protocol method call's self argument behaves li…

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1082,11 +1082,12 @@ bool irgen::isSelfContextParameter(SILParameterInfo param) {
     return metatype->getRepresentation() != MetatypeRepresentation::Thin;
   }
 
-  // Classes and class-bounded archetypes.
+  // Classes and class-bounded archetypes or ObjC existentials.
   // No need to apply this to existentials.
   // The direct check for SubstitutableType works because only
   // class-bounded generic types can be passed directly.
-  if (type->mayHaveSuperclass() || isa<SubstitutableType>(type)) {
+  if (type->mayHaveSuperclass() || isa<SubstitutableType>(type) ||
+      type->isObjCExistentialType()) {
     return true;
   }
 

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -179,3 +179,35 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   return undef : $()
 }
+
+@objc protocol ProtocolA : class {
+ @objc optional func funcA()
+}
+
+// CHECK: define swiftcc void @useObjcProtocol(%objc_object* swiftself)
+// CHECK: entry:
+// CHECK:   load i8*, i8** @"\01L_selector(funcA)"
+// CHECK:   load i8*, i8** @"\01L_selector(respondsToSelector:)"
+// CHECK:   [[TMP:%.*]] = call i1 bitcast (void ()* @objc_msgSend
+// CHECK:   br i1 [[TMP]]
+//
+// CHECK:   [[SELF:%.*]] = bitcast %objc_object* %0 to i8*
+// CHECK:   call void bitcast (void ()* @objc_msgSend to void (i8*, i8*)*)(i8* [[SELF]]
+// CHECK:   ret void
+// CHECK: }
+
+sil public @useObjcProtocol : $@convention(method) (@guaranteed ProtocolA) -> () {
+bb0(%0 : $ProtocolA):
+  dynamic_method_br %0 : $ProtocolA, #ProtocolA.funcA!1.foreign, bb1, bb2
+
+bb1(%1 : $@convention(objc_method) (ProtocolA) -> ()):
+  %3 = apply %1(%0) : $@convention(objc_method) (ProtocolA) -> ()
+  br bb3
+
+bb2:
+ br bb3
+
+bb3:
+ %4 = tuple()
+ return %4 : $()
+}


### PR DESCRIPTION
…ke a class method's

rdar://34847037
SR-6068

* Explanation: The compiler did not handle the self argument emission for calls to objective c methods where self argument type is a objective c existential correctly resulting in a compiler crash.

* Scope: I believe this to be a longer standing bug

* Risk: Low, the code change should only affect objective c method calls with objc existential self arguments

* Testing: A test case added to the Swift regression suite