### PR TITLE
build: special case Windows ARM target

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -179,8 +179,13 @@ macro(configure_sdk_windows prefix sdk_name environment architectures)
   set(SWIFT_SDK_${prefix}_OBJECT_FORMAT "COFF")
 
   foreach(arch ${architectures})
-    set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
-        "${arch}-unknown-windows-${environment}")
+    if(arch STREQUAL armv7)
+      set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
+          "thumbv7-unknown-windows-${environment}")
+    else()
+      set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
+          "${arch}-unknown-windows-${environment}")
+    endif()
   endforeach()
 
   # Add this to the list of known SDKs.


### PR DESCRIPTION
Windows ARM NT (the modern, non-Windows CE environment) is a pure thumb2
environment.  The frontend does not canonicalise the target like in
clang.  Ensure that we map the triple by hand to the desired target
triple.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
