### PR TITLE
[SILVerifier] Add a flag to not abort upon verification failure.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -50,6 +50,12 @@ static llvm::cl::opt<bool> SkipUnreachableMustBeLastErrors(
                               "verify-skip-unreachable-must-be-last",
                               llvm::cl::init(false));
 
+// This flag controls the default behaviour when hitting a verification
+// failure (abort/exit).
+static llvm::cl::opt<bool> AbortOnFailure(
+                              "verify-abort-on-failure",
+                              llvm::cl::init(true));
+
 // The verifier is basically all assertions, so don't compile it with NDEBUG to
 // prevent release builds from triggering spurious unused variable warnings.
 
@@ -139,7 +145,12 @@ public:
       F.print(llvm::dbgs());
     }
 
-    abort();
+    // We abort by default because we want to always crash in
+    // the debugger.
+    if (AbortOnFailure)
+      abort();
+    else
+      exit(1);
   }
 #define require(condition, complaint) \
   _require(bool(condition), complaint ": " #condition)


### PR DESCRIPTION
Exit somewhat carefully instead. This matches what LLVM does,
and makes testing/fuzzing easier. It's also slightly more friendly
in case the user violates an assumption.

I'd prefer to have the compiler never aborting on user input (in particular, something text based), but this seems an OK middle-ground. I'll be happy to change the default altogether if people like it.