### PR TITLE
SILGen: Fix memory leak when calling constructor requirement of @objc protocol [4.0]

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -697,12 +697,12 @@ public:
     }
 
     // Allocate the object.
-    return ManagedValue(SGF.B.createAllocRefDynamic(
+    return SGF.emitManagedRValueWithCleanup(
+        SGF.B.createAllocRefDynamic(
                           loc,
                           selfMetaObjC.getValue(),
                           SGF.SGM.getLoweredType(type),
-                          /*objc=*/true, {}, {}),
-                          selfMetaObjC.getCleanup());
+                          /*objc=*/true, {}, {}));
   }
 
   //

--- a/test/Interpreter/objc_protocols.swift
+++ b/test/Interpreter/objc_protocols.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+@objc protocol Horse {
+  init()
+}
+
+class Pony : Horse {
+  let x = LifetimeTracked(0)
+
+  required init() {}
+}
+
+var ObjCProtocolsTest = TestSuite("ObjCProtocols")
+
+ObjCProtocolsTest.test("InitRequirement") {
+  let t: Horse.Type = Pony.self
+
+  _ = t.init()
+}
+
+runAllTests()

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -267,8 +267,7 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
   // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type
   // CHECK:   [[I2_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[ARCHETYPE_META_OBJC]] : $@objc_metatype (@opened([[N]]) Initializable).Type, $@opened([[N]]) Initializable
   // CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method [volatile] $@opened([[N]]) Initializable, #Initializable.init!initializer.1.foreign : {{.*}}, [[ARCHETYPE_META]]{{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
-  // CHECK:   [[I2_COPY:%.*]] = copy_value [[I2_ALLOC]]
-  // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_COPY]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
+  // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_ALLOC]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
   // CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*Initializable


### PR DESCRIPTION
* Description: When calling an init requirement of an @objc protocol, we were using the cleanup for the metatype (which is trivial) for the new value. This is wrong because the new value is +1 and not +0, so it was getting leaked.

* Scope of the issue: It has been reported externally several times.

* Origination: A quick glance at git blame shows it's been broken since Swift 1.0.

* Risk: Low, the old code was doing the wrong thing anyway.

* Tested: Existing SILGen test updated, new executable test added.

* Radar: <rdar://problem/35139568>

* Reviewed by: @gottesmm 