### PR TITLE
IRGen: do not use the Large Code Model on Win64

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -544,17 +544,9 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
   }
 
   // Create a target machine.
-  auto cmodel = CodeModel::Default;
-
-  // On Windows 64 bit, dlls are loaded above the max address for 32 bits.
-  // This means that a default CodeModel causes generated code to segfault
-  // when run.
-  if (Triple.isArch64Bit() && Triple.isOSWindows())
-    cmodel = CodeModel::Large;
-
   llvm::TargetMachine *TargetMachine =
       Target->createTargetMachine(Triple.str(), CPU, targetFeatures, TargetOpts,
-                                  Reloc::PIC_, cmodel, OptLevel);
+                                  Reloc::PIC_, CodeModel::Default, OptLevel);
   if (!TargetMachine) {
     Ctx.Diags.diagnose(SourceLoc(), diag::no_llvm_target,
                        Triple.str(), "no LLVM target machine");


### PR DESCRIPTION
The large code model is not necessary.  Large Address Aware should be
sufficient for dealing with the higher address ranges.  Using the large
code model breaks the DLL storage semantics on Windows.  With this we
are able to build most of the standard library for all variants of
Windows.

Addresses SR-6150!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
