### PR TITLE
[SIL] Enforce dominance property of the entry block

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4003,7 +4003,11 @@ public:
             "final component should match leaf value type of key path type");
   }
 
-  void verifyEntryPointArguments(SILBasicBlock *entry) {
+  // This verifies that the entry block of a SIL function doesn't have
+  // any predecessors and also verifies the entry point arguments.
+  void verifyEntryBlock(SILBasicBlock *entry) {
+    require(entry->pred_empty(), "entry block cannot have predecessors");
+
     DEBUG(llvm::dbgs() << "Argument types for entry point BB:\n";
           for (auto *arg
                : make_range(entry->args_begin(), entry->args_end()))
@@ -4384,7 +4388,7 @@ public:
     }
 
     // Otherwise, verify the body of the function.
-    verifyEntryPointArguments(&*F->getBlocks().begin());
+    verifyEntryBlock(&*F->getBlocks().begin());
     verifyEpilogBlocks(F);
     verifyFlowSensitiveRules(F);
     verifyBranches(F);

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -99,7 +99,10 @@ class E : B { }
 
 sil @exit : $@convention(thin) () -> Never {
 bb0:
-  br bb0
+  br bb1
+
+bb1:
+  br bb1
 }
 
 // CHECK-LABEL: sil @removeTriviallyDeadInstructions

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -61,11 +61,15 @@ bb3:
 // loops.
 // CHECK-LABEL: sil @dead3
 sil @dead3 : $@convention(thin) () -> () {
-// CHECK: bb0
 bb0:
+// CHECK: bb0
+  br bb1
+// CHECK: bb1
+bb1:
 // CHECK: integer_literal $Builtin.Int32, 0
+// CHECK: br bb1
   %0 = integer_literal $Builtin.Int32, 0
-  br bb0
+  br bb1
 }
 
 // CHECK-LABEL: sil hidden @test_dce_bbargs

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -131,7 +131,9 @@ class E : B { }
 
 sil @exit : $@convention(thin) () -> Never {
 bb0:
-  br bb0
+  br bb1
+bb1:
+  br bb1
 }
 
 // CHECK-LABEL: sil @removeTriviallyDeadInstructions

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -132,7 +132,9 @@ bb2:
 
 sil @exit : $@convention(thin) () -> Never {
 bb0:
-  br bb0
+  br bb1
+bb1:
+  br bb1
 }
 
 // CHECK-LABEL: sil @removeTriviallyDeadInstructions

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -562,10 +562,14 @@ bb6(%8 : $Int64):
 
 // CHECK-LABEL: @infinite_loop
 // CHECK: bb0
-// CHECK-NEXT: br bb0
+// CHECK-NEXT: br bb1
+// CHECK: bb1
+// CHECK-NEXT: br bb1
 sil @infinite_loop : $@convention(thin) () -> () {
 bb0:
-  br bb0
+  br bb1
+bb1:
+  br bb1
 }
 
 import Builtin


### PR DESCRIPTION
An entry block can't have predecessors. I'll commit a test as a follow-up to make sure this doesn't regress.

This fixes SR-6170