### PR TITLE
[swiftc (67 vs. 5600)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28861-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers/28861-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol
+P{protocol A:P{{}}typealias e:A{}class a<a{}class a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 67 (5600 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth && "parameter hasn't been validated"` added on 2017-02-22 by you in commit fdb0a186 :-)

Assertion failure in [`lib/AST/Type.cpp (line 1107)`](https://github.com/apple/swift/blob/ab72b541f99fb67dcba3caecd44934f5ac8399e3/lib/AST/Type.cpp#L1107):

```
Assertion `gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth && "parameter hasn't been validated"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++

  case TypeKind::GenericTypeParam: {
    GenericTypeParamType *gp = cast<GenericTypeParamType>(this);
    auto gpDecl = gp->getDecl();
    assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&
           "parameter hasn't been validated");
    Result = GenericTypeParamType::get(gpDecl->getDepth(), gpDecl->getIndex(),
                                       gpDecl->getASTContext());
    break;
  }

```
Stack trace:

```
0 0x0000000003eb9144 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3eb9144)
1 0x0000000003eb9486 SignalHandler(int) (/path/to/swift/bin/swift+0x3eb9486)
2 0x00007ff3236da390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007ff321bff428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff321c0102a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007ff321bf7bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007ff321bf7c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016e8c57 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16e8c57)
8 0x00000000016e8e6c swift::QuerySubstitutionMap::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x16e8e6c)
9 0x00000000016f68e9 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_20>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16f68e9)
10 0x00000000016f2d86 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16f2d86)
11 0x00000000016f309d swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16f309d)
12 0x00000000016edf35 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16edf35)
13 0x0000000000f51803 llvm::Optional<swift::Requirement> swift::Requirement::subst<swift::SubstitutionMap&>(swift::SubstitutionMap&) const (/path/to/swift/bin/swift+0xf51803)
14 0x000000000168fc42 swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool)::$_16::operator()(swift::TypeDecl*, swift::TypeDecl*) const (/path/to/swift/bin/swift+0x168fc42)
15 0x000000000168ec4f swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x168ec4f)
16 0x00000000016914d9 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x16914d9)
17 0x00000000016a8c1d swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x16a8c1d)
18 0x000000000169ee12 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_55>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x169ee12)
19 0x000000000168d29e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x168d29e)
20 0x000000000168d8ee swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x168d8ee)
21 0x00000000016914d9 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x16914d9)
22 0x00000000016a8c1d swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x16a8c1d)
23 0x000000000169ee12 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_55>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x169ee12)
24 0x000000000168d29e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x168d29e)
25 0x000000000168d60c swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x168d60c)
26 0x00000000016914d9 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x16914d9)
27 0x00000000016a8c1d swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x16a8c1d)
28 0x000000000169ee12 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_55>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x169ee12)
29 0x000000000168d29e swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x168d29e)
30 0x000000000168d8ee swift::GenericSignatureBuilder::expandConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, bool) (/path/to/swift/bin/swift+0x168d8ee)
31 0x00000000016914d9 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x16914d9)
32 0x000000000168547c swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x168547c)
33 0x000000000169d0dc swift::GenericSignatureBuilder::computeRequirementSignature(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x169d0dc)
34 0x0000000001658ed6 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x1658ed6)
35 0x00000000012d7b48 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12d7b48)
36 0x00000000012a5ab8 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12a5ab8)
37 0x00000000012b6ba4 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12b6ba4)
38 0x00000000012a3c4f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a3c4f)
39 0x00000000012a3ae3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a3ae3)
40 0x00000000013367f5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13367f5)
41 0x0000000001056f44 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1056f44)
42 0x0000000001056007 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056007)
43 0x000000000105592a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105592a)
44 0x00000000004bfed2 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfed2)
45 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
46 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
47 0x00007ff321bea830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
48 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```