### PR TITLE
Improve lowercased comments documentation

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1138,7 +1138,7 @@ extension String {
   ///
   /// Here's an example of transforming a string to all lowercase letters.
   ///
-  ///     let cafe = "Café 🍵"
+  ///     let cafe = "CAfé 🍵"
   ///     print(cafe.lowercased())
   ///     // Prints "café 🍵"
   ///

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1138,9 +1138,9 @@ extension String {
   ///
   /// Here's an example of transforming a string to all lowercase letters.
   ///
-  ///     let cafe = "CAfé 🍵"
+  ///     let cafe = "BBQ Café 🍵"
   ///     print(cafe.lowercased())
-  ///     // Prints "café 🍵"
+  ///     // Prints "bbq café 🍵"
   ///
   /// - Returns: A lowercase copy of the string.
   ///


### PR DESCRIPTION
<!-- What's in this pull request? -->
Improvement to the String.lowercased comments/documentation.
Differentiate better between a full string .lowercased and a first character only .lowercased