### PR TITLE
Save optimization remarks in an external YAML file

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -136,6 +136,11 @@ WARNING(verify_debug_info_requires_debug_option,none,
 ERROR(error_profile_missing,none,
       "no profdata file exists at '%0'", (StringRef))
 
+WARNING(warn_opt_remark_disabled, none,
+        "Emission of optimization records has been disabled, because it "
+        "requires a single compiler invocation: consider enabling the "
+        "-whole-module-optimization flag", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -150,6 +150,10 @@ public:
   /// \brief Enable large loadable types IRGen pass.
   bool EnableLargeLoadableTypes = true;
 
+  /// The name of the file to which the backend should save YAML optimization
+  /// records.
+  std::string OptRecordFile;
+
   SILOptions() {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Driver/Types.def
+++ b/include/swift/Driver/Types.def
@@ -61,6 +61,7 @@ TYPE("imported-modules", ImportedModules,   "importedmodules", "")
 TYPE("tbd",             TBD,                "tbd",             "")
 TYPE("module-trace",    ModuleTrace,        "trace.json",      "")
 TYPE("index-data",      IndexData,          "",                "")
+TYPE("opt-record",      OptRecord,          "opt.yaml",        "")
 
 // Misc types
 TYPE("pcm",             ClangModuleFile,    "pcm",             "")

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -331,6 +331,13 @@ def Rpass_missed_EQ : Joined<["-"], "Rpass-missed=">,
   HelpText<"Report missed transformations by optimization passes whose "
            "name matches the given POSIX regular expression">;
 
+def save_optimization_record : Flag<["-"], "save-optimization-record">,
+  Flags<[FrontendOption]>, HelpText<"Generate a YAML optimization record file">;
+def save_optimization_record_path :
+  Separate<["-"], "save-optimization-record-path">,
+  Flags<[FrontendOption]>,
+  HelpText<"Specify the file name of any generated YAML optimization record">;
+
 // Platform options.
 def enable_app_extension : Flag<["-"], "application-extension">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -20,12 +20,13 @@
 #define SWIFT_SIL_OPTIMIZATIONREMARKEMITTER_H
 
 #include "swift/Basic/SourceLoc.h"
+#include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace swift {
 
-class ASTContext;
 class SILFunction;
 
 namespace OptRemark {
@@ -60,6 +61,9 @@ template <typename DerivedT> class Remark {
   /// Arguments collected via the streaming interface.
   SmallVector<Argument, 4> Args;
 
+  /// The name of the pass generating the remark.
+  StringRef PassName;
+
   /// Textual identifier for the remark (single-word, camel-case). Can be used
   /// by external tools reading the YAML output file for optimization remarks to
   /// identify the remark.
@@ -68,9 +72,13 @@ template <typename DerivedT> class Remark {
   /// Source location for the diagnostics.
   SourceLoc Location;
 
+  /// The function for the diagnostics.
+  SILFunction *Function;
+
 protected:
   Remark(StringRef Identifier, SILInstruction &I)
-      : Identifier(Identifier), Location(I.getLoc().getSourceLoc()) {}
+      : Identifier(Identifier), Location(I.getLoc().getSourceLoc()),
+        Function(I.getParent()->getParent()) {}
 
 public:
   DerivedT &operator<<(StringRef S) {
@@ -83,8 +91,15 @@ public:
     return *static_cast<DerivedT *>(this);
   }
 
+  StringRef getPassName() const { return PassName; }
+  StringRef getIdentifier() const { return Identifier; }
+  SILFunction *getFunction() const { return Function; }
   SourceLoc getLocation() const { return Location; }
   std::string getMsg() const;
+  Remark<DerivedT> &getRemark() { return *this; }
+  SmallVector<Argument, 4> &getArgs() { return Args; }
+
+  void setPassName(StringRef PN) { PassName = PN; }
 };
 
 /// Remark to report a successful optimization.
@@ -99,7 +114,7 @@ struct RemarkMissed : public Remark<RemarkMissed> {
 /// Used to emit the remarks.  Passes reporting remarks should create an
 /// instance of this.
 class Emitter {
-  ASTContext &Ctx;
+  SILModule &Module;
   std::string PassName;
   bool PassedEnabled;
   bool MissedEnabled;
@@ -110,7 +125,7 @@ class Emitter {
   template <typename RemarkT> bool isEnabled();
 
 public:
-  Emitter(StringRef PassName, ASTContext &Ctx);
+  Emitter(StringRef PassName, SILModule &M);
 
   /// \brief Take a lambda that returns a remark which will be emitted.  The
   /// lambda is not evaluated unless remarks are enabled.  Second argument is
@@ -119,8 +134,9 @@ public:
   void emit(T RemarkBuilder, decltype(RemarkBuilder()) * = nullptr) {
     using RemarkT = decltype(RemarkBuilder());
     // Avoid building the remark unless remarks are enabled.
-    if (isEnabled<RemarkT>()) {
+    if (isEnabled<RemarkT>() || Module.getOptRecordStream()) {
       auto R = RemarkBuilder();
+      R.setPassName(PassName);
       emit(R);
     }
   }

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -46,6 +46,12 @@
 #include "llvm/Support/raw_ostream.h"
 #include <functional>
 
+namespace llvm {
+namespace yaml {
+class Output;
+} // end namespace yaml
+} // end namespace llvm
+
 namespace swift {
   class AnyFunctionType;
   class ASTContext;
@@ -177,6 +183,14 @@ private:
 
   // The list of SILCoverageMaps in the module.
   CoverageMapListType coverageMaps;
+
+  /// This is the underlying raw stream of OptRecordStream.
+  ///
+  /// It is also owned by SILModule in order to keep their lifetime in sync.
+  std::unique_ptr<llvm::raw_ostream> OptRecordRawStream;
+
+  /// If non-null, the YAML file where remarks should be recorded.
+  std::unique_ptr<llvm::yaml::Output> OptRecordStream;
 
   /// This is a cache of intrinsic Function declarations to numeric ID mappings.
   llvm::DenseMap<Identifier, IntrinsicInfo> IntrinsicIDCache;
@@ -448,7 +462,11 @@ public:
   }
   iterator_range<coverage_map_const_iterator> getCoverageMaps() const {
     return {coverageMaps.begin(), coverageMaps.end()};
- }
+  }
+
+  llvm::yaml::Output *getOptRecordStream() { return OptRecordStream.get(); }
+  void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,
+                          std::unique_ptr<llvm::raw_ostream> &&RawStream);
 
   /// Look for a global variable by name.
   ///

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1453,6 +1453,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case types::TY_ImportedModules:
       case types::TY_TBD:
       case types::TY_ModuleTrace:
+      case types::TY_OptRecord:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,
@@ -2234,6 +2235,19 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
         Output->setAdditionalOutputForType(types::TY_TBD, filename);
       }
     }
+  }
+
+  if (C.getArgs().hasArg(options::OPT_save_optimization_record,
+                         options::OPT_save_optimization_record_path)) {
+    if (OI.CompilerMode == OutputInfo::Mode::SingleCompile) {
+      auto filename = *getOutputFilenameFromPathArgOrAsTopLevel(
+          OI, C.getArgs(), options::OPT_save_optimization_record_path,
+          types::TY_OptRecord, /*TreatAsTopLevelOutput=*/true, "opt.yaml", Buf);
+
+      Output->setAdditionalOutputForType(types::TY_OptRecord, filename);
+    } else
+      // FIXME: We should use the OutputMap in this case.
+      Diags.diagnose({}, diag::warn_opt_remark_disabled);
   }
 
   // Choose the Objective-C header output path.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -272,6 +272,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_SwiftDeps:
     case types::TY_ModuleTrace:
     case types::TY_TBD:
+    case types::TY_OptRecord:
       llvm_unreachable("Output type can never be primary output.");
     case types::TY_INVALID:
       llvm_unreachable("Invalid type ID");
@@ -448,6 +449,13 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back(TBDPath.c_str());
   }
 
+  const std::string &OptRecordPath =
+      context.Output.getAdditionalOutputForType(types::TY_OptRecord);
+  if (!OptRecordPath.empty()) {
+    Arguments.push_back("-save-optimization-record-path");
+    Arguments.push_back(OptRecordPath.c_str());
+  }
+
   if (context.Args.hasArg(options::OPT_migrate_keep_objc_visibility)) {
     Arguments.push_back("-migrate-keep-objc-visibility");
   }
@@ -586,6 +594,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case types::TY_SwiftDeps:
     case types::TY_Remapping:
     case types::TY_ModuleTrace:
+    case types::TY_OptRecord:
       llvm_unreachable("Output type can never be primary output.");
     case types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Driver/Types.cpp
+++ b/lib/Driver/Types.cpp
@@ -77,6 +77,7 @@ bool types::isTextual(ID Id) {
   case types::TY_ImportedModules:
   case types::TY_TBD:
   case types::TY_ModuleTrace:
+  case types::TY_OptRecord:
     return true;
   case types::TY_Image:
   case types::TY_Object:
@@ -131,6 +132,7 @@ bool types::isAfterLLVM(ID Id) {
   case types::TY_Remapping:
   case types::TY_IndexData:
   case types::TY_ModuleTrace:
+  case types::TY_OptRecord:
     return false;
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -169,6 +171,7 @@ bool types::isPartOfSwiftCompilation(ID Id) {
   case types::TY_Remapping:
   case types::TY_IndexData:
   case types::TY_ModuleTrace:
+  case types::TY_OptRecord:
     return false;
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1304,6 +1304,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       !Args.hasArg(OPT_disable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);
 
+  if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_path))
+    Opts.OptRecordFile = A->getValue();
+
   if (Args.hasArg(OPT_debug_on_sil)) {
     // Derive the name of the SIL file for debugging from
     // the regular outputfile.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/YAMLTraits.h"
 #include <functional>
 using namespace swift;
 using namespace Lowering;
@@ -781,3 +782,9 @@ void SILModule::serialize() {
   setSerialized();
 }
 
+void SILModule::setOptRecordStream(
+    std::unique_ptr<llvm::yaml::Output> &&Stream,
+    std::unique_ptr<llvm::raw_ostream> &&RawStream) {
+  OptRecordStream = std::move(Stream);
+  OptRecordRawStream = std::move(RawStream);
+}

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -897,8 +897,7 @@ public:
     DominanceAnalysis *DA = PM->getAnalysis<DominanceAnalysis>();
     SILLoopAnalysis *LA = PM->getAnalysis<SILLoopAnalysis>();
     SideEffectAnalysis *SEA = PM->getAnalysis<SideEffectAnalysis>();
-    OptRemark::Emitter ORE(DEBUG_TYPE,
-                           getFunction()->getModule().getASTContext());
+    OptRemark::Emitter ORE(DEBUG_TYPE, getFunction()->getModule());
 
     if (getOptions().InlineThreshold == 0) {
       return;

--- a/test/Driver/opt-record.swift
+++ b/test/Driver/opt-record.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -O -wmo -save-optimization-record %s -module-name optrecordmod -o %t/opt-record 2>&1 | %FileCheck -allow-empty %s
+// RUN: %FileCheck -check-prefix=YAML %s < %t/optrecordmod.opt.yaml
+// RUN: %target-swiftc_driver -O -wmo -save-optimization-record-path %t/specified.opt.yaml %s -module-name optrecordmod -o %t/opt-record 2>&1 | %FileCheck -allow-empty %s
+// RUN: %FileCheck -check-prefix=YAML %s < %t/specified.opt.yaml
+
+// CHECK-NOT: remark
+
+var a: Int = 1
+
+func foo() {
+  a = 2
+}
+
+public func bar() {
+  // YAML:      --- !Passed
+  // YAML-NEXT: Pass:            sil-inliner
+  // YAML-NEXT: Name:            Inlined
+  // YAML-NEXT: DebugLoc:
+  // YAML-NEXT:   File:            {{.*}}opt-record.swift
+  // YAML-NEXT:   Line:            42
+  // YAML-NEXT:   Column:          3
+  // YAML-NEXT: Function:        _T012optrecordmod3baryyF
+  // YAML-NEXT: Args:
+  // YAML-NEXT:   - Callee:          _T012optrecordmod3fooyyF
+  // YAML-NEXT:     DebugLoc:
+  // YAML-NEXT:       File:            {{.*}}opt-record.swift
+  // YAML-NEXT:       Line:            11
+  // YAML-NEXT:       Column:          6
+  // YAML-NEXT:   - String:          ' inlined into '
+  // YAML-NEXT:   - Caller:          _T012optrecordmod3baryyF
+  // YAML-NEXT:     DebugLoc:
+  // YAML-NEXT:       File:            {{.*}}opt-record.swift
+  // YAML-NEXT:       Line:            15
+  // YAML-NEXT:       Column:          13
+  // YAML-NEXT:   - String:          ' (cost = '
+  // YAML-NEXT:   - Cost:            '{{.*}}'
+  // YAML-NEXT:   - String:          ', benefit = '
+  // YAML-NEXT:   - Benefit:         '{{.*}}'
+  // YAML-NEXT:   - String:          ')'
+  // YAML-NEXT: ...
+  foo()
+}

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -2,9 +2,12 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-remarks=sil-inliner -o %t.sil 2>&1 | %FileCheck -check-prefix=REMARKS_PASSED %s
 // RUN: %FileCheck %s < %t.sil
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-remarks-missed=sil-inliner -o /dev/null 2>&1 | %FileCheck -check-prefix=REMARKS_MISSED %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -save-optimization-record-path %t.yaml -o /dev/null 2>&1 | %FileCheck -allow-empty -check-prefix=NO_REMARKS %s
+// RUN: %FileCheck -check-prefix=YAML %s < %t.yaml
 
 // REMARKS_PASSED-NOT: remark:
 // REMARKS_MISSED-NOT: remark:
+// NO_REMARKS-NOT: remark:
 
 sil_stage canonical
 
@@ -190,7 +193,33 @@ bb0:
   %c30 = builtin "assert_configuration"() : $Builtin.Int32
 
   %f = function_ref @update_global: $@convention(thin) () -> ()
-  // REMARKS_PASSED: inliner_coldblocks.sil:194:3: remark: update_global inlined into regular_large_callee (cost = {{.*}}, benefit = {{.*}})
+  // REMARKS_PASSED: inliner_coldblocks.sil:223:3: remark: update_global inlined into regular_large_callee (cost = {{.*}}, benefit = {{.*}})
+  // YAML:      --- !Passed
+  // YAML-NEXT: Pass:            sil-inliner
+  // YAML-NEXT: Name:            Inlined
+  // YAML-NEXT: DebugLoc:
+  // YAML-NEXT:   File:            {{.*}}inliner_coldblocks.sil
+  // YAML-NEXT:   Line:            223
+  // YAML-NEXT:   Column:          3
+  // YAML-NEXT: Function:        regular_large_callee
+  // YAML-NEXT: Args:
+  // YAML-NEXT:   - Callee:          update_global
+  // YAML-NEXT:     DebugLoc:
+  // YAML-NEXT:       File:            {{.*}}inliner_coldblocks.sil
+  // YAML-NEXT:       Line:            20
+  // YAML-NEXT:       Column:          6
+  // YAML-NEXT:   - String:          ' inlined into '
+  // YAML-NEXT:   - Caller:          regular_large_callee
+  // YAML-NEXT:     DebugLoc:
+  // YAML-NEXT:       File:            {{.*}}inliner_coldblocks.sil
+  // YAML-NEXT:       Line:            162
+  // YAML-NEXT:       Column:          6
+  // YAML-NEXT:   - String:          ' (cost = '
+  // YAML-NEXT:   - Cost:            '{{.*}}'
+  // YAML-NEXT:   - String:          ', benefit = '
+  // YAML-NEXT:   - Benefit:         '{{.*}}'
+  // YAML-NEXT:   - String:          ')'
+  // YAML-NEXT: ...
   apply %f() : $@convention(thin) () -> ()
 
   %r = tuple ()
@@ -204,7 +233,22 @@ bb0:
 sil @dont_inline_regular_large_callee : $@convention(thin) () -> () {
 bb0:
   %f = function_ref @regular_large_callee : $@convention(thin) () -> ()
-  // REMARKS_MISSED: inliner_coldblocks.sil:208:8: remark: Not profitable to inline (cost = {{.*}}, benefit = {{.*}})
+  // REMARKS_MISSED: inliner_coldblocks.sil:252:8: remark: Not profitable to inline (cost = {{.*}}, benefit = {{.*}})
+  // YAML:      --- !Missed
+  // YAML-NEXT: Pass:            sil-inliner
+  // YAML-NEXT: Name:            NoInlinedCost
+  // YAML-NEXT: DebugLoc:
+  // YAML-NEXT:   File:            {{.*}}inliner_coldblocks.sil
+  // YAML-NEXT:   Line:            252
+  // YAML-NEXT:   Column:          8
+  // YAML-NEXT: Function:        dont_inline_regular_large_callee
+  // YAML-NEXT: Args:
+  // YAML-NEXT:   - String:          'Not profitable to inline (cost = '
+  // YAML-NEXT:   - Cost:            '{{.*}}'
+  // YAML-NEXT:   - String:          ', benefit = '
+  // YAML-NEXT:   - Benefit:         '{{.*}}'
+  // YAML-NEXT:   - String:          ')'
+  // YAML-NEXT: ...
   %a = apply %f() : $@convention(thin) () -> ()
   %r = tuple ()
   return %r : $()


### PR DESCRIPTION
This brings the capability from clang to save remarks in an external YAML files.
This allows them to be viewed with tools like the opt-viewer.

Saving the remarks is activated with the new option -fsave-optimization-record.
The command-line interface closely follows the one in clang.

Similarly to -emit-tbd, I've only added support for single-compile mode for now.
In this case the default filename is determined by
getOutputFilenameFromPathArgOrAsTopLevel, i.e. unless explicitly specified
with -foptimization-record-file, the file is placed in the directory of the main
output file as <modulename>.opt.yaml.

I need to think more where the files should end up in non-wmo mode.  Probably
where the .dia files go?  Suggestions are welcome!