### PR TITLE
[stdlib] use Collection.isEmpty rather than Collection.count

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -467,7 +467,7 @@ public struct Unsafe${Mutable}RawBufferPointer
       _debugPrecondition(bounds.upperBound <= endIndex)
       _debugPrecondition(bounds.count == newValue.count)
 
-      if newValue.count > 0 {
+      if !newValue.isEmpty {
         (baseAddress! + bounds.lowerBound).copyBytes(
           from: newValue.base.baseAddress! + newValue.startIndex,
           count: newValue.count)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Use `Collection.isEmpty` rather than `Collection.count` in `UnsafeMutableRawBufferPointer`'s ranged subscript setter. As suggested by @airspeedswift and @atrick in https://github.com/apple/swift/pull/12504.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->