### PR TITLE
[swiftc (70 vs. 5600)] Add crasher in swift::ASTContext::getConformance

### DIFF
--- a/validation-test/compiler_crashers/28864-bool-typesig-bool-extensionsig-unexpected-generic-ness-mismatch-on-conformance.swift
+++ b/validation-test/compiler_crashers/28864-bool-typesig-bool-extensionsig-unexpected-generic-ness-mismatch-on-conformance.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{class a}protocol A:P
+extension P.a:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTContext::getConformance`.

Current number of unresolved compiler crashers: 70 (5600 resolved)

/cc @huonw - just wanted to let you know that this crasher caused an assertion failure for the assertion `(bool)typeSig == (bool)extensionSig && "unexpected generic-ness mismatch on conformance"` added on 2017-09-14 by you in commit 945f723d :-)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 320)`](https://github.com/apple/swift/blob/01416ab5bf42891ba33c6ed7ad959fef8e2b1117/lib/AST/ProtocolConformance.cpp#L320):

```
Assertion `(bool)typeSig == (bool)extensionSig && "unexpected generic-ness mismatch on conformance"' failed.

When executing: void swift::NormalProtocolConformance::differenceAndStoreConditionalRequirements()
```

Assertion context:

```c++
                     ->getGenericSignature();
  auto extensionSig = DC->getGenericSignatureOfContext();

  // If the type is generic, the extension should be too, and vice versa.
  assert((bool)typeSig == (bool)extensionSig &&
         "unexpected generic-ness mismatch on conformance");
  if (!typeSig)
    return;

  auto canExtensionSig = extensionSig->getCanonicalSignature();
  auto canTypeSig = typeSig->getCanonicalSignature();
```
Stack trace:

```
0 0x0000000003ebc124 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3ebc124)
1 0x0000000003ebc466 SignalHandler(int) (/path/to/swift/bin/swift+0x3ebc466)
2 0x00007f1c947e3390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f1c92d08428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1c92d0a02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1c92d00bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f1c92d00c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016dcc3b (/path/to/swift/bin/swift+0x16dcc3b)
8 0x00000000015ad8fc swift::ASTContext::getConformance(swift::Type, swift::ProtocolDecl*, swift::SourceLoc, swift::DeclContext*, swift::ProtocolConformanceState) (/path/to/swift/bin/swift+0x15ad8fc)
9 0x0000000001708ab3 swift::ConformanceLookupTable::getConformance(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceEntry*) (/path/to/swift/bin/swift+0x1708ab3)
10 0x000000000170c53b bool __gnu_cxx::__ops::_Iter_pred<swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*)::$_12>::operator()<swift::ConformanceLookupTable::ConformanceEntry**>(swift::ConformanceLookupTable::ConformanceEntry**) (/path/to/swift/bin/swift+0x170c53b)
11 0x0000000001709287 swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*) (/path/to/swift/bin/swift+0x1709287)
12 0x00000000016dee3f swift::DeclContext::getLocalConformances(swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*, bool) const (/path/to/swift/bin/swift+0x16dee3f)
13 0x00000000012ea9a6 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x12ea9a6)
14 0x00000000012b7898 (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12b7898)
15 0x00000000012a631f (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12a631f)
16 0x00000000012a6183 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12a6183)
17 0x0000000001338f7a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1338f7a)
18 0x0000000001057b54 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1057b54)
19 0x0000000001056c17 swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x1056c17)
20 0x000000000105653a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x105653a)
21 0x00000000004bfec5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4bfec5)
22 0x00000000004bec2b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4bec2b)
23 0x0000000000476fd4 main (/path/to/swift/bin/swift+0x476fd4)
24 0x00007f1c92cf3830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000474889 _start (/path/to/swift/bin/swift+0x474889)
```