### PR TITLE
Fix crash parsing #available with missing version.

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1123,7 +1123,8 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
       // also in the shorthand syntax and provide a more specific diagnostic if
       // that's not the case.
       if (Tok.isIdentifierOrUnderscore() &&
-          !peekToken().isAny(tok::integer_literal, tok::floating_literal)) {
+          !peekToken().isAny(tok::integer_literal, tok::floating_literal) &&
+          !Specs.empty()) {
         auto Text = Tok.getText();
         if (Text == "deprecated" || Text == "renamed" || Text == "introduced" ||
             Text == "message" || Text == "obsoleted" || Text == "unavailable") {

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -55,6 +55,9 @@ if #available(OSX 10.51, iOS 8.0) { }  // expected-error {{must handle potential
 if #available(iOS 8.0, *) {
 }
 
+if #available(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+}
+	
 // Want to make sure we can parse this. Perhaps we should not let this validate, though.
 if #available(*) {
 }


### PR DESCRIPTION
In a multipart #available spec list, don't attempt to look at the SpecResult for the previous part if there wasn't one (a missing version number for example).

Added a test case that asserted before this change.

Resolves [SR-6195](https://bugs.swift.org/browse/SR-6195).
