### PR TITLE
Sema: Name lookup of protocol typealiases from expression context [4.0]

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -121,6 +121,7 @@ namespace {
       if (!Options.contains(NameLookupFlags::ProtocolMembers) ||
           !isa<ProtocolDecl>(foundDC) ||
           isa<GenericTypeParamDecl>(found) ||
+          isa<TypeAliasDecl>(found) ||
           (isa<FuncDecl>(found) && cast<FuncDecl>(found)->isOperator())) {
         addResult(found);
         return;

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -338,10 +338,10 @@ class AnotherGeneric<T> {}
 
 protocol P {
   associatedtype A
-  typealias G1<T> = MyType<Self, T> // expected-note {{did you mean 'G1'?}}
-  typealias G2<T> = MyType<T, A> // expected-note {{did you mean 'G2'?}}
-  typealias G3<T> = () -> () // expected-note {{did you mean 'G3'?}}
-  typealias G4<T> = (T) -> () // expected-note {{did you mean 'G4'?}}
+  typealias G1<T> = MyType<Self, T>
+  typealias G2<T> = MyType<T, A>
+  typealias G3<T> = () -> ()
+  typealias G4<T> = (T) -> ()
 
   func firstRequirement(_: G1<Int>)
   func secondRequirement(_: G2<Int>)
@@ -368,19 +368,19 @@ struct S : P {
   func fourthRequirement(_: G4<Int>) {}
 
   func firstRequirementGeneric<T>(_: G1<T>) {
-    _ = G1<T>.self // FIXME // expected-error {{use of unresolved identifier 'G1'}}
+    _ = G1<T>.self
   }
 
   func secondRequirementGeneric<T>(_: G2<T>) {
-    _ = G2<T>.self // FIXME // expected-error {{use of unresolved identifier 'G2'}}
+    _ = G2<T>.self
   }
 
   func thirdRequirementGeneric<T>(_: G3<T>, _: T) {
-    _ = G3<T>.self // FIXME // expected-error {{use of unresolved identifier 'G3'}}
+    _ = G3<T>.self
   }
 
   func fourthRequirementGeneric<T>(_: G4<T>) {
-    _ = G4<T>.self // FIXME // expected-error {{use of unresolved identifier 'G4'}}
+    _ = G4<T>.self
   }
 
   func expressionContext() {

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -189,6 +189,7 @@ struct T5 : P5 {
 // Unqualified lookup finds typealiases in protocol extensions, though
 protocol P7 {
   associatedtype A
+  typealias Z = A
 }
 
 extension P7 {
@@ -202,6 +203,9 @@ struct S7 : P7 {
 
   func inExpressionContext() {
     _ = Y.self
+    _ = Z.self
+    _ = T5.T1.self
+    _ = T5.T2.self
   }
 }
 


### PR DESCRIPTION
* Description: Unqualified references to typealiases defined in protocols did not work in expression context.

* Scope of the issue: One day, we'll have a complete implementation of [SE-0092](https://github.com/apple/swift-evolution/blob/master/proposals/0092-typealiases-in-protocols.md).

* Risk: Low, the outcome of the conditional expression in question should only change if we hit a typealias defined in a protocol, and it's hard to see how this change makes things worse.

* Tested: New tests added, and some existing FIXMEs in the generic typealias tests are now resolved.

* Reviewed by: @DougGregor 

* Radar: <rdar://problem/34911524>.