### PR TITLE
[emacs] Fix unbalanced parentheses in swift-project-stdlib-aux-swiftc…

### DIFF
--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -369,7 +369,7 @@ libraries that require a single frontend invocation" )
 
 (defconst swift-project-stdlib-aux-swiftc-args
   (append swift-project-single-frontend-swiftc-args
-          (list -sil-serialize-vtables" "-parse-stdlib"))
+          (list "-sil-serialize-vtables" "-parse-stdlib"))
   "swiftc arguments for library components that are compiled as
   though they are part of the standard library even though
   they're not strictly in that binary."  )


### PR DESCRIPTION
<!-- What's in this pull request? -->
#### What's in this pull request?

Fix utils/swift-project-settings.el (list arguments): 

```elisp
(defconst swift-project-stdlib-aux-swiftc-args
  (append swift-project-single-frontend-swiftc-args
          (list -sil-serialize-vtables" "-parse-stdlib"))
  "swiftc arguments for library components that are compiled as
  though they are part of the standard library even though
  they're not strictly in that binary."  )
```

```elisp
(defconst swift-project-stdlib-aux-swiftc-args
  (append swift-project-single-frontend-swiftc-args
          (list "-sil-serialize-vtables" "-parse-stdlib"))
  "swiftc arguments for library components that are compiled as
  though they are part of the standard library even though
  they're not strictly in that binary."  )
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

None

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->