### PR TITLE
[ClangImporter] Handle property with getter that returns instancetype

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3772,7 +3772,7 @@ namespace {
 
       // If the method has a related result type that is representable
       // in Swift as DynamicSelf, do so.
-      if (decl->hasRelatedResultType()) {
+      if (!prop && decl->hasRelatedResultType()) {
         result->setDynamicSelf(true);
         resultTy = DynamicSelfType::get(dc->getSelfInterfaceType(),
                                         Impl.SwiftContext);

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -198,3 +198,8 @@ typedef SomeCell <NSCopying> *CopyableSomeCell;
 // Note the custom setter name here; this is important.
 @property (setter=takeFooForBar:) BOOL fooForBar;
 @end
+
+@interface InstancetypeAccessor : NSObject
+@property (class, readonly) InstancetypeAccessor *prop;
++ (instancetype)prop;
+@end

--- a/test/ClangImporter/objc_parse_verifier.swift
+++ b/test/ClangImporter/objc_parse_verifier.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify > /dev/null
+
+// REQUIRES: objc_interop
+// expected-no-diagnostics
+
+// This file tests the AST verifier, which performs extra checks when there are
+// no errors emitted. Please do not add any.
+
+
+import ObjCParseExtras
+
+func test() {
+  // Properties with instancetype getters.
+  _ = InstancetypeAccessor.prop
+}


### PR DESCRIPTION
We just import this as a property, and Swift doesn't support properties with dynamic Self type, even if they are read-only. Don't mark the getter as returning dynamic Self in this case.

(This was only a problem in builds with the AST verifier turned on.)

[SR-5684](https://bugs.swift.org/browse/SR-5684) / rdar://problem/33897488