### PR TITLE
[lsan] Split the preset for lsan into stdlib -O and -Onone presets.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -900,12 +900,26 @@ build-subdir=buildbot_incremental_asan
 
 enable-asan
 
-[preset: buildbot_incremental_linux,lsan]
+# This does not currently pass due to leakers in the optimizer.
+[preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=RDA,test=no]
 build-subdir=buildbot_incremental_lsan
 
 release-debuginfo
 assertions
 enable-lsan
+
+dash-dash
+
+build-ninja
+reconfigure
+
+[preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=DA,test=no]
+build-subdir=buildbot_incremental_lsan
+
+release-debuginfo
+assertions
+enable-lsan
+debug-swift-stdlib
 
 dash-dash
 


### PR DESCRIPTION
The current lsan preset used by the bot assumes -O. This is incorrect since:

1. It is a currently known problem that the -O build of swift leaks in the
optimizer on linux.

2. The point of the bot is to ensure that when compiling the stdlib at -Onone,
we are leaks clean.

For more information about the bot see below. Once this lands, I will update the
bot to use the new split preset.

rdar://32876901

----

For those who are unaware, I spent some time investigating and resolving the
leaks at -Onone b/c SourceKit for diagnostic purposes compiles sources at
-Onone, so the leaks could have hit SourceKit. Since SourceKit is a long running
process this could add up over time/etc.