### PR TITLE
[silgen] Fix ownership when peepholing bridging and enable ownership …

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -138,8 +138,7 @@ emitBridgeNativeToObjectiveC(SILGenFunction &SGF,
   if (witnessConv.isSILIndirect(witnessConv.getParameters()[0])
       && !swiftValue.getType().isAddress()) {
     auto tmp = SGF.emitTemporaryAllocation(loc, swiftValue.getType());
-    SGF.B.emitStoreValueOperation(loc, swiftValue.getValue(), tmp,
-                                  StoreOwnershipQualifier::Init);
+    SGF.B.createStoreBorrowOrTrivial(loc, swiftValue.borrow(SGF, loc), tmp);
     swiftValue = ManagedValue::forUnmanaged(tmp);
   }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -714,6 +714,23 @@ createValueMetatype(SILLocation loc, SILType metatype,
   return ManagedValue::forUnmanaged(v);
 }
 
+void SILGenBuilder::createStoreBorrow(SILLocation loc, ManagedValue value,
+                                      SILValue address) {
+  assert(value.getOwnershipKind() == ValueOwnershipKind::Guaranteed);
+  createStoreBorrow(loc, value.getValue(), address);
+}
+
+void SILGenBuilder::createStoreBorrowOrTrivial(SILLocation loc,
+                                               ManagedValue value,
+                                               SILValue address) {
+  if (value.getOwnershipKind() == ValueOwnershipKind::Trivial) {
+    createStore(loc, value, address, StoreOwnershipQualifier::Trivial);
+    return;
+  }
+
+  createStoreBorrow(loc, value, address);
+}
+
 //===----------------------------------------------------------------------===//
 //                            Switch Enum Builder
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -206,6 +206,14 @@ public:
   ManagedValue createLoadBorrow(SILLocation loc, ManagedValue base);
   ManagedValue createFormalAccessLoadBorrow(SILLocation loc, ManagedValue base);
 
+  using SILBuilder::createStoreBorrow;
+  void createStoreBorrow(SILLocation loc, ManagedValue value, SILValue address);
+
+  /// Create a store_borrow if we have a non-trivial value and a store [trivial]
+  /// otherwise.
+  void createStoreBorrowOrTrivial(SILLocation loc, ManagedValue value,
+                                  SILValue address);
+
   /// Prepares a buffer to receive the result of an expression, either using the
   /// 'emit into' initialization buffer if available, or allocating a temporary
   /// allocation if not. After the buffer has been prepared, the rvalueEmitter


### PR DESCRIPTION
…verification on test/SILGen/objc_bridging_any.swift

The bridging function that we are calling here takes in the value to be bridged
at +0. We were storing that value via a normal store. This looks like a double
consume since we were destroying the value later. Now we use a store_borrow.

rdar://29791263