### PR TITLE
[swiftc (64 vs. 5600)] Add crasher in swift::ProtocolCompositionType::get

### DIFF
--- a/validation-test/compiler_crashers/28858-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers/28858-val-isa-used-on-a-null-pointer.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func a
+class a<b}let d=a?as?CVarArg
+& a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolCompositionType::get`.

Current number of unresolved compiler crashers: 64 (5600 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 106)`:

```
Assertion `Val && "isa<> used on a null pointer"' failed.

When executing: static bool llvm::isa_impl_cl<swift::ClassDecl, const swift::NominalTypeDecl *>::doit(const From *) [To = swift::ClassDecl, From = const swift::NominalTypeDecl *]
```

Assertion context:

```c++
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*> {
  static inline bool doit(const From *Val) {
    assert(Val && "isa<> used on a null pointer");
    return isa_impl<To, From>::doit(*Val);
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*const> {
```
Stack trace:

```
0 0x0000000003eb9144 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3eb9144)
1 0x0000000003eb9486 SignalHandler(int) (/path/to/swift/bin/swift+0x3eb9486)
2 0x00007fcbd737c390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fcbd58a1428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fcbd58a302a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fcbd5899bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fcbd5899c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016f139d addProtocols(swift::Type, llvm::SmallVectorImpl<swift::ProtocolDecl*>&, swift::Type&, bool&) (/path/to/swift/bin/swift+0x16f139d)
8 0x00000000016ecc61 swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ecc61)
9 0x00000000016f4555 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16f4555)
10 0x00000000016ea0a7 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0x16ea0a7)
11 0x0000000001271548 swift::constraints::ConstraintSystem::openUnboundGenericType(swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x1271548)
12 0x0000000001228157 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1228157)
13 0x000000000122fa0e (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x122fa0e)
14 0x0000000001630dbc swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1630dbc)
15 0x00000000012264cf swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12264cf)
16 0x0000000001254361 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1254361)
17 0x0000000001288447 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1288447)
18 0x000000000128c20c swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x128c20c)
19 0x0000000001290b36 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x1290b36)
20 0x0000000001290db6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x1290db6)
21 0x00000000012a96f8 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12a96f8)
22 0x00000000012a3c98 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a3c98)
23 0x00000000012a3ae3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a3ae3)
24 0x00000000013173c5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13173c5)
25 0x0000000001316c36 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1316c36)
26 0x0000000001336860 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1336860)
27 0x0000000001056f44 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1056f44)
28 0x0000000001056007 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056007)
29 0x000000000105592a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105592a)
30 0x00000000004bfed2 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfed2)
31 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
32 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
33 0x00007fcbd588c830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```