### PR TITLE
[Serialization] Make sure -enable-testing -enable-resilience works

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -769,7 +769,7 @@ void Serializer::writeHeader(const SerializationOptions &options) {
     Target.emit(ScratchRecord, M->getASTContext().LangOpts.Target.str());
 
     {
-      llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 3);
+      llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 4);
 
       options_block::IsSIBLayout IsSIB(Out);
       IsSIB.emit(ScratchRecord, options.IsSIB);

--- a/test/Serialization/testability.swift
+++ b/test/Serialization/testability.swift
@@ -20,6 +20,13 @@
 // RUN: %target-swift-frontend -emit-sil -DMAIN -DTESTABLE %s -module-name main -I %t > /dev/null
 // RUN: %target-swift-frontend -emit-sil -DMAIN -DDEBUG -disable-access-control %s -module-name main -I %t > /dev/null
 
+// Then we do it one more time with resilience enabled.
+
+// RUN: %target-swift-frontend -emit-module -DSUB -o %t -enable-testing -enable-resilience %s -module-name testability_client -I %t
+// RUN: %target-swift-frontend -emit-sil -DMAIN %s -module-name main -I %t > /dev/null
+// RUN: %target-swift-frontend -emit-sil -DMAIN -DTESTABLE %s -module-name main -I %t > /dev/null
+// RUN: %target-swift-frontend -emit-sil -DMAIN -DDEBUG -disable-access-control %s -module-name main -I %t > /dev/null
+
 // CHECK: <MODULE_BLOCK {{.*}}>
 // TESTING: <IS_TESTABLE abbrevid={{[0-9]+}}/>
 // NO-TESTING-NOT: IS_TESTABLE


### PR DESCRIPTION
It didn't, because the bitcode format said we only needed 8 possible kinds of record within this block, which was a lie when both of these flags were passed.

This is a backwards-compatible change, so no need to update the module format version number.