### PR TITLE
[Sema] When subscripting with a keypath, check for the path being an IUO.

### DIFF
--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -376,6 +376,11 @@ class CC {
 func testKeyPathOptional() {
   _ = \AA.c?.i
   _ = \AA.c!.i
+
+  // SR-6198
+  let path: KeyPath<CC,Int>! = \CC.i
+  let cc = CC()
+  _ = cc[keyPath: path]
 }
 
 func testLiteralInAnyContext() {


### PR DESCRIPTION
Resolves [SR-6198](https://bugs.swift.org/browse/SR-6198).
