### PR TITLE
Relax the open_existential_addr immutable_access verifier further after sil-combine bail-out

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2412,6 +2412,7 @@ public:
                 if (!isConsumingOrMutatingApplyUse(use))
                   return true;
                 break;
+              case SILInstructionKind::StructElementAddrInst:
               case SILInstructionKind::LoadInst:
               case SILInstructionKind::DebugValueAddrInst:
                 if (I->hasOneUse())

--- a/test/SILOptimizer/sil_combine1.swift
+++ b/test/SILOptimizer/sil_combine1.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck %s
+
+func curry<T1, T2, T3, T4>(_ f: @escaping (T1, T2, T3) -> T4) -> (T1) -> (T2) -> (T3) -> T4 {
+  return { x in { y in { z in f(x, y, z) } } }
+}
+
+public protocol P {
+  func val() -> Int32
+}
+
+struct CP: P {
+  let v: Int32
+
+  func val() -> Int32 {
+     return v
+  }
+
+  init(_ v: Int32) {
+    self.v = v
+  }
+}
+
+func compose(_ x: P, _ y: P, _ z: P) -> Int32 {
+  return x.val() + y.val() + z.val()
+}
+
+//CHECK-LABEL: sil [noinline] @_T012sil_combine120test_compose_closures5Int32VyF : $@convention(thin) () -> Int32 {
+//CHECK: [[OEADDR:%.*]] = open_existential_addr immutable_access {{%.*}} : $*P to $*@opened
+//CHECK: [[ADDRCAST:%.*]] = unchecked_addr_cast [[OEADDR]] : $*@opened
+//CHECK: struct_element_addr [[ADDRCAST]] : $*CP, #CP.v
+@inline(never)
+public func test_compose_closure() -> Int32 {
+  let insult = curry(compose)(CP(1))(CP(2))
+  let gs = insult(CP(3))
+  return gs
+}
+


### PR DESCRIPTION
radar rdar://problem/35010515

Found another `open_existential_addr immutable_access` pattern that got exposed by the new sil-combiner changes:

After keeping the `open_existential_addr immutable_access` we have a new pattern created by an interaction of a few different optimizations: we have an unchecked address cast (devirtualization) + immutable use of that address. Support said pattern in the SIL Verifier.