### PR TITLE
Named lazy member loading 1/N

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -218,11 +218,22 @@ class alignas(void*) LazyMemberLoader {
 public:
   virtual ~LazyMemberLoader() = default;
 
-  /// Populates the given vector with all member decls for \p D.
+  /// Populates a given decl \p D with all of its members.
   ///
   /// The implementation should add the members to D.
   virtual void
   loadAllMembers(Decl *D, uint64_t contextData) = 0;
+
+  /// Populates a vector with all members of \p D that have DeclName
+  /// matching \p N.
+  ///
+  /// Returns true if an error occurred \em or the set of returned
+  /// \p Members is otherwise incomplete, due to implementation limitations
+  /// (eg. the implementation is unable to do named lookup at all, or within
+  /// the particular type of Decl that \p D is).
+  virtual bool
+  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData,
+                   TinyPtrVector<ValueDecl *> &Members) = 0;
 
   /// Populates the given vector with all conformances for \p D.
   ///

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -227,13 +227,10 @@ public:
   /// Populates a vector with all members of \p D that have DeclName
   /// matching \p N.
   ///
-  /// Returns true if an error occurred \em or the set of returned
-  /// \p Members is otherwise incomplete, due to implementation limitations
-  /// (eg. the implementation is unable to do named lookup at all, or within
-  /// the particular type of Decl that \p D is).
-  virtual bool
-  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData,
-                   TinyPtrVector<ValueDecl *> &Members) = 0;
+  /// Returns None if an error occurred \em or named member-lookup
+  /// was otherwise unsupported in this implementation or Decl.
+  virtual Optional<TinyPtrVector<ValueDecl *>>
+  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData) = 0;
 
   /// Populates the given vector with all conformances for \p D.
   ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -153,6 +153,9 @@ namespace swift {
     /// \brief Enable the iterative type checker.
     bool IterativeTypeChecker = false;
 
+    /// \brief Enable named lazy member loading.
+    bool NamedLazyMemberLoading = false;
+
     /// Debug the generic signatures computed by the generic signature builder.
     bool DebugGenericSignatures = false;
 

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -161,6 +161,12 @@ FRONTEND_STATISTIC(Sema, NumLazyIterableDeclContexts)
 /// Number of direct member-name lookups performed on nominal types.
 FRONTEND_STATISTIC(Sema, NominalTypeLookupDirectCount)
 
+/// Number of member-name lookups that avoided loading all members.
+FRONTEND_STATISTIC(Sema, NamedLazyMemberLoadSuccessCount)
+
+/// Number of member-name lookups that wound up loading all members.
+FRONTEND_STATISTIC(Sema, NamedLazyMemberLoadFailureCount)
+
 /// Number of types deserialized.
 FRONTEND_STATISTIC(Sema, NumTypesDeserialized)
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -156,6 +156,9 @@ def propagate_constraints : Flag<["-"], "propagate-constraints">,
 def iterative_type_checker : Flag<["-"], "iterative-type-checker">,
   HelpText<"Enable the iterative type checker">;
 
+def enable_named_lazy_member_loading : Flag<["-"], "enable-named-lazy-member-loading">,
+  HelpText<"Enable per-name lazy member loading">;
+
 def debug_generic_signatures : Flag<["-"], "debug-generic-signatures">,
   HelpText<"Debug generic signatures">;
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -700,10 +700,10 @@ public:
   virtual void loadAllMembers(Decl *D,
                               uint64_t contextData) override;
 
-  virtual bool
+  virtual
+  Optional<TinyPtrVector<ValueDecl *>>
   loadNamedMembers(const Decl *D, DeclName N,
-                   uint64_t contextData,
-                   TinyPtrVector<ValueDecl *> &Members) override;
+                   uint64_t contextData) override;
 
   virtual void
   loadAllConformances(const Decl *D, uint64_t contextData,

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -700,6 +700,11 @@ public:
   virtual void loadAllMembers(Decl *D,
                               uint64_t contextData) override;
 
+  virtual bool
+  loadNamedMembers(const Decl *D, DeclName N,
+                   uint64_t contextData,
+                   TinyPtrVector<ValueDecl *> &Members) override;
+
   virtual void
   loadAllConformances(const Decl *D, uint64_t contextData,
                     SmallVectorImpl<ProtocolConformance*> &Conforms) override;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3268,6 +3268,10 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     }
   }
 
