### PR TITLE
[Sema] Disallow override of dynamic Self return with non-dynamic.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1885,6 +1885,9 @@ ERROR(override_ownership_mismatch,none,
       "cannot override %select{strong|weak|unowned|unowned(unsafe)}0 property "
       "with %select{strong|weak|unowned|unowned(unsafe)}1 property",
       (/*Ownership*/unsigned, /*Ownership*/unsigned))
+ERROR(override_dynamic_self_mismatch,none,
+      "cannot override a Self return type with a non-Self return type",
+      ())
 ERROR(override_class_declaration_in_extension,none,
       "cannot override a non-dynamic class declaration from an extension",
       ())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6086,6 +6086,19 @@ public:
       }
     }
 
+    // If a super method returns Self, and the subclass overrides it to
+    // instead return the subclass type, complain.
+    // This case gets this far because the type matching above specifically
+    // strips out dynamic self via replaceCovariantResultType(), and that
+    // is helpful in several cases - just not this one.
+    if (decl->getASTContext().isSwiftVersionAtLeast(5) &&
+        matchDecl->getInterfaceType()->hasDynamicSelfType() &&
+        !decl->getInterfaceType()->hasDynamicSelfType() &&
+        !classDecl->isFinal()) {
+      TC.diagnose(decl, diag::override_dynamic_self_mismatch);
+      TC.diagnose(matchDecl, diag::overridden_here);
+    }
+
     // Check that the override has the required access level.
     // Overrides have to be at least as accessible as what they
     // override, except:

--- a/test/Compatibility/self.swift
+++ b/test/Compatibility/self.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// SR-695
+// in version 4 and earlier all of these should build with no diagnostic
+class Mario {
+    func getFriend() -> Self { return self }
+    func getEnemy() -> Mario { return self }
+}
+class SuperMario : Mario {
+    override func getFriend() -> SuperMario {
+        return SuperMario()
+    }
+    override func getEnemy() -> Self { return self }
+}
+final class FinalMario : Mario {
+    override func getFriend() -> FinalMario {
+        return FinalMario()
+    }
+}

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 struct S0<T> {
   func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'S0'?}}{{21-25=S0}}
@@ -25,3 +25,21 @@ extension X {
 extension X.Inner {
   func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'X.Inner'?}}{{21-25=X.Inner}}
 }
+
+// SR-695
+class Mario {
+  func getFriend() -> Self { return self } // expected-note{{overridden declaration is here}}
+  func getEnemy() -> Mario { return self }
+}
+class SuperMario : Mario {
+  override func getFriend() -> SuperMario { // expected-error{{cannot override a Self return type with a non-Self return type}}
+    return SuperMario()
+  }
+  override func getEnemy() -> Self { return self }
+}
+final class FinalMario : Mario {
+    override func getFriend() -> FinalMario {
+        return FinalMario()
+    }
+}
+


### PR DESCRIPTION
... Unless the subclass where the override occurs is final. Because this change causes previously working code to fail to compile, this new diagnostic is only enabled in swift 5 mode.

(There are examples of this pattern in the existing tests, e.g. test/stdlib/TestMeasurement.swift baseUnit(), which continues to build without problems thus serving as tests for the "only swift 5 mode" portion of this change.)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-695](https://bugs.swift.org/browse/SR-695).