### PR TITLE
[stdlib] changes to remove `_Strideable` protocol.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7874,7 +7874,7 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   cs.cacheExprTypes(call);
 
   // If the system failed to produce a solution, post any available diagnostics.
-  if (cs.solve(solutions) || solutions.size() != 1) {
+  if (cs.solve(call, solutions) || solutions.size() != 1) {
     cs.salvage(solutions, base);
     return nullptr;
   }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -8410,7 +8410,7 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
 
   {
     // Set up solver state.
-    SolverState state(*this);
+    SolverState state(expr, *this);
     state.recordFixes = true;
 
     // Solve the system.
@@ -8418,7 +8418,8 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
 
     // Check whether we have a best solution; this can happen if we found
     // a series of fixes that worked.
-    if (auto best = findBestSolution(viable, /*minimize=*/true)) {
+    if (auto best = findBestSolution(viable, state.ExprWeights,
+                                     /*minimize=*/true)) {
       if (*best != 0)
         viable[0] = std::move(viable[*best]);
       viable.erase(viable.begin() + 1, viable.end());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3431,7 +3431,7 @@ bool swift::typeCheckUnresolvedExpr(DeclContext &DC,
   }
 
   SmallVector<Solution, 3> solutions;
-  if (CS.solve(solutions, FreeTypeVariableBinding::Allow)) {
+  if (CS.solve(Parent, solutions, FreeTypeVariableBinding::Allow)) {
     return false;
   }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -691,12 +691,10 @@ Comparison TypeChecker::compareDeclarations(DeclContext *dc,
   return decl1Better? Comparison::Better : Comparison::Worse;
 }
 
-SolutionCompareResult
-ConstraintSystem::compareSolutions(ConstraintSystem &cs,
-                                   ArrayRef<Solution> solutions,
-                                   const SolutionDiff &diff,
-                                   unsigned idx1, unsigned idx2) {
-
+SolutionCompareResult ConstraintSystem::compareSolutions(
+    ConstraintSystem &cs, ArrayRef<Solution> solutions,
+    const SolutionDiff &diff, unsigned idx1, unsigned idx2,
+    llvm::DenseMap<Expr *, unsigned> &weights) {
   if (cs.TC.getLangOpts().DebugConstraintSolver) {
     auto &log = cs.getASTContext().TypeCheckerDebug->getStream();
     log.indent(cs.solverState->depth * 2)
@@ -723,8 +721,20 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
   bool isStdlibOptionalMPlusOperator1 = false;
   bool isStdlibOptionalMPlusOperator2 = false;
 
+  auto getWeight = [&](ConstraintLocator *locator) -> unsigned {
+    if (auto *anchor = locator->getAnchor()) {
+      auto weight = weights.find(anchor);
+      if (weight != weights.end())
+        return weight->getSecond() + 1;
+    }
+
+    return 1;
+  };
+
   // Compare overload sets.
   for (auto &overload : diff.overloads) {
+    unsigned weight = getWeight(overload.locator);
+
     auto choice1 = overload.choices[idx1];
     auto choice2 = overload.choices[idx2];
 
@@ -772,7 +782,7 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
           (choice2.getKind() == OverloadChoiceKind::DeclViaDynamic || 
            choice2.getKind() == OverloadChoiceKind::DeclViaBridge ||
            choice2.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional)) {
-        ++score1;
+        score1 += weight;
         continue;
       }
 
@@ -780,7 +790,7 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
            choice1.getKind() == OverloadChoiceKind::DeclViaBridge ||
            choice1.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional) &&
           choice2.getKind() == OverloadChoiceKind::Decl) {
-        ++score2;
+        score2 += weight;
         continue;
       }
 
@@ -808,11 +818,11 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
     bool firstAsSpecializedAs = false;
     bool secondAsSpecializedAs = false;
     if (isDeclAsSpecializedAs(tc, cs.DC, decl1, decl2)) {
-      ++score1;
+      score1 += weight;
       firstAsSpecializedAs = true;
     }
     if (isDeclAsSpecializedAs(tc, cs.DC, decl2, decl1)) {
-      ++score2;
+      score2 += weight;
       secondAsSpecializedAs = true;
     }
 
@@ -823,9 +833,9 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
         if (auto ctor2 = dyn_cast<ConstructorDecl>(decl2)) {
           if (ctor1->getInitKind() != ctor2->getInitKind()) {
             if (ctor1->getInitKind() < ctor2->getInitKind())
-              ++score1;
+              score1 += weight;
             else
-              ++score2;
+              score2 += weight;
           } else if (ctor1->getInitKind() ==
                      CtorInitializerKind::Convenience) {
             
@@ -838,9 +848,9 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
             
             if (!resType1->isEqual(resType2)) {
               if (tc.isSubtypeOf(resType1, resType2, cs.DC)) {
-                ++score1;
+                score1 += weight;
               } else if (tc.isSubtypeOf(resType2, resType1, cs.DC)) {
-                ++score2;
+                score2 += weight;
               }
             }
           }
@@ -857,22 +867,22 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
          (isa<AbstractFunctionDecl>(decl1) &&
           isa<TypeDecl>(decl2)))) {
       if (isa<TypeDecl>(decl1))
-        ++score2;
+        score2 += weight;
       else
-        ++score1;
+        score1 += weight;
     }
 
     // A class member is always better than a curried instance member.
     // If the members agree on instance-ness, a property is better than a
     // method (because a method is usually immediately invoked).
     if (!decl1->isInstanceMember() && decl2->isInstanceMember())
-      ++score1;
+      score1 += weight;
     else if (!decl2->isInstanceMember() && decl1->isInstanceMember())
-      ++score2;
+      score2 += weight;
     else if (isa<VarDecl>(decl1) && isa<FuncDecl>(decl2))
-      ++score1;
+      score1 += weight;
     else if (isa<VarDecl>(decl2) && isa<FuncDecl>(decl1))
-      ++score2;
+      score2 += weight;
 
     // If both are class properties with the same name, prefer
     // the one attached to the subclass because it could only be
@@ -887,10 +897,10 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
           auto base2 = nominal2->getDeclaredType();
 
           if (isNominallySuperclassOf(base1, base2))
-            ++score2;
+            score2 += weight;
 
           if (isNominallySuperclassOf(base2, base1))
-            ++score1;
+            score1 += weight;
         }
       }
     }
@@ -1105,6 +1115,7 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
 
 Optional<unsigned>
 ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
+                                   llvm::DenseMap<Expr *, unsigned> &weights,
                                    bool minimize) {
   if (viable.empty())
     return None;
@@ -1115,6 +1126,11 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log.indent(solverState->depth * 2)
         << "Comparing " << viable.size() << " viable solutions\n";
+
+    for (unsigned i = 0, n = viable.size(); i != n; ++i) {
+      log.indent(solverState->depth * 2) << "--- Solution #" << i << " ---\n";
+      viable[i].dump(log.indent(solverState->depth * 2));
+    }
   }
 
   SolutionDiff diff(viable);
@@ -1123,7 +1139,7 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
   SmallVector<bool, 16> losers(viable.size(), false);
   unsigned bestIdx = 0;
   for (unsigned i = 1, n = viable.size(); i != n; ++i) {
-    switch (compareSolutions(*this, viable, diff, i, bestIdx)) {
+    switch (compareSolutions(*this, viable, diff, i, bestIdx, weights)) {
     case SolutionCompareResult::Identical:
       // FIXME: Might want to warn about this in debug builds, so we can
       // find a way to eliminate the redundancy in the search space.
@@ -1147,7 +1163,7 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
     if (i == bestIdx)
       continue;
 
-    switch (compareSolutions(*this, viable, diff, bestIdx, i)) {
+    switch (compareSolutions(*this, viable, diff, bestIdx, i, weights)) {
     case SolutionCompareResult::Identical:
       // FIXME: Might want to warn about this in debug builds, so we can
       // find a way to eliminate the redundancy in the search space.
@@ -1191,7 +1207,7 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
       if (losers[j])
         continue;
 
-      switch (compareSolutions(*this, viable, diff, i, j)) {
+      switch (compareSolutions(*this, viable, diff, i, j, weights)) {
       case SolutionCompareResult::Identical:
         // FIXME: Dub one of these the loser arbitrarily?
         break;
@@ -1313,20 +1329,16 @@ SolutionDiff::SolutionDiff(ArrayRef<Solution> solutions) {
     }
   }
 
-  // Look through the overload locators that have overload choices in all of
-  // the solutions, and add those that have differences to the diff.
   for (auto &overloadChoice : overloadChoices) {
     OverloadChoice singleChoice = overloadChoice.second[0];
     for (auto choice : overloadChoice.second) {
-      if (!sameOverloadChoice(singleChoice, choice)) {
-        // We have a difference. Add this set of overload choices to the diff.
-        this->overloads.push_back(
-          SolutionDiff::OverloadDiff{
-            overloadChoice.first,
-            overloadChoice.second
-          });
-        
-      }
+      if (sameOverloadChoice(singleChoice, choice))
+        continue;
+
+      // We have a difference. Add this set of overload choices to the diff.
+      this->overloads.push_back(SolutionDiff::OverloadDiff{
+          overloadChoice.first, std::move(overloadChoice.second)});
+      break;
     }
   }
 }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2016,7 +2016,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
-  if (CS.solve(viable, FreeTypeVariableBinding::UnresolvedType))
+  if (CS.solve(expr, viable, FreeTypeVariableBinding::UnresolvedType))
     return true;
 
   auto &solution = viable[0];
@@ -2060,7 +2060,7 @@ bool TypeChecker::typeCheckExpressionShallow(Expr *&expr, DeclContext *dc) {
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
-  if ((cs.solve(viable) || viable.size() != 1) &&
+  if ((cs.solve(expr, viable) || viable.size() != 1) &&
       cs.salvage(viable, expr)) {
     return true;
   }
@@ -2762,7 +2762,7 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
   if (openArchetypes) {
     assert(!unwrappedIUO && "FIXME");
     SmallVector<Solution, 4> solutions;
-    return !cs.solve(solutions, FreeTypeVariableBinding::Allow);
+    return !cs.solve(nullptr, solutions, FreeTypeVariableBinding::Allow);
   }
 
   if (auto solution = cs.solveSingle()) {
@@ -2943,7 +2943,7 @@ bool TypeChecker::convertToType(Expr *&expr, Type type, DeclContext *dc,
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
-  if ((cs.solve(viable) || viable.size() != 1) &&
+  if ((cs.solve(expr, viable) || viable.size() != 1) &&
       cs.salvage(viable, expr)) {
     return true;
   }
@@ -2999,10 +2999,15 @@ void Solution::dump(raw_ostream &out) const {
 
   out << "Type variables:\n";
   for (auto binding : typeBindings) {
+    auto &typeVar = binding.first->getImpl();
     out.indent(2);
-    binding.first->getImpl().print(out);
+    typeVar.print(out);
     out << " as ";
     binding.second.print(out);
+    if (auto *locator = typeVar.getLocator()) {
+      out << " @ ";
+      locator->dump(&ctx.SourceMgr, out);
+    }
     out << "\n";
   }
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -323,7 +323,7 @@ public func expectGE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
 extension Range
 %   if 'Countable' in OtherRange:
   where
-  Bound : _Strideable, Bound.Stride : SignedInteger
+  Bound : Strideable, Bound.Stride : SignedInteger
 %   end
 {
   internal func _contains(_ other: ${OtherRange}<Bound>) -> Bool {

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -16,9 +16,7 @@
 @_versioned
 internal enum _ClosedRangeIndexRepresentation<Bound>
   where
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be Bound : Strideable
-  Bound : _Strideable & Comparable {
+  Bound : Strideable, Bound.Stride : BinaryInteger {
   case pastEnd
   case inRange(Bound)
 }
@@ -29,13 +27,10 @@ internal enum _ClosedRangeIndexRepresentation<Bound>
 @_fixed_layout
 public struct ClosedRangeIndex<Bound>
   where
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be Bound : Strideable
   // swift-3-indexing-model: should conform to _Strideable, otherwise
   // CountableClosedRange is not interchangeable with CountableRange in all
   // contexts.
-  Bound : _Strideable & Comparable,
-  Bound.Stride : SignedNumeric {
+  Bound : Strideable, Bound.Stride : SignedInteger {
   /// Creates the "past the end" position.
   @_inlineable
   @_versioned
@@ -96,10 +91,7 @@ extension ClosedRangeIndex : Comparable {
 @_fixed_layout
 public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
   where
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
-  Bound.Stride : SignedInteger {
+  Bound : Strideable, Bound.Stride : SignedInteger {
 
   @_inlineable
   @_versioned
@@ -176,10 +168,7 @@ public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
 @_fixed_layout
 public struct CountableClosedRange<Bound> : RandomAccessCollection
   where
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
-  Bound.Stride : SignedInteger {
+  Bound : Strideable, Bound.Stride : SignedInteger {
 
   /// The range's lower bound.
   public let lowerBound: Bound
@@ -420,57 +409,61 @@ public struct ClosedRange<
   }
 }
 
-/// Returns a closed range that contains both of its bounds.
-///
-/// Use the closed range operator (`...`) to create a closed range of any type
-/// that conforms to the `Comparable` protocol. This example creates a
-/// `ClosedRange<Character>` from "a" up to, and including, "z".
-///
-///     let lowercase = "a"..."z"
-///     print(lowercase.contains("z"))
-///     // Prints "true"
-///
-/// - Parameters:
-///   - minimum: The lower bound for the range.
-///   - maximum: The upper bound for the range.
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public func ... <Bound>(minimum: Bound, maximum: Bound)
-  -> ClosedRange<Bound> {
-  _precondition(
-    minimum <= maximum, "Can't form Range with upperBound < lowerBound")
-  return ClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
+extension Comparable {  
+  /// Returns a closed range that contains both of its bounds.
+  ///
+  /// Use the closed range operator (`...`) to create a closed range of any type
+  /// that conforms to the `Comparable` protocol. This example creates a
+  /// `ClosedRange<Character>` from "a" up to, and including, "z".
+  ///
+  ///     let lowercase = "a"..."z"
+  ///     print(lowercase.contains("z"))
+  ///     // Prints "true"
+  ///
+  /// - Parameters:
+  ///   - minimum: The lower bound for the range.
+  ///   - maximum: The upper bound for the range.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func ... (minimum: Self, maximum: Self)
+    -> ClosedRange<Self> {
+    _precondition(
+      minimum <= maximum, "Can't form Range with upperBound < lowerBound")
+    return ClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
+  }
 }
 
-/// Returns a countable closed range that contains both of its bounds.
-///
-/// Use the closed range operator (`...`) to create a closed range of any type
-/// that conforms to the `Strideable` protocol with an associated signed
-/// integer `Stride` type, such as any of the standard library's integer
-/// types. This example creates a `CountableClosedRange<Int>` from zero up to,
-/// and including, nine.
-///
-///     let singleDigits = 0...9
-///     print(singleDigits.contains(9))
-///     // Prints "true"
-///
-/// You can use sequence or collection methods on the `singleDigits` range.
-///
-///     print(singleDigits.count)
-///     // Prints "10"
-///     print(singleDigits.last)
-///     // Prints "9"
-///
-/// - Parameters:
-///   - minimum: The lower bound for the range.
-///   - maximum: The upper bound for the range.
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public func ... <Bound>(
-  minimum: Bound, maximum: Bound
-) -> CountableClosedRange<Bound> {
-  // FIXME: swift-3-indexing-model: tests for traps.
-  _precondition(
-    minimum <= maximum, "Can't form Range with upperBound < lowerBound")
-  return CountableClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
+extension Strideable where Stride: SignedInteger {  
+  /// Returns a countable closed range that contains both of its bounds.
+  ///
+  /// Use the closed range operator (`...`) to create a closed range of any type
+  /// that conforms to the `Strideable` protocol with an associated signed
+  /// integer `Stride` type, such as any of the standard library's integer
+  /// types. This example creates a `CountableClosedRange<Int>` from zero up to,
+  /// and including, nine.
+  ///
+  ///     let singleDigits = 0...9
+  ///     print(singleDigits.contains(9))
+  ///     // Prints "true"
+  ///
+  /// You can use sequence or collection methods on the `singleDigits` range.
+  ///
+  ///     print(singleDigits.count)
+  ///     // Prints "10"
+  ///     print(singleDigits.last)
+  ///     // Prints "9"
+  ///
+  /// - Parameters:
+  ///   - minimum: The lower bound for the range.
+  ///   - maximum: The upper bound for the range.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func ... (
+    minimum: Self, maximum: Self
+  ) -> CountableClosedRange<Self> {
+    // FIXME: swift-3-indexing-model: tests for traps.
+    _precondition(
+      minimum <= maximum, "Can't form Range with upperBound < lowerBound")
+    return CountableClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
+  }
 }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -336,6 +336,21 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
   public var isEmpty: Bool {
     return false
   }
+
+  /// Returns a Boolean value indicating whether the given element is contained
+  /// within the range.
+  ///
+  /// A `CountableClosedRange` instance contains both its lower and upper bound.
+  /// `element` is contained in the range if it is between the two bounds or
+  /// equal to either bound.
+  ///
+  /// - Parameter element: The element to check for containment.
+  /// - Returns: `true` if `element` is contained in the range; otherwise,
+  ///   `false`.
+  @_inlineable
+  public func contains(_ element: Bound) -> Bool {
+    return element >= self.lowerBound && element <= self.upperBound
+  }
 }
 
 /// An interval over a comparable type, from a lower bound up to, and

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -275,6 +275,22 @@ extension LazyCollectionProtocol
 
 % end
 
+extension LazyMapCollection {
+  // This overload is needed to re-enable Swift 3 source compatibility related
+  // to a bugfix in ranking behavior of the constraint solver.
+  @available(swift, obsoleted: 4.0)
+  public static func + <
+    Other : LazyCollectionProtocol
+  >(lhs: LazyMapCollection, rhs: Other) -> [Element]
+  where Other.Element == Element, Other.IndexDistance == IndexDistance {
+    var result: [Element] = []
+    result.reserveCapacity(numericCast(lhs.count + rhs.count))
+    result.append(contentsOf: lhs)
+    result.append(contentsOf: rhs)
+    return result
+  }
+}
+
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -270,6 +270,22 @@ public struct CountableRange<Bound> : RandomAccessCollection
   public var isEmpty: Bool {
     return lowerBound == upperBound
   }
+
+  /// Returns a Boolean value indicating whether the given element is contained
+  /// within the range.
+  ///
+  /// Because `CountableRange` represents a half-open range, a `CountableRange`
+  /// instance does not contain its upper bound. `element` is contained in the
+  /// range if it is greater than or equal to the lower bound and less than
+  /// the upper bound.
+  ///
+  /// - Parameter element: The element to check for containment.
+  /// - Returns: `true` if `element` is contained in the range; otherwise,
+  ///   `false`.
+  @_inlineable
+  public func contains(_ element: Bound) -> Bool {
+    return lowerBound <= element && element < upperBound
+  }
 }
 
 //===--- Protection against 0-based indexing assumption -------------------===//

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -149,10 +149,7 @@ public enum _DisabledRangeIndex_ {}
 @_fixed_layout
 public struct CountableRange<Bound> : RandomAccessCollection
   where
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
-  Bound.Stride : SignedInteger {
+  Bound : Strideable, Bound.Stride : SignedInteger {
 
   /// The range's lower bound.
   ///
@@ -479,7 +476,7 @@ extension ${Self}
 %   if ('Countable' in OtherSelf or 'Closed' in OtherSelf or 'Closed' in Self) \
 %   and not 'Countable' in Self:
   where
-  Bound : _Strideable, Bound.Stride : SignedInteger
+  Bound : Strideable, Bound.Stride : SignedInteger
 %   end
 {
   /// Creates an instance equivalent to the given range.
@@ -506,7 +503,7 @@ ${get_init_warning(Self, OtherSelf)}
 extension ${Self}
 %   if 'Countable' in OtherSelf and not 'Countable' in Self:
   where
-  Bound : _Strideable, Bound.Stride : SignedInteger
+  Bound : Strideable, Bound.Stride : SignedInteger
 %   end
 {
   /// Returns a Boolean value indicating whether this range and the given range
@@ -718,10 +715,7 @@ extension ${Self} : Equatable {
 ///
 /// Unfortunately, we can't forward the full collection API, so we are
 /// forwarding a few select APIs.
-extension ${Self} where Bound : _Strideable, Bound.Stride : SignedInteger {
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be Bound : Strideable
-
+extension ${Self} where Bound : Strideable, Bound.Stride : SignedInteger {
   /// The number of values contained in the range.
   @_inlineable
   public var count: Bound.Stride {
@@ -734,62 +728,6 @@ extension ${Self} where Bound : _Strideable, Bound.Stride : SignedInteger {
   }
 }
 % end
-
-/// Returns a half-open range that contains its lower bound but not its upper
-/// bound.
-///
-/// Use the half-open range operator (`..<`) to create a range of any type that
-/// conforms to the `Comparable` protocol. This example creates a
-/// `Range<Double>` from zero up to, but not including, 5.0.
-///
-///     let lessThanFive = 0.0..<5.0
-///     print(lessThanFive.contains(3.14))  // Prints "true"
-///     print(lessThanFive.contains(5.0))   // Prints "false"
-///
-/// - Parameters:
-///   - minimum: The lower bound for the range.
-///   - maximum: The upper bound for the range.
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public func ..< <Bound>(minimum: Bound, maximum: Bound)
-  -> Range<Bound> {
-  _precondition(minimum <= maximum,
-    "Can't form Range with upperBound < lowerBound")
-  return Range(uncheckedBounds: (lower: minimum, upper: maximum))
-}
-
-/// Returns a countable half-open range that contains its lower bound but not
-/// its upper bound.
-///
-/// Use the half-open range operator (`..<`) to create a range of any type that
-/// conforms to the `Strideable` protocol with an associated integer `Stride`
-/// type, such as any of the standard library's integer types. This example
-/// creates a `CountableRange<Int>` from zero up to, but not including, 5.
-///
-///     let upToFive = 0..<5
-///     print(upToFive.contains(3))         // Prints "true"
-///     print(upToFive.contains(5))         // Prints "false"
-///
-/// You can use sequence or collection methods on the `upToFive` countable
-/// range.
-///
-///     print(upToFive.count)               // Prints "5"
-///     print(upToFive.last)                // Prints "4"
-///
-/// - Parameters:
-///   - minimum: The lower bound for the range.
-///   - maximum: The upper bound for the range.
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public func ..< <Bound>(
-  minimum: Bound, maximum: Bound
-) -> CountableRange<Bound> {
-
-  // FIXME: swift-3-indexing-model: tests for traps.
-  _precondition(minimum <= maximum,
-    "Can't form Range with upperBound < lowerBound")
-  return CountableRange(uncheckedBounds: (lower: minimum, upper: maximum))
-}
 
 /// A partial half-open interval up to, but not including, an upper bound.
 ///
@@ -1036,6 +974,28 @@ extension CountablePartialRangeFrom: Sequence {
 }
 
 extension Comparable {
+  /// Returns a half-open range that contains its lower bound but not its upper
+  /// bound.
+  ///
+  /// Use the half-open range operator (`..<`) to create a range of any type that
+  /// conforms to the `Comparable` protocol. This example creates a
+  /// `Range<Double>` from zero up to, but not including, 5.0.
+  ///
+  ///     let lessThanFive = 0.0..<5.0
+  ///     print(lessThanFive.contains(3.14))  // Prints "true"
+  ///     print(lessThanFive.contains(5.0))   // Prints "false"
+  ///
+  /// - Parameters:
+  ///   - minimum: The lower bound for the range.
+  ///   - maximum: The upper bound for the range.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func ..< (minimum: Self, maximum: Self) -> Range<Self> {
+    _precondition(minimum <= maximum,
+      "Can't form Range with upperBound < lowerBound")
+    return Range(uncheckedBounds: (lower: minimum, upper: maximum))
+  }
+
   /// Returns a partial range up to, but not including, its upper bound.
   ///
   /// Use the prefix half-open range operator (prefix `..<`) to create a
@@ -1060,7 +1020,7 @@ extension Comparable {
   /// - Parameter maximum: The upper bound for the range.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static prefix func ..<(maximum: Self) -> PartialRangeUpTo<Self> {
+  public static prefix func ..< (maximum: Self) -> PartialRangeUpTo<Self> {
     return PartialRangeUpTo(maximum)
   }
 
@@ -1088,7 +1048,7 @@ extension Comparable {
   /// - Parameter maximum: The upper bound for the range.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static prefix func ...(maximum: Self) -> PartialRangeThrough<Self> {
+  public static prefix func ... (maximum: Self) -> PartialRangeThrough<Self> {
     return PartialRangeThrough(maximum)
   }
 
@@ -1116,12 +1076,42 @@ extension Comparable {
   /// - Parameter minimum: The lower bound for the range.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static postfix func ...(minimum: Self) -> PartialRangeFrom<Self> {
+  public static postfix func ... (minimum: Self) -> PartialRangeFrom<Self> {
     return PartialRangeFrom(minimum)
   }
 }
 
 extension Strideable where Stride: SignedInteger {
+  /// Returns a countable half-open range that contains its lower bound but not
+  /// its upper bound.
+  ///
+  /// Use the half-open range operator (`..<`) to create a range of any type that
+  /// conforms to the `Strideable` protocol with an associated integer `Stride`
+  /// type, such as any of the standard library's integer types. This example
+  /// creates a `CountableRange<Int>` from zero up to, but not including, 5.
+  ///
+  ///     let upToFive = 0..<5
+  ///     print(upToFive.contains(3))         // Prints "true"
+  ///     print(upToFive.contains(5))         // Prints "false"
+  ///
+  /// You can use sequence or collection methods on the `upToFive` countable
+  /// range.
+  ///
+  ///     print(upToFive.count)               // Prints "5"
+  ///     print(upToFive.last)                // Prints "4"
+  ///
+  /// - Parameters:
+  ///   - minimum: The lower bound for the range.
+  ///   - maximum: The upper bound for the range.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func ..< (minimum: Self, maximum: Self) -> CountableRange<Self> {
+    // FIXME: swift-3-indexing-model: tests for traps.
+    _precondition(minimum <= maximum,
+      "Can't form Range with upperBound < lowerBound")
+    return CountableRange(uncheckedBounds: (lower: minimum, upper: maximum))
+  }
+
   /// Returns a countable partial range extending upward from a lower bound.
   ///
   /// Use the postfix range operator (postfix `...`) to create a partial range
@@ -1198,7 +1188,7 @@ extension Strideable where Stride: SignedInteger {
   /// - Parameter minimum: The lower bound for the range.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static postfix func ...(minimum: Self)
+  public static postfix func ... (minimum: Self)
   -> CountablePartialRangeFrom<Self> {
     return CountablePartialRangeFrom(minimum)
   }

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -10,17 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME(ABI)#69 (Overload Resolution): Remove `_Strideable`.
-// WORKAROUND rdar://25214598 - should be:
-// protocol Strideable : Comparable {...}
-
-% for Self in ['_Strideable', 'Strideable']:
-
-%{
-    Conformance = (
-      'Equatable' if Self == '_Strideable' else '_Strideable, Comparable'
-    )
-}%
 /// Conforming types are notionally continuous, one-dimensional
 /// values that can be offset and measured.
 ///
@@ -29,11 +18,9 @@
 ///   `Stride` type's implementations. If a type conforming to `Strideable`
 ///   is its own `Stride` type, it must provide concrete implementations of
 ///   the two operators to avoid infinite recursion.
-public protocol ${Self} : ${Conformance} {
-%   if Self == '_Strideable':
+public protocol Strideable : Comparable {
   /// A type that represents the distance between two values of `Self`.
   associatedtype Stride : SignedNumeric, Comparable
-%   end
 
   /// Returns a stride `x` such that `self.advanced(by: x)` approximates
   /// `other`.
@@ -57,26 +44,6 @@ public protocol ${Self} : ${Conformance} {
   ) -> (index: Int?, value: Self)
 
   associatedtype _DisabledRangeIndex = _DisabledRangeIndex_
-}
-
-% end
-
-extension Strideable where Stride == Self {
-  @available(*, deprecated, message: "Strideable conformance where 'Stride == Self' requires user-defined implementation of the '<' operator")
-  public static func < (x: Self, y: Self) -> Bool {
-    fatalError("""
-      Strideable conformance where 'Stride == Self' requires user-defined \
-      implementation of the '<' operator
-      """)
-  }
-
-  @available(*, deprecated, message: "Strideable conformance where 'Stride == Self' requires user-defined implementation of the '==' operator")
-  public static func == (x: Self, y: Self) -> Bool {
-    fatalError("""
-      Strideable conformance where 'Stride == Self' requires user-defined \
-      implementation of the '==' operator
-      """)
-  }
 }
 
 extension Strideable {

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -341,5 +341,5 @@ func takesRawBuffer(_ b: UnsafeRawBufferPointer) {}
 func f29586888(b: UnsafeRawBufferPointer) {
   takesRawBuffer(b[1..<2]) // expected-error {{'subscript' is unavailable: use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.}}
   let slice = b[1..<2]
-  takesRawBuffer(slice) // expected-error {{cannot convert value of type 'RandomAccessSlice<UnsafeRawBufferPointer>' to expected argument type 'UnsafeRawBufferPointer'}}
+  takesRawBuffer(slice) // expected-error {{cannot convert value of type 'UnsafeRawBufferPointer.SubSequence' (aka 'RandomAccessSlice<UnsafeRawBufferPointer>') to expected argument type 'UnsafeRawBufferPointer'}}
 }

--- a/test/stdlib/LazyCollectionPlus.swift
+++ b/test/stdlib/LazyCollectionPlus.swift
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var tests = TestSuite("LazyCollectionPlus")
+
+tests.test("NoAmbiguity") {
+  let d: [String: Int] = ["" : 0]
+  let xs = d.values.map { $0 }
+  let ys = d.values.map { $0 + 42 }
+  let actual = xs + ys // this line should compile without ambiguity
+  expectEqualSequence([0, 42], actual)
+}
+
+runAllTests()

--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -37,10 +37,10 @@ func typeInference_Comparable<C : Comparable>(v: C) {
   do {
     let r1: Range<C>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<C>' to specified type 'Range<C>'}}
     let r2: ClosedRange<C> = v..<v // expected-error {{cannot convert value of type 'Range<C>' to specified type 'ClosedRange<C>'}}
-    let r3: CountableRange<C>       = v..<v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
-    let r4: CountableClosedRange<C> = v...v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
-    let r5: CountableRange<C>       = v...v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
-    let r6: CountableClosedRange<C> = v..<v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
+    let r3: CountableRange<C>       = v..<v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
+    let r4: CountableClosedRange<C> = v...v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
+    let r5: CountableRange<C>       = v...v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
+    let r6: CountableClosedRange<C> = v..<v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
   }
 }
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -201,10 +201,7 @@ func getBridgedVerbatimSet(_ members: [Int] = [1010, 2020, 3030])
 /// Get a Set<NSObject> (Set<TestObjCKeyTy>) backed by native storage
 func getNativeBridgedVerbatimSet(_ members: [Int] = [1010, 2020, 3030]) ->
   Set<NSObject> {
-  // SR-4724: Should not need to be split out but if it is not it
-  // is considered ambiguous.
-  let temp = members.map({ TestObjCKeyTy($0) })
-  let result: Set<NSObject> = Set(temp)
+  let result: Set<NSObject> = Set(members.map({ TestObjCKeyTy($0) }))
   expectTrue(isNativeSet(result))
   return result
 }


### PR DESCRIPTION
ABI work to remove unnecessary `_Strideable` protocol and use `Strideable` everywhere instead, which already conforms to `Comparable`.

Initial changes are done by @airspeedswift.

Resolves: rdar://problem/25214598
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