+  // Remaining logic is not relevant in ObjC protocol cases.
+  if (proto->isObjC())
+    return ConstraintResult::Resolved;
+
   // Collect all of the inherited associated types and typealiases in the
   // inherited protocols (recursively).
   llvm::MapVector<DeclName, TinyPtrVector<TypeDecl *>> inheritedTypeDecls;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -29,6 +29,10 @@
 #include "swift/Basic/STLExtras.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "namelookup"
 
 using namespace swift;
 
@@ -1201,6 +1205,11 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
     guard = s->getFrontendRecursiveSharedTimers()
                 .NominalTypeDecl__lookupDirect.getGuard();
   }
+
+  DEBUG(llvm::dbgs() << getNameStr() << ".lookupDirect(" << name << ")"
+        << ", lookupTable.getInt()=" << LookupTable.getInt()
+        << ", hasLazyMembers()=" << hasLazyMembers()
+        << "\n");
 
   if (ctx.LangOpts.NamedLazyMemberLoading &&
       !LookupTable.getInt() &&

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3262,9 +3262,9 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
   }
 }
 
-bool ClangImporter::Implementation::loadNamedMembers(
-    const Decl *D, DeclName N, uint64_t contextData,
-    TinyPtrVector<ValueDecl *> &Members) {
+Optional<TinyPtrVector<ValueDecl *>>
+ClangImporter::Implementation::loadNamedMembers(
+    const Decl *D, DeclName N, uint64_t contextData) {
 
   auto *DC = cast<DeclContext>(D);
 
@@ -3294,6 +3294,7 @@ bool ClangImporter::Implementation::loadNamedMembers(
 
   clang::ASTContext &clangCtx = getClangASTContext();
 
+  TinyPtrVector<ValueDecl *> Members;
   if (auto *CPD = dyn_cast<clang::ObjCProtocolDecl>(CD)) {
     for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()), CPD)) {
       if (!entry.is<clang::NamedDecl *>()) continue;
@@ -3312,10 +3313,10 @@ bool ClangImporter::Implementation::loadNamedMembers(
         }
       }
     }
-    return false;
+    return Members;
   }
 
-  return true;
+  return None;
 }
 
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3262,6 +3262,63 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
   }
 }
 
