### PR TITLE
Refactoring for GenericSignature.h

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -16,7 +16,6 @@
 #include "swift/Basic/Mangler.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/GenericSignature.h"
 
 namespace swift {
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -23,7 +23,6 @@
 #include "swift/AST/ClangNode.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DefaultArgumentKind.h"
-#include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/LayoutConstraint.h"
@@ -1460,20 +1459,10 @@ public:
   GenericEnvironment *getGenericEnvironment() const;
 
   /// Retrieve the innermost generic parameter types.
-  ArrayRef<GenericTypeParamType *> getInnermostGenericParamTypes() const {
-    if (auto sig = getGenericSignature())
-      return sig->getInnermostGenericParams();
-    else
-      return { };
-  }
+  ArrayRef<GenericTypeParamType *> getInnermostGenericParamTypes() const;
 
   /// Retrieve the generic requirements.
-  ArrayRef<Requirement> getGenericRequirements() const {
-    if (auto sig = getGenericSignature())
-      return sig->getRequirements();
-    else
-      return { };
-  }
+  ArrayRef<Requirement> getGenericRequirements() const;
 
   /// Set a lazy generic environment.
   void setLazyGenericEnvironment(LazyMemberLoader *lazyLoader,

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -17,9 +17,10 @@
 #ifndef SWIFT_AST_GENERIC_ENVIRONMENT_H
 #define SWIFT_AST_GENERIC_ENVIRONMENT_H
 
+#include "swift/AST/SubstitutionList.h"
 #include "swift/AST/SubstitutionMap.h"
-#include "swift/AST/GenericParamKey.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/GenericParamKey.h"
 #include "swift/Basic/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -44,25 +45,17 @@ class alignas(1 << DeclAlignInBits) GenericEnvironment final
 
   friend TrailingObjects;
 
-  size_t numTrailingObjects(OverloadToken<Type>) const {
-    return Signature->getGenericParams().size();
-  }
+  size_t numTrailingObjects(OverloadToken<Type>) const;
 
   /// Retrieve the array containing the context types associated with the
   /// generic parameters, stored in parallel with the generic parameters of the
   /// generic signature.
-  MutableArrayRef<Type> getContextTypes() {
-    return MutableArrayRef<Type>(getTrailingObjects<Type>(),
-                                 Signature->getGenericParams().size());
-  }
+  MutableArrayRef<Type> getContextTypes();
 
   /// Retrieve the array containing the context types associated with the
   /// generic parameters, stored in parallel with the generic parameters of the
   /// generic signature.
-  ArrayRef<Type> getContextTypes() const {
-    return ArrayRef<Type>(getTrailingObjects<Type>(),
-                          Signature->getGenericParams().size());
-  }
+  ArrayRef<Type> getContextTypes() const;
 
   GenericEnvironment(GenericSignature *signature,
                      GenericSignatureBuilder *builder);
@@ -90,9 +83,7 @@ public:
     return Signature;
   }
 
-  ArrayRef<GenericTypeParamType *> getGenericParams() const {
-    return Signature->getGenericParams();
-  }
+  ArrayRef<GenericTypeParamType *> getGenericParams() const;
 
   /// Create a new, "incomplete" generic environment that will be populated
   /// by calls to \c addMapping().

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -302,6 +302,14 @@ public:
   /// are concrete, not type parameters.
   bool isRequirementSatisfied(Requirement requirement);
 
+  /// Return the requirements of this generic signature that are not also
+  /// satisfied by \c otherSig.
+  ///
+  /// \param otherSig Another generic signature whose generic parameters are
+  /// equivalent to or a subset of the generic parameters in this signature.
+  SmallVector<Requirement, 4> requirementsNotSatisfiedBy(
+                                               GenericSignature *otherSig);
+
   /// Return the canonical version of the given type under this generic
   /// signature.
   CanType getCanonicalTypeInContext(Type type);

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -28,6 +28,7 @@ namespace swift {
   class DeclContext;
   class DeclName;
   class Expr;
+  class GenericSignatureBuilder;
   class LazyResolver;
   class TupleType;
   class Type;

--- a/include/swift/AST/SILLayout.h
+++ b/include/swift/AST/SILLayout.h
@@ -29,12 +29,12 @@
 #define SWIFT_SIL_LAYOUT_H
 
 #include "llvm/ADT/PointerIntPair.h"
-#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
 
 namespace swift {
 
+class GenericSignature;
 class SILType;
 
 /// A field of a SIL aggregate layout.

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -705,34 +705,9 @@ public:
 
   /// Is this an interface type that is subject to a concrete
   /// same-type constraint?
-  bool isConcreteType() const {
-    assert(isTypeParameter());
-    return (getKind() != Kind::Opaque &&
-            GenericSig != nullptr &&
-            GenericSig->isConcreteType(getType()));
-  }
+  bool isConcreteType() const;
 
-  bool requiresClass() {
-    switch (getKind()) {
-    case Kind::Opaque:
-      return false;
-    case Kind::Type:
-    case Kind::Discard: {
-      auto type = getType();
-      if (auto archetype = dyn_cast<ArchetypeType>(type))
-        return archetype->requiresClass();
-      else if (isa<DependentMemberType>(type) ||
-               isa<GenericTypeParamType>(type)) {
-        assert(GenericSig &&
-               "Dependent type in pattern without generic signature?");
-        return GenericSig->requiresClass(type);
-      }
-      return false;
-    }
-    default:
-      return false;
-    }
-  }
+  bool requiresClass();
 
   /// Return the Swift type which provides structure for this
   /// abstraction pattern.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1602,17 +1602,7 @@ bool ASTMangler::appendGenericSignature(const GenericSignature *sig,
       genericParams = canSig->getGenericParams();
       requirements = canSig->getRequirements();
     } else {
-      // Otherwise, only include those requirements that aren't satisfied by the
-      // context signature.
-      for (auto &reqt : canSig->getRequirements()) {
-        // If the requirement is satisfied by the context signature,
-        // we don't need to mangle it here.
-        if (contextSig->isRequirementSatisfied(reqt))
-          continue;
-
-        // Mangle the requirement.
-        requirementsBuffer.push_back(reqt);
-      }
+      requirementsBuffer = canSig->requirementsNotSatisfiedBy(contextSig);
       requirements = requirementsBuffer;
     }
   } else {

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -16,7 +16,6 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/AST/AccessScope.h"
-#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -25,6 +24,8 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ASTMangler.h"
@@ -621,6 +622,22 @@ TrailingWhereClause *TrailingWhereClause::create(
   unsigned size = totalSizeToAlloc<RequirementRepr>(requirements.size());
   void *mem = ctx.Allocate(size, alignof(TrailingWhereClause));
   return new (mem) TrailingWhereClause(whereLoc, requirements);
+}
+
+ArrayRef<GenericTypeParamType *>
+GenericContext::getInnermostGenericParamTypes() const {
+  if (auto sig = getGenericSignature())
+    return sig->getInnermostGenericParams();
+  else
+    return { };
+}
+
+/// Retrieve the generic requirements.
+ArrayRef<Requirement> GenericContext::getGenericRequirements() const {
+  if (auto sig = getGenericSignature())
+    return sig->getRequirements();
+  else
+    return { };
 }
 
 void GenericContext::setGenericParams(GenericParamList *params) {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -21,6 +21,30 @@
 
 using namespace swift;
 
+size_t GenericEnvironment::numTrailingObjects(OverloadToken<Type>) const {
+  return Signature->getGenericParams().size();
+}
+
+/// Retrieve the array containing the context types associated with the
+/// generic parameters, stored in parallel with the generic parameters of the
+/// generic signature.
+MutableArrayRef<Type> GenericEnvironment::getContextTypes() {
+  return MutableArrayRef<Type>(getTrailingObjects<Type>(),
+                               Signature->getGenericParams().size());
+}
+
+/// Retrieve the array containing the context types associated with the
+/// generic parameters, stored in parallel with the generic parameters of the
+/// generic signature.
+ArrayRef<Type> GenericEnvironment::getContextTypes() const {
+  return ArrayRef<Type>(getTrailingObjects<Type>(),
+                        Signature->getGenericParams().size());
+}
+
+ArrayRef<GenericTypeParamType *> GenericEnvironment::getGenericParams() const {
+  return Signature->getGenericParams();
+}
+
 GenericEnvironment::GenericEnvironment(GenericSignature *signature,
                                        GenericSignatureBuilder *builder)
   : Signature(signature), Builder(builder)

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -693,6 +693,29 @@ bool GenericSignature::isRequirementSatisfied(Requirement requirement) {
   }
 }
 
+SmallVector<Requirement, 4> GenericSignature::requirementsNotSatisfiedBy(
+                                                 GenericSignature *otherSig) {
+  SmallVector<Requirement, 4> result;
+
+  // If the signatures are the same, all requirements are satisfied.
+  if (otherSig == this) return result;
+
+  // If there is no other signature, no requirements are satisfied.
+  if (!otherSig){
+    result.insert(result.end(),
+                  getRequirements().begin(), getRequirements().end());
+    return result;
+  }
+
+  // Find the requirements that aren't satisfied.
+  for (const auto &req : getRequirements()) {
+    if (!otherSig->isRequirementSatisfied(req))
+      result.push_back(req);
+  }
+
+  return result;
+}
+
 bool GenericSignature::isCanonicalTypeInContext(Type type) {
   // If the type isn't independently canonical, it's certainly not canonical
   // in this context.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -335,12 +335,8 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements() {
 
   // Find the requirements in the extension that aren't proved by the original
   // type, these are the ones that make the conformance conditional.
-  SmallVector<Requirement, 4> reqs;
-  for (auto requirement : canExtensionSig->getRequirements()) {
-    if (!canTypeSig->isRequirementSatisfied(requirement))
-      reqs.push_back(requirement);
-  }
-  ConditionalRequirements = ctxt.AllocateCopy(reqs);
+  ConditionalRequirements =
+    ctxt.AllocateCopy(canExtensionSig->requirementsNotSatisfiedBy(canTypeSig));
 }
 
 void NormalProtocolConformance::setSignatureConformances(

--- a/lib/AST/SILLayout.cpp
+++ b/lib/AST/SILLayout.cpp
@@ -27,6 +27,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/SILLayout.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Range.h"
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Expr.h"

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsIRGen.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -19,6 +19,7 @@
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/SubstitutionMap.h"

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/ExternalUnion.h"

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -16,6 +16,7 @@
 #include "SILGenFunction.h"
 #include "Scope.h"
 #include "SwitchCaseFullExpr.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 
 using namespace swift;

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -13,6 +13,7 @@
 #include "SILGenFunction.h"
 #include "RValue.h"
 #include "Scope.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/TypeLowering.h"
 

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -14,6 +14,7 @@
 #include "ManagedValue.h"
 #include "Scope.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/SIL/FormalLinkage.h"
 
 using namespace swift;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -12,6 +12,7 @@
 
 #define DEBUG_TYPE "sil-combine"
 #include "SILCombiner.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/PatternMatch.h"

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -15,6 +15,7 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "llvm/ADT/Statistic.h"
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -14,6 +14,7 @@
 #include "swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -15,6 +15,7 @@
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/SILArgument.h"

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
 #include "swift/SIL/SILGlobalVariable.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Demangling/ManglingMacros.h"
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ConstraintSystem.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ParameterList.h"
 #include "llvm/ADT/Statistic.h"

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "deserialize"
 #include "DeserializeSIL.h"
 #include "swift/Basic/Defer.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Serialization/ModuleFile.h"
 #include "SILFormat.h"

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -15,6 +15,7 @@
 #include "Serialization.h"
 #include "swift/Strings.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/SILArgument.h"

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -20,6 +20,7 @@
 
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/SourceEntityWalker.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -12,6 +12,7 @@
 
 #include "ModuleAPIDiff.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Driver/FrontendUtil.h"


### PR DESCRIPTION
Two NFC refactors for GenericSignature.h:

* Don't include it in `Decl.h` or any other header, except for the paired `GenericEnvironment.h`.
* Add a utility function to compute the set of requirements of a generic signature that aren't satisfied by another generic signature