### PR TITLE
[GSB] Flatten list of same-type requirements.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -120,11 +120,8 @@ public:
     llvm::MapVector<ProtocolDecl *, std::vector<Constraint<ProtocolDecl *>>>
       conformsTo;
 
-    /// Same-type constraints between each potential archetype and any other
-    /// archetype in its equivalence class.
-    llvm::MapVector<PotentialArchetype *,
-                    std::vector<Constraint<PotentialArchetype *>>>
-      sameTypeConstraints;
+    /// Same-type constraints within this equivalence class.
+    std::vector<Constraint<PotentialArchetype *>> sameTypeConstraints;
 
     /// Concrete type to which this equivalence class is equal.
     ///
@@ -1668,18 +1665,6 @@ public:
   /// \brief Retrieve the potential archetype to be used as the anchor for
   /// potential archetype computations.
   PotentialArchetype *getArchetypeAnchor(GenericSignatureBuilder &builder);
-
-  /// Retrieve the same-type constraints.
-  ArrayRef<Constraint<PotentialArchetype *>> getSameTypeConstraints() const {
-    if (auto equivClass = getEquivalenceClassIfPresent()) {
-      auto known = equivClass->sameTypeConstraints.find(
-                                       const_cast<PotentialArchetype *>(this));
-      if (known == equivClass->sameTypeConstraints.end()) return { };
-      return known->second;
-    }
-
-    return { };
-  }
 
   /// \brief Retrieve (or create) a nested type that is the current best
   /// nested archetype anchor (locally) with the given name.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -215,8 +215,7 @@ public:
     ///
     /// \returns true if this same-type constraint merges two equivalence
     /// classes, and false otherwise.
