### PR TITLE
[FreeBSD] Fix a few issues

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1531,6 +1531,11 @@ function(add_swift_library name)
             if("${sdk}" STREQUAL "ANDROID")
               list(APPEND swiftlib_private_link_libraries_targets
                    "-latomic")
+            # the same issue on FreeBSD, missing symbols:
+            # __atomic_store, __atomic_compare_exchange, __atomic_load
+            elseif("${sdk}" STREQUAL "FREEBSD")
+              list(APPEND swiftlib_private_link_libraries_targets
+                   "${SWIFTLIB_DIR}/clang/lib/freebsd/libclang_rt.builtins-${arch}.a")
             endif()
           elseif("${lib}" STREQUAL "ICU_I18N")
             list(APPEND swiftlib_private_link_libraries_targets

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -27,7 +27,7 @@
 #include <link.h>
 #include <string.h>
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(__FreeBSD__)
 #include "llvm/ADT/StringRef.h"
 #endif
 
@@ -72,9 +72,14 @@ static SectionInfo getSectionInfo(const char *imageName,
   SectionInfo sectionInfo = { 0, nullptr };
   void *handle = dlopen(imageName, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(__FreeBSD__)
+#if defined(__ANDROID__)
+    const char *systemPath = "/system/lib";
+#elif defined(__FreeBSD__)
+    const char *systemPath = "/libexec";
+#endif
     llvm::StringRef imagePath = llvm::StringRef(imageName);
-    if (imagePath.startswith("/system/lib") ||
+    if (imagePath.startswith(systemPath) ||
         (imageName && !imagePath.endswith(".so"))) {
       return sectionInfo;
     }

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3448,8 +3448,8 @@ function build_and_test_installable_package() {
           with_pushd "${host_install_destdir}" \
               call tar -c -z -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}"
         else
-            # tar on OS X doesn't support --owner/--group.
-            if [[ "$(uname -s)" == "Darwin" ]] ; then
+            # BSD tar doesn't support --owner/--group.
+            if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "FreeBSD" ]] ; then
                 with_pushd "${host_install_destdir}" \
                     tar -c -z -f "${package_for_host}" "${host_install_prefix/#\/}"
             else


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a few issues on FreeBSD 11 / 12
1. creation of installable .tar.gz package
2. libswiftCore.so: undefined reference to
`__atomic_store` `__atomic_compare_exchange` `__atomic_load` *
3. crash of produced executables: `dlopen() failed on ./main: (NULL)Abort (core dumped)`

Related issues: https://github.com/apple/swift/pull/10836#issuecomment-317014783 

\* Couldn't find a better way.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->