### PR TITLE
Sema: Fix some issues with overrides of materializeForSet [4.0]

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2038,10 +2038,17 @@ public:
                  "Storage overrides but setter does not");
         if (ASD->getMaterializeForSetFunc() &&
             baseASD->getMaterializeForSetFunc() &&
-            baseASD->isSetterAccessibleFrom(ASD->getDeclContext()))
-          assert(ASD->getMaterializeForSetFunc()->getOverriddenDecl() ==
-                 baseASD->getMaterializeForSetFunc() &&
-                 "Storage override but materializeForSet does not");
+            baseASD->isSetterAccessibleFrom(ASD->getDeclContext())) {
+          if (baseASD->getMaterializeForSetFunc()->hasForcedStaticDispatch()) {
+            assert(ASD->getMaterializeForSetFunc()->getOverriddenDecl() == nullptr
+                   && "Forced static dispatch materializeForSet should not be "
+                   "overridden");
+          } else {
+            assert(ASD->getMaterializeForSetFunc()->getOverriddenDecl() ==
+                   baseASD->getMaterializeForSetFunc() &&
+                   "Storage override but materializeForSet does not");
+          }
+        }
       } else {
         if (ASD->getGetter())
           assert(!ASD->getGetter()->getOverriddenDecl() &&

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -872,6 +872,7 @@ static FuncDecl *addMaterializeForSet(AbstractStorageDecl *storage,
     // materializeForSet either.
     auto *baseMFS = baseASD->getMaterializeForSetFunc();
     if (baseMFS != nullptr &&
+        !baseMFS->hasForcedStaticDispatch() &&
         baseASD->isSetterAccessibleFrom(storage->getDeclContext())) {
       materializeForSet->setOverriddenDecl(baseMFS);
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6532,6 +6532,13 @@ public:
             !baseASD->isSetterAccessibleFrom(overridingASD->getDeclContext()))
           return;
 
+        // A materializeForSet for an override of storage with a
+        // forced static dispatch materializeForSet is not itself an
+        // override.
+        if (kind == AccessorKind::IsMaterializeForSet &&
+            baseAccessor->hasForcedStaticDispatch())
+          return;
+
         // FIXME: Egregious hack to set an 'override' attribute.
         if (!overridingAccessor->getAttrs().hasAttribute<OverrideAttr>()) {
           auto loc = overridingASD->getOverrideLoc();

--- a/test/multifile/synthesized-accessors/materialize-for-set-1/Inputs/counter.h
+++ b/test/multifile/synthesized-accessors/materialize-for-set-1/Inputs/counter.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Counter : NSObject
+@property(readwrite) int value;
+@end

--- a/test/multifile/synthesized-accessors/materialize-for-set-1/Inputs/library.swift
+++ b/test/multifile/synthesized-accessors/materialize-for-set-1/Inputs/library.swift
@@ -1,0 +1,12 @@
+import Foundation
+import CounterFramework
+
+public protocol CounterProtocol {
+  var value: Int32 { get set }
+}
+
+extension Counter : CounterProtocol {}
+
+open class MyCounter : Counter {
+  open override var value: Int32 { didSet { } }
+}

--- a/test/multifile/synthesized-accessors/materialize-for-set-1/Inputs/module.map
+++ b/test/multifile/synthesized-accessors/materialize-for-set-1/Inputs/module.map
@@ -1,0 +1,4 @@
+module CounterFramework {
+  header "counter.h"
+  export *
+}

--- a/test/multifile/synthesized-accessors/materialize-for-set-1/main.swift
+++ b/test/multifile/synthesized-accessors/materialize-for-set-1/main.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// RUN: mkdir -p %t/onone %t/wmo
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -I %S/Inputs/ -module-name=library %S/Inputs/library.swift
+// RUN: %target-build-swift %S/main.swift -I %S/Inputs/ -I %t/onone/ -emit-ir > /dev/null
+
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -I %S/Inputs/ -module-name=library -wmo %S/Inputs/library.swift
+// RUN: %target-build-swift %S/main.swift -I %S/Inputs/ -I %t/wmo/ -emit-ir > /dev/null
+
+// REQUIRES: objc_interop
+
+import Foundation
+import library
+
+class CustomCounter : MyCounter {
+  override var value: Int32 { didSet { } }
+}

--- a/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/counter.h
+++ b/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/counter.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Counter : NSObject
+@property(readwrite) int value;
+@end

--- a/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/library1.swift
+++ b/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/library1.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CounterFramework
+
+public protocol CounterProtocol {
+  var value: Int32 { get set }
+}
+
+extension Counter : CounterProtocol {}

--- a/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/library2.swift
+++ b/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/library2.swift
@@ -1,0 +1,6 @@
+import Foundation
+import CounterFramework
+
+open class MyCounter : Counter {
+  open override var value: Int32 { didSet { } }
+}

--- a/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/module.map
+++ b/test/multifile/synthesized-accessors/materialize-for-set-2/Inputs/module.map
@@ -1,0 +1,4 @@
+module CounterFramework {
+  header "counter.h"
+  export *
+}

--- a/test/multifile/synthesized-accessors/materialize-for-set-2/main.swift
+++ b/test/multifile/synthesized-accessors/materialize-for-set-2/main.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// RUN: mkdir -p %t/onone %t/wmo
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -I %S/Inputs/ -module-name=library %S/Inputs/library1.swift %S/Inputs/library2.swift
+// RUN: %target-build-swift %S/main.swift -I %S/Inputs/ -I %t/onone/ -emit-ir > /dev/null
+
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -I %S/Inputs/ -module-name=library -wmo %S/Inputs/library1.swift %S/Inputs/library2.swift
+// RUN: %target-build-swift %S/main.swift -I %S/Inputs/ -I %t/wmo/ -emit-ir > /dev/null
+
+// REQUIRES: objc_interop
+
+import Foundation
+import library
+
+class CustomCounter : MyCounter {
+  override var value: Int32 { didSet { } }
+}


### PR DESCRIPTION
* Description: Fixes a deserialization crash when referencing a property in another module that overrides an imported property, and the imported property witnessed a protocol requirement.

* Scope of the issue: Reported by a user on Twitter. Serialization crashes are generally hard to pin down and root cause so it's hard to say how many people were affected by this.

* Tested: New tests added.

* Risk: Low, we're just not marking materializeForSet as an override in some cases.

* Radar: <rdar://problem/35138127>

* Reviewed by: @jrose-apple