### PR TITLE
Add a warning that ImplicitlyUnwrappedOptional is deprecated

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1924,10 +1924,6 @@ NOTE(override_unnecessary_IUO_use_strict,none,
 NOTE(override_unnecessary_IUO_silence,none,
      "add parentheses to silence this warning", ())
 
-ERROR(iuo_in_illegal_position,none,
-      "implicitly unwrapped optionals are only allowed at top level and as "
-      "function results", ())
-
 ERROR(override_mutable_covariant_property,none,
       "cannot override mutable property %0 of type %1 with covariant type %2",
       (Identifier, Type, Type))
@@ -3110,6 +3106,16 @@ ERROR(tuple_single_element,none,
       "cannot create a single-element tuple with an element label", ())
 ERROR(tuple_ellipsis,none,
       "cannot create a variadic tuple", ())
+
+WARNING(implicitly_unwrapped_optional_spelling_deprecated,none,
+        "the spelling 'ImplicitlyUnwrappedOptional' is deprecated", ())
+
+WARNING(implicitly_unwrapped_optional_spelling_deprecated_with_fixit,none,
+        "the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name", ())
+
+ERROR(iuo_in_illegal_position,none,
+      "implicitly unwrapped optionals are only allowed at top level and as "
+      "function results", ())
 
 // Ownership
 ERROR(invalid_ownership_type,none,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1012,6 +1012,7 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   options |= TR_AllowUnspecifiedTypes;
   options |= TR_AllowUnboundGenerics;
   options |= TR_InExpression;
+  options |= TR_AllowIUO;
   bool hadParameterError = false;
 
   GenericTypeToArchetypeResolver resolver(closure);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -457,7 +457,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   // Check the parameter patterns.
   for (auto params : func->getParameterLists()) {
     // Check the pattern.
-    if (tc.typeCheckParameterList(params, func, TypeResolutionOptions(),
+    if (tc.typeCheckParameterList(params, func, TR_AllowIUO,
                                   resolver))
       badType = true;
 
@@ -472,7 +472,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   if (auto fn = dyn_cast<FuncDecl>(func)) {
     if (!fn->getBodyResultTypeLoc().isNull()) {
       // Check the result type of the function.
-      TypeResolutionOptions options;
+      TypeResolutionOptions options = TR_AllowIUO;
       if (fn->hasDynamicSelf())
         options |= TR_DynamicSelfResult;
 
@@ -949,8 +949,12 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   // Check the indices.
   auto params = subscript->getIndices();
 
+  TypeResolutionOptions options;
+  options |= TR_SubscriptParameters;
+  options |= TR_AllowIUO;
+
   badType |= tc.typeCheckParameterList(params, subscript,
-                                       TR_SubscriptParameters,
+                                       options,
                                        resolver);
 
   // Infer requirements from the pattern.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -536,6 +536,9 @@ enum TypeResolutionFlags : unsigned {
 
   /// Whether we are checking the parameter list of a subscript.
   TR_SubscriptParameters = 0x2000000,
+
+  /// Is it okay to resolve an IUO sigil ("!") here?
+  TR_AllowIUO = 0x4000000,
 };
 
 /// Option set describing how type resolution should work.

--- a/test/Sema/diag_deprecated_iuo.swift
+++ b/test/Sema/diag_deprecated_iuo.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+let _: ImplicitlyUnwrappedOptional<Int> = 1 // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{8-36=}}{{39-39=!}}{{39-40=}}
+let _: ImplicitlyUnwrappedOptional = 1 // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+
+extension ImplicitlyUnwrappedOptional {} // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+
+func function(
+  _: ImplicitlyUnwrappedOptional<Int> // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{6-34=}}{{37-37=!}}{{37-38=}}
+) -> ImplicitlyUnwrappedOptional<Int> { // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{6-34=}}{{37-37=!}}{{37-38=}}
+  return 1
+}
+
+func genericFunction<T>(
+  iuo: ImplicitlyUnwrappedOptional<T> // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{8-36=}}{{37-37=!}}{{37-38=}}
+) -> ImplicitlyUnwrappedOptional<T> { // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{6-34=}}{{35-35=!}}{{35-36=}}
+  return iuo
+}
+
+protocol P {
+  associatedtype T
+  associatedtype U
+}
+
+struct S : P {
+  typealias T = ImplicitlyUnwrappedOptional<Int> // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+  typealias U = Optional<ImplicitlyUnwrappedOptional<Int>> // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+
+  subscript (
+    index: ImplicitlyUnwrappedOptional<Int> // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{12-40=}}{{43-43=!}}{{43-44=}}
+  )     -> ImplicitlyUnwrappedOptional<Int> { // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{12-40=}}{{43-43=!}}{{43-44=}}
+    return index
+  }
+}
+
+func generic<T : P>(_: T) where T.T == ImplicitlyUnwrappedOptional<Int> { } // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+func genericOptIUO<T : P>(_: T) where T.U == Optional<ImplicitlyUnwrappedOptional<Int>> {} // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+
+func testClosure() -> Int {
+  return {
+    (i: ImplicitlyUnwrappedOptional<Int>) // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{9-37=}}{{40-40=!}}{{40-41=}}
+     -> ImplicitlyUnwrappedOptional<Int> in // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}
+    return i
+  }(1)
+}

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -121,7 +121,7 @@ func testModuloOptionalness() {
   func setIUOClosure(_ fn: () -> Void) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{28-28=@escaping }}
     iuoClosure = fn // expected-error{{assigning non-escaping parameter 'fn' to an @escaping closure}}
   }
-  var iuoClosureExplicit: ImplicitlyUnwrappedOptional<() -> Void>
+  var iuoClosureExplicit: ImplicitlyUnwrappedOptional<() -> Void> // expected-warning {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}
   func setExplicitIUOClosure(_ fn: () -> Void) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{36-36=@escaping }}
     iuoClosureExplicit = fn // expected-error{{assigning non-escaping parameter 'fn' to an @escaping closure}}
   }

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -221,8 +221,10 @@ class IUOTestSubclass2 : IUOTestBaseClass {
   // expected-note@-1 {{remove '!' to make the parameter required}} {{36-37=}}
   // expected-note@-2 {{add parentheses to silence this warning}} {{27-27=(}} {{37-37=)}}
 
-  override func oneB(x: ImplicitlyUnwrappedOptional<AnyObject>) {}  // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'ImplicitlyUnwrappedOptional<AnyObject>'}}
-  // expected-note@-1 {{add parentheses to silence this warning}} {{25-25=(}} {{63-63=)}}
+  override func oneB(x: ImplicitlyUnwrappedOptional<AnyObject>) {}
+  // expected-warning@-1 {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated; use '!' after the type name}}{{25-53=}}{{62-62=!}}{{62-63=}}
+  // expected-warning@-2 {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'ImplicitlyUnwrappedOptional<AnyObject>'}}
+  // expected-note@-3 {{add parentheses to silence this warning}} {{25-25=(}} {{63-63=)}}
 
   override func oneC(_: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
   // expected-note@-1 {{remove '!' to make the parameter required}} {{34-35=}}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28048391.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28048391.swift
@@ -12,3 +12,4 @@ extension rdar28048391 {
 }
 
 extension ImplicitlyUnwrappedOptional : rdar28048391 { }
+// expected-warning@-1 {{the spelling 'ImplicitlyUnwrappedOptional' is deprecated}}


### PR DESCRIPTION
Per SE-0054, implicitly unwrapped optional is not a distinct type in the type system, but rather just the notion that certain Optionals (denoted by the sigil "!" rather than "?") can be implicitly unwrapped.

This is a first step in the direction of implementing this notion by emitting a warning if the type is spelled out.
    
Later on this will be reworked a bit by having "ImplicitlyUnwrappedOptional" resolve to the Optional type for versions < 5, with the standard library type ImplicitlyUnwrappedOptional completely removed (so versions >= 5 will error out on references).