### PR TITLE
Fix LoadableByAddress to handle convert_functions.

### DIFF
--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -259,6 +259,26 @@ bb0:
   return %99 : $()
 }
 
+sil @convertToThickHelper : $@convention(thin) (@owned BigStruct) -> ()
+
+// CHECK-LABAL: define {{.*}} swiftcc void @convertToThick(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}})) #0 {
+// CHECK: entry:
+// CHECK:   [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV, align 4
+// CHECK:   call void @llvm.memcpy.p0i8.p0i8.i64
+// CHECK:   call swiftcc void bitcast (void (%T22big_types_corner_cases9BigStructV*)* @convertToThickHelper to void (%T22big_types_corner_cases9BigStructV*, %swift.refcounted*)*)(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) [[ALLOC]], %swift.refcounted* swiftself null)
+// CHECK:   ret void
+// CHECK-LABEL: }
+sil @convertToThick : $@convention(thin) (@in BigStruct) -> () {
+bb0(%0 : $*BigStruct):
+  %3 = function_ref @convertToThickHelper : $@convention(thin) (@owned BigStruct) -> ()
+  %4 = convert_function %3 : $@convention(thin) (@owned BigStruct) -> () to $@convention(thin) @noescape (@owned BigStruct) -> ()
+  %5 = thin_to_thick_function %4 : $@convention(thin) @noescape (@owned BigStruct) -> () to $@noescape @callee_owned (@owned BigStruct) -> ()
+  %8 = load %0 : $*BigStruct
+  %10 = apply %5(%8) : $@noescape @callee_owned (@owned BigStruct) -> ()
+  %12 = tuple ()
+  return %12 : $()
+}
+
 sil_vtable SuperBase {
 }
 


### PR DESCRIPTION
Handle function_ref -> convert_function -> thin_to_thick.

Fixes <rdar://problem/35059942> Failed - Lark, 3.0, Swift Package - Source Compatibility Suite (master)