### PR TITLE
[emacs] Add variables surrounded with backticks to swift-font-lock-keywords

### DIFF
--- a/utils/swift-mode.el
+++ b/utils/swift-mode.el
@@ -39,6 +39,8 @@
   (list
    ;; Comments
    '("^#!.*" . font-lock-comment-face)
+   ;; Variables surrounded with backticks (`)
+   '("`[a-zA-Z_][a-zA-Z_0-9]*`" . font-lock-variable-name-face)
    ;; Types
    '("\\b[A-Z][a-zA-Z_0-9]*\\b" . font-lock-type-face)
    ;; Floating point constants


### PR DESCRIPTION
<!-- What's in this pull request? -->
#### What's in this pull request?

The `util/swift-mode.el` improvement is included.

Add variables surrounded with backticks (\`) to `swift-font-lock-keywords`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

None

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->