### PR TITLE
[SR-6100] Reject unbound generic types in case patterns.

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1321,8 +1321,9 @@ recur:
       }
       // Otherwise, if the type is an unbound generic of the context type, use
       // the context type to resolve the parameters.
-      else if (parentTy->is<UnboundGenericType>()) {
-        if (parentTy->getAnyNominal() == type->getAnyNominal()) {
+      else if (parentTy->hasUnboundGenericType()) {
+        if (parentTy->is<UnboundGenericType>() &&
+            parentTy->getAnyNominal() == type->getAnyNominal()) {
           enumTy = type;
         } else {
           diagnose(EEP->getLoc(), diag::ambiguous_enum_pattern_type,

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -336,3 +336,19 @@ func rdar32241441() {
     break;
   }
 }
+
+
+// SR-6100
+struct One<Two> {
+    public enum E: Error {
+        // if you remove associated value, everything works
+        case SomeError(String)
+    }
+}
+
+func testOne() {
+  do {
+  } catch let error { // expected-warning{{'catch' block is unreachable because no errors are thrown in 'do' block}}
+    if case One.E.SomeError = error {} // expected-error{{generic enum type 'One.E' is ambiguous without explicit generic parameters when matching value of type 'Error'}}
+  }
+}


### PR DESCRIPTION
Fixes [SR-6100](https://bugs.swift.org/browse/SR-6100) / rdar://problem/34898452.
