### PR TITLE
[Sema] Crash fix for key path for an optional chain to optional lvalue.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4172,7 +4172,7 @@ namespace {
       if (didOptionalChain &&
           baseTy &&
           !baseTy->hasUnresolvedType() &&
-          !baseTy->isEqual(leafTy)) {
+          !baseTy->getWithoutSpecifierType()->isEqual(leafTy)) {
         assert(leafTy->getAnyOptionalObjectType()
                      ->isEqual(baseTy->getWithoutSpecifierType()));
         auto component = KeyPathExpr::Component::forOptionalWrap(leafTy);

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -434,6 +434,20 @@ func testImplicitConversionInSubscriptIndex() {
   _ = \BassSubscript.["hello"] // expected-error{{must be Hashable}}
 }
 
+// SR-6106
+func sr6106() {
+  class B {}
+  class A {
+    var b: B? = nil
+  }
+  class C {
+    var a: A?
+    func myFunc() {
+      let _ = \C.a?.b
+    }
+  }
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
Incorrect condition here resulted in incorrectly trying to optional-wrap for an optional chain to optional lvalue.

Resolves [SR-6106](https://bugs.swift.org/browse/SR-6106) | rdar://problem/34911379.