### PR TITLE
[ConstraintSolver] Avoid unnecessarily increasing score when matching function types

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1150,8 +1150,6 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
 
-  increaseScore(ScoreKind::SK_FunctionConversion);
-
   // Add a very narrow exception to SE-0110 by allowing functions that
   // take multiple arguments to be passed as an argument in places
   // that expect a function that takes a single tuple (of the same

--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -36,3 +36,9 @@ a(c.d)
 func b<T>(_: (T) -> () -> ()) {}
 
 b(c.e)
+
+func bar(_: () -> ()) {}
+func bar(_: () throws -> ()) {}
+func bar_empty() {}
+
+bar(bar_empty)

--- a/test/Constraints/rdar35142121.swift
+++ b/test/Constraints/rdar35142121.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+func foo<T>(_ a: T) -> Int {
+  return 0
+}
+
+func foo(_ a: (Int) -> (Int)) -> Int {
+  return 42
+}
+
+// CHECK: function_ref @_T012rdar351421213fooS3icF : $@convention(thin) (@owned @noescape @callee_owned (Int) -> Int) -> Int
+let _ = foo({ (a: Int) -> Int in a + 1 })

--- a/validation-test/Sema/type_checker_perf/fast/rdar33292740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33292740.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 2 --end 7 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 2 --end 10 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 6 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Remove function-to-function type match score increase, which should only
happen contextually in presence of other restrictions, this used to fix
the case related to matching of arrays of functions with and w/e `throws`
as function parameters which used to be ambigious, and now handled by
collection-upcast conversion score.

Resolves: rdar://problem/35142121

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
