### PR TITLE
 [GSB] Stop warning about 'bare' associated type redeclarations.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3497,7 +3497,9 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
       bool shouldWarnAboutRedeclaration =
         source->kind == RequirementSource::RequirementSignatureSelf &&
-        assocTypeDecl->getDefaultDefinitionLoc().isNull();
+        assocTypeDecl->getDefaultDefinitionLoc().isNull() &&
+        (!assocTypeDecl->getInherited().empty() ||
+         assocTypeDecl->getTrailingWhereClause());
       for (auto inheritedType : knownInherited->second) {
         // If we have inherited associated type...
         if (auto inheritedAssocTypeDecl =

--- a/test/Constraints/generic_overload.swift
+++ b/test/Constraints/generic_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
-protocol P1 { associatedtype Assoc } // expected-note{{declared here}}
-protocol P2 : P1 { associatedtype Assoc } // expected-warning{{redeclaration of associated type}}
+protocol P1 { associatedtype Assoc }
+protocol P2 : P1 { associatedtype Assoc }
 protocol P3 { }
 
 struct X1 : P1 { typealias Assoc = X3 }

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -138,16 +138,16 @@ protocol P {
 
 // Lookup of same-named associated types aren't ambiguous in this context.
 protocol P1 {
-  associatedtype A // expected-note 2{{declared here}}
+  associatedtype A
 }
 
 protocol P2: P1 {
-  associatedtype A // expected-warning{{redeclaration of associated type}}
+  associatedtype A
   associatedtype B where A == B
 }
 
 protocol P3: P1 {
-  associatedtype A // expected-warning{{redeclaration of associated type}}
+  associatedtype A
 }
 
 protocol P4 {

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -4,11 +4,11 @@
 protocol P0 { }
 
 protocol P {
-  associatedtype A // expected-note{{declared here}}
+  associatedtype A
 }
 
 protocol Q : P {
-  associatedtype A // expected-warning{{redeclaration of associated type 'A' from protocol 'P' is better expressed as a 'where' clause on the protocol}}
+  associatedtype A
 }
 
 func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -22,7 +22,7 @@ protocol P3 {}
 // CHECK-NEXT: Requirement signature: <Self where Self.X : P1>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.X : P1>
 protocol Q1 {
-    associatedtype X: P1 // expected-note 2{{declared here}}
+    associatedtype X: P1 // expected-note {{declared here}}
 }
 
 // inheritance
@@ -36,7 +36,7 @@ protocol Q2: Q1 {}
 // CHECK-NEXT: Requirement signature: <Self where Self : Q1>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1>
 protocol Q3: Q1 {
-    associatedtype X // expected-warning{{redeclaration of associated type 'X'}}
+    associatedtype X
 }
 
 // inheritance adding a new conformance

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -139,13 +139,13 @@ extension P7 where AssocP6.Element : P6, // expected-note{{conformance constrain
 }
 
 protocol P8 {
-  associatedtype A // expected-note{{'A' declared here}}
-  associatedtype B // expected-note{{'B' declared here}}
+  associatedtype A
+  associatedtype B
 }
 
 protocol P9 : P8 {
-  associatedtype A // expected-warning{{redeclaration of associated type 'A' from protocol 'P8' is better expressed as a 'where' clause on the protocol}}
-  associatedtype B // expected-warning{{redeclaration of associated type 'B' from protocol 'P8' is better expressed as a 'where' clause on the protocol}}
+  associatedtype A
+  associatedtype B
 }
 
 protocol P10 {

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -32,8 +32,8 @@ protocol FooBaseProtocolWithAssociatedTypes {
   associatedtype FooBaseDefaultedTypeB = Int
   associatedtype FooBaseDefaultedTypeC = Int
 
-  associatedtype DeducedTypeCommonA // expected-note{{declared here}}
-  associatedtype DeducedTypeCommonB // expected-note{{declared here}}
+  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonB
   associatedtype DeducedTypeCommonC
   associatedtype DeducedTypeCommonD
   func deduceCommonA() -> DeducedTypeCommonA
@@ -57,8 +57,8 @@ protocol FooProtocolWithAssociatedTypes : FooBaseProtocolWithAssociatedTypes {
 
   associatedtype FooBaseDefaultedTypeB = Double
 
-  associatedtype DeducedTypeCommonA // expected-warning{{redeclaration of associated type}}
-  associatedtype DeducedTypeCommonB // expected-warning{{redeclaration of associated type}}
+  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonB
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonB() -> DeducedTypeCommonB
 
@@ -79,7 +79,7 @@ protocol BarBaseProtocolWithAssociatedTypes {
   associatedtype DefaultedTypeCommonA = Int
   associatedtype DefaultedTypeCommonC = Int
 
-  associatedtype DeducedTypeCommonA // expected-note{{'DeducedTypeCommonA' declared here}}
+  associatedtype DeducedTypeCommonA
   associatedtype DeducedTypeCommonC
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonC() -> DeducedTypeCommonC
@@ -102,7 +102,7 @@ protocol BarProtocolWithAssociatedTypes : BarBaseProtocolWithAssociatedTypes {
   associatedtype DefaultedTypeCommonA = Int
   associatedtype DefaultedTypeCommonD = Int
 
-  associatedtype DeducedTypeCommonA // expected-warning{{redeclaration of associated type}}
+  associatedtype DeducedTypeCommonA
   associatedtype DeducedTypeCommonD
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonD() -> DeducedTypeCommonD

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -42,10 +42,10 @@ class DerivedClass {
 }
 
 protocol P1 {
-  associatedtype Element // expected-note{{declared here}}
+  associatedtype Element
 }
 protocol P2 : P1 {
-  associatedtype Element // expected-warning{{redeclaration of associated type 'Element'}}
+  associatedtype Element
 }
 
 func overloadedEach<O: P1>(_ source: O, _ closure: @escaping () -> ()) {

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -183,10 +183,10 @@ func redundant(_ fn : @noescape  // expected-error @+1 {{@noescape is implied by
 
 
 protocol P1 {
-  associatedtype Element // expected-note{{declared here}}
+  associatedtype Element
 }
 protocol P2 : P1 {
-  associatedtype Element // expected-warning{{redeclaration of associated type 'Element'}}
+  associatedtype Element
 }
 
 func overloadedEach<O: P1, T>(_ source: O, _ transform: @escaping (O.Element) -> (), _: T) {}

--- a/test/decl/protocol/indirectly_recursive_requirement.swift
+++ b/test/decl/protocol/indirectly_recursive_requirement.swift
@@ -5,7 +5,7 @@ protocol Incrementable  {
 }
 
 protocol _ForwardIndex  {
-  associatedtype Distance  = MyInt // expected-note{{declared here}}
+  associatedtype Distance  = MyInt
 }
 
 protocol ForwardIndex : _ForwardIndex {
@@ -19,7 +19,7 @@ protocol BidirectionalIndex : ForwardIndex, _BidirectionalIndex {
 }
 
 protocol _RandomAccessIndex : _BidirectionalIndex {
-  associatedtype Distance // expected-warning{{redeclaration of associated type 'Distance}}
+  associatedtype Distance
 }
 
 protocol RandomAccessIndex 

--- a/validation-test/compiler_crashers_2_fixed/0129-rdar35019075.swift
+++ b/validation-test/compiler_crashers_2_fixed/0129-rdar35019075.swift
@@ -1,0 +1,43 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+enum SortOrder {
+    case ascending
+    case equal
+    case descending
+}
+
+struct SortedArray<Element> {
+    var contents = [Element]()
+    let compare: (Element, Element) -> SortOrder
+
+    init(_ comparator: @escaping (Element, Element) -> SortOrder) {
+        compare = comparator
+    }
+
+    mutating func add(_ element: Element) {
+
+    }
+}
+
+extension SortedArray where Element: Comparable {
+    init() {
+        compare = { a, b in
+            if a < b { return .ascending }
+            else if a > b { return .descending }
+            else { return .equal }
+        }
+    }
+
+    init<S: Sequence>(_ sequence: S) where S.Iterator.Element == Element {
+        self.init()
+
+        for element in sequence {
+            add(element)
+        }
+    }
+}
+
+extension SortedArray: Sequence {
+    typealias Iterator = IndexingIterator
+
+}


### PR DESCRIPTION
Associated type redeclarations occasionally occur to push around
associated type witness inference. Suppress the warning about redeclarations
that add no requirements (i.e., have neither an inheritance nor a
where clause).