### PR TITLE
[Foundation] Guard Data access to NSData._isCompact under availability guards

### DIFF
--- a/stdlib/public/SwiftShims/NSDataShims.h
+++ b/stdlib/public/SwiftShims/NSDataShims.h
@@ -21,7 +21,7 @@ FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorFree;
 FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorNone;
 
 @interface NSData (FoundationSPI)
-- (BOOL)_isCompact;
+- (BOOL)_isCompact API_AVAILABLE(macos(10.10), ios(8.0), watchos(2.0), tvos(9.0));
 @end
 
 NS_END_DECLS


### PR DESCRIPTION
Explanation:
The SPI method `-[NSData _isCompact]` was introduced in macOS 10.10 for interoperation with dispatch_data_t and was not present in 10.9; we can still provide the behavior of determining of the underlying NSData is actually compact (a contiguous backing storage for the underlying bytes) via a shim emulating the default behavior of the abstract base class of NSData.

Scope:
This only applies to building for 10.9 support and running on that OS.

Radar (and possibly SR Issue):
<rdar://problem/35109205>

Risk:
The risk here should be relatively low since it only applies to a limited supported edge of platform versions and thunks access to a re-implementation similar to the base abstract implementation of NSData.

Reviewed by:
Itai Ferber

Testing:
The current tests should hit this code-path (but branch to the delegation to NSData's implementation)

Directions for QE:
None