### PR TITLE
 [GSB] Resolve type into an equivalence class without building a new PA.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1593,41 +1593,12 @@ public:
     return identifier.assocTypeOrConcrete;
   }
 
-  /// Retrieve the set of protocols to which this potential archetype
-  /// conforms.
-  SmallVector<ProtocolDecl *, 4> getConformsTo() const {
-    SmallVector<ProtocolDecl *, 4> result;
-
-    if (auto equiv = getEquivalenceClassIfPresent()) {
-      for (const auto &entry : equiv->conformsTo)
-        result.push_back(entry.first);
-    }
-
-    return result;
-  }
-
   /// Add a conformance to this potential archetype.
   ///
   /// \returns true if the conformance was new, false if it already existed.
   bool addConformance(ProtocolDecl *proto,
                       const RequirementSource *source,
                       GenericSignatureBuilder &builder);
-
-  /// Retrieve the superclass of this archetype.
-  Type getSuperclass() const {
-    if (auto equiv = getEquivalenceClassIfPresent())
-      return equiv->superclass;
-    
-    return nullptr;
-  }
-
-  /// Retrieve the layout constraint of this archetype.
-  LayoutConstraint getLayout() const {
-    if (auto equivClass = getEquivalenceClassIfPresent())
-      return equivClass->layout;
-
-    return LayoutConstraint();
-  }
 
   /// Retrieve the set of nested types.
   const llvm::MapVector<Identifier, StoredNestedType> &getNestedTypes() const {
@@ -1741,14 +1712,6 @@ public:
     return false;
   }
   
-  /// Get the concrete type this potential archetype is constrained to.
-  Type getConcreteType() const {
-    if (auto equivClass = getEquivalenceClassIfPresent())
-      return equivClass->concreteType;
-
-    return Type();
-  }
-
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const,
       "only for use within the debugger");

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -158,6 +158,10 @@ public:
     std::vector<Constraint<LayoutConstraint>> layoutConstraints;
 
     /// The members of the equivalence class.
+    ///
+    /// This list of members is slightly ordered, in that the first
+    /// element always has a depth no greater than the depth of any other
+    /// member.
     TinyPtrVector<PotentialArchetype *> members;
 
     /// Describes a component within the graph of same-type constraints within
@@ -202,6 +206,9 @@ public:
     EquivalenceClass(EquivalenceClass &&) = delete;
     EquivalenceClass &operator=(const EquivalenceClass &) = delete;
     EquivalenceClass &operator=(EquivalenceClass &&) = delete;
+
+    /// Add a new member to this equivalence class.
+    void addMember(PotentialArchetype *pa);
 
     /// Record the conformance of this equivalence class to the given
     /// protocol as found via the given requirement source.
@@ -758,13 +765,11 @@ public:
   resolvePotentialArchetype(Type type,
                             ArchetypeResolutionKind resolutionKind);
 
-private:
   /// \brief Try to resolvew the equivalence class of the given type.
   ResolveResult maybeResolveEquivalenceClass(
                                       Type type,
                                       ArchetypeResolutionKind resolutionKind);
 
-public:
   /// \brief Resolve the equivalence class for the given type parameter,
   /// which provides information about that type.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -758,6 +758,13 @@ public:
   resolvePotentialArchetype(Type type,
                             ArchetypeResolutionKind resolutionKind);
 
+private:
+  /// \brief Try to resolvew the equivalence class of the given type.
+  ResolveResult maybeResolveEquivalenceClass(
+                                      Type type,
+                                      ArchetypeResolutionKind resolutionKind);
+
+public:
   /// \brief Resolve the equivalence class for the given type parameter,
   /// which provides information about that type.
   ///

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -448,14 +448,23 @@ bool ConformanceLookupTable::addProtocol(NominalTypeDecl *nominal,
         return false;
 
       case ConformanceEntryKind::Implied:
-        // An implied conformance is better than a synthesized one.
         // Ignore implied circular protocol inheritance
-        if (kind == ConformanceEntryKind::Synthesized ||
-            existingEntry->getProtocol() == protocol)
+        if (existingEntry->getProtocol() == protocol)
           return false;
+
+        // An implied conformance is better than a synthesized one, unless
+        // the implied conformance was deserialized.
+        if (kind == ConformanceEntryKind::Synthesized &&
+            existingEntry->getDeclContext()->getParentSourceFile() == nullptr)
+          return false;
+
         break;
 
       case ConformanceEntryKind::Synthesized:
+        // An implied conformance is better unless it was deserialized.
+        if (dc->getParentSourceFile() == nullptr)
+          return false;
+
         break;
       }
     }

--- a/test/Serialization/Inputs/use_imported_enums.swift
+++ b/test/Serialization/Inputs/use_imported_enums.swift
@@ -7,3 +7,25 @@ import Foundation
 @inline(__always) @_transparent public func compareImportedEnumToSelf(_ e: NSRuncingMode) -> Bool {
   return compareToSelf(e)
 }
+
+// SR-6105
+open class EVC<EnumType : EVT> where EnumType.RawValue : Hashable {
+}
+
+public protocol EVT : RawRepresentable {
+    associatedtype Wrapper
+    associatedtype Constructor
+}
+
+open class EVO<EnumType> {
+}
+
+final public class CSWrapperConstructorClass : EVC<ByteCountFormatter.CountStyle> {
+}
+
+final public class CSWrapperClass : EVO<ByteCountFormatter.CountStyle> {
+}
+extension ByteCountFormatter.CountStyle : EVT {
+    public typealias Wrapper = CSWrapperClass
+    public typealias Constructor = CSWrapperConstructorClass
+}

--- a/test/Serialization/imported_enum_merge.swift
+++ b/test/Serialization/imported_enum_merge.swift
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t/UsesImportedEnums-a.swiftmodule -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -merge-modules -module-name UsesImportedEnums -emit-module -o %t/UsesImportedEnums.swiftmodule %t/UsesImportedEnums-a.swiftmodule
+
+// REQUIRES: objc_interop


### PR DESCRIPTION
Teach `GenericSignatureBuilder::resolveEquivalenceClass()` to perform
resolution of a type into a dependent type and its equivalence class
without realizing that potential archetype. Improves type-checking
time for the standard library by ~6%.