### PR TITLE
Address post-commit review comments on PR #11910

### DIFF
--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -110,7 +110,7 @@ struct _RuntimeFunctionCounters {
 
   /// Get the names of all runtime functions whose calls are being
   /// tracked.
-  @_silgen_name("getRuntimeFunctionNames")
+  @_silgen_name("_swift_getRuntimeFunctionNames")
   static public func _getRuntimeFunctionNames() ->
     UnsafePointer<UnsafePointer<CChar>>
 
@@ -129,21 +129,21 @@ struct _RuntimeFunctionCounters {
 
   /// Get the offsets of the collected runtime function counters inside
   /// the state.
-  @_silgen_name("getRuntimeFunctionCountersOffsets")
+  @_silgen_name("_swift_getRuntimeFunctionCountersOffsets")
   static public func getRuntimeFunctionCountersOffsets() ->
     UnsafePointer<UInt16>
 
   /// Get the number of different runtime functions whose calls are being
   /// tracked.
-  @_silgen_name("getNumRuntimeFunctionCounters")
+  @_silgen_name("_swift_getNumRuntimeFunctionCounters")
   static public func getNumRuntimeFunctionCounters() -> Int
 
   /// Dump all per-object runtime function counters.
-  @_silgen_name("dumpObjectsRuntimeFunctionPointers")
+  @_silgen_name("_swift_dumpObjectsRuntimeFunctionPointers")
   static public func dumpObjectsRuntimeFunctionPointers()
 
   @discardableResult
-  @_silgen_name("setGlobalRuntimeFunctionCountersUpdateHandler")
+  @_silgen_name("_swift_setGlobalRuntimeFunctionCountersUpdateHandler")
   static public func setGlobalRuntimeFunctionCountersUpdateHandler(
     handler: RuntimeFunctionCountersUpdateHandler?
   ) -> RuntimeFunctionCountersUpdateHandler?
@@ -312,31 +312,31 @@ internal struct _RuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
 }
 
 extension _RuntimeFunctionCounters {
-  @_silgen_name("getObjectRuntimeFunctionCounters")
+  @_silgen_name("_swift_getObjectRuntimeFunctionCounters")
   static internal func getObjectRuntimeFunctionCounters(
     _ object: UnsafeRawPointer, _ result: inout _RuntimeFunctionCountersState)
 
-  @_silgen_name("getGlobalRuntimeFunctionCounters")
+  @_silgen_name("_swift_getGlobalRuntimeFunctionCounters")
   static internal func getGlobalRuntimeFunctionCounters(
     _ result: inout _RuntimeFunctionCountersState)
 
-  @_silgen_name("setGlobalRuntimeFunctionCounters")
+  @_silgen_name("_swift_setGlobalRuntimeFunctionCounters")
   static internal func setGlobalRuntimeFunctionCounters(
     _ state: inout _RuntimeFunctionCountersState)
 
-  @_silgen_name("setObjectRuntimeFunctionCounters")
+  @_silgen_name("_swift_setObjectRuntimeFunctionCounters")
   static internal func setObjectRuntimeFunctionCounters(
     _ object: UnsafeRawPointer,
     _ state: inout _RuntimeFunctionCountersState)
 
   @discardableResult
-  @_silgen_name("setGlobalRuntimeFunctionCountersMode")
+  @_silgen_name("_swift_setGlobalRuntimeFunctionCountersMode")
   static
   public // @testable
   func setGlobalRuntimeFunctionCountersMode(enable: Bool) -> Bool
 
   @discardableResult
-  @_silgen_name("setPerObjectRuntimeFunctionCountersMode")
+  @_silgen_name("_swift_setPerObjectRuntimeFunctionCountersMode")
   static
   public // @testable
   func setPerObjectRuntimeFunctionCountersMode(enable: Bool) -> Bool

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -69,52 +69,53 @@ using RuntimeFunctionCountersUpdateHandler =
 
 /// Get the runtime object state associated with an object and store it
 /// into the result.
-SWIFT_RT_ENTRY_VISIBILITY void
-getObjectRuntimeFunctionCounters(HeapObject *object,
-                                 RuntimeFunctionCountersState *result);
+SWIFT_RUNTIME_EXPORT void
+_swift_getObjectRuntimeFunctionCounters(HeapObject *object,
+                                        RuntimeFunctionCountersState *result);
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest and store it into the result.
-SWIFT_RT_ENTRY_VISIBILITY void
-getGlobalRuntimeFunctionCounters(swift::RuntimeFunctionCountersState *result);
+SWIFT_RUNTIME_EXPORT void _swift_getGlobalRuntimeFunctionCounters(
+    swift::RuntimeFunctionCountersState *result);
 
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure.
-SWIFT_RT_ENTRY_VISIBILITY const char **getRuntimeFunctionNames();
+SWIFT_RUNTIME_EXPORT const char **_swift_getRuntimeFunctionNames();
 
 /// Return the offsets of the runtime function counters being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeFunctionCountersState structure.
-SWIFT_RT_ENTRY_VISIBILITY const uint16_t *getRuntimeFunctionCountersOffsets();
+SWIFT_RUNTIME_EXPORT const uint16_t *_swift_getRuntimeFunctionCountersOffsets();
 
 /// Return the number of runtime functions being tracked.
-SWIFT_RT_ENTRY_VISIBILITY uint64_t getNumRuntimeFunctionCounters();
+SWIFT_RUNTIME_EXPORT uint64_t _swift_getNumRuntimeFunctionCounters();
 
 /// Dump all per-object runtime function pointers.
-SWIFT_RT_ENTRY_VISIBILITY void dumpObjectsRuntimeFunctionPointers();
+SWIFT_RUNTIME_EXPORT void _swift_dumpObjectsRuntimeFunctionPointers();
 
 /// Set mode for global runtime function counters.
 /// Return the old value of this flag.
-SWIFT_RT_ENTRY_VISIBILITY int setPerObjectRuntimeFunctionCountersMode(int mode);
+SWIFT_RUNTIME_EXPORT int
+_swift_setPerObjectRuntimeFunctionCountersMode(int mode);
 
 /// Set mode for per object runtime function counters.
 /// Return the old value of this flag.
-SWIFT_RT_ENTRY_VISIBILITY int setGlobalRuntimeFunctionCountersMode(int mode);
+SWIFT_RUNTIME_EXPORT int _swift_setGlobalRuntimeFunctionCountersMode(int mode);
 
 /// Set the global runtime state of function pointers from a provided state.
-SWIFT_RT_ENTRY_VISIBILITY void
-setGlobalRuntimeFunctionCounters(swift::RuntimeFunctionCountersState *state);
+SWIFT_RUNTIME_EXPORT void _swift_setGlobalRuntimeFunctionCounters(
+    swift::RuntimeFunctionCountersState *state);
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
-SWIFT_RT_ENTRY_VISIBILITY void
-setObjectRuntimeFunctionCounters(HeapObject *object,
-                                 RuntimeFunctionCountersState *state);
+SWIFT_RUNTIME_EXPORT void
+_swift_setObjectRuntimeFunctionCounters(HeapObject *object,
+                                        RuntimeFunctionCountersState *state);
 
 /// Set the global runtime function counters update handler.
-SWIFT_RT_ENTRY_VISIBILITY RuntimeFunctionCountersUpdateHandler
-setGlobalRuntimeFunctionCountersUpdateHandler(
+SWIFT_RUNTIME_EXPORT RuntimeFunctionCountersUpdateHandler
+_swift_setGlobalRuntimeFunctionCountersUpdateHandler(
     RuntimeFunctionCountersUpdateHandler handler);
 
 #endif


### PR DESCRIPTION
- Use SWIFT_RUNTIME_EXPORT instead of SWIFT_RT_ENTRY_VISIBILITY for exposed functions
- Use `_swift_`  prefixes on the names of exposed functions
- Make the global counters and per-object counters cache thread-safe by using locks
- Use Lazy to avoid warnings about global destructors for global objects
