### PR TITLE
SIL: Keep stable pointer identities for cached SILConstantInfos.

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -531,9 +531,9 @@ class TypeConverter {
 
   llvm::SmallVector<DependentTypeState, 1> DependentTypes;
 
-  llvm::DenseMap<SILDeclRef, SILConstantInfo> ConstantTypes;
+  llvm::DenseMap<SILDeclRef, SILConstantInfo *> ConstantTypes;
   
-  llvm::DenseMap<OverrideKey, SILConstantInfo> ConstantOverrideTypes;
+  llvm::DenseMap<OverrideKey, SILConstantInfo *> ConstantOverrideTypes;
 
   llvm::DenseMap<AnyFunctionRef, CaptureInfo> LoweredCaptures;
 


### PR DESCRIPTION
TypeConverter::getConstantInfo was changed to return its found records by reference, but by reference into the inline storage of a DenseMap, which is a bad idea if someone else makes a getConstantInfo call that causes the cache to rehash before we're done with the reference from a previous call. Change it so that the cached SILConstantInfos get allocated out of the SILModule's arena, and so that we store the pointers in the hashtable, so that the references remain stable. Should fix rdar://problem/35132592.