### PR TITLE
[runtime] Clean up symbols in StdlibUnittest and the internal leak checker.

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -312,9 +312,9 @@ func internalMedian(_ inputs: [UInt64]) -> UInt64 {
 
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
 
-@_silgen_name("swift_leaks_startTrackingObjects")
+@_silgen_name("_swift_leaks_startTrackingObjects")
 func startTrackingObjects(_: UnsafeMutableRawPointer) -> ()
-@_silgen_name("swift_leaks_stopTrackingObjects")
+@_silgen_name("_swift_leaks_stopTrackingObjects")
 func stopTrackingObjects(_: UnsafeMutableRawPointer) -> Int
 
 #endif

--- a/stdlib/private/StdlibUnittest/GetOSVersion.mm
+++ b/stdlib/private/StdlibUnittest/GetOSVersion.mm
@@ -15,9 +15,9 @@
 
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift)
-extern "C" const char *
-swift_stdlib_getSystemVersionPlistProperty(const char *PropertyName) {
+SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+const char *
+getSystemVersionPlistProperty(const char *PropertyName) {
   // This function is implemented in Objective-C because Swift does not support
   // failing initializers.
   if (!PropertyName)

--- a/stdlib/private/StdlibUnittest/InspectValue.cpp
+++ b/stdlib/private/StdlibUnittest/InspectValue.cpp
@@ -15,9 +15,8 @@
 
 using namespace swift;
 
-SWIFT_CC(swift)
-extern "C"
-uint32_t swift_StdlibUnittest_getMetadataKindOf(
+SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+uint32_t getMetadataKindOf(
     OpaqueValue *value,
     const Metadata *type
 ) {

--- a/stdlib/private/StdlibUnittest/InspectValue.swift
+++ b/stdlib/private/StdlibUnittest/InspectValue.swift
@@ -30,11 +30,11 @@ public enum SwiftRuntime {
     case errorObject = 128
   }
 
-  @_silgen_name("swift_StdlibUnittest_getMetadataKindOf")
-  static func _metadataKindImpl<T>(of value: T) -> UInt32
+  @_silgen_name("getMetadataKindOf")
+  private static func _metadataKind<T>(of value: T) -> UInt32
 
   public static func metadataKind<T>(of value: T) -> MetadataKind {
-    return MetadataKind(rawValue: Int(_metadataKindImpl(of: value)))!
+    return MetadataKind(rawValue: Int(_metadataKind(of: value)))!
   }
 }
 

--- a/stdlib/private/StdlibUnittest/InterceptTraps.cpp
+++ b/stdlib/private/StdlibUnittest/InterceptTraps.cpp
@@ -33,8 +33,8 @@ static void CrashCatcher(int Sig) {
   _exit(0);
 }
 
-SWIFT_CC(swift)
-extern "C" void swift_stdlib_installTrapInterceptor() {
+SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+void installTrapInterceptor() {
   // Disable buffering on stdout so that everything is printed before crashing.
   setbuf(stdout, 0);
 

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp
@@ -12,7 +12,6 @@
 
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift)
-extern "C"
-void *swift_stdlib_getPointer(void *x) { return x; }
+SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+void *getPointer(void *x) { return x; }
 

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -10,21 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_silgen_name("swift_stdlib_getPointer")
-func _stdlib_getPointer(_ x: OpaquePointer) -> OpaquePointer
+@_silgen_name("getPointer")
+func _getPointer(_ x: OpaquePointer) -> OpaquePointer
 
 public func _opaqueIdentity<T>(_ x: T) -> T {
   let ptr = UnsafeMutablePointer<T>.allocate(capacity: 1)
   ptr.initialize(to: x)
   let result =
-    UnsafeMutablePointer<T>(_stdlib_getPointer(OpaquePointer(ptr))).pointee
+    UnsafeMutablePointer<T>(_getPointer(OpaquePointer(ptr))).pointee
   ptr.deinitialize()
   ptr.deallocate(capacity: 1)
   return result
 }
 
 func _blackHolePtr<T>(_ x: UnsafePointer<T>) {
-  _ = _stdlib_getPointer(OpaquePointer(x))
+  _ = _getPointer(OpaquePointer(x))
 }
 
 public func _blackHole<T>(_ x: T) {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -617,8 +617,8 @@ var _testSuiteNameToIndex: [String : Int] = [:]
 let _stdlibUnittestStreamPrefix = "__STDLIB_UNITTEST__"
 let _crashedPrefix = "CRASHED:"
 
-@_silgen_name("swift_stdlib_installTrapInterceptor")
-func _stdlib_installTrapInterceptor()
+@_silgen_name("installTrapInterceptor")
+func _installTrapInterceptor()
 
 #if _runtime(_ObjC)
 @objc protocol _StdlibUnittestNSException {
@@ -629,7 +629,7 @@ func _stdlib_installTrapInterceptor()
 // Avoid serializing references to objc_setUncaughtExceptionHandler in SIL.
 @inline(never)
 func _childProcess() {
-  _stdlib_installTrapInterceptor()
+  _installTrapInterceptor()
 
 #if _runtime(_ObjC)
   objc_setUncaughtExceptionHandler {
@@ -1192,9 +1192,9 @@ public func runAllTests() {
 
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
 
-@_silgen_name("swift_leaks_startTrackingObjects")
+@_silgen_name("_swift_leaks_startTrackingObjects")
 func startTrackingObjects(_: UnsafePointer<CChar>)
-@_silgen_name("swift_leaks_stopTrackingObjects")
+@_silgen_name("_swift_leaks_stopTrackingObjects")
 func stopTrackingObjects(_: UnsafePointer<CChar>) -> Int
 
 #endif
@@ -1408,12 +1408,12 @@ public final class TestSuite {
 }
 
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
-@_silgen_name("swift_stdlib_getSystemVersionPlistProperty")
-func _stdlib_getSystemVersionPlistPropertyImpl(
+@_silgen_name("getSystemVersionPlistProperty")
+func _getSystemVersionPlistPropertyImpl(
   _ propertyName: UnsafePointer<CChar>) -> UnsafePointer<CChar>?
 
-func _stdlib_getSystemVersionPlistProperty(_ propertyName: String) -> String? {
-  let cs = _stdlib_getSystemVersionPlistPropertyImpl(propertyName)
+func _getSystemVersionPlistProperty(_ propertyName: String) -> String? {
+  let cs = _getSystemVersionPlistPropertyImpl(propertyName)
   return cs.map(String.init(cString:))
 }
 #endif
@@ -1509,7 +1509,7 @@ func _getOSVersion() -> OSVersion {
 #elseif os(Haiku)
   return .haiku
 #else
-  let productVersion = _stdlib_getSystemVersionPlistProperty("ProductVersion")!
+  let productVersion = _getSystemVersionPlistProperty("ProductVersion")!
   let (major, minor, bugFix) = _parseDottedVersionTriple(productVersion)
   #if os(OSX)
   return .osx(major: major, minor: minor, bugFix: bugFix)

--- a/stdlib/private/StdlibUnittest/TestHelpers.swift
+++ b/stdlib/private/StdlibUnittest/TestHelpers.swift
@@ -14,7 +14,7 @@ class DummyClass {}
 
 // Used by the weak.mm runtime tests. All that matters is that the returned
 // object is an instance of a pure Swift class.
-@_silgen_name("make_swift_object")
+@_silgen_name("_swift_StdlibUnittest_make_swift_object")
 public func make_swift_object() -> AnyObject {
   return DummyClass()
 }

--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -80,8 +80,8 @@ public func autoreleasepoolIfUnoptimizedReturnAutoreleased(
 }
 
 @_versioned
-@_silgen_name("swift_stdlib_NSArray_getObjects")
-internal func _stdlib_NSArray_getObjects(
+@_silgen_name("NSArray_getObjects")
+func NSArray_getObjects(
   nsArray: AnyObject,
   objects: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
   rangeLocation: Int,
@@ -92,7 +92,7 @@ extension NSArray {
   public func available_getObjects(
     _ objects: AutoreleasingUnsafeMutablePointer<AnyObject?>?, range: NSRange
   ) {
-    return _stdlib_NSArray_getObjects(
+    return NSArray_getObjects(
       nsArray: self,
       objects: objects,
       rangeLocation: range.location,
@@ -100,8 +100,8 @@ extension NSArray {
   }
 }
 
-@_silgen_name("swift_stdlib_NSDictionary_getObjects")
-func _stdlib_NSDictionary_getObjects(
+@_silgen_name("NSDictionary_getObjects")
+func NSDictionary_getObjects(
   nsDictionary: NSDictionary,
   objects: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
   andKeys keys: AutoreleasingUnsafeMutablePointer<AnyObject?>?
@@ -113,7 +113,7 @@ extension NSDictionary {
     _ objects: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
     andKeys keys: AutoreleasingUnsafeMutablePointer<AnyObject?>?
   ) {
-    return _stdlib_NSDictionary_getObjects(
+    return NSDictionary_getObjects(
       nsDictionary: self,
       objects: objects,
       andKeys: keys)

--- a/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
+++ b/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
@@ -13,19 +13,19 @@
 #include <Foundation/Foundation.h>
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift)
+SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY
 extern "C" void
-swift_stdlib_NSArray_getObjects(NSArray NS_RELEASES_ARGUMENT *_Nonnull nsArray,
-                                id *objects, NSUInteger rangeLocation,
-                                NSUInteger rangeLength) {
+NSArray_getObjects(NSArray NS_RELEASES_ARGUMENT *_Nonnull nsArray,
+                   id *objects, NSUInteger rangeLocation,
+                   NSUInteger rangeLength) {
   [nsArray getObjects:objects range:NSMakeRange(rangeLocation, rangeLength)];
   [nsArray release];
 }
 
-SWIFT_CC(swift)
+SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY
 extern "C" void
-swift_stdlib_NSDictionary_getObjects(NSDictionary *_Nonnull nsDictionary,
-                                     id *objects, id *keys) {
+NSDictionary_getObjects(NSDictionary *_Nonnull nsDictionary,
+                        id *objects, id *keys) {
   [nsDictionary getObjects:objects andKeys:keys];
   [nsDictionary release];
 }

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -31,21 +31,26 @@ struct HeapObject;
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
-void swift_leaks_startTrackingObjects(const char *);
+void _swift_leaks_startTrackingObjects(const char *);
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
-int swift_leaks_stopTrackingObjects(const char *);
+int _swift_leaks_stopTrackingObjects(const char *);
 SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
-void swift_leaks_startTrackingObject(swift::HeapObject *);
+void _swift_leaks_startTrackingObject(swift::HeapObject *);
 SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
-void swift_leaks_stopTrackingObject(swift::HeapObject *);
+void _swift_leaks_stopTrackingObject(swift::HeapObject *);
 
 #define SWIFT_LEAKS_START_TRACKING_OBJECT(obj)                                 \
-  swift_leaks_startTrackingObject(obj)
+  _swift_leaks_startTrackingObject(obj)
 #define SWIFT_LEAKS_STOP_TRACKING_OBJECT(obj)                                  \
-  swift_leaks_stopTrackingObject(obj)
+  _swift_leaks_stopTrackingObject(obj)
+
+// SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
 #else
+// not SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
+
 #define SWIFT_LEAKS_START_TRACKING_OBJECT(obj)
 #define SWIFT_LEAKS_STOP_TRACKING_OBJECT(obj)
+
 #endif
 
 #endif

--- a/unittests/runtime/weak.mm
+++ b/unittests/runtime/weak.mm
@@ -42,8 +42,13 @@ static HeapObject *make_objc_object() {
 }
 
 // Make a Native Swift object by calling a Swift function.
-// make_swift_object is defined in TestHelpers.swift as part of StdlibUnittest.
-SWIFT_CC(swift) extern "C" HeapObject *make_swift_object();
+// _swift_StdlibUnittest_make_swift_object is implemented in StdlibUnittest.
+SWIFT_CC(swift) extern "C"
+HeapObject *_swift_StdlibUnittest_make_swift_object();
+
+static HeapObject *make_swift_object() {
+  return _swift_StdlibUnittest_make_swift_object();
+}
 
 static unsigned getUnownedRetainCount(HeapObject *object) {
   return swift_unownedRetainCount(object) - 1;


### PR DESCRIPTION
* Export fewer symbols.
* Prefix exported but not-public symbols with .