### PR TITLE
Fix transitive unavailability check

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1500,24 +1500,24 @@ bool TypeChecker::isInsideUnavailableDeclaration(
 }
 
 bool TypeChecker::isInsideCompatibleUnavailableDeclaration(
-	SourceRange ReferenceRange, const DeclContext *ReferenceDC,
-	const AvailableAttr *attr)
-{
-	if (!attr->isUnconditionallyUnavailable()) {
-		return false;
-	}
-	PlatformKind platform = attr->Platform;
-	if (platform == PlatformKind::none) {
-		return false;
-	}
+    SourceRange ReferenceRange, const DeclContext *ReferenceDC,
+    const AvailableAttr *attr) {
+  if (!attr->isUnconditionallyUnavailable()) {
+    return false;
+  }
+  PlatformKind platform = attr->Platform;
+  if (platform == PlatformKind::none) {
+    return false;
+  }
 
-    auto IsUnavailable = [platform](const Decl *D) {
-      auto EnclosingUnavailable = D->getAttrs().getUnavailable(D->getASTContext());
-	  return EnclosingUnavailable && EnclosingUnavailable->Platform == platform;
-    };
+  auto IsUnavailable = [platform](const Decl *D) {
+    auto EnclosingUnavailable =
+        D->getAttrs().getUnavailable(D->getASTContext());
+    return EnclosingUnavailable && EnclosingUnavailable->Platform == platform;
+  };
 
-    return someEnclosingDeclMatches(ReferenceRange, ReferenceDC, *this,
-                                    IsUnavailable);
+  return someEnclosingDeclMatches(ReferenceRange, ReferenceDC, *this,
+                                  IsUnavailable);
 }
 
 bool TypeChecker::isInsideDeprecatedDeclaration(SourceRange ReferenceRange,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1499,6 +1499,27 @@ bool TypeChecker::isInsideUnavailableDeclaration(
                                   IsUnavailable);
 }
 
