### PR TITLE
Fix a test portability bug

### DIFF
--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -253,6 +253,6 @@ class HasLazyProperty : NSObject, HasProperty {
 //   which can cause fits for SILGenApply the way it's currently implemented.
 // CHECK-LABEL: sil hidden @_T015objc_properties26testPropSetWithPreposition
 func testPropSetWithPreposition(object: ObjectWithSplitProperty?) {
-  // CHECK: #ObjectWithSplitProperty.flagForSomething!setter.1.foreign : (ObjectWithSplitProperty) -> (Bool) -> (), $@convention(objc_method) (ObjCBool, ObjectWithSplitProperty) -> ()
+  // CHECK: #ObjectWithSplitProperty.flagForSomething!setter.1.foreign : (ObjectWithSplitProperty) -> (Bool) -> (), $@convention(objc_method) ({{Bool|ObjCBool}}, ObjectWithSplitProperty) -> ()
   object?.flagForSomething = false
 }


### PR DESCRIPTION
Bug was introduced in #12646.  I figured that our playground SDK would be portable, but no, apparently we decided to make it non-portable.