### PR TITLE
Named lazy member loading 2

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3307,8 +3307,8 @@ ClangImporter::Implementation::loadNamedMembers(
   clang::ASTContext &clangCtx = getClangASTContext();
 
   TinyPtrVector<ValueDecl *> Members;
-  if (auto *CPD = dyn_cast<clang::ObjCProtocolDecl>(CD)) {
-    for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()), CPD)) {
+  if (auto *CCD = dyn_cast<clang::ObjCContainerDecl>(CD)) {
+    for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()), CCD)) {
       if (!entry.is<clang::NamedDecl *>()) continue;
       auto member = entry.get<clang::NamedDecl *>();
       if (!isVisibleClangEntry(clangCtx, member)) continue;

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
@@ -30,5 +30,23 @@
 + (SimpleDoer*)Doer;
 + (SimpleDoer*)DoerOfNoWork;
 
+- (void)simplyDoSomeWork;
+- (void)simplyDoSomeWorkWithSpeed:(int)s;
+- (void)simplyDoSomeWorkWithSpeed:(int)s thoroughness:(int)t
+  NS_SWIFT_NAME(simplyDoVeryImportantWork(speed:thoroughness:));
+- (void)simplyDoSomeWorkWithSpeed:(int)s alacrity:(int)a
+  NS_SWIFT_NAME(simplyDoSomeWorkWithSpeed(speed:levelOfAlacrity:));
+
+// These we are generally trying to not-import, via laziness.
+- (void)simplyGoForWalk;
+- (void)simplyTakeNap;
+- (void)simplyEatMeal;
+- (void)simplyTidyHome;
+- (void)simplyCallFamily;
+- (void)simplySingSong;
+- (void)simplyReadBook;
+- (void)simplyAttendLecture;
+- (void)simplyWriteLetter;
+
 @end
 

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -6,21 +6,18 @@
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s
 //
 // Check that without lazy named member loading, we're importing too much.
-// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck -stats-output-dir %t/stats-pre %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 35' %t/stats-pre
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-pre %s
+// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 20' %t/stats-pre
 //
 // Check that with lazy named member loading, we're importing less.
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 20' %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 10' %t/stats-post
 
 import NamedLazyMembers
 
-public func foo(d: Doer) {
-  d.doSomeWork()
-  d.doSomeWork(withSpeed:10)
-  d.doVeryImportantWork(speed:10, thoroughness:12)
-  d.doSomeWorkWithSpeed(speed:10, levelOfAlacrity:12)
-
-  let _ = SimpleDoer()
-  let _ = SimpleDoer.ofNoWork()
+public func foo(d: SimpleDoer) {
+  let _ = d.simplyDoSomeWork()
+  let _ = d.simplyDoSomeWork(withSpeed:10)
+  let _ = d.simplyDoVeryImportantWork(speed:10, thoroughness:12)
+  let _ = d.simplyDoSomeWorkWithSpeed(speed:10, levelOfAlacrity:12)
 }


### PR DESCRIPTION
This is round two of the named lazy member loading work. This time we expand the logic to treat the LookupTable like a cache. It can be populated incrementally by a single lookupDirect, or else purged and reconstructed if someone requests the full set of members in the IterableDeclContext.

This along with recursion-inhibition in the cache-filling part seems sufficient to get @interface named lazy member loading to work. I'll flesh out the tests a bit more later (and obviously test the other remaining ObjC container types) but I wanted to get @DougGregor and @jrose-apple to look it over first, make sure this is the right track.

(And then next stop is starting to teach the swiftmodule lazy loader about all this, I guess?)