### PR TITLE
[Mangling] Mangle generic signature requirements not satisfied by parent context

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -195,7 +195,17 @@ protected:
 
   void appendTypeList(Type listTy);
 
-  void appendGenericSignature(const GenericSignature *sig);
+  /// Append a generic signature to the mangling.
+  ///
+  /// \param sig The generic signature.
+  ///
+  /// \param contextSig The signature of the known context. This function
+  /// will only mangle the difference between \c sig and \c contextSig.
+  ///
+  /// \returns \c true if a generic signature was appended, \c false
+  /// if it was empty.
+  bool appendGenericSignature(const GenericSignature *sig,
+                              GenericSignature *contextSig = nullptr);
 
   void appendRequirement(const Requirement &reqt);
 
@@ -218,10 +228,8 @@ protected:
   void appendInitializerEntity(const VarDecl *var);
 
   CanType getDeclTypeForMangling(const ValueDecl *decl,
-                                 ArrayRef<GenericTypeParamType *> &genericParams,
-                                 unsigned &initialParamIndex,
-                                 ArrayRef<Requirement> &requirements,
-                                 SmallVectorImpl<Requirement> &requirementsBuf);
+                                 GenericSignature *&genericSig,
+                                 GenericSignature *&parentGenericSig);
 
   void appendDeclType(const ValueDecl *decl, bool isFunctionMangling = false);
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1537,11 +1537,57 @@ void ASTMangler::appendTypeList(Type listTy) {
   }
 }
 
