### PR TITLE
Condition statement name lookup fix [4.0]

### DIFF
--- a/lib/AST/NameLookupImpl.h
+++ b/lib/AST/NameLookupImpl.h
@@ -121,10 +121,16 @@ private:
   }
 
   void checkStmtCondition(const StmtCondition &Cond) {
-    for (auto entry : Cond)
-      if (auto *P = entry.getPatternOrNull())
-        if (!isReferencePointInRange(entry.getSourceRange()))
+    SourceLoc start = SourceLoc();
+    for (auto entry : Cond) {
+      if (start.isInvalid())
+        start = entry.getStartLoc();
+      if (auto *P = entry.getPatternOrNull()) {
+        SourceRange previousConditionsToHere = SourceRange(start, entry.getEndLoc());
+        if (!isReferencePointInRange(previousConditionsToHere))
           checkPattern(P, DeclVisibilityKind::LocalVariable);
+      }
+    }
   }
 
   void visitIfStmt(IfStmt *S) {

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -566,3 +566,9 @@ func foo1() {
   _ = MyGenericEnum<Int>.One // expected-error {{enum type 'MyGenericEnum<Int>' has no case 'One'; did you mean 'one'}}{{26-29=one}}
   _ = MyGenericEnum<Int>.OneTwo // expected-error {{enum type 'MyGenericEnum<Int>' has no case 'OneTwo'; did you mean 'oneTwo'}}{{26-32=oneTwo}}
 }
+
+// SR-4082
+func foo2() {
+  let x = 5
+  if x < 0, let x = Optional(1) { } // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -572,3 +572,32 @@ func foo2() {
   let x = 5
   if x < 0, let x = Optional(1) { } // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 }
+
+struct Person {
+  let name: String?
+}
+
+struct Company { // expected-note 2{{did you mean 'Company'?}}
+  let owner: Person?
+}
+
+func test1() {
+  let example: Company? = Company(owner: Person(name: "Owner"))
+  if let person = aCompany.owner, // expected-error {{use of unresolved identifier 'aCompany'}}
+     let aCompany = example {
+    _ = person
+  }
+}
+
+func test2() {
+  let example: Company? = Company(owner: Person(name: "Owner"))
+  guard let person = aCompany.owner, // expected-error {{use of unresolved identifier 'aCompany'}}
+        let aCompany = example else { return }
+}
+
+func test3() {
+  var c: String? = "c" // expected-note {{did you mean 'c'?}}
+  if let a = b = c, let b = c { // expected-error {{use of unresolved identifier 'b'}}
+    _ = b
+  }
+}


### PR DESCRIPTION
* Description: Fixes a crash when a statement in an 'if let' referenced a binding defined later, for example `if let b = c, c = ...`. The actual fix is by @gregomni, I'm just adding a couple more test cases and cherry picking. Thanks Greg!

* Scope of the issue: This has been reported a number of times, and in a build without asserts, the crash happens later in SILGen and it's not obvious what the problem is.

* Risk: Low, I think any code that used to type check but is now rejected with this change was already invalid and going to crash SILGen.

* Tested: New tests added.

* Radar: <rdar://problem/30651948>

* Reviewed by: @DougGregor 