### PR TITLE
Add a regression test for rdar://problem/35088384

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0128-rdar35088384.swift
+++ b/validation-test/compiler_crashers_2_fixed/0128-rdar35088384.swift
@@ -1,0 +1,12 @@
+// RUN: %swift-target-frontend -typecheck -verify %s
+
+protocol Command {}
+
+struct A : Command {}
+struct B : Command {}
+
+// This used to crash in Xcode 9 GM, and fails with a diagnostic in more
+// recent swift-4.0-branch builds, because we incorrectly infer the type
+// of the array literal as [Any].
+
+let a = Array<Command.Type>([A.self, B.self])


### PR DESCRIPTION
This used to fail to type check and crash in diagnostics due to rdar://35088384, which is now fixed on swift-4.0-branch. At some point between swift-4.0-branch and master, it started to type check, probably due to @rudkx's Type::join() work. Yay!