### PR TITLE
Warn on “near-misses” when defaults are used for protocol witnesses. 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1635,17 +1635,18 @@ NOTE(redundant_conformance_witness_ignored,none,
      (DescriptiveDeclKind, DeclName, DeclName))
 
 // "Near matches"
-WARNING(optional_req_near_match,none,
-        "%0 %1 nearly matches optional requirement %2 of protocol %3",
-        (DescriptiveDeclKind, DeclName, DeclName, DeclName))
+WARNING(req_near_match,none,
+        "%0 %1 nearly matches %select{defaulted|optional}2 requirement %3 "
+        "of protocol %4",
+        (DescriptiveDeclKind, DeclName, bool, DeclName, DeclName))
 NOTE(optional_req_nonobjc_near_match_add_objc,none,
      "add '@objc' to provide an Objective-C entrypoint", ())
-NOTE(optional_req_near_match_move,none,
+NOTE(req_near_match_move,none,
      "move %0 to %select{an|another}1 extension to silence this warning",
      (DeclName, unsigned))
-NOTE(optional_req_near_match_nonobjc,none,
+NOTE(req_near_match_nonobjc,none,
      "add '@nonobjc' to silence this %select{warning|error}0", (bool))
-NOTE(optional_req_near_match_access,none,
+NOTE(req_near_match_access,none,
      "make %0 %select{ERROR|private|private|non-public|non-public}1 to silence this "
      "warning", (DeclName, AccessLevel))
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2874,7 +2874,7 @@ bool ASTContext::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
     if (auto objcAttr = conflicts[0]->getAttrs().getAttribute<ObjCAttr>())
       hasExplicitObjCAttribute = !objcAttr->isImplicit();
     if (!hasExplicitObjCAttribute)
-      Diags.diagnose(conflicts[0], diag::optional_req_near_match_nonobjc, true)
+      Diags.diagnose(conflicts[0], diag::req_near_match_nonobjc, true)
         .fixItInsert(
           conflicts[0]->getAttributeInsertionLoc(/*forModifier=*/false),
           "@nonobjc ");

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2717,7 +2717,7 @@ static void inferObjCName(TypeChecker &tc, ValueDecl *decl) {
 
       // Suggest '@nonobjc' to suppress this error, and not try to
       // infer @objc for anything.
-      tc.diagnose(decl, diag::optional_req_near_match_nonobjc, true)
+      tc.diagnose(decl, diag::req_near_match_nonobjc, true)
         .fixItInsert(decl->getAttributeInsertionLoc(false), "@nonobjc ");
       break;
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -760,6 +760,10 @@ GenericParamList *ModuleFile::maybeReadGenericParams(DeclContext *DC,
       break;
   }
 
+  // Don't create empty generic parameter lists.
+  if (params.empty())
+    return nullptr;
+
   auto paramList = GenericParamList::create(getContext(), SourceLoc(),
                                             params, SourceLoc(), { },
                                             SourceLoc());

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -354,6 +354,9 @@ public protocol RangeReplaceableCollection : Collection
   mutating func removeAll(keepingCapacity keepCapacity: Bool /*= false*/)
 
   // FIXME(ABI): Associated type inference requires this.
+  subscript(bounds: Index) -> Element { get }
+
+  // FIXME(ABI): Associated type inference requires this.
   subscript(bounds: Range<Index>) -> SubSequence { get }
 }
 

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -4,8 +4,8 @@ enum MSV : Error {
   case Foo, Bar, Baz
   case CarriesInt(Int)
 
-  var domain: String { return "" }
-  var code: Int { return 0 }
+  var _domain: String { return "" }
+  var _code: Int { return 0 }
 }
 
 func opaque_error() -> Error { return MSV.Foo }

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -510,7 +510,7 @@ struct SConforms7a : PConforms7 { }
 protocol PConforms8 {
   associatedtype Assoc
 
-  func method() -> Assoc
+  func method() -> Assoc // expected-note{{requirement 'method()' declared here}}
   var property: Assoc { get }
   subscript (i: Assoc) -> Assoc { get }
 }
@@ -535,7 +535,10 @@ func testSConforms8b() {
 }
 
 struct SConforms8c : PConforms8 { 
-  func method() -> String { return "" }
+  func method() -> String { return "" } // expected-warning{{instance method 'method()' nearly matches defaulted requirement 'method()' of protocol 'PConforms8'}}
+  // expected-note@-1{{candidate has non-matching type '() -> String' [with Assoc = Int]}}
+  // expected-note@-2{{move 'method()' to an extension to silence this warning}}
+  // expected-note@-3{{make 'method()' private to silence this warning}}
 }
 
 func testSConforms8c() {

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -2,8 +2,8 @@
 enum MSV : Error {
   case Foo, Bar, Baz
 
-  var domain: String { return "" }
-  var code: Int { return 0 }
+  var _domain: String { return "" }
+  var _code: Int { return 0 }
 }
 
 func a() {}


### PR DESCRIPTION
When a particular nominal type or extension thereof declares conformance
to a protocol, check whether that type or extension contains any members
that *nearly* match a defaulted requirement (i.e., a requirement that 
is satisfied by something in a protocol extension), but didn’t match
for some reason and weren’t used to satisfy any other requirement of
that protocol. It’s intended to catch subtle mistakes where a default
gets picked instead of the intended member.

This is a generalization of the code we’ve had for @objc optional
requirements for a long time.

Fixes rdar://problem/24714887.