### PR TITLE
[Conformance lookup table] Prefer synthesized conformances to deserialized ones.

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -440,14 +440,23 @@ bool ConformanceLookupTable::addProtocol(NominalTypeDecl *nominal,
         return false;
 
       case ConformanceEntryKind::Implied:
-        // An implied conformance is better than a synthesized one.
         // Ignore implied circular protocol inheritance
-        if (kind == ConformanceEntryKind::Synthesized ||
-            existingEntry->getProtocol() == protocol)
+        if (existingEntry->getProtocol() == protocol)
           return false;
+
+        // An implied conformance is better than a synthesized one, unless
+        // the implied conformance was deserialized.
+        if (kind == ConformanceEntryKind::Synthesized &&
+            existingEntry->getDeclContext()->getParentSourceFile() == nullptr)
+          return false;
+
         break;
 
       case ConformanceEntryKind::Synthesized:
+        // An implied conformance is better unless it was deserialized.
+        if (dc->getParentSourceFile() == nullptr)
+          return false;
+
         break;
       }
     }

--- a/test/Serialization/Inputs/use_imported_enums.swift
+++ b/test/Serialization/Inputs/use_imported_enums.swift
@@ -7,3 +7,25 @@ import Foundation
 @inline(__always) @_transparent public func compareImportedEnumToSelf(_ e: NSRuncingMode) -> Bool {
   return compareToSelf(e)
 }
+
+// SR-6105
+open class EVC<EnumType : EVT> where EnumType.RawValue : Hashable {
+}
+
+public protocol EVT : RawRepresentable {
+    associatedtype Wrapper
+    associatedtype Constructor
+}
+
+open class EVO<EnumType> {
+}
+
+final public class CSWrapperConstructorClass : EVC<ByteCountFormatter.CountStyle> {
+}
+
+final public class CSWrapperClass : EVO<ByteCountFormatter.CountStyle> {
+}
+extension ByteCountFormatter.CountStyle : EVT {
+    public typealias Wrapper = CSWrapperClass
+    public typealias Constructor = CSWrapperConstructorClass
+}

--- a/test/Serialization/imported_enum_merge.swift
+++ b/test/Serialization/imported_enum_merge.swift
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t/UsesImportedEnums-a.swiftmodule -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -merge-modules -module-name UsesImportedEnums -emit-module -o %t/UsesImportedEnums.swiftmodule %t/UsesImportedEnums-a.swiftmodule
+
+// REQUIRES: objc_interop

--- a/test/Serialization/imported_enum_merge.swift
+++ b/test/Serialization/imported_enum_merge.swift
@@ -7,6 +7,6 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t/UsesImportedEnums-a.swiftmodule -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -merge-modules -module-name UsesImportedEnums -emit-module -o %t/UsesImportedEnums.swiftmodule %t/UsesImportedEnums-a.swiftmodule
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name UsesImportedEnums -emit-module -o %t/UsesImportedEnums.swiftmodule %t/UsesImportedEnums-a.swiftmodule
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
* Explanation: Fixes a crash involving the addition of protocol conformances to imported types.
* Scope of Issue: Affects only those cases where we have extensions of imported types that add conformances to protocols that are themselves related to synthesized conformances, e.g., user-defined protocols that inherit `RawRepresentable`.
* Risk: Minimal
* Reviewed By: @slavapestov 
* Testing: Automated test suite
* Directions for QA: N/A
* Radar/SR: rdar://problem/34911378/[SR-6105](https://bugs.swift.org/browse/SR-6105)