-void ASTMangler::appendGenericSignature(const GenericSignature *sig) {
+bool ASTMangler::appendGenericSignature(const GenericSignature *sig,
+                                        GenericSignature *contextSig) {
   auto canSig = sig->getCanonicalSignature();
   CurGenericSignature = canSig;
-  appendGenericSignatureParts(canSig->getGenericParams(), 0,
-                              canSig->getRequirements());
+
+  unsigned initialParamDepth;
+  ArrayRef<GenericTypeParamType *> genericParams;
+  ArrayRef<Requirement> requirements;
+  SmallVector<Requirement, 4> requirementsBuffer;
+  if (contextSig) {
+    // If the signature is the same as the context signature, there's nothing
+    // to do.
+    if (contextSig->getCanonicalSignature() == canSig) {
+      return false;
+    }
+
+    // The signature depth starts above the depth of the context signature.
+    if (!contextSig->getGenericParams().empty()) {
+      initialParamDepth = contextSig->getGenericParams().back()->getDepth() + 1;
+    }
+
+    // Find the parameters at this depth (or greater).
+    genericParams = canSig->getGenericParams();
+    unsigned firstParam = genericParams.size();
+    while (firstParam > 1 &&
+           genericParams[firstParam-1]->getDepth() >= initialParamDepth)
+      --firstParam;
+    genericParams = genericParams.slice(firstParam);
+
+    for (auto &reqt : canSig->getRequirements()) {
+      // If the requirement is satisfied by the context signature,
+      // we don't need to mangle it here.
+      if (contextSig->isRequirementSatisfied(reqt))
+        continue;
+
+      // Mangle the requirement.
+      requirementsBuffer.push_back(reqt);
+    }
+    requirements = requirementsBuffer;
+  } else {
+    // Use the complete canonical signature.
+    initialParamDepth = 0;
+    genericParams = canSig->getGenericParams();
+    requirements = canSig->getRequirements();
+  }
+
+  if (genericParams.empty() && requirements.empty())
+    return false;
+
+  appendGenericSignatureParts(genericParams, initialParamDepth, requirements);
+  return true;
 }
 
 void ASTMangler::appendRequirement(const Requirement &reqt) {
@@ -1737,11 +1783,12 @@ static bool isMethodDecl(const Decl *decl) {
 }
 
 CanType ASTMangler::getDeclTypeForMangling(
-    const ValueDecl *decl,
-    ArrayRef<GenericTypeParamType *> &genericParams,
-    unsigned &initialParamDepth,
-    ArrayRef<Requirement> &requirements,
-    SmallVectorImpl<Requirement> &requirementsBuf) {
+                                       const ValueDecl *decl,
+                                       GenericSignature *&genericSig,
+                                       GenericSignature *&parentGenericSig) {
+  genericSig = nullptr;
+  parentGenericSig = nullptr;
+
   auto &C = decl->getASTContext();
   if (!decl->hasInterfaceType() || decl->getInterfaceType()->is<ErrorType>()) {
     if (isa<AbstractFunctionDecl>(decl))
@@ -1750,21 +1797,14 @@ CanType ASTMangler::getDeclTypeForMangling(
     return C.TheErrorType;
   }
 
-  auto type = decl->getInterfaceType()->getCanonicalType();
 
-  initialParamDepth = 0;
-  CanGenericSignature sig;
+  CanType type = decl->getInterfaceType()->getCanonicalType();
   if (auto gft = dyn_cast<GenericFunctionType>(type)) {
-    sig = gft.getGenericSignature();
-    CurGenericSignature = sig;
-    genericParams = sig->getGenericParams();
-    requirements = sig->getRequirements();
+    genericSig = gft.getGenericSignature();
+    CurGenericSignature = gft.getGenericSignature();
 
     type = CanFunctionType::get(gft->getParams(), gft.getResult(),
                                 gft->getExtInfo());
-  } else {
-    genericParams = {};
-    requirements = {};
   }
 
   if (!type->hasError()) {
@@ -1774,49 +1814,19 @@ CanType ASTMangler::getDeclTypeForMangling(
       type = cast<AnyFunctionType>(type).getResult();
     }
 
-    if (isMethodDecl(decl) || isa<SubscriptDecl>(decl)) {
-      // Drop generic parameters and requirements from the method's context.
-      auto parentGenericSig =
-        decl->getDeclContext()->getGenericSignatureOfContext();
-      if (parentGenericSig && sig) {
-        // The method's depth starts above the depth of the context.
-        if (!parentGenericSig->getGenericParams().empty())
-          initialParamDepth =
-            parentGenericSig->getGenericParams().back()->getDepth() + 1;
-
-        while (!genericParams.empty()) {
-          if (genericParams.front()->getDepth() >= initialParamDepth)
-            break;
-          genericParams = genericParams.slice(1);
-        }
-
-        requirementsBuf.clear();
-        for (auto &reqt : sig->getRequirements()) {
-          // If the requirement is satisfied by the enclosing context,
-          // we don't need to mangle it here.
-          if (parentGenericSig->isRequirementSatisfied(reqt))
-            continue;
-
-          // Mangle the requirement.
-          requirementsBuf.push_back(reqt);
-        }
-        requirements = requirementsBuf;
-      }
-    }
+    if (isMethodDecl(decl) || isa<SubscriptDecl>(decl))
+      parentGenericSig = decl->getDeclContext()->getGenericSignatureOfContext();
   }
-  return type->getCanonicalType();
+
+  return type;
 }
 
 void ASTMangler::appendDeclType(const ValueDecl *decl, bool isFunctionMangling) {
-  ArrayRef<GenericTypeParamType *> genericParams;
-  unsigned initialParamDepth;
-  ArrayRef<Requirement> requirements;
-  SmallVector<Requirement, 4> requirementsBuf;
   Mod = decl->getModuleContext();
-  auto type = getDeclTypeForMangling(decl,
-                                     genericParams, initialParamDepth,
-                                     requirements, requirementsBuf);
- 
+  GenericSignature *genericSig = nullptr;
+  GenericSignature *parentGenericSig = nullptr;
+  auto type = getDeclTypeForMangling(decl, genericSig, parentGenericSig);
+
   if (AnyFunctionType *FuncTy = type->getAs<AnyFunctionType>()) {
 
     const ParameterList *Params = nullptr;
@@ -1841,9 +1851,7 @@ void ASTMangler::appendDeclType(const ValueDecl *decl, bool isFunctionMangling) 
   }
 
   // Mangle the generic signature, if any.
-  if (!genericParams.empty() || !requirements.empty()) {
-    appendGenericSignatureParts(genericParams, initialParamDepth,
-                                requirements);
+  if (genericSig && appendGenericSignature(genericSig, parentGenericSig)) {
     // The 'F' function mangling doesn't need a 'u' for its generic signature.
     if (!isFunctionMangling)
       appendOperator("u");

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -678,14 +678,17 @@ bool GenericSignature::isRequirementSatisfied(Requirement requirement) {
   case RequirementKind::Layout: {
     auto requiredLayout = requirement.getLayoutConstraint();
 
-    if (canFirstType->isTypeParameter())
-      return getLayoutConstraint(canFirstType) == requiredLayout;
-    else {
-      // The requirement is on a concrete type, so it's either globally correct
-      // or globally incorrect, independent of this generic context. The latter
-      // case should be diagnosed elsewhere, so let's assume it's correct.
-      return true;
+    if (canFirstType->isTypeParameter()) {
+      if (auto layout = getLayoutConstraint(canFirstType))
+        return static_cast<bool>(layout.merge(requiredLayout));
+
+      return false;
     }
+
+    // The requirement is on a concrete type, so it's either globally correct
+    // or globally incorrect, independent of this generic context. The latter
+    // case should be diagnosed elsewhere, so let's assume it's correct.
+    return true;
   }
   }
 }

--- a/test/SILGen/mangling_generic_extensions.swift
+++ b/test/SILGen/mangling_generic_extensions.swift
@@ -21,7 +21,7 @@ extension Foo {
   // NO-SELF-LABEL: sil hidden @_T027mangling_generic_extensions3FooV4zangyqd__lF
   func zang<U>(_: U) { }
   // NO-SELF-LABEL: sil hidden @_T027mangling_generic_extensions3FooV4zungyqd__AA8RuncibleRd__3HatQyd__Rs_lF
-  func zung<U: Runcible where U.Hat == T>(_: U) { }
+  func zung<U: Runcible>(_: U) where U.Hat == T { }
 }
 
 extension Foo where T: Runcible {
@@ -55,4 +55,15 @@ extension Runcible {
 extension Runcible where Self.Spoon == Self.Hat {
   // CHECK-LABEL: sil hidden @_T027mangling_generic_extensions8RunciblePA2aBRz5SpoonQz3HatRtzlE5runceyyF
   func runce() {}
+}
+
+
+struct Bar<T: Runcible, U: Runcible> { }
+
+extension Bar {
+  // CHECK-LABEL: _T027mangling_generic_extensions3BarV4bar1yqd__AA8RuncibleRd__AaE5SpoonRpzAFQy_AGRSlF
+  func bar1<V: Runcible>(_: V) where U.Spoon: Runcible, T.Spoon == U.Spoon { }
+
+  // CHECK-LABEL: _T027mangling_generic_extensions3BarV4bar1yqd__AA8RuncibleRd__AaE5SpoonRp_lF
+  func bar1<V: Runcible>(_: V) where U.Spoon: Runcible { }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The mangler had some ad hoc logic for only mangling requirements in a
generic signature that are not requirements in the parent context's
generic signature. However, it was based on an heuristic that isn't
correct. Replace that logic with a check to determine whether
the requirement is satisfied by the parent generic signature, which is
far simpler.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6107](https://bugs.swift.org/browse/SR-6107) / rdar://problem/31889040

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->