### PR TITLE
[WIP] stdlib: add support for AAPCS64 variadics

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -201,6 +201,30 @@ extension OpaquePointer : Equatable {
 }
 
 /// The corresponding Swift type to `va_list` in imported C APIs.
+#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+
+// non-Darwin AAPCS64 ABI
+@_fixed_layout
+public struct CVaListPointer {
+  @_versioned // FIXME(sil-serialize-all)
+  internal var value: (__stack: UnsafeMutablePointer<Int>?,
+                       __gr_top: UnsafeMutablePointer<Int>?,
+                       __vr_top: UnsafeMutablePointer<Int>?,
+                       __gr_off: Int32,
+                       __vr_off: Int32)
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public // @testable
+  init(__stack: UnsafeMutablePointer<Int>?,
+       __gr_top: UnsafeMutablePointer<Int>?,
+       __vr_top: UnsafeMutablePointer<Int>?,
+       __gr_off: Int32,
+       __vr_off: Int32) {
+    value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
+  }
+}
+
+#else
 @_fixed_layout
 public struct CVaListPointer {
   @_versioned // FIXME(sil-serialize-all)
@@ -220,6 +244,7 @@ extension CVaListPointer : CustomDebugStringConvertible {
     return value.debugDescription
   }
 }
+#endif
 
 @_versioned
 @_inlineable

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -350,7 +350,40 @@ extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-#if arch(x86_64)
+#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+
+@_fixed_layout // FIXME(sil-serialize-all)
+@_versioned // FIXME(sil-serialize-all)
+final internal class _VaListBuilder {
+  @_versioned // FIXME(sil-serialize-all)
+  internal var __stack: ContiguousArray<Int>
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal init() {
+    __stack = ContiguousArray(repeating: 0, count: 0)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  deinit {}
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal func append(_ arg: CVarArg) {
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal func va_list() -> CVaListPointer {
+    let __gr_top = UnsafeMutablePointer<Int>(bitPattern: 0)
+    let __vr_top = UnsafeMutablePointer<Int>(bitPattern: 0)
+    return CVaListPointer(__stack: __stack._baseAddress, __gr_top: __gr_top,
+                          __vr_top: __vr_top, __gr_off: 0, __vr_off: 0)
+  }
+}
+
+#elseif arch(x86_64)
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.


### PR DESCRIPTION
The AAPCS64 ABI requires that `va_list` be defined as:

    typedef struct __va_list {
      void *__stack;  /* next stack param */
      void *__gr_top; /* end of GP reg save area */
      void *__vr_top; /* end of FP/SIMD reg save area */
      int __gr_offs;  /* offset from __gr_top to next GP register arg */
      int __vr_offs;  /* offset from __vr_top to next FP register arg */
    } va_list;

This type does not decay and does not match pointer size.

`__stack` points to the register save area.  `__gr_top` points to the
byte immediately following the GPR save area, which is rounded to a
16-byte boundary.  `__vr_top` points to the byte immediately following
the FPR save area, which is rounded to a 16-byte boundary.  `__gr_offs`
contains the `((8 - GRCount) * 8)`, `__vr_offs` contains
`((8 - FPCount) * 16)`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
