### PR TITLE
[PrintAsObjC] Don't define char{16,32}_t in C++-pre-11

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -2385,7 +2385,7 @@ public:
            "# define SWIFT_TYPEDEFS 1\n"
            "# if __has_include(<uchar.h>)\n"
            "#  include <uchar.h>\n"
-           "# elif !defined(__cplusplus) || __cplusplus < 201103L\n"
+           "# elif !defined(__cplusplus)\n"
            "typedef uint_least16_t char16_t;\n"
            "typedef uint_least32_t char32_t;\n"
            "# endif\n"

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/empty.h
 // RUN: %FileCheck %s < %t/empty.h
+
 // RUN: %check-in-clang -std=c99 %t/empty.h
+// RUN: %check-in-clang -std=c11 %t/empty.h
+// RUN: %check-in-clang++ -std=c++98 %t/empty.h
+// RUN: %check-in-clang++ -std=c++14 %t/empty.h
+
 // RUN: %check-in-clang -std=c99 -fno-modules -Qunused-arguments %t/empty.h
 // RUN: not %check-in-clang -I %S/Inputs/clang-headers %t/empty.h 2>&1 | %FileCheck %s --check-prefix=CUSTOM-OBJC-PROLOGUE
 

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -8,3 +8,11 @@ config.substitutions.insert(0, ('%check-in-clang',
   '-Wno-auto-import '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )
+
+config.substitutions.insert(0, ('%check-in-clang\+\+',
+  '%%clang++ -fsyntax-only -x objective-c++-header -fobjc-arc '
+  '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
+  '-Wno-auto-import -Wno-variadic-macros -Wno-c++98-compat-pedantic '
+  '-Wno-unused-command-line-argument ' # for -fmodules-cache-path
+  '-I %%clang-include-dir '
+  '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )


### PR DESCRIPTION
Turns out libc++ already defines compatibility typedefs in this case, and we don't care about any other C++ stdlibs on Apple platforms at the moment.

rdar://problem/34861807