### PR TITLE
[Sema] Improve subscript diagnostics in assignment destinations

### DIFF
--- a/test/Sema/diag_get_vs_set_subscripts.swift
+++ b/test/Sema/diag_get_vs_set_subscripts.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Key: Int {
+  case aKey
+  case anotherKey // expected-note {{did you mean 'anotherKey'?}}
+}
+ 
+class sr6175 {
+  var dict: [Key: String] = [:]
+  func what() -> Void {
+    dict[.notAKey] = "something" // expected-error {{type 'Key' has no member 'notAKey'}}
+  }
+  
+  subscript(i: Int) -> Int {
+    return i*i
+  }
+  subscript(j: Double) -> Double {
+    get { return j*j }
+    set {}
+  }
+}
+
+let s = sr6175()
+let one: Int = 1
+// Should choose the settable subscript to find a problem with, not the get-only subscript
+s[one] = 2.5 // expected-error {{cannot convert value of type 'Int' to expected argument type 'Double'}}


### PR DESCRIPTION
We can produce better diagnostics for subscript candidates by noticing when the subscript is on the destination side of an assignment and restricting matching overload candidates to only the set-able members.

Resolves [SR-6175](https://bugs.swift.org/browse/SR-6175).