### PR TITLE
[swiftc (66 vs. 5600)] Add crasher in swift::TypeChecker::resolveTypeWitness

### DIFF
--- a/validation-test/compiler_crashers/28860-iscomplete-isinvalid-conformance-already-complete.swift
+++ b/validation-test/compiler_crashers/28860-iscomplete-isinvalid-conformance-already-complete.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{class a:P{let d=a}@objc protocol P{class a{}{}typealias a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveTypeWitness`.

Current number of unresolved compiler crashers: 66 (5600 resolved)

/cc @jtbandes - just wanted to let you know that this crasher caused an assertion failure for the assertion `(!isComplete() || isInvalid()) && "Conformance already complete?"` added on 2016-01-07 by you in commit 8cc8c5cc :-)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 542)`](https://github.com/apple/swift/blob/9ec6587ec33a3168c17648e7996ca950a714f6ae/lib/AST/ProtocolConformance.cpp#L542):

```
Assertion `(!isComplete() || isInvalid()) && "Conformance already complete?"' failed.

When executing: void swift::NormalProtocolConformance::setTypeWitness(swift::AssociatedTypeDecl *, swift::Type, swift::TypeDecl *) const
```

Assertion context:

```c++
                                               Type type,
                                               TypeDecl *typeDecl) const {
  assert(getProtocol() == cast<ProtocolDecl>(assocType->getDeclContext()) &&
         "associated type in wrong protocol");
  assert(TypeWitnesses.count(assocType) == 0 && "Type witness already known");
  assert((!isComplete() || isInvalid()) && "Conformance already complete?");
  TypeWitnesses[assocType] = std::make_pair(type, typeDecl);
}

Type ProtocolConformance::getAssociatedType(Type assocType,
                                            LazyResolver *resolver) const {
```
Stack trace:

```
0 0x0000000003eb9144 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3eb9144)
1 0x0000000003eb9486 SignalHandler(int) (/path/to/swift/bin/swift+0x3eb9486)
2 0x00007f7723992390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f7721eb7428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f7721eb902a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f7721eafbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f7721eafc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016dabd6 (/path/to/swift/bin/swift+0x16dabd6)
8 0x0000000001303613 (anonymous namespace)::ConformanceChecker::recordTypeWitness(swift::AssociatedTypeDecl*, swift::Type, swift::TypeDecl*, bool) (/path/to/swift/bin/swift+0x1303613)
9 0x0000000001300778 (anonymous namespace)::ConformanceChecker::resolveTypeWitnessViaLookup(swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x1300778)
10 0x00000000012eca30 swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x12eca30)
11 0x00000000016d92f3 swift::NormalProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16d92f3)
12 0x00000000016d9018 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16d9018)
13 0x00000000012da41b (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::DeclContext*, swift::Type) (/path/to/swift/bin/swift+0x12da41b)
14 0x00000000012da031 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12da031)
15 0x00000000012865b6 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0x12865b6)
16 0x0000000001295062 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1295062)
17 0x0000000001630d6b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1630d6b)
18 0x000000000128827a swift::TypeChecker::preCheckExpression(swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0x128827a)
19 0x000000000128bfcb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x128bfcb)
20 0x0000000001290b36 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x1290b36)
21 0x0000000001290db6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x1290db6)
22 0x00000000012a96f8 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12a96f8)
23 0x00000000012a3c98 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a3c98)
24 0x00000000012b5bcb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b5bcb)
25 0x00000000012a3d3e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a3d3e)
26 0x00000000012a3ae3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a3ae3)
27 0x00000000013173c5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13173c5)
28 0x0000000001316526 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0x1316526)
29 0x0000000001316af4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x1316af4)
30 0x000000000133c2bb swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x133c2bb)
31 0x000000000128c306 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x128c306)
32 0x0000000001317425 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1317425)
33 0x0000000001316c36 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1316c36)
34 0x0000000001336860 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1336860)
35 0x0000000001056f44 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1056f44)
36 0x0000000001056007 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056007)
37 0x000000000105592a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105592a)
38 0x00000000004bfed2 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfed2)
39 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
40 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
41 0x00007f7721ea2830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
42 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```