### PR TITLE
fix a typo

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -201,7 +201,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///
 %if Mutable:
   /// The following example uses the buffer pointer's subscript to access and
-  /// modifying the elements of a mutable buffer pointing to the contiguous
+  /// modify the elements of a mutable buffer pointing to the contiguous
   /// contents of an array:
   ///
   ///     var numbers = [1, 2, 3, 4, 5]


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a typo in UnsafeMutableBufferPointer's subscript doc-comment.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
