### PR TITLE
Disable Unsafe[Raw]BufferPointer testing in optimized mode.

### DIFF
--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -5,8 +5,15 @@
 // General Collection behavior tests are in
 // validation-test/stdlib/UnsafeBufferPointer.swift.
 
-// rdar://35052802 unexpected assertions when test is run with optimize_size
-// XFAIL: swift_test_mode_optimize_size && optimized_stdlib
+// FIXME: The optimized-build behavior of UnsafeBufferPointer bounds/overflow
+// checking cannot be tested. The standard library always compiles with debug
+// checking enabled, so the behavior of the optimized test depends on whether
+// the inlining heuristics decide to inline these methods. To fix this, we need
+// a way to force @_inlineable UnsafeBufferPointer methods to be emitted inside
+// the client code, and thereby subject the stdlib implementation to the test
+// case's compile options.
+//
+// REQUIRES: swift_test_mode_optimize_none
 
 import StdlibUnittest
 

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -1,8 +1,15 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// rdar://35052802 unexpected assertions when test is run with optimize_size
-// XFAIL: swift_test_mode_optimize_size && optimized_stdlib
+// FIXME: The optimized-build behavior of UnsafeBufferPointer bounds/overflow
+// checking cannot be tested. The standard library always compiles with debug
+// checking enabled, so the behavior of the optimized test depends on whether
+// the inlining heuristics decide to inline these methods. To fix this, we need
+// a way to force @_inlineable UnsafeBufferPointer methods to be emitted inside
+// the client code, and thereby subject the stdlib implementation to the test
+// case's compile options.
+//
+// REQUIRES: swift_test_mode_optimize_none
 
 import StdlibUnittest
 import StdlibCollectionUnittest


### PR DESCRIPTION
The optimized-build behavior of UnsafeBufferPointer bounds/overflow
checking cannot be tested. The standard library always compiles with debug
checking enabled, so the behavior of the optimized test depends on whether
the inlining heuristics decide to inline these methods. To fix this, we need
a way to force @_inlineable UnsafeBufferPointer methods to be emitted inside
the client code, and thereby subject the stdlib implementation to the test
case's compile options.
