### PR TITLE
[stdlib] Limit ranged subscript default implementations

### DIFF
--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -193,7 +193,26 @@ extension MutableCollection {
   ) rethrows -> R? {
     return nil
   }
+  
+  /// Exchanges the values at the specified indices of the collection.
+  ///
+  /// Both parameters must be valid indices of the collection that are not
+  /// equal to `endIndex`. Calling `swapAt(_:_:)` with the same index as both
+  /// `i` and `j` has no effect.
+  ///
+  /// - Parameters:
+  ///   - i: The index of the first value to swap.
+  ///   - j: The index of the second value to swap.
+  @_inlineable
+  public mutating func swapAt(_ i: Index, _ j: Index) {
+    guard i != j else { return }
+    let tmp = self[i]
+    self[i] = self[j]
+    self[j] = tmp
+  }
+}
 
+extension MutableCollection where SubSequence == MutableSlice<Self> {
   /// Accesses a contiguous subrange of the collection's elements.
   ///
   /// The accessed slice uses the same indices for the same elements as the
@@ -226,26 +245,11 @@ extension MutableCollection {
       _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
     }
   }
-
-  /// Exchanges the values at the specified indices of the collection.
-  ///
-  /// Both parameters must be valid indices of the collection that are not
-  /// equal to `endIndex`. Calling `swapAt(_:_:)` with the same index as both
-  /// `i` and `j` has no effect.
-  ///
-  /// - Parameters:
-  ///   - i: The index of the first value to swap.
-  ///   - j: The index of the second value to swap.
-  @_inlineable
-  public mutating func swapAt(_ i: Index, _ j: Index) {
-    guard i != j else { return }
-    let tmp = self[i]
-    self[i] = self[j]
-    self[j] = tmp
-  }
 }
 
-extension MutableCollection where Self: BidirectionalCollection {
+extension MutableCollection
+  where SubSequence == MutableBidirectionalSlice<Self>
+{
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(bounds: Range<Index>) -> MutableBidirectionalSlice<Self> {
     get {
@@ -258,7 +262,9 @@ extension MutableCollection where Self: BidirectionalCollection {
   }
 }
 
-extension MutableCollection where Self: RandomAccessCollection {
+extension MutableCollection
+  where SubSequence == MutableRandomAccessSlice<Self>
+{
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(bounds: Range<Index>) -> MutableRandomAccessSlice<Self> {
     get {

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -362,11 +362,6 @@ public protocol RangeReplaceableCollection : Collection
 //===----------------------------------------------------------------------===//
 
 extension RangeReplaceableCollection {
-  @_inlineable
-  public subscript(bounds: Range<Index>) -> RangeReplaceableSlice<Self> {
-    return RangeReplaceableSlice(base: self, bounds: bounds)
-  }
-
   /// Creates a new collection containing the specified number of a single,
   /// repeated value.
   ///
@@ -657,7 +652,6 @@ extension RangeReplaceableCollection {
 // collections.
 
 % for capability in ['', 'Bidirectional', 'RandomAccess']:
-%   if capability:
 extension RangeReplaceableCollection where
     Self.SubSequence == RangeReplaceable${capability}Slice<Self> {
   @_inlineable // FIXME(sil-serialize-all)
@@ -666,7 +660,6 @@ extension RangeReplaceableCollection where
     return RangeReplaceable${capability}Slice(base: self, bounds: bounds)
   }
 }
-%   end
 
 extension RangeReplaceableCollection where
   Self.SubSequence == MutableRangeReplaceable${capability}Slice<Self>


### PR DESCRIPTION
This change limits the default implementations for subscript(Range<Index>) to collections where the SubSequence type matches the slice type that the implementation provides. This cuts down on the number of extraneous subscript overloads. (Related to #12029.)
