### PR TITLE
[SEMA] SR-6207: Fix misleading error for unqualified use of static variable from instance method

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -99,7 +99,7 @@ ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
       (Type, DeclName))
 ERROR(could_not_use_type_member_on_instance_without_name,none,
-      "static element %0 cannot be referenced as an instance member",
+      "static member %0 cannot be referenced as an instance member",
       (DeclName))
 ERROR(could_not_use_enum_element_on_instance,none,
       "enum element %0 cannot be referenced as an instance member",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -98,6 +98,9 @@ ERROR(could_not_use_type_member,none,
 ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
       (Type, DeclName))
+ERROR(could_not_use_type_member_on_instance_without_name,none,
+      "static element %0 cannot be referenced as an instance member",
+      (DeclName))
 ERROR(could_not_use_enum_element_on_instance,none,
       "enum element %0 cannot be referenced as an instance member",
       (DeclName))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1246,7 +1246,7 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
   if (isa<EnumElementDecl>(member)) {
     Diag.emplace(diagnose(loc, diag::could_not_use_enum_element_on_instance,
                           memberName));
-  } else if (isa<DeclRefExpr>(member)) {
+  } else if (isa<DeclRefExpr>(baseExpr) || isa<MemberRefExpr>(baseExpr)) {
     Diag.emplace(diagnose(loc, diag::could_not_use_type_member_on_instance_without_name,
                           memberName));
   } else {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1243,12 +1243,16 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
     return;
   }
 
-  if (isa<EnumElementDecl>(member))
+  if (isa<EnumElementDecl>(member)) {
     Diag.emplace(diagnose(loc, diag::could_not_use_enum_element_on_instance,
                           memberName));
-  else
+  } else if (isa<DeclRefExpr>(member)) {
+    Diag.emplace(diagnose(loc, diag::could_not_use_type_member_on_instance_without_name,
+                          memberName));
+  } else {
     Diag.emplace(diagnose(loc, diag::could_not_use_type_member_on_instance,
                           baseObjTy, memberName));
+  }
 
   Diag->highlight(nameLoc.getSourceRange());
 

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -1,4 +1,3 @@
-
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
 ////

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -1,3 +1,4 @@
+
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
 ////
@@ -463,4 +464,12 @@ struct Outer {
       // expected-error@-1 {{instance member 'outer' of type 'Outer' cannot be used on instance of nested type 'Outer.Inner'}}
     }
   }
+}
+
+struct HasStaticSR6207 {
+  func foo() {
+    print(cvar) // expected-error {{static element cvar cannot be referenced as an instance member}}
+  }
+
+  static let cvar = 123
 }

--- a/test/Sema/diag_typealias.swift
+++ b/test/Sema/diag_typealias.swift
@@ -4,11 +4,3 @@ struct S {}
 
 typealias S = S // expected-error {{redundant type alias declaration}}{{1-17=}}
 
-
-struct HasStatic {
-	func foo() {
-		print(cvar) // expected-error {{static element cvar cannot be referenced as an instance member}}
-	}
-
-	static let cvar = 123
-}

--- a/test/Sema/diag_typealias.swift
+++ b/test/Sema/diag_typealias.swift
@@ -4,3 +4,11 @@ struct S {}
 
 typealias S = S // expected-error {{redundant type alias declaration}}{{1-17=}}
 
+
+struct HasStatic {
+	func foo() {
+		print(cvar) // expected-error {{static element cvar cannot be referenced as an instance member}}
+	}
+
+	static let cvar = 123
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
~I'm trying to check if the expression is either a MemberRefExpr or a DeclRefExpr, as per @jrose-apple's comment on the ticket. However, I don't think this is the right place/way to do it. Opened the PR just to keep track of things and maybe get some pointers from people more familiar with the matter.~

Checks for a DeclRefExpr or a MembeRefExpr in 8d58457 now

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #48759.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->