### PR TITLE
[AST] Drop unnecessary friend declaration

### DIFF
--- a/include/swift/AST/SyntaxASTMap.h
+++ b/include/swift/AST/SyntaxASTMap.h
@@ -35,7 +35,6 @@ namespace syntax {
 /// a mapping from lib/AST nodes to lib/Syntax nodes while we integrate
 /// the infrastructure into the compiler.
 class SyntaxASTMap final {
-  friend class LegacyASTTransformer;
   llvm::DenseMap<RC<syntax::SyntaxData>, ASTNode> SyntaxMap;
 public:
 


### PR DESCRIPTION
Summary:
The friend declaration wasn't qualified (it should have included the
namespace, i.e. `syntax::LegacyASTTransformer`). The effect was instead
to declare a `LegacyASTTransformer` inside the `swift` namespace, which
would then trip up Windows compilation because of non-conforming
two-phase lookup. The implication is that the friend declaration is
actually unneeded, since the incorrect declaration wasn't causing any
other problems, so we can just drop it.