### PR TITLE
Ensure that hashing data with zero bytes avoids empty allocations and fix bridged empty data hashes from de-referencing null values

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1627,9 +1627,11 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public var hashValue: Int {
         var hashValue = 0
         let hashRange: Range<Int> = _sliceRange.lowerBound..<Swift.min(_sliceRange.lowerBound + 80, _sliceRange.upperBound)
-        _withStackOrHeapBuffer(hashRange.count) { buffer in
-            _backing.withUnsafeBytes(in: hashRange) {
-                memcpy(buffer.pointee.memory, $0.baseAddress!, hashRange.count)
+        _withStackOrHeapBuffer(hashRange.count + 1) { buffer in
+            if hashRange.count > 0 {
+                _backing.withUnsafeBytes(in: hashRange) {
+                    memcpy(buffer.pointee.memory, $0.baseAddress!, hashRange.count)
+                }
             }
             hashValue = Int(bitPattern: CFHashBytes(buffer.pointee.memory.assumingMemoryBound(to: UInt8.self), hashRange.count))
         }

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -3656,6 +3656,20 @@ class TestData : TestDataSuper {
         expectEqual(Data(bytes: [0, 1, 2, 3, 4]), regionData[1]) //passes
         expectEqual(Data(bytes: [0]), regionData[2]) //fails
     }
+
+    func test_hashEmptyData() {
+        let d1 = Data()
+        let h1 = d1.hashValue
+
+        let d2 = NSData() as Data
+        let h2 = d2.hashValue
+        expectEqual(h1, h2)
+
+        let data = Data(bytes: [0, 1, 2, 3, 4, 5, 6])
+        let d3 = data[4..<4]
+        let h3 = d3.hashValue
+        expectEqual(h1, h3)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -3966,6 +3980,7 @@ DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubr
 DataTests.test("test_sliceHash") { TestData().test_sliceHash() }
 DataTests.test("test_slice_resize_growth") { TestData().test_slice_resize_growth() }
 DataTests.test("test_sliceEnumeration") { TestData().test_sliceEnumeration() }
+DataTests.test("test_hashEmptyData") { TestData().test_hashEmptyData() }
 
 
 // XCTest does not have a crash detection, whereas lit does


### PR DESCRIPTION
Explanation:
With the slice range fixes for data it changed the copy-out mechanism for hashing bridged data references; this caused a regression due to the fact the buffer was potentially allocated with zero bytes as well as the memcpy would be passed a null pointer from NSData for the bytes when the length was zero. This accounts for both problems and adds tests for empty Data (which worked before), empty bridged Data, and empty sliced Data (which also worked previously).

Scope:
This only applies to the hashing of empty Data objects

Radar (and possibly SR Issue):
rdar://problem/32359974

Risk:
Overall the code risk here is low since it restricts to the empty cases and allocates one byte extra of space (to avoid zero allocations).

Testing:
Additional unit tests were added to validate the correctness of this patch.