### PR TITLE
SILGen: Fix bug with NSString import-as-member globals

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3213,6 +3213,9 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
   // Any writebacks should be scoped to after the load.
   FormalEvaluationScope scope(*this);
 
+  // We shouldn't need to re-abstract here, but we might have to bridge.
+  // This should only happen if we have a global variable of NSString type.
+  auto origFormalType = src.getOrigFormalType();
   auto substFormalType = src.getSubstFormalType();
   auto &rvalueTL = getTypeLowering(src.getTypeOfRValue());
 
@@ -3226,6 +3229,7 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
              .offset(*this, loc, addr, AccessKind::Read);
     return RValue(*this, loc, substFormalType,
                   emitLoad(loc, addr.getValue(),
+                           origFormalType, substFormalType,
                            rvalueTL, C, IsNotTake,
                            isBaseGuaranteed));
   }

--- a/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
+++ b/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
@@ -32,4 +32,15 @@ UnavailableDefaultInit * _Nonnull MakeUnavailableDefaultInit(void);
 __attribute__((swift_name("UnavailableDefaultInitSub.init()")))
 UnavailableDefaultInitSub * _Nonnull MakeUnavailableDefaultInitSub(void);
 
+#pragma clang assume_nonnull begin
+
+extern NSString * PKPandaCutenessFactor __attribute__((swift_name("Panda.cutenessFactor")));
+extern NSString * _Nullable PKPandaCuddlynessFactor __attribute__((swift_name("Panda.cuddlynessFactor")));
+
+__attribute__((swift_name("Panda")))
+@interface PKPanda : NSObject
+@end
+
+#pragma clang assume_nonnull end
+
 #endif


### PR DESCRIPTION
This is not really the right fix if we want to have physically
addressed lvalues support bridging in general, but doing so
requires adding a new LValue component type and doing a bunch
more refactoring, so just hack in a narrow fix for now since
it only seems to occur in one case.

Fixes <rdar://problem/34913892>.