### PR TITLE
[swiftc (63 vs. 5600)] Add crasher in swift::GenericSignatureBuilder::RequirementSource::getMinimalConformanceSource

### DIFF
--- a/validation-test/compiler_crashers/28857-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
+++ b/validation-test/compiler_crashers/28857-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:RangeReplaceableCollection&a:class a:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::RequirementSource::getMinimalConformanceSource`.

Current number of unresolved compiler crashers: 63 (5600 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `nestedPAByName && "Didn't find the associated type we wanted"` added on 2017-03-23 by you in commit 8bd863e6 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 640)`](https://github.com/apple/swift/blob/f1d8f94b6d6b326dcaca369b719e9f397a1e380a/lib/AST/GenericSignatureBuilder.cpp#L640):

```
Assertion `nestedPAByName && "Didn't find the associated type we wanted"' failed.

When executing: PotentialArchetype *replaceSelfWithPotentialArchetype(PotentialArchetype *, swift::Type)
```

Assertion context:

```c++

      if (auto result = findNested(otherBasePA))
        return result;
    }

    assert(nestedPAByName && "Didn't find the associated type we wanted");
    return nestedPAByName;
  }

  assert(depTy->is<GenericTypeParamType>() && "missing Self?");
  return selfPA;
```
Stack trace:

```
0 0x0000000003eb9144 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3eb9144)
1 0x0000000003eb9486 SignalHandler(int) (/path/to/swift/bin/swift+0x3eb9486)
2 0x00007f81bfff8390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f81be51d428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f81be51f02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f81be515bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f81be515c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001680b5c replaceSelfWithPotentialArchetype(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type) (/path/to/swift/bin/swift+0x1680b5c)
8 0x000000000167edba swift::GenericSignatureBuilder::RequirementSource::getMinimalConformanceSource(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, bool&) const (/path/to/swift/bin/swift+0x167edba)
9 0x000000000167ef35 swift::GenericSignatureBuilder::RequirementSource::getMinimalConformanceSource(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, bool&) const (/path/to/swift/bin/swift+0x167ef35)
10 0x00000000016aa278 bool __gnu_cxx::__ops::_Iter_pred<bool (anonymous namespace)::removeSelfDerived<swift::GenericSignatureBuilder::PotentialArchetype*>(std::vector<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*> > >&, swift::ProtocolDecl*, bool, bool)::{lambda(swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*> const&)#1}>::operator()<__gnu_cxx::__normal_iterator<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*>*, std::vector<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*> > > > >(__gnu_cxx::__normal_iterator<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*>*, std::vector<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*> > > >) (/path/to/swift/bin/swift+0x16aa278)
11 0x000000000169aeb3 bool (anonymous namespace)::removeSelfDerived<swift::GenericSignatureBuilder::PotentialArchetype*>(std::vector<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::GenericSignatureBuilder::PotentialArchetype*> > >&, swift::ProtocolDecl*, bool, bool) (/path/to/swift/bin/swift+0x169aeb3)
12 0x000000000169707f swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x169707f)
13 0x00000000016951a5 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x16951a5)
14 0x000000000169ceba swift::GenericSignatureBuilder::computeGenericSignature(swift::SourceLoc, bool, bool) && (/path/to/swift/bin/swift+0x169ceba)
15 0x000000000169d0e8 swift::GenericSignatureBuilder::computeRequirementSignature(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x169d0e8)
16 0x0000000001658ed6 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x1658ed6)
17 0x00000000012d7b48 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12d7b48)
18 0x00000000012a5ab8 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a5ab8)
19 0x00000000012b6ba4 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b6ba4)
20 0x00000000012a3c4f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a3c4f)
21 0x00000000012a3ae3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a3ae3)
22 0x00000000013367f5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13367f5)
23 0x0000000001056f44 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1056f44)
24 0x0000000001056007 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056007)
25 0x000000000105592a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105592a)
26 0x00000000004bfed2 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfed2)
27 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
28 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
29 0x00007f81be508830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```