### PR TITLE
[NFC] More InOut Cleanup

### DIFF
--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -72,9 +72,9 @@ AbstractionPattern TypeConverter::getAbstractionPattern(VarDecl *var) {
   if (auto sig = var->getDeclContext()->getGenericSignatureOfContext())
     genericSig = sig->getCanonicalSignature();
 
-  CanType swiftType = var->getInterfaceType()->getCanonicalType();
-  if (auto inout = dyn_cast<InOutType>(swiftType))
-    swiftType = inout.getObjectType();
+  CanType swiftType = var->getInterfaceType()
+                         ->getInOutObjectType()
+                         ->getCanonicalType();
 
   if (auto clangDecl = var->getClangDecl()) {
     auto clangType = getClangType(clangDecl);

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -433,18 +433,14 @@ public:
       return LValue::forValue(self, SubstSelfType);
     }
 
+    auto selfParam = computeSelfParam(Witness);
     CanType witnessSelfType =
-      computeSelfParam(Witness).getType()->getCanonicalType(GenericSig);
+      selfParam.getPlainType()->getCanonicalType(GenericSig);
     witnessSelfType = getSubstWitnessInterfaceType(witnessSelfType);
-
-    // Get the inout object type, but remember whether we needed to.
-    auto witnessSelfInOutType = dyn_cast<InOutType>(witnessSelfType);
-    if (witnessSelfInOutType)
-      witnessSelfType = witnessSelfInOutType.getObjectType();
 
     // If the witness wants an inout and the types match, just use
     // this value.
-    if (witnessSelfInOutType && witnessSelfType == SubstSelfType) {
+    if (selfParam.isInOut() && witnessSelfType == SubstSelfType) {
       return LValue::forValue(self, witnessSelfType);
     }
 
@@ -462,7 +458,7 @@ public:
     }
 
     // Put the object back in memory if necessary.
-    if (witnessSelfInOutType) {
+    if (selfParam.isInOut()) {
       self = self.materialize(SGF, loc);
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1293,8 +1293,7 @@ namespace {
       // Create an overload choice referencing this declaration and immediately
       // resolve it. This records the overload for use later.
       auto tv = CS.createTypeVariable(locator,
-                                      TVO_CanBindToLValue |
-                                      TVO_CanBindToInOut);
+                                      TVO_CanBindToLValue);
       CS.resolveOverload(locator, tv,
                          OverloadChoice(Type(), E->getDecl(),
                                         E->getFunctionRefKind()),
@@ -1635,8 +1634,9 @@ namespace {
       SmallVector<TupleTypeElt, 4> elements;
       elements.reserve(expr->getNumElements());
       for (unsigned i = 0, n = expr->getNumElements(); i != n; ++i) {
-        auto ty = CS.getType(expr->getElement(i));
-        auto flags = ParameterTypeFlags().withInOut(ty->is<InOutType>());
+        auto *elt = expr->getElement(i);
+        auto ty = CS.getType(elt);
+        auto flags = ParameterTypeFlags().withInOut(elt->isSemanticallyInOutExpr());
         elements.push_back(TupleTypeElt(ty->getInOutObjectType(),
                                         expr->getElementName(i), flags));
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4444,11 +4444,8 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
   // T <p U ===> T[] <a UnsafeMutablePointer<U>
   case ConversionRestrictionKind::ArrayToPointer: {
     addContextualScore();
-    auto obj1 = type1;
     // Unwrap an inout type.
-    if (auto inout1 = obj1->getAs<InOutType>()) {
-      obj1 = inout1->getObjectType();
-    }
+    auto obj1 = type1->getInOutObjectType();
     
     obj1 = getFixedTypeRecursive(obj1, false, false);
     

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -370,7 +370,8 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
     // Bindings specify the arguments that source the parameter.  The only case
     // this returns a non-singular value is when there are varargs in play.
     auto &bindings = paramBindings[i];
-    auto paramType = getParamResultType(candArgs[i]);
+    auto param = candArgs[i];
+    auto paramType = getParamResultType(param);
     
     for (auto argNo : bindings) {
       auto argType = getParamResultType(actualArgs[argNo]);
@@ -392,7 +393,7 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
         auto matchType = paramType;
         // If the parameter is an inout type, and we have a proper lvalue, match
         // against the type contained therein.
-        if (paramType->is<InOutType>() && argType->is<LValueType>())
+        if (param.isInOut() && argType->is<LValueType>())
           matchType = matchType->getInOutObjectType();
         
         if (candidate.substituted) {

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -675,10 +675,8 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   unsigned inoutCount = 0;
   for (auto C : Captures) {
     if (auto PD = dyn_cast<ParamDecl>(C.getDecl()))
-      if (PD->hasType())
-        if (auto type = PD->getType())
-          if (isa<InOutType>(type.getPointer()))
-            inoutCount++;
+      if (PD->isInOut())
+        inoutCount++;
   }
 
   if (inoutCount > 0) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2179,6 +2179,28 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
   auto resultTy = typeCheckExpression(initializer, DC, contextualType,
                                       contextualPurpose, flags, &listener);
+
+  // If we detected that the initializer would have a non-materializable type,
+  // complain.
+  if (resultTy && listener.isInOut()) {
+    diagnose(pattern->getStartLoc(), diag::var_type_not_materializable,
+             resultTy);
+
+    pattern->setType(ErrorType::get(Context));
+    pattern->forEachVariable([&](VarDecl *var) {
+      // Don't change the type of a variable that we've been able to
+      // compute a type for.
+      if (var->hasType() &&
+          !var->getType()->hasUnboundGenericType() &&
+          !var->getType()->hasError())
+        return;
+
+      var->markInvalid();
+    });
+
+    return true;
+  }
+
   if (resultTy) {
     TypeResolutionOptions options;
     options |= TR_OverrideType;
@@ -2196,7 +2218,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
     // Apply the solution to the pattern as well.
     if (coercePatternToType(pattern, DC, initTy, options,
-                            nullptr, TypeLoc(), listener.isInOut())) {
+                            nullptr, TypeLoc())) {
       return true;
     }
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3984,12 +3984,6 @@ public:
 
   void visitBoundVariable(VarDecl *VD) {
     TC.validateDecl(VD);
-    
-    if (!VD->getType()->isMaterializable()) {
-      TC.diagnose(VD->getStartLoc(), diag::var_type_not_materializable,
-                  VD->getType());
-      VD->markInvalid();
-    }
 
     // Check the behavior.
     checkVarBehavior(VD, TC);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -914,8 +914,7 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
 bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                                       TypeResolutionOptions options,
                                       GenericTypeResolver *resolver,
-                                      TypeLoc tyLoc,
-                                      bool forceInOut) {
+                                      TypeLoc tyLoc) {
 recur:
   if (tyLoc.isNull()) {
     tyLoc = TypeLoc::withoutLoc(type);
@@ -1001,9 +1000,6 @@ recur:
     VarDecl *var = NP->getDecl();
     if (var->isInvalid())
       type = ErrorType::get(Context);
-    if (forceInOut) {
-      var->setSpecifier(VarDecl::Specifier::InOut);
-    }
     var->setType(type->getInOutObjectType());
     // FIXME: wtf
     if (type->hasTypeParameter())

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1799,8 +1799,7 @@ public:
   bool coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                            TypeResolutionOptions options,
                            GenericTypeResolver *resolver = nullptr,
-                           TypeLoc tyLoc = TypeLoc(),
-                           bool forceInOut = false);
+                           TypeLoc tyLoc = TypeLoc());
   bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                             Type type);
 


### PR DESCRIPTION
Trying to do two things here (and do them without hurting anything)

- Remove more uses of `<InOutType>()`
- Make coercing patterns stop resetting specifiers on variables - this was just for a diagnostic anyways.
<strike>- Teach CSBindings what to do with declrefs for closure parameters.</strike>