### PR TITLE
[WIP] Accommodate exceptional values for array comparison

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2190,9 +2190,13 @@ public func == <Element : Equatable>(
   if lhsCount != rhs.count {
     return false
   }
+  if lhsCount == 0 {
+    return true
+  }
 
   // Test referential equality.
-  if lhsCount == 0 || lhs._buffer.identity == rhs._buffer.identity {
+  if lhs._buffer.identity == rhs._buffer.identity
+    && !Element._containsExceptionalValues {
     return true
   }
 

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -163,6 +163,15 @@ public protocol Equatable {
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
   static func == (lhs: Self, rhs: Self) -> Bool
+
+  /// A Boolean value indicating whether the type contains a subset of values
+  /// which are treated as exceptional.
+  ///
+  /// A value is exceptional if it is outside the domain of meaningful
+  /// arguments for the purposes of the `Equatable` protocol. For example, the
+  /// special "not a number" value for floating-point types
+  /// (`FloatingPoint.nan`) compares not equal to itself.
+  static var _containsExceptionalValues: Bool { get }
 }
 
 extension Equatable {
@@ -181,6 +190,12 @@ extension Equatable {
   @_transparent
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static var _containsExceptionalValues: Bool {
+    return false
   }
 }
 

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1425,6 +1425,12 @@ extension FloatingPoint {
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return rhs.isLessThanOrEqualTo(lhs)
   }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static var _containsExceptionalValues: Bool {
+    return true
+  }
 }
 
 /// A radix-2 (binary) floating-point type.


### PR DESCRIPTION
<!-- What's in this pull request? -->
`Array.==` tests for referential equality and returns `true` if the underlying buffer is shared between two instances. This provides for unexpected behavior in the case of comparisons involving floating-point NaN. Since `Double.nan != Double.nan`, the result of a comparison of arrays that contain NaN would depend on whether the underlying buffer is shared.

```swift
var a: [Double] = [1, .nan]
var b: [Double] = [1, .nan]

var copy = a

a == b // false
a == copy // true
```

Whether `Equatable` ought to accommodate IEEE-mandated behavior of floating-point NaN is potentially a design topic to be revisited, but the inconsistent behavior here requires a fix in order to permit predictable behavior in the face of the current, deliberate implementation of `FloatingPoint.==`.

In documentation for `Comparable`, a note states:

> A conforming type may contain a subset of values which are treated as exceptional—that is, values that are outside the domain of meaningful arguments for the purposes of the `Comparable` protocol. For example, the special “not a number” value for floating-point types (`FloatingPoint.nan`) compares as neither less than, greater than, nor equal to any normal floating-point value. Exceptional values need not take part in the strict total order.

This PR incorporates this particular exception into an underscored static protocol requirement of `Equatable` named `_containsExceptionalValues`. A default implementation returns `false` and floating-point types return `true`. `Array.==` then consults this static requirement prior to relying on referential equality.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6181](https://bugs.swift.org/browse/SR-6181).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->