### PR TITLE
Rename: OS X -> macOS

### DIFF
--- a/apinotes/README.md
+++ b/apinotes/README.md
@@ -29,7 +29,7 @@ and architecture.
 
 Platform  | Path
 :------------- | :-------------
-  OSX | `$SWIFT_EXEC/lib/swift/macosx/`
+  macOS | `$SWIFT_EXEC/lib/swift/macosx/`
   iOS (32-bit) | `$SWIFT_EXEC/lib/swift/iphoneos/32`
   iOS (64-bit) | `$SWIFT_EXEC/lib/swift/iphoneos`
   iOS Simulator (32-bit) | `$SWIFT_EXEC/lib/swift/iphonesimulator/32`
@@ -44,7 +44,7 @@ Swift compiler itself need not be recompiled except in rare cases
 where the changes affect how the SDK overlays are built. To recompile
 API notes for a given module `$MODULE` and place them into their
 
-### OS X
+### macOS
 ```
 xcrun swift -apinotes -yaml-to-binary -target x86_64-apple-macosx10.10 -o $SWIFT_EXEC/lib/swift/macosx/$MODULE.apinotesc $MODULE.apinotes
 ```


### PR DESCRIPTION
Replace  "**OS X**" and "**OSX**" to "**macOS**" in _apinotes/README.md_.