### PR TITLE
[Sema] Disregard reference storage types when inferring associated types from witnesses. 

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3991,7 +3991,7 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
   Type model = conformance->getType();
   TypeSubstitutionMap substitutions = model->getMemberSubstitutions(witness);
   if (substitutions.empty())
-    return witness->getInterfaceType();
+    return witness->getInterfaceType()->getReferenceStorageReferent();
 
   Type type = witness->getInterfaceType();
   

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -199,3 +199,25 @@ extension M {
     _ = B.A.isP
   }
 }
+
+// SR-6097
+protocol sr6097 {
+  associatedtype A : AnyObject
+  var aProperty: A { get }
+}
+
+class C1 {}
+class C2 : sr6097 {
+  unowned let aProperty: C1 // should deduce A == C1 despite 'unowned'
+  init() { fatalError() }
+}
+
+protocol sr6097_b {
+  associatedtype A : AnyObject
+  var aProperty: A? { get }
+}
+class C3 : sr6097_b {
+  weak var aProperty: C1? // and same here, despite 'weak'
+  init() { fatalError() }
+}
+


### PR DESCRIPTION
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6097](https://bugs.swift.org/browse/SR-6097).