+bool ClangImporter::Implementation::loadNamedMembers(
+    const Decl *D, DeclName N, uint64_t contextData,
+    TinyPtrVector<ValueDecl *> &Members) {
+
+  auto *DC = cast<DeclContext>(D);
+
+  auto *CD = D->getClangDecl();
+  assert(CD && "loadNamedMembers on a Decl without a clangDecl");
+
+  // There are 3 cases:
+  //
+  //  - The decl is from a bridging header, CMO is Some(nullptr)
+  //    which denotes the __ObjC Swift module and its associated
+  //    BridgingHeaderLookupTable.
+  //
+  //  - The decl is from a clang module, CMO is Some(M) for non-null
+  //    M and we can use the table for that module.
+  //
+  //  - The decl is a forward declaration, CMO is None, which should
+  //    never be the case if we got here (someone is asking for members).
+  //
+  // findLookupTable, below, handles the first two cases; we assert on the
+  // third.
+
+  auto CMO = getClangSubmoduleForDecl(CD);
+  assert(CMO && "loadNamedMembers on a forward-declared Decl");
+
+  auto table = findLookupTable(*CMO);
+  assert(table && "clang module without lookup table");
+
+  clang::ASTContext &clangCtx = getClangASTContext();
+
+  if (auto *CPD = dyn_cast<clang::ObjCProtocolDecl>(CD)) {
+    for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()), CPD)) {
+      if (!entry.is<clang::NamedDecl *>()) continue;
+      auto member = entry.get<clang::NamedDecl *>();
+      if (!isVisibleClangEntry(clangCtx, member)) continue;
+      SmallVector<Decl*, 4> tmp;
+      insertMembersAndAlternates(member, tmp);
+      for (auto *TD : tmp) {
+        if (auto *V = dyn_cast<ValueDecl>(TD)) {
+          // Skip ValueDecls if they import into different DeclContexts
+          // or under different names than the one we asked about.
+          if (V->getDeclContext() == DC &&
+              V->getFullName().matchesRef(N)) {
+            Members.push_back(V);
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  return true;
+}
+
+
 EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
     const NominalTypeDecl *nominal) {
   // If we have a Clang declaration, look at it to determine the

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7994,6 +7994,13 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   loadAllMembersIntoExtension(D, extra);
 }
 
+bool ClangImporter::Implementation::loadNamedMembers(
+    const Decl *D, DeclName N, uint64_t contextData,
+    TinyPtrVector<ValueDecl *> &Members) {
+  // Not presently supported.
+  return true;
+}
+
 void ClangImporter::Implementation::loadAllMembersIntoExtension(
     Decl *D, uint64_t extra) {
   // We have extension.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7994,13 +7994,6 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   loadAllMembersIntoExtension(D, extra);
 }
 
-bool ClangImporter::Implementation::loadNamedMembers(
-    const Decl *D, DeclName N, uint64_t contextData,
-    TinyPtrVector<ValueDecl *> &Members) {
-  // Not presently supported.
-  return true;
-}
-
 void ClangImporter::Implementation::loadAllMembersIntoExtension(
     Decl *D, uint64_t extra) {
   // We have extension.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1122,6 +1122,10 @@ public:
   virtual void
   loadAllMembers(Decl *D, uint64_t unused) override;
 
+  virtual bool
+  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData,
+                   TinyPtrVector<ValueDecl *> &Members) override;
+
 private:
   void
   loadAllMembersOfObjcContainer(Decl *D,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1122,9 +1122,8 @@ public:
   virtual void
   loadAllMembers(Decl *D, uint64_t unused) override;
 
-  virtual bool
-  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData,
-                   TinyPtrVector<ValueDecl *> &Members) override;
+  virtual Optional<TinyPtrVector<ValueDecl *>>
+  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData) override;
 
 private:
   void

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -845,6 +845,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.EnableConstraintPropagation |= Args.hasArg(OPT_propagate_constraints);
   Opts.IterativeTypeChecker |= Args.hasArg(OPT_iterative_type_checker);
+  Opts.NamedLazyMemberLoading |= Args.hasArg(OPT_enable_named_lazy_member_loading);
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
 
   Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -145,8 +145,14 @@ namespace {
       // pull out the superclass instead, and use that below.
       if (foundInType->isExistentialType()) {
         auto layout = foundInType->getExistentialLayout();
-        if (layout.superclass)
+        if (layout.superclass) {
           conformingType = layout.superclass;
+        } else {
+          // Non-subclass existential: don't need to look for further
+          // conformance or witness.
+          addResult(found);
+          return;
+        }
       }
 
       // Dig out the protocol conformance.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4678,6 +4678,13 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   }
 }
 
+bool ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
+                                  uint64_t contextData,
+                                  TinyPtrVector<ValueDecl *> &Members) {
+  // Not presently supported.
+  return true;
+}
+
 void
 ModuleFile::loadAllConformances(const Decl *D, uint64_t contextData,
                           SmallVectorImpl<ProtocolConformance*> &conformances) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4678,11 +4678,11 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   }
 }
 
