### PR TITLE
Process stats evaluate and lit diagnostics docs

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -83,6 +83,10 @@ out with ``lit.py -h``. We document some of the more useful ones below:
 
 * ``-s`` reduces the amount of output that lit shows.
 * ``-v`` causes a test's commandline and output to be printed if the test fails.
+* ``-vv`` causes a test's commandline and output to be printed if the test fails,
+         showing the exact command in the test execution script where progress
+         stopped; this can be useful for finding a single silently-failing RUN
+         line, amid a sequence.
 * ``-a`` causes a test's commandline and output to always be printed.
 * ``--filter=<pattern>`` causes only tests with paths matching the given regular
   expression to be run.

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -425,7 +425,11 @@ def evaluate(args):
                 print("%s => %s" % (i, v))
             env[i] = v
     try:
-        return 0 if eval(args.evaluate, env) else 1
+        if eval(args.evaluate, env):
+            return 0
+        else:
+            print("evaluate condition failed: '%s'" % args.evaluate)
+            return 1
     except Exception as e:
         print(e)
         return 1

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -401,6 +401,36 @@ def compare_stats_dirs(args):
     return write_comparison(args, old_stats.stats, new_stats.stats)
 
 
+# Evaluate a boolean expression in terms of the provided stats-dir; all stats
+# are projected into python dicts (thus variables in the eval expr) named by
+# the last identifier in the stat definition. This means you can evaluate
+# things like 'NumIRInsts < 1000' or
+# 'NumTypesValidated == NumTypesDeserialized'
+def evaluate(args):
+    if len(args.remainder) != 1:
+        raise ValueError("Expected exactly 1 stats-dir to evaluate against")
+
+    d = args.remainder[0]
+    vargs = vars_of_args(args)
+    merged = merge_all_jobstats(load_stats_dir(d, **vargs), **vargs)
+    env = {}
+    ident = re.compile('(\w+)$')
+    for (k, v) in merged.stats.items():
+        if k.startswith("time.") or '.time.' in k:
+            continue
+        m = re.search(ident, k)
+        if m:
+            i = m.groups()[0]
+            if args.verbose:
+                print("%s => %s" % (i, v))
+            env[i] = v
+    try:
+        return 0 if eval(args.evaluate, env) else 1
+    except Exception as e:
+        print(e)
+        return 1
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", action="store_true",
@@ -492,6 +522,8 @@ def main():
                        help="Compare two stats dirs directly")
     modes.add_argument("--lnt", action="store_true",
                        help="Emit an LNT-compatible test summary")
+    modes.add_argument("--evaluate", type=str, default=None,
+                       help="evaluate an expression of stat-names")
     parser.add_argument('remainder', nargs=argparse.REMAINDER,
                         help="stats-dirs to process")
 
@@ -514,6 +546,8 @@ def main():
             show_incrementality(args)
     elif args.lnt:
         write_lnt_values(args)
+    elif args.evaluate:
+        return evaluate(args)
     return None
 
 


### PR DESCRIPTION
This adds a new mode to process-stats-dir.py that handles evaluating expressions over specific
stats-dir values. Also includes mention of a lit.py mode I had to employ today, as per @gottesmm's
request.