### PR TITLE
[Driver] Infer target-specific dylib names

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1726,6 +1726,7 @@ static StringRef getOutputFilename(Compilation &C,
                                    const JobAction *JA,
                                    const OutputInfo &OI,
                                    const TypeToPathMap *OutputMap,
+                                   const llvm::Triple &Triple,
                                    const llvm::opt::DerivedArgList &Args,
                                    bool AtTopLevel,
                                    StringRef BaseInput,
@@ -1814,10 +1815,17 @@ static StringRef getOutputFilename(Compilation &C,
       BaseName = llvm::sys::path::stem(BaseInput);
     if (auto link = dyn_cast<LinkJobAction>(JA)) {
       if (link->getKind() == LinkKind::DynamicLibrary) {
-        // FIXME: This should be target-specific.
-        Buffer = "lib";
+        if (Triple.isOSWindows())
+          Buffer = "";
+        else
+          Buffer = "lib";
         Buffer.append(BaseName);
-        Buffer.append(LTDL_SHLIB_EXT);
+        if (Triple.isOSDarwin())
+          Buffer.append(".dylib");
+        else if (Triple.isOSWindows())
+          Buffer.append(".dll");
+        else
+          Buffer.append(".so");
         return Buffer.str();
       }
     }
@@ -2030,9 +2038,9 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
       const TypeToPathMap *OMForInput = nullptr;
       if (OFM)
         OMForInput = OFM->getOutputMapForInput(Input);
-      
-      OutputFile = getOutputFilename(C, JA, OI, OMForInput, C.getArgs(),
-                                     AtTopLevel, Input, InputJobs,
+
+      OutputFile = getOutputFilename(C, JA, OI, OMForInput, TC.getTriple(),
+                                     C.getArgs(), AtTopLevel, Input, InputJobs,
                                      Diags, Buf);
       Output->addPrimaryOutput(OutputFile, Input);
     };
@@ -2048,9 +2056,9 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     }
   } else {
     // The common case: there is a single output file.
-    OutputFile = getOutputFilename(C, JA, OI, OutputMap, C.getArgs(),
-                                   AtTopLevel, BaseInput, InputJobs,
-                                   Diags, Buf);
+    OutputFile = getOutputFilename(C, JA, OI, OutputMap, TC.getTriple(),
+                                   C.getArgs(), AtTopLevel, BaseInput,
+                                   InputJobs, Diags, Buf);
     Output->addPrimaryOutput(OutputFile, BaseInput);
   }
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -51,8 +51,14 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -o linker 2>&1 | %FileCheck -check-prefix COMPILE_AND_LINK %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -driver-use-filelists -o linker 2>&1 | %FileCheck -check-prefix FILELIST %s
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -o libLINKER.dylib | %FileCheck -check-prefix INFERRED_NAME %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_LINUX %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_WINDOWS %s
+
+// Here we specify an output file name using '-o'. For ease of writing these
+// tests, we happen to specify the same file name as is inferred in the
+// INFERRED_NAMED_DARWIN tests above: 'libLINKER.dylib'.
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -o libLINKER.dylib | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
 
 // There are more RUN lines further down in the file.
 
@@ -285,10 +291,12 @@
 // FILELIST: -o linker
 
 
-// INFERRED_NAME: bin/swift
-// INFERRED_NAME: -module-name LINKER
-// INFERRED_NAME: bin/ld{{"? }}
-// INFERRED_NAME: -o libLINKER.{{dylib|so}}
+// INFERRED_NAME_DARWIN: bin/swift
+// INFERRED_NAME_DARWIN: -module-name LINKER
+// INFERRED_NAME_DARWIN: bin/ld{{"? }}
+// INFERRED_NAME_DARWIN:  -o libLINKER.dylib
+// INFERRED_NAME_LINUX:   -o libLINKER.so
+// INFERRED_NAME_WINDOWS: -o LINKER.dll
 
 
 // Test ld detection. We use hard links to make sure


### PR DESCRIPTION
When the Swift driver is invoked with the `-emit-library` option, but without an `-o` option that specifies the emitted library's filename, logic in the `getOutputFilename()` function derives a filename: `"lib" + <a plasible base name>"`, and then the value of the `LTDL_SHLIB_EXT` macro.

There are two problems here:

1. Windows shared library file names, by convention, do not begin with "lib".
2. The `LTDL_SHLIB_EXT` macro is set by `llvm/cmake/modules/HandleLLVMOptions.cmake`, based on `CMAKE_SHARED_LIBRARY_SUFFIX`, a built-in CMake variable that is set at the time LLVM is configured to be built. So, if LLVM and Swift were built on a Linux machine, but the `swiftc` executable that was built was then invoked to produce a shared library for a Darwin target, the library would have a ".so" suffix, not ".dylib". (It's for this reason that the tests for this name inference, in `test/Driver/linker.swift`, must use a regular expression that matches both ".dylib" and ".so", despite specifying a Darwin `-target`.)

In order to produce conventionally correct prefixes and suffixes based on the target, modify the `getOutputFilename()` function to take an `llvm::Triple` argument.