### PR TITLE
[GSB] Reduce use of potential archetypes when describing constraints

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1546,9 +1546,9 @@ public:
   /// path compression on the way.
   PotentialArchetype *getRepresentative() const;
 
+private:
   /// Retrieve the generic signature builder with which this archetype is
   /// associated.
-  /// FIXME: Only EquivalenceClassVizIterator gets to use this.
   GenericSignatureBuilder *getBuilder() const {
     const PotentialArchetype *pa = this;
     while (auto parent = pa->getParent())
@@ -1556,7 +1556,6 @@ public:
     return pa->parentOrBuilder.get<GenericSignatureBuilder *>();
   }
 
-private:
   // Replace the generic signature builder.
   void replaceBuilder(GenericSignatureBuilder *builder) {
     assert(parentOrBuilder.is<GenericSignatureBuilder *>());

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -104,37 +104,7 @@ public:
 
   class DelayedRequirement;
 
-  /// Describes a specific constraint on a particular type.
-  template<typename T>
-  struct Constraint {
-    /// The specific subject of the constraint.
-    ///
-    /// This may either be a (resolved) dependent type or the potential
-    /// archetype that it resolves to.
-    mutable UnresolvedType subject;
-
-    /// A value used to describe the constraint.
-    T value;
-
-    /// The requirement source used to derive this constraint.
-    const RequirementSource *source;
-
-    /// Retrieve the dependent type describing the subject of the constraint.
-    Type getSubjectDependentType() const;
-
-    /// Realizes and retrieves the potential archetype describing the
-    /// subject of the constraint.
-    PotentialArchetype *realizeSubjectPotentialArchetype(
-                          GenericSignatureBuilder &builder) const;
-
-    /// Determine whether the subject is equivalence to the given potential
-    /// archetype.
-    bool isSubjectEqualTo(const PotentialArchetype *pa) const;
-
-    /// Determine whether this constraint has the same subject as the
-    /// given constraint.
-    bool hasSameSubjectAs(const Constraint<T> &other) const;
-  };
+  template<typename T> struct Constraint;
 
   /// Describes a concrete constraint on a potential archetype where, where the
   /// other parameter is a concrete type.
@@ -1447,6 +1417,38 @@ public:
   /// Whether this requirement source is recursive when composed with
   /// the given type.
   bool isRecursive(Type rootType, GenericSignatureBuilder &builder) const;
+};
+
+/// Describes a specific constraint on a particular type.
+template<typename T>
+struct GenericSignatureBuilder::Constraint {
+  /// The specific subject of the constraint.
+  ///
+  /// This may either be a (resolved) dependent type or the potential
+  /// archetype that it resolves to.
+  mutable UnresolvedType subject;
+
+  /// A value used to describe the constraint.
+  T value;
+
+  /// The requirement source used to derive this constraint.
+  const RequirementSource *source;
+
+  /// Retrieve the dependent type describing the subject of the constraint.
+  Type getSubjectDependentType() const;
+
+  /// Realizes and retrieves the potential archetype describing the
+  /// subject of the constraint.
+  PotentialArchetype *realizeSubjectPotentialArchetype(
+                        GenericSignatureBuilder &builder) const;
+
+  /// Determine whether the subject is equivalence to the given potential
+  /// archetype.
+  bool isSubjectEqualTo(const PotentialArchetype *pa) const;
+
+  /// Determine whether this constraint has the same subject as the
+  /// given constraint.
+  bool hasSameSubjectAs(const Constraint<T> &other) const;
 };
 
 class GenericSignatureBuilder::PotentialArchetype {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -213,6 +213,16 @@ public:
                                      ProtocolDecl *proto,
                                      FloatingRequirementSource source);
 
+    /// Record a same-type constraint between \c type1 and \c type2 determined
+    /// via the given source.
+    ///
+    /// \returns true if this same-type constraint merges two equivalence
+    /// classes, and false otherwise.
+    bool recordSameTypeConstraint(GenericSignatureBuilder &builder,
+                                  PotentialArchetype *type1,
+                                  PotentialArchetype *type2,
+                                  const RequirementSource *source);
+
     /// Find a source of the same-type constraint that maps a potential
     /// archetype in this equivalence class to a concrete type along with
     /// that concrete type as written.
@@ -1655,7 +1665,8 @@ public:
   }
 
   /// Retrieve or create the equivalence class.
