### PR TITLE
Bump Swift version number to 4.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ set_property(CACHE SWIFT_ANALYZE_CODE_COVERAGE PROPERTY
 # SWIFT_VERSION is deliberately /not/ cached so that an existing build directory
 # can be reused when a new version of Swift comes out (assuming the user hasn't
 # manually set it as part of their own CMake configuration).
-set(SWIFT_VERSION "4.0.2")
+set(SWIFT_VERSION "4.0.3")
 
 set(SWIFT_VENDOR "" CACHE STRING
     "The vendor name of the Swift compiler")
@@ -735,10 +735,10 @@ if(swift_build_android AND NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
 
   set(SWIFT_ANDROID_PREBUILT_PATH
       "${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-${SWIFT_ANDROID_NDK_GCC_VERSION}/prebuilt/${_swift_android_prebuilt_suffix}")
-  
+
   # Resolve the correct linker based on the file name of CMAKE_LINKER (being 'ld' or 'ld.gold' the options)
   get_filename_component(SWIFT_ANDROID_LINKER_NAME "${CMAKE_LINKER}" NAME)
-  set(SWIFT_SDK_ANDROID_ARCH_armv7_LINKER 
+  set(SWIFT_SDK_ANDROID_ARCH_armv7_LINKER
       "${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-${SWIFT_ANDROID_NDK_GCC_VERSION}/prebuilt/${_swift_android_prebuilt_suffix}/bin/arm-linux-androideabi-${SWIFT_ANDROID_LINKER_NAME}")
 
   configure_sdk_unix(ANDROID "Android" "android" "android" "armv7" "armv7-none-linux-androideabi" "${SWIFT_ANDROID_SDK_PATH}")

--- a/test/Parse/ConditionalCompilation/language_version_explicit.swift
+++ b/test/Parse/ConditionalCompilation/language_version_explicit.swift
@@ -21,7 +21,7 @@
   asdf asdf asdf asdf
 #endif
 
-#if swift(>=4.0.3)
+#if swift(>=4.0.4)
   // This shouldn't emit any diagnostics.
   asdf asdf asdf asdf
 #else

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -14,7 +14,7 @@ public class Sub: Base {
 
 // CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please file a bug report with your project and the crash log
 // CHECK-CRASH-3-NOT: note
-// CHECK-CRASH-4: note: compiling as Swift 4.0.2, with 'Lib' built as Swift 3.2
+// CHECK-CRASH-4: note: compiling as Swift 4.0.3, with 'Lib' built as Swift 3.2
 // CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE (please include this section in any bug report) ***
 // CHECK-CRASH: could not find 'disappearingMethod()' in parent class
 // CHECK-CRASH: While loading members for 'Sub' in module 'Lib'

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -16,8 +16,8 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
-class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0.2) because it has overridable members that could not be loaded in Swift 3.2}}
-class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.0.2) because it has requirements that could not be loaded in Swift 3.2}}
+class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0.3) because it has overridable members that could not be loaded in Swift 3.2}}
+class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.0.3) because it has requirements that could not be loaded in Swift 3.2}}
 
 #else // TEST
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -2060,7 +2060,7 @@ iterations with -O",
         "--swift-user-visible-version",
         help="User-visible version of the embedded Swift compiler",
         type=arguments.type.swift_compiler_version,
-        default="4.0.2",
+        default="4.0.3",
         metavar="MAJOR.MINOR")
 
     parser.add_argument(


### PR DESCRIPTION
Bump Swift version number to 4.0.3

rdar://35074252

––– CCC Information –––
• Explanation: Bumping Swift version number to 4.0.3
• Scope of Issue: Affects tests only
• Origination: N/A
• Risk: Minimal
• Testing: CI bots