### PR TITLE
Sema: Fix a failure to emit a diagnostic in pre-check expression pass

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -635,7 +635,14 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   // FIXME: If we reach this point, the program we're being handed is likely
   // very broken, but it's still conceivable that this may happen due to
   // invalid shadowed declarations.
-  // llvm_unreachable("Can't represent lookup result");
+  //
+  // Make sure we emit a diagnostic, since returning an ErrorExpr without
+  // producing one will break things downstream.
+  diagnose(Loc, diag::ambiguous_decl_ref, Name);
+  for (auto Result : Lookup) {
+    auto *Decl = Result.getValueDecl();
+    diagnose(Decl, diag::decl_declared_here, Decl->getFullName());
+  }
   return new (Context) ErrorExpr(UDRE->getSourceRange());
 }
 

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -52,3 +52,17 @@ struct SR3715 {
     take([overloaded]) // no error
   }
 }
+
+// rdar://35116378 - Here the ambiguity is in the pre-check pass; make sure
+// we emit a diagnostic instead of crashing.
+struct Movie {}
+
+class MoviesViewController {
+  typealias itemType = Movie // expected-note {{'itemType' declared here}}
+  let itemType = [Movie].self // expected-note {{'itemType' declared here}}
+  var items: [Movie] = [Movie]()
+
+  func loadData() {
+    _ = itemType // expected-error {{ambiguous use of 'itemType'}}
+  }
+}


### PR DESCRIPTION
This has been broken for four years at least. What a bummer.

Fixes <rdar://problem/35116378>.