-  EquivalenceClass *getOrCreateEquivalenceClass() const;
+  EquivalenceClass *getOrCreateEquivalenceClass(
+                                    GenericSignatureBuilder &builder) const;
 
   /// Retrieve the equivalence class containing this potential archetype.
   TinyPtrVector<PotentialArchetype *> getEquivalenceClassMembers() const {
@@ -1669,11 +1680,6 @@ public:
   /// \brief Retrieve the potential archetype to be used as the anchor for
   /// potential archetype computations.
   PotentialArchetype *getArchetypeAnchor(GenericSignatureBuilder &builder);
-
-  /// Add a same-type constraint between this archetype and the given
-  /// other archetype.
-  void addSameTypeConstraint(PotentialArchetype *otherPA,
-                             const RequirementSource *source);
 
   /// Retrieve the same-type constraints.
   ArrayRef<Constraint<PotentialArchetype *>> getSameTypeConstraints() const {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -108,7 +108,10 @@ public:
   template<typename T>
   struct Constraint {
     /// The specific subject of the constraint.
-    PotentialArchetype *subject;
+    ///
+    /// This may either be a (resolved) dependent type or the potential
+    /// archetype that it resolves to.
+    mutable UnresolvedType subject;
 
     /// A value used to describe the constraint.
     T value;
@@ -1698,7 +1701,7 @@ public:
   ///
   /// \param genericParams The set of generic parameters to use in the resulting
   /// dependent type.
-  Type getDependentType(ArrayRef<GenericTypeParamType *> genericParams);
+  Type getDependentType(ArrayRef<GenericTypeParamType *> genericParams) const;
 
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1176,24 +1176,20 @@ public:
   /// Retrieve the type at the root.
   Type getRootType() const;
 
-  /// Retrieve the potential archetype to which this source refers.
-  PotentialArchetype *getAffectedPotentialArchetype() const;
-
   /// Retrieve the type to which this source refers.
   Type getAffectedType() const;
 
-  /// Visit each of the potential archetypes along the path, from the root
-  /// potential archetype to each potential archetype named via (e.g.) a
-  /// protocol requirement or parent source.
+  /// Visit each of the types along the path, from the root type
+  /// each type named via (e.g.) a protocol requirement or parent source.
   ///
-  /// \param visitor Called with each potential archetype along the path along
+  /// \param visitor Called with each type along the path along
   /// with the requirement source that is being applied on top of that
-  /// potential archetype. Can return \c true to halt the search.
+  /// type. Can return \c true to halt the search.
   ///
-  /// \returns nullptr if any call to \c visitor returned true. Otherwise,
-  /// returns the potential archetype to which the entire source refers.
-  PotentialArchetype *visitPotentialArchetypesAlongPath(
-           llvm::function_ref<bool(PotentialArchetype *,
+  /// \returns a null type if any call to \c visitor returned true. Otherwise,
+  /// returns the type to which the entire source refers.
+  Type visitPotentialArchetypesAlongPath(
+           llvm::function_ref<bool(Type,
                                    const RequirementSource *)> visitor) const;
 
   /// Whether this source is a requirement in a protocol.
@@ -1228,10 +1224,11 @@ public:
   /// requirement. Such "self-derived" requirements do not make the original
   /// requirement redundant, because without said original requirement, the
   /// derived requirement ceases to hold.
-  bool isSelfDerivedSource(PotentialArchetype *pa,
+  bool isSelfDerivedSource(GenericSignatureBuilder &builder,
+                           Type type,
                            bool &derivedViaConcrete) const;
 
-  /// For a requirement source that describes the requirement \c pa:proto,
+  /// For a requirement source that describes the requirement \c type:proto,
   /// retrieve the minimal subpath of this requirement source that will
   /// compute that requirement.
   ///
@@ -1239,7 +1236,8 @@ public:
   /// nullptr (indicating an embedded, distinct self-derived subpath), the
   /// conformance requirement is considered to be "self-derived".
   const RequirementSource *getMinimalConformanceSource(
-                                            PotentialArchetype *pa,
+                                            GenericSignatureBuilder &builder,
+                                            Type type,
                                             ProtocolDecl *proto,
                                             bool &derivedViaConcrete) const;
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -778,6 +778,9 @@ public:
   /// class that would need to change to resolve this type.
   ResolvedType resolve(UnresolvedType type, FloatingRequirementSource source);
 
+  /// Determine whether the two given types are in the same equivalence class.
+  bool areInSameEquivalenceClass(Type type1, Type type2);
+
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump(),
@@ -1158,17 +1161,26 @@ public:
   /// It is the caller's responsibility to ensure that the path up to \c start
   /// and the path through \c start to \c end produce the same thing.
   const RequirementSource *withoutRedundantSubpath(
+                                          GenericSignatureBuilder &builder,
                                           const RequirementSource *start,
                                           const RequirementSource *end) const;
 
   /// Retrieve the root requirement source.
   const RequirementSource *getRoot() const;
 
+private:
   /// Retrieve the potential archetype at the root.
   PotentialArchetype *getRootPotentialArchetype() const;
 
+public:
+  /// Retrieve the type at the root.
+  Type getRootType() const;
+
   /// Retrieve the potential archetype to which this source refers.
   PotentialArchetype *getAffectedPotentialArchetype() const;
+
+  /// Retrieve the type to which this source refers.
+  Type getAffectedType() const;
 
   /// Visit each of the potential archetypes along the path, from the root
   /// potential archetype to each potential archetype named via (e.g.) a

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -104,12 +104,33 @@ public:
 
   class DelayedRequirement;
 
-  /// Describes a specific constraint on a potential archetype.
+  /// Describes a specific constraint on a particular type.
   template<typename T>
   struct Constraint {
-    PotentialArchetype *archetype;
+    /// The specific subject of the constraint.
+    PotentialArchetype *subject;
+
+    /// A value used to describe the constraint.
     T value;
+
+    /// The requirement source used to derive this constraint.
     const RequirementSource *source;
+
+    /// Retrieve the dependent type describing the subject of the constraint.
+    Type getSubjectDependentType() const;
+
+    /// Realizes and retrieves the potential archetype describing the
+    /// subject of the constraint.
+    PotentialArchetype *realizeSubjectPotentialArchetype(
+                          GenericSignatureBuilder &builder) const;
+
+    /// Determine whether the subject is equivalence to the given potential
+    /// archetype.
+    bool isSubjectEqualTo(const PotentialArchetype *pa) const;
+
+    /// Determine whether this constraint has the same subject as the
+    /// given constraint.
+    bool hasSameSubjectAs(const Constraint<T> &other) const;
   };
 
   /// Describes a concrete constraint on a potential archetype where, where the
@@ -1513,9 +1534,9 @@ public:
   /// path compression on the way.
   PotentialArchetype *getRepresentative() const;
 
-private:
   /// Retrieve the generic signature builder with which this archetype is
   /// associated.
+  /// FIXME: Only EquivalenceClassVizIterator gets to use this.
   GenericSignatureBuilder *getBuilder() const {
     const PotentialArchetype *pa = this;
     while (auto parent = pa->getParent())
@@ -1523,6 +1544,7 @@ private:
     return pa->parentOrBuilder.get<GenericSignatureBuilder *>();
   }
 
+private:
   // Replace the generic signature builder.
   void replaceBuilder(GenericSignatureBuilder *builder) {
     assert(parentOrBuilder.is<GenericSignatureBuilder *>());

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -547,6 +547,10 @@ public:
                             const RequirementSource *source)> f);
 
 public:
+  /// Retrieve the generic parameters used to describe the generic
+  /// signature being built.
+  ArrayRef<GenericTypeParamType *> getGenericParams() const;
+
   /// \brief Add a new generic parameter for which there may be requirements.
   void addGenericParameter(GenericTypeParamDecl *GenericParam);
 
@@ -1455,7 +1459,8 @@ struct GenericSignatureBuilder::Constraint {
   const RequirementSource *source;
 
   /// Retrieve the dependent type describing the subject of the constraint.
-  Type getSubjectDependentType() const;
+  Type getSubjectDependentType(
+                       ArrayRef<GenericTypeParamType *> genericParams) const;
 
   /// Realizes and retrieves the potential archetype describing the
   /// subject of the constraint.
@@ -1560,15 +1565,6 @@ public:
   PotentialArchetype *getRepresentative() const;
 
 private:
-  /// Retrieve the generic signature builder with which this archetype is
-  /// associated.
-  GenericSignatureBuilder *getBuilder() const {
-    const PotentialArchetype *pa = this;
-    while (auto parent = pa->getParent())
-      pa = parent;
-    return pa->parentOrBuilder.get<GenericSignatureBuilder *>();
-  }
-
   // Replace the generic signature builder.
   void replaceBuilder(GenericSignatureBuilder *builder) {
     assert(parentOrBuilder.is<GenericSignatureBuilder *>());
@@ -1729,7 +1725,10 @@ public:
 
     return false;
   }
-  
+
+  /// Retrieve the AST context in which this potential archetype resides.
+  ASTContext &getASTContext() const;
+
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const,
       "only for use within the debugger");

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -363,7 +363,7 @@ public:
   /// adding the requirements from its requirement signature, rooted at
   /// the given requirement \c source.
   ConstraintResult expandConformanceRequirement(
-                                      PotentialArchetype *pa,
+                                      ResolvedType selfType,
                                       ProtocolDecl *proto,
                                       const RequirementSource *source,
                                       bool onlySameTypeConstraints);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -208,7 +208,8 @@ public:
     ///
     /// \returns true if this conformance is new to the equivalence class,
     /// and false otherwise.
-    bool recordConformanceConstraint(ResolvedType type,
+    bool recordConformanceConstraint(GenericSignatureBuilder &builder,
+                                     ResolvedType type,
                                      ProtocolDecl *proto,
                                      FloatingRequirementSource source);
 
@@ -236,12 +237,14 @@ public:
     /// \param otherConcreteTypes If non-null, will be filled in the all of the
     /// concrete types we found (other than the result) with the same name.
     TypeDecl *lookupNestedType(
+                   GenericSignatureBuilder &builder,
                    Identifier name,
                    SmallVectorImpl<TypeDecl *> *otherConcreteTypes = nullptr);
 
     /// Retrieve the "anchor" type that canonically describes this equivalence
     /// class, for use in the canonical type.
-    Type getAnchor(ArrayRef<GenericTypeParamType *> genericParams);
+    Type getAnchor(GenericSignatureBuilder &builder,
+                   ArrayRef<GenericTypeParamType *> genericParams);
 
     /// \brief Retrieve (or build) the contextual type corresponding to
     /// this equivalence class within the given generic environment.
@@ -1701,6 +1704,7 @@ public:
   /// type or typealias of the given protocol, unless the \c kind implies that
   /// a potential archetype should not be created if it's missing.
   PotentialArchetype *updateNestedTypeForConformance(
+                        GenericSignatureBuilder &builder,
                         TypeDecl *type,
                         ArchetypeResolutionKind kind);
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -754,7 +754,8 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
     if (!equivClass) return false;
 
     return (equivClass->concreteType ||
-            !component->isEqual(equivClass->getAnchor(getGenericParams())));
+            !component->isEqual(equivClass->getAnchor(builder,
+                                                      getGenericParams())));
   });
 }
 
@@ -784,7 +785,7 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type,
       return getCanonicalTypeInContext(equivClass->concreteType, builder);
     }
 
-    return equivClass->getAnchor(getGenericParams());
+    return equivClass->getAnchor(builder, getGenericParams());
   });
   
   auto result = type->getCanonicalType();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -963,8 +963,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
       // Compute the root type, canonicalizing it w.r.t. the protocol context.
       auto conformsSource = getBestRequirementSource(conforms->second);
       assert(conformsSource != source || !requirementSignatureProto);
