### PR TITLE
AST: Call setValidationStarted() on synthesized declarations

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -163,6 +163,7 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
                                       Identifier(), argType,
                                       DC);
     PD->setInterfaceType(argType);
+    PD->setValidationStarted();
     PD->setImplicit();
     params.push_back(PD);
   }
@@ -180,6 +181,7 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
                              paramList,
                              TypeLoc::withoutLoc(ResType), DC);
   FD->setInterfaceType(FnType);
+  FD->setValidationStarted();
   FD->setImplicit();
   FD->setAccess(AccessLevel::Public);
   return FD;
@@ -226,6 +228,7 @@ getBuiltinGenericFunction(Identifier Id,
                                       Identifier(),
                                       paramType->getInOutObjectType(), DC);
     PD->setInterfaceType(paramIfaceType->getInOutObjectType());
+    PD->setValidationStarted();
     PD->setImplicit();
     params.push_back(PD);
   }
@@ -244,6 +247,7 @@ getBuiltinGenericFunction(Identifier Id,
                                TypeLoc::withoutLoc(ResBodyType), DC);
     
   func->setInterfaceType(InterfaceType);
+  func->setValidationStarted();
   func->setGenericEnvironment(Env);
   func->setImplicit();
   func->setAccess(AccessLevel::Public);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4315,6 +4315,7 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
                                      Identifier(), loc, C.Id_self, selfType,DC);
   selfDecl->setImplicit();
   selfDecl->setInterfaceType(selfInterfaceType);
+  selfDecl->setValidationStarted();
   return selfDecl;
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -352,6 +352,10 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx)
   ctx.addDestructorCleanup(*this);
   setImplicit();
   setInterfaceType(ModuleType::get(this));
+
+  // validateDecl() should return immediately given a ModuleDecl.
+  setValidationStarted();
+
   setAccess(AccessLevel::Public);
 }
 


### PR DESCRIPTION
This avoids doing unnecessary work in validateDecl().