### PR TITLE
[SIL] Gardening: Change stale comment into a useful "NOTE:"

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -950,7 +950,8 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
 
   bool pseudogeneric = (constant ? isPseudogeneric(*constant) : false);
 
-  // Always strip the auto-closure and no-escape bit.
+  // NOTE: SILFunctionType::ExtInfo doesn't track everything that
+  // AnyFunctionType::ExtInfo tracks. For example: 'throws' or 'auto-closure'
   auto silExtInfo = SILFunctionType::ExtInfo()
     .withRepresentation(extInfo.getSILRepresentation())
     .withIsPseudogeneric(pseudogeneric)


### PR DESCRIPTION
1) SILFunctionType and FunctionType no longer use the same ExtInfo data structure and therefore "strip" doesn't accurately describe what is going on.
2) The 'no-escape' bit is clearly being preserved, while the 'throws' bit is clearly not.