### PR TITLE
[GSB] Yet more cleanup to realize fewer potential archetypes

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -91,8 +91,11 @@ public:
   using UnresolvedType = llvm::PointerUnion<PotentialArchetype *, Type>;
   class ResolvedType;
 
-  using RequirementRHS =
+  using UnresolvedRequirementRHS =
       llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
+
+  using RequirementRHS =
+    llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
 
   /// The location of a requirement as written somewhere in the source.
   typedef llvm::PointerUnion<const TypeRepr *, const RequirementRepr *>
@@ -337,7 +340,7 @@ private:
   /// as appropriate based on \c unresolvedHandling.
   ConstraintResult handleUnresolvedRequirement(RequirementKind kind,
                                    UnresolvedType lhs,
-                                   RequirementRHS rhs,
+                                   UnresolvedRequirementRHS rhs,
                                    FloatingRequirementSource source,
                                    EquivalenceClass *unresolvedEquivClass,
                                    UnresolvedHandlingKind unresolvedHandling);
@@ -534,13 +537,14 @@ public:
   ///
   /// \param f A function object that will be passed each requirement
   /// and requirement source.
-  void enumerateRequirements(llvm::function_ref<
+  void enumerateRequirements(
+                    ArrayRef<GenericTypeParamType *> genericParams,
+                    llvm::function_ref<
                       void (RequirementKind kind,
-                            PotentialArchetype *archetype,
+                            Type type,
                             RequirementRHS constraint,
                             const RequirementSource *source)> f);
 
-public:
   /// Retrieve the generic parameters used to describe the generic
   /// signature being built.
   ArrayRef<GenericTypeParamType *> getGenericParams() const;
@@ -1731,7 +1735,7 @@ public:
 
   Kind kind;
   UnresolvedType lhs;
-  RequirementRHS rhs;
+  UnresolvedRequirementRHS rhs;
   FloatingRequirementSource source;
 
   /// Dump a debugging representation of this delayed requirement class.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -729,30 +729,30 @@ private:
   /// class of the given potential archetype.
   void checkConcreteTypeConstraints(
                             ArrayRef<GenericTypeParamType *> genericParams,
-                            PotentialArchetype *pa);
+                            EquivalenceClass *equivClass);
 
   /// Check the superclass constraints within the equivalence
   /// class of the given potential archetype.
   void checkSuperclassConstraints(
                             ArrayRef<GenericTypeParamType *> genericParams,
-                            PotentialArchetype *pa);
+                            EquivalenceClass *equivClass);
 
   /// Check conformance constraints within the equivalence class of the
   /// given potential archetype.
   void checkConformanceConstraints(
                             ArrayRef<GenericTypeParamType *> genericParams,
-                            PotentialArchetype *pa);
+                            EquivalenceClass *equivClass);
 
   /// Check layout constraints within the equivalence class of the given
   /// potential archetype.
   void checkLayoutConstraints(ArrayRef<GenericTypeParamType *> genericParams,
-                              PotentialArchetype *pa);
+                              EquivalenceClass *equivClass);
 
   /// Check same-type constraints within the equivalence class of the
   /// given potential archetype.
   void checkSameTypeConstraints(
                             ArrayRef<GenericTypeParamType *> genericParams,
-                            PotentialArchetype *pa);
+                            EquivalenceClass *equivClass);
 
   /// Realize a potential archetype for the given type.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -158,7 +158,7 @@ public:
     /// the equivalence class that is held together by derived constraints.
     struct DerivedSameTypeComponent {
       /// The potential archetype that acts as the anchor for this component.
-      PotentialArchetype *anchor;
+      UnresolvedType anchor;
 
       /// The (best) requirement source within the component that makes the
       /// potential archetypes in this component equivalent to the concrete
@@ -749,6 +749,12 @@ private:
   void checkSameTypeConstraints(
                             ArrayRef<GenericTypeParamType *> genericParams,
                             PotentialArchetype *pa);
+
+  /// Realize a potential archetype for the given type.
+  ///
+  /// The resolved archetype will be written back into the unresolved type,
+  /// to make the next resolution more efficient.
+  PotentialArchetype *realizePotentialArchetype(UnresolvedType &type);
 
 public:
   /// \brief Try to resolve the equivalence class of the given type.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -223,15 +223,13 @@ public:
     /// archetype in this equivalence class to a concrete type along with
     /// that concrete type as written.
     Optional<ConcreteConstraint>
-    findAnyConcreteConstraintAsWritten(
-                              PotentialArchetype *preferredPA = nullptr) const;
+    findAnyConcreteConstraintAsWritten(Type preferredType = Type()) const;
 
     /// Find a source of the superclass constraint in this equivalence class
     /// that has a type equivalence to \c superclass, along with that
     /// superclass type as written.
     Optional<ConcreteConstraint>
-    findAnySuperclassConstraintAsWritten(
-                              PotentialArchetype *preferredPA = nullptr) const;
+    findAnySuperclassConstraintAsWritten(Type preferredType = Type()) const;
 
     /// Determine whether conformance to the given protocol is satisfied by
     /// a superclass requirement.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -268,8 +268,8 @@ public:
 
     /// The cached archetype anchor.
     struct {
-      /// The cached archetype anchor itself.
-      PotentialArchetype *anchor = nullptr;
+      /// The cached anchor itself.
+      Type anchor;
 
       /// The number of members of the equivalence class when the archetype
       /// anchor was cached.
@@ -1663,20 +1663,6 @@ public:
     return TinyPtrVector<PotentialArchetype *>(
                                        const_cast<PotentialArchetype *>(this));
   }
-
-  /// \brief Retrieve the potential archetype to be used as the anchor for
-  /// potential archetype computations.
-  PotentialArchetype *getArchetypeAnchor(GenericSignatureBuilder &builder);
-
-  /// \brief Retrieve (or create) a nested type that is the current best
-  /// nested archetype anchor (locally) with the given name.
-  ///
-  /// When called on the archetype anchor, this will produce the named
-  /// archetype anchor.
-  PotentialArchetype *getNestedArchetypeAnchor(
-                       Identifier name,
-                       GenericSignatureBuilder &builder,
-                       ArchetypeResolutionKind kind);
 
   /// Update the named nested type when we know this type conforms to the given
   /// protocol.

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -295,8 +295,8 @@ struct X22<T, U> {
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P22>
 // CHECK: Protocol requirement signature:
 // CHECK: .P22@
-// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X20<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X20<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X20<Self.B>, Self.B : P20>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X20<τ_0_0.B>, τ_0_0.B : P20>
 protocol P22 {
   associatedtype A
   associatedtype B where A == X20<B>
@@ -306,8 +306,8 @@ protocol P22 {
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P23>
 // CHECK: Protocol requirement signature:
 // CHECK: .P23@
-// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X20<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X20<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X20<Self.B>, Self.B : P20>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X20<τ_0_0.B>, τ_0_0.B : P20>
 protocol P23 {
   associatedtype A
   associatedtype B: P20
@@ -323,16 +323,16 @@ struct X24<T: P20> : P24 {
 }
 
 // CHECK-LABEL: .P25a@
-// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X24<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X24<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X24<Self.B>, Self.B : P20>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25a {
   associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A': 'P24'}}
   associatedtype B where A == X24<B> // expected-note{{conformance constraint 'Self.A': 'P24' implied here}}
 }
 
 // CHECK-LABEL: .P25b@
-// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X24<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X24<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X24<Self.B>, Self.B : P20>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25b {
   associatedtype A
   associatedtype B where A == X24<B>
@@ -353,16 +353,16 @@ struct X26<T: X3> : P26 {
 }
 
 // CHECK-LABEL: .P27a@
-// CHECK-NEXT: Requirement signature: <Self where Self.B : X3, Self.A == X26<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : X3, τ_0_0.A == X26<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A': 'P26'}}
   associatedtype B where A == X26<B> // expected-note{{conformance constraint 'Self.A': 'P26' implied here}}
 }
 
 // CHECK-LABEL: .P27b@
-// CHECK-NEXT: Requirement signature: <Self where Self.B : X3, Self.A == X26<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : X3, τ_0_0.A == X26<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27b {
   associatedtype A
   associatedtype B where A == X26<B>

--- a/validation-test/compiler_crashers_2_fixed/0075-rdar30248571.swift
+++ b/validation-test/compiler_crashers_2_fixed/0075-rdar30248571.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -typecheck
-// FIXME: %target-swift-frontend %s -emit-ir -- see https://github.com/apple/swift/pull/7414
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
 
 protocol P {
   associatedtype A

--- a/validation-test/compiler_crashers_fixed/28803-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28803-swift-typebase-getdesugaredtype.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{typealias a:Collection
 typealias a=(t:Self.a

--- a/validation-test/compiler_crashers_fixed/28846-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28846-swift-typebase-getdesugaredtype.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{typealias a{}func a:a.a{}class a{{}protocol 0
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol A{typealias a:A=a{}typealias a=Self.a

--- a/validation-test/compiler_crashers_fixed/28848-iscanonicaltypeincontext-result-builder.swift
+++ b/validation-test/compiler_crashers_fixed/28848-iscanonicaltypeincontext-result-builder.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol A{typealias a:A=a{}typealias a=Self.a
+// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{typealias a{}func a:a.a{}class a{{}protocol 0


### PR DESCRIPTION
Clean up and rework some `PotentialArchetype`-wielding APIs in the `GenericSignatureBuilder`, including:

* Use `UnresolvedType` or `EquivalenceClass *` rather than `PotentialArchetype *` in a number of places where we don't *need* a potential archetype.
* Simplify `enumerateRequirements()` to operate on equivalence classes and same-type component anchors. It eliminates an O(n^2) algorithm (where n is small, but still) and fixes a canonicalization issue
* Reimplement archetype "anchor" computation in a more efficient, sensible manner.

Three crashers fixed, 5% speedup in type-checking time for the standard library, and few places that realize potential archetypes.