### PR TITLE
[GSB] Start delaying the realization of potential archetypes

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -488,10 +488,6 @@ private:
                                 const RequirementSource *parentSource,
                                 ModuleDecl *inferForModule);
 
-  /// Visit all of the potential archetypes.
-  template<typename F>
-  void visitPotentialArchetypes(F f);
-
 public:
   /// Construct a new generic signature builder.
   explicit GenericSignatureBuilder(ASTContext &ctx);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1655,15 +1655,6 @@ public:
     return { };
   }
 
-  /// \brief Retrieve (or create) a nested type with the given name.
-  PotentialArchetype *getNestedType(Identifier Name,
-                                    ArchetypeResolutionKind kind,
-                                    GenericSignatureBuilder &builder);
-
-  /// \brief Retrieve (or create) a nested type with a known type.
-  PotentialArchetype *getNestedType(TypeDecl *type,
-                                    GenericSignatureBuilder &builder);
-
   /// \brief Retrieve (or create) a nested type that is the current best
   /// nested archetype anchor (locally) with the given name.
   ///
@@ -1682,17 +1673,6 @@ public:
   /// a potential archetype should not be created if it's missing.
   PotentialArchetype *updateNestedTypeForConformance(
                         TypeDecl *type,
-                        ArchetypeResolutionKind kind);
-
-  /// Update the named nested type when we know this type conforms to the given
-  /// protocol.
-  ///
-  /// \returns the potential archetype associated with either an associated
-  /// type or typealias of the given protocol, unless the \c kind implies that
-  /// a potential archetype should not be created if it's missing.
-  PotentialArchetype *updateNestedTypeForConformance(
-                        Identifier name,
-                        ProtocolDecl *protocol,
                         ArchetypeResolutionKind kind);
 
   /// Retrieve the dependent type that describes this potential

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -89,7 +89,7 @@ public:
   class PotentialArchetype;
 
   using UnresolvedType = llvm::PointerUnion<PotentialArchetype *, Type>;
-  class ResolveResult;
+  class ResolvedType;
 
   using RequirementRHS =
       llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