-bool ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
-                                  uint64_t contextData,
-                                  TinyPtrVector<ValueDecl *> &Members) {
+Optional<TinyPtrVector<ValueDecl *>>
+ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
+                             uint64_t contextData) {
   // Not presently supported.
-  return true;
+  return None;
 }
 
 void

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
@@ -1,0 +1,34 @@
+#import <Foundation/Foundation.h>
+
+@protocol Doer
+
+- (void)doSomeWork;
+- (void)doSomeWorkWithSpeed:(int)s;
+- (void)doSomeWorkWithSpeed:(int)s thoroughness:(int)t
+  NS_SWIFT_NAME(doVeryImportantWork(speed:thoroughness:));
+- (void)doSomeWorkWithSpeed:(int)s alacrity:(int)a
+  NS_SWIFT_NAME(doSomeWorkWithSpeed(speed:levelOfAlacrity:));
+
+// These we are generally trying to not-import, via laziness.
+- (void)goForWalk;
+- (void)takeNap;
+- (void)eatMeal;
+- (void)tidyHome;
+- (void)callFamily;
+- (void)singSong;
+- (void)readBook;
+- (void)attendLecture;
+- (void)writeLetter;
+
+@end
+
+
+// Don't conform to the protocol; that loads all protocol members.
+@interface SimpleDoer
+
+// These are names we're hoping don't interfere with Doer, above.
++ (SimpleDoer*)Doer;
++ (SimpleDoer*)DoerOfNoWork;
+
+@end
+

--- a/test/NameBinding/Inputs/NamedLazyMembers/module.modulemap
+++ b/test/NameBinding/Inputs/NamedLazyMembers/module.modulemap
@@ -1,0 +1,4 @@
+module NamedLazyMembers {
+  header "NamedLazyMembers.h"
+  export *
+}

--- a/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
@@ -1,0 +1,26 @@
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+//
+// Prime module cache
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s
+//
+// Check that without lazy named member loading, we're importing too much.
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck -stats-output-dir %t/stats-pre %s
+// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 20' %t/stats-pre
+//
+// Check that with lazy named member loading, we're importing less.
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
+// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 15' %t/stats-post
+
+import NamedLazyMembers
+
+public func foo(d: Doer) {
+  d.doSomeWork()
+  d.doSomeWork(withSpeed:10)
+  d.doVeryImportantWork(speed:10, thoroughness:12)
+  d.doSomeWorkWithSpeed(speed:10, levelOfAlacrity:12)
+
+  let _ = SimpleDoer()
+  let _ = SimpleDoer.ofNoWork()
+}

--- a/validation-test/compiler_crashers_fixed/28855-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
+++ b/validation-test/compiler_crashers_fixed/28855-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 @objc protocol P{typealias e where f=a


### PR DESCRIPTION
This is an initial grab-bag of work related to reducing the number of codepaths in the frontend that eventually call `LazyMemberLoader::loadAllMembers`, specifically as a consequence of doing a named member-lookup (as in `NominalTypeDecl::lookupDirect`).

The goal here (grand plan provided by @DougGregor and @jrose-apple) is to support loading _just_ the plausibly-same-named members of an `IterableDeclContext` that a given named member-lookup is after, rather than all the members.

I'm starting with the lazy member loader in the clang importer (because it already has member names in the clang module lookuptables, which we can use for direct lookup). Within that, focusing on ObjC _protocol_ members (because they're the simplest case, according to Jordan). And within that, at this stage it seems there are a bunch of _non_ name-lookup-related paths that wind up triggering `loadAllMembers` anyways, so this PR mostly just works on those.

Commits included here:

  - Adding some counters, an `-Xfrontend -enable-named-lazy-member-loading` option flag, and debug logging
  - Adding a rough-cut API `LazyMemberLoader::loadNamedMembers`
  - Implementing the simplest case of it for ObjC protocol members, from clang
  - Cutting down a couple more paths that force all-member loads on protocols elsewhere (
9c79770 and 1c306cc)
  - Adding a bunch of comments to the unified stats reporter: a bit of a ride-along patch but @ematejska requested it this afternoon and I had it done before I realized I'd documented the counters at the _end_ of this PR rather than the beginning. Figured I'd include it here rather than delete and re-add comments in a separate PR.

There are going to be a bunch more PRs in this series before it's done, but I figured I'd get review and integration started on the first set, to make sure I'm on the right path.