### PR TITLE
[Driver] Fix linker test by preparing empty dir

### DIFF
--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -42,6 +42,7 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | %FileCheck -check-prefix DEBUG %s
 
+// RUN: %empty-directory(%t)
 // RUN: touch %t/a.o
 // RUN: touch %t/a.swiftmodule
 // RUN: touch %t/b.o


### PR DESCRIPTION
This fixes an intermittent failure introduced by https://github.com/apple/swift/pull/12507.