### PR TITLE
NFC code cleanup changes

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -271,6 +271,9 @@ public:
   /// false otherwise.
   explicit operator bool() const { return Value != nullptr; }
 
+  /// Get a location for this value.
+  SILLocation getLoc() const;
+
   /// Convert this SILValue into an opaque pointer like type. For use with
   /// PointerLikeTypeTraits.
   void *getOpaqueValue() const {

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -877,7 +877,7 @@ SILInstruction::MemoryBehavior SILInstruction::getMemoryBehavior() const {
                                 : MemoryBehavior::MayHaveSideEffects;
 
     // Handle LLVM intrinsic functions.
-    const IntrinsicInfo & IInfo = BI->getIntrinsicInfo();
+    const IntrinsicInfo &IInfo = BI->getIntrinsicInfo();
     if (IInfo.ID != llvm::Intrinsic::not_intrinsic) {
       // Read-only.
       if (IInfo.hasAttribute(llvm::Attribute::ReadOnly) &&

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -110,6 +110,20 @@ const SILNode *SILNode::getCanonicalSILNodeSlowPath() const {
               static_cast<const ValueBase &>(*this)));
 }
 
+/// Get a location for this value.
+SILLocation SILValue::getLoc() const {
+  if (auto *instr = Value->getDefiningInstruction())
+    return instr->getLoc();
+
+  if (auto *arg = dyn_cast<SILArgument>(*this)) {
+    if (arg->getDecl())
+      return RegularLocation(const_cast<ValueDecl *>(arg->getDecl()));
+  }
+  // TODO: bbargs should probably use one of their operand locations.
+  return Value->getFunction()->getLocation();
+}
+
+
 //===----------------------------------------------------------------------===//
 //                             ValueOwnershipKind
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -474,21 +474,6 @@ unsigned OpaqueStorageAllocation::insertIndirectReturnArgs() {
   return argIdx;
 }
 
-/// Utility to derive SILLocation.
-/// 
-/// TODO: This should be a common utility.
-static SILLocation getLocForValue(SILValue value) {
-  if (auto *instr = value->getDefiningInstruction()) {
-    return instr->getLoc();
-  }
-  if (auto *arg = dyn_cast<SILArgument>(value)) {
-    if (arg->getDecl())
-      return RegularLocation(const_cast<ValueDecl *>(arg->getDecl()));
-  }
-  // TODO: bbargs should probably use one of their operand locations.
-  return value->getFunction()->getLocation();
-}
-
 /// Is this operand composing an aggregate from a subobject, or simply
 /// forwarding the operand's value to storage defined elsewhere?
 ///
@@ -587,7 +572,7 @@ void OpaqueStorageAllocation::allocateForValue(SILValue value,
   allocBuilder.setSILConventions(
       SILModuleConventions::getLoweredAddressConventions());
   AllocStackInst *allocInstr =
-      allocBuilder.createAllocStack(getLocForValue(value), value->getType());
+      allocBuilder.createAllocStack(value.getLoc(), value->getType());
 
   storage.storageAddress = allocInstr;
 


### PR DESCRIPTION
 - Hoist a duplicated static function with a fixme out to SILValue::getLoc()
 - Fix a whitespace issue.