### PR TITLE
[runtime] Use an unnamed bitfield to avoid -Wglobal-constructor

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -736,7 +736,7 @@ class RefCounts {
 #if __POINTER_WIDTH__ == 32
   // FIXME: hack - something somewhere is assuming a 3-word header on 32-bit
   // See also other fixmes marked "small header for 32-bit"
-  uintptr_t unused SWIFT_ATTRIBUTE_UNAVAILABLE;
+  uintptr_t : 32;
 #endif
 
   // Out-of-line slow paths.
@@ -772,11 +772,7 @@ class RefCounts {
   
   // Refcount of a new object is 1.
   constexpr RefCounts(Initialized_t)
-    : refCounts(RefCountBits(0, 1))
-#if __POINTER_WIDTH__ == 32 && !__has_attribute(unavailable)
-      , unused(0)
-#endif
-  { }
+    : refCounts(RefCountBits(0, 1)) {}
 
   void init() {
     refCounts.store(RefCountBits(0, 1), std::memory_order_relaxed);


### PR DESCRIPTION
(instead of an unused field that we'd rather not initialize)

`constexpr` can't be 100% enforced in a template, so instead it gets silently dropped if the instantiated function doesn't fulfill all the requirements of being `constexpr`. In this case, that was a constructor not explicitly initializing all fields, even the one we marked unavailable. This meant we were using a non-constexpr constructor to instantiate a global, which semantically requires static initialization.

(The actual initialization is still optimized away at the LLVM level. But the Clang frontend doesn't know that.)

Note that the warning will still fire unless you update your Clang build; I just today cherry-picked the change that handles unnamed bitfields correctly (apple/swift-clang#136).