### PR TITLE
[Sema] Don't suggest adding 'as' in a pattern matching context where it will do no good.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7543,6 +7543,16 @@ bool ConstraintSystem::applySolutionFix(Expr *expr,
                                                         DC);
     if (!useAs && !useAsBang)
       return false;
+    
+    // If we're performing pattern matching, "as" means something completely different...
+    if (auto binOpExpr = dyn_cast<BinaryExpr>(expr)) {
+      auto overloadedFn = dyn_cast<OverloadedDeclRefExpr>(binOpExpr->getFn());
+      if (overloadedFn && overloadedFn->getDecls().size() > 0) {
+        ValueDecl *decl0 = overloadedFn->getDecls()[0];
+        if (decl0->getBaseName() == decl0->getASTContext().Id_MatchOperator)
+          return false;
+      }
+    }
 
     bool needsParensInside = exprNeedsParensBeforeAddingAs(TC, DC, affected);
     bool needsParensOutside = exprNeedsParensAfterAddingAs(TC, DC, affected,

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -53,6 +53,9 @@ func testAmbiguousStringComparisons(s: String) {
   let a10 = nsString <= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
   let a11 = nsString >= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
   let a12 = nsString > s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
+  
+  // Shouldn't suggest 'as' in a pattern-matching context, as opposed to all these other situations
+  if case nsString = "" {} // expected-error{{expression pattern of type 'NSString' cannot match values of type 'String'}}
 }
 
 func testStringDeprecation(hello: String) {


### PR DESCRIPTION
Ideally we'd provide a more clever diagnostic or fixits here (see some of the chat in SR-6204), but it's a corner of Swift where The Right Thing isn't very obvious, so I eventually decided to be content with just avoiding the wrong diagnostic. 
Resolves [SR-6204](https://bugs.swift.org/browse/SR-6204).
