### PR TITLE
[Sema] Extend fix for reference storage types in protocol witnesses to include generics.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3990,10 +3990,10 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
   // Retrieve the set of substitutions to be applied to the witness.
   Type model = conformance->getType();
   TypeSubstitutionMap substitutions = model->getMemberSubstitutions(witness);
+  Type type = witness->getInterfaceType()->getReferenceStorageReferent();
+  
   if (substitutions.empty())
-    return witness->getInterfaceType()->getReferenceStorageReferent();
-
-  Type type = witness->getInterfaceType();
+    return type;
   
   // Strip off the requirements of a generic function type.
   // FIXME: This doesn't actually break recursion when substitution

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -220,4 +220,8 @@ class C3 : sr6097_b {
   weak var aProperty: C1? // and same here, despite 'weak'
   init() { fatalError() }
 }
+class G<T> : sr6097_b where T : AnyObject {
+  weak var aProperty: T?
+}
+
 


### PR DESCRIPTION
Had wrongly disregarded generic conformers in my original fix for sr-6097. This commit extends that fix.

(I had only been thinking in terms of methods with generic parameters before (which obviously couldn't contain reference storage types) -- oops.)