### PR TITLE
[asan] On Linux, when running with ASAN, disable leaks detection.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -546,6 +546,11 @@ class BuildScriptInvocation(object):
         # NOT pass them to build-script-impl.
         if args.enable_asan:
             impl_args += ["--enable-asan"]
+            # If we are on linux, disable leak detection when running ASAN. We
+            # have a separate bot that checks for leaks.
+            if platform.system() == 'Linux':
+                os.environ['ASAN_OPTIONS'] = 'detect_leaks=0'
+
         # If we have lsan, we need to export our suppression list. The actual
         # passing in of the LSAN flag is done via the normal cmake method. We
         # do not pass the flag to build-script-impl.


### PR DESCRIPTION
The reason to do this is that:

1. We already have a separate leaks bot.
2. We are not leaks clean at -O, but are ASAN clean at -O.

It doesn't make sense to limit our ability to verify that on Linux, we stay ASAN
clean at -O since we are not leaks clean at -O. Once we get leaks clean at -O,
we should create a separate bot.

rdar://31276806