+bool TypeChecker::isInsideCompatibleUnavailableDeclaration(
+	SourceRange ReferenceRange, const DeclContext *ReferenceDC,
+	const AvailableAttr *attr)
+{
+	if (!attr->isUnconditionallyUnavailable()) {
+		return false;
+	}
+	PlatformKind platform = attr->Platform;
+	if (platform == PlatformKind::none) {
+		return false;
+	}
+
+    auto IsUnavailable = [platform](const Decl *D) {
+      auto EnclosingUnavailable = D->getAttrs().getUnavailable(D->getASTContext());
+	  return EnclosingUnavailable && EnclosingUnavailable->Platform == platform;
+    };
+
+    return someEnclosingDeclMatches(ReferenceRange, ReferenceDC, *this,
+                                    IsUnavailable);
+}
+
 bool TypeChecker::isInsideDeprecatedDeclaration(SourceRange ReferenceRange,
                                                 const DeclContext *ReferenceDC){
   auto IsDeprecated = [](const Decl *D) {
@@ -2097,7 +2118,7 @@ bool TypeChecker::diagnoseExplicitUnavailability(
   // unavailability is OK -- the eventual caller can't call the
   // enclosing code in the same situations it wouldn't be able to
   // call this code.
-  if (isInsideUnavailableDeclaration(R, DC)) {
+  if (isInsideCompatibleUnavailableDeclaration(R, DC, Attr)) {
     return false;
   }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2093,6 +2093,14 @@ bool TypeChecker::diagnoseExplicitUnavailability(
     return false;
   }
 
+  // Calling unavailable code from within code with the same
+  // unavailability is OK -- the eventual caller can't call the
+  // enclosing code in the same situations it wouldn't be able to
+  // call this code.
+  if (isInsideUnavailableDeclaration(R, DC)) {
+    return false;
+  }
+
   SourceLoc Loc = R.Start;
   auto Name = D->getFullName();
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2364,6 +2364,12 @@ public:
   bool isInsideUnavailableDeclaration(SourceRange ReferenceRange,
                                       const DeclContext *DC);
 
+  /// Returns true if the reference or any of its parents is an
+  /// unconditional unavailable declaration for the same platform.
+  bool isInsideCompatibleUnavailableDeclaration(SourceRange ReferenceRange,
+                                                const DeclContext *DC,
+                                                const AvailableAttr *attr);
+
   /// Returns true if the reference is lexically contained in a declaration
   /// that is deprecated on all deployment targets.
   bool isInsideDeprecatedDeclaration(SourceRange ReferenceRange,

--- a/test/attr/attr_availability_transitive_ios.swift
+++ b/test/attr/attr_availability_transitive_ios.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=ios
+
+// Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
+
+@available(iOS, unavailable)
+func ios() {} // expected-note 2{{'ios()' has been explicitly marked unavailable here}}
+
+@available(iOSApplicationExtension, unavailable)
+func ios_extension() {}
+
+func call_ios_extension() {
+    ios_extension() // OK; ios_extension is only unavailable if -application-extension is passed.
+}
+func call_ios() {
+    ios() // expected-error {{'ios()' is unavailable}}
+}
+
+@available(iOS, unavailable)
+func ios_call_ios_extension() {
+    ios_extension() // OK; ios_extension is only unavailable if -application-extension is passed.
+}
+
+@available(iOS, unavailable)
+func ios_call_ios() {
+    ios() // OK; same
+}
+
+@available(iOSApplicationExtension, unavailable)
+func ios_extension_call_ios_extension() {
+    ios_extension()
+}
+
+@available(iOSApplicationExtension, unavailable)
+func ios_extension_call_ios() {
+    ios() // expected-error {{'ios()' is unavailable}}
+}

--- a/test/attr/attr_availability_transitive_ios_extension.swift
+++ b/test/attr/attr_availability_transitive_ios_extension.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -application-extension
+// REQUIRES: OS=ios
+
+// Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
+
+@available(iOS, unavailable)
+func ios() {} // expected-note 2{{'ios()' has been explicitly marked unavailable here}}
+
+@available(iOSApplicationExtension, unavailable)
+func ios_extension() {} // expected-note 2{{'ios_extension()' has been explicitly marked unavailable here}}
+
+func call_ios_extension() {
+    ios_extension() // expected-error {{'ios_extension()' is unavailable}}
+}
+func call_ios() {
+    ios() // expected-error {{'ios()' is unavailable}}
+}
+
+@available(iOS, unavailable)
+func ios_call_ios_extension() {
+    ios_extension() // expected-error {{'ios_extension()' is unavailable}}
+}
+
+@available(iOS, unavailable)
+func ios_call_ios() {
+    ios()
+}
+
+@available(iOSApplicationExtension, unavailable)
+func ios_extension_call_ios_extension() {
+    ios_extension()
+}
+
+@available(iOSApplicationExtension, unavailable)
+func ios_extension_call_ios() {
+    ios() // expected-error {{'ios()' is unavailable}}
+}

--- a/test/attr/attr_availability_transitive_multiple.swift
+++ b/test/attr/attr_availability_transitive_multiple.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=macosx
+
+// Check that only the platform we are compiling for is considered when allowing access to unavailable declarations.
+
+@available(iOS, unavailable)
+@available(OSX, unavailable)
+func unavailable() {} // expected-note {{'unavailable()' has been explicitly marked unavailable here}}
+
+@available(iOS, unavailable)
+func call_with_ios_unavailable() {
+	unavailable() // expected-error {{'unavailable()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+func call_with_osx_unavailable() {
+	unavailable() // OK: same
+}

--- a/test/attr/attr_availability_transitive_nested.swift
+++ b/test/attr/attr_availability_transitive_nested.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=macosx
+
+// Make sure that a compatible unavailable wrapping doesn't allow referencing declarations that are completely unavailable.
+
+@available(iOS, unavailable)
+class Outer {
+  @available(*, unavailable)
+  func completelyBadMethod() {} // expected-note {{'completelyBadMethod()' has been explicitly marked unavailable here}}
+}
+
+@available(iOS, unavailable)
+func test(outer: Outer) {
+  outer.completelyBadMethod() // expected-error {{'completelyBadMethod()' is unavailable}}
+}
+
+@available(*, unavailable)
+class Outer2 { // expected-note {{'Outer2' has been explicitly marked unavailable here}}
+	@available(iOS, unavailable)
+    func innerUnavailable() {}
+}
+@available(iOS, unavailable)
+func test2(outer: Outer2) { // expected-error {{'Outer2' is unavailable}}
+  outer.innerUnavailable()
+}

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=macosx
+
+// Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
+
+@available(OSX, unavailable)
+func osx() {} // expected-note 2{{'osx()' has been explicitly marked unavailable here}}
+
+@available(OSXApplicationExtension, unavailable)
+func osx_extension() {}
+
+func call_osx_extension() {
+    osx_extension() // OK; osx_extension is only unavailable if -application-extension is passed.
+}
+func call_osx() {
+    osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+func osx_call_osx_extension() {
+    osx_extension() // OK; osx_extension is only unavailable if -application-extension is passed.
+}
+
+@available(OSX, unavailable)
+func osx_call_osx() {
+    osx() // OK; same
+}
+
+@available(OSXApplicationExtension, unavailable)
+func osx_extension_call_osx_extension() {
+    osx_extension()
+}
+
+@available(OSXApplicationExtension, unavailable)
+func osx_extension_call_osx() {
+    osx() // expected-error {{'osx()' is unavailable}}
+}

--- a/test/attr/attr_availability_transitive_osx_extension.swift
+++ b/test/attr/attr_availability_transitive_osx_extension.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -application-extension
+// REQUIRES: OS=macosx
+
+// Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
+
+@available(OSX, unavailable)
+func osx() {} // expected-note 2{{'osx()' has been explicitly marked unavailable here}}
+
+@available(OSXApplicationExtension, unavailable)
+func osx_extension() {} // expected-note 2{{'osx_extension()' has been explicitly marked unavailable here}}
+
+func call_osx_extension() {
+    osx_extension() // expected-error {{'osx_extension()' is unavailable}}
+}
+func call_osx() {
+    osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+func osx_call_osx_extension() {
+    osx_extension() // expected-error {{'osx_extension()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+func osx_call_osx() {
+    osx()
+}
+
+@available(OSXApplicationExtension, unavailable)
+func osx_extension_call_osx_extension() {
+    osx_extension()
+}
+
+@available(OSXApplicationExtension, unavailable)
+func osx_extension_call_osx() {
+    osx() // expected-error {{'osx()' is unavailable}}
+}


### PR DESCRIPTION
Allow calls to explicitly unavailable code when the caller has the
same unavailability.

For example, in a framework compiled with `-application-extension`, this should
be allowed:

	@available(iOSApplicationExtension, unavailable)
	    func x() {
            _ = UIApplication.shared
	    }
	}

since the consumer of the framework, or other call sites within the same
framework will be unable to call the unsafe wrapper in the same situations they
couldn't call the original unsafe code.

Resolves [SR-1226](https://bugs.swift.org/browse/SR-1226).
