### PR TITLE
Synthesize ==/hashValue for tuple fields/payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Swift 4.1
 
 * [SE-0185][]
 
-  Structs and enums that declare a conformance to `Equatable`/`Hashable` now get an automatically synthesized implementation of `==`/`hashValue`. For structs, all stored properties must be `Equatable`/`Hashable`. For enums, all enum cases with associated values must be `Equatable`/`Hashable`.
+  Structs and enums that declare a conformance to `Equatable`/`Hashable` now get an automatically synthesized implementation of `==`/`hashValue`. For structs, all stored properties must either be `Equatable`/`Hashable` or tuples where all elements are `Equatable`/`Hashable`. For enums, all enum cases with associated values must be `Equatable`/`Hashable` or tuples where all elements are `Equatable`/`Hashable`.
 
   ```swift
   public struct Point: Hashable {

--- a/test/Interpreter/enum_equatable_hashable_correctness.swift
+++ b/test/Interpreter/enum_equatable_hashable_correctness.swift
@@ -93,4 +93,36 @@ EnumSynthesisTests.test("IndirectEquatability/Hashability") {
   checkHashable([one, two, three, four], equalityOracle: { $0 == $1 })
 }
 
+// Test the synthesized members when the enum contains tuples of various
+// arities.
+enum HasTuple6: Hashable {
+  case v((Int, Int, Int, Int, Int, Int))
+}
+enum HasTuple7: Hashable {
+  case v((a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int))
+}
+
+EnumSynthesisTests.test("TupleEquatability/Hashability") {
+  checkHashable([
+    HasTuple6.v((1, 2, 3, 4, 5, 6)), .v((1, 2, 3, 4, 5, 7)),
+  ], equalityOracle: { $0 == $1 })
+
+  checkHashable([
+    HasTuple7.v((a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7)),
+    .v((a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 8)),
+  ], equalityOracle: { $0 == $1 })
+}
+
+EnumSynthesisTests.test("CloseTupleValuesDoNotCollide") {
+  expectNotEqual(
+    HasTuple6.v((1, 2, 3, 4, 5, 6)).hashValue,
+    HasTuple6.v((1, 2, 3, 4, 5, 7)).hashValue
+  )
+
+  expectNotEqual(
+    HasTuple7.v((a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7)).hashValue,
+    HasTuple7.v((a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 8)).hashValue
+  )
+}
+
 runAllTests()

--- a/test/Interpreter/struct_equatable_hashable_correctness.swift
+++ b/test/Interpreter/struct_equatable_hashable_correctness.swift
@@ -67,4 +67,37 @@ StructSynthesisTests.test("ExplicitOverridesSynthesizedInExtension") {
   expectEqual(OverridesInExtension(a: 4).hashValue, 2)
 }
 
+// Test the synthesized members when the struct contains tuples of various
+// arities.
+struct HasTuple6: Hashable {
+  let v: (Int, Int, Int, Int, Int, Int)
+}
+struct HasTuple7: Hashable {
+  let v: (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int)
+}
+
+StructSynthesisTests.test("TupleEquatability/Hashability") {
+  checkHashable([
+    HasTuple6(v: (1, 2, 3, 4, 5, 6)),
+    HasTuple6(v: (1, 2, 3, 4, 5, 7)),
+  ], equalityOracle: { $0 == $1 })
+
+  checkHashable([
+    HasTuple7(v: (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7)),
+    HasTuple7(v: (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 8)),
+  ], equalityOracle: { $0 == $1 })
+}
+
+StructSynthesisTests.test("CloseTupleValuesDoNotCollide") {
+  expectNotEqual(
+    HasTuple6(v: (1, 2, 3, 4, 5, 6)).hashValue,
+    HasTuple6(v: (1, 2, 3, 4, 5, 7)).hashValue
+  )
+
+  expectNotEqual(
+    HasTuple7(v: (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7)).hashValue,
+    HasTuple7(v: (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 8)).hashValue
+  )
+}
+
 runAllTests()

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -35,7 +35,7 @@ enum CustomHashable {
 
   var hashValue: Int { return 0 }
 }
-func ==(x: CustomHashable, y: CustomHashable) -> Bool { // expected-note 3 {{non-matching type}}
+func ==(x: CustomHashable, y: CustomHashable) -> Bool { // expected-note 4 {{non-matching type}}
   return true
 }
 
@@ -50,7 +50,7 @@ enum InvalidCustomHashable {
 
   var hashValue: String { return "" } // expected-note{{previously declared here}}
 }
-func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String { // expected-note 3 {{non-matching type}}
+func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String { // expected-note 4 {{non-matching type}}
   return ""
 }
 if InvalidCustomHashable.A == .B { }
@@ -172,7 +172,7 @@ public enum Medicine {
 
 extension Medicine : Equatable {}
 
-public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 2 {{non-matching type}}
+public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 3 {{non-matching type}}
   return true
 }
 
@@ -189,7 +189,7 @@ extension NotExplicitlyHashableAndCannotDerive : Hashable {} // expected-error 2
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
 extension OtherFileNonconforming: Hashable {
-  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 2 {{non-matching type}}
+  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 3 {{non-matching type}}
     return true
   }
   var hashValue: Int { return 0 }
@@ -224,6 +224,22 @@ enum MutuallyIndirectB: Hashable {
 indirect enum TotallyIndirect: Hashable {
   case another(TotallyIndirect)
   case end(Int)
+}
+
+// Verify the expected results for a few tuple cases. The arity-7 case is
+// important because the stdlib's built-in == operators end at 6 and we want to
+// make sure we can handle higher ones.
+enum SatisfyingTuple0: Hashable {
+  case value(payload: ())
+}
+enum SatisfyingTuple6: Hashable {
+  case value(payload: (Int, Int, Int, Int, Int, Int))
+}
+enum SatisfyingTuple7: Hashable {
+  case value(payload: (Int, Int, Int, Int, Int, Int, Int))
+}
+enum NotSatisfyingTuple: Hashable {  // expected-error 2 {{does not conform}}
+  case value(payload: (Int, Int, NotHashable, Int, Int, Int))
 }
 
 // FIXME: Remove -verify-ignore-unknown.

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -38,7 +38,7 @@ struct CustomHashable: Hashable {
 
   var hashValue: Int { return 0 }
 
-  static func ==(x: CustomHashable, y: CustomHashable) -> Bool { return true } // expected-note 2 {{non-matching type}}
+  static func ==(x: CustomHashable, y: CustomHashable) -> Bool { return true } // expected-note 3 {{non-matching type}}
 }
 
 if CustomHashable(x: 1, y: 2) == CustomHashable(x: 2, y: 3) { }
@@ -121,7 +121,7 @@ public struct StructConformsAndImplementsInExtension {
   let v: Int
 }
 extension StructConformsAndImplementsInExtension : Equatable {
-  public static func ==(lhs: StructConformsAndImplementsInExtension, rhs: StructConformsAndImplementsInExtension) -> Bool {  // expected-note {{non-matching type}}
+  public static func ==(lhs: StructConformsAndImplementsInExtension, rhs: StructConformsAndImplementsInExtension) -> Bool {  // expected-note 2 {{non-matching type}}
     return true
   }  
 }
@@ -138,13 +138,29 @@ struct NoStoredProperties: Hashable {}
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
 extension OtherFileNonconforming: Hashable {
-  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note {{non-matching type}}
+  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 2 {{non-matching type}}
     return true
   }
   var hashValue: Int { return 0 }
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
 extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+
+// Verify the expected results for a few tuple cases. The arity-7 case is
+// important because the stdlib's built-in == operators end at 6 and we want to
+// make sure we can handle higher ones.
+struct SatisfyingTuple0: Hashable {
+  let value: ()
+}
+struct SatisfyingTuple6: Hashable {
+  let value: (Int, Int, Int, Int, Int, Int)
+}
+struct SatisfyingTuple7: Hashable {
+  let value: (Int, Int, Int, Int, Int, Int, Int)
+}
+struct NotSatisfyingTuple: Hashable {  // expected-error 2 {{does not conform}}
+  let value: (Int, Int, NotHashable, Int, Int, Int)
+}
 
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'


### PR DESCRIPTION
The original PR (#9619) implementing `Equatable`/`Hashable` only covered types that directly conformed to those protocols. This is a bit restrictive for real-world usage—for example, a `struct` with an `Int?` field won't be able to synthesize, so this PR fills in some gaps for the sake of usability: synthesis for fields/associated values that are ~`Optional<T> where T: Equatable/Hashable` and for~ tuples where all fields are `Equatable`/`Hashable`.

~In each case, ~future language improvements will eventually allow the special cases to go away. ~For `Optional`, we need conditional conformances.~ For tuples, we need the ability to conform non-nominal types to protocols (and variadic generics).

**Update:** As discussed below, the support for `Optional` has been removed because it will be covered better by conditional conformances. Exciting!