-      Type localRootType = conformsSource->getRootPotentialArchetype()
-                             ->getDependentType(inProtoSig->getGenericParams());
+      Type localRootType = conformsSource->getRootType();
       localRootType = inProtoSig->getCanonicalTypeInContext(localRootType);
 
       // Build the path according to the requirement signature.
@@ -1001,9 +1000,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
 
   // Canonicalize the root type.
   auto source = getBestRequirementSource(conforms->second);
-  auto subjectPA = source->getRootPotentialArchetype();
-  Type rootType =
-    subjectPA->getOrCreateEquivalenceClass()->getAnchor(getGenericParams());
+  Type rootType = source->getRootType()->getCanonicalType(this);
 
   // Build the path.
   buildPath(getRequirements(), source, protocol, rootType, nullptr);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -223,9 +223,9 @@ namespace {
 
     void advance() {
       while (base != baseEnd) {
-       if (compareDependentTypes(base->getSubjectDependentType(),
-                                 base->value->getDependentType({ })) <= 0)
-         break;
+        if (compareDependentTypes(base->getSubjectDependentType({ }),
+                                  base->value->getDependentType({ })) <= 0)
+          break;
 
         ++base;
       }
@@ -1574,7 +1574,7 @@ public:
   explicit operator bool() const { return !type.isNull(); }
 
   /// Retrieve the dependent type.
-  Type getDependentType() const;
+  Type getDependentType(GenericSignatureBuilder &builder) const;
 
   /// Retrieve the concrete type, or a null type if this result doesn't store
   /// a concrete type.
@@ -1651,7 +1651,8 @@ bool EquivalenceClass::recordConformanceConstraint(
 
   // Record this conformance source.
   known->second.push_back({type.getUnresolvedType(), proto,
-                           source.getSource(builder, type.getDependentType())});
+                           source.getSource(builder,
+                                            type.getDependentType(builder))});
   ++NumConformanceConstraints;
 
   return inserted;
@@ -1675,11 +1676,12 @@ bool EquivalenceClass::recordSameTypeConstraint(
 }
 
 template<typename T>
-Type Constraint<T>::getSubjectDependentType() const {
+Type Constraint<T>::getSubjectDependentType(
+                        ArrayRef<GenericTypeParamType *> genericParams) const {
   if (auto type = subject.dyn_cast<Type>())
     return type;
 
-  return subject.get<PotentialArchetype *>()->getDependentType({ });
+  return subject.get<PotentialArchetype *>()->getDependentType(genericParams);
 }
 
 template<typename T>
@@ -1707,7 +1709,7 @@ bool Constraint<T>::isSubjectEqualTo(const PotentialArchetype *pa) const {
   if (auto subjectPA = subject.dyn_cast<PotentialArchetype *>())
     return subjectPA == pa;
 
-  return getSubjectDependentType()->isEqual(pa->getDependentType({ }));
+  return getSubjectDependentType({ })->isEqual(pa->getDependentType({ }));
 }
 
 template<typename T>
@@ -1718,7 +1720,8 @@ bool Constraint<T>::hasSameSubjectAs(const Constraint<T> &other) const {
       return subjectPA == otherSubjectPA;
   }
 
-  return getSubjectDependentType()->isEqual(other.getSubjectDependentType());
+  return getSubjectDependentType({ })
+    ->isEqual(other.getSubjectDependentType({ }));
 }
 
 Optional<ConcreteConstraint>
@@ -1913,7 +1916,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
 
   // Infer same-type constraints among same-named associated type anchors.
   if (assocTypeAnchors.size() > 1) {
-    auto anchorType = getAnchor(builder, { });
+    auto anchorType = getAnchor(builder, builder.getGenericParams());
     auto inferredSource = FloatingRequirementSource::forInferred(nullptr);
     for (auto assocType : assocTypeAnchors) {
       if (assocType == bestAssocType) continue;
@@ -2272,7 +2275,7 @@ GenericSignatureBuilder::resolveConcreteConformance(ResolvedType type,
 
   // Lookup the conformance of the concrete type to this protocol.
   auto conformance =
-      lookupConformance(type.getDependentType()->getCanonicalType(),
+      lookupConformance(type.getDependentType(*this)->getCanonicalType(),
                         concrete,
                         proto->getDeclaredInterfaceType()
                           ->castTo<ProtocolType>());
@@ -2305,7 +2308,7 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
 
   // Lookup the conformance of the superclass to this protocol.
   auto conformance =
-    lookupConformance(type.getDependentType()->getCanonicalType(),
+    lookupConformance(type.getDependentType(*this)->getCanonicalType(),
                       superclass,
                       proto->getDeclaredInterfaceType()
                         ->castTo<ProtocolType>());
@@ -2348,10 +2351,10 @@ PotentialArchetype *ResolvedType::realizePotentialArchetype(
   return pa;
 }
 
-Type ResolvedType::getDependentType() const {
+Type ResolvedType::getDependentType(GenericSignatureBuilder &builder) const {
   // Already-resolved potential archetype.
   if (auto pa = type.dyn_cast<PotentialArchetype *>())
-    return pa->getDependentType({ });
+    return pa->getDependentType(builder.getGenericParams());
 
   Type result = type.get<Type>();
   return result->isTypeParameter() ? result : Type();
@@ -2371,7 +2374,7 @@ static void maybeAddSameTypeRequirementForNestedType(
 
   // Dig out the associated type.
   AssociatedTypeDecl *assocType = nullptr;
-  if (auto depMemTy = nested.getDependentType()->getAs<DependentMemberType>())
+  if (auto depMemTy = nested.getDependentType(builder)->getAs<DependentMemberType>())
     assocType = depMemTy->getAssocType();
 
   if (!assocType) return;
@@ -2833,7 +2836,7 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
           // Substitute in the type of the current PotentialArchetype in
           // place of 'Self' here.
           auto subMap = SubstitutionMap::getProtocolSubstitutions(
-            proto, getDependentType(/*genericParams=*/{}),
+            proto, getDependentType(builder.getGenericParams()),
             ProtocolConformanceRef(proto));
           type = type.subst(subMap, SubstFlags::UseErrorType);
           if (!type)
@@ -2851,8 +2854,8 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
                          UnresolvedType(resultPA),
                          UnresolvedType(type),
                          RequirementSource::forConcreteTypeBinding(
-                                             builder,
-                                             resultPA->getDependentType({ })),
+                           builder,
+                           resultPA->getDependentType(builder.getGenericParams())),
                          UnresolvedHandlingKind::GenerateConstraints);
       }
     }
@@ -2911,12 +2914,21 @@ Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
   
   assert(isGenericParam() && "Not a generic parameter?");
 
-  // FIXME: This is a temporary workaround.
-  if (genericParams.empty())
-    genericParams = getBuilder()->Impl->GenericParams;
+  if (genericParams.empty()) {
+    return GenericTypeParamType::get(getGenericParamKey().Depth,
+                                     getGenericParamKey().Index,
+                                     getASTContext());
+  }
 
   unsigned index = getGenericParamKey().findIndexIn(genericParams);
   return genericParams[index];
+}
+
+ASTContext &PotentialArchetype::getASTContext() const {
+  if (auto builder = parentOrBuilder.dyn_cast<GenericSignatureBuilder *>())
+    return builder->getASTContext();
+
+  return getResolvedType()->getASTContext();
 }
 
 void GenericSignatureBuilder::PotentialArchetype::dump() const {
@@ -3191,7 +3203,7 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
       return ResolvedType(nestedPA);
 
     // Compute the resolved dependent type to return.
-    Type resolvedBaseType = resolvedBase.getDependentType();
+    Type resolvedBaseType = resolvedBase.getDependentType(*this);
     Type resolvedMemberType;
     if (auto assocType = dyn_cast<AssociatedTypeDecl>(nestedTypeDecl)) {
       resolvedMemberType =
@@ -3254,6 +3266,11 @@ bool GenericSignatureBuilder::areInSameEquivalenceClass(Type type1,
                                                         Type type2) {
   return resolveEquivalenceClass(type1, ArchetypeResolutionKind::WellFormed)
     == resolveEquivalenceClass(type2, ArchetypeResolutionKind::WellFormed);
+}
+
+ArrayRef<GenericTypeParamType *>
+GenericSignatureBuilder::getGenericParams() const {
+  return Impl->GenericParams;
 }
 
 void GenericSignatureBuilder::addGenericParameter(GenericTypeParamDecl *GenericParam) {
@@ -3332,7 +3349,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
                                             const RequirementSource *source,
                                             bool onlySameTypeConstraints) {
   auto protocolSubMap = SubstitutionMap::getProtocolSubstitutions(
-      proto, selfType.getDependentType(), ProtocolConformanceRef(proto));
+      proto, selfType.getDependentType(*this), ProtocolConformanceRef(proto));
 
   // Use the requirement signature to avoid rewalking the entire protocol.  This
   // cannot compute the requirement signature directly, because that may be
@@ -3494,7 +3511,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     if (auto assocTypeDecl = dyn_cast<AssociatedTypeDecl>(Member)) {
       // Add requirements placed directly on this associated type.
       Type assocType =
-        DependentMemberType::get(selfType.getDependentType(), assocTypeDecl);
+        DependentMemberType::get(selfType.getDependentType(*this), assocTypeDecl);
       if (!onlySameTypeConstraints) {
         auto assocResult =
           addInheritedRequirements(assocTypeDecl, assocType, source,
@@ -3641,7 +3658,8 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   if (!equivClass->recordConformanceConstraint(*this, type, proto, source))
     return ConstraintResult::Resolved;
 
-  auto resolvedSource = source.getSource(*this, type.getDependentType());
+  auto resolvedSource = source.getSource(*this,
+                                         type.getDependentType(*this));
   return expandConformanceRequirement(type, proto, resolvedSource,
                                       /*onlySameTypeRequirements=*/false);
 }
@@ -3668,7 +3686,7 @@ ConstraintResult GenericSignatureBuilder::addLayoutRequirementDirect(
 
   // Record this layout constraint.
   equivClass->layoutConstraints.push_back({type.getUnresolvedType(),
-    layout, source.getSource(*this, type.getDependentType())});
+    layout, source.getSource(*this, type.getDependentType(*this))});
   equivClass->modified(*this);
   ++NumLayoutConstraints;
   if (!anyChanges) ++NumLayoutConstraintsExtra;
@@ -3732,7 +3750,7 @@ bool GenericSignatureBuilder::updateSuperclass(
 
           // FIXME: More efficient way to extend resolved type?
           Type nestedType =
-            DependentMemberType::get(type.getDependentType(), assocType);
+            DependentMemberType::get(type.getDependentType(*this), assocType);
           if (auto nested =
                 maybeResolveEquivalenceClass(
                                  nestedType,
@@ -3755,7 +3773,8 @@ bool GenericSignatureBuilder::updateSuperclass(
     // Presence of a superclass constraint implies a _Class layout
     // constraint.
     auto layoutReqSource =
-      source.getSource(*this, type.getDependentType())->viaDerived(*this);
+      source.getSource(*this,
+                       type.getDependentType(*this))->viaDerived(*this);
     addLayoutRequirementDirect(type,
                          LayoutConstraint::getLayoutConstraint(
                              superclass->getClassOrBoundGenericClass()->isObjC()
@@ -3793,7 +3812,8 @@ ConstraintResult GenericSignatureBuilder::addSuperclassRequirementDirect(
                                             ResolvedType type,
                                             Type superclass,
                                             FloatingRequirementSource source) {
-  auto resolvedSource = source.getSource(*this, type.getDependentType());
+  auto resolvedSource =
+    source.getSource(*this, type.getDependentType(*this));
 
   // Record the constraint.
   auto equivClass = type.getEquivalenceClass(*this);
@@ -3835,7 +3855,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
   // The right-hand side needs to be concrete.
   Type constraintType = resolvedConstraint.getAsConcreteType();
   if (!constraintType) {
-    constraintType = resolvedConstraint.getDependentType();
+    constraintType = resolvedConstraint.getDependentType(*this);
     assert(constraintType && "No type to express resolved constraint?");
   }
 
@@ -3846,7 +3866,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
       auto subjectType = subject.dyn_cast<Type>();
       if (!subjectType)
         subjectType = subject.get<PotentialArchetype *>()
-                        ->getDependentType(Impl->GenericParams);
+                        ->getDependentType(getGenericParams());
 
       Impl->HadAnyError = true;
       Diags.diagnose(source.getLoc(), diag::requires_conformance_nonprotocol,
@@ -4096,7 +4116,7 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
   }
 
   // Recursively merge the associated types of T2 into T1.
-  auto dependentT1 = T1->getDependentType({ });
+  auto dependentT1 = T1->getDependentType(getGenericParams());
   for (auto equivT2 : equivClass2Members) {
     for (auto T2Nested : equivT2->NestedTypes) {
       // If T1 is concrete but T2 is not, concretize the nested types of T2.
@@ -4279,14 +4299,17 @@ ConstraintResult GenericSignatureBuilder::addSameTypeRequirementDirect(
   if (pa1 && pa2) {
     return addSameTypeRequirementBetweenArchetypes(
                        pa1, pa2,
-                       source.getSource(*this, paOrT2.getDependentType()));
+                       source.getSource(*this,
+                                        paOrT2.getDependentType(*this)));
     // If just one side is a type parameter, map it to a concrete type.
   } else if (pa1) {
     return addSameTypeRequirementToConcrete(
-                  pa1, t2, source.getSource(*this, paOrT1.getDependentType()));
+                  pa1, t2,
+                  source.getSource(*this, paOrT1.getDependentType(*this)));
   } else if (pa2) {
     return addSameTypeRequirementToConcrete(
-                pa2, t1, source.getSource(*this, paOrT2.getDependentType()));
+                pa2, t1,
+                source.getSource(*this, paOrT2.getDependentType(*this)));
   } else {
     return addSameTypeRequirementBetweenConcrete(t1, t2, source,
                                                  diagnoseMismatch);
@@ -4579,8 +4602,8 @@ namespace swift {
   template<typename T>
   bool operator<(const Constraint<T> &lhs, const Constraint<T> &rhs) {
     // FIXME: Awful.
-    auto lhsSource = lhs.getSubjectDependentType();
-    auto rhsSource = rhs.getSubjectDependentType();
+    auto lhsSource = lhs.getSubjectDependentType({ });
+    auto rhsSource = rhs.getSubjectDependentType({ });
     if (int result = compareDependentTypes(lhsSource, rhsSource))
       return result < 0;
 
@@ -4674,6 +4697,7 @@ namespace {
 /// protocol.
 static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
                                       EquivalenceClass *equivClass) {
+  auto genericParams = builder.getGenericParams();
   auto existingMembers = equivClass->members;
   for (auto pa : existingMembers) {
     // Make sure that there are only associated types that chain up to the
@@ -4688,7 +4712,7 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
     }
     if (foundNonAssociatedType) continue;
 
-    auto dependentType = pa->getDependentType({ });
+    auto dependentType = pa->getDependentType(genericParams);
     for (const auto &conforms : equivClass->conformsTo) {
       auto proto = conforms.first;
 
@@ -4851,7 +4875,7 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
 
           Diags.diagnose(source->source->getLoc(),
                          diag::recursive_superclass_constraint,
-                         source->getSubjectDependentType(),
+                         source->getSubjectDependentType(genericParams),
                          equivClass.superclass);
         }
 
@@ -5068,6 +5092,7 @@ namespace {
                          ProtocolDecl *proto,
                          bool dropDerivedViaConcrete = true,
                          bool allCanBeSelfDerived = false) {
+    auto genericParams = builder.getGenericParams();
     bool anyDerivedViaConcrete = false;
     Optional<Constraint<T>> remainingConcrete;
     SmallVector<Constraint<T>, 4> minimalSources;
@@ -5078,7 +5103,7 @@ namespace {
           auto minimalSource =
             constraint.source->getMinimalConformanceSource(
                          builder,
-                         constraint.getSubjectDependentType(),
+                         constraint.getSubjectDependentType(genericParams),
                          proto, derivedViaConcrete);
           if (minimalSource != constraint.source) {
             // The minimal source is smaller than the original source, so the
@@ -5176,7 +5201,8 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
     Diags.diagnose(representativeConstraint->source->getLoc(),
                    otherNoteDiag,
                    representativeConstraint->source->classifyDiagKind(),
-                   representativeConstraint->getSubjectDependentType(),
+                   representativeConstraint->getSubjectDependentType(
+                                                               genericParams),
                    diagValue(representativeConstraint->value));
   };
 
@@ -5219,7 +5245,8 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
       if (constraint.source->getLoc().isValid()) {
         Impl->HadAnyError = true;
 
-        auto subject = getSubjectType(constraint.getSubjectDependentType());
+        auto subject =
+          getSubjectType(constraint.getSubjectDependentType(genericParams));
         Diags.diagnose(constraint.source->getLoc(), *conflictingDiag,
                        subject.first, subject.second,
                        diagValue(constraint.value),
@@ -5236,7 +5263,8 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
         Impl->HadAnyError = true;
 
         auto subject =
-          getSubjectType(representativeConstraint->getSubjectDependentType());
+          getSubjectType(
+            representativeConstraint->getSubjectDependentType(genericParams));
         Diags.diagnose(representativeConstraint->source->getLoc(),
                        *conflictingDiag,
                        subject.first, subject.second,
@@ -5258,7 +5286,7 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
           representativeConstraint->source->shouldDiagnoseRedundancy(false)) {
         Diags.diagnose(constraint.source->getLoc(),
                        redundancyDiag,
-                       constraint.getSubjectDependentType(),
+                       constraint.getSubjectDependentType(genericParams),
                        diagValue(constraint.value));
 
         noteRepresentativeConstraint();
@@ -5461,7 +5489,8 @@ static void computeDerivedSameTypeComponents(
   // per component.
   for (const auto &concrete : equivClass->concreteTypeConstraints) {
     // Dig out the component associated with constraint.
-    Type subjectType = concrete.getSubjectDependentType();
+    Type subjectType =
+      concrete.getSubjectDependentType(builder.getGenericParams());
     auto subjectPA = concrete.realizeSubjectPotentialArchetype(builder);
     assert(componentOf.count(subjectPA) > 0);
     auto &component = components[componentOf[subjectPA]];
@@ -5523,7 +5552,7 @@ namespace {
 }
 
 void IntercomponentEdge::dump() const {
-  llvm::errs() << constraint.getSubjectDependentType().getString() << " -- "
+  llvm::errs() << constraint.getSubjectDependentType({ }).getString() << " -- "
     << constraint.value->getDebugName() << ": ";
   constraint.source->print(llvm::errs(), nullptr);
   llvm::errs() << "\n";
@@ -5674,8 +5703,9 @@ static void collapseSameTypeComponentsThroughDelayedRequirements(
     // We found a potential archetype in another equivalence class. Treat it
     // as a "virtual" component representing that potential archetype's
     // equivalence class.
+    auto genericParams = builder.getGenericParams();
     return getTypeVirtualComponent(
-                             pa->getRepresentative()->getDependentType({ }));
+             pa->getRepresentative()->getDependentType(genericParams));
   };
 
   /// Local function to retrieve the component with which the given type is
@@ -5882,7 +5912,7 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
         if (constraint.source->shouldDiagnoseRedundancy(true)) {
           Diags.diagnose(constraint.source->getLoc(),
                          diag::redundant_same_type_constraint,
-                         constraint.getSubjectDependentType(),
+                         constraint.getSubjectDependentType(genericParams),
                          constraint.value->getDependentType(genericParams));
         }
 
@@ -5997,12 +6027,12 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
 
         Diags.diagnose(lhs.constraint.source->getLoc(),
                        diag::redundant_same_type_constraint,
-                       lhs.constraint.getSubjectDependentType(),
+                       lhs.constraint.getSubjectDependentType(genericParams),
                        lhs.constraint.value->getDependentType(genericParams));
         Diags.diagnose(rhs.constraint.source->getLoc(),
                        diag::previous_same_type_constraint,
                        rhs.constraint.source->classifyDiagKind(),
-                       rhs.constraint.getSubjectDependentType(),
+                       rhs.constraint.getSubjectDependentType(genericParams),
                        rhs.constraint.value->getDependentType(genericParams));
         return true;
       }),
@@ -6023,14 +6053,16 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
             firstEdge.constraint.source->shouldDiagnoseRedundancy(false)) {
           Diags.diagnose(edge.constraint.source->getLoc(),
                          diag::redundant_same_type_constraint,
-                         edge.constraint.getSubjectDependentType(),
+                         edge.constraint.getSubjectDependentType(
+                                                          genericParams),
                          edge.constraint.value->getDependentType(
                                                           genericParams));
 
           Diags.diagnose(firstEdge.constraint.source->getLoc(),
                          diag::previous_same_type_constraint,
                          firstEdge.constraint.source->classifyDiagKind(),
-                         firstEdge.constraint.getSubjectDependentType(),
+                         firstEdge.constraint.getSubjectDependentType(
+                                                          genericParams),
                          firstEdge.constraint.value->getDependentType(
                                                           genericParams));
         }
@@ -6137,20 +6169,22 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
       Impl->HadAnyError = true;
       if (existing) {
         Diags.diagnose(existing->source->getLoc(), diag::type_does_not_inherit,
-                       existing->getSubjectDependentType(),
+                       existing->getSubjectDependentType(getGenericParams()),
                        existing->value, equivClass->superclass);
 
         if (representativeConstraint.source->getLoc().isValid()) {
           Diags.diagnose(representativeConstraint.source->getLoc(),
                          diag::superclass_redundancy_here,
                          representativeConstraint.source->classifyDiagKind(),
-                         representativeConstraint.getSubjectDependentType(),
+                         representativeConstraint.getSubjectDependentType(
+                                                              genericParams),
                          equivClass->superclass);
         }
       } else if (representativeConstraint.source->getLoc().isValid()) {
         Diags.diagnose(representativeConstraint.source->getLoc(),
                        diag::type_does_not_inherit,
-                       representativeConstraint.getSubjectDependentType(),
+                       representativeConstraint.getSubjectDependentType(
+                                                              genericParams),
                        equivClass->concreteType, equivClass->superclass);
       }
     } else if (representativeConstraint.source->shouldDiagnoseRedundancy(true)
@@ -6159,13 +6193,14 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
       // It does fulfill the requirement; diagnose the redundancy.
       Diags.diagnose(representativeConstraint.source->getLoc(),
                      diag::redundant_superclass_constraint,
-                     representativeConstraint.getSubjectDependentType(),
+                     representativeConstraint.getSubjectDependentType(
+                                                              genericParams),
                      representativeConstraint.value);
 
       Diags.diagnose(existing->source->getLoc(),
                      diag::same_type_redundancy_here,
                      existing->source->classifyDiagKind(),
-                     existing->getSubjectDependentType(),
+                     existing->getSubjectDependentType(genericParams),
                      existing->value);
     }
   }
@@ -6224,7 +6259,7 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
   SmallVector<PotentialArchetype *, 8> archetypes;
   for (auto &equivClass : Impl->EquivalenceClasses) {
     if (equivClass.derivedSameTypeComponents.empty()) {
-      checkSameTypeConstraints(Impl->GenericParams,
+      checkSameTypeConstraints(getGenericParams(),
                                equivClass.members.front()->getRepresentative());
     }
 
@@ -6237,6 +6272,7 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
   llvm::array_pod_sort(archetypes.begin(), archetypes.end(),
                        compareDependentTypes);
 
+  auto genericParams = getGenericParams();
   for (auto *archetype : archetypes) {
     // Check whether this archetype is one of the anchors within its
     // connected component. If so, we may need to emit a same-type constraint.
@@ -6269,7 +6305,7 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
           knownAnchor->concreteTypeSource
             ? knownAnchor->concreteTypeSource
             : RequirementSource::forAbstract(*this,
-                                             archetype->getDependentType({ }));
+                             archetype->getDependentType(getGenericParams()));
 
         // Drop recursive and invalid concrete-type constraints.
         if (equivClass->recursiveConcreteType ||
@@ -6289,11 +6325,13 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
         // to the next.
         // FIXME: Distinguish between explicit and inferred here?
         auto otherPA = nextAnchor->anchor;
-        deferredSameTypeRequirement = [&f, archetype, otherPA, this] {
-          f(RequirementKind::SameType, archetype, otherPA,
-            RequirementSource::forAbstract(*this,
-                                           archetype->getDependentType({ })));
-        };
+        deferredSameTypeRequirement =
+          [&f, archetype, otherPA, this, genericParams] {
+            f(RequirementKind::SameType, archetype, otherPA,
+              RequirementSource::forAbstract(
+                                     *this,
+                                     archetype->getDependentType(genericParams)));
+          };
       }
     }
     SWIFT_DEFER {
@@ -6314,8 +6352,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
       if (!bestSource)
         bestSource =
-          RequirementSource::forAbstract(*this,
-                                         archetype->getDependentType({ }));
+          RequirementSource::forAbstract(
+                                 *this,
+                                 archetype->getDependentType(genericParams));
 
       f(RequirementKind::Superclass, archetype, equivClass->superclass,
         *bestSource);
@@ -6330,8 +6369,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
                           });
       if (!bestSource)
         bestSource =
-          RequirementSource::forAbstract(*this,
-                                         archetype->getDependentType({ }));
+          RequirementSource::forAbstract(
+                                   *this,
+                                   archetype->getDependentType(genericParams));
 
       f(RequirementKind::Layout, archetype, equivClass->layout, *bestSource);
     }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2925,8 +2925,8 @@ Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
 }
 
 ASTContext &PotentialArchetype::getASTContext() const {
-  if (auto builder = parentOrBuilder.dyn_cast<GenericSignatureBuilder *>())
-    return builder->getASTContext();
+  if (auto context = parentOrContext.dyn_cast<ASTContext *>())
+    return *context;
 
   return getResolvedType()->getASTContext();
 }
@@ -3068,10 +3068,6 @@ GenericSignatureBuilder::GenericSignatureBuilder(
     for (auto &gp : Impl->GenericParams) {
       gp = gp->getCanonicalType()->castTo<GenericTypeParamType>();
     }
-
-    // Point each root potential archetype at this generic signature builder.
-    for (auto pa : Impl->PotentialArchetypes)
-      pa->replaceBuilder(this);
   }
 }
 
@@ -3299,7 +3295,7 @@ void GenericSignatureBuilder::addGenericParameter(GenericTypeParamType *GenericP
 
   // Create a potential archetype for this type parameter.
   void *mem = Impl->Allocator.Allocate<PotentialArchetype>();
-  auto PA = new (mem) PotentialArchetype(this, GenericParam);
+  auto PA = new (mem) PotentialArchetype(getASTContext(), GenericParam);
   Impl->GenericParams.push_back(GenericParam);
   Impl->PotentialArchetypes.push_back(PA);
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -200,6 +200,9 @@ static int compareDependentTypes(PotentialArchetype * const* pa,
   return compareDependentTypes(pa, pb, /*outermost=*/true);
 }
 
+static int compareDependentTypes(Type type1, Type type2,
+                                 bool outermost = true);
+
 namespace {
   /// A node in the equivalence class, used for visualization.
   struct EquivalenceClassVizNode {
@@ -220,10 +223,8 @@ namespace {
 
     void advance() {
       while (base != baseEnd) {
-        // FIXME: Only legitimate current use of getBuilder().
-        auto subjectPA =
-          base->realizeSubjectPotentialArchetype(*base->value->getBuilder());
-       if (compareDependentTypes(&subjectPA, &base->value) <= 0)
+       if (compareDependentTypes(base->getSubjectDependentType(),
+                                 base->value->getDependentType({ })) <= 0)
          break;
 
         ++base;
@@ -2428,7 +2429,7 @@ static bool hasConcreteDecls(const PotentialArchetype *pa) {
 
 /// Canonical ordering for dependent types.
 static int compareDependentTypes(Type type1, Type type2,
-                                 bool outermost = true) {
+                                 bool outermost) {
   // Fast-path check for equality.
   if (type1->isEqual(type2)) return 0;
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1489,10 +1489,12 @@ std::string GenericSignatureBuilder::PotentialArchetype::getDebugName() const {
 
   auto parent = getParent();
   if (!parent) {
-    return GenericTypeParamType::get(getGenericParamKey().Depth,
-                                     getGenericParamKey().Index,
-                                     getBuilder()->getASTContext())->getName()
-             .str();
+    static const char *tau = u8"\u03C4_";
+
+    llvm::raw_svector_ostream os(result);
+    os << tau << getGenericParamKey().Depth << '_'
+       << getGenericParamKey().Index;
+    return os.str().str();
   }
 
   // Nested types.
@@ -1616,11 +1618,10 @@ public:
 };
 
 bool EquivalenceClass::recordConformanceConstraint(
+                                 GenericSignatureBuilder &builder,
                                  ResolvedType type,
                                  ProtocolDecl *proto,
                                  FloatingRequirementSource source) {
-  auto &builder = *members.front()->getBuilder();
-
   // If we haven't seen a conformance to this protocol yet, add it.
   bool inserted = false;
   auto known = conformsTo.find(proto);
@@ -1641,7 +1642,7 @@ bool EquivalenceClass::recordConformanceConstraint(
     // Resolve any associated type members.
     for (auto assocType : proto->getAssociatedTypeMembers()) {
       type.realizePotentialArchetype(builder)->updateNestedTypeForConformance(
-                                        assocType,
+                                        builder, assocType,
                                         ArchetypeResolutionKind::AlreadyKnown);
     }
   }
@@ -1783,6 +1784,7 @@ static int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
 }
 
 TypeDecl *EquivalenceClass::lookupNestedType(
+                             GenericSignatureBuilder &builder,
                              Identifier name,
                              SmallVectorImpl<TypeDecl *> *otherConcreteTypes) {
   // Populates the result structures from the given cache entry.
@@ -1892,8 +1894,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
 
   // Infer same-type constraints among same-named associated type anchors.
   if (assocTypeAnchors.size() > 1) {
-    auto &builder = *members.front()->getBuilder();
-    auto anchorType = getAnchor({ });
+    auto anchorType = getAnchor(builder, { });
     auto inferredSource = FloatingRequirementSource::forInferred(nullptr);
     for (auto assocType : assocTypeAnchors) {
       if (assocType == bestAssocType) continue;
@@ -1937,9 +1938,9 @@ TypeDecl *EquivalenceClass::lookupNestedType(
 }
 
 Type EquivalenceClass::getAnchor(
+                            GenericSignatureBuilder &builder,
                             ArrayRef<GenericTypeParamType *> genericParams) {
-  auto anchorPA =
-    members.front()->getArchetypeAnchor(*members.front()->getBuilder());
+  auto anchorPA = members.front()->getArchetypeAnchor(builder);
   return anchorPA->getDependentType(genericParams);
 }
 
@@ -1949,7 +1950,7 @@ Type EquivalenceClass::getTypeInContext(GenericSignatureBuilder &builder,
     genericEnv->getGenericParams();
 
   // The anchor descr
-  Type anchor = getAnchor(genericParams);
+  Type anchor = getAnchor(builder, genericParams);
 
   // If this equivalence class is mapped to a concrete type, produce that
   // type.
@@ -2271,7 +2272,7 @@ GenericSignatureBuilder::resolveConcreteConformance(ResolvedType type,
   }
 
   concreteSource = concreteSource->viaConcrete(*this, *conformance);
-  equivClass->recordConformanceConstraint(type, proto, concreteSource);
+  equivClass->recordConformanceConstraint(*this, type, proto, concreteSource);
   addConditionalRequirements(*this, *conformance);
   return concreteSource;
 }
@@ -2302,7 +2303,7 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
 
   superclassSource =
     superclassSource->viaSuperclass(*this, *conformance);
-  equivClass->recordConformanceConstraint(type, proto, superclassSource);
+  equivClass->recordConformanceConstraint(*this, type, proto, superclassSource);
   addConditionalRequirements(*this, *conformance);
   return superclassSource;
 }
@@ -2653,7 +2654,7 @@ static void concretizeNestedTypeFromConcreteParent(
   // add it now; it was elided earlier.
   if (parentEquiv->conformsTo.count(proto) == 0) {
     auto source = parentEquiv->concreteTypeConstraints.front().source;
-    parentEquiv->recordConformanceConstraint(parent, proto, source);
+    parentEquiv->recordConformanceConstraint(builder, parent, proto, source);
   }
 
   assert(parentEquiv->conformsTo.count(proto) > 0 &&
@@ -2695,18 +2696,19 @@ PotentialArchetype *PotentialArchetype::getNestedArchetypeAnchor(
                                            ArchetypeResolutionKind kind) {
   SmallVector<TypeDecl *, 4> concreteDecls;
   auto bestType =
-    getOrCreateEquivalenceClass()->lookupNestedType(name, &concreteDecls);
+    getOrCreateEquivalenceClass()->lookupNestedType(builder, name,
+                                                    &concreteDecls);
 
   // We didn't find any type with this name.
   if (!bestType) return nullptr;
 
   // Resolve the nested type.
-  auto resultPA = updateNestedTypeForConformance(bestType, kind);
+  auto resultPA = updateNestedTypeForConformance(builder, bestType, kind);
 
   // Update for all of the concrete decls with this name, which will introduce
   // various same-type constraints.
   for (auto concreteDecl : concreteDecls) {
-    (void)updateNestedTypeForConformance(concreteDecl,
+    (void)updateNestedTypeForConformance(builder, concreteDecl,
                                          ArchetypeResolutionKind::WellFormed);
   }
 
@@ -2715,6 +2717,7 @@ PotentialArchetype *PotentialArchetype::getNestedArchetypeAnchor(
 
 
 PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
+                                              GenericSignatureBuilder &builder,
                                               TypeDecl *type,
                                               ArchetypeResolutionKind kind) {
   if (!type) return nullptr;
@@ -2731,7 +2734,7 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
   // process delayed requirements if anything changed.
   SWIFT_DEFER {
     if (kind == ArchetypeResolutionKind::CompleteWellFormed)
-      getBuilder()->processDelayedRequirements();
+      builder.processDelayedRequirements();
   };
 
   Identifier name = assocType ? assocType->getName() : concreteDecl->getName();
@@ -2746,7 +2749,6 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
   PotentialArchetype *resultPA = nullptr;
   auto knownNestedTypes = NestedTypes.find(name);
   bool shouldUpdatePA = false;
-  auto &builder = *getBuilder();
   if (knownNestedTypes != NestedTypes.end()) {
     for (auto existingPA : knownNestedTypes->second) {
       // Do we have an associated-type match?
@@ -3091,7 +3093,8 @@ static Type resolveDependentMemberTypes(GenericSignatureBuilder &builder,
       if (!parentEquivClass)
         return ErrorType::get(depTy);
 
-      auto memberType = parentEquivClass->lookupNestedType(depTy->getName());
+      auto memberType =
+        parentEquivClass->lookupNestedType(builder, depTy->getName());
       if (!memberType)
         return ErrorType::get(depTy);
 
@@ -3137,7 +3140,8 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
     if (auto assocType = depMemTy->getAssocType()) {
       nestedTypeDecl = assocType;
     } else {
-      nestedTypeDecl = baseEquivClass->lookupNestedType(depMemTy->getName());
+      nestedTypeDecl =
+        baseEquivClass->lookupNestedType(*this, depMemTy->getName());
       if (!nestedTypeDecl) {
         return ResolvedType::forUnresolved(baseEquivClass);
       }
@@ -3155,7 +3159,8 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
     }
 
     auto nestedPA =
-      basePA->updateNestedTypeForConformance(nestedTypeDecl, resolutionKind);
+      basePA->updateNestedTypeForConformance(*this, nestedTypeDecl,
+                                             resolutionKind);
     if (!nestedPA)
       return ResolvedType::forUnresolved(baseEquivClass);
 
@@ -3613,7 +3618,7 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   // Add the conformance requirement, bailing out earlier if we've already
   // seen it.
   auto equivClass = type.getEquivalenceClass();
-  if (!equivClass->recordConformanceConstraint(type, proto, source))
+  if (!equivClass->recordConformanceConstraint(*this, type, proto, source))
     return ConstraintResult::Resolved;
 
   auto resolvedSource = source.getSource(*this, type.getDependentType());
@@ -3960,6 +3965,7 @@ void GenericSignatureBuilder::addedNestedType(PotentialArchetype *nestedPA) {
 
   PotentialArchetype *existingPA =
     parentRepPA->updateNestedTypeForConformance(
+                                        *this,
                                         nestedPA->getResolvedType(),
                                         ArchetypeResolutionKind::WellFormed);
 
@@ -4071,7 +4077,7 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
   // Add all of the protocol conformance requirements of T2 to T1.
   if (equivClass2) {
     for (const auto &entry : equivClass2->conformsTo) {
-      equivClass->recordConformanceConstraint(T1, entry.first,
+      equivClass->recordConformanceConstraint(*this, T1, entry.first,
                                               entry.second.front().source);
 
       auto &constraints1 = equivClass->conformsTo[entry.first];

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -142,7 +142,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 
   // Look for a nested type with the given name.
   if (auto nestedType =
-          baseEquivClass->lookupNestedType(ref->getIdentifier())) {
+          baseEquivClass->lookupNestedType(builder, ref->getIdentifier())) {
     // Record the type we found.
     ref->setValue(nestedType, nullptr);
   } else {

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -37,22 +37,22 @@ func acceptP3<T: P3>(_: T) { }
 
 
 func testPaths1<T: P2 & P4>(_ t: T) {
-	// CHECK: Conformance access path for T.AssocP2.AssocP1: P0 is T: P2 -> τ_0_0.AssocP2: P1 -> τ_0_0.AssocP1: Q0 -> τ_0_0: P0
+	// CHECK: Conformance access path for T.AssocP2.AssocP1: P0 is τ_0_0: P2 -> τ_0_0.AssocP2: P1 -> τ_0_0.AssocP1: Q0 -> τ_0_0: P0
 	acceptP0(t.getAssocP2().getAssocP1())
-	// CHECK: Conformance access path for T.AssocP3: P0 is T: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
+	// CHECK: Conformance access path for T.AssocP3: P0 is τ_0_0: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
 	acceptP0(t.getAssocP3())
 }
 
 func testPaths2<U: P2 & P4>(_ t: U) where U.AssocP3 == U.AssocP2.AssocP1 {
-	// CHECK: Conformance access path for U.AssocP3: P0 is U: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
+	// CHECK: Conformance access path for U.AssocP3: P0 is τ_0_0: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
 	acceptP0(t.getAssocP2().getAssocP1())
 }
 
 func testPaths3<V: P5>(_ v: V) {
-	// CHECK: Conformance access path for V.AssocP3: P0 is V: P5 -> τ_0_0.AssocP3: Q0 -> τ_0_0: P0
+	// CHECK: Conformance access path for V.AssocP3: P0 is τ_0_0: P5 -> τ_0_0.AssocP3: Q0 -> τ_0_0: P0
 	acceptP0(v.getAssocP3())
 
-	// CHECK: Conformance access path for V.AssocP3: Q0 is V: P5 -> τ_0_0.AssocP3: Q0
+	// CHECK: Conformance access path for V.AssocP3: Q0 is τ_0_0: P5 -> τ_0_0.AssocP3: Q0
 	acceptQ0(v.getAssocP3())
 }
 
@@ -68,6 +68,6 @@ protocol P5Unordered {
 }
 
 func testUnorderedP5_P6<W: P6Unordered>(_ w: W) {
-	// CHECK: Conformance access path for W.A: P0 is W: P6Unordered -> τ_0_0: P5Unordered -> τ_0_0.A: P0
+	// CHECK: Conformance access path for W.A: P0 is τ_0_0: P6Unordered -> τ_0_0: P5Unordered -> τ_0_0.A: P0
 	acceptP0(w.getA())
 }


### PR DESCRIPTION
Start delaying the realization of potential archetypes in a few ways:

* `Constraint` can now store a dependent type that will be lazily (and explicitly) realized to a potential archetype
* The `RequirementSource` APIs traffic mostly in dependent types now