### PR TITLE
[Serialization] Move LLVM_NORETURN to declaration start

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -434,7 +434,7 @@ public:
 
   /// Emits one last diagnostic, logs the error, and then aborts for the stack
   /// trace.
-  void fatal(llvm::Error error) LLVM_ATTRIBUTE_NORETURN;
+  LLVM_ATTRIBUTE_NORETURN void fatal(llvm::Error error);
 
   ASTContext &getContext() const {
     assert(FileContext && "no associated context yet");


### PR DESCRIPTION
On Windows, `LLVM_NORETURN` expands to `__declspec(noreturn)`, which
must be placed at the start of the declaration. All other possible
expansions of that macro should also support being placed at the start
of the declaration.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