-    bool recordSameTypeConstraint(GenericSignatureBuilder &builder,
-                                  PotentialArchetype *type1,
+    bool recordSameTypeConstraint(PotentialArchetype *type1,
                                   PotentialArchetype *type2,
                                   const RequirementSource *source);
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1642,14 +1642,13 @@ bool EquivalenceClass::recordConformanceConstraint(
 }
 
 bool EquivalenceClass::recordSameTypeConstraint(
-                              GenericSignatureBuilder &builder,
                               PotentialArchetype *type1,
                               PotentialArchetype *type2,
                               const RequirementSource *source) {
-  // FIXME: Drop builder?
   sameTypeConstraints.push_back({type1, type2, source});
   ++NumSameTypeConstraints;
-  return true;
+  return type1->getEquivalenceClassIfPresent() !=
+    type2->getEquivalenceClassIfPresent();
 }
 
 template<typename T>
@@ -3977,23 +3976,20 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
        PotentialArchetype *OrigT2,
        const RequirementSource *Source) 
 {
+  // Record the same-type constraint, and bail out if it was already known.
+  if (!OrigT1->getOrCreateEquivalenceClass(*this)
+        ->recordSameTypeConstraint(OrigT1, OrigT2, Source))
+    return ConstraintResult::Resolved;
+
   // Operate on the representatives
   auto T1 = OrigT1->getRepresentative();
   auto T2 = OrigT2->getRepresentative();
 
-  // If the representatives are already the same, we're done.
-  if (T1 == T2) {
-    T1->getOrCreateEquivalenceClass(*this)
-      ->recordSameTypeConstraint(*this, OrigT1, OrigT2, Source);
-    return ConstraintResult::Resolved;
-  }
-
-  unsigned nestingDepth1 = T1->getNestingDepth();
-  unsigned nestingDepth2 = T2->getNestingDepth();
-
   // Decide which potential archetype is to be considered the representative.
   // We prefer potential archetypes with lower nesting depths, because it
   // prevents us from unnecessarily building deeply nested potential archetypes.
+  unsigned nestingDepth1 = T1->getNestingDepth();
+  unsigned nestingDepth2 = T2->getNestingDepth();
   if (nestingDepth2 < nestingDepth1) {
     std::swap(T1, T2);
     std::swap(OrigT1, OrigT2);
@@ -4002,9 +3998,6 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
   // Merge the equivalence classes.
   auto equivClass = T1->getOrCreateEquivalenceClass(*this);
   equivClass->modified(*this);
-
-  // Record the same-type constraint.
-  equivClass->recordSameTypeConstraint(*this, OrigT1, OrigT2, Source);
 
   auto equivClass1Members = equivClass->members;
   auto equivClass2Members = T2->getEquivalenceClassMembers();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5381,44 +5381,6 @@ void GenericSignatureBuilder::checkConformanceConstraints(
   }
 }
 
-/// Perform a depth-first search from the given potential archetype through
-/// the *implicit* same-type constraints.
-///
-/// \param pa The potential archetype to visit.
-/// \param paToComponent A mapping from each potential archetype to its
-/// component number.
-/// \param component The component number we're currently visiting.
-///
-/// \returns the best archetype anchor seen so far.
-static PotentialArchetype *sameTypeDFS(PotentialArchetype *pa,
-          unsigned component,
-          llvm::SmallDenseMap<PotentialArchetype *, unsigned> &paToComponent) {
-  PotentialArchetype *anchor = pa;
-
-  // If we've already visited this potential archetype, we're done.
-  if (!paToComponent.insert({pa, component}).second) return anchor;
-
-  // Visit its adjacent potential archetypes.
-  for (const auto &constraint : pa->getSameTypeConstraints()) {
-    // Treat nested-type-name-match constraints specially.
-    if (constraint.source->getRoot()->kind ==
-          RequirementSource::NestedTypeNameMatch)
-      continue;
-
-    // Skip non-derived constraints.
-    if (!constraint.source->isDerivedRequirement()) continue;
-
-    auto newAnchor =
-      sameTypeDFS(constraint.value, component, paToComponent);
-
-    // If this type is better than the anchor, use it for the anchor.
-    if (compareDependentTypes(&newAnchor, &anchor) < 0)
-      anchor = newAnchor;
-  }
-
-  return anchor;
-}
-
 namespace swift {
   bool operator<(const DerivedSameTypeComponent &lhs,
                  const DerivedSameTypeComponent &rhs) {
@@ -5426,16 +5388,50 @@ namespace swift {
   }
 } // namespace swift
 
+/// Find the representative in a simple union-find data structure of
+/// integral values.
+static unsigned findRepresentative(SmallVectorImpl<unsigned> &parents,
+                                   unsigned index) {
+  if (parents[index] == index) return index;
+
+  return parents[index] = findRepresentative(parents, parents[index]);
+}
+
+/// Union the same-type components denoted by \c index1 and \c index2.
+///
+/// \param successThreshold Returns true when two sets have been joined
+/// and both representatives are below the threshold. The default of 0
+/// is equivalent to \c successThreshold == parents.size().
+///
+/// \returns \c true if the two components were separate and have now
+/// been joined; \c false if they were already in the same set.
+static bool unionSets(SmallVectorImpl<unsigned> &parents,
+                      unsigned index1, unsigned index2,
+                      unsigned successThreshold = 0) {
+  // Find the representatives of each component class.
+  unsigned rep1 = findRepresentative(parents, index1);
+  unsigned rep2 = findRepresentative(parents, index2);
+  if (rep1 == rep2) return false;
+
+  // Point at the lowest-numbered representative.
+  if (rep1 < rep2)
+    parents[rep2] = rep1;
+  else
+    parents[rep1] = rep2;
+
+  return (successThreshold == 0) ||
+    (rep1 < successThreshold && rep2 < successThreshold);
+}
+
 /// Computes the ordered set of archetype anchors required to form a minimum
 /// spanning tree among the connected components formed by only the derived
-/// same-type requirements within the equivalence class of \c rep.
+/// same-type requirements within the equivalence class \c equivClass.
 ///
-/// The equivalence class of the given representative potential archetype
-/// (\c rep) contains all potential archetypes that are made equivalent by
-/// the known set of same-type constraints, which includes both directly-
-/// stated same-type constraints (e.g., \c T.A == T.B) as well as same-type
-/// constraints that are implied either because the names coincide (e.g.,
-/// \c T[.P1].A == T[.P2].A) or due to a requirement in a protocol.
+/// The equivalence class contains all potential archetypes that are made
+/// equivalent by the known set of same-type constraints, which includes both
+/// directly-stated same-type constraints (e.g., \c T.A == T.B) as well as
+/// same-type constraints that are implied either because the names coincide
+/// (e.g., \c T[.P1].A == T[.P2].A) or due to a requirement in a protocol.
 ///
 /// The equivalence class of the given representative potential archetype
 /// (\c rep) is formed from a graph whose vertices are the potential archetypes
@@ -5464,21 +5460,68 @@ namespace swift {
 /// canonical edges connects vertex i to vertex i+1 for i in 0..<size-1.
 static void computeDerivedSameTypeComponents(
               GenericSignatureBuilder &builder,
-              PotentialArchetype *rep,
+              EquivalenceClass *equivClass,
               llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf){
-  // Perform a depth-first search to identify the components.
-  auto equivClass = rep->getOrCreateEquivalenceClass(builder);
+  // Set up the array of "parents" in the union-find data structure.
+  llvm::SmallDenseMap<CanType, unsigned> parentIndices;
+  SmallVector<unsigned, 4> parents;
+  for (unsigned i : indices(equivClass->members)) {
+    Type depType = equivClass->members[i]->getDependentType({ });
+    parentIndices[depType->getCanonicalType()] = parents.size();
+    parents.push_back(i);
+  }
+
+  // Walk all of the same-type constraints, performing a union-find operation.
+  for (const auto &entry : equivClass->sameTypeConstraints) {
+    for (const auto &constraint : entry.second) {
+      // Treat nested-type-name-match constraints specially.
+      if (constraint.source->getRoot()->kind ==
+            RequirementSource::NestedTypeNameMatch)
+        continue;
+
+      // Skip non-derived constraints.
+      if (!constraint.source->isDerivedRequirement()) continue;
+
+      CanType source =
+        constraint.getSubjectDependentType({ })->getCanonicalType();
+      CanType target =
+        constraint.value->getDependentType({ })->getCanonicalType();
+
+      assert(parentIndices.count(source) == 1 && "Missing source");
+      assert(parentIndices.count(target) == 1 && "Missing target");
+      unionSets(parents, parentIndices[source], parentIndices[target]);
+    }
+  }
+
+  // Compute and record the components.
   auto &components = equivClass->derivedSameTypeComponents;
-  for (auto pa : rep->getEquivalenceClassMembers()) {
-    // If we've already seen this potential archetype, there's nothing else to
-    // do.
-    if (componentOf.count(pa) != 0) continue;
+  for (unsigned i : indices(equivClass->members)) {
+    auto pa = equivClass->members[i];
+    CanType depType = pa->getDependentType({ })->getCanonicalType();
 
-    // Find all of the potential archetypes within this connected component.
-    auto anchor = sameTypeDFS(pa, components.size(), componentOf);
+    // Find the representative of this set.
+    assert(parentIndices.count(depType) == 1 && "Unknown member?");
+    unsigned index = parentIndices[depType];
+    unsigned representative = findRepresentative(parents, index);
 
-    // Record the anchor.
-    components.push_back({anchor, nullptr});
+    // If this is the representative, add a component for it.
+    if (representative == index) {
+      componentOf[pa] = components.size();
+      components.push_back(DerivedSameTypeComponent{pa, nullptr});
+      continue;
+    }
+
+    // This is not the representative; point at the component of the
+    // representative.
+    auto representativePA = equivClass->members[representative];
+    assert(componentOf.count(representativePA) == 1 &&
+           "Missing representative component?");
+    unsigned componentIndex = componentOf[representativePA];
+    componentOf[pa] = componentIndex;
+
+    // If this is a better anchor, record it.
+    if (compareDependentTypes(&pa, &components[componentIndex].anchor) < 0)
+      components[componentIndex].anchor = pa;
   }
 
   // If there is a concrete type, figure out the best concrete type anchor
@@ -5552,42 +5595,6 @@ void IntercomponentEdge::dump() const {
     << constraint.value->getDebugName() << ": ";
   constraint.source->print(llvm::errs(), nullptr);
   llvm::errs() << "\n";
-}
-
-/// Find the representative in a simple union-find data structure of
-/// integral values.
-static unsigned findRepresentative(SmallVectorImpl<unsigned> &parents,
-                                   unsigned index) {
-  if (parents[index] == index) return index;
-
-  return parents[index] = findRepresentative(parents, parents[index]);
-}
-
-
-/// Union the same-type components denoted by \c index1 and \c index2.
-///
-/// \param successThreshold Returns true when two sets have been joined
-/// and both representatives are below the threshold. The default of 0
-/// is equivalent to \c successThreshold == parents.size().
-///
-/// \returns \c true if the two components were separate and have now
-/// been joined; \c false if they were already in the same set.
-static bool unionSets(SmallVectorImpl<unsigned> &parents,
-                      unsigned index1, unsigned index2,
-                      unsigned successThreshold = 0) {
-  // Find the representatives of each component class.
-  unsigned rep1 = findRepresentative(parents, index1);
-  unsigned rep2 = findRepresentative(parents, index2);
-  if (rep1 == rep2) return false;
-
-  // Point at the lowest-numbered representative.
-  if (rep1 < rep2)
-    parents[rep2] = rep1;
-  else
-    parents[rep1] = rep2;
-
-  return (successThreshold == 0) ||
-    (rep1 < successThreshold && rep2 < successThreshold);
 }
 
 /// Determine whether the removal of the given edge will disconnect the
@@ -5883,7 +5890,7 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
   // Compute the components in the subgraph of the same-type constraint graph
   // that includes only derived constraints.
   llvm::SmallDenseMap<PotentialArchetype *, unsigned> componentOf;
-  computeDerivedSameTypeComponents(*this, pa, componentOf);
+  computeDerivedSameTypeComponents(*this, equivClass, componentOf);
 
   // Go through all of the same-type constraints, collecting all of the
   // non-derived constraints to put them into bins: intra-component and

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -348,15 +348,14 @@ func intracomponent<T: P11>(_: T) // expected-note{{previous same-type constrain
 
 func intercomponentSameComponents<T: P10>(_: T)
   where T.A == T.B, // expected-warning{{redundant same-type constraint 'T.A' == 'T.B'}}
-        T.B == T.A { } // expected-note{{previous same-type constraint 'T.A' == 'T.B' written here}}
-                       // FIXME: directionality of constraint above is weird
+        T.B == T.A { } // expected-note{{previous same-type constraint 'T.B' == 'T.A' written here}}
 
 func intercomponentMoreThanSpanningTree<T: P10>(_: T)
   where T.A == T.B,
         T.B == T.C,
         T.D == T.E, // expected-note{{previous same-type constraint 'T.D' == 'T.E' written here}}
         T.D == T.B,
-        T.E == T.B  // expected-warning{{redundant same-type constraint 'T.B' == 'T.E'}}
+        T.E == T.B  // expected-warning{{redundant same-type constraint 'T.E' == 'T.B'}}
         { }
 
 func trivialRedundancy<T: P10>(_: T) where T.A == T.A { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.A'}}


### PR DESCRIPTION
Equivalence classes stored their same-type constraints in a MapVector
keyed on the source potential archetype, which allowed traversal along the
paths of the graph. This was used in a depth-first search to compute connected
components in the graph, so switch over to a union-find based algorithm.
Then, flatten the list of same-type constraints to a single vector, eliminating
constraint duplication between the source and the target out-edge lists.

This cuts down on the number of same-type constraints we record by 50%,
but performance gains are limited (6% of stdlib type-checking time)
because most of the time these same-type constraints were skipped
anyway.