### PR TITLE
[SR-2660][Driver] Handle .swiftmodule inputs

### DIFF
--- a/test/Driver/actions.swift
+++ b/test/Driver/actions.swift
@@ -118,6 +118,16 @@
 // DEBUG-LINK-ONLY: 5: link, {0, 1, 4}, image
 // DEBUG-LINK-ONLY: 6: generate-dSYM, {5}, dSYM
 
+// RUN: touch %t/c.swift
+// RUN: %swiftc_driver -driver-print-actions %t/c.swift %t/a.o %t/b.o %t/a.swiftmodule %t/b.swiftmodule -o main 2>&1 | %FileCheck %s -check-prefix=LINK-SWIFTMODULES
+// LINK-SWIFTMODULES: 0: input, "{{.*}}/c.swift", swift
+// LINK-SWIFTMODULES: 1: compile, {0}, object
+// LINK-SWIFTMODULES: 2: input, "{{.*}}/a.o", object
+// LINK-SWIFTMODULES: 3: input, "{{.*}}/b.o", object
+// LINK-SWIFTMODULES: 4: input, "{{.*}}/a.swiftmodule", swiftmodule
+// LINK-SWIFTMODULES: 5: input, "{{.*}}/b.swiftmodule", swiftmodule
+// LINK-SWIFTMODULES: 6: link, {1, 2, 3, 4, 5}, image
+
 // RUN: touch %t/a.o %t/b.o
 // RUN: %swiftc_driver -driver-print-actions %t/a.o %s -o main 2>&1 | %FileCheck %s -check-prefix=COMPILE-PLUS-OBJECT
 // COMPILE-PLUS-OBJECT: 0: input, "{{.*}}/a.o", object

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -42,6 +42,12 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | %FileCheck -check-prefix DEBUG %s
 
+// RUN: touch %t/a.o
+// RUN: touch %t/a.swiftmodule
+// RUN: touch %t/b.o
+// RUN: touch %t/b.swiftmodule
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o %t/a.swiftmodule %t/b.o %t/b.swiftmodule -o linker | %FileCheck -check-prefix LINK-SWIFTMODULES %s
+
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10   %s > %t.simple-macosx10.10.txt
 // RUN: %FileCheck %s < %t.simple-macosx10.10.txt
 // RUN: %FileCheck -check-prefix SIMPLE %s < %t.simple-macosx10.10.txt
@@ -265,6 +271,11 @@
 // DEBUG: linker
 // DEBUG: -o linker.dSYM
 
+// LINK-SWIFTMODULES: bin/swift
+// LINK-SWIFTMODULES-NEXT: bin/ld{{"? }}
+// LINK-SWIFTMODULES-SAME: -add_ast_path {{.*}}/a.swiftmodule
+// LINK-SWIFTMODULES-SAME: -add_ast_path {{.*}}/b.swiftmodule
+// LINK-SWIFTMODULES-SAME: -o linker
 
 // COMPILE_AND_LINK: bin/swift
 // COMPILE_AND_LINK-NOT: /a.o

--- a/test/Driver/unknown-inputs.swift
+++ b/test/Driver/unknown-inputs.swift
@@ -11,7 +11,7 @@
 // COMPILE: 1: compile, {0}, object
 
 // RUN: %swiftc_driver -driver-print-actions %t/empty 2>&1 | %FileCheck -check-prefix=LINK-%target-object-format %s
-// RUN: not %swiftc_driver -driver-print-actions %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=ERROR %s
+// RUN: %swiftc_driver -driver-print-actions %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=LINK-SWIFTMODULES %s
 // RUN: %swiftc_driver -driver-print-actions %t/empty.o 2>&1 | %FileCheck -check-prefix=LINK-%target-object-format %s
 // RUN: not %swiftc_driver -driver-print-actions %t/empty.h 2>&1 | %FileCheck -check-prefix=ERROR %s
 // RUN: %swiftc_driver -driver-print-actions %t/empty.swift 2>&1 | %FileCheck -check-prefix=COMPILE %s
@@ -22,6 +22,9 @@
 // LINK-elf: 0: input
 // LINK-elf: 1: swift-autolink-extract, {0}, autolink
 // LINK-elf: 2: link, {0, 1}, image
+
+// LINK-SWIFTMODULES: 0: input, "{{.*}}.swiftmodule", swiftmodule
+// LINK-SWIFTMODULES: 1: link, {0}, image
 
 // RUN: not %swiftc_driver -driver-print-actions -emit-module %t/empty 2>&1 | %FileCheck -check-prefix=ERROR %s
 // RUN: %swiftc_driver -driver-print-actions -emit-module %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=MODULE %s


### PR DESCRIPTION
Allow users to pass `.swiftmodule` files into the Swift driver when compiling without `-g`. The `.swiftmodule` files are then passed to the linker via `-add_ast_path` so that LLDB can access their AST information.

This addresses one of two driver changes suggested in the comments of https://bugs.swift.org/browse/SR-2660. The second is to detangle the `-g` option with the driver logic that determines whether to run a merge module job or not.

In addition to the unit tests, to make sure the debug info was being read properly by lldb, I also ran `bash build-driver.sh` on an updated version of the sample project attached to the original bug report, which I've uploaded here: https://github.com/modocache/SR-2660. I tested that on macOS.