### PR TITLE
[AST] Name lookup shouldn't find pattern declarations later in the same condition.

### DIFF
--- a/lib/AST/NameLookupImpl.h
+++ b/lib/AST/NameLookupImpl.h
@@ -121,10 +121,16 @@ private:
   }
 
   void checkStmtCondition(const StmtCondition &Cond) {
-    for (auto entry : Cond)
-      if (auto *P = entry.getPatternOrNull())
-        if (!isReferencePointInRange(entry.getSourceRange()))
+    SourceLoc start = SourceLoc();
+    for (auto entry : Cond) {
+      if (start.isInvalid())
+        start = entry.getStartLoc();
+      if (auto *P = entry.getPatternOrNull()) {
+        SourceRange previousConditionsToHere = SourceRange(start, entry.getEndLoc());
+        if (!isReferencePointInRange(previousConditionsToHere))
           checkPattern(P, DeclVisibilityKind::LocalVariable);
+      }
+    }
   }
 
   void visitIfStmt(IfStmt *S) {

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -566,3 +566,9 @@ func foo1() {
   _ = MyGenericEnum<Int>.One // expected-error {{enum type 'MyGenericEnum<Int>' has no case 'One'; did you mean 'one'}}{{26-29=one}}
   _ = MyGenericEnum<Int>.OneTwo // expected-error {{enum type 'MyGenericEnum<Int>' has no case 'OneTwo'; did you mean 'oneTwo'}}{{26-32=oneTwo}}
 }
+
+// SR-4082
+func foo2() {
+  let x = 5
+  if x < 0, let x = Optional(1) { } // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+}


### PR DESCRIPTION
In the code:
```
let x = 5
if x > 0, let x = Optional(1) { }
```
The name lookup of "x" in x > 0 was finding the let pattern declaration after it in the same condition, not the "x" in the previous line. This change disallows finding later patterns when looking up source locations that are earlier in the same condition.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4082](https://bugs.swift.org/browse/SR-4082).
Resolves [SR-4387](https://bugs.swift.org/browse/SR-4387).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->