### PR TITLE
[swiftc (69 vs. 5600)] Add crasher in swift::TypeBase::getSuperclassForDecl

### DIFF
--- a/validation-test/compiler_crashers/28863-t-is-archetypetype-t-isexistentialtype-expected-a-class-archetype-or-existential.swift
+++ b/validation-test/compiler_crashers/28863-t-is-archetypetype-t-isexistentialtype-expected-a-class-archetype-or-existential.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a
+class a<a{{}class a<a{var f=a
+& ManagedBuffer
+protocol a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getSuperclassForDecl`.

Current number of unresolved compiler crashers: 69 (5600 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `t->is<ArchetypeType>() || t->isExistentialType() && "expected a class, archetype or existential"` added on 2017-04-07 by you in commit 473faf1e :-)

Assertion failure in [`lib/AST/Type.cpp (line 3245)`](https://github.com/apple/swift/blob/ab06b148ee0a83c35d9bc3d0e6fd47eaaffe89c2/lib/AST/Type.cpp#L3245):

```
Assertion `t->is<ArchetypeType>() || t->isExistentialType() && "expected a class, archetype or existential"' failed.

When executing: swift::Type swift::TypeBase::getSuperclassForDecl(const swift::ClassDecl *)
```

Assertion context:

```c++
    // If we have a class-constrained archetype or class-constrained
    // existential, get the underlying superclass constraint.
    auto *nominalDecl = t->getAnyNominal();
    if (!nominalDecl) {
      assert(t->is<ArchetypeType>() || t->isExistentialType() &&
             "expected a class, archetype or existential");
      t = t->getSuperclass();
      assert(t && "archetype or existential is not class constrained");
      continue;
    }
    assert(isa<ClassDecl>(nominalDecl) && "expected a class here");
```
Stack trace:

```
0 0x0000000003ebc124 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ebc124)
1 0x0000000003ebc466 SignalHandler(int) (/path/to/swift/bin/swift+0x3ebc466)
2 0x00007f9690e07390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f968f32c428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f968f32e02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f968f324bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f968f324c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016f4c5a swift::TypeBase::getSuperclassForDecl(swift::ClassDecl const*) (/path/to/swift/bin/swift+0x16f4c5a)
8 0x00000000016f4d5f swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x16f4d5f)
9 0x00000000012734a1 swift::constraints::ConstraintSystem::openUnboundGenericType(swift::UnboundGenericType*, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >&) (/path/to/swift/bin/swift+0x12734a1)
10 0x0000000001279f20 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::constraints::ConstraintSystem::openUnboundGenericType(swift::Type, swift::constraints::ConstraintLocatorBuilder)::$_1>(long, swift::Type) (/path/to/swift/bin/swift+0x1279f20)
11 0x00000000016fc286 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const::$_15>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x16fc286)
12 0x00000000016f56f6 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16f56f6)
13 0x00000000016f5783 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16f5783)
14 0x00000000016f60e7 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x16f60e7)
15 0x00000000016eca17 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0x16eca17)
16 0x0000000001273be8 swift::constraints::ConstraintSystem::openUnboundGenericType(swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x1273be8)
17 0x000000000122c292 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x122c292)
18 0x00000000012320be (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12320be)
19 0x000000000163319c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x163319c)
20 0x0000000001228bbf swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x1228bbf)
21 0x0000000001256a11 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1256a11)
22 0x000000000128aae7 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x128aae7)
23 0x000000000128e8ac swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x128e8ac)
24 0x00000000012931d6 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x12931d6)
25 0x0000000001293456 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x1293456)
26 0x00000000012abd98 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12abd98)
27 0x00000000012a6338 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a6338)
28 0x00000000012b826b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b826b)
29 0x00000000012a63de (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a63de)
30 0x00000000012b826b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12b826b)
31 0x00000000012a63de (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a63de)
32 0x00000000012a6183 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a6183)
33 0x0000000001338ef5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1338ef5)
34 0x0000000001057b54 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1057b54)
35 0x0000000001056c17 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056c17)
36 0x000000000105653a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105653a)
37 0x00000000004bfec5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfec5)
38 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
39 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
40 0x00007f968f317830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
41 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```