### PR TITLE
Serialization: Serialize FuncDecl::hasForcedStaticDispatch()

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 372; // Last change: VTable serialized
+const uint16_t VERSION_MINOR = 373; // Last change: has forced static dispatch
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -955,6 +955,7 @@ namespace decls_block {
     BCFixed<1>,   // explicitly objc?
     SelfAccessKindField,   // self access kind
     BCFixed<1>,   // has dynamic self?
+    BCFixed<1>,   // has forced static dispatch?
     BCFixed<1>,   // throws?
     BCVBR<5>,     // number of parameter patterns
     GenericEnvironmentIDField, // generic environment

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2872,7 +2872,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     bool isImplicit;
     bool isStatic;
     uint8_t rawStaticSpelling, rawAccessLevel, rawAddressorKind, rawMutModifier;
-    bool isObjC, hasDynamicSelf, throws;
+    bool isObjC, hasDynamicSelf, hasForcedStaticDispatch, throws;
     unsigned numParamPatterns, numNameComponentsBiased;
     GenericEnvironmentID genericEnvID;
     TypeID interfaceTypeID;
@@ -2885,7 +2885,8 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     decls_block::FuncLayout::readRecord(scratch, contextID, isImplicit,
                                         isStatic, rawStaticSpelling, isObjC,
-                                        rawMutModifier, hasDynamicSelf, throws,
+                                        rawMutModifier, hasDynamicSelf,
+                                        hasForcedStaticDispatch, throws,
                                         numParamPatterns, genericEnvID,
                                         interfaceTypeID,
                                         associatedDeclID, overriddenID,
@@ -3030,6 +3031,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     if (isImplicit)
       fn->setImplicit();
     fn->setDynamicSelf(hasDynamicSelf);
+    fn->setForcedStaticDispatch(hasForcedStaticDispatch);
     fn->setNeedsNewVTableEntry(needsNewVTableEntry);
 
     if (auto defaultArgumentResilienceExpansion = getActualResilienceExpansion(

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2991,6 +2991,7 @@ void Serializer::writeDecl(const Decl *D) {
                            uint8_t(
                              getStableSelfAccessKind(fn->getSelfAccessKind())),
                            fn->hasDynamicSelf(),
+                           fn->hasForcedStaticDispatch(),
                            fn->hasThrows(),
                            fn->getParameterLists().size(),
                            addGenericEnvironmentRef(

--- a/test/SILGen/Inputs/dynamic_witness_other_module_other.swift
+++ b/test/SILGen/Inputs/dynamic_witness_other_module_other.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public class ExtremeLateBindingCounter {
+  @objc public dynamic var counter: Int = 0
+}

--- a/test/SILGen/dynamic_witness_other_module.swift
+++ b/test/SILGen/dynamic_witness_other_module.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module %S/Inputs/dynamic_witness_other_module_other.swift -emit-module-path %t
+
+// RUN: %target-swift-frontend -emit-silgen %s -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t > /dev/null
+
+import dynamic_witness_other_module_other
+
+protocol EvenMoreExtremeLateBindingCounter {
+  var counter: Int { get set }
+}
+
+extension ExtremeLateBindingCounter : EvenMoreExtremeLateBindingCounter {}
+
+// Make sure we emit a direct reference to the witness's materializeForSet
+// instead of dispatching via class_method.
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T0029dynamic_witness_other_module_C025ExtremeLateBindingCounterC0a1_b1_c1_D008EvenMoreefgH0A2dEP7counterSivmTW : $@convention(witness_method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout ExtremeLateBindingCounter) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+// CHECK: function_ref @_T0029dynamic_witness_other_module_C025ExtremeLateBindingCounterC7counterSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed ExtremeLateBindingCounter) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+// CHECK: return


### PR DESCRIPTION
Otherwise, a protocol conformance where the witness was a dynamic
property in another module would trigger an assertion while building
the materializeForSet witness, or miscompile and fail at runtime
if asserts are off.