### PR TITLE
IRGen: Call destroyMetadataLayoutMap()

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -412,6 +412,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
 IRGenModule::~IRGenModule() {
   destroyClangTypeConverter();
+  destroyMetadataLayoutMap();
   delete &Types;
   delete DebugInfo;
 }


### PR DESCRIPTION
We added this function but forgot to call it in IRGenModule's destructor
resulting in a leak caught by the leaks bot.

rdar://35116417