### PR TITLE
Merge pull request #12411 from shajrawi/silcombine_bugfix

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -956,8 +956,20 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
 
   // Propagate the concrete type into a callee-operand, which is a
   // witness_method instruction.
-  auto PropagateIntoOperand = [this, &WMI, &AI](CanType ConcreteType,
-                                           ProtocolConformanceRef Conformance) {
+  auto PropagateIntoOperand = [this, &WMI, &AI](
+      CanType ConcreteType, ProtocolConformanceRef Conformance) {
+    if (ConcreteType == WMI->getLookupType() &&
+        Conformance == WMI->getConformance()) {
+      // If we create a new instruction that’s the same as the old one we’ll
+      // cause an infinite loop:
+      // NewWMI will be added to the Builder’s tracker list.
+      // SILCombine, in turn, uses the tracker list to populate the worklist
+      // As such, if we don’t remove the witness method later on in the pass, we
+      // are stuck:
+      // We will re-create the same instruction and re-populate the worklist
+      // with it
+      return;
+    }
     // Keep around the dependence on the open instruction unless we've
     // actually eliminated the use.
     auto *NewWMI = Builder.createWitnessMethod(WMI->getLoc(),
@@ -970,7 +982,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
     MutableArrayRef<Operand> Operands = AI.getInstruction()->getAllOperands();
     for (auto &Op : Operands) {
       if (Op.get() == WMI)
-         Op.set(NewWMI); 
+        Op.set(NewWMI);
     }
     if (WMI->use_empty())
       eraseInstFromFunction(*WMI);

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -343,3 +343,20 @@ bb0(%0 : $*MutatingProto, %1 : $MStruct):
   return %27 : $()
 }
 
+// CHECK-LABEL: sil @dont_replace_copied_self_in_mutating_method_call2
+sil @dont_replace_copied_self_in_mutating_method_call2 : $@convention(thin) (@thick MutatingProto.Type) -> (@out MutatingProto) {
+bb0(%0 : $*MutatingProto, %1 : $@thick MutatingProto.Type):
+  %alloc1 = alloc_stack $MutatingProto, let, name "p"
+  %openType = open_existential_metatype %1 : $@thick MutatingProto.Type to $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto).Type
+  %initType =  init_existential_addr %alloc1 : $*MutatingProto, $@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto
+  %alloc2 = alloc_stack $MutatingProto
+  copy_addr %alloc1 to [initialization] %alloc2 : $*MutatingProto
+  %oeaddr = open_existential_addr mutable_access %alloc2 : $*MutatingProto to $*@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto
+  %witmethod = witness_method $@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto, #MutatingProto.mutatingMethod!1 : <Self where Self : MutatingProto> (inout Self) -> () -> (), %openType : $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto).Type : $@convention(witness_method) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
+  // CHECK: apply {{%.*}}<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto>({{%.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> () // type-defs
+  %apply = apply %witmethod<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto>(%oeaddr) : $@convention(witness_method) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
+  dealloc_stack %alloc2 : $*MutatingProto
+  dealloc_stack %alloc1 : $*MutatingProto
+  %27 = tuple ()
+  return %27 : $()
+}


### PR DESCRIPTION
radar rdar://problem/34966696

• Explanation: Fixes an infinite loop. The infinite loop was there for over a year but it got exposed by the following bug fix: rdar://problem/34753633

• Scope of Issue: Fixes an infinite loop in SILCombiner: we should not create a new witness method instruction if it exactly the same as the old one: doing so might cause the transformation to go into an infinite loop: The new method instruction will be added to the Builder’s tracker list. SILCombine, in turn, uses the tracker list to populate the worklist. As such, if we don’t remove the witness method later on in the pass, we are stuck: We will re-create the same instruction and re-populate the worklist with it. This SILCombiner bug was always there, we just never hit it before because we always removed the witness method instruction later on in the transformation (creating the new apply / making the witness instruction dead). Since we now bail on creating new apply instructions, which is the right thing to do as seen in rdar://problem/34753633, it got exposed.

• Origination: This was discovered while debugging <rdar://problem/34966696> Swift CI: 2. Swift Source Compatibility Suite (master)

• Risk: Low - The bug fix is a very simple if statement: if we are trying to replace a witness method instruction with itself (exact same conformance and lookup type) bail. Don’t do so. There’s no point in creating the exact same instruction, replacing all uses with the new one, and deleting the old one. The old one should do the job. That way we are not adding a new instruction to the builder’s tracker list.

• Reviewed By: @eeckstein 