### PR TITLE
[swiftc (68 vs. 5600)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28862-swift-protocoldecl-getinheritedprotocols-const.swift
+++ b/validation-test/compiler_crashers/28862-swift-protocoldecl-getinheritedprotocols-const.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:RangeReplaceableCollection&(t:A{extension{}a e:class a{}class a
+{{}lass a=_{case.a<a =nil??as?=
+:a<a
+?as?=


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 68 (5600 resolved)

Stack trace:

```
0 0x0000000003ebc124 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ebc124)
1 0x0000000003ebc466 SignalHandler(int) (/path/to/swift/bin/swift+0x3ebc466)
2 0x00007fe07c778390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000016ee71e swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16ee71e)
4 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
5 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
6 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
7 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
8 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
9 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
10 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
11 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
12 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
13 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
14 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
15 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
16 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
17 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
18 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
19 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
20 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
21 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
22 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
23 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
24 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
25 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
26 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
27 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
28 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
29 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
30 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
31 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
32 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
33 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
34 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
35 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
36 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
37 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
38 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
39 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
40 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
41 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
42 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
43 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
44 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
45 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
46 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
47 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
48 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
49 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
50 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
51 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
52 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
53 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
54 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
55 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
56 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
57 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
58 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
59 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
60 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
61 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
62 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
63 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
64 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
65 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
66 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
67 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
68 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
69 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
70 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
71 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
72 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
73 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
74 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
75 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
76 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
77 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
78 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
79 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
80 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
81 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
82 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
83 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
84 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
85 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
86 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
87 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
88 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
89 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
90 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
91 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
92 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
93 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
94 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
95 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
96 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
97 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
98 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
99 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
100 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
101 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
102 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
103 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
104 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
105 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
106 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
107 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
108 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
109 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
110 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
111 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
112 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
113 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
114 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
115 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
116 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
117 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
118 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
119 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
120 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
121 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
122 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
123 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
124 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
125 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
126 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
127 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
128 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
129 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
130 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
131 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
132 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
133 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
134 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
135 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
136 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
137 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
138 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
139 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
140 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
141 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
142 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
143 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
144 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
145 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
146 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
147 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
148 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
149 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
150 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
151 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
152 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
153 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
154 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
155 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
156 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
157 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
158 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
159 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
160 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
161 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
162 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
163 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
164 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
165 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
166 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
167 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
168 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
169 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
170 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
171 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
172 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
173 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
174 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
175 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
176 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
177 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
178 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
179 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
180 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
181 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
182 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
183 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
184 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
185 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
186 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
187 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
188 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
189 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
190 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
191 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
192 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
193 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
194 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
195 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
196 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
197 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
198 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
199 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
200 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
201 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
202 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
203 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
204 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
205 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
206 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
207 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
208 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
209 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
210 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
211 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
212 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
213 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
214 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
215 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
216 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
217 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
218 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
219 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
220 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
221 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
222 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
223 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
224 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
225 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
226 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
227 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
228 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
229 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
230 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
231 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
232 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
233 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
234 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
235 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
236 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
237 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
238 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
239 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
240 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
241 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
242 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
243 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
244 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
245 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
246 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
247 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
248 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
249 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
250 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
251 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
252 0x00000000016ef5ea swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x16ef5ea)
253 0x00000000016eaff9 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x16eaff9)
254 0x0000000001659ae5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x1659ae5)
255 0x00000000016eeaa0 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x16eeaa0)
```