### PR TITLE
libSyntax: ensure copy constructor of OwnedString to release previously allocated data. rdar://35116413

### DIFF
--- a/include/swift/Basic/OwnedString.h
+++ b/include/swift/Basic/OwnedString.h
@@ -44,10 +44,15 @@ class OwnedString {
   size_t Length;
   StringOwnership Ownership;
 
+  void release() {
+    if (Ownership == StringOwnership::Copied)
+      free(const_cast<char *>(Data));
+  }
+
   OwnedString(const char* Data, size_t Length, StringOwnership Ownership)
       : Length(Length), Ownership(Ownership) {
     assert(Length >= 0 && "expected length to be non-negative");
-
+    release();
     if (Ownership == StringOwnership::Copied && Data) {
       char *substring = static_cast<char *>(malloc(Length + 1));
       assert(substring && "expected successful malloc of copy");
@@ -73,7 +78,7 @@ public:
 
   OwnedString(const OwnedString &Other)
       : OwnedString(Other.Data, Other.Length, Other.Ownership) {}
-  
+
   OwnedString copy() {
     return OwnedString(Data, Length, StringOwnership::Copied);
   }
@@ -99,8 +104,7 @@ public:
   }
 
   ~OwnedString() {
-    if (Ownership == StringOwnership::Copied)
-      free(const_cast<char *>(Data));
+    release();
   }
 };
 

--- a/include/swift/Basic/OwnedString.h
+++ b/include/swift/Basic/OwnedString.h
@@ -78,10 +78,33 @@ public:
 
   OwnedString(const char *Data) : OwnedString(StringRef(Data)) {}
 
-  OwnedString(const OwnedString &Other) {
-    // Release previously allocated data.
-    release();
-    initialize(Other.Data, Other.Length, Other.Ownership);
+  OwnedString(const OwnedString &Other):
+    OwnedString(Other.Data, Other.Length, Other.Ownership) {}
+
+  OwnedString(OwnedString &&Other): Data(Other.Data), Length(Other.Length),
+      Ownership(Other.Ownership) {
+    Other.Data = nullptr;
+    Other.Ownership = StringOwnership::Unowned;
+  }
+
+  OwnedString& operator=(const OwnedString &Other) {
+    if (&Other != this) {
+      release();
+      initialize(Other.Data, Other.Length, Other.Ownership);
+    }
+    return *this;
+  }
+
+  OwnedString& operator=(OwnedString &&Other) {
+    if (&Other != this) {
+      release();
+      this->Data = Other.Data;
+      this->Length = Other.Length;
+      this->Ownership = Other.Ownership;
+      Other.Ownership = StringOwnership::Unowned;
+      Other.Data = nullptr;
+    }
+    return *this;
   }
 
   OwnedString copy() {

--- a/include/swift/Basic/OwnedString.h
+++ b/include/swift/Basic/OwnedString.h
@@ -49,10 +49,11 @@ class OwnedString {
       free(const_cast<char *>(Data));
   }
 
-  OwnedString(const char* Data, size_t Length, StringOwnership Ownership)
-      : Length(Length), Ownership(Ownership) {
-    assert(Length >= 0 && "expected length to be non-negative");
+  OwnedString(const char* Data, size_t Length, StringOwnership Ownership) {
     release();
+    this->Length = Length;
+    this->Ownership = Ownership;
+    assert(Length >= 0 && "expected length to be non-negative");
     if (Ownership == StringOwnership::Copied && Data) {
       char *substring = static_cast<char *>(malloc(Length + 1));
       assert(substring && "expected successful malloc of copy");


### PR DESCRIPTION
Issue detected by the awesome leak sanitizer bot.

cc @gottesmm 
