### PR TITLE
[swift-4.0-branch][overlay] Fix newMeshes to return proper modelIO meshes

### DIFF
--- a/stdlib/public/SDK/MetalKit/MetalKit.swift
+++ b/stdlib/public/SDK/MetalKit/MetalKit.swift
@@ -16,10 +16,9 @@
 @available(macOS 10.11, iOS 9.0, tvOS 9.0, *)
 extension MTKMesh {
     public class func newMeshes(asset: MDLAsset, device: MTLDevice) throws -> (modelIOMeshes: [MDLMesh], metalKitMeshes: [MTKMesh]) {
-        var resultTuple : (modelIOMeshes: [MDLMesh], metalKitMeshes: [MTKMesh])
-        resultTuple.modelIOMeshes = [MDLMesh]()
-        resultTuple.metalKitMeshes = try MTKMesh.newMeshes(from: asset, device: device, sourceMeshes: AutoreleasingUnsafeMutablePointer<NSArray?>(&resultTuple.modelIOMeshes))
-        return resultTuple
+        var modelIOMeshes: NSArray?
+        var metalKitMeshes = try MTKMesh.newMeshes(from: asset, device: device, sourceMeshes: &modelIOMeshes)
+        return (modelIOMeshes: modelIOMeshes as! [MDLMesh], metalKitMeshes: metalKitMeshes)
     }
 }
 


### PR DESCRIPTION
* Explanation: Fixes the behavior of the MTKMesh.newMeshes(asset:device:) method.
* Scope of Issue: A bug fix. No API change.
* Risk: Minimal
* Reviewed By: Ryan Schmitt
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/34624659>