### PR TITLE
[ASTWalker] Walk NominalTypeDecl parts in source order

### DIFF
--- a/test/SourceKit/Refactoring/find-rename-ranges/rename-layer.expected
+++ b/test/SourceKit/Refactoring/find-rename-ranges/rename-layer.expected
@@ -1,0 +1,8 @@
+source.edit.kind.active:
+  77:10-77:15 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  80:27-80:32 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  80:37-80:42 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  80:45-80:50 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/syntactic-rename.swift
+++ b/test/SourceKit/Refactoring/syntactic-rename.swift
@@ -74,6 +74,13 @@ struct Memberwise2 {
 
 _ = Memberwise2(m: Memberwise1(x: 1), n: Memberwise1.init(x: 2))
 
+protocol Layer {
+  associatedtype Content
+}
+struct MultiPaneLayout<A: Layer, B: Layer>: Layer where A.Content == B.Content{
+  typealias Content = Int
+}
+
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/x.in.json %s >> %t.result/x.expected
 // RUN: diff -u %S/syntactic-rename/x.expected %t.result/x.expected
@@ -94,6 +101,8 @@ _ = Memberwise2(m: Memberwise1(x: 1), n: Memberwise1.init(x: 2))
 // RUN: not %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/invalid.in.json %s
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/rename-memberwise.in.json %s >> %t.result/rename-memberwise.expected
 // RUN: diff -u %S/syntactic-rename/rename-memberwise.expected %t.result/rename-memberwise.expected
+// RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/rename-layer.in.json %s >> %t.result/rename-layer.expected
+// RUN: diff -u %S/syntactic-rename/rename-layer.expected %t.result/rename-layer.expected
 
 // RUN: rm -rf %t.ranges && mkdir -p %t.ranges
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/x.in.json %s >> %t.ranges/x.expected
@@ -112,3 +121,5 @@ _ = Memberwise2(m: Memberwise1(x: 1), n: Memberwise1.init(x: 2))
 // RUN: diff -u %S/syntactic-rename/enum_case.expected %t.result/enum_case.expected
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/rename-memberwise.in.json %s >> %t.ranges/rename-memberwise.expected
 // RUN: diff -u %S/find-rename-ranges/rename-memberwise.expected %t.ranges/rename-memberwise.expected
+// RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/rename-layer.in.json %s >> %t.ranges/rename-layer.expected
+// RUN: diff -u %S/find-rename-ranges/rename-layer.expected %t.ranges/rename-layer.expected

--- a/test/SourceKit/Refactoring/syntactic-rename/rename-layer.expected
+++ b/test/SourceKit/Refactoring/syntactic-rename/rename-layer.expected
@@ -1,0 +1,8 @@
+source.edit.kind.active:
+  77:10-77:15 "NewLayer"
+source.edit.kind.active:
+  80:27-80:32 "NewLayer"
+source.edit.kind.active:
+  80:37-80:42 "NewLayer"
+source.edit.kind.active:
+  80:45-80:50 "NewLayer"

--- a/test/SourceKit/Refactoring/syntactic-rename/rename-layer.in.json
+++ b/test/SourceKit/Refactoring/syntactic-rename/rename-layer.in.json
@@ -1,0 +1,30 @@
+[
+  {
+    "key.name": "Layer",
+    "key.newname": "NewLayer",
+    "key.is_function_like": 0,
+    "key.is_non_protocol_type": 0,
+    "key.locations": [
+      {
+        "key.line": 77,
+        "key.column": 10,
+        "key.nametype": source.syntacticrename.definition
+      },
+      {
+        "key.line": 80,
+        "key.column": 27,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 80,
+        "key.column": 37,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 80,
+        "key.column": 45,
+        "key.nametype": source.syntacticrename.reference
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- What's in this pull request? -->
When walking a `NominalTypeDecl`, we were walking its inherited/conformed-to `TypeLoc`s after any generic param requirements in the where clause. This was breaking syntactic rename which assumes source order when matching against given locations from the index.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/35016463

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->