### PR TITLE
SIL-Combine: fix test case failure on watch

### DIFF
--- a/test/SILOptimizer/sr-5068.sil
+++ b/test/SILOptimizer/sr-5068.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -sil-combine | %FileCheck %s
 
+// REQUIRES: PTRSIZE=64
+
 sil_stage canonical
 
 import Builtin


### PR DESCRIPTION
Disables a newly-created test-case on 32-bit platforms to fix a test case failure