### PR TITLE
[build-script-impl] Remove destdir from cmake install path for libdis…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2545,7 +2545,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
                     -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
                     -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
-                    -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
+                    -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                    -DCMAKE_INSTALL_LIBDIR:PATH="lib"
 
                     -DENABLE_SWIFT=YES
                     -DSWIFT_RUNTIME_LIBDIR:PATH="${SWIFT_BUILD_PATH}/lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"


### PR DESCRIPTION
…patch

This is passed as an env variable so it is not needed in the prefix.

https://bugs.swift.org/browse/SR-6084
<rdar://problem/35040697> [SR-6084]: libdispatch missing from Trunk Development snapshots