### PR TITLE
[Sema] Better ambiguity diagnosis in overloaded function calls

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4385,6 +4385,21 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
   return false;
 }
 
+// Extract expression for failed argument number
+static Expr *getFailedArgumentExpr(CalleeCandidateInfo CCI, Expr *argExpr) {
+  if (auto *TE = dyn_cast<TupleExpr>(argExpr))
+    return TE->getElement(CCI.failedArgument.argumentNumber);
+  else if (auto *PE = dyn_cast<ParenExpr>(argExpr)) {
+    assert(CCI.failedArgument.argumentNumber == 0 &&
+           "Unexpected argument #");
+    return PE->getSubExpr();
+  } else {
+    assert(CCI.failedArgument.argumentNumber == 0 &&
+           "Unexpected argument #");
+    return argExpr;
+  }
+}
+
 /// If the candidate set has been narrowed down to a specific structural
 /// problem, e.g. that there are too few parameters specified or that argument
 /// labels don't match up, diagnose that error and return true.
@@ -4449,20 +4464,8 @@ bool FailureDiagnosis::diagnoseParameterErrors(CalleeCandidateInfo &CCI,
     if (CCI.failedArgument.parameterType->is<InOutType>())
       options |= TCC_AllowLValue;
 
-    Expr *badArgExpr;
-    if (auto *TE = dyn_cast<TupleExpr>(argExpr))
-      badArgExpr = TE->getElement(CCI.failedArgument.argumentNumber);
-    else if (auto *PE = dyn_cast<ParenExpr>(argExpr)) {
-      assert(CCI.failedArgument.argumentNumber == 0 &&
-             "Unexpected argument #");
-      badArgExpr = PE->getSubExpr();
-    } else {
-      assert(CCI.failedArgument.argumentNumber == 0 &&
-             "Unexpected argument #");
-      badArgExpr = argExpr;
-    }
-
     // It could be that the argument doesn't conform to an archetype.
+    Expr *badArgExpr = getFailedArgumentExpr(CCI, argExpr);
     if (CCI.diagnoseGenericParameterErrors(badArgExpr))
       return true;
 
@@ -5712,9 +5715,17 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
                                           calleeInfo, argLabels))
     return true;
 
+  // If we have a failure where closeness is an exact match, but there is
+  // still a failed argument, it is because one (or more) of the arguments
+  // types are unresolved.
+  if (calleeInfo.closeness == CC_ExactMatch && calleeInfo.failedArgument.isValid()) {
+    diagnoseAmbiguity(getFailedArgumentExpr(calleeInfo, argExpr));
+    return true;
+  }
+
   if (isContextualConversionFailure(argExpr))
     return false;
-  
+
   // Generate specific error messages for unary operators.
   if (isa<PrefixUnaryExpr>(callExpr) || isa<PostfixUnaryExpr>(callExpr)) {
     assert(!overloadName.empty());

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -470,20 +470,22 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
       
       if (matched)
         continue;
-      
+
       // If the real argument is unresolved, the candidate isn't a mismatch because
-      // the type could be anything, but it's still useful to save the argument as
+      // the type could be anything, but it's still useful to save the argument number as
       // failureInfo.
-      if (!rArgType->hasUnresolvedType()) {
+      if (rArgType->hasUnresolvedType() && !mismatchingArgs) {
+        failureInfo.argumentNumber = argNo;
+      } else {
         if (archetypesMap.empty())
           mismatchesAreNearMisses &= argumentMismatchIsNearMiss(argType, paramType);
         ++mismatchingArgs;
+
+        failureInfo.argumentNumber = argNo;
+        failureInfo.parameterType = paramType;
+        if (paramType->hasTypeParameter())
+          failureInfo.declContext = dc;
       }
-      
-      failureInfo.argumentNumber = argNo;
-      failureInfo.parameterType = paramType;
-      if (paramType->hasTypeParameter())
-        failureInfo.declContext = dc;
     }
   }
   

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift
+
+enum E : String {
+  case foo = "foo"
+  case bar = "bar" // expected-note {{did you mean 'bar'?}}
+}
+func fe(_: E) {}
+func fe(_: Int) {}
+func fe(_: Int, _: E) {}
+func fe(_: Int, _: Int) {}
+
+fe(E.baz) // expected-error {{type 'E' has no member 'baz'}}
+fe(.baz) // expected-error {{reference to member 'baz' cannot be resolved without a contextual type}}
+
+// FIXME: maybe complain about .nope also?
+fe(.nope, .nyet) // expected-error {{reference to member 'nyet' cannot be resolved without a contextual type}}
+
+func fg<T>(_ f: (T) -> T) -> Void {} // expected-note {{in call to function 'fg'}}
+fg({x in x}) // expected-error {{generic parameter 'T' could not be inferred}}
+
+
+// FIXME: Both f & g should complain about ambiguity of arg1, but in both cases the generic member
+// never gets into the list of candidates in the first place.
+struct S {
+  func f<T>(_ i: (T) -> T, _ j: Int) -> Void {}
+  func f(_ d: (Double) -> Double) -> Void {}
+  func test() -> Void {
+    f({x in x}, 2) // expected-error {{extra argument in call}}
+  }
+  
+  func g<T>(_ a: T, _ b: Int) -> Void {}
+  func g(_ a: String) -> Void {}
+  func test2() -> Void {
+    g(.notAThing, 7) // expected-error {{extra argument in call}}
+  }
+  
+  func h(_ a: Int, _ b: Int) -> Void {}
+  func h(_ a: String) -> Void {}
+  func test3() -> Void {
+    h(.notAThing, 3) // expected-error {{type 'Int' has no member 'notAThing'}}
+    h(.notAThing) // expected-error {{type 'String' has no member 'notAThing'}}
+  }
+}
+

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -118,8 +118,8 @@ func rdar32431165_1(_: Int, _: E_32431165) {}
 rdar32431165_1(E_32431165.baz)
 // expected-error@-1 {{type 'E_32431165' has no member 'baz'}}
 
-rdar32431165_1(.baz) // FIXME: the error should be {{reference to member 'baz' cannot be resolved without a contextual type}}
-// expected-error@-1 {{expression type '()' is ambiguous without more context}}
+rdar32431165_1(.baz)
+// expected-error@-1 {{reference to member 'baz' cannot be resolved without a contextual type}}
 
 rdar32431165_1("")
 // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'E_32431165'}} {{15-15=E_32431165(rawValue: }} {{19-19=)}}


### PR DESCRIPTION
Save unresolved argument number from callee candidate info, use it to diagnose ambiguity sooner and more specifically.