### PR TITLE
build: pass along CMAKE_BUILD_PROGRAM to sub-build

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -98,6 +98,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                         CMAKE_ARGS
                           -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
                           -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
+                          -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
                           -DCMAKE_SWIFT_COMPILER=$<TARGET_FILE:swift>c
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DENABLE_SWIFT=YES


### PR DESCRIPTION
Pass along our `CMAKE_BUILD_PROGRAM` to the libdispatch build which is
done as part of the build for SourceKit.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6132](https://bugs.swift.org/browse/SR-6132).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