@@ -385,7 +385,7 @@ public:
   /// previous example).
   ConstraintResult
   addSameTypeRequirementDirect(
-                         ResolveResult paOrT1, ResolveResult paOrT2,
+                         ResolvedType paOrT1, ResolvedType paOrT2,
                          FloatingRequirementSource Source,
                          llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 
@@ -758,7 +758,7 @@ public:
   /// \param wantExactPotentialArchetype Whether to return the precise
   /// potential archetype described by the type (vs. just the equivalance
   /// class and resolved type).
-  ResolveResult maybeResolveEquivalenceClass(
+  ResolvedType maybeResolveEquivalenceClass(
                                       Type type,
                                       ArchetypeResolutionKind resolutionKind,
                                       bool wantExactPotentialArchetype);
@@ -785,7 +785,7 @@ public:
   /// If the type cannot be resolved, e.g., because it is "too" recursive
   /// given the source, returns an unresolved result containing the equivalence
   /// class that would need to change to resolve this type.
-  ResolveResult resolve(UnresolvedType type, FloatingRequirementSource source);
+  ResolvedType resolve(UnresolvedType type, FloatingRequirementSource source);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -353,11 +353,10 @@ private:
   /// Retrieve the constraint source conformance for the superclass constraint
   /// of the given potential archetype (if present) to the given protocol.
   ///
-  /// \param pa The potential archetype whose superclass constraint is being
-  /// queried.
+  /// \param type The type whose superclass constraint is being queried.
   ///
   /// \param proto The protocol to which we are establishing conformance.
-  const RequirementSource *resolveSuperConformance(PotentialArchetype *pa,
+  const RequirementSource *resolveSuperConformance(ResolvedType type,
                                                    ProtocolDecl *proto);
 
   /// \brief Add a new conformance requirement specifying that the given
@@ -413,17 +412,20 @@ public:
   /// Update the superclass for the equivalence class of \c T.
   ///
   /// This assumes that the constraint has already been recorded.
-  void updateSuperclass(PotentialArchetype *T,
+  ///
+  /// \returns true if anything in the equivalence class changed, false
+  /// otherwise.
+  bool updateSuperclass(ResolvedType type,
                         Type superclass,
-                        const RequirementSource *source);
+                        FloatingRequirementSource source);
 
 private:
   /// \brief Add a new superclass requirement specifying that the given
   /// potential archetype has the given type as an ancestor.
   ConstraintResult addSuperclassRequirementDirect(
-                                              PotentialArchetype *T,
-                                              Type Superclass,
-                                              const RequirementSource *Source);
+                                              ResolvedType type,
+                                              Type superclass,
+                                              FloatingRequirementSource source);
 
   /// \brief Add a new type requirement specifying that the given
   /// type conforms-to or is a superclass of the second type.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -341,13 +341,12 @@ private:
                                    EquivalenceClass *unresolvedEquivClass,
                                    UnresolvedHandlingKind unresolvedHandling);
 
-  /// Resolve the conformance of the given potential archetype to
-  /// the given protocol when the potential archetype is known to be equivalent
-  /// to a concrete type.
+  /// Resolve the conformance of the given type to the given protocol when the
+  /// potential archetype is known to be equivalent to a concrete type.
   ///
   /// \returns the requirement source for the resolved conformance, or nullptr
   /// if the conformance could not be resolved.
-  const RequirementSource *resolveConcreteConformance(PotentialArchetype *pa,
+  const RequirementSource *resolveConcreteConformance(ResolvedType type,
                                                       ProtocolDecl *proto);
 
   /// Retrieve the constraint source conformance for the superclass constraint

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -214,9 +214,9 @@ public:
     ///
     /// \returns true if this conformance is new to the equivalence class,
     /// and false otherwise.
-    bool recordConformanceConstraint(PotentialArchetype *pa,
+    bool recordConformanceConstraint(ResolvedType type,
                                      ProtocolDecl *proto,
-                                     const RequirementSource *source);
+                                     FloatingRequirementSource source);
 
     /// Find a source of the same-type constraint that maps a potential
     /// archetype in this equivalence class to a concrete type along with
@@ -1598,13 +1598,6 @@ public:
 
     return identifier.assocTypeOrConcrete;
   }
-
-  /// Add a conformance to this potential archetype.
-  ///
-  /// \returns true if the conformance was new, false if it already existed.
-  bool addConformance(ProtocolDecl *proto,
-                      const RequirementSource *source,
-                      GenericSignatureBuilder &builder);
 
   /// Retrieve the set of nested types.
   const llvm::MapVector<Identifier, StoredNestedType> &getNestedTypes() const {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -89,7 +89,6 @@ public:
   class PotentialArchetype;
 
   using UnresolvedType = llvm::PointerUnion<PotentialArchetype *, Type>;
-  struct ResolvedType;
   class ResolveResult;
 
   using RequirementRHS =
@@ -386,7 +385,7 @@ public:
   /// previous example).
   ConstraintResult
   addSameTypeRequirementDirect(
-                         ResolvedType paOrT1, ResolvedType paOrT2,
+                         ResolveResult paOrT1, ResolveResult paOrT2,
                          FloatingRequirementSource Source,
                          llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -358,13 +358,13 @@ private:
   const RequirementSource *resolveSuperConformance(ResolvedType type,
                                                    ProtocolDecl *proto);
 
-  /// \brief Add a new conformance requirement specifying that the given
-  /// potential archetype conforms to the given protocol.
-  ConstraintResult addConformanceRequirement(PotentialArchetype *T,
-                                             ProtocolDecl *Proto,
-                                             const RequirementSource *Source);
-
 public:
+  /// \brief Add a new conformance requirement specifying that the given
+  /// type conforms to the given protocol.
+  ConstraintResult addConformanceRequirement(ResolvedType type,
+                                             ProtocolDecl *proto,
+                                             FloatingRequirementSource source);
+
   /// "Expand" the conformance of the given \c pa to the protocol \c proto,
   /// adding the requirements from its requirement signature, rooted at
   /// the given requirement \c source.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -465,9 +465,9 @@ private:
   ///
   /// \returns true if this requirement makes the set of requirements
   /// inconsistent, in which case a diagnostic will have been issued.
-  ConstraintResult addLayoutRequirementDirect(PotentialArchetype *PAT,
-                                              LayoutConstraint Layout,
-                                              const RequirementSource *Source);
+  ConstraintResult addLayoutRequirementDirect(ResolvedType type,
+                                              LayoutConstraint layout,
+                                              FloatingRequirementSource source);
 
   /// Add a new layout requirement to the subject.
   ConstraintResult addLayoutRequirement(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -750,25 +750,19 @@ private:
                             PotentialArchetype *pa);
 
 public:
-  /// \brief Resolve the given type to the potential archetype it names.
+  /// \brief Try to resolve the equivalence class of the given type.
   ///
-  /// The \c resolutionKind parameter describes how resolution should be
-  /// performed. If the potential archetype named by the given dependent type
-  /// already exists, it will be always returned. If it doesn't exist yet,
-  /// the \c resolutionKind dictates whether the potential archetype will
-  /// be created or whether null will be returned.
+  /// \param type The type to resolve.
   ///
-  /// For any type that cannot refer to an archetype, this routine returns the
-  /// equivalence class that would have to change to make the potential
-  /// archetype resolvable.
-  llvm::PointerUnion<PotentialArchetype *, EquivalenceClass *>
-  resolvePotentialArchetype(Type type,
-                            ArchetypeResolutionKind resolutionKind);
-
-  /// \brief Try to resolvew the equivalence class of the given type.
+  /// \param resolutionKind How to perform the resolution.
+  ///
+  /// \param wantExactPotentialArchetype Whether to return the precise
+  /// potential archetype described by the type (vs. just the equivalance
+  /// class and resolved type).
   ResolveResult maybeResolveEquivalenceClass(
                                       Type type,
-                                      ArchetypeResolutionKind resolutionKind);
+                                      ArchetypeResolutionKind resolutionKind,
+                                      bool wantExactPotentialArchetype);
 
   /// \brief Resolve the equivalence class for the given type parameter,
   /// which provides information about that type.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1684,6 +1684,11 @@ ArrayRef<AssociatedTypeDecl *> AssociatedTypeDecl::getOverriddenDecls() const {
     return known->second;
   }
 
+  // While we are computing overridden declarations, pretend there are none.
+  auto mutableThis = const_cast<AssociatedTypeDecl *>(this);
+  mutableThis->AssociatedTypeDeclBits.ComputedOverridden = true;
+  mutableThis->AssociatedTypeDeclBits.HasOverridden = false;
+
   // Find associated types with the given name in all of the inherited
   // protocols.
   SmallVector<AssociatedTypeDecl *, 4> inheritedAssociatedTypes;
@@ -1718,8 +1723,8 @@ ArrayRef<AssociatedTypeDecl *> AssociatedTypeDecl::getOverriddenDecls() const {
                        inheritedAssociatedTypes.end(),
                        compareSimilarAssociatedTypes);
 
-  return const_cast<AssociatedTypeDecl *>(this)
-    ->setOverriddenDecls(inheritedAssociatedTypes);
+  mutableThis->AssociatedTypeDeclBits.ComputedOverridden = false;
+  return mutableThis->setOverriddenDecls(inheritedAssociatedTypes);
 }
 
 ArrayRef<AssociatedTypeDecl *> AssociatedTypeDecl::setOverriddenDecls(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3000,6 +3000,8 @@ ProtocolDecl::getInheritedProtocols() const {
   // We shouldn't need this, but it shows up in recursive invocations.
   if (!isRequirementSignatureComputed()) {
     SmallPtrSet<ProtocolDecl *, 4> known;
+    if (auto resolver = getASTContext().getLazyResolver())
+      resolver->resolveInheritanceClause(const_cast<ProtocolDecl *>(this));
     for (auto inherited : getInherited()) {
       if (auto type = inherited.getType()) {
         // Only protocols can appear in the inheritance clause

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1002,8 +1002,8 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
   // Canonicalize the root type.
   auto source = getBestRequirementSource(conforms->second);
   auto subjectPA = source->getRootPotentialArchetype();
-  subjectPA = subjectPA->getArchetypeAnchor(*subjectPA->getBuilder());
-  Type rootType = subjectPA->getDependentType(getGenericParams());
+  Type rootType =
+    subjectPA->getOrCreateEquivalenceClass()->getAnchor(getGenericParams());
 
   // Build the path.
   buildPath(getRequirements(), source, protocol, rootType, nullptr);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6115,14 +6115,7 @@ void GenericSignatureBuilder::visitPotentialArchetypes(F f) {
     stack.pop_back();
     f(pa);
 
-    // Visit the archetype anchor.
-    if (auto anchor = pa->getArchetypeAnchor(*this)) {
-      if (visited.insert(anchor).second) {
-        stack.push_back(anchor);
-      }
-    }
-
-    // Visit everything else in this equivalence class.
+    // Visit everything in this equivalence class.
     for (auto equivPA : pa->getEquivalenceClassMembers()) {
       if (visited.insert(equivPA).second) {
         stack.push_back(equivPA);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2805,11 +2805,8 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
 
     // We know something concrete about the parent PA, so we need to propagate
     // that information to this new archetype.
-    // FIXME: This feels like massive overkill. Why do we have to loop?
     if (isConcreteType()) {
-      for (auto equivT : getRepresentative()->getEquivalenceClassMembers()) {
-        concretizeNestedTypeFromConcreteParent(equivT, resultPA, builder);
-      }
+      concretizeNestedTypeFromConcreteParent(this, resultPA, builder);
     }
   }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3154,18 +3154,13 @@ auto GenericSignatureBuilder::resolve(UnresolvedType paOrT,
     -> ResolveResult {
   auto pa = paOrT.dyn_cast<PotentialArchetype *>();
   if (auto type = paOrT.dyn_cast<Type>()) {
-    // Determine what kind of resolution we want.
-    ArchetypeResolutionKind resolutionKind =
-      ArchetypeResolutionKind::WellFormed;
-    if (!source.isExplicit() && source.isRecursive(type, *this))
-      resolutionKind = ArchetypeResolutionKind::AlreadyKnown;
-
     // If it's not a type parameter, it won't directly resolve to one.
     if (!type->isTypeParameter()) {
       // If there is a type parameter somewhere in this type, resolve it.
       if (type->hasTypeParameter()) {
         Type resolved =
-          resolveDependentMemberTypes(*this, type, resolutionKind);
+          resolveDependentMemberTypes(*this, type,
+                                      ArchetypeResolutionKind::WellFormed);
         if (resolved->hasError() && !type->hasError())
           return ResolveResult::forUnresolved(nullptr);
 
@@ -3174,6 +3169,12 @@ auto GenericSignatureBuilder::resolve(UnresolvedType paOrT,
 
       return ResolveResult(type, nullptr);
     }
+
+    // Determine what kind of resolution we want.
+    ArchetypeResolutionKind resolutionKind =
+      ArchetypeResolutionKind::WellFormed;
+    if (!source.isExplicit() && source.isRecursive(type, *this))
+      resolutionKind = ArchetypeResolutionKind::AlreadyKnown;
 
     return maybeResolveEquivalenceClass(type, resolutionKind,
                                         /*wantExactPotentialArchetype=*/true);

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -71,7 +71,7 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
   U.RuncerType.Runcee.accelerate()
 }
 
-// CHECK: define hidden swiftcc void @_T016associated_types16testFastRuncibleyx_q_1utAA0E0RzAA0dE0R_10RuncerTypeQy_AFRtzAF_6RunceeAA0F0PQZAF_AiA0dF0PRTzr0_lF(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T, %swift.type* %U, i8** %T.Runcible, i8** %U.FastRuncible) #0 {
+// CHECK: define hidden swiftcc void @_T016associated_types16testFastRuncibleyx_q_1utAA0E0RzAA0dE0R_10RuncerTypeQy_AFRtzr0_lF(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T, %swift.type* %U, i8** %T.Runcible, i8** %U.FastRuncible) #0 {
 //   1. Get the type metadata for U.RuncerType.Runcee.
 //     1a. Get the type metadata for U.RuncerType.
 //         Note that we actually look things up in T, which is going to prove unfortunate.

--- a/validation-test/compiler_crashers_fixed/28771-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28771-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A{typealias a{}typealias a=FlattenCollection}protocol b:A

--- a/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
+++ b/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a:RangeReplaceableCollection}protocol P{{}typealias e:a{{}}typealias e:Collection

--- a/validation-test/compiler_crashers_fixed/28857-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
+++ b/validation-test/compiler_crashers_fixed/28857-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A:RangeReplaceableCollection&a:class a:A


### PR DESCRIPTION
Start building in infrastructure that can delay the realization of potential archetypes so we can build fewer of them. There are a few steps here:

* Replace `resolvePotentialArchetype` with `maybeResolveEquivalenceClass`: unless specifically requested, the latter resolves to an (interface type, equivalence class) pair so we can ask questions about the capabilities of a resolved type without having to realize a potential archetype.
* Actual realization of a potential archetype is delayed until the point where we need it to record something. This still happens too often, but it's down at the leaves now.
* Eliminate a bunch of extra API on `PotentialArchetype`.