### PR TITLE
[SE-0155][WIP] Normalize Enum Case Representation

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -91,7 +91,7 @@ public:
   std::string mangleGlobalGetterEntity(const ValueDecl *decl,
                                        SymbolKind SKind = SymbolKind::Default);
 
-  std::string mangleDefaultArgumentEntity(const DeclContext *func,
+  std::string mangleDefaultArgumentEntity(const ValueDecl *decl,
                                           unsigned index,
                                           SymbolKind SKind);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5746,7 +5746,7 @@ class EnumElementDecl : public ValueDecl {
   Expr *TypeCheckedRawValueExpr = nullptr;
   
 public:
-  EnumElementDecl(SourceLoc IdentifierLoc, Identifier Name,
+  EnumElementDecl(SourceLoc IdentifierLoc, DeclName Name,
                   ParameterList *Params,
                   SourceLoc EqualsLoc,
                   LiteralExpr *RawValueExpr,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -351,14 +351,14 @@ protected:
   );
 
   SWIFT_INLINE_BITFIELD(EnumElementDecl, ValueDecl, 3,
-    /// \brief Whether or not this element has an associated value.
-    HasArgumentType : 1,
+    /// \brief The ResilienceExpansion to use for default arguments.
+    DefaultArgumentResilienceExpansion : 1,
 
     /// \brief Whether or not this element directly or indirectly references
     /// the enum type.
     Recursiveness : 2
   );
-  
+
   SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+5+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
@@ -5758,6 +5758,8 @@ public:
   {
     Bits.EnumElementDecl.Recursiveness =
         static_cast<unsigned>(ElementRecursiveness::NotRecursive);
+    EnumElementDeclBits.DefaultArgumentResilienceExpansion =
+        static_cast<unsigned>(ResilienceExpansion::Maximal);
   }
 
   Identifier getName() const { return getFullName().getBaseIdentifier(); }
@@ -5807,6 +5809,21 @@ public:
   
   void setRecursiveness(ElementRecursiveness recursiveness) {
     Bits.EnumElementDecl.Recursiveness = static_cast<unsigned>(recursiveness);
+  }
+
+    /// The ResilienceExpansion for default arguments.
+  ///
+  /// In Swift 4 mode, default argument expressions are serialized, and must
+  /// obey the restrictions imposed upon inlineable function bodies.
+  ResilienceExpansion getDefaultArgumentResilienceExpansion() const {
+    return ResilienceExpansion(
+        EnumElementDeclBits.DefaultArgumentResilienceExpansion);
+  }
+
+  /// Set the ResilienceExpansion for default arguments.
+  void setDefaultArgumentResilienceExpansion(ResilienceExpansion expansion) {
+    EnumElementDeclBits.DefaultArgumentResilienceExpansion =
+        unsigned(expansion);
   }
 
   bool hasAssociatedValues() const {
@@ -6677,7 +6694,7 @@ inline EnumElementDecl *EnumDecl::getUniqueElement(bool hasValue) const {
 /// \returns the default argument kind and, if there is a default argument,
 /// the type of the corresponding parameter.
 std::pair<DefaultArgumentKind, Type>
-getDefaultArgumentInfo(ValueDecl *source, unsigned Index);
+getDefaultArgumentInfo(ArrayRef<const ParameterList *> paramLists, unsigned Index);
 
 } // end namespace swift
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5758,7 +5758,7 @@ public:
   {
     Bits.EnumElementDecl.Recursiveness =
         static_cast<unsigned>(ElementRecursiveness::NotRecursive);
-    EnumElementDeclBits.DefaultArgumentResilienceExpansion =
+    Bits.EnumElementDecl.DefaultArgumentResilienceExpansion =
         static_cast<unsigned>(ResilienceExpansion::Maximal);
   }
 
@@ -5811,18 +5811,18 @@ public:
     Bits.EnumElementDecl.Recursiveness = static_cast<unsigned>(recursiveness);
   }
 
-    /// The ResilienceExpansion for default arguments.
+  /// The ResilienceExpansion for default arguments.
   ///
   /// In Swift 4 mode, default argument expressions are serialized, and must
   /// obey the restrictions imposed upon inlineable function bodies.
   ResilienceExpansion getDefaultArgumentResilienceExpansion() const {
     return ResilienceExpansion(
-        EnumElementDeclBits.DefaultArgumentResilienceExpansion);
+        Bits.EnumElementDecl.DefaultArgumentResilienceExpansion);
   }
 
   /// Set the ResilienceExpansion for default arguments.
   void setDefaultArgumentResilienceExpansion(ResilienceExpansion expansion) {
-    EnumElementDeclBits.DefaultArgumentResilienceExpansion =
+    Bits.EnumElementDecl.DefaultArgumentResilienceExpansion =
         unsigned(expansion);
   }
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -333,6 +333,8 @@ ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
 // Func
 ERROR(func_decl_without_paren,PointsToFirstBadToken,
       "expected '(' in argument list of function declaration", ())
+ERROR(enum_element_decl_without_paren,PointsToFirstBadToken,
+      "expected '(' in argument list of enum element declaration", ())
 ERROR(static_func_decl_global_scope,none,
       "%select{%error|static methods|class methods}0 may only be declared on a type",
       (StaticSpellingKind))

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -895,6 +895,11 @@ WARNING(swift3_unlabeled_parameter_following_variadic_parameter,none,
 ERROR(unlabeled_parameter_following_variadic_parameter,none,
       "a parameter following a variadic parameter requires a label", ())
 
+ERROR(enum_element_empty_arglist,none,
+      "empty enum element argument list must be spelled with 'Void'", ())
+WARNING(enum_element_empty_arglist_swift3,none,
+        "empty enum element argument list must be spelled with 'Void'", ())
+
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -879,7 +879,7 @@ WARNING(parameter_extraneous_double_up,none,
         "extraneous duplicate parameter name; %0 already has an argument "
         "label", (Identifier))
 ERROR(parameter_operator_keyword_argument,none,
-      "%select{operator|closure}0 cannot have keyword arguments", (bool))
+      "%select{operator|closure|enum case}0 cannot have keyword arguments", (unsigned))
 
 ERROR(parameter_unnamed,none,
       "unnamed parameters must be written with the empty name '_'", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2953,6 +2953,12 @@ ERROR(type_pattern_missing_is,none,
 ERROR(pattern_type_mismatch_context,none,
       "type annotation does not match contextual type %0", (Type))
 
+ERROR(paren_pattern_in_tuple_context,none,
+      "parenthesized pattern cannot match value of tuple type %0", (Type))
+WARNING(paren_pattern_in_tuple_context_warn_swift3,none,
+        "parenthesized pattern matches value of tuple type %0; this may be "
+        "unintended and will be removed in a future version of Swift", (Type))
+
 ERROR(tuple_pattern_in_non_tuple_context,none,
       "tuple pattern cannot match values of the non-tuple type %0", (Type))
 ERROR(closure_argument_list_tuple,none,
@@ -2980,10 +2986,18 @@ ERROR(enum_element_pattern_assoc_values_mismatch,none,
       (Identifier))
 NOTE(enum_element_pattern_assoc_values_remove,none,
      "remove associated values to make the pattern match", ())
+
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))
 ERROR(tuple_pattern_label_mismatch,none,
       "tuple pattern element label %0 must be %1", (Identifier, Identifier))
+ERROR(tuple_pattern_label_missing,none,
+      "tuple pattern mentioning element labels must also specify label '%0'",
+      (Identifier))
+ERROR(tuple_pattern_label_should_be_elided,none,
+      "tuple pattern not mentioning element labels may not specify label %0",
+      (Identifier))
+
 ERROR(enum_element_pattern_member_not_found,none,
       "enum case '%0' not found in type %1", (StringRef, Type))
 ERROR(optional_element_pattern_not_valid_type,none,
@@ -3008,6 +3022,13 @@ ERROR(isa_collection_downcast_pattern_value_unimplemented,none,
 WARNING(swift3_ignore_specialized_enum_element_call,none,
         "cannot specialize enum case; ignoring generic argument, "
         "which will be rejected in future version of Swift", ())
+
+ERROR(ambiguous_enum_element_in_pattern,none,
+      "enum case %0 is ambiguous without explicit pattern matching "
+      "associated values",
+      (Identifier))
+NOTE(ambiguous_enum_element_candidate,none,
+     "found potentially matching case %0", (DeclName))
 
 //------------------------------------------------------------------------------
 // Error-handling diagnostics

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3025,8 +3025,7 @@ WARNING(swift3_ignore_specialized_enum_element_call,none,
 
 ERROR(ambiguous_enum_element_in_pattern,none,
       "enum case %0 is ambiguous without explicit pattern matching "
-      "associated values",
-      (Identifier))
+      "associated values", (Identifier))
 NOTE(ambiguous_enum_element_candidate,none,
      "found potentially matching case %0", (DeclName))
 

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -162,7 +162,7 @@ public:
   /// Change the parent of this context.  This is necessary because
   /// the function signature is parsed before the function
   /// declaration/expression itself is built.
-  void changeFunction(AbstractFunctionDecl *parent);
+  void changeFunction(DeclContext *parent, MutableArrayRef<ParameterList *> paramLists);
 
   static bool classof(const DeclContext *DC) {
     if (auto init = dyn_cast<Initializer>(DC))

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -285,6 +285,7 @@ struct PrintOptions {
     ArgumentOnly,
     MatchSource,
     BothAlways,
+    EnumElement,
   };
 
   /// Whether to print the doc-comment from the conformance if a member decl

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1050,6 +1050,8 @@ public:
     Subscript,
     /// A curried argument clause.
     Curried,
+    /// An enum element.
+    EnumElement,
   };
 
   /// Parse a parameter-clause.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -988,7 +988,7 @@ public:
 
     /// Set the parsed context for all the initializers to the given
     /// function.
-    void setFunctionContext(AbstractFunctionDecl *AFD);
+    void setFunctionContext(DeclContext *DC, MutableArrayRef<ParameterList *> paramList);
     
     DefaultArgumentInfo(bool inTypeContext) {
       NextIndex = inTypeContext ? 1 : 0;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -535,7 +535,8 @@ private:
   llvm::Expected<Pattern *> readPattern(DeclContext *owningDC);
 
   ParameterList *readParameterList();
-  
+  ParameterList *maybeReadParameterList();
+
   /// Reads a generic param list from \c DeclTypeCursor.
   ///
   /// If the record at the cursor is not a generic param list, returns null

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 403; // Last change: `init` special name
+const uint16_t VERSION_MINOR = 404; // Last change: SE-0155 
 
 using DeclIDField = BCFixed<31>;
 
@@ -1077,11 +1077,13 @@ namespace decls_block {
     IdentifierIDField, // name
     DeclContextIDField,// context decl
     TypeIDField, // interface type
-    BCFixed<1>,  // has argument type?
     BCFixed<1>,  // implicit?
     EnumElementRawValueKindField,  // raw value kind
     BCFixed<1>,  // negative raw value?
     BCBlob       // raw value
+
+    // The record is trailed by:
+    // - its argument parameters, if any
   >;
 
   using SubscriptLayout = BCRecordLayout<

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1074,13 +1074,14 @@ namespace decls_block {
 
   using EnumElementLayout = BCRecordLayout<
     ENUM_ELEMENT_DECL,
-    IdentifierIDField, // name
     DeclContextIDField,// context decl
     TypeIDField, // interface type
     BCFixed<1>,  // implicit?
     EnumElementRawValueKindField,  // raw value kind
     BCFixed<1>,  // negative raw value?
-    BCBlob       // raw value
+    IdentifierIDField, // raw value
+    BCVBR<5>, // number of parameter name components
+    BCArray<IdentifierIDField> // name components,
 
     // The record is trailed by:
     // - its argument parameters, if any

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1080,6 +1080,7 @@ namespace decls_block {
     EnumElementRawValueKindField,  // raw value kind
     BCFixed<1>,  // negative raw value?
     IdentifierIDField, // raw value
+    BCFixed<1>,   // default argument resilience expansion
     BCVBR<5>, // number of parameter name components
     BCArray<IdentifierIDField> // name components,
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -159,11 +159,15 @@ std::string ASTMangler::mangleGlobalGetterEntity(const ValueDecl *decl,
   return finalize();
 }
 
-std::string ASTMangler::mangleDefaultArgumentEntity(const DeclContext *func,
+std::string ASTMangler::mangleDefaultArgumentEntity(const ValueDecl *decl,
                                                     unsigned index,
                                                     SymbolKind SKind) {
   beginMangling();
-  appendDefaultArgumentEntity(func, index);
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(decl)) {
+    appendDefaultArgumentEntity(AFD, index);
+  } else {
+    appendDefaultArgumentEntity(decl->getDeclContext(), index);
+  }
   appendSymbolKind(SKind);
   return finalize();
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4229,42 +4229,31 @@ void swift::printEnumElementsAsCases(
               return LHS->getNameStr().compare(RHS->getNameStr()) < 0;
             });
 
-  auto printPayloads = [](EnumElementDecl *EE, llvm::raw_ostream &OS) {
+  auto printPayloads = [](ParameterList *PL, llvm::raw_ostream &OS) {
     // If the enum element has no payloads, return.
-    auto TL = EE->getArgumentTypeLoc();
-    if (TL.isNull())
+    if (!PL)
       return;
-    TypeRepr *TR = EE->getArgumentTypeLoc().getTypeRepr();
-    if (auto *TTR = dyn_cast<TupleTypeRepr>(TR)) {
-      SmallVector<Identifier, 4> Names;
-      if (TTR->hasElementNames()) {
-        // Get the name from the tuple repr, if exist.
-        TTR->getElementNames(Names);
+    OS << "(";
+    // Print each element in the pattern match.
+    for (auto i = PL->begin(); i != PL->end(); ++i) {
+      auto *param = *i;
+      if (param->hasName()) {
+        OS << tok::kw_let << " " << param->getName().str();
       } else {
-        // Create same amount of empty names to the elements.
-        Names.assign(TTR->getNumElements(), Identifier());
+        OS << "_";
       }
-      OS << "(";
-      // Print each element in the pattern match.
-      for (unsigned I = 0, N = Names.size(); I < N; I++) {
-        auto Id = Names[I];
-        if (Id.empty())
-          OS << "_";
-        else
-          OS << tok::kw_let << " " << Id.str();
-        if (I + 1 != N) {
-          OS << ", ";
-        }
+      if (i + 1 != PL->end()) {
+        OS << ", ";
       }
-      OS << ")";
     }
+    OS << ")";
   };
 
   // Print each enum element name.
   std::for_each(SortedElements.begin(), SortedElements.end(),
                 [&](EnumElementDecl *EE) {
                   OS << tok::kw_case << " ." << EE->getNameStr();
-                  printPayloads(EE, OS);
+                  printPayloads(EE->getParameterList(), OS);
                   OS << ": " << getCodePlaceholder() << "\n";
                 });
 }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -349,10 +349,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitEnumElementDecl(EnumElementDecl *ED) {
-    if (auto TR = ED->getArgumentTypeLoc().getTypeRepr()) {
-      if (doIt(TR)) {
-        return true;
-      }
+    if (auto *PL = ED->getParameterList()) {
+      visit(PL);
     }
 
     // The getRawValueExpr should remain the untouched original LiteralExpr for

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4681,11 +4681,17 @@ ParamDecl *AbstractFunctionDecl::getImplicitSelfDecl() {
 }
 
 std::pair<DefaultArgumentKind, Type>
-AbstractFunctionDecl::getDefaultArg(unsigned Index) const {
-  auto paramLists = getParameterLists();
+swift::getDefaultArgumentInfo(ValueDecl *source, unsigned Index) {
+  ArrayRef<const ParameterList *> paramLists;
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(source)) {
+    paramLists = AFD->getParameterLists();
 
-  if (getImplicitSelfDecl()) // Skip the 'self' parameter; it is not counted.
-    paramLists = paramLists.slice(1);
+    // Skip the 'self' parameter; it is not counted.
+    if (AFD->getImplicitSelfDecl())
+      paramLists = paramLists.slice(1);
+  } else {
+    paramLists = cast<EnumElementDecl>(source)->getParameterList();
+  }
 
   for (auto paramList : paramLists) {
     if (Index < paramList->size()) {
@@ -5277,8 +5283,8 @@ SourceRange FuncDecl::getSourceRange() const {
 SourceRange EnumElementDecl::getSourceRange() const {
   if (RawValueExpr && !RawValueExpr->isImplicit())
     return {getStartLoc(), RawValueExpr->getEndLoc()};
-  if (ArgumentType.hasLocation())
-    return {getStartLoc(), ArgumentType.getSourceRange().End};
+  if (auto *PL = getParameterList())
+    return {getStartLoc(), PL->getSourceRange().End};
   return {getStartLoc(), getNameLoc()};
 }
 
@@ -5297,8 +5303,9 @@ bool EnumElementDecl::computeType() {
   Type selfTy = MetatypeType::get(resultTy);
 
   // The type of the enum element is either (T) -> T or (T) -> ArgType -> T.
-  if (auto inputTy = getArgumentTypeLoc().getType()) {
-    resultTy = FunctionType::get(inputTy->mapTypeOutOfContext(), resultTy);
+  if (auto *PL = getParameterList()) {
+    auto paramTy = PL->getType(getASTContext());
+    resultTy = FunctionType::get(paramTy->mapTypeOutOfContext(), resultTy);
   }
 
   if (auto *genericSig = ED->getGenericSignatureOfContext())
@@ -5314,7 +5321,7 @@ bool EnumElementDecl::computeType() {
 }
 
 Type EnumElementDecl::getArgumentInterfaceType() const {
-  if (!Bits.EnumElementDecl.HasArgumentType)
+  if (!hasAssociatedValues())
     return nullptr;
 
   auto interfaceType = getInterfaceType();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1805,6 +1805,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   signature.IsInstanceMember = isInstanceMember();
   signature.IsProperty = isa<VarDecl>(this);
 
+  // Unary operators also include prefix/postfix.
   if (auto func = dyn_cast<FuncDecl>(this)) {
     if (func->isUnaryOperator()) {
       signature.UnaryOperator = func->getAttrs().getUnaryOperatorKind();
@@ -1842,11 +1843,10 @@ CanType ValueDecl::getOverloadSignatureType() const {
                                       funcTy->getExtInfo())
               ->getCanonicalType();
     }
-
     return interfaceType;
-  }
-
-  if (isa<VarDecl>(this)) {
+  } else if (isa<EnumElementDecl>(this)) {
+    return getInterfaceType()->getCanonicalType();
+  } else if (isa<VarDecl>(this)) {
     // If the variable declaration occurs within a generic extension context,
     // consider the generic signature of the extension.
     auto ext = dyn_cast<ExtensionDecl>(getDeclContext());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4509,12 +4509,13 @@ void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
   DefaultValueAndIsVariadic.getPointer()->InitContext = initContext;
 }
 
-void DefaultArgumentInitializer::changeFunction(AbstractFunctionDecl *parent) {
-  assert(parent->isLocalContext());
-  setParent(parent);
+void DefaultArgumentInitializer::changeFunction(DeclContext *parent, MutableArrayRef<ParameterList *> paramLists) {
+  if (parent->isLocalContext()) {
+    setParent(parent);
+  }
 
   unsigned offset = getIndex();
-  for (auto list : parent->getParameterLists()) {
+  for (auto list : paramLists) {
     if (offset < list->size()) {
       auto param = list->get(offset);
       if (param->getDefaultValue())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4682,18 +4682,8 @@ ParamDecl *AbstractFunctionDecl::getImplicitSelfDecl() {
 }
 
 std::pair<DefaultArgumentKind, Type>
-swift::getDefaultArgumentInfo(ValueDecl *source, unsigned Index) {
-  ArrayRef<const ParameterList *> paramLists;
-  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(source)) {
-    paramLists = AFD->getParameterLists();
-
-    // Skip the 'self' parameter; it is not counted.
-    if (AFD->getImplicitSelfDecl())
-      paramLists = paramLists.slice(1);
-  } else {
-    paramLists = cast<EnumElementDecl>(source)->getParameterList();
-  }
-
+swift::getDefaultArgumentInfo(ArrayRef<const ParameterList *> paramLists,
+                              unsigned Index) {
   for (auto paramList : paramLists) {
     if (Index < paramList->size()) {
       auto param = paramList->get(Index);

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -333,6 +333,9 @@ ResilienceExpansion DeclContext::getResilienceExpansion() const {
     // Default argument initializer contexts have their resilience expansion
     // set when they're type checked.
     if (isa<DefaultArgumentInitializer>(dc)) {
+      if (auto *ED = dyn_cast<EnumDecl>(dc->getParent())) {
+        return ED->getResilienceExpansion();
+      }
       return cast<AbstractFunctionDecl>(dc->getParent())
           ->getDefaultArgumentResilienceExpansion();
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -747,12 +747,15 @@ void swift::computeDefaultMap(Type type, const ValueDecl *paramOwner,
   // Find the corresponding parameter list.
   const ParameterList *paramList = nullptr;
   if (paramOwner) {
-    if (auto func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
+    if (auto *func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
       if (level < func->getNumParameterLists())
         paramList = func->getParameterList(level);
-    } else if (auto subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
+    } else if (auto *subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
       if (level == 1)
         paramList = subscript->getIndices();
+    } else if (auto *enumElement = dyn_cast<EnumElementDecl>(paramOwner)) {
+      if (level == 1)
+        paramList = enumElement->getParameterList();
     }
   }
   

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5467,7 +5467,7 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
     rawValueExpr->setNegative(SourceLoc());
 
   auto element = Impl.createDeclWithClangNode<EnumElementDecl>(
-      decl, AccessLevel::Public, SourceLoc(), name, TypeLoc(), false,
+      decl, AccessLevel::Public, SourceLoc(), name, nullptr,
       SourceLoc(), rawValueExpr, theEnum);
 
   // Give the enum element the appropriate type.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2785,8 +2785,8 @@ public:
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(EED->getName().str());
-    if (auto argTy = EED->getArgumentInterfaceType())
-      addPatternFromType(Builder, argTy);
+    if (auto *params = EED->getParameterList())
+      addParameters(Builder, params);
 
     // Enum element is of function type such as EnumName.type -> Int ->
     // EnumName; however we should show Int -> EnumName as the type

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2785,8 +2785,11 @@ public:
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(EED->getName().str());
-    if (auto *params = EED->getParameterList())
+    if (auto *params = EED->getParameterList()) {
+      Builder.addLeftParen();
       addParameters(Builder, params);
+      Builder.addRightParen();
+    }
 
     // Enum element is of function type such as EnumName.type -> Int ->
     // EnumName; however we should show Int -> EnumName as the type

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -152,6 +152,14 @@ private:
     // add an empty range for the local name, or for the decl argument label if
     // IsCollapsible is false.
     StringRef Content = Range.str();
+    if (Content.empty()) {
+      // We can have nothing in the original range if we're trying to rename
+      // a previously nameless enum argument.  This rename behaves like a
+      // rename for a call argument in that case.
+      doRenameLabel(Range, RefactoringRangeKind::CallArgumentCombined, NameIndex);
+      return;
+    }
+
     size_t ExternalNameEnd = Content.find_first_of(" \t\n\v\f\r/");
 
     if (ExternalNameEnd == StringRef::npos) { // foo([a]: Int)

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -373,21 +373,10 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
     tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::NoncollapsibleParam,
                getLabelRanges(SD->getIndices(), getSourceMgr()));
   } else if (EnumElementDecl *EED = dyn_cast<EnumElementDecl>(D)) {
-    if (TupleTypeRepr *TTR = dyn_cast_or_null<TupleTypeRepr>(EED->getArgumentTypeLoc().getTypeRepr())) {
-      size_t ElemIndex = 0;
-      std::vector<CharSourceRange> LabelRanges;
-      for(const TupleTypeReprElement &Elem: TTR->getElements()) {
-        SourceLoc LabelStart(Elem.Type->getStartLoc());
-        SourceLoc LabelEnd(LabelStart);
-
-        auto NameIdentifier = TTR->getElementName(ElemIndex);
-        if (!NameIdentifier.empty()) {
-          LabelStart = TTR->getElementNameLoc(ElemIndex);
-        }
-        LabelRanges.push_back(CharSourceRange(getSourceMgr(), LabelStart, LabelEnd));
-        ++ElemIndex;
-      }
-      tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::CallArg, LabelRanges);
+    if (auto *ParamList = EED->getParameterList()) {
+      auto LabelRanges = getLabelRanges(ParamList, getSourceMgr());
+      tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::CallArg,
+                 LabelRanges);
     } else {
       tryResolve(ASTWalker::ParentTy(D), D->getLoc());
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -316,9 +316,13 @@ static std::vector<CharSourceRange> getLabelRanges(const ParameterList* List, co
     if (NameLoc.isValid()) {
       LabelRanges.push_back(Lexer::getCharSourceRangeFromSourceRange(SM,
                                                                      SourceRange(NameLoc, ParamLoc)));
-    } else {
+    } else if (ParamLoc.isValid()) {
       NameLoc = ParamLoc;
       NameLength = Param->getNameStr().size();
+      LabelRanges.push_back(CharSourceRange(NameLoc, NameLength));
+    } else {
+      NameLoc = Param->getTypeLoc().getLoc();
+      NameLength = 0;
       LabelRanges.push_back(CharSourceRange(NameLoc, NameLength));
     }
   }
@@ -375,7 +379,7 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
   } else if (EnumElementDecl *EED = dyn_cast<EnumElementDecl>(D)) {
     if (auto *ParamList = EED->getParameterList()) {
       auto LabelRanges = getLabelRanges(ParamList, getSourceMgr());
-      tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::CallArg,
+      tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::Param,
                  LabelRanges);
     } else {
       tryResolve(ASTWalker::ParentTy(D), D->getLoc());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5428,14 +5428,14 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     }
 
     // See if there's a following argument type.
-    ParserResult<ParameterList> ArgType;
+    ParserResult<ParameterList> ArgParams;
     SmallVector<Identifier, 4> argumentNames;
     if (Tok.isFollowingLParen()) {
       DefaultArgumentInfo DefaultArgs(/*inTypeContext*/true);
-      ArgType = parseSingleParameterClause(ParameterContextKind::EnumElement,
+      ArgParams = parseSingleParameterClause(ParameterContextKind::EnumElement,
                                            &argumentNames, &DefaultArgs);
-      if (ArgType.isNull() || ArgType.hasCodeCompletion())
-        return ParserStatus(ArgType);
+      if (ArgParams.isNull() || ArgParams.hasCodeCompletion())
+        return ParserStatus(ArgParams);
     }
     
     // See if there's a raw value expression.
@@ -5487,9 +5487,16 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       return Status;
     }
     
+    
     // Create the element.
-    auto *result = new (Context) EnumElementDecl(NameLoc, Name,
-                                                 ArgType.getPtrOrNull(),
+    DeclName FullName;
+    if (ArgParams.isNull()) {
+      FullName = Name;
+    } else {
+      FullName = DeclName(Context, Name, argumentNames);
+    }
+    auto *result = new (Context) EnumElementDecl(NameLoc, FullName,
+                                                 ArgParams.getPtrOrNull(),
                                                  EqualsLoc,
                                                  LiteralRawValueExpr,
                                                  CurDeclContext);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -56,9 +56,9 @@ static DefaultArgumentKind getDefaultArgKind(Expr *init) {
   llvm_unreachable("Unhandled MagicIdentifierLiteralExpr in switch.");
 }
 
-void Parser::DefaultArgumentInfo::setFunctionContext(AbstractFunctionDecl *AFD){
+void Parser::DefaultArgumentInfo::setFunctionContext(DeclContext *DC, MutableArrayRef<ParameterList *> paramList){
   for (auto context : ParsedContexts) {
-    context->changeFunction(AFD);
+    context->changeFunction(DC, paramList);
   }
 }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -91,6 +91,7 @@ static ParserStatus parseDefaultArgument(Parser &P,
   case Parser::ParameterContextKind::Function:
   case Parser::ParameterContextKind::Operator:
   case Parser::ParameterContextKind::Initializer:
+  case Parser::ParameterContextKind::EnumElement:
     break;
   case Parser::ParameterContextKind::Closure:
     diagID = diag::no_default_arg_closure;
@@ -184,8 +185,9 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     unsigned defaultArgIndex = defaultArgs ? defaultArgs->NextIndex++ : 0;
 
     // Attributes.
-    bool FoundCCToken;
-    parseDeclAttributeList(param.Attrs, FoundCCToken);
+    bool FoundCCToken = false;
+    if (paramContext != ParameterContextKind::EnumElement)
+      parseDeclAttributeList(param.Attrs, FoundCCToken);
     if (FoundCCToken) {
       if (CodeCompletion) {
         CodeCompletion->completeDeclAttrKeyword(nullptr, isInSILMode(), true);
@@ -253,9 +255,10 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         param.SecondNameLoc = consumeToken();
       }
 
-      // Operators and closures cannot have API names.
+      // Operators, closures, and enum elements cannot have API names.
       if ((paramContext == ParameterContextKind::Operator ||
-           paramContext == ParameterContextKind::Closure) &&
+           paramContext == ParameterContextKind::Closure ||
+           paramContext == ParameterContextKind::EnumElement) &&
           !param.FirstName.empty() &&
           param.SecondNameLoc.isValid()) {
         diagnose(param.FirstNameLoc, diag::parameter_operator_keyword_argument,
@@ -289,7 +292,15 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                                                  tok::equal);
       }
 
-      if (isBareType) {
+      if (isBareType && paramContext == ParameterContextKind::EnumElement) {
+        auto type = parseType(diag::expected_parameter_type, false);
+        status |= type;
+        param.Type = type.getPtrOrNull();
+        param.FirstName = Identifier();
+        param.FirstNameLoc = SourceLoc();
+        param.SecondName = Identifier();
+        param.SecondNameLoc = SourceLoc();
+      } else if (isBareType) {
         // Otherwise, if this is a bare type, then the user forgot to name the
         // parameter, e.g. "func foo(Int) {}"
         SourceLoc typeStartLoc = Tok.getLoc();
@@ -469,6 +480,7 @@ mapParsedParameters(Parser &parser,
     case Parser::ParameterContextKind::Operator:
       isKeywordArgumentByDefault = false;
       break;
+    case Parser::ParameterContextKind::EnumElement:
     case Parser::ParameterContextKind::Curried:
     case Parser::ParameterContextKind::Initializer:
     case Parser::ParameterContextKind::Function:
@@ -538,7 +550,8 @@ mapParsedParameters(Parser &parser,
     if (param.DefaultArg) {
       assert((paramContext == Parser::ParameterContextKind::Function ||
               paramContext == Parser::ParameterContextKind::Operator ||
-              paramContext == Parser::ParameterContextKind::Initializer) &&
+              paramContext == Parser::ParameterContextKind::Initializer ||
+              paramContext == Parser::ParameterContextKind::EnumElement) &&
              "Default arguments are only permitted on the first param clause");
       result->setDefaultArgumentKind(getDefaultArgKind(param.DefaultArg));
       result->setDefaultValue(param.DefaultArg);
@@ -566,6 +579,9 @@ Parser::parseSingleParameterClause(ParameterContextKind paramContext,
     case ParameterContextKind::Function:
     case ParameterContextKind::Operator:
       diagID = diag::func_decl_without_paren;
+      break;
+    case ParameterContextKind::EnumElement:
+      diagID = diag::enum_element_decl_without_paren;
       break;
     case ParameterContextKind::Subscript:
       skipIdentifier = Tok.is(tok::identifier) &&

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -168,6 +168,21 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                                           SyntaxKind::FunctionParameterList);
     }
     rightParenLoc = consumeToken(tok::r_paren);
+
+    // Per SE-0155, enum elements may not have empty parameter lists.
+    // Diagnose and insert 'Void' where appropriate.
+    if (paramContext == ParameterContextKind::EnumElement) {
+      decltype(diag::enum_element_empty_arglist) diagnostic;
+      if (Context.isSwiftVersion3()) {
+        diagnostic = diag::enum_element_empty_arglist_swift3;
+      } else {
+        diagnostic = diag::enum_element_empty_arglist;
+      }
+
+      diagnose(leftParenLoc, diagnostic)
+        .highlight({leftParenLoc, rightParenLoc})
+        .fixItInsert(leftParenLoc, "Void");
+    }
     return ParserStatus();
   }
 

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -412,8 +412,14 @@ IsSerialized_t SILDeclRef::isSerialized() const {
     // Default argument generators are serialized if the function was
     // type-checked in Swift 4 mode.
     if (kind == SILDeclRef::Kind::DefaultArgGenerator) {
-      auto *afd = cast<AbstractFunctionDecl>(d);
-      switch (afd->getDefaultArgumentResilienceExpansion()) {
+      ResilienceExpansion expansion;
+      if (auto *EED = dyn_cast<EnumElementDecl>(d)) {
+        expansion = EED->getDefaultArgumentResilienceExpansion();
+      } else {
+        expansion = cast<AbstractFunctionDecl>(d)
+                        ->getDefaultArgumentResilienceExpansion();
+      }
+      switch (expansion) {
       case ResilienceExpansion::Minimal:
         return IsSerialized;
       case ResilienceExpansion::Maximal:
@@ -660,10 +666,8 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
 
   case SILDeclRef::Kind::DefaultArgGenerator:
     assert(!isCurried);
-    return mangler.mangleDefaultArgumentEntity(
-                                        cast<AbstractFunctionDecl>(getDecl()),
-                                        defaultArgIndex,
-                                        SKind);
+    return mangler.mangleDefaultArgumentEntity(getDecl(), defaultArgIndex,
+                                               SKind);
 
   case SILDeclRef::Kind::StoredPropertyInitializer:
     assert(!isCurried);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1968,8 +1968,9 @@ public:
               "EnumInst operand must be an object");
       SILType caseTy = UI->getType().getEnumElementType(UI->getElement(),
                                                         F.getModule());
-      if (UI->getModule().getStage() != SILStage::Lowered) {
-        require(caseTy == UI->getOperand()->getType(),
+      if (UI->getModule().getStage() != SILStage::Lowered
+          && !caseTy.is<SILBoxType>()) {
+        requireSameType(caseTy, UI->getOperand()->getType(),
                 "EnumInst operand type does not match type of case");
       }
     }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1722,14 +1722,16 @@ static CanAnyFunctionType getGlobalAccessorType(CanType varType) {
 /// Get the type of a default argument generator, () -> T.
 static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
                                                      TypeConverter &TC,
-                                                     AbstractFunctionDecl *AFD,
+                                                     ValueDecl *VD,
+                                                     DeclContext *DC,
                                                      unsigned DefaultArgIndex) {
-  auto resultTy = AFD->getDefaultArg(DefaultArgIndex).second;
+  auto resultTy = getDefaultArgumentInfo(VD, DefaultArgIndex).second;
   assert(resultTy && "Didn't find default argument?");
 
   // The result type might be written in terms of type parameters
   // that have been made fully concrete.
-  CanType canResultTy = resultTy->getCanonicalType(AFD->getGenericSignature());
+  CanType canResultTy = resultTy->getCanonicalType(
+                            DC->getGenericSignatureOfContext());
 
   // Remove @noescape from function return types. A @noescape
   // function return type is a contradiction.
@@ -1740,7 +1742,7 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
   }
 
   // Get the generic signature from the surrounding context.
-  auto funcInfo = TC.getConstantInfo(SILDeclRef(AFD));
+  auto funcInfo = TC.getConstantInfo(SILDeclRef(VD));
   return CanAnyFunctionType::get(funcInfo.FormalType.getOptGenericSignature(),
                                  TupleType::getEmpty(TC.Context),
                                  canResultTy);
@@ -1914,8 +1916,7 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     return getGlobalAccessorType(var->getInterfaceType()->getCanonicalType());
   }
   case SILDeclRef::Kind::DefaultArgGenerator:
-    return getDefaultArgGeneratorInterfaceType(*this,
-                                               cast<AbstractFunctionDecl>(vd),
+    return getDefaultArgGeneratorInterfaceType(*this, vd, vd->getDeclContext(),
                                                c.defaultArgIndex);
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return getStoredPropertyInitializerInterfaceType(*this,

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -225,9 +225,11 @@ public:
   bool isTuple() const & { return StoredKind == Kind::Tuple; }
   bool isTupleShuffleExpr() const & {
     if (StoredKind == Kind::Expr) {
-      if (auto *TSE = dyn_cast<TupleShuffleExpr>(asKnownExpr())) {
+      auto *e = asKnownExpr();
+      if (auto *TSE = dyn_cast<TupleShuffleExpr>(e)) {
         return llvm::any_of(TSE->getElementMapping(), [](const int &i) {
-          return i == TupleShuffleExpr::DefaultInitialize;
+          return i == TupleShuffleExpr::DefaultInitialize
+              || i == TupleShuffleExpr::CallerDefaultInitialize;
         });
       }
     }

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -223,18 +223,6 @@ public:
   bool isRValue() const & { return StoredKind == Kind::RValue; }
   bool isLValue() const & { return StoredKind == Kind::LValue; }
   bool isTuple() const & { return StoredKind == Kind::Tuple; }
-  bool isTupleShuffleExpr() const & {
-    if (StoredKind == Kind::Expr) {
-      auto *e = asKnownExpr();
-      if (auto *TSE = dyn_cast<TupleShuffleExpr>(e)) {
-        return llvm::any_of(TSE->getElementMapping(), [](const int &i) {
-          return i == TupleShuffleExpr::DefaultInitialize
-              || i == TupleShuffleExpr::CallerDefaultInitialize;
-        });
-      }
-    }
-    return false;
-  }
   
   /// Given that this source is storing an RValue, extract and clear
   /// that value.

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -223,7 +223,17 @@ public:
   bool isRValue() const & { return StoredKind == Kind::RValue; }
   bool isLValue() const & { return StoredKind == Kind::LValue; }
   bool isTuple() const & { return StoredKind == Kind::Tuple; }
-
+  bool isTupleShuffleExpr() const & {
+    if (StoredKind == Kind::Expr) {
+      if (auto *TSE = dyn_cast<TupleShuffleExpr>(asKnownExpr())) {
+        return llvm::any_of(TSE->getElementMapping(), [](const int &i) {
+          return i == TupleShuffleExpr::DefaultInitialize;
+        });
+      }
+    }
+    return false;
+  }
+  
   /// Given that this source is storing an RValue, extract and clear
   /// that value.
   RValue &&asKnownRValue(SILGenFunction &SGF) && {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -788,6 +788,9 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
 void SILGenModule::emitEnumConstructor(EnumElementDecl *decl) {
   // Enum element constructors are always emitted by need, so don't need
   // delayed emission.
+  if (auto params = decl->getParameterList())
+    emitDefaultArgGenerators(decl, params);
+
   SILDeclRef constant(decl);
   SILFunction *f = getFunction(constant, ForDefinition);
   preEmitFunction(constant, decl, f, decl);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3481,10 +3481,6 @@ public:
     extraSites.push_back(std::move(site));
   }
 
-  bool isArgTupleShuffle() const {
-    return ArgValue.isTupleShuffleExpr();
-  }
-  
   /// Add a level of function application by passing in its possibly
   /// unevaluated arguments and their formal type
   template<typename...T>
@@ -3637,12 +3633,6 @@ CallEmission::applyFirstLevelCallee(SGFContext C) {
 
   if (isPartiallyAppliedSuperMethod()) {
     return applyPartiallyAppliedSuperMethod(C);
-  }
-
-  if (isEnumElementConstructor() && !llvm::any_of(uncurriedSites, [](const CallSite &s){
-     return s.isArgTupleShuffle();
-   })) {
-    return applyEnumElementConstructor(C);
   }
 
   return applyNormalCall(C);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -110,6 +110,9 @@ DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
   case SILDeclRef::Kind::GlobalAccessor:
     return getMagicFunctionName(cast<VarDecl>(ref.getDecl())->getDeclContext());
   case SILDeclRef::Kind::DefaultArgGenerator:
+    if (auto *ED = dyn_cast<EnumElementDecl>(ref.getDecl())) {
+      return ED->getFullName();
+    }
     return getMagicFunctionName(cast<AbstractFunctionDecl>(ref.getDecl()));
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return getMagicFunctionName(cast<VarDecl>(ref.getDecl())->getDeclContext());

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4964,8 +4964,8 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
                     SourceLoc loc, ConcreteDeclRef &owner,
                     unsigned index) {
   auto &tc = cs.getTypeChecker();
-  auto ownerFn = cast<AbstractFunctionDecl>(owner.getDecl());
-  auto defArg = ownerFn->getDefaultArg(index);
+
+  auto defArg = getDefaultArgumentInfo(cast<ValueDecl>(owner.getDecl()), index);
   Expr *init = nullptr;
   switch (defArg.first) {
   case DefaultArgumentKind::None:
@@ -5025,7 +5025,8 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
   }
 
   // Convert the literal to the appropriate type.
-  auto defArgType = ownerFn->mapTypeIntoContext(defArg.second);
+  auto defArgType = owner.getDecl()->getDeclContext()
+                       ->mapTypeIntoContext(defArg.second);
   auto resultTy = tc.typeCheckExpression(
       init, dc, TypeLoc::withoutLoc(defArgType), CTP_CannotFail);
   assert(resultTy && "Conversion cannot fail");

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -596,6 +596,21 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         break;
 
       case CheckInput: {
+        if (auto *ED1 = dyn_cast<EnumElementDecl>(decl1)) {
+          if (auto *ED2 = dyn_cast<EnumElementDecl>(decl2)) {
+            assert(ED1->hasAssociatedValues() || ED2->hasAssociatedValues());
+
+            // If the first function has fewer effective parameters than the
+            // second, it is more specialized.
+            if (!ED1->hasAssociatedValues() && ED2->hasAssociatedValues())
+              return true;
+            if (ED1->hasAssociatedValues() && !ED2->hasAssociatedValues())
+              return false;
+
+            // Else, fall through to compare function type specialization.
+          }
+        }
+
         // Check whether the first function type's input is a subtype of the
         // second type's inputs, i.e., can we forward the arguments?
         auto funcTy1 = openedType1->castTo<FunctionType>();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -638,6 +638,9 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
       } else if (isa<SubscriptDecl>(decl)) {
         // Subscript level 1 == the indices.
         level = 1;
+      } else if (isa<EnumElementDecl>(decl)) {
+        // Enum element level 1 == the payload.
+        level = 1;
       }
     }
 

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -90,9 +90,11 @@ ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
       
       // The associated data of the case.
       if (level == 1) {
-        auto argTy = enumElt->getArgumentInterfaceType();
-        if (!argTy) return { };
-        gatherArgumentLabels(argTy, scratch);
+        auto *paramList = enumElt->getParameterList();
+        if (!paramList) return { };
+        for (auto param : *paramList) {
+          scratch.push_back(param->getArgumentName());
+        }
         return scratch;
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -786,8 +786,7 @@ static unsigned getNumRemovedArgumentLabels(TypeChecker &TC, ValueDecl *decl,
   unsigned numParameterLists = 0;
 
   // Enum element with associated value has to be treated
-  // as regular function value and all of the labels have to be
-  // stripped from its parameters.
+  // as regular function value.
   //
   // enum E {
   //   case foo(a: Int)

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -356,8 +356,7 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
     // TODO: Ensure the class doesn't already have or inherit a variable named
     // "`super`"; otherwise we will generate an invalid enum. In that case,
     // diagnose and bail.
-    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, TypeLoc(),
-                                          /*HasArgumentType=*/false,
+    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, nullptr,
                                           SourceLoc(), nullptr, enumDecl);
     super->setImplicit();
     enumDecl->addMember(super);
@@ -376,9 +375,8 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
       case Conforms:
       {
         auto *elt = new (C) EnumElementDecl(SourceLoc(), varDecl->getName(),
-                                            TypeLoc(),
-                                            /*HasArgumentType=*/false,
-                                            SourceLoc(), nullptr, enumDecl);
+                                            nullptr, SourceLoc(), nullptr,
+                                            enumDecl);
         elt->setImplicit();
         enumDecl->addMember(elt);
         break;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -235,7 +235,7 @@ public:
   void visitIndirectAttr(IndirectAttr *attr) {
     if (auto caseDecl = dyn_cast<EnumElementDecl>(D)) {
       // An indirect case should have a payload.
-      if (caseDecl->getArgumentTypeLoc().isNull())
+      if (!caseDecl->hasAssociatedValues())
         TC.diagnose(attr->getLocation(),
                     diag::indirect_case_without_payload, caseDecl->getName());
       // If the enum is already indirect, its cases don't need to be.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -429,11 +429,12 @@ public:
 
       // Can default parameter initializers capture state?  That seems like
       // a really bad idea.
-      for (auto *paramList : AFD->getParameterLists())
+      for (auto *paramList : AFD->getParameterLists()) {
         for (auto param : *paramList) {
           if (auto E = param->getDefaultValue())
             E->walk(*this);
         }
+      }
       return false;
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2334,7 +2334,7 @@ static void checkAccessControl(TypeChecker &TC, const Decl *D) {
                              [&](AccessScope typeAccessScope,
                                  const TypeRepr *complainRepr,
                                  DowngradeToWarning downgradeToWarning) {
-        auto typeAccess = typeAccessScope.accessibilityForDiagnostics();
+        auto typeAccess = typeAccessScope.accessLevelForDiagnostics();
         auto diagID = diag::enum_case_access;
         if (downgradeToWarning == DowngradeToWarning::Yes)
           diagID = diag::enum_case_access_warn;
@@ -4462,10 +4462,10 @@ public:
       }
       {
         // Check for duplicate enum members.
-        llvm::DenseMap<Identifier, EnumElementDecl *> Elements;
+        llvm::DenseMap<DeclName, EnumElementDecl *> Elements;
         bool hasErrors = false;
         for (auto *EED : ED->getAllElements()) {
-          auto Res = Elements.insert({ EED->getName(), EED });
+          auto Res = Elements.insert({ EED->getFullName(), EED });
           if (!Res.second) {
             EED->setInvalid();
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1700,7 +1700,9 @@ static void checkTypeAccess(
   if (isa<ParamDecl>(context)) {
     context = dyn_cast<AbstractFunctionDecl>(DC);
     if (!context)
-      context = cast<SubscriptDecl>(DC);
+      context = dyn_cast<SubscriptDecl>(DC);
+    if (!context)
+      context = cast<EnumDecl>(DC);
     DC = context->getDeclContext();
   }
 
@@ -2325,20 +2327,22 @@ static void checkAccessControl(TypeChecker &TC, const Decl *D) {
   case DeclKind::EnumElement: {
     auto EED = cast<EnumElementDecl>(D);
 
-    if (!EED->getArgumentTypeLoc().getType())
+    if (!EED->hasAssociatedValues())
       return;
-    checkTypeAccess(TC, EED->getArgumentTypeLoc(), EED,
-                    [&](AccessScope typeAccessScope,
-                        const TypeRepr *complainRepr,
-                        DowngradeToWarning downgradeToWarning) {
-      auto typeAccess = typeAccessScope.accessLevelForDiagnostics();
-      auto diagID = diag::enum_case_access;
-      if (downgradeToWarning == DowngradeToWarning::Yes)
-        diagID = diag::enum_case_access_warn;
-      auto diag = TC.diagnose(EED, diagID,
-                              EED->getFormalAccess(), typeAccess);
-      highlightOffendingType(TC, diag, complainRepr);
-    });
+    for (auto &P : *EED->getParameterList()) {
+      checkTypeAccess(TC, P->getTypeLoc(), P,
+                             [&](AccessScope typeAccessScope,
+                                 const TypeRepr *complainRepr,
+                                 DowngradeToWarning downgradeToWarning) {
+        auto typeAccess = typeAccessScope.accessibilityForDiagnostics();
+        auto diagID = diag::enum_case_access;
+        if (downgradeToWarning == DowngradeToWarning::Yes)
+          diagID = diag::enum_case_access_warn;
+        auto diag = TC.diagnose(EED, diagID,
+                                EED->getFormalAccess(), typeAccess);
+        highlightOffendingType(TC, diag, complainRepr);
+      });
+    }
 
     return;
   }
@@ -6934,13 +6938,19 @@ public:
       EED->setRecursiveness(ElementRecursiveness::PotentiallyRecursive);
       
       validateAttributes(TC, EED);
-      
-      if (!EED->getArgumentTypeLoc().isNull()) {
-        if (TC.validateType(EED->getArgumentTypeLoc(), EED->getDeclContext(),
-                            TypeResolutionFlags::EnumCase)) {
+
+      if (auto *PL = EED->getParameterList()) {
+        GenericTypeToArchetypeResolver resolver(EED->getParentEnum());
+
+        bool isInvalid
+          = TC.typeCheckParameterList(PL, EED->getParentEnum(),
+                                      TypeResolutionFlags::EnumCase, resolver);
+
+        if (isInvalid || EED->isInvalid()) {
           EED->setInterfaceType(ErrorType::get(TC.Context));
           EED->setInvalid();
-          return;
+        } else {
+          TC.checkDefaultArguments(PL, EED);
         }
       }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1231,12 +1231,12 @@ recur:
 
       // If the tuple pattern had a label for the tuple element, it must match
       // the label for the tuple type being matched.
-      if (!hadError && !tupleTy->getElement(i).getName().empty() &&
-          elt.getLabel() != tupleTy->getElement(i).getName()) {
-        diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
-                 elt.getLabel(), tupleTy->getElement(i).getName());
-        hadError = true;
-      }
+//      if (!hadError && !tupleTy->getElement(i).getName().empty() &&
+//          elt.getLabel() != tupleTy->getElement(i).getName()) {
+//        diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+//                 elt.getLabel(), tupleTy->getElement(i).getName());
+//        hadError = true;
+//      }
       
       hadError |= coercePatternToType(pattern, dc, CoercionType,
                                       options, resolver);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -68,14 +68,19 @@ extractEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
   return dyn_cast<EnumElementDecl>(ctorExpr->getDecl());
 }
 
-/// Find the first enum element in \p foundElements.
+/// Filter the most relevant enum elements from a lookup into an out vector.
 ///
 /// If there are no enum elements but there are properties, attempts to map
 /// an arbitrary property to an enum element using extractEnumElement.
-static EnumElementDecl *
+///
+/// This function returns true if there are no matching elements, and false if
+/// there are one or more matching element decls.  Note that if there is
+/// more than one element in the out parameter it indicates an ambiguity.
+static bool
 filterForEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
-                     bool unqualifiedLookup, LookupResult foundElements) {
-  EnumElementDecl *foundElement = nullptr;
+                     DeclName elemName,
+                     bool unqualifiedLookup, LookupResult foundElements,
+                     SmallVectorImpl<EnumElementDecl *> &filteredDecls) {
   VarDecl *foundConstant = nullptr;
 
   for (LookupResultEntry result : foundElements) {
@@ -93,10 +98,19 @@ filterForEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
     }
 
     if (auto *oe = dyn_cast<EnumElementDecl>(e)) {
-      // Ambiguities should be ruled out by parsing.
-      assert(!foundElement && "ambiguity in enum case name lookup?!");
-      foundElement = oe;
-      continue;
+      // Break ambiguities between decls with similar base names as in:
+      //
+      // enum Foo { case bar; case bar(x: Int) }
+      //
+      // by preferring matching the base name to an element with no associated
+      // values if we can find it.
+      if (elemName.getArgumentNames().empty() && !oe->hasAssociatedValues()) {
+        filteredDecls.clear();
+        filteredDecls.push_back(oe);
+        return false;
+      }
+
+      filteredDecls.push_back(oe);
     }
 
     if (auto *var = dyn_cast<VarDecl>(e)) {
@@ -105,37 +119,41 @@ filterForEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
     }
   }
 
-  if (!foundElement && foundConstant && foundConstant->hasClangNode())
-    foundElement = extractEnumElement(TC, DC, UseLoc, foundConstant);
+  if (filteredDecls.empty() && foundConstant && foundConstant->hasClangNode()) {
+    if (auto *foundElement = extractEnumElement(TC, DC, UseLoc, foundConstant))
+      filteredDecls.push_back(foundElement);
+  }
 
-  return foundElement;
+  return filteredDecls.empty();
 }
 
 /// Find an unqualified enum element.
-static EnumElementDecl *
+static bool
 lookupUnqualifiedEnumMemberElement(TypeChecker &TC, DeclContext *DC,
-                                   Identifier name, SourceLoc UseLoc) {
+                                   Identifier name, SourceLoc UseLoc,
+                                   SmallVectorImpl<EnumElementDecl *> &fds) {
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   lookupOptions |= NameLookupFlags::KnownPrivate;
   auto lookup = TC.lookupUnqualified(DC, name, SourceLoc(), lookupOptions);
-  return filterForEnumElement(TC, DC, UseLoc,
-                              /*unqualifiedLookup=*/true, lookup);
+  return filterForEnumElement(TC, DC, UseLoc, name,
+                              /*unqualifiedLookup=*/true, lookup, fds);
 }
 
 /// Find an enum element in an enum type.
-static EnumElementDecl *
+static bool
 lookupEnumMemberElement(TypeChecker &TC, DeclContext *DC, Type ty,
-                        Identifier name, SourceLoc UseLoc) {
+                        DeclName name, SourceLoc UseLoc,
+                        SmallVectorImpl<EnumElementDecl *> &fds) {
   if (!ty->mayHaveMembers())
-    return nullptr;
+    return true;
 
   // Look up the case inside the enum.
   // FIXME: We should be able to tell if this is a private lookup.
   NameLookupOptions lookupOptions
     = defaultMemberLookupOptions - NameLookupFlags::DynamicLookup;
   LookupResult foundElements = TC.lookupMember(DC, ty, name, lookupOptions);
-  return filterForEnumElement(TC, DC, UseLoc,
-                              /*unqualifiedLookup=*/false, foundElements);
+  return filterForEnumElement(TC, DC, UseLoc, name,
+                              /*unqualifiedLookup=*/false, foundElements, fds);
 }
 
 namespace {
@@ -471,10 +489,13 @@ public:
       return nullptr;
 
     // FIXME: Argument labels?
-    EnumElementDecl *referencedElement
-      = lookupEnumMemberElement(TC, DC, ty, ude->getName().getBaseIdentifier(),
-                                ude->getLoc());
-    if (!referencedElement)
+    SmallVector<EnumElementDecl *, 2> referencedElements;
+    if (lookupEnumMemberElement(TC, DC, ty, ude->getName().getBaseIdentifier(),
+                                ude->getLoc(), referencedElements))
+      return nullptr;
+
+    // If there were any ambiguities, bail.
+    if (referencedElements.size() > 1)
       return nullptr;
     
     // Build a TypeRepr from the head of the full path.
@@ -487,7 +508,7 @@ public:
                                                  .getBaseNameLoc(),
                                                ude->getName()
                                                  .getBaseIdentifier(),
-                                               referencedElement,
+                                               referencedElements.front(),
                                                nullptr);
   }
   
@@ -512,25 +533,26 @@ public:
     // rdar://20879992 is addressed.
     //
     // Try looking up an enum element in context.
-    if (EnumElementDecl *referencedElement
-        = lookupUnqualifiedEnumMemberElement(TC, DC,
-                                             ude->getName().getBaseIdentifier(),
-                                             ude->getLoc())) {
-      auto *enumDecl = referencedElement->getParentEnum();
-      auto enumTy = enumDecl->getDeclaredTypeInContext();
-      TypeLoc loc = TypeLoc::withoutLoc(enumTy);
-      
-      return new (TC.Context) EnumElementPattern(loc, SourceLoc(),
-                                                 ude->getLoc(),
-                                                 ude->getName()
-                                                   .getBaseIdentifier(),
-                                                 referencedElement,
-                                                 nullptr);
+    SmallVector<EnumElementDecl *, 2> referencedElements;
+    if (lookupUnqualifiedEnumMemberElement(TC, DC,
+                                           ude->getName().getBaseIdentifier(),
+                                           ude->getLoc(), referencedElements)
+        || referencedElements.size() > 1) {
+      // Perform unqualified name lookup to find out what the UDRE is.
+      return getSubExprPattern(TC.resolveDeclRefExpr(ude, DC));
     }
-      
-    
-    // Perform unqualified name lookup to find out what the UDRE is.
-    return getSubExprPattern(TC.resolveDeclRefExpr(ude, DC));
+
+    auto referencedElement = referencedElements.front();
+    auto *enumDecl = referencedElement->getParentEnum();
+    auto enumTy = enumDecl->getDeclaredTypeInContext();
+    TypeLoc loc = TypeLoc::withoutLoc(enumTy);
+
+    return new (TC.Context) EnumElementPattern(loc, SourceLoc(),
+                                               ude->getLoc(),
+                                               ude->getName()
+                                               .getBaseIdentifier(),
+                                               referencedElement,
+                                               nullptr);
   }
   
   // Call syntax forms a pattern if:
@@ -566,13 +588,16 @@ public:
 
     if (components.empty()) {
       // Only one component. Try looking up an enum element in context.
-      referencedElement
-        = lookupUnqualifiedEnumMemberElement(TC, DC,
+      SmallVector<EnumElementDecl *, 2> referencedElements;
+      if (lookupUnqualifiedEnumMemberElement(TC, DC,
                                              tailComponent->getIdentifier(),
-                                             tailComponent->getLoc());
-      if (!referencedElement)
+                                             tailComponent->getLoc(),
+                                             referencedElements)
+          || referencedElements.size() > 1) {
         return nullptr;
+      }
 
+      referencedElement = referencedElements.front();
       auto *enumDecl = referencedElement->getParentEnum();
       loc = TypeLoc::withoutLoc(enumDecl->getDeclaredTypeInContext());
     } else {
@@ -587,13 +612,16 @@ public:
       if (!dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal()))
         return nullptr;
 
-      referencedElement
-        = lookupEnumMemberElement(TC, DC, enumTy,
+      SmallVector<EnumElementDecl *, 2> referencedElements;
+      if (lookupEnumMemberElement(TC, DC, enumTy,
                                   tailComponent->getIdentifier(),
-                                  tailComponent->getLoc());
-      if (!referencedElement)
-        return nullptr;
+                                  tailComponent->getLoc(),
+                                  referencedElements)
+          || referencedElements.size() > 1) {
+          return nullptr;
+      }
 
+      referencedElement = referencedElements.front();
       loc = TypeLoc(prefixRepr);
       loc.setType(enumTy);
     }
@@ -1020,6 +1048,22 @@ recur:
   // For parens and vars, just set the type annotation and propagate inwards.
   case PatternKind::Paren: {
     auto PP = cast<ParenPattern>(P);
+    // Paren Patterns may not match enum payloads when not in Swift 3 mode.
+    if ((options & TR_EnumPatternPayload) && type->is<TupleType>() && !PP->isImplicit()) {
+      if (Context.isSwiftVersion3()) {
+        diagnose(PP->getStartLoc(),
+                 diag::paren_pattern_in_tuple_context_warn_swift3, type)
+          .highlight(PP->getSourceRange());
+
+        // Fall through to old pattern matching behavior
+      } else {
+        diagnose(PP->getStartLoc(), diag::paren_pattern_in_tuple_context,
+                 type)
+          .highlight(PP->getSourceRange());
+        return true;
+      }
+    }
+
     auto sub = PP->getSubPattern();
     auto semantic = P->getSemanticsProvidingPattern();
     // If this is the payload of an enum, and the type is a single-element
@@ -1193,32 +1237,16 @@ recur:
     // Coerce each tuple element to the respective type.
     P->setType(type);
 
-    enum MatchingStrategy_t {
-      NoStrategy,
-      ByTypeLabel,
-      ByVariableName,
-      ByTypeLabelMismatch,
-      ByVariableNameMismatch,
+    enum class TuplePatternMatchStrategy {
+      None,
+      Swift3,
+      ByPosition,
+      ByLabels,
     };
 
-    auto deriveStrategy = [](const TuplePatternElt &patternElt, const TupleTypeElt &typeElt) {
-      if (!typeElt.getName().empty()) {
-        if (patternElt.getLabel() == typeElt.getName())
-          return ByTypeLabel;
-        else
-          return ByTypeLabelMismatch;
-      }
-
-      if (auto *VP = dyn_cast<VarPattern>(patternElt.getPattern())) {
-        if (VP->getBoundName() == typeElt.getName())
-          return ByVariableName;
-        else
-          return ByVariableNameMismatch;
-      }
-
-      return NoStrategy;
-    };
-
+    auto strategy = //Context.isSwiftVersion3()
+                /*?*/ TuplePatternMatchStrategy::Swift3;
+                  //: TuplePatternMatchStrategy::None;
     for (unsigned i = 0, e = TP->getNumElements(); i != e; ++i) {
       TuplePatternElt &elt = TP->getElement(i);
       Pattern *pattern = elt.getPattern();
@@ -1229,15 +1257,76 @@ recur:
       else
         CoercionType = tupleTy->getElement(i).getType();
 
-      // If the tuple pattern had a label for the tuple element, it must match
-      // the label for the tuple type being matched.
-//      if (!hadError && !tupleTy->getElement(i).getName().empty() &&
-//          elt.getLabel() != tupleTy->getElement(i).getName()) {
-//        diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
-//                 elt.getLabel(), tupleTy->getElement(i).getName());
-//        hadError = true;
-//      }
-      
+      if (strategy == TuplePatternMatchStrategy::Swift3) {
+        // If the tuple pattern had a label for the tuple element, it must match
+        // the label for the tuple type being matched.
+        //
+        // N.B. Swift <=3 has the source of truth regarding the labels
+        // backwards.  This allows e.g. patterns without labels to match a
+        // value of labeled tuple type.
+        if (!hadError && !elt.getLabel().empty() &&
+            elt.getLabel() != tupleTy->getElement(i).getName()) {
+          diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+                   elt.getLabel(), tupleTy->getElement(i).getName());
+          hadError = true;
+        }
+      } else {
+        // If the type has no label here but the pattern does, complain.
+        if (!tupleTy->getElement(i).hasName() && !elt.getLabel().empty()) {
+          diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+                   elt.getLabel(), tupleTy->getElement(i).getName());
+          hadError = true;
+        } else if (tupleTy->getElement(i).hasName() && elt.getLabel().empty()) {
+          // If the type has a label but the pattern doesn't, we had better
+          // be matching this pattern by position.
+          switch (strategy) {
+          case TuplePatternMatchStrategy::None:
+          case TuplePatternMatchStrategy::ByPosition:
+            strategy = TuplePatternMatchStrategy::ByPosition;
+            break;
+          case TuplePatternMatchStrategy::ByLabels: {
+            diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+                     elt.getLabel(), tupleTy->getElement(i).getName());
+            hadError = true;
+          }
+            break;
+
+          case TuplePatternMatchStrategy::Swift3:
+            llvm_unreachable("should have handled Swift 3 matching already");
+          }
+        } else if (tupleTy->getElement(i).hasName() && !elt.getLabel().empty()) {
+          // If the type has a label and the pattern does too, we had
+          // better be matching this pattern by label:
+          switch (strategy) {
+          case TuplePatternMatchStrategy::None:
+          case TuplePatternMatchStrategy::ByLabels: {
+            strategy = TuplePatternMatchStrategy::ByLabels;
+
+            // Check if the label matches.
+            if (tupleTy->getElement(i).getName() != elt.getLabel()) {
+              diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+                       elt.getLabel(), tupleTy->getElement(i).getName());
+              hadError = true;
+            }
+          }
+            break;
+          case TuplePatternMatchStrategy::ByPosition: {
+            diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_missing,
+                     tupleTy->getElement(i).getName());
+            hadError = true;
+          }
+          break;
+
+          case TuplePatternMatchStrategy::Swift3:
+            llvm_unreachable("should have handled Swift 3 matching already");
+          }
+        } else {
+          // Finally, if the type has no label and the pattern has no label,
+          // then they match and we can't make a judgement call yet as to the
+          // matching strategy.  Continue onward.
+        }
+      }
+
       hadError |= coercePatternToType(pattern, dc, CoercionType,
                                       options, resolver);
       if (!hadError)
@@ -1381,12 +1470,23 @@ recur:
     Optional<CheckedCastKind> castKind;
     
     EnumElementDecl *elt = EEP->getElementDecl();
-    
     Type enumTy;
     if (!elt) {
-      elt = lookupEnumMemberElement(*this, dc, type, EEP->getName(),
-                                    EEP->getLoc());
-      if (!elt) {
+      SmallVector<Identifier, 4> components;
+      DeclName lookupName = EEP->getName();
+      if (EEP->hasSubPattern() && !Context.isSwiftVersion3()) {
+        /// Gather any argument names so we can perform lookup with a full name.
+        if (auto *ArgP = dyn_cast<TuplePattern>(EEP->getSubPattern())) {
+          for (auto &comp : ArgP->getElements()) {
+            components.push_back(comp.getLabel());
+          }
+         lookupName = DeclName(Context, EEP->getName(), components);
+        }
+      }
+
+      SmallVector<EnumElementDecl *, 2> candidateElements;
+      if (lookupEnumMemberElement(*this, dc, type, lookupName,
+                                  EEP->getLoc(), candidateElements)) {
         if (!type->hasError()) {
           // Lowercasing of Swift.Optional's cases is handled in the
           // standard library itself, not through the clang importer,
@@ -1422,12 +1522,27 @@ recur:
           // If we have an optional type let's try to see if the case
           // exists in its base type, if so we can suggest a fix-it for that.
           if (auto baseType = type->getOptionalObjectType()) {
-            if (lookupEnumMemberElement(*this, dc, baseType, EEP->getName(),
-                                        EEP->getLoc()))
+            SmallVector<EnumElementDecl *, 2> scratch;
+            if (!lookupEnumMemberElement(*this, dc, baseType, EEP->getName(),
+                                         EEP->getLoc(), scratch))
               diag.fixItInsertAfter(EEP->getEndLoc(), "?");
           }
         }
         return true;
+      } else {
+        // Validate the candidates.
+        if (candidateElements.size() == 1) {
+          elt = candidateElements.front();
+        } else {
+          assert(candidateElements.size() > 1);
+          diagnose(EEP->getLoc(), diag::ambiguous_enum_element_in_pattern,
+                   EEP->getName());
+          for (auto &eed : candidateElements) {
+            diagnose(eed->getLoc(), diag::ambiguous_enum_element_candidate,
+                     eed->getFullName());
+          }
+          return true;
+        }
       }
       enumTy = type;
     } else {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -207,7 +207,7 @@ static void setAutoClosureDiscriminators(DeclContext *DC, Stmt *S) {
   S->walk(ContextualizeClosures(DC));
 }
 
-bool TypeChecker::contextualizeInitializer(Initializer *DC, Expr *E) {
+bool TypeChecker::contextualizeInitializer(DeclContext *DC, Expr *E) {
   ContextualizeClosures CC(DC);
   E->walk(CC);
   return CC.hasAutoClosures();
@@ -1354,7 +1354,7 @@ static void checkDefaultArguments(TypeChecker &tc,
     if (!param->getDefaultValue() || !param->hasType() ||
         param->getType()->hasError())
       continue;
-    
+
     Expr *e = param->getDefaultValue();
     auto initContext = param->getDefaultArgumentInitContext();
 
@@ -1377,21 +1377,23 @@ static void checkDefaultArguments(TypeChecker &tc,
 }
 
 /// Check the default arguments that occur within this pattern.
-static void checkDefaultArguments(TypeChecker &tc,
-                                  AbstractFunctionDecl *func) {
+void TypeChecker::checkDefaultArguments(ArrayRef<ParameterList *> paramLists,
+                                        ValueDecl *VD) {
   // In Swift 4 mode, default argument bodies are inlined into the
   // caller.
-  auto expansion = func->getResilienceExpansion();
-  if (!tc.Context.isSwiftVersion3() &&
-      func->getFormalAccessScope(/*useDC=*/nullptr,
-                                 /*respectVersionedAttr=*/true).isPublic())
-    expansion = ResilienceExpansion::Minimal;
+  if (auto *func = dyn_cast<AbstractFunctionDecl>(VD)) {
+    auto expansion = func->getResilienceExpansion();
+    if (!Context.isSwiftVersion3() &&
+        func->getFormalAccessScope(/*useDC=*/nullptr,
+                                   /*respectVersionedAttr=*/true).isPublic())
+      expansion = ResilienceExpansion::Minimal;
 
-  func->setDefaultArgumentResilienceExpansion(expansion);
+    func->setDefaultArgumentResilienceExpansion(expansion);
+  }
 
   unsigned nextArgIndex = 0;
-  for (auto paramList : func->getParameterLists())
-    checkDefaultArguments(tc, paramList, nextArgIndex, func);
+  for (auto *paramList : paramLists)
+    checkDefaultArguments(*this, paramList, nextArgIndex, func);
 }
 
 bool TypeChecker::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
@@ -1436,7 +1438,8 @@ bool TypeChecker::typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD) {
 // named function or an anonymous func expression.
 bool TypeChecker::typeCheckFunctionBodyUntil(FuncDecl *FD,
                                              SourceLoc EndTypeCheckLoc) {
-  checkDefaultArguments(*this, FD);
+  // Check the default argument definitions.
+  checkDefaultArguments(FD->getParameterLists(), FD);
 
   // Clang imported inline functions do not have a Swift body to
   // typecheck.
@@ -1540,7 +1543,8 @@ static bool isKnownEndOfConstructor(ASTNode N) {
 
 bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
                                                 SourceLoc EndTypeCheckLoc) {
-  checkDefaultArguments(*this, ctor);
+  // Check the default argument definitions.
+  checkDefaultArguments(ctor->getParameterLists(), ctor);
 
   BraceStmt *body = ctor->getBody();
   if (!body)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1391,9 +1391,10 @@ void TypeChecker::checkDefaultArguments(ArrayRef<ParameterList *> paramLists,
   } else {
     auto *EED = cast<EnumElementDecl>(VD);
     auto expansion = EED->getParentEnum()->getResilienceExpansion();
-    if (!Context.isSwiftVersion3() &&
+    // Enum payloads parameter lists may have default arguments as of Swift 5.
+    if (Context.isSwiftVersionAtLeast(5) &&
         EED->getFormalAccessScope(/*useDC=*/nullptr,
-                                   /*respectVersionedAttr=*/true).isPublic())
+                                  /*respectVersionedAttr=*/true).isPublic())
       expansion = ResilienceExpansion::Minimal;
 
     EED->setDefaultArgumentResilienceExpansion(expansion);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1425,11 +1425,10 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
                                         Type ty,
                                         TypeResolutionOptions options) {
   // Remember whether this is a function parameter.
-  bool isFunctionParam =
-    options.contains(TypeResolutionFlags::FunctionInput) ||
-    options.contains(TypeResolutionFlags::ImmediateFunctionInput);
-
-  bool defaultNoEscape = isFunctionParam;
+  bool defaultNoEscape =
+    !options.contains(TypeResolutionFlags::EnumCase) &&
+    (options.contains(TypeResolutionFlags::FunctionInput) ||
+     options.contains(TypeResolutionFlags::ImmediateFunctionInput);
 
   // Desugar here
   auto *funcTy = ty->castTo<FunctionType>();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1428,7 +1428,7 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
   bool defaultNoEscape =
     !options.contains(TypeResolutionFlags::EnumCase) &&
     (options.contains(TypeResolutionFlags::FunctionInput) ||
-     options.contains(TypeResolutionFlags::ImmediateFunctionInput);
+     options.contains(TypeResolutionFlags::ImmediateFunctionInput));
 
   // Desugar here
   auto *funcTy = ty->castTo<FunctionType>();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1327,7 +1327,7 @@ public:
   void checkDefaultArguments(ArrayRef<ParameterList *> params, ValueDecl *VD);
 
   virtual void resolveAccessControl(ValueDecl *VD) override {
-    validateAccessibility(VD);
+    validateAccessControl(VD);
   }
 
   virtual void resolveDeclSignature(ValueDecl *VD) override {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1323,8 +1323,11 @@ public:
   void computeAccessLevel(ValueDecl *D);
   void computeDefaultAccessLevel(ExtensionDecl *D);
 
+  /// Check the default arguments that occur within this value decl.
+  void checkDefaultArguments(ArrayRef<ParameterList *> params, ValueDecl *VD);
+
   virtual void resolveAccessControl(ValueDecl *VD) override {
-    validateAccessControl(VD);
+    validateAccessibility(VD);
   }
 
   virtual void resolveDeclSignature(ValueDecl *VD) override {
@@ -1863,7 +1866,7 @@ public:
   /// expression to the given context.
   ///
   /// \returns true if any closures were found
-  static bool contextualizeInitializer(Initializer *DC, Expr *init);
+  static bool contextualizeInitializer(DeclContext *DC, Expr *init);
   static void contextualizeTopLevelCode(TopLevelContext &TLC,
                                         ArrayRef<Decl*> topLevelDecls);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3722,6 +3722,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
     bool isImplicit; bool isNegative;
     unsigned rawValueKindID;
     IdentifierID blobData;
+    uint8_t rawDefaultArgumentResilienceExpansion;
     unsigned numArgNames;
     ArrayRef<uint64_t> argNameAndDependencyIDs;
 
@@ -3730,6 +3731,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
                                                isImplicit, rawValueKindID,
                                                isNegative,
                                                blobData,
+                                               rawDefaultArgumentResilienceExpansion,
                                                numArgNames,
                                                argNameAndDependencyIDs);
 
@@ -3782,6 +3784,15 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
       elem->setImplicit();
     elem->setAccess(std::max(cast<EnumDecl>(DC)->getFormalAccess(),
                              AccessLevel::Internal));
+
+    if (auto defaultArgumentResilienceExpansion = getActualResilienceExpansion(
+            rawDefaultArgumentResilienceExpansion)) {
+      elem->setDefaultArgumentResilienceExpansion(
+          *defaultArgumentResilienceExpansion);
+    } else {
+      error();
+      return nullptr;
+    }
 
     break;
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3305,11 +3305,12 @@ void Serializer::writeDecl(const Decl *D) {
                                   addDeclBaseNameRef(elem->getName()),
                                   contextID,
                                   addTypeRef(elem->getInterfaceType()),
-                                  elem->hasAssociatedValues(),
                                   elem->isImplicit(),
                                   (unsigned)RawValueKind,
                                   Negative,
                                   RawValueText);
+    if (auto *PL = elem->getParameterList())
+      writeParameterList(PL);
     break;
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3309,6 +3309,10 @@ void Serializer::writeDecl(const Decl *D) {
       Negative = ILE->isNegative();
     }
 
+    uint8_t rawDefaultArgumentResilienceExpansion =
+        getRawStableResilienceExpansion(
+            elem->getDefaultArgumentResilienceExpansion());
+
     unsigned abbrCode = DeclTypeAbbrCodes[EnumElementLayout::Code];
     EnumElementLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                   contextID,
@@ -3317,6 +3321,7 @@ void Serializer::writeDecl(const Decl *D) {
                                   (unsigned)RawValueKind,
                                   Negative,
                                   addDeclBaseNameRef(RawValueText),
+                                  rawDefaultArgumentResilienceExpansion,
                                   elem->getFullName().getArgumentNames().size()+1,
                                   nameComponentsAndDependencies);
     if (auto *PL = elem->getParameterList())

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3287,28 +3287,38 @@ void Serializer::writeDecl(const Decl *D) {
     auto elem = cast<EnumElementDecl>(D);
     auto contextID = addDeclContextRef(elem->getDeclContext());
 
+    SmallVector<IdentifierID, 4> nameComponentsAndDependencies;
+    nameComponentsAndDependencies.push_back(addDeclBaseNameRef(elem->getBaseName()));
+    for (auto argName : elem->getFullName().getArgumentNames())
+      nameComponentsAndDependencies.push_back(addDeclBaseNameRef(argName));
+
+    Type ty = elem->getInterfaceType();
+    for (Type dependency : collectDependenciesFromType(ty->getCanonicalType()))
+      nameComponentsAndDependencies.push_back(addTypeRef(dependency));
+
     // We only serialize the raw values of @objc enums, because they're part
     // of the ABI. That isn't the case for Swift enums.
     auto RawValueKind = EnumElementRawValueKind::None;
     bool Negative = false;
-    StringRef RawValueText;
+    Identifier RawValueText;
     if (elem->getParentEnum()->isObjC()) {
       // Currently ObjC enums always have integer raw values.
       RawValueKind = EnumElementRawValueKind::IntegerLiteral;
       auto ILE = cast<IntegerLiteralExpr>(elem->getRawValueExpr());
-      RawValueText = ILE->getDigitsText();
+      RawValueText = M->getASTContext().getIdentifier(ILE->getDigitsText());
       Negative = ILE->isNegative();
     }
 
     unsigned abbrCode = DeclTypeAbbrCodes[EnumElementLayout::Code];
     EnumElementLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                  addDeclBaseNameRef(elem->getName()),
                                   contextID,
                                   addTypeRef(elem->getInterfaceType()),
                                   elem->isImplicit(),
                                   (unsigned)RawValueKind,
                                   Negative,
-                                  RawValueText);
+                                  addDeclBaseNameRef(RawValueText),
+                                  elem->getFullName().getArgumentNames().size()+1,
+                                  nameComponentsAndDependencies);
     if (auto *PL = elem->getParameterList())
       writeParameterList(PL);
     break;

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -27,7 +27,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		case unmap
 
 		/// A custom deallocator
-		case custom(DispatchQueue?, @convention(block) @escaping () -> Void)
+		case custom(DispatchQueue?, @convention(block) () -> Void)
 
 		fileprivate var _deallocator: (DispatchQueue?, @convention(block) () -> Void) {
 			switch self {

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -27,7 +27,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		case unmap
 
 		/// A custom deallocator
-		case custom(DispatchQueue?, @convention(block) () -> Void)
+		case custom(DispatchQueue?, @convention(block) @escaping () -> Void)
 
 		fileprivate var _deallocator: (DispatchQueue?, @convention(block) () -> Void) {
 			switch self {

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1018,7 +1018,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         case none
         
         /// A custom deallocator.
-        case custom(@escaping (UnsafeMutableRawPointer, Int) -> Void)
+        case custom((UnsafeMutableRawPointer, Int) -> Void)
         
         fileprivate var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void) {
 #if DEPLOYMENT_RUNTIME_SWIFT

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1018,7 +1018,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         case none
         
         /// A custom deallocator.
-        case custom((UnsafeMutableRawPointer, Int) -> Void)
+        case custom(@escaping (UnsafeMutableRawPointer, Int) -> Void)
         
         fileprivate var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void) {
 #if DEPLOYMENT_RUNTIME_SWIFT

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -79,7 +79,7 @@ func _XCTFailureDescription(_ assertionType: _XCTAssertionType, _ formatIndex: I
 enum _XCTThrowableBlockResult {
   case success
   case failedWithError(error: Error)
-  case failedWithException(className: String, name: String, reason: String)
+  case failedWithException(_ className: String, _ name: String, _ reason: String)
   case failedWithUnknownException
 }
 
@@ -102,9 +102,9 @@ func _XCTRunThrowableBlock(_ block: () throws -> Void) -> _XCTThrowableBlockResu
 
     if exceptionResult["type"] == "objc" {
       return .failedWithException(
-        className: exceptionResult["className"]!,
-        name: exceptionResult["name"]!,
-        reason: exceptionResult["reason"]!)
+        exceptionResult["className"]!,
+        exceptionResult["name"]!,
+        exceptionResult["reason"]!)
     } else {
       return .failedWithUnknownException
     }

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -96,7 +96,7 @@ public struct Mirror {
     ///             children: ["someProperty": self.someProperty],
     ///             ancestorRepresentation: .customized({ super.customMirror })) // <==
     ///     }
-    case customized(() -> Mirror)
+    case customized(@escaping () -> Mirror)
 
     /// Suppresses the representation of all ancestor classes.
     ///

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -96,7 +96,7 @@ public struct Mirror {
     ///             children: ["someProperty": self.someProperty],
     ///             ancestorRepresentation: .customized({ super.customMirror })) // <==
     ///     }
-    case customized(@escaping () -> Mirror)
+    case customized(() -> Mirror)
 
     /// Suppresses the representation of all ancestor classes.
     ///

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -458,8 +458,8 @@ enum DefaultEnumPrivate {
 }
 public enum PublicEnumPI {
   case A(InternalStruct) // expected-error {{enum case in a public enum uses an internal type}}
-  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a private type}}
-  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a private type}}
+  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a private type}} expected-error {{enum case in a public enum uses an internal type}}
+  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a private type}} expected-error {{enum case in a public enum uses an internal type}}
 }
 enum DefaultEnumPublic {
   case A(PublicStruct) // no-warning

--- a/test/Compatibility/enum_element_pattern.swift
+++ b/test/Compatibility/enum_element_pattern.swift
@@ -26,7 +26,7 @@ func testE(e: E) {
     break
   case .C(): // Ok.
     break
-  case .D(let payload): // Ok. 'payload' has type '()'.
+  case .D(let payload):
     let _: () = payload
     break
   default:
@@ -35,7 +35,7 @@ func testE(e: E) {
 
   guard
     case .C() = e, // Ok. SILGen assert this, but no-assert Swift3 GM build didn't assert.
-    case .D(let payload) = e // FIXME: Should be rejected. Swift3 IRGen verifier did catch this.
+    case .D(let payload) = e
   else { return }
   print(payload)
 }
@@ -49,6 +49,6 @@ do {
   try canThrow()
 } catch E.A() { // Ok.
   // ..
-} catch E.B(let payload) { // Ok. 'payload' has type '()'.
+} catch E.B(let payload) {
   let _: () = payload
 }

--- a/test/Compatibility/enum_element_pattern.swift
+++ b/test/Compatibility/enum_element_pattern.swift
@@ -26,7 +26,7 @@ func testE(e: E) {
     break
   case .C(): // Ok.
     break
-  case .D(let payload):
+  case .D(let payload): // Ok. 'payload' has type '()'.
     let _: () = payload
     break
   default:
@@ -35,7 +35,7 @@ func testE(e: E) {
 
   guard
     case .C() = e, // Ok. SILGen assert this, but no-assert Swift3 GM build didn't assert.
-    case .D(let payload) = e
+    case .D(let payload) = e // FIXME: Should be rejected. Swift3 IRGen verifier did catch this.
   else { return }
   print(payload)
 }
@@ -49,6 +49,6 @@ do {
   try canThrow()
 } catch E.A() { // Ok.
   // ..
-} catch E.B(let payload) {
+} catch E.B(let payload) { // Ok. 'payload' has type '()'.
   let _: () = payload
 }

--- a/test/IDE/comment_attach.swift
+++ b/test/IDE/comment_attach.swift
@@ -288,7 +288,10 @@ func unterminatedBlockDocComment() {}
 // CHECK-NEXT: comment_attach.swift:166:6: Enum/decl_enum_1 RawComment=[/// decl_enum_1 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:168:8: EnumElement/decl_enum_1.Case1 RawComment=[/// Case1 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:171:8: EnumElement/decl_enum_1.Case2 RawComment=[/// Case2 Aaa.\n]
+// CHECK-NEXT: Param/decl_enum_1.<anonymous> RawComment=none BriefComment=none DocCommentAsXML=none
 // CHECK-NEXT: comment_attach.swift:174:8: EnumElement/decl_enum_1.Case3 RawComment=[/// Case3 Aaa.\n]
+// CHECK-NEXT: Param/decl_enum_1.<anonymous> RawComment=none BriefComment=none DocCommentAsXML=none
+// CHECK-NEXT: Param/decl_enum_1.<anonymous> RawComment=none BriefComment=none DocCommentAsXML=none
 // CHECK-NEXT: comment_attach.swift:177:8: EnumElement/decl_enum_1.Case4 RawComment=[/// Case4 Case5 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:177:15: EnumElement/decl_enum_1.Case5 RawComment=[/// Case4 Case5 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:181:7: Class/decl_class_1 RawComment=[/// decl_class_1 Aaa.\n]

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -127,50 +127,50 @@ enum BarEnum {
 // BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar2()[#() -> BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar3({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar4({#a: Int#}, {#b: Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar6({#a: Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar6({#a: Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar7({#a: Int#}, ({#b: Float#}, {#c: Double#}))[#(Int, (b: Float, c: Double)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar8({#a: Int#}, b: ({#c: Float#}, {#d: Double#}))[#(Int, (c: Float, d: Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar5({#a: Int#}, {#(Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar6({#a: Int#}, {#b: (Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#(Int, (b: Float, c: Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#(Int, (c: Float, d: Double)) -> BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar9({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar10({#Int#}, {#Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar11({#Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar12({#Int#}, ({#Float#}, {#Double#}))[#(Int, (Float, Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar11({#Int#}, {#(Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar12({#Int#}, {#(Float, Double)#})[#(Int, (Float, Double)) -> BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT: End completions
 
 // BAR_ENUM_NO_DOT: Begin completions
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar1[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar2()[#() -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar3({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar4({#a: Int#}, {#b: Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar5({#a: Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar6({#a: Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar7({#a: Int#}, ({#b: Float#}, {#c: Double#}))[#(Int, (b: Float, c: Double)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar8({#a: Int#}, b: ({#c: Float#}, {#d: Double#}))[#(Int, (c: Float, d: Double)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar9({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar10({#Int#}, {#Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar11({#Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Bar12({#Int#}, ({#Float#}, {#Double#}))[#(Int, (Float, Double)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .barInstanceFunc({#self: &BarEnum#})[#() -> Void#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[StaticVar]/CurrNominal:      .staticVar[#Int#]{{; name=.+$}}
-// BAR_ENUM_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .barStaticFunc()[#Void#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar1[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar2()[#() -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar3({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar4({#a: Int#}, {#b: Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar5({#a: Int#}, {#(Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar6({#a: Int#}, {#b: (Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#(Int, (b: Float, c: Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#(Int, (c: Float, d: Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar9({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar10({#Int#}, {#Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar11({#Int#}, {#(Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:      .Bar12({#Int#}, {#(Float, Double)#})[#(Int, (Float, Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal:   .barInstanceFunc({#self: &BarEnum#})[#() -> Void#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[StaticVar]/CurrNominal:        .staticVar[#Int#]{{; name=.+$}}
+// BAR_ENUM_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:     .barStaticFunc()[#Void#]{{; name=.+$}}
 // BAR_ENUM_NO_DOT-NEXT: End completions
 
 // BAR_ENUM_DOT: Begin completions
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar1[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar2()[#() -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar3({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar4({#a: Int#}, {#b: Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar5({#a: Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar6({#a: Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar7({#a: Int#}, ({#b: Float#}, {#c: Double#}))[#(Int, (b: Float, c: Double)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar8({#a: Int#}, b: ({#c: Float#}, {#d: Double#}))[#(Int, (c: Float, d: Double)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar9({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar10({#Int#}, {#Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar11({#Int#}, {#Float#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Bar12({#Int#}, ({#Float#}, {#Double#}))[#(Int, (Float, Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar1[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar2()[#() -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar3({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar4({#a: Int#}, {#b: Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar5({#a: Int#}, {#(Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar6({#a: Int#}, {#b: (Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#(Int, (b: Float, c: Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#(Int, (c: Float, d: Double)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar9({#Int#})[#(Int) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar10({#Int#}, {#Float#})[#(Int, Float) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar11({#Int#}, {#(Float)#})[#(Int, (Float)) -> BarEnum#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:      Bar12({#Int#}, {#(Float, Double)#})[#(Int, (Float, Double)) -> BarEnum#]{{; name=.+$}}
 // BAR_ENUM_DOT-NEXT: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: barInstanceFunc({#self: &BarEnum#})[#() -> Void#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[StaticVar]/CurrNominal:      staticVar[#Int#]{{; name=.+$}}
-// BAR_ENUM_DOT-NEXT: Decl[StaticMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]:   barStaticFunc()[#Void#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[StaticVar]/CurrNominal:        staticVar[#Int#]{{; name=.+$}}
+// BAR_ENUM_DOT-NEXT: Decl[StaticMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: barStaticFunc()[#Void#]{{; name=.+$}}
 // BAR_ENUM_DOT-NEXT: End completions
 
 enum BazEnum<T> {

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -130,7 +130,7 @@ func test1() {
 // CHECK: <enum>enum <name>SomeEnum</name> {
 // CHECK:   <enum-case>case <enum-elem><name>North</name></enum-elem></enum-case>
 // CHECK:   <enum-case>case <enum-elem><name>South</name></enum-elem>, <enum-elem><name>East</name></enum-elem></enum-case>
-// CHECK:   <enum-case>case <enum-elem><name>QRCode</name>(String)</enum-elem></enum-case>
+// CHECK:   <enum-case>case <enum-elem><name>QRCode</name>(<param><type>String</type></param>)</enum-elem></enum-case>
 // CHECK:   <enum-case>case</enum-case>
 // CHECK: }</enum>
 enum SomeEnum {

--- a/test/IRGen/class_resilience_thunks.swift
+++ b/test/IRGen/class_resilience_thunks.swift
@@ -29,10 +29,10 @@ public func testDispatchThunkDerived(d: Derived) {
   // CHECK: call swiftcc void @"$S22resilient_class_thunks4BaseC6takesTyyxFTj"(%swift.opaque* noalias nocapture dereferenceable({{4|8}}) {{%.*}}, %T22resilient_class_thunks4BaseC* swiftself {{%.*}})
   d.takesT(0)
 
-  // CHECK: call swiftcc void @"$S22resilient_class_thunks7DerivedC8takesIntyySiSgFTj"([[INT]] 0, i8 1, %T22resilient_class_thunks7DerivedC* swiftself %0)
+  // CHECK: call swiftcc void @"$S22resilient_class_thunks7DerivedC8takesIntyySiSgFTj"([[INT]] {{%.*}}, i8 {{%.*}}, %T22resilient_class_thunks7DerivedC* swiftself %0)
   d.takesInt(nil)
 
-  // CHECK: call swiftcc void @"$S22resilient_class_thunks4BaseC14takesReferenceyyAA6ObjectCFTj"(%T22resilient_class_thunks6ObjectC* null, %T22resilient_class_thunks4BaseC* swiftself {{%.*}})
+  // CHECK: call swiftcc void @"$S22resilient_class_thunks4BaseC14takesReferenceyyAA6ObjectCFTj"(%T22resilient_class_thunks6ObjectC* {{%.*}}, %T22resilient_class_thunks4BaseC* swiftself {{%.*}})
   d.takesReference(nil)
 
   // CHECK: ret void

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -15,11 +15,11 @@
 class C {
   class func fromMetatype() -> Self? { return nil }
   // CHECK-LABEL: define hidden swiftcc i64 @"$S21dynamic_self_metadata1CC12fromMetatypeACXDSgyFZ"(%swift.type* swiftself)
-  // CHECK: ret i64 0
+  // CHECK: ret i64 {{%.*}}
 
   func fromInstance() -> Self? { return nil }
   // CHECK-LABEL: define hidden swiftcc i64 @"$S21dynamic_self_metadata1CC12fromInstanceACXDSgyF"(%T21dynamic_self_metadata1CC* swiftself)
-  // CHECK: ret i64 0
+  // CHECK: ret i64 {{%.*}}
 
   func dynamicSelfArgument() -> Self? {
     return id(nil)

--- a/test/IRGen/enum_empty_payloads.sil
+++ b/test/IRGen/enum_empty_payloads.sil
@@ -1,19 +1,21 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
 sil_stage canonical
 
+typealias Void = ()
+
 struct Empty<T> {}
 
 enum SinglePayload<T> {
   case A(T)
-  case B()
+  case B(Void)
   case C(Empty<T>)
 }
 
 enum MultiPayload<T, U> {
   case A(T)
   case B(U)
-  case C()
-  case D()
+  case C(Void)
+  case D(Void)
   case E(Empty<T>)
   case F(Empty<U>)
 }

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -119,10 +119,22 @@ public func constructResilientEnumPayload(_ s: Size) -> Medium {
 // CHECK-NEXT: [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[METADATA_ADDR]], [[INT:i32|i64]] -1
 // CHECK-NEXT: [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
 
+// CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 9
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]], align 8, !invariant.load !11
+// CHECK-NEXT: [[ALLOCA_SIZE:%.*]] = ptrtoint i8* [[WITNESS]] to i64
+// CHECK-NEXT: [[STACK:%.*]] = alloca i8, i64 [[ALLOCA_SIZE]], align 16
+// CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 -1, i8* [[STACK]])
+// CHECK-NEXT: [[DEST:%.*]] = bitcast i8* [[STACK]] to %swift.opaque*
+
 // CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
 // CHECK-NEXT: [[WITNESS:%.*]]  = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[WITNESS_FN:%.*]] = bitcast i8* [[WITNESS]]
-// CHECK-NEXT: [[COPY:%.*]] = call %swift.opaque* %initializeWithCopy(%swift.opaque* noalias %0, %swift.opaque* noalias %1, %swift.type* [[METADATA]])
+// CHECK-NEXT: [[COPY:%.*]] = call %swift.opaque* %initializeWithCopy(%swift.opaque* noalias [[DEST]], %swift.opaque* noalias %1, %swift.type* [[METADATA]])
+
+// CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 4
+// CHECK-NEXT: [[WITNESS:%.*]]  = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[WITNESS_FN:%.*]] = bitcast i8* [[WITNESS]]
+// CHECK-NEXT: [[COPY:%.*]] = call %swift.opaque* %initializeWithTake(%swift.opaque* noalias %0, %swift.opaque* noalias [[DEST]], %swift.type* [[METADATA]])
 
 // CHECK-NEXT: [[METADATA2:%.*]] = call %swift.type* @"$S14resilient_enum6MediumOMa"()
 // CHECK-NEXT: [[METADATA_ADDR2:%.*]] = bitcast %swift.type* [[METADATA2]] to i8***
@@ -138,6 +150,9 @@ public func constructResilientEnumPayload(_ s: Size) -> Medium {
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[WITNESS_FN:%.*]] = bitcast i8* [[WITNESS]]
 // CHECK-NEXT: call void [[WITNESS_FN]](%swift.opaque* noalias %1, %swift.type* [[METADATA]])
+
+// CHECK-NEXT: [[STACK:%.*]] = bitcast %swift.opaque* [[DEST]] to i8*
+// CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 -1, i8* [[STACK]])
 
 // CHECK-NEXT: ret void
   return Medium.Postcard(s)

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -27,16 +27,16 @@ func foo(a: Int, b: Int, c: Int) {
         // CHECK-NOT: [[@LINE-2]]:10 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR:.*]] | Def,RelChild | rel: 1
 
         case foo(x: LocalStruct)
-        // LOCAL: [[@LINE-1]]:14 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
-        // CHECK-NOT: [[@LINE-2]]:14 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
+        // LOCAL: [[@LINE-1]]:14 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
+        // CHECK-NOT: [[@LINE-2]]:14 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
         // LOCAL: [[@LINE-3]]:21 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref | rel: 0
     }
 
     let _ = LocalEnum.foo(x: LocalStruct())
     // LOCAL: [[@LINE-1]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-2]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
-    // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
-    // CHECK-NOT: [[@LINE-4]]:23 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
+    // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-4]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
     // LOCAL: [[@LINE-5]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-6]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
 

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -558,13 +558,13 @@ func foo() {
 }
 
 enum MyGenericEnum<T> {
-  case one(T)
-  case oneTwo(T)
+  case one(T) // expected-note {{did you mean 'one'?}}
+  case oneTwo(T) // expected-note {{did you mean 'oneTwo'?}}
 }
 
 func foo1() {
-  _ = MyGenericEnum<Int>.One // expected-error {{enum type 'MyGenericEnum<Int>' has no case 'One'; did you mean 'one'}}{{26-29=one}}
-  _ = MyGenericEnum<Int>.OneTwo // expected-error {{enum type 'MyGenericEnum<Int>' has no case 'OneTwo'; did you mean 'oneTwo'}}{{26-32=oneTwo}}
+  _ = MyGenericEnum<Int>.One // expected-error {{type 'MyGenericEnum<Int>' has no member 'One'}}
+  _ = MyGenericEnum<Int>.OneTwo // expected-error {{type 'MyGenericEnum<Int>' has no member 'OneTwo'}}
 }
 
 // SR-4082

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -110,7 +110,7 @@ enum Recovery2 {
   case UE1: // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
 enum Recovery3 {
-  case UE2(): // expected-error {{'case' label can only appear inside a 'switch' statement}}
+  case UE2(Void): // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
 enum Recovery4 { // expected-note {{in declaration of 'Recovery4'}}
   case Self Self // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Self`}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{12-12=;}} expected-error {{expected declaration}}
@@ -335,8 +335,8 @@ enum DuplicateMembers2 {
 }
 
 enum DuplicateMembers3 {
-  case Foo // expected-note {{previous definition of 'Foo' is here}}
-  case Foo(Int) // expected-error {{duplicate definition of enum element}}
+  case Foo // expected-note {{'Foo' previously declared here}}
+  case Foo(Int) // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
 enum DuplicateMembers4 : Int { // expected-error {{'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -21,7 +21,7 @@ struct S {
 
 enum E {
   case Case
-  case DataCase(())
+  case DataCase(Void)
 }
 
 sil @general_test : $() -> () {

--- a/test/SILGen/argument_shuffle_swift3.swift
+++ b/test/SILGen/argument_shuffle_swift3.swift
@@ -17,10 +17,14 @@ func g(x: Any) {
   // CHECK: apply [[FN:%.*]]({{.*}}) : $@convention(thin) (@in Any) -> ()
   fn(data: x)
 
-  // CHECK: inject_enum_addr {{.*}} : $*HasAnyCase, #HasAnyCase.any!enumelt.1
+  // CHECK:      // function_ref HasAnyCase.any(_:)
+  // CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$S23argument_shuffle_swift310HasAnyCaseO3anyyACypcACmF
+  // CHECK-NEXT: apply [[ENUM_CASE]]({{.*}})
   _ = HasAnyCase.any(123)
 
-  // CHECK: inject_enum_addr {{.*}} : $*HasAnyCase, #HasAnyCase.any!enumelt.1
+  // CHECK:      // function_ref HasAnyCase.any(_:)
+  // CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$S23argument_shuffle_swift310HasAnyCaseO3anyyACypcACmF
+  // CHECK-NEXT: apply [[ENUM_CASE]]({{.*}})
   _ = HasAnyCase.any(data: 123)
 
   // CHECK: return

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -377,19 +377,19 @@ enum default_args {
   case defarg2(i: Int, d: Double = 3.14159, s: String = "Hello")
 }
 
-// CHECK-LABEL: sil hidden @_T017default_arguments18testDefaultArgEnumyyF
+// CHECK-LABEL: sil hidden @$S17default_arguments18testDefaultArgEnumyyF
 func testDefaultArgEnum() {
   // CHECK: [[METATYPE_DEF_1:%[0-9]+]] = metatype $@thin default_args.Type
 
   // implicit closure #1
-  // CHECK: [[THIN_FILE_ARG_THUNK1:%[0-9]+]] = function_ref @_T017default_arguments18testDefaultArgEnumyyFSSyXKfu_ : $@convention(thin) () -> @owned String
+  // CHECK: [[THIN_FILE_ARG_THUNK1:%[0-9]+]] = function_ref @$S17default_arguments18testDefaultArgEnumyyFSSyXAfu_ : $@convention(thin) () -> @owned String
   // CHECK-NEXT: [[THICK_FILE_ARG_THUNK1:%[0-9]+]] = thin_to_thick_function [[THIN_FILE_ARG_THUNK1]] : $@convention(thin) () -> @owned String to $@callee_guaranteed () -> @owned String
 
   // implicit closure #2
-  // CHECK: [[THIN_LINE_ARG_THUNK2:%[0-9]+]] = function_ref @_T017default_arguments18testDefaultArgEnumyyFSiyXKfu0_ : $@convention(thin) () -> Int
+  // CHECK: [[THIN_LINE_ARG_THUNK2:%[0-9]+]] = function_ref @$S17default_arguments18testDefaultArgEnumyyFSiyXAfu0_ : $@convention(thin) () -> Int
   // CHECK-NEXT: [[THICK_LINE_ARG_THUNK2:%[0-9]+]] = thin_to_thick_function [[THIN_LINE_ARG_THUNK2]] : $@convention(thin) () -> Int to $@callee_guaranteed () -> Int
 
-  // CHECK: [[DEF1_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsO7defarg1yACSSyXK_SiyXKtcACmF : $@convention(method) (@owned @callee_guaranteed () -> @owned String, @owned @callee_guaranteed () -> Int, @thin default_args.Type) -> @owned default_args
+  // CHECK: [[DEF1_THUNK:%[0-9]+]] = function_ref @$S17default_arguments0A5_argsO7defarg1yACSSyXA_SiyXAtcACmF : $@convention(method) (@owned @callee_guaranteed () -> @owned String, @owned @callee_guaranteed () -> Int, @thin default_args.Type) -> @owned default_args
 
   // CHECK: apply [[DEF1_THUNK]]([[THICK_FILE_ARG_THUNK1]], [[THICK_LINE_ARG_THUNK2]], [[METATYPE_DEF_1]])
   _ = default_args.defarg1()
@@ -400,14 +400,14 @@ func testDefaultArgEnum() {
   // CHECK: integer_literal $Builtin.Int
 
   // default argument 1
-  // CHECK: [[DOUBLE_ARG_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsOfA0_ : $@convention(thin) () -> Double
+  // CHECK: [[DOUBLE_ARG_THUNK:%[0-9]+]] = function_ref @$S17default_arguments0A5_argsOfA0_ : $@convention(thin) () -> Double
   // CHECK-NEXT: [[DOUBLE_ARG:%[0-9]+]] = apply [[DOUBLE_ARG_THUNK]]() : $@convention(thin) () -> Double
 
   // default argument 2
-  // CHECK: [[STRING_ARG_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsOfA1_ : $@convention(thin) () -> @owned String
+  // CHECK: [[STRING_ARG_THUNK:%[0-9]+]] = function_ref @$S17default_arguments0A5_argsOfA1_ : $@convention(thin) () -> @owned String
   // CHECK-NEXT: [[STRING_ARG:%[0-9]+]] = apply [[STRING_ARG_THUNK]]() : $@convention(thin) () -> @owned String
 
-  // CHECK: [[DEF2_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsO7defarg2yACSi_SdSStcACmF : $@convention(method) (Int, Double, @owned String, @thin default_args.Type) -> @owned default_args
+  // CHECK: [[DEF2_THUNK:%[0-9]+]] = function_ref @$S17default_arguments0A5_argsO7defarg2yACSi_SdSStcACmF : $@convention(method) (Int, Double, @owned String, @thin default_args.Type) -> @owned default_args
 
   // CHECK: apply [[DEF2_THUNK]]({{%[0-9]+}}, [[DOUBLE_ARG]], [[STRING_ARG]], [[METATYPE_DEF_2]])
   _ = default_args.defarg2(i: 5)

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -371,3 +371,44 @@ func callThem() throws {
    defaultEscaping()
    autoclosureDefaultEscaping()
 }
+
+enum default_args {
+  case defarg1(x: @autoclosure () -> String = #file, y: @autoclosure () -> Int = #line)
+  case defarg2(i: Int, d: Double = 3.14159, s: String = "Hello")
+}
+
+// CHECK-LABEL: sil hidden @_T017default_arguments18testDefaultArgEnumyyF
+func testDefaultArgEnum() {
+  // CHECK: [[METATYPE_DEF_1:%[0-9]+]] = metatype $@thin default_args.Type
+
+  // implicit closure #1
+  // CHECK: [[THIN_FILE_ARG_THUNK1:%[0-9]+]] = function_ref @_T017default_arguments18testDefaultArgEnumyyFSSyXKfu_ : $@convention(thin) () -> @owned String
+  // CHECK-NEXT: [[THICK_FILE_ARG_THUNK1:%[0-9]+]] = thin_to_thick_function [[THIN_FILE_ARG_THUNK1]] : $@convention(thin) () -> @owned String to $@callee_guaranteed () -> @owned String
+
+  // implicit closure #2
+  // CHECK: [[THIN_LINE_ARG_THUNK2:%[0-9]+]] = function_ref @_T017default_arguments18testDefaultArgEnumyyFSiyXKfu0_ : $@convention(thin) () -> Int
+  // CHECK-NEXT: [[THICK_LINE_ARG_THUNK2:%[0-9]+]] = thin_to_thick_function [[THIN_LINE_ARG_THUNK2]] : $@convention(thin) () -> Int to $@callee_guaranteed () -> Int
+
+  // CHECK: [[DEF1_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsO7defarg1yACSSyXK_SiyXKtcACmF : $@convention(method) (@owned @callee_guaranteed () -> @owned String, @owned @callee_guaranteed () -> Int, @thin default_args.Type) -> @owned default_args
+
+  // CHECK: apply [[DEF1_THUNK]]([[THICK_FILE_ARG_THUNK1]], [[THICK_LINE_ARG_THUNK2]], [[METATYPE_DEF_1]])
+  _ = default_args.defarg1()
+
+  // CHECK: [[METATYPE_DEF_2:%[0-9]+]] = metatype $@thin default_args.Type
+
+  // user-supplied argument
+  // CHECK: integer_literal $Builtin.Int
+
+  // default argument 1
+  // CHECK: [[DOUBLE_ARG_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsOfA0_ : $@convention(thin) () -> Double
+  // CHECK-NEXT: [[DOUBLE_ARG:%[0-9]+]] = apply [[DOUBLE_ARG_THUNK]]() : $@convention(thin) () -> Double
+
+  // default argument 2
+  // CHECK: [[STRING_ARG_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsOfA1_ : $@convention(thin) () -> @owned String
+  // CHECK-NEXT: [[STRING_ARG:%[0-9]+]] = apply [[STRING_ARG_THUNK]]() : $@convention(thin) () -> @owned String
+
+  // CHECK: [[DEF2_THUNK:%[0-9]+]] = function_ref @_T017default_arguments0A5_argsO7defarg2yACSi_SdSStcACmF : $@convention(method) (Int, Double, @owned String, @thin default_args.Type) -> @owned default_args
+
+  // CHECK: apply [[DEF2_THUNK]]({{%[0-9]+}}, [[DOUBLE_ARG]], [[STRING_ARG]], [[METATYPE_DEF_2]])
+  _ = default_args.defarg2(i: 5)
+}

--- a/test/SILGen/default_arguments_imported.swift
+++ b/test/SILGen/default_arguments_imported.swift
@@ -8,7 +8,9 @@ import gizmo
 
 // CHECK-LABEL: sil hidden @$S26default_arguments_imported9testGizmo{{[_0-9a-zA-Z]*}}F
 func testGizmo(gizmo: Gizmo) {
-  // CHECK: enum $Optional<@callee_guaranteed (@owned Optional<Gizmo>) -> ()>, #Optional.none!enumelt
+  // CHECK: // function_ref Optional.none<A>(_:)
+  // CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$SSq4noneyxSgABmlF : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
+  // CHECK-NEXT: apply [[ENUM_CASE]]<(Gizmo?) -> ()>({{%.*}}, {{%.*}})
   // CHECK: objc_method [[SELF:%[0-9]+]] : $Gizmo, #Gizmo.enumerateSubGizmos!1.foreign
   gizmo.enumerateSubGizmos()
 } // CHECK: } // end sil function '$S26default_arguments_imported9testGizmo5gizmoySo0E0C_tF'
@@ -24,7 +26,9 @@ func testNonnullDictionary(gizmo: Gizmo) {
 // CHECK-LABEL: sil hidden @$S26default_arguments_imported22testNullableDictionary5gizmoySo5GizmoC_tF
 func testNullableDictionary(gizmo: Gizmo) {
   // CHECK-NOT: dictionaryLiteral
-  // CHECK: enum $Optional<Dictionary<AnyHashable, Any>>, #Optional.none!enumelt
+  // CHECK: // function_ref Optional.none<A>(_:)
+  // CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$SSq4noneyxSgABmlF : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
+  // CHECK-NEXT: apply [[ENUM_CASE]]<[AnyHashable : Any]>({{%.*}}, {{%.*}})
   // CHECK: objc_method [[SELF:%[0-9]+]] : $Gizmo, #Gizmo.doTheOtherThing!1.foreign
   gizmo.doTheOtherThing()
 } // CHECK: } // end sil function '$S26default_arguments_imported22testNullableDictionary5gizmoySo5GizmoC_tF'

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -17,11 +17,15 @@ enum Boolish {
 // CHECK-LABEL: sil hidden @$Ss13Boolish_casesyyF
 func Boolish_cases() {
   // CHECK:       [[BOOLISH:%[0-9]+]] = metatype $@thin Boolish.Type
-  // CHECK-NEXT:  [[FALSY:%[0-9]+]] = enum $Boolish, #Boolish.falsy!enumelt
+  // CHECK-NEXT:  // function_ref Boolish.falsy(_:)
+  // CHECK-NEXT:  [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss7BoolishO5falsyyA2BmF
+  // CHECK-NEXT:  [[FALSY:%[0-9]+]] = apply [[ENUM_CASE]]([[BOOLISH]])
   _ = Boolish.falsy
 
   // CHECK-NEXT:  [[BOOLISH:%[0-9]+]] = metatype $@thin Boolish.Type
-  // CHECK-NEXT:  [[TRUTHY:%[0-9]+]] = enum $Boolish, #Boolish.truthy!enumelt
+  // CHECK-NEXT:  // function_ref Boolish.truthy(_:)
+  // CHECK-NEXT:  [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss7BoolishO6truthyyA2BmF
+  // CHECK-NEXT:  [[TRUTHY:%[0-9]+]] = apply [[ENUM_CASE]]([[BOOLISH]])
   _ = Boolish.truthy
 }
 
@@ -42,7 +46,9 @@ func Optionable_cases(_ x: Int) {
   _ = Optionable.mere
 
   // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin Optionable.Type
-  // CHECK-NEXT:  [[RES:%.*]] = enum $Optionable, #Optionable.mere!enumelt.1, %0 : $Int
+  // CHECK-NEXT:  // function_ref Optionable.mere(_:)
+  // CHECK-NEXT:  [[ENUM_CASE:%.*]] = function_ref @$Ss10OptionableO4mereyABSicABmF
+  // CHECK-NEXT:  [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]](%0, [[METATYPE]])
   _ = Optionable.mere(x)
 }
 
@@ -75,30 +81,35 @@ func AddressOnly_cases(_ s: S) {
   // CHECK-NEXT:  destroy_value [[CTOR]]
   _ = AddressOnly.mere
 
-  // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
   // CHECK-NEXT:  [[NOUGHT:%.*]] = alloc_stack $AddressOnly
-  // CHECK-NEXT:  inject_enum_addr [[NOUGHT]]
+  // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
+  // CHECK-NEXT:  // function_ref AddressOnly.nought(_:)
+  // CHECK-NEXT:  [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss11AddressOnlyO6noughtyA2BmF
+  // CHECK-NEXT:  [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]([[NOUGHT]], [[METATYPE]])
   // CHECK-NEXT:  destroy_addr [[NOUGHT]]
   // CHECK-NEXT:  dealloc_stack [[NOUGHT]]
   _ = AddressOnly.nought
 
-  // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
   // CHECK-NEXT:  [[MERE:%.*]] = alloc_stack $AddressOnly
-  // CHECK-NEXT:  [[PAYLOAD:%.*]] = init_enum_data_addr [[MERE]]
+  // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
+  // CHECK-NEXT:  [[PAYLOAD:%.*]] = alloc_stack $P
   // CHECK-NEXT:  [[PAYLOAD_ADDR:%.*]] = init_existential_addr [[PAYLOAD]]
   // CHECK-NEXT:  store %0 to [trivial] [[PAYLOAD_ADDR]]
-  // CHECK-NEXT:  inject_enum_addr [[MERE]]
+  // CHECK-NEXT:  // function_ref AddressOnly.mere(_:)
+  // CHECK-NEXT:  [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss11AddressOnlyO4mereyABs1P_pcABmF
+  // CHECK-NEXT:  [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]([[MERE]], [[PAYLOAD]], [[METATYPE]])
+  // CHECK-NEXT:  dealloc_stack [[PAYLOAD]]
   // CHECK-NEXT:  destroy_addr [[MERE]]
   // CHECK-NEXT:  dealloc_stack [[MERE]]
   _ = AddressOnly.mere(s)
 
   // Address-only enum vs loadable payload
 
-  // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
   // CHECK-NEXT:  [[PHANTOM:%.*]] = alloc_stack $AddressOnly
-  // CHECK-NEXT:  [[PAYLOAD:%.*]] = init_enum_data_addr [[PHANTOM]] : $*AddressOnly, #AddressOnly.phantom!enumelt.1
-  // CHECK-NEXT:  store %0 to [trivial] [[PAYLOAD]]
-  // CHECK-NEXT:  inject_enum_addr [[PHANTOM]] : $*AddressOnly, #AddressOnly.phantom!enumelt.1
+  // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
+  // CHECK-NEXT:  // function_ref AddressOnly.phantom(_:)
+  // CHECK-NEXT:  [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss11AddressOnlyO7phantomyABs1SVcABmF
+  // CHECK-NEXT:  [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]([[PHANTOM]], %0, [[METATYPE]])
   // CHECK-NEXT:  destroy_addr [[PHANTOM]]
   // CHECK-NEXT:  dealloc_stack [[PHANTOM]]
 
@@ -127,18 +138,23 @@ enum PolyOptionable<T> {
 // CHECK-LABEL: sil hidden @$Ss20PolyOptionable_casesyyxlF
 func PolyOptionable_cases<T>(_ t: T) {
 
-// CHECK:         [[METATYPE:%.*]] = metatype $@thin PolyOptionable<T>.Type
-// CHECK-NEXT:    [[NOUGHT:%.*]] = alloc_stack $PolyOptionable<T>
-// CHECK-NEXT:    inject_enum_addr [[NOUGHT]]
+// CHECK:         [[NOUGHT:%.*]] = alloc_stack $PolyOptionable<T>
+// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin PolyOptionable<T>.Type
+// CHECK-NEXT:    // function_ref PolyOptionable.nought<A>(_:)
+// CHECK-NEXT:    [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss14PolyOptionableO6noughtyAByxGADmlF
+// CHECK-NEXT:    [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]<T>([[NOUGHT]], [[METATYPE]])
 // CHECK-NEXT:    destroy_addr [[NOUGHT]]
 // CHECK-NEXT:    dealloc_stack [[NOUGHT]]
   _ = PolyOptionable<T>.nought
 
-// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin PolyOptionable<T>.Type
 // CHECK-NEXT:    [[MERE:%.*]] = alloc_stack $PolyOptionable<T>
-// CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[MERE]]
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[PAYLOAD]]
-// CHECK-NEXT:    inject_enum_addr [[MERE]]
+// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin PolyOptionable<T>.Type
+// CHECK-NEXT:    [[PAYLOAD:%.*]] = alloc_stack $T
+// CHECK-NEXT:    copy_addr %0 to [initialization] [[PAYLOAD]] : $*T
+// CHECK-NEXT:    // function_ref PolyOptionable.mere<A>(_:)
+// CHECK-NEXT:    [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss14PolyOptionableO4mereyAByxGxcADmlF
+// CHECK-NEXT:    [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]<T>([[MERE]], [[PAYLOAD]], [[METATYPE]])
+// CHECK-NEXT:    dealloc_stack [[PAYLOAD]]
 // CHECK-NEXT:    destroy_addr [[MERE]]
 // CHECK-NEXT:    dealloc_stack [[MERE]]
 
@@ -154,12 +170,25 @@ func PolyOptionable_cases<T>(_ t: T) {
 // CHECK-LABEL: sil hidden @$Ss32PolyOptionable_specialized_casesyySiF
 func PolyOptionable_specialized_cases(_ t: Int) {
 
-// CHECK:         [[METATYPE:%.*]] = metatype $@thin PolyOptionable<Int>.Type
-// CHECK-NEXT:    [[NOUGHT:%.*]] = enum $PolyOptionable<Int>, #PolyOptionable.nought!enumelt
+// CHECK:         [[NOUGHT:%.*]] = alloc_stack $PolyOptionable<Int>
+// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin PolyOptionable<Int>.Type
+// CHECK-NEXT:    // function_ref PolyOptionable.nought<A>(_:)
+// CHECK-NEXT:    [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss14PolyOptionableO6noughtyAByxGADmlF
+// CHECK-NEXT:    [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]<Int>([[NOUGHT]], [[METATYPE]])
+// CHECK-NEXT:    [[RES:%.*]] = load [trivial] [[NOUGHT]]
+// CHECK-NEXT:    dealloc_stack [[NOUGHT]]
   _ = PolyOptionable<Int>.nought
 
+// CHECK-NEXT:    [[MERE:%.*]] = alloc_stack $PolyOptionable<Int>
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin PolyOptionable<Int>.Type
-// CHECK-NEXT:    [[NOUGHT:%.*]] = enum $PolyOptionable<Int>, #PolyOptionable.mere!enumelt.1, %0
+// CHECK-NEXT:    [[ARG_STACK:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    store %0 to [trivial] [[ARG_STACK]] : $*Int
+// CHECK-NEXT:    // function_ref PolyOptionable.mere<A>(_:)
+// CHECK-NEXT:    [[ENUM_CASE:%[0-9]+]] = function_ref @$Ss14PolyOptionableO4mereyAByxGxcADmlF
+// CHECK-NEXT:    [[ENUM_ELT:%[0-9]+]] = apply [[ENUM_CASE]]<Int>([[MERE]], [[ARG_STACK]], [[METATYPE]])
+// CHECK-NEXT:    dealloc_stack [[ARG_STACK]]
+// CHECK-NEXT:    [[RES:%.*]] = load [trivial] [[MERE]]
+// CHECK-NEXT:    dealloc_stack [[MERE]]
   _ = PolyOptionable<Int>.mere(t)
 
 // CHECK:         return

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -26,7 +26,9 @@ func make_a_cat() throws -> Cat {
 // CHECK:      [[BOX:%.*]] = alloc_existential_box $Error, $HomeworkError
 // CHECK-NEXT: [[ADDR:%.*]] = project_existential_box $HomeworkError in [[BOX]] : $Error
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thin HomeworkError.Type
-// CHECK-NEXT: [[T1:%.*]] = enum $HomeworkError, #HomeworkError.TooHard!enumelt
+// CHECK-NEXT: // function_ref HomeworkError.TooHard(_:)
+// CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$S6errors13HomeworkErrorO7TooHardyA2CmF
+// CHECK-NEXT: [[T1:%.*]] = apply [[ENUM_CASE]]([[T0]])
 // CHECK-NEXT: store [[T1]] to [init] [[ADDR]]
 // CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: throw [[BOX]]
@@ -38,7 +40,9 @@ func dont_make_a_cat() throws -> Cat {
 // CHECK:      [[BOX:%.*]] = alloc_existential_box $Error, $HomeworkError
 // CHECK-NEXT: [[ADDR:%.*]] = project_existential_box $HomeworkError in [[BOX]] : $Error
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thin HomeworkError.Type
-// CHECK-NEXT: [[T1:%.*]] = enum $HomeworkError, #HomeworkError.TooMuch!enumelt
+// CHECK-NEXT: // function_ref HomeworkError.TooMuch(_:)
+// CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$S6errors13HomeworkErrorO7TooMuchyA2CmF
+// CHECK-NEXT: [[T1:%.*]] = apply [[ENUM_CASE]]([[T0]])
 // CHECK-NEXT: store [[T1]] to [init] [[ADDR]]
 // CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: destroy_addr %1 : $*T

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -43,9 +43,11 @@ func extensionMethodCurrying(_ x: Foo) {
 // Extensions of generic types with stored property initializers
 
 // CHECK-LABEL: sil hidden [transparent] @$S10extensions3BoxV1txSgvpfi : $@convention(thin) <T> () -> @out Optional<T>
-// CHECK:      bb0(%0 : @trivial $*Optional<T>):
+// CHECK:      bb0([[ARG1:%.*]] : @trivial $*Optional<T>):
 // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin Optional<T>.Type
-// CHECK:      inject_enum_addr %0 : $*Optional<T>, #Optional.none!enumelt
+// CHECK-NEXT: // function_ref Optional.none<A>(_:)
+// CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$SSq4noneyxSgABmlF
+// CHECK-NEXT: apply [[ENUM_CASE]]<T>([[ARG1]], [[METATYPE]])
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]] : $()
 

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -12,33 +12,30 @@ indirect enum TreeA<T> {
 func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 // CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $TreeA<T>, [[ARG3:%.*]] : $TreeA<T>):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
-// CHECK-NEXT:    [[NIL:%.*]] = enum $TreeA<T>, #TreeA.Nil!enumelt
-// CHECK-NOT:     destroy_value [[NIL]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeAO3NilyACyxGAEmlF
+// CHECK-NEXT:    [[NIL:%.*]] = apply [[ENUM_CASE]]<T>([[METATYPE]])
+// CHECK:         destroy_value [[NIL]]
   let _ = TreeA<T>.Nil
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
-// CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    copy_addr [[ARG1]] to [initialization] [[PB]]
-// CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<T>, #TreeA.Leaf!enumelt.1, [[BOX]]
+// CHECK-NEXT:    [[STACK:%.*]] = alloc_stack $T
+// CHECK-NEXT:    copy_addr [[ARG1]] to [initialization] [[STACK]] : $*T
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeAO4LeafyACyxGxcAEmlF
+// CHECK-NEXT:    [[LEAF:%.*]] = apply [[ENUM_CASE]]<T>([[STACK]], [[METATYPE]])
+// CHECK-NEXT:    dealloc_stack [[STACK]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
   let _ = TreeA<T>.Leaf(t)
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>
-// CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 0
-// CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 1
 // CHECK-NEXT:    [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
 // CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]]
-// CHECK-NEXT:    store [[ARG2_COPY]] to [init] [[LEFT]]
 // CHECK-NEXT:    [[BORROWED_ARG3:%.*]] = begin_borrow [[ARG3]]
 // CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[BORROWED_ARG3]]
-// CHECK-NEXT:    store [[ARG3_COPY]] to [init] [[RIGHT]]
-// CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeA<T>, #TreeA.Branch!enumelt.1, [[BOX]]
-// CHECK-NEXT:    destroy_value [[BRANCH]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeAO6BranchyACyxGAE_AEtcAEmlF
+// CHECK-NEXT:    [[BRANCH:%.*]] = apply [[ENUM_CASE]]<T>([[ARG2_COPY]], [[ARG3_COPY]], [[METATYPE]])
 // CHECK-NEXT:    end_borrow [[BORROWED_ARG3]] from [[ARG3]]
 // CHECK-NEXT:    end_borrow [[BORROWED_ARG2]] from [[ARG2]]
+// CHECK-NEXT:    destroy_value [[BRANCH]]
 // CHECK-NEXT:    destroy_value [[ARG3]]
 // CHECK-NEXT:    destroy_value [[ARG2]]
 // CHECK-NEXT:    destroy_addr [[ARG1]]
@@ -52,16 +49,17 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
 // CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (Int) -> Int):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int) -> Int>
-// CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
+// CHECK-NEXT:    [[STACK:%.*]] = alloc_stack $@callee_guaranteed (@in Int) -> @out Int
 // CHECK-NEXT:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:         [[THUNK:%.*]] = function_ref @$SS2iIegyd_S2iIegir_TR
+// CHECK:         [[THUNK:%.*]] = function_ref @$SS2iIegyd_S2iIegir_TR : $@convention(thin) (@in Int, @guaranteed @callee_guaranteed (Int) -> Int) -> @out Int
 // CHECK-NEXT:    [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[ARG_COPY]])
-// CHECK-NEXT:    store [[FN]] to [init] [[PB]]
-// CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<(Int) -> Int>, #TreeA.Leaf!enumelt.1, [[BOX]]
-// CHECK-NEXT:    destroy_value [[LEAF]]
+// CHECK-NEXT:    store [[FN]] to [init] [[STACK]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeAO4LeafyACyxGxcAEmlF
+// CHECK-NEXT:    [[LEAF:%.*]] = apply [[ENUM_CASE]]<(Int) -> Int>([[STACK]], [[METATYPE]])
 // CHECK-NEXT:    end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK-NEXT:    dealloc_stack [[STACK]]
+// CHECK-NEXT:    destroy_value [[LEAF]]
 // CHECK-NEXT:    destroy_value [[ARG]]
 // CHECK: return
   let _ = TreeA<(Int) -> Int>.Leaf(f)
@@ -76,39 +74,43 @@ enum TreeB<T> {
 
 // CHECK-LABEL: sil hidden @$S13indirect_enum11TreeB_cases_1l1ryx_AA0C1BOyxGAGtlF
 func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
+// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $*TreeB<T>, [[ARG3:%.*]] : $*TreeB<T>):
 
-// CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
 // CHECK:         [[NIL:%.*]] = alloc_stack $TreeB<T>
-// CHECK-NEXT:    inject_enum_addr [[NIL]] : $*TreeB<T>, #TreeB.Nil!enumelt
+// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeBO3NilyACyxGAEmlF
+// CHECK-NEXT:    [[NIL_CASE:%.*]] = apply [[ENUM_CASE]]<T>([[NIL]], [[METATYPE]])
+// CHECK-NOT:     destroy_value [[NIL_CASE]]
 // CHECK-NEXT:    destroy_addr [[NIL]]
 // CHECK-NEXT:    dealloc_stack [[NIL]]
   let _ = TreeB<T>.Nil
 
-// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
 // CHECK-NEXT:    [[LEAF:%.*]] = alloc_stack $TreeB<T>
-// CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[LEAF]] : $*TreeB<T>, #TreeB.Leaf!enumelt.1
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[PAYLOAD]]
-// CHECK-NEXT:    inject_enum_addr [[LEAF]] : $*TreeB<T>, #TreeB.Leaf!enumelt
+// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
+// CHECK-NEXT:    [[PAYLOAD:%.*]] = alloc_stack $T
+// CHECK-NEXT:    copy_addr [[ARG1]] to [initialization] [[PAYLOAD]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeBO4LeafyACyxGxcAEmlF
+// CHECK-NEXT:    [[LEAF_CASE:%.*]] = apply [[ENUM_CASE]]<T>([[LEAF]], [[PAYLOAD]], [[METATYPE]])
+// CHECK-NEXT:    dealloc_stack [[PAYLOAD]]
 // CHECK-NEXT:    destroy_addr [[LEAF]]
 // CHECK-NEXT:    dealloc_stack [[LEAF]]
   let _ = TreeB<T>.Leaf(t)
 
-// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var (left: TreeB<τ_0_0>, right: TreeB<τ_0_0>) } <T>
-// CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
-// CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
-// CHECK-NEXT:    copy_addr %1 to [initialization] [[LEFT]] : $*TreeB<T>
-// CHECK-NEXT:    copy_addr %2 to [initialization] [[RIGHT]] : $*TreeB<T>
 // CHECK-NEXT:    [[BRANCH:%.*]] = alloc_stack $TreeB<T>
-// CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[BRANCH]]
-// CHECK-NEXT:    store [[BOX]] to [init] [[PAYLOAD]]
-// CHECK-NEXT:    inject_enum_addr [[BRANCH]] : $*TreeB<T>, #TreeB.Branch!enumelt.1
+// CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
+// CHECK-NEXT:    [[LEFT_STACK:%.*]] = alloc_stack $TreeB<T>
+// CHECK-NEXT:    copy_addr [[ARG2]] to [initialization] [[LEFT_STACK]]
+// CHECK-NEXT:    [[RIGHT_STACK:%.*]] = alloc_stack $TreeB<T>
+// CHECK-NEXT:    copy_addr [[ARG3]] to [initialization] [[RIGHT_STACK]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum5TreeBO6BranchyACyxGAE_AEtcAEmlF
+// CHECK-NEXT:    [[BRANCH_CASE:%.*]] = apply [[ENUM_CASE]]<T>([[BRANCH]], [[LEFT_STACK]], [[RIGHT_STACK]], [[METATYPE]])
+// CHECK-NEXT:    dealloc_stack [[RIGHT_STACK]]
+// CHECK-NEXT:    dealloc_stack [[LEFT_STACK]]
 // CHECK-NEXT:    destroy_addr [[BRANCH]]
 // CHECK-NEXT:    dealloc_stack [[BRANCH]]
-// CHECK-NEXT:    destroy_addr %2
-// CHECK-NEXT:    destroy_addr %1
-// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    destroy_addr [[ARG3]]
+// CHECK-NEXT:    destroy_addr [[ARG2]]
+// CHECK-NEXT:    destroy_addr [[ARG1]]
   let _ = TreeB<T>.Branch(left: l, right: r)
 
 // CHECK:         return
@@ -118,31 +120,29 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
 // CHECK-LABEL: sil hidden @$S13indirect_enum13TreeInt_cases_1l1rySi_AA0cD0OAFtF : $@convention(thin) (Int, @owned TreeInt, @owned TreeInt) -> ()
 func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
 // CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $TreeInt, [[ARG3:%.*]] : $TreeInt):
+
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
-// CHECK-NEXT:    [[NIL:%.*]] = enum $TreeInt, #TreeInt.Nil!enumelt
-// CHECK-NOT:     destroy_value [[NIL]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum7TreeIntO3NilyA2CmF
+// CHECK-NEXT:    [[NIL_CASE:%.*]] = apply [[ENUM_CASE]]([[METATYPE]])
+// CHECK-NEXT:    destroy_value [[NIL_CASE]]
   let _ = TreeInt.Nil
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
-// CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeInt, #TreeInt.Leaf!enumelt.1, [[ARG1]]
-// CHECK-NOT:     destroy_value [[LEAF]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum7TreeIntO4LeafyACSicACmF
+// CHECK-NEXT:    [[LEAF_CASE:%.*]] = apply [[ENUM_CASE]]([[ARG1]], [[METATYPE]])
+// CHECK-NEXT:    destroy_value [[LEAF_CASE]]
   let _ = TreeInt.Leaf(t)
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ var (left: TreeInt, right: TreeInt) }
-// CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
-// CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
 // CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]]
-// CHECK-NEXT:    store [[ARG2_COPY]] to [init] [[LEFT]]
 // CHECK-NEXT:    [[BORROWED_ARG3:%.*]] = begin_borrow [[ARG3]]
 // CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[BORROWED_ARG3]]
-// CHECK-NEXT:    store [[ARG3_COPY]] to [init] [[RIGHT]]
-// CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeInt, #TreeInt.Branch!enumelt.1, [[BOX]]
-// CHECK-NEXT:    destroy_value [[BRANCH]]
+// CHECK:         [[ENUM_CASE:%.*]] = function_ref @$S13indirect_enum7TreeIntO6BranchyA2C_ACtcACmF
+// CHECK-NEXT:    [[BRANCH_CASE:%.*]] = apply [[ENUM_CASE]]([[ARG2_COPY]], [[ARG3_COPY]], [[METATYPE]])
 // CHECK-NEXT:    end_borrow [[BORROWED_ARG3]] from [[ARG3]]
 // CHECK-NEXT:    end_borrow [[BORROWED_ARG2]] from [[ARG2]]
+// CHECK-NEXT:    destroy_value [[BRANCH_CASE]]
 // CHECK-NEXT:    destroy_value [[ARG3]]
 // CHECK-NEXT:    destroy_value [[ARG2]]
   let _ = TreeInt.Branch(left: l, right: r)

--- a/test/SILGen/nil_literal.swift
+++ b/test/SILGen/nil_literal.swift
@@ -13,8 +13,10 @@ func takesANull(_: CustomNull) {}
 // CHECK-LABEL: sil hidden @$S11nil_literal4testyyF : $@convention(thin) () -> ()
 func test() {
   // CHECK: [[NIL:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
+  // CHECK: br [[DEST_BB:bb.*]]([[NIL]] : $Optional<@callee_guaranteed () -> ()>)
+  // CHECK: [[DEST_BB]]([[NIL_ARG:%.*]] : @owned $Optional<@callee_guaranteed () -> ()>):
   // CHECK: [[FN:%.*]] = function_ref @$S11nil_literal21takesOptionalFunctionyyyycSgF
-  // CHECK: apply [[FN]]([[NIL]])
+  // CHECK: apply [[FN]]([[NIL_ARG]])
   _ = takesOptionalFunction(nil)
 
   // CHECK: [[METATYPE:%.*]] = metatype $@thin CustomNull.Type

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -120,8 +120,10 @@ func genericFunc<V: AnyObject>(_ v: V.Type) {
 }
 
 // CHECK-LABEL: sil hidden @$S21objc_imported_generic23configureWithoutOptionsyyF : $@convention(thin) () -> ()
-// CHECK: enum $Optional<Dictionary<GenericOption, Any>>, #Optional.none!enumelt
-// CHECK: return
+// CHECK:      // function_ref Optional.none<A>(_:)
+// CHECK-NEXT: [[ENUM_CASE:%.*]] = function_ref @$SSq4noneyxSgABmlF
+// CHECK-NEXT: apply [[ENUM_CASE]]<[GenericOption : Any]>({{%.*}}, {{%.*}})
+// CHECK:      return
 func configureWithoutOptions() {
   _ = GenericClass<NSObject>(options: nil)
 }

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -9,7 +9,8 @@ throw MyError.A
 // CHECK: sil @main
 // CHECK: [[ERR:%.*]] = alloc_existential_box $Error, $MyError
 // CHECK: [[ADDR:%.*]] = project_existential_box $MyError in [[ERR]] : $Error
-// CHECK: [[T0:%.*]] = enum $MyError, #MyError.A!enumelt
+// CHECK: [[ENUM_CASE:%.*]] = function_ref @$S15toplevel_errors7MyErrorO1AyA2CmF : $@convention(method) (@thin MyError.Type) -> MyError
+// CHECK: [[T0:%.*]] = apply [[ENUM_CASE]]({{%.*}})
 // CHECK: store [[T0]] to [trivial] [[ADDR]] : $*MyError
 // CHECK: builtin "willThrow"([[ERR]] : $Error)
 // CHECK: br bb2([[ERR]] : $Error)

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -119,10 +119,16 @@ func testTupleUnsplat() {
   let x = 1, y = 2
 
   // CHECK: [[TUPLE:%.+]] = tuple ([[X]] : $Int, [[Y]] : $Int)
-  // CHECK: enum $GenericEnum<(Int, Int)>, #GenericEnum.one!enumelt.1, [[TUPLE]]
+  // CHECK: [[TUPLE_VAL:%.+]] = alloc_stack $(Int, Int)
+  // CHECK: store [[TUPLE]] to [trivial] [[TUPLE_VAL]] : $*(Int, Int)
+  // CHECK: [[ENUM_CASE:%.+]] = function_ref @$S6tuples11GenericEnumO3oneyACyxGxcAEmlF
+  // CHECK: apply [[ENUM_CASE]]<(Int, Int)>({{%.+}}, [[TUPLE_VAL]], {{%.+}})
   _ = GenericEnum<(Int, Int)>.one((x, y))
   // CHECK: [[TUPLE:%.+]] = tuple ([[X]] : $Int, [[Y]] : $Int)
-  // CHECK: enum $GenericEnum<(Int, Int)>, #GenericEnum.one!enumelt.1, [[TUPLE]]
+  // CHECK: [[TUPLE_VAL:%.+]] = alloc_stack $(Int, Int)
+  // CHECK: store [[TUPLE]] to [trivial] [[TUPLE_VAL]] : $*(Int, Int)
+  // CHECK: [[ENUM_CASE:%.+]] = function_ref @$S6tuples11GenericEnumO3oneyACyxGxcAEmlF
+  // CHECK: apply [[ENUM_CASE]]<(Int, Int)>({{%.+}}, [[TUPLE_VAL]], {{%.+}})
   _ = GenericEnum<(Int, Int)>.one(x, y)
 
   // CHECK: [[THUNK:%.+]] = function_ref @$SSi_SitIegi_S2iIegyy_TR

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -335,10 +335,6 @@ func testInitGenericEnum<T>(t: T) -> GenericEnum<T>? {
 // CHECK:   mark_uninitialized [delegatingself] %3 : $<τ_0_0> { var GenericEnum<τ_0_0> } <T>
 // CHECK:   [[PROJ:%.*]] = project_box
 // CHECK:   [[STK:%.*]] = alloc_stack $GenericEnum<T>
-// CHECK:   [[ADR1:%.*]] = init_enum_data_addr [[STK]]
-// CHECK-NOT: begin_access
-// CHECK:   copy_addr %1 to [initialization] [[ADR1]] : $*T
-// CHECK:   inject_enum_addr
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]]
 // CHECK:   copy_addr [take] %{{.*}} to [[ACCESS]] : $*GenericEnum<T>
 // CHECK:   end_access [[ACCESS]] : $*GenericEnum<T>
@@ -356,17 +352,16 @@ enum IndirectEnum {
 func testIndirectEnum() -> IndirectEnum {
   return IndirectEnum.V(3)
 }
-// CHECK-LABEL: sil hidden @$S20access_marker_verify16testIndirectEnumAA0eF0OyF : $@convention(thin) () -> @owned IndirectEnum {
-// CHECK: bb0:
+// CHECK-LABEL: sil shared [transparent] @$S20access_marker_verify12IndirectEnumO1VyACSicACmF : $@convention(method) (Int, @thin IndirectEnum.Type) -> @owned IndirectEnum {
+// CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $@thin IndirectEnum.Type):
 // CHECK:   alloc_box ${ var Int }
 // CHECK:   [[PROJ:%.*]] = project_box
-// CHECK:   apply
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]]
 // CHECK:   store %{{.*}} to [trivial] [[ACCESS]] : $*Int
 // CHECK:   end_access
 // CHECK:   enum $IndirectEnum, #IndirectEnum.V!enumelt.1
 // CHECK:   return
-// CHECK-LABEL: } // end sil function '$S20access_marker_verify16testIndirectEnumAA0eF0OyF'
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify12IndirectEnumO1VyACSicACmF'
 
 // -- indirect enum with getter.
 enum IntEnum {

--- a/test/SILOptimizer/loweraggregateinstrs.sil
+++ b/test/SILOptimizer/loweraggregateinstrs.sil
@@ -37,7 +37,7 @@ struct S {
 }
 
 enum E {
-  case NoElement()
+  case NoElement(Void)
   case TrivialElement(Builtin.Int64)
   case ReferenceElement(C1)
   case StructNonTrivialElt(S)

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -458,8 +458,8 @@ enum DefaultEnumPrivate {
 }
 public enum PublicEnumPI {
   case A(InternalStruct) // expected-error {{enum case in a public enum uses an internal type}}
-  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a private type}}
-  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a private type}}
+  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a private type}} expected-error {{enum case in a public enum uses an internal type}}
+  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses an internal type}} expected-error {{enum case in a public enum uses a private type}}
 }
 enum DefaultEnumPublic {
   case A(PublicStruct) // no-warning

--- a/test/Sema/unsupported_recursive_value_type.swift
+++ b/test/Sema/unsupported_recursive_value_type.swift
@@ -6,7 +6,7 @@ struct SelfRecursiveStruct {
 
 struct OptionallyRecursiveStruct {
   let a: OptionallyRecursiveStruct? // expected-error{{value type 'OptionallyRecursiveStruct' cannot have a stored property that recursively contains it}}
-  // expected-note@-1 {{cycle beginning here: OptionallyRecursiveStruct? -> (some: OptionallyRecursiveStruct)}}
+  // expected-note@-1 {{cycle beginning here: OptionallyRecursiveStruct? -> (some(_:): OptionallyRecursiveStruct)}}
 
   init() { a = OptionallyRecursiveStruct() }
 }
@@ -31,11 +31,11 @@ enum TerminatingSelfRecursiveEnum { // expected-error{{recursive enum 'Terminati
 
 enum IndirectlyRecursiveEnum1 { // expected-error{{recursive enum 'IndirectlyRecursiveEnum1' is not marked 'indirect'}} {{1-1=indirect }}
   case A(IndirectlyRecursiveEnum2)
-  // expected-note@-1 {{cycle beginning here: IndirectlyRecursiveEnum2 -> (A: IndirectlyRecursiveEnum1)}}
+  // expected-note@-1 {{cycle beginning here: IndirectlyRecursiveEnum2 -> (A(_:): IndirectlyRecursiveEnum1)}}
 }
 enum IndirectlyRecursiveEnum2 { // expected-error{{recursive enum 'IndirectlyRecursiveEnum2' is not marked 'indirect'}}
   case A(IndirectlyRecursiveEnum1)
-  // expected-note@-1 {{cycle beginning here: IndirectlyRecursiveEnum1 -> (A: IndirectlyRecursiveEnum2)}}
+  // expected-note@-1 {{cycle beginning here: IndirectlyRecursiveEnum1 -> (A(_:): IndirectlyRecursiveEnum2)}}
 }
 
 enum RecursiveByGenericSubstitutionEnum<T> {
@@ -49,12 +49,12 @@ struct RecursiveByBeingInTupleStruct {
 
 struct OptionallySelfRecursiveStruct { // expected-error{{value type 'OptionallySelfRecursiveStruct' has infinite size}}
   let a: Optional<OptionallyRecursiveStruct>
-  // expected-note@-1 {{cycle beginning here: Optional<OptionallyRecursiveStruct> -> (some: OptionallyRecursiveStruct) -> (a: OptionallyRecursiveStruct?)}}
+  // expected-note@-1 {{cycle beginning here: Optional<OptionallyRecursiveStruct> -> (some(_:): OptionallyRecursiveStruct) -> (a: OptionallyRecursiveStruct?)}}
 }
 
 enum OptionallySelfRecursiveEnum { // expected-error{{recursive enum 'OptionallySelfRecursiveEnum' is not marked 'indirect'}}
   case A(Optional<OptionallySelfRecursiveEnum>)
-  // expected-note@-1 {{cycle beginning here: Optional<OptionallySelfRecursiveEnum> -> (some: OptionallySelfRecursiveEnum)}}
+  // expected-note@-1 {{cycle beginning here: Optional<OptionallySelfRecursiveEnum> -> (some(_:): OptionallySelfRecursiveEnum)}}
 }
 
 // self-recursive struct with self as member's type argument, a proper name would
@@ -68,7 +68,7 @@ struct X<T> { // expected-error{{value type 'X<T>' has infinite size}}
 // name would be too long
 enum Y<T> { // expected-error{{value type 'Y<T>' has infinite size}}
     case A(Int, Y<Y>)
-    // expected-note@-1 {{cycle beginning here: (Int, Y<Y<T>>) -> (.1: Y<Y<T>>) -> (A: (Int, Y<Y<Y<T>>>)) -> (.1: Y<Y<Y<T>>>) -> (A: (Int, Y<Y<Y<Y<T>>>>)) -> (.1: Y<Y<Y<Y<T>>>>) -> ...}}
+  // expected-note@-1 {{cycle beginning here: (Int, Y<Y<T>>) -> (.1: Y<Y<T>>) -> (A(_:_:): (Int, Y<Y<Y<T>>>)) -> (.1: Y<Y<Y<T>>>) -> (A(_:_:): (Int, Y<Y<Y<Y<T>>>>)) -> (.1: Y<Y<Y<Y<T>>>>) -> ...}}
 }
 
 // ultra super nest-acular type
@@ -80,7 +80,7 @@ struct Z<T, U> { // expected-error{{value type 'Z<T, U>' has infinite size}}
 struct RecursiveByGenericSubstitutionStruct {
   let a: RecursiveByGenericSubstitutionEnum<RecursiveByGenericSubstitutionStruct>
   // expected-error@-1{{value type 'RecursiveByGenericSubstitutionStruct' cannot have a stored property that recursively contains it}}
-  // expected-note@-2 {{cycle beginning here: RecursiveByGenericSubstitutionEnum<RecursiveByGenericSubstitutionStruct> -> (A: RecursiveByGenericSubstitutionStruct)}}
+  // expected-note@-2 {{cycle beginning here: RecursiveByGenericSubstitutionEnum<RecursiveByGenericSubstitutionStruct> -> (A(_:): RecursiveByGenericSubstitutionStruct)}}
 }
 
 struct RecursiveWithLocal {
@@ -143,12 +143,12 @@ struct Bad {
 // FIXME: this diagnostic is unnecessary
 struct Test1 { // expected-error {{value type 'Test1' has infinite size}}
   var test1: StructCyclesWithEnum<Int>
-  // expected-note@-1 {{cycle beginning here: StructCyclesWithEnum<Int> -> (sField: EnumCyclesWithStruct<Int>) -> (eCase: StructCyclesWithEnum<Int>)}}
+  // expected-note@-1 {{cycle beginning here: StructCyclesWithEnum<Int> -> (sField: EnumCyclesWithStruct<Int>) -> (eCase(_:): StructCyclesWithEnum<Int>)}}
 }
 
 struct StructCyclesWithEnum<T> {
   var sField: EnumCyclesWithStruct<T> // expected-error {{value type 'StructCyclesWithEnum<T>' cannot have a stored property that recursively contains it}}
-  // expected-note@-1 {{cycle beginning here: EnumCyclesWithStruct<T> -> (eCase: StructCyclesWithEnum<T>)}}
+  // expected-note@-1 {{cycle beginning here: EnumCyclesWithStruct<T> -> (eCase(_:): StructCyclesWithEnum<T>)}}
 }
 
 enum EnumCyclesWithStruct<T> { // expected-error {{recursive enum 'EnumCyclesWithStruct<T>' is not marked 'indirect'}}

--- a/test/Sema/unsupported_recursive_value_type_multifile.swift
+++ b/test/Sema/unsupported_recursive_value_type_multifile.swift
@@ -3,5 +3,5 @@
 struct A {
   var b: B?
   // expected-error@-1 {{value type 'A' cannot have a stored property that recursively contains it}}
-  // expected-note@-2 {{cycle beginning here: B? -> (some: B) -> (a: A)}}
+  // expected-note@-2 {{cycle beginning here: B? -> (some(_:): B) -> (a: A)}}
 }

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -488,7 +488,7 @@ typealias typeWithNestedAutoclosure = (@autoclosure () -> ()) -> ()
 // CHECK40-NEXT: s:11cursor_info2E2O2C2yACSi_SStcACmF
 // CHECK40-NEXT: (E2.Type) -> (Int, String) -> E2
 // CHECK40: <Declaration>case C2(x: <Type usr="s:Si">Int</Type>, y: <Type usr="s:SS">String</Type>)</Declaration>
-// CHECK40-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name><tuple>(<tuple.element><tuple.element.argument_label>x</tuple.element.argument_label>: <tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.argument_label>y</tuple.element.argument_label>: <tuple.element.type><ref.struct usr="s:SS">String</ref.struct></tuple.element.type></tuple.element>)</tuple></decl.enumelement>
+// CHECK40-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:SS">String</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.enumelement>
 
 // RUN: %sourcekitd-test -req=cursor -pos=92:31 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK41
 // CHECK41: source.lang.swift.decl.enumelement (92:31-92:33)
@@ -496,8 +496,7 @@ typealias typeWithNestedAutoclosure = (@autoclosure () -> ()) -> ()
 // CHECK41-NEXT: s:11cursor_info2E2O2C3yACSicACmF
 // CHECK41-NEXT: (E2.Type) -> (Int) -> E2
 // CHECK41: <Declaration>case C3(<Type usr="s:Si">Int</Type>)</Declaration>
-// CHECK41-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C3</decl.name>(<ref.struct usr="s:Si">Int</ref.struct>)</decl.enumelement>
-// FIXME: Wrap parameters in <decl.var.parameter>
+// CHECK41-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C3</decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.enumelement>
 
 // RUN: %sourcekitd-test -req=cursor -pos=96:8 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK42
 // CHECK42: source.lang.swift.decl.enumelement (96:8-96:9)
@@ -517,13 +516,13 @@ typealias typeWithNestedAutoclosure = (@autoclosure () -> ()) -> ()
 // CHECK44: source.lang.swift.ref.enumelement (92:8-92:10)
 // CHECK44-NEXT: C2
 // CHECK44: <Declaration>case C2(x: <Type usr="s:Si">Int</Type>, y: <Type usr="s:SS">String</Type>)</Declaration>
-// CHECK44-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name><tuple>(<tuple.element><tuple.element.argument_label>x</tuple.element.argument_label>: <tuple.element.type><ref
+// CHECK44-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref
 
 // RUN: %sourcekitd-test -req=cursor -pos=102:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK45
 // CHECK45: source.lang.swift.ref.enumelement (92:8-92:10)
 // CHECK45-NEXT: C2
 // CHECK45: <Declaration>case C2(x: <Type usr="s:Si">Int</Type>, y: <Type usr="s:SS">String</Type>)</Declaration>
-// CHECK45-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name><tuple>(<tuple.element><tuple.element.argument_label>x
+// CHECK45-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x
 
 // RUN: %sourcekitd-test -req=cursor -pos=103:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK46
 // CHECK46: source.lang.swift.ref.enumelement (96:8-96:9)

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -26,7 +26,7 @@
         },
         {
           key.kind: source.lang.swift.decl.enumelement,
-          key.name: "two",
+          key.name: "two(a:)",
           key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
           key.line: 6,
           key.column: 15,
@@ -70,7 +70,7 @@
                 },
                 {
                   key.kind: source.lang.swift.ref.enumelement,
-                  key.name: "two",
+                  key.name: "two(a:)",
                   key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
                   key.line: 12,
                   key.column: 15
@@ -130,7 +130,7 @@
     },
     {
       key.kind: source.lang.swift.ref.enumelement,
-      key.name: "two",
+      key.name: "two(a:)",
       key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
       key.line: 21,
       key.column: 13

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -124,8 +124,8 @@ class TestFunc12 {
 
 
 enum AutoclosureFailableOf<T> {
-  case Success(@autoclosure () -> T)  // expected-error {{@autoclosure may only be used on parameters}}
-  case Failure()
+  case Success(@autoclosure () -> T)
+  case Failure(Void)
 }
 
 let _ : (@autoclosure () -> ()) -> ()

--- a/test/decl/func/keyword-argument-defaults.swift
+++ b/test/decl/func/keyword-argument-defaults.swift
@@ -119,3 +119,9 @@ func +(_ a: String,
 func +(a: Double, b: String) -> (Int) -> (_ d: Int) -> () {
   return { c in { e in () } }
 }
+
+// Enum elements
+enum TestEnumElements {
+  case element(_ a : String,
+               d d : Double) // expected-error {{enum case cannot have keyword arguments}}
+}

--- a/test/refactoring/SyntacticRename/Outputs/types/case-qrCode.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/types/case-qrCode.swift.expected
@@ -26,7 +26,7 @@ extension /*class-Animal:def*/Animal {
 
 enum /*enum-Barcode:def*/Barcode {
 	case upc(Int, Int, Int, Int)
-	case /*case-qrCode:def*/QRCode(String)
+	case /*case-qrCode:def*/QRCode(_ code: String)
 	case /*case-other:def*/other(Int)
 	case /*case-another:def*/another
 }


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ 

SE-0155 Requirements:

- [x] Ban `case Foo()`, rewrite to `case Foo(Void)`
- [x] Labels in associated value clauses are part of the case name
- [x] Case name overloading on distinct full names
- [x] Default arguments in associated value clauses
- [ ] Consistent pattern matching behavior (see below)

A number of cleanups fell out of this patch:

- `EnumElementDecl`s owning a parameter list simplifies both serialization and AST printing
- SourceKit now reports `EnumElementDecl`s as owning a parameter list instead of a tuple
- Function types in enum cases are implicitly marked `@escaping` and actually participate in semantic checks

Some open questions:

- [ ] [I would like the role of labels in patterns clarified](https://forums.swift.org/t/se-0155-discuss-the-role-of-labels-in-enum-case-patterns/6603) before I finish off the work in TypeCheckPattern
- [x] The SILVerifier really doesn't like when uncurried applies and `EnumInst`s interact
