### PR TITLE
Improve Osize

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -32,6 +32,12 @@ public:
   /// Controls the aggressiveness of the performance inliner.
   int InlineThreshold = -1;
 
+  /// Controls the aggressiveness of the performance inliner for Osize.
+  int CallerBaseBenefitReductionFactor = 2;
+
+  /// Controls the aggressiveness of the loop unroller.
+  int UnrollThreshold = 250;
+
   /// The number of threads for multi-threaded code generation.
   int NumThreads = 0;
   

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -369,6 +369,16 @@ def sil_inline_threshold : Separate<["-"], "sil-inline-threshold">,
   MetaVarName<"<50>">,
   HelpText<"Controls the aggressiveness of performance inlining">;
 
+def sil_inline_caller_benefit_reduction_factor : Separate<["-"], "sil-inline-caller-benefit-reduction-factor">,
+  MetaVarName<"<2>">,
+  HelpText<"Controls the aggressiveness of performance inlining in -Osize "
+          "mode by reducing the base benefits of a caller (lower value "
+          "permits more inlining!)">;
+
+def sil_unroll_threshold : Separate<["-"], "sil-unroll-threshold">,
+  MetaVarName<"<250>">,
+  HelpText<"Controls the aggressiveness of loop unrolling">;
+
 def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
   HelpText<"Merge SIL from all partial swiftmodules into the final module">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1188,6 +1188,20 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       return true;
     }
   }
+  if (const Arg *A = Args.getLastArg(OPT_sil_inline_caller_benefit_reduction_factor)) {
+    if (StringRef(A->getValue()).getAsInteger(10, Opts.CallerBaseBenefitReductionFactor)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return true;
+    }
+  }
+  if (const Arg *A = Args.getLastArg(OPT_sil_unroll_threshold)) {
+    if (StringRef(A->getValue()).getAsInteger(10, Opts.UnrollThreshold)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return true;
+    }
+  }
   if (const Arg *A = Args.getLastArg(OPT_num_threads)) {
     if (StringRef(A->getValue()).getAsInteger(10, Opts.NumThreads)) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -845,7 +845,7 @@ void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs) {
     Attrs.addAttribute("target-features", allFeatures);
   }
   if (IRGen.Opts.OptimizeForSize)
-    Attrs.addAttribute(llvm::Attribute::OptimizeForSize);
+    Attrs.addAttribute(llvm::Attribute::MinSize);
 }
 
 llvm::AttributeList IRGenModule::constructInitialAttributes() {

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -29,7 +29,6 @@ using namespace swift::PatternMatch;
 using llvm::DenseMap;
 using llvm::MapVector;
 
-static const uint64_t SILLoopUnrollThreshold = 250;
 
 namespace {
 
@@ -187,6 +186,9 @@ static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount) {
   // It is used to estimate the cost of the callee
   // inside a loop.
   const uint64_t InsnsPerBB = 4;
+  // Use command-line threshold for unrolling.
+  const uint64_t SILLoopUnrollThreshold = Loop->getBlocks().empty() ? 0 : 
+    (Loop->getBlocks())[0]->getParent()->getModule().getOptions().UnrollThreshold;
   for (auto *BB : Loop->getBlocks()) {
     for (auto &Inst : *BB) {
       if (!Loop->canDuplicate(&Inst))

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -256,7 +256,9 @@ bool SILPerformanceInliner::isProfitableToInline(
         return false;
     }
 
-    BaseBenefit = BaseBenefit / 2;
+    // Use command line option to control inlining in Osize mode.
+    const uint64_t CallerBaseBenefitReductionFactor = AI.getFunction()->getModule().getOptions().CallerBaseBenefitReductionFactor;
+    BaseBenefit = BaseBenefit / CallerBaseBenefitReductionFactor;
   }
 
   // It is always OK to inline a simple call.

--- a/test/IRGen/optimize_for_size.sil
+++ b/test/IRGen/optimize_for_size.sil
@@ -13,4 +13,4 @@ bb0(%0 : $Builtin.Int32):
 }
 
 // O-NOT: attributes #0 = {{{.*}}optsize
-// CHECK: attributes #0 = {{{.*}}optsize
+// CHECK: attributes #0 = {{{.*}}minsize


### PR DESCRIPTION
Improve Osize by
commit 1: Expose UnrollThreshold and Inline_Benefit_Reduction_Factor in the command line for code size tuning
commit 2:  Use MinSize instead of OptimizeForSize in LLVM function annotation;
