### PR TITLE
Sema: Fix a failure to emit a diagnostic in pre-check expression pass [4.0]

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -623,7 +623,14 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   // FIXME: If we reach this point, the program we're being handed is likely
   // very broken, but it's still conceivable that this may happen due to
   // invalid shadowed declarations.
-  // llvm_unreachable("Can't represent lookup result");
+  //
+  // Make sure we emit a diagnostic, since returning an ErrorExpr without
+  // producing one will break things downstream.
+  diagnose(Loc, diag::ambiguous_decl_ref, Name);
+  for (auto Result : Lookup) {
+    auto *Decl = Result.Decl;
+    diagnose(Decl, diag::decl_declared_here, Decl->getFullName());
+  }
   return new (Context) ErrorExpr(UDRE->getSourceRange());
 }
 

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 func f0(_ i: Int, _ d: Double) {} // expected-note{{found this candidate}}
 func f0(_ d: Double, _ i: Int) {} // expected-note{{found this candidate}}
@@ -50,5 +50,23 @@ struct SR3715 {
 
   func test() {
     take([overloaded]) // no error
+  }
+}
+
+// rdar://35116378 - Here the ambiguity is in the pre-check pass; make sure
+// we emit a diagnostic instead of crashing.
+struct Movie {}
+
+protocol P {
+  associatedtype itemType
+  var items: [itemType] { get set }
+}
+
+class MoviesViewController : P {
+  let itemType = [Movie].self // expected-note {{'itemType' declared here}}
+  var items: [Movie] = [Movie]()
+
+  func loadData() {
+    _ = itemType // expected-error {{ambiguous use of 'itemType'}}
   }
 }


### PR DESCRIPTION
* Description: Fix crash when unqualified lookup in expression context finds a type and non-type member with the same name.

* Origination: The problem has existed since Swift 1, but the symptom in a no-assert build is a non-obvious SILGen crash so it's hard to say if it's a common bug or not.

* Risk: Very low, the change only affects an error path that was previously producing invalid AST.

* Tested: New test added.

* Radar: <rdar://problem/35139476>.

* Reviewed by: @rudkx