### PR TITLE
 IRGen: Use swiftcc for swift_unexpectedError and swift_errorInMain

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -142,13 +142,13 @@ FUNCTION(WillThrow, swift_willThrow, DefaultCC,
          ATTRS(NoUnwind))
 
 // void swift_errorInMain(error *ptr);
-FUNCTION(ErrorInMain, swift_errorInMain, DefaultCC,
+FUNCTION(ErrorInMain, swift_errorInMain, SwiftCC,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_unexpectedError(error *ptr);
-FUNCTION(UnexpectedError, swift_unexpectedError, DefaultCC,
+FUNCTION(UnexpectedError, swift_unexpectedError, SwiftCC,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind, NoReturn))

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -271,14 +271,14 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, Identifier FnId,
     return out.add(v); \
   }
 
-#define BUILTIN_RUNTIME_CALL(id, name, attrs) \
-  if (Builtin.ID == BuiltinValueKind::id) { \
-    llvm::CallInst *call = IGF.Builder.CreateCall(IGF.IGM.get##id##Fn(),  \
-                           args.claimNext()); \
-    call->setCallingConv(IGF.IGM.DefaultCC); \
-    call->setDoesNotThrow(); \
-    return out.add(call); \
- }
+#define BUILTIN_RUNTIME_CALL(id, name, attrs)                                  \
+  if (Builtin.ID == BuiltinValueKind::id) {                                    \
+    auto *fn = cast<llvm::Function>(IGF.IGM.get##id##Fn());                    \
+    llvm::CallInst *call = IGF.Builder.CreateCall(fn, args.claimNext());       \
+    call->setCallingConv(fn->getCallingConv());                                \
+    call->setAttributes(fn->getAttributes());                                  \
+    return out.add(call);                                                      \
+  }
 
 #define BUILTIN_BINARY_OPERATION_WITH_OVERFLOW(id, name, uncheckedID, attrs, overload) \
 if (Builtin.ID == BuiltinValueKind::id) { \

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -208,6 +208,8 @@ SWIFT_RUNTIME_EXPORT
 void swift_errorInMain(SwiftError *object);
 SWIFT_RUNTIME_EXPORT
 void swift_willThrow(SwiftError *object);
+
+SWIFT_CC(swift)
 SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NORETURN
 void swift_unexpectedError(SwiftError *object);
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -11,6 +11,8 @@ import Swift
 typealias Int = Builtin.Int32
 typealias Bool = Builtin.Int1
 
+// CHECK: call swiftcc void @swift_errorInMain(
+
 infix operator * {
   associativity left
   precedence 200
@@ -837,6 +839,23 @@ func atomicload(_ p: Builtin.RawPointer) {
   // CHECK: store atomic volatile i32 [[D1]], i32* {{.*}} seq_cst, align 4
   Builtin.atomicstore_seqcst_volatile_FPIEEE32(p, d)
 }
+
+func createInt(_ fn: () -> ()) throws {}
+// CHECK-LABEL: define {{.*}}testForceTry
+// CHECK: call swiftcc void @swift_unexpectedError(%swift.error*
+func testForceTry(_ fn: () -> ()) {
+  try! createInt(fn)
+}
+
+// CHECK-LABEL: declare swiftcc void @swift_unexpectedError(%swift.error*
+
+enum MyError : Error {
+  case A, B
+}
+
+throw MyError.A
+
+
 
 // CHECK: ![[R]] = !{i64 0, i64 9223372036854775807}
 


### PR DESCRIPTION
It is a runtime function defined in swift. This currently did not have
ABI implications because the ABI happened to be compatible but ...

SR-6235
rdar://problem/35222489