### PR TITLE
[GSB] Additional cleanups

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1229,15 +1229,6 @@ public:
   /// source that would be used for the accompanying note.
   bool shouldDiagnoseRedundancy(bool primary) const;
 
-  /// Determine whether the given derived requirement \c source, when rooted at
-  /// the potential archetype \c pa, is actually derived from the same
-  /// requirement. Such "self-derived" requirements do not make the original
-  /// requirement redundant, because without said original requirement, the
-  /// derived requirement ceases to hold.
-  bool isSelfDerivedSource(GenericSignatureBuilder &builder,
-                           Type type,
-                           bool &derivedViaConcrete) const;
-
   /// For a requirement source that describes the requirement \c type:proto,
   /// retrieve the minimal subpath of this requirement source that will
   /// compute that requirement.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -563,14 +563,6 @@ bool RequirementSource::shouldDiagnoseRedundancy(bool primary) const {
          (!primary || !isDerivedRequirement());
 }
 
-bool RequirementSource::isSelfDerivedSource(GenericSignatureBuilder &builder,
-                                            Type type,
-                                            bool &derivedViaConcrete) const {
-  return getMinimalConformanceSource(builder, type, /*proto=*/nullptr,
-                                     derivedViaConcrete)
-    != this;
-}
-
 /// Replace 'Self' in the given dependent type (\c depTy) with the given
 /// potential archetype, producing a new potential archetype that refers to
 /// the nested type. This limited operation makes sure that it does not
@@ -5496,20 +5488,9 @@ static void computeDerivedSameTypeComponents(
   // per component.
   for (const auto &concrete : equivClass->concreteTypeConstraints) {
     // Dig out the component associated with constraint.
-    Type subjectType =
-      concrete.getSubjectDependentType(builder.getGenericParams());
     auto subjectPA = concrete.realizeSubjectPotentialArchetype(builder);
     assert(componentOf.count(subjectPA) > 0);
     auto &component = components[componentOf[subjectPA]];
-
-    // FIXME: Skip self-derived sources. This means our attempts to "stage"
-    // construction of self-derived sources really don't work, because we
-    // discover more information later, so we need a more on-line or
-    // iterative approach.
-    bool derivedViaConcrete;
-    if (concrete.source->isSelfDerivedSource(builder, subjectType,
-                                             derivedViaConcrete))
-      continue;
 
     // If it has a better source than we'd seen before for this component,
     // keep it.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5423,7 +5423,7 @@ static bool unionSets(SmallVectorImpl<unsigned> &parents,
 static void computeDerivedSameTypeComponents(
               GenericSignatureBuilder &builder,
               EquivalenceClass *equivClass,
-              llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf){
+              llvm::SmallDenseMap<CanType, unsigned> &componentOf){
   // Set up the array of "parents" in the union-find data structure.
   llvm::SmallDenseMap<CanType, unsigned> parentIndices;
   SmallVector<unsigned, 4> parents;
@@ -5466,18 +5466,20 @@ static void computeDerivedSameTypeComponents(
 
     // If this is the representative, add a component for it.
     if (representative == index) {
-      componentOf[pa] = components.size();
+      componentOf[depType] = components.size();
       components.push_back(DerivedSameTypeComponent{pa, nullptr});
       continue;
     }
 
     // This is not the representative; point at the component of the
     // representative.
-    auto representativePA = equivClass->members[representative];
-    assert(componentOf.count(representativePA) == 1 &&
+    CanType representativeDepTy =
+      equivClass->members[representative]->getDependentType({ })
+        ->getCanonicalType();
+    assert(componentOf.count(representativeDepTy) == 1 &&
            "Missing representative component?");
-    unsigned componentIndex = componentOf[representativePA];
-    componentOf[pa] = componentIndex;
+    unsigned componentIndex = componentOf[representativeDepTy];
+    componentOf[depType] = componentIndex;
 
     // If this is a better anchor, record it.
     if (compareDependentTypes(&pa, &components[componentIndex].anchor) < 0)
@@ -5488,9 +5490,10 @@ static void computeDerivedSameTypeComponents(
   // per component.
   for (const auto &concrete : equivClass->concreteTypeConstraints) {
     // Dig out the component associated with constraint.
-    auto subjectPA = concrete.realizeSubjectPotentialArchetype(builder);
-    assert(componentOf.count(subjectPA) > 0);
-    auto &component = components[componentOf[subjectPA]];
+    CanType subjectType =
+      concrete.getSubjectDependentType({ })->getCanonicalType();
+    assert(componentOf.count(subjectType) > 0);
+    auto &component = components[componentOf[subjectType]];
 
     // If it has a better source than we'd seen before for this component,
     // keep it.
@@ -5550,16 +5553,17 @@ void IntercomponentEdge::dump() const {
 /// nodes \c from and \c to within the given equivalence class.
 static bool removalDisconnectsEquivalenceClass(
                EquivalenceClass *equivClass,
-               llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
+               llvm::SmallDenseMap<CanType, unsigned> &componentOf,
                std::vector<IntercomponentEdge> &sameTypeEdges,
                unsigned edgeIndex,
-               PotentialArchetype *from,
-               PotentialArchetype *to) {
+               CanType fromDepType,
+               CanType toDepType) {
   // Which component are "from" and "to" in within the intercomponent edges?
-  assert(componentOf.count(from) > 0);
-  auto fromComponentIndex = componentOf[from];
-  assert(componentOf.count(to) > 0);
-  auto toComponentIndex = componentOf[to];
+  assert(componentOf.count(fromDepType) > 0);
+  auto fromComponentIndex = componentOf[fromDepType];
+
+  assert(componentOf.count(toDepType) > 0);
+  auto toComponentIndex = componentOf[toDepType];
 
   // If they're in the same component, they're always connected (due to
   // derived edges).
@@ -5593,24 +5597,33 @@ static bool removalDisconnectsEquivalenceClass(
 static bool isSelfDerivedNestedTypeNameMatchEdge(
               GenericSignatureBuilder &builder,
               EquivalenceClass *equivClass,
-              llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
+              llvm::SmallDenseMap<CanType, unsigned> &componentOf,
               std::vector<IntercomponentEdge> &sameTypeEdges,
               unsigned edgeIndex) {
   const auto &edge = sameTypeEdges[edgeIndex];
-  PotentialArchetype *source =
-    edge.constraint.realizeSubjectPotentialArchetype(builder);
+  auto genericParams = builder.getGenericParams();
+  Type sourceType = edge.constraint.getSubjectDependentType(genericParams);
   PotentialArchetype *target = edge.constraint.value;
-  while (source->getParent() && target->getParent() &&
-         source->getResolvedAssociatedType() ==
-           target->getResolvedAssociatedType()) {
-    source = source->getParent();
+
+  DependentMemberType *sourceDepMemTy;
+  while ((sourceDepMemTy = sourceType->getAs<DependentMemberType>()) &&
+         target->getParent() &&
+         sourceDepMemTy->getAssocType() &&
+         sourceDepMemTy->getAssocType() == target->getResolvedAssociatedType()){
+    sourceType = sourceDepMemTy->getBase();
     target = target->getParent();
 
-    if (source->isInSameEquivalenceClassAs(target) &&
-        source->getEquivalenceClassIfPresent() == equivClass &&
+    if (target->getEquivalenceClassIfPresent() == equivClass &&
+        builder.maybeResolveEquivalenceClass(
+                                     sourceType,
+                                     ArchetypeResolutionKind::WellFormed,
+                                     /*wantExactPotentialArchetype=*/false)
+          .getEquivalenceClass(builder) == equivClass &&
         !removalDisconnectsEquivalenceClass(equivClass, componentOf,
                                             sameTypeEdges, edgeIndex,
-                                            source, target))
+                                            sourceType->getCanonicalType(),
+                                            target->getDependentType({ })
+                                              ->getCanonicalType()))
       return true;
   }
 
@@ -5625,7 +5638,7 @@ static bool isSelfDerivedNestedTypeNameMatchEdge(
 static void collapseSameTypeComponentsThroughDelayedRequirements(
               GenericSignatureBuilder &builder,
               EquivalenceClass *equivClass,
-              llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
+              llvm::SmallDenseMap<CanType, unsigned> &componentOf,
               SmallVectorImpl<unsigned> &collapsedParents,
               unsigned &remainingComponents) {
   unsigned numCollapsedParents = collapsedParents.size();
@@ -5637,6 +5650,10 @@ static void collapseSameTypeComponentsThroughDelayedRequirements(
   /// Retrieve the component for a type representing a virtual component
   auto getTypeVirtualComponent = [&](Type type) {
     CanType canType = type->getCanonicalType();
+    auto knownActual = componentOf.find(canType);
+    if (knownActual != componentOf.end())
+      return knownActual->second;
+
     auto knownVirtual = virtualComponents.find(canType);
     if (knownVirtual != virtualComponents.end())
       return knownVirtual->second;
@@ -5648,30 +5665,16 @@ static void collapseSameTypeComponentsThroughDelayedRequirements(
   };
 
   /// Retrieve the component for the given potential archetype.
+  auto genericParams = builder.getGenericParams();
   auto getPotentialArchetypeVirtualComponent = [&](PotentialArchetype *pa) {
     if (pa->getEquivalenceClassIfPresent() == equivClass)
-      return componentOf[pa];
+      return getTypeVirtualComponent(pa->getDependentType(genericParams));
 
     // We found a potential archetype in another equivalence class. Treat it
     // as a "virtual" component representing that potential archetype's
     // equivalence class.
-    auto genericParams = builder.getGenericParams();
     return getTypeVirtualComponent(
              pa->getRepresentative()->getDependentType(genericParams));
-  };
-
-  /// Local function to retrieve the component with which the given type is
-  /// associated, for a type that we haven't tried to resolve yet.
-  auto getUnknownTypeVirtualComponent = [&](Type type) {
-    if (auto pa =
-            builder.maybeResolveEquivalenceClass(
-                                     type,
-                                     ArchetypeResolutionKind::AlreadyKnown,
-                                     /*wantExactPotentialArchetype=*/true)
-              .getPotentialArchetypeIfKnown())
-      return getPotentialArchetypeVirtualComponent(pa);
-
-    return getTypeVirtualComponent(type);
   };
 
   for (const auto &delayedReq : equivClass->delayedRequirements) {
@@ -5682,13 +5685,13 @@ static void collapseSameTypeComponentsThroughDelayedRequirements(
     if (auto lhsPA = delayedReq.lhs.dyn_cast<PotentialArchetype *>())
       lhsComponent = getPotentialArchetypeVirtualComponent(lhsPA);
     else
-      lhsComponent = getUnknownTypeVirtualComponent(delayedReq.lhs.get<Type>());
+      lhsComponent = getTypeVirtualComponent(delayedReq.lhs.get<Type>());
 
     unsigned rhsComponent;
     if (auto rhsPA = delayedReq.rhs.dyn_cast<PotentialArchetype *>())
       rhsComponent = getPotentialArchetypeVirtualComponent(rhsPA);
     else
-      rhsComponent = getUnknownTypeVirtualComponent(delayedReq.rhs.get<Type>());
+      rhsComponent = getTypeVirtualComponent(delayedReq.rhs.get<Type>());
 
     // Collapse the sets
     if (unionSets(collapsedParents, lhsComponent, rhsComponent,
@@ -5708,7 +5711,7 @@ static void collapseSameTypeComponentsThroughDelayedRequirements(
 static void collapseSameTypeComponents(
               GenericSignatureBuilder &builder,
               EquivalenceClass *equivClass,
-              llvm::SmallDenseMap<PotentialArchetype *, unsigned> &componentOf,
+              llvm::SmallDenseMap<CanType, unsigned> &componentOf,
               std::vector<IntercomponentEdge> &sameTypeEdges) {
   SmallVector<unsigned, 4> collapsedParents;
   for (unsigned i : indices(equivClass->derivedSameTypeComponents)) {
@@ -5828,7 +5831,7 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
 
   // Compute the components in the subgraph of the same-type constraint graph
   // that includes only derived constraints.
-  llvm::SmallDenseMap<PotentialArchetype *, unsigned> componentOf;
+  llvm::SmallDenseMap<CanType, unsigned> componentOf;
   computeDerivedSameTypeComponents(*this, equivClass, componentOf);
 
   // Go through all of the same-type constraints, collecting all of the
@@ -5860,13 +5863,16 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
     }
 
     // Determine which component each of the source/destination fall into.
-    auto subjectPA = constraint.realizeSubjectPotentialArchetype(*this);
-    assert(componentOf.count(subjectPA) > 0 &&
+    CanType subjectType =
+      constraint.getSubjectDependentType({ })->getCanonicalType();
+    assert(componentOf.count(subjectType) > 0 &&
            "unknown potential archetype?");
-    unsigned firstComponentIdx = componentOf[subjectPA];
-    assert(componentOf.count(constraint.value) > 0 &&
+    unsigned firstComponentIdx = componentOf[subjectType];
+    assert(componentOf.count(
+             constraint.value->getDependentType({ })->getCanonicalType()) > 0 &&
            "unknown potential archetype?");
-    unsigned secondComponentIdx = componentOf[constraint.value];
+    unsigned secondComponentIdx =
+      componentOf[constraint.value->getDependentType({ })->getCanonicalType()];
 
     // Separately track nested-type-name-match constraints.
     if (constraint.source->getRoot()->kind ==


### PR DESCRIPTION
* Eliminate `RequirementSource::isSelfDerivedSource()`, whose sole caller was unnecessary code
* Move the potential archetype -> component index mapping off of potential archetypes