### PR TITLE
SILGen: Fixes #function when called by lazy initializer

### DIFF
--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -242,6 +242,8 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
 
 void SILGenFunction::emitLazyGlobalInitializer(PatternBindingDecl *binding,
                                                unsigned pbdEntry) {
+  MagicFunctionName = SILGenModule::getMagicFunctionName(binding->getDeclContext());
+
   {
     Scope scope(Cleanups, binding);
 

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -116,7 +116,7 @@ class Foo {
 
   // CHECK-LABEL: sil hidden @_T017default_arguments3FooCACSi3int_SS6stringtcfc : $@convention(method) (Int, @owned String, @owned Foo) -> @owned Foo
   // CHECK:         string_literal utf16 "init(int:string:)"
-  init(int: Int, string: String) {
+  init(int: Int, string: String = #function) {
     testMagicLiterals()
     closure { testMagicLiterals() }
     autoclosure(testMagicLiterals())
@@ -138,6 +138,9 @@ class Foo {
     autoclosure(testMagicLiterals())
     return x
   }
+ 
+  static let x = Foo(int:0)
+
 }
 
 // Test at top level.

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -139,6 +139,8 @@ class Foo {
     return x
   }
  
+  // CHECK-LABEL: sil private @globalinit_33_E52D764B1F2009F2390B2B8DF62DAEB8_func0
+  // CHECK:         string_literal utf16 "Foo" 
   static let x = Foo(int:0)
 
 }
@@ -147,6 +149,9 @@ class Foo {
 testMagicLiterals()
 closure { testMagicLiterals() }
 autoclosure(testMagicLiterals())
+
+// CHECK: string_literal utf16 "default_arguments"
+let y : String = #function 
 
 // CHECK-LABEL: sil hidden @_T017default_arguments16testSelectorCallySi_Si17withMagicLiteralstF
 // CHECK:         string_literal utf16 "testSelectorCall(_:withMagicLiterals:)"


### PR DESCRIPTION
Resolves [SR-5380](https://bugs.swift.org/browse/SR-5380).