### PR TITLE
[swiftc (65 vs. 5600)] Add crasher in swift::NormalProtocolConformance::getTypeWitnessAndDecl

### DIFF
--- a/validation-test/compiler_crashers/28859-resolver-unable-to-resolve-type-witness.swift
+++ b/validation-test/compiler_crashers/28859-resolver-unable-to-resolve-type-witness.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a:P@objc protocol P{{}func a:a{}{}typealias a


### PR DESCRIPTION
Add test case for crash triggered in `swift::NormalProtocolConformance::getTypeWitnessAndDecl`.

Current number of unresolved compiler crashers: 65 (5600 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `resolver && "Unable to resolve type witness"` added on 2017-09-12 by you in commit e26949d3 :-)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 528)`](https://github.com/apple/swift/blob/1a9533ca7e734d69fecdec44c3759a66b71b4338/lib/AST/ProtocolConformance.cpp#L528):

```
Assertion `resolver && "Unable to resolve type witness"' failed.

When executing: std::pair<Type, TypeDecl *> swift::NormalProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl *, swift::LazyResolver *, swift::SubstOptions) const
```

Assertion context:

```c++
    return { Type(), nullptr };
  }

  // Otherwise, resolve the type witness.
  PrettyStackTraceRequirement trace("resolving", this, assocType);
  assert(resolver && "Unable to resolve type witness");
  resolver->resolveTypeWitness(this, assocType);

  known = TypeWitnesses.find(assocType);
  assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
  return known->second;
```
Stack trace:

```
0 0x0000000003eb9144 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3eb9144)
1 0x0000000003eb9486 SignalHandler(int) (/path/to/swift/bin/swift+0x3eb9486)
2 0x00007f91ecfd4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f91eb4f9428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f91eb4fb02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f91eb4f1bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f91eb4f1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016d93dc swift::NormalProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16d93dc)
8 0x00000000016d9018 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16d9018)
9 0x00000000016d8b39 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16d8b39)
10 0x00000000012f0e98 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12f0e98)
11 0x00000000012e77ac (anonymous namespace)::MultiConformanceChecker::checkAllConformances() (/path/to/swift/bin/swift+0x12e77ac)
12 0x00000000012e8d3b swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x12e8d3b)
13 0x00000000012b5b9d (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b5b9d)
14 0x00000000012a3d3e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a3d3e)
15 0x00000000012a3ae3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a3ae3)
16 0x000000000133687a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x133687a)
17 0x0000000001056f44 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1056f44)
18 0x0000000001056007 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056007)
19 0x000000000105592a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105592a)
20 0x00000000004bfed2 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfed2)
21 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
22 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
23 0x00007f91eb4e4830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```