### PR TITLE
[WIP] Named lazy member loading 3

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2178,7 +2178,7 @@ public:
   bool wasDeserialized() const;
 
   /// Get the DeclID this Decl was deserialized from.
-  serialization::DeclID getDeclID() {
+  serialization::DeclID getDeclID() const {
     assert(wasDeserialized());
     return SerialID;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2169,7 +2169,7 @@ public:
   /// Objective-C name, if used to satisfy the given requirement.
   bool canInferObjCFromRequirement(ValueDecl *requirement);
 
-  /// Get either NameLoc or an empty SourceLog if wasDeserialized()
+  /// Get either NameLoc or an empty SourceLoc if wasDeserialized()
   SourceLoc getNameLoc() const {
     if (wasDeserialized())
       return SourceLoc();

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2169,9 +2169,14 @@ public:
   /// Objective-C name, if used to satisfy the given requirement.
   bool canInferObjCFromRequirement(ValueDecl *requirement);
 
-  /// Get NameLoc, only valid if !isDeserialized()
-  SourceLoc getNameLoc() const { assert(!wasDeserialized()); return NameLoc; }
-  SourceLoc getLoc() const { assert(!wasDeserialized()); return NameLoc; }
+  /// Get either NameLoc or an empty SourceLog if wasDeserialized()
+  SourceLoc getNameLoc() const {
+    if (wasDeserialized())
+      return SourceLoc();
+    else
+      return NameLoc;
+  }
+  SourceLoc getLoc() const { return getNameLoc(); }
 
   /// Determine whether this Decl was deserialized (and thus DeserializedID is
   /// valid). If not, NameLoc is valid.

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -26,6 +26,7 @@ namespace swift {
 class AssociatedTypeDecl;
 class Decl;
 class DeclContext;
+class IterableDeclContext;
 class ExtensionDecl;
 class Identifier;
 class NominalTypeDecl;
@@ -224,13 +225,14 @@ public:
   virtual void
   loadAllMembers(Decl *D, uint64_t contextData) = 0;
 
-  /// Populates a vector with all members of \p D that have DeclName
+  /// Populates a vector with all members of \p IDC that have DeclName
   /// matching \p N.
   ///
   /// Returns None if an error occurred \em or named member-lookup
   /// was otherwise unsupported in this implementation or Decl.
   virtual Optional<TinyPtrVector<ValueDecl *>>
-  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData) = 0;
+  loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
+                   uint64_t contextData) = 0;
 
   /// Populates the given vector with all conformances for \p D.
   ///

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -66,6 +66,7 @@ class ModuleFile
 
   llvm::BitstreamCursor SILCursor;
   llvm::BitstreamCursor SILIndexCursor;
+  llvm::BitstreamCursor DeclMemberTablesCursor;
 
   /// The name of the module.
   StringRef Name;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -730,7 +730,7 @@ public:
 
   virtual
   Optional<TinyPtrVector<ValueDecl *>>
-  loadNamedMembers(const Decl *D, DeclName N,
+  loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
                    uint64_t contextData) override;
 
   virtual void

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -354,7 +354,7 @@ private:
   std::unique_ptr<SerializedNestedTypeDeclsTable> NestedTypeDecls;
   std::unique_ptr<SerializedDeclMemberNamesTable> DeclMemberNames;
 
-  llvm::DenseMap<serialization::BitOffset,
+  llvm::DenseMap<uint32_t,
            std::unique_ptr<SerializedDeclMembersTable>> DeclMembersTables;
 
   class ObjCMethodTableInfo;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -477,6 +477,11 @@ private:
   std::unique_ptr<SerializedNestedTypeDeclsTable>
   readNestedTypeDeclsTable(ArrayRef<uint64_t> fields, StringRef blobData);
 
+  /// Main logic of getDeclChecked.
+  llvm::Expected<Decl *>
+  getDeclCheckedImpl(serialization::DeclID DID,
+                     Optional<DeclContext *> ForcedContext = None);
+
   /// Reads the index block, which contains global tables.
   ///
   /// Returns false if there was an error.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -335,6 +335,14 @@ private:
   using SerializedNestedTypeDeclsTable =
       llvm::OnDiskIterableChainedHashTable<NestedTypeDeclsTableInfo>;
 
+  class DeclMemberNamesTableInfo;
+  using SerializedDeclMemberNamesTable =
+      llvm::OnDiskIterableChainedHashTable<DeclMemberNamesTableInfo>;
+
+  class DeclMembersTableInfo;
+  using SerializedDeclMembersTable =
+      llvm::OnDiskIterableChainedHashTable<DeclMembersTableInfo>;
+
   std::unique_ptr<SerializedDeclTable> TopLevelDecls;
   std::unique_ptr<SerializedDeclTable> OperatorDecls;
   std::unique_ptr<SerializedDeclTable> PrecedenceGroupDecls;
@@ -343,6 +351,10 @@ private:
   std::unique_ptr<SerializedExtensionTable> ExtensionDecls;
   std::unique_ptr<SerializedLocalDeclTable> LocalTypeDecls;
   std::unique_ptr<SerializedNestedTypeDeclsTable> NestedTypeDecls;
+  std::unique_ptr<SerializedDeclMemberNamesTable> DeclMemberNames;
+
+  llvm::DenseMap<serialization::BitOffset,
+           std::unique_ptr<SerializedDeclMembersTable>> DeclMembersTables;
 
   class ObjCMethodTableInfo;
   using SerializedObjCMethodTable =
@@ -476,6 +488,16 @@ private:
   /// index_block::NestedTypeDeclsLayout format.
   std::unique_ptr<SerializedNestedTypeDeclsTable>
   readNestedTypeDeclsTable(ArrayRef<uint64_t> fields, StringRef blobData);
+
+  /// Read an on-disk local decl-name hash table stored in
+  /// index_block::DeclMemberNamesLayout format.
+  std::unique_ptr<SerializedDeclMemberNamesTable>
+  readDeclMemberNamesTable(ArrayRef<uint64_t> fields, StringRef blobData);
+
+  /// Read an on-disk local decl-members hash table stored in
+  /// index_block::DeclMembersLayout format.
+  std::unique_ptr<SerializedDeclMembersTable>
+  readDeclMembersTable(ArrayRef<uint64_t> fields, StringRef blobData);
 
   /// Main logic of getDeclChecked.
   llvm::Expected<Decl *>

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -338,7 +338,7 @@ private:
   std::unique_ptr<SerializedDeclTable> TopLevelDecls;
   std::unique_ptr<SerializedDeclTable> OperatorDecls;
   std::unique_ptr<SerializedDeclTable> PrecedenceGroupDecls;
-  std::unique_ptr<SerializedDeclTable> ClassMembersByName;
+  std::unique_ptr<SerializedDeclTable> ClassMembersForDynamicLookup;
   std::unique_ptr<SerializedDeclTable> OperatorMethodDecls;
   std::unique_ptr<SerializedExtensionTable> ExtensionDecls;
   std::unique_ptr<SerializedLocalDeclTable> LocalTypeDecls;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -56,7 +56,6 @@ const uint16_t VERSION_MAJOR = 0;
 /// it just ensures a conflict if two people change the module format.
 const uint16_t VERSION_MINOR = 377; // Last change: SILFunctionType witness_method conformances
 
-using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
 
 // TypeID must be the same as DeclID because it is stored in the same way.

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -440,11 +440,6 @@ enum BlockID {
   /// \sa index_block
   INDEX_BLOCK_ID,
 
-  /// The declaration member-tables index block, a sub-blocb of the index block.
-  ///
-  /// \sa decl_member_tables_block
-  DECL_MEMBER_TABLES_BLOCK_ID,
-
   /// The block for SIL functions.
   ///
   /// \sa sil_block
@@ -468,7 +463,12 @@ enum BlockID {
   /// The comment block, which contains documentation comments.
   ///
   /// \sa comment_block
-  COMMENT_BLOCK_ID
+  COMMENT_BLOCK_ID,
+
+  /// The declaration member-tables index block, a sub-blocb of the index block.
+  ///
+  /// \sa decl_member_tables_block
+  DECL_MEMBER_TABLES_BLOCK_ID
 };
 
 /// The record types within the control block.
@@ -1523,7 +1523,7 @@ namespace index_block {
     NESTED_TYPE_DECLS,
     DECL_MEMBER_NAMES,
 
-    LastRecordKind = PRECEDENCE_GROUPS,
+    LastRecordKind = DECL_MEMBER_NAMES,
   };
   
   constexpr const unsigned RecordIDFieldWidth = 5;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 377; // Last change: SILFunctionType witness_method conformances
+const uint16_t VERSION_MINOR = 378; // Last change: DECL_MEMBER_NAMES
 
 using DeclIDField = BCFixed<31>;
 
@@ -439,6 +439,11 @@ enum BlockID {
   ///
   /// \sa index_block
   INDEX_BLOCK_ID,
+
+  /// The declaration member-tables index block, a sub-blocb of the index block.
+  ///
+  /// \sa decl_member_tables_block
+  DECL_MEMBER_TABLES_BLOCK_ID,
 
   /// The block for SIL functions.
   ///
@@ -1516,6 +1521,7 @@ namespace index_block {
 
     PRECEDENCE_GROUPS,
     NESTED_TYPE_DECLS,
+    DECL_MEMBER_NAMES,
 
     LastRecordKind = PRECEDENCE_GROUPS,
   };
@@ -1559,10 +1565,30 @@ namespace index_block {
     BCBlob  // map from identifier strings to decl kinds / decl IDs
   >;
 
+  using DeclMemberNamesLayout = BCRecordLayout<
+    DECL_MEMBER_NAMES, // record ID
+    BCVBR<16>,  // table offset within the blob (see below)
+    BCBlob  // map from member DeclBaseNames to offsets of DECL_MEMBERS records
+  >;
+
   using EntryPointLayout = BCRecordLayout<
     ENTRY_POINT,
     DeclIDField  // the ID of the main class; 0 if there was a main source file
   >;
+}
+
+/// \sa DECL_MEMBER_TABLES_BLOCK_ID
+namespace decl_member_tables_block {
+  enum RecordKind {
+    DECL_MEMBERS = 1,
+  };
+
+  using DeclMembersLayout = BCRecordLayout<
+    DECL_MEMBERS, // record ID
+    BCVBR<16>,  // table offset within the blob (see below)
+    BCBlob  // maps from DeclIDs to DeclID vectors
+  >;
+
 }
 
 /// \sa COMMENT_BLOCK_ID

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1499,7 +1499,7 @@ namespace index_block {
     TOP_LEVEL_DECLS,
     OPERATORS,
     EXTENSIONS,
-    CLASS_MEMBERS,
+    CLASS_MEMBERS_FOR_DYNAMIC_LOOKUP,
     OPERATOR_METHODS,
 
     /// The Objective-C method index, which contains a mapping from

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -37,6 +37,7 @@ namespace swift {
 
     bool AutolinkForceLoad = false;
     bool EnableNestedTypeLookupTable = false;
+    bool EnableDeclMemberNamesTable = false;
     bool SerializeAllSIL = false;
     bool SerializeOptionsForDebugging = false;
     bool IsSIB = false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2006,14 +2006,6 @@ bool ValueDecl::canInferObjCFromRequirement(ValueDecl *requirement) {
   return false;
 }
 
-bool ValueDecl::wasDeserialized() const {
-  auto *DC = getDeclContext();
-  if (auto F = dyn_cast<FileUnit>(DC->getModuleScopeContext())) {
-    return F->getKind() == FileUnitKind::SerializedAST;
-  }
-  return false;
-}
-
 SourceLoc ValueDecl::getAttributeInsertionLoc(bool forModifier) const {
   if (auto var = dyn_cast<VarDecl>(this)) {
     // [attrs] var ...

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2006,6 +2006,14 @@ bool ValueDecl::canInferObjCFromRequirement(ValueDecl *requirement) {
   return false;
 }
 
+bool ValueDecl::wasDeserialized() const {
+  auto *DC = getDeclContext();
+  if (auto F = dyn_cast<FileUnit>(DC->getModuleScopeContext())) {
+    return F->getKind() == FileUnitKind::SerializedAST;
+  }
+  return false;
+}
+
 SourceLoc ValueDecl::getAttributeInsertionLoc(bool forModifier) const {
   if (auto var = dyn_cast<VarDecl>(this)) {
     // [attrs] var ...

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1040,7 +1040,7 @@ public:
     // LastExtensionIncluded would only be non-null if this was populated from
     // an IterableDeclContext (though it might still be null in that case).
     assert(LastExtensionIncluded == nullptr);
-    for (auto i : Lookup) {
+    for (auto const &i : Lookup) {
       for (auto d : i.getSecond()) {
         d->ValueDeclBits.AlreadyInLookupTable = false;
       }
@@ -1235,7 +1235,7 @@ void ExtensionDecl::addedMember(Decl *member) {
 // (IDC's) list of Decls is populated. But MemberLookupTable can also be
 // populated incrementally by one-name-at-a-time lookups by lookupDirect, in
 // which case those Decls are _not_ added to the IDC's list. They are cached in
-// the loader they come from, lifecycle-wise, and are added to the the
+// the loader they come from, lifecycle-wise, and are added to the
 // MemberLookupTable to accelerate subsequent retrieval, but the IDC is not
 // considered populated until someone calls getMembers().
 //
@@ -1365,7 +1365,7 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
     for (auto d : *res) {
       LookupTable.getPointer()->addMember(d);
     }
-    // Retry lookup in refeshed table. Note: don't try refactoring this to merge
+    // Retry lookup in refreshed table. Note: don't try refactoring this to merge
     // with the iterator compare-and-return above. There's epoch-based
     // invalidation tracking on DenseMap iterators in assert builds that require
     // us to treat iterators from each probe separately.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3307,8 +3307,8 @@ ClangImporter::Implementation::loadNamedMembers(
   clang::ASTContext &clangCtx = getClangASTContext();
 
   TinyPtrVector<ValueDecl *> Members;
-  if (auto *CPD = dyn_cast<clang::ObjCProtocolDecl>(CD)) {
-    for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()), CPD)) {
+  if (auto *CCD = dyn_cast<clang::ObjCContainerDecl>(CD)) {
+    for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()), CCD)) {
       if (!entry.is<clang::NamedDecl *>()) continue;
       auto member = entry.get<clang::NamedDecl *>();
       if (!isVisibleClangEntry(clangCtx, member)) continue;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3276,10 +3276,10 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
 
 Optional<TinyPtrVector<ValueDecl *>>
 ClangImporter::Implementation::loadNamedMembers(
-    const Decl *D, DeclName N, uint64_t contextData) {
+    const IterableDeclContext *IDC, DeclName N, uint64_t contextData) {
 
+  auto *D = IDC->getDecl();
   auto *DC = cast<DeclContext>(D);
-
   auto *CD = D->getClangDecl();
   assert(CD && "loadNamedMembers on a Decl without a clangDecl");
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1123,7 +1123,8 @@ public:
   loadAllMembers(Decl *D, uint64_t unused) override;
 
   virtual Optional<TinyPtrVector<ValueDecl *>>
-  loadNamedMembers(const Decl *D, DeclName N, uint64_t contextData) override;
+  loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
+                   uint64_t contextData) override;
 
 private:
   void

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -835,6 +835,8 @@ static bool performCompile(CompilerInstance &Instance,
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
+      serializationOpts.EnableDeclMemberNamesTable =
+        Invocation.getLangOptions().NamedLazyMemberLoading;
 
       serialize(DC, serializationOpts, SM.get());
     }
@@ -899,6 +901,8 @@ static bool performCompile(CompilerInstance &Instance,
             Invocation.getClangImporterOptions().ExtraArgs;
         serializationOpts.EnableNestedTypeLookupTable =
             opts.EnableSerializationNestedTypeLookupTable;
+        serializationOpts.EnableDeclMemberNamesTable =
+          Invocation.getLangOptions().NamedLazyMemberLoading;
         if (!IRGenOpts.ForceLoadSymbolName.empty())
           serializationOpts.AutolinkForceLoad = true;
 
@@ -977,6 +981,8 @@ static bool performCompile(CompilerInstance &Instance,
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
+      serializationOpts.EnableDeclMemberNamesTable =
+        Invocation.getLangOptions().NamedLazyMemberLoading;
 
       serialize(DC, serializationOpts, SM.get());
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4703,13 +4703,6 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   }
 }
 
-Optional<TinyPtrVector<ValueDecl *>>
-ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
-                             uint64_t contextData) {
-  // Not presently supported.
-  return None;
-}
-
 void
 ModuleFile::loadAllConformances(const Decl *D, uint64_t contextData,
                           SmallVectorImpl<ProtocolConformance*> &conformances) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2112,9 +2112,9 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   // Tag every deserialized ValueDecl coming out of getDeclChecked with its ID.
   Expected<Decl *> deserialized = getDeclCheckedImpl(DID, ForcedContext);
   if (deserialized && deserialized.get()) {
-    if (auto *VD = dyn_cast<ValueDecl>(deserialized.get())) {
-      if (VD->wasDeserialized()) {
-        VD->setDeclID(DID);
+    if (auto *IDC = dyn_cast<IterableDeclContext>(deserialized.get())) {
+      if (IDC->wasDeserialized()) {
+        IDC->setDeclID(DID);
       }
     }
   }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -775,6 +775,7 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
           subentry = DeclMemberTablesCursor.advance(
             llvm::BitstreamCursor::AF_DontPopBlockAtEnd);
         } while (!DeclMemberTablesCursor.AtEndOfStream() &&
+                 subentry.Kind != llvm::BitstreamEntry::Record &&
                  subentry.Kind != llvm::BitstreamEntry::EndBlock);
       }
       if (cursor.SkipBlock())

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -768,6 +768,14 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
       if (entry.ID == DECL_MEMBER_TABLES_BLOCK_ID) {
         DeclMemberTablesCursor = cursor;
         DeclMemberTablesCursor.EnterSubBlock(DECL_MEMBER_TABLES_BLOCK_ID);
+        llvm::BitstreamEntry subentry;
+        do {
+          // Scan forward, to load the cursor with any abbrevs we'll need while
+          // seeking inside this block later.
+          subentry = DeclMemberTablesCursor.advance(
+            llvm::BitstreamCursor::AF_DontPopBlockAtEnd);
+        } while (!DeclMemberTablesCursor.AtEndOfStream() &&
+                 subentry.Kind != llvm::BitstreamEntry::EndBlock);
       }
       if (cursor.SkipBlock())
         return false;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -667,8 +667,8 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
       case index_block::EXTENSIONS:
         ExtensionDecls = readExtensionTable(scratch, blobData);
         break;
-      case index_block::CLASS_MEMBERS:
-        ClassMembersByName = readDeclTable(scratch, blobData);
+      case index_block::CLASS_MEMBERS_FOR_DYNAMIC_LOOKUP:
+        ClassMembersForDynamicLookup = readDeclTable(scratch, blobData);
         break;
       case index_block::OPERATOR_METHODS:
         OperatorMethodDecls = readDeclTable(scratch, blobData);
@@ -1640,11 +1640,11 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
   PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
-  if (!ClassMembersByName)
+  if (!ClassMembersForDynamicLookup)
     return;
 
-  auto iter = ClassMembersByName->find(name.getBaseName());
-  if (iter == ClassMembersByName->end())
+  auto iter = ClassMembersForDynamicLookup->find(name.getBaseName());
+  if (iter == ClassMembersForDynamicLookup->end())
     return;
 
   if (!accessPath.empty()) {
@@ -1689,11 +1689,11 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
   PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
-  if (!ClassMembersByName)
+  if (!ClassMembersForDynamicLookup)
     return;
 
   if (!accessPath.empty()) {
-    for (const auto &list : ClassMembersByName->data()) {
+    for (const auto &list : ClassMembersForDynamicLookup->data()) {
       for (auto item : list) {
         auto vd = cast<ValueDecl>(getDecl(item.second));
         auto dc = vd->getDeclContext();
@@ -1707,7 +1707,7 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
     return;
   }
 
-  for (const auto &list : ClassMembersByName->data()) {
+  for (const auto &list : ClassMembersForDynamicLookup->data()) {
     for (auto item : list)
       consumer.foundDecl(cast<ValueDecl>(getDecl(item.second)),
                          DeclVisibilityKind::DynamicLookup);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -540,7 +540,7 @@ public:
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
     unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, sizeof(serialization::BitOffset) };
+    return { keyLength, sizeof(uint32_t) };
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
@@ -562,8 +562,8 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    assert(length == sizeof(serialization::BitOffset));
-    return endian::readNext<serialization::BitOffset, little, unaligned>(data);
+    assert(length == sizeof(uint32_t));
+    return endian::readNext<uint32_t, little, unaligned>(data);
   }
 };
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1787,13 +1787,10 @@ void ModuleFile::loadObjCMethods(
 }
 
 Optional<TinyPtrVector<ValueDecl *>>
-ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
+ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
                              uint64_t contextData) {
 
-  auto VD = dyn_cast<ValueDecl>(D);
-  if (!VD)
-    return None;
-  assert(VD->wasDeserialized());
+  assert(IDC->wasDeserialized());
 
   if (!DeclMemberNames)
     return None;
@@ -1823,9 +1820,9 @@ ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
   }
 
   assert(subTable);
-  auto j = subTable->find(VD->getDeclID());
+  TinyPtrVector<ValueDecl *> results;
+  auto j = subTable->find(IDC->getDeclID());
   if (j != subTable->end()) {
-    TinyPtrVector<ValueDecl *> results;
     for (DeclID d : *j) {
       Expected<Decl *> mem = getDeclChecked(d);
       if (mem) {
@@ -1841,9 +1838,8 @@ ModuleFile::loadNamedMembers(const Decl *D, DeclName N,
         return None;
       }
     }
-    return results;
   }
-  return None;
+  return results;
 }
 
 void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -651,6 +651,10 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(index_block, SIL_LAYOUT_OFFSETS);
   BLOCK_RECORD(index_block, PRECEDENCE_GROUPS);
   BLOCK_RECORD(index_block, NESTED_TYPE_DECLS);
+  BLOCK_RECORD(index_block, DECL_MEMBER_NAMES);
+
+  BLOCK(DECL_MEMBER_TABLES_BLOCK);
+  BLOCK_RECORD(decl_member_tables_block, DECL_MEMBERS);
 
   BLOCK(SIL_BLOCK);
   BLOCK_RECORD(sil_block, SIL_FUNCTION);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -638,7 +638,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(index_block, TOP_LEVEL_DECLS);
   BLOCK_RECORD(index_block, OPERATORS);
   BLOCK_RECORD(index_block, EXTENSIONS);
-  BLOCK_RECORD(index_block, CLASS_MEMBERS);
+  BLOCK_RECORD(index_block, CLASS_MEMBERS_FOR_DYNAMIC_LOOKUP);
   BLOCK_RECORD(index_block, OPERATOR_METHODS);
   BLOCK_RECORD(index_block, OBJC_METHODS);
   BLOCK_RECORD(index_block, ENTRY_POINT);
@@ -1624,7 +1624,7 @@ void Serializer::writeMembers(DeclRange members, bool isClass) {
     if (isClass) {
       if (auto VD = dyn_cast<ValueDecl>(member)) {
         if (VD->canBeAccessedByDynamicLookup()) {
-          auto &list = ClassMembersByName[VD->getBaseName()];
+          auto &list = ClassMembersForDynamicLookup[VD->getBaseName()];
           list.push_back({getKindForTable(VD), memberID});
         }
       }
@@ -4596,7 +4596,8 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
     writeDeclTable(DeclList, index_block::TOP_LEVEL_DECLS, topLevelDecls);
     writeDeclTable(DeclList, index_block::OPERATORS, operatorDecls);
     writeDeclTable(DeclList, index_block::PRECEDENCE_GROUPS, precedenceGroupDecls);
-    writeDeclTable(DeclList, index_block::CLASS_MEMBERS, ClassMembersByName);
+    writeDeclTable(DeclList, index_block::CLASS_MEMBERS_FOR_DYNAMIC_LOOKUP,
+                   ClassMembersForDynamicLookup);
     writeDeclTable(DeclList, index_block::OPERATOR_METHODS, operatorMethodDecls);
     if (hasLocalTypes)
       writeLocalDeclTable(DeclList, index_block::LOCAL_TYPE_DECLS,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -327,7 +327,7 @@ namespace {
       if (key.getKind() == DeclBaseName::Kind::Normal) {
         keyLength += key.getIdentifier().str().size(); // The name's length
       }
-      uint32_t dataLength = sizeof(data_type);
+      uint32_t dataLength = sizeof(uint32_t);
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
       // No need to write dataLength, it's constant.
@@ -354,7 +354,7 @@ namespace {
                   unsigned len) {
       static_assert(bitOffsetFitsIn32Bits(), "BitOffset too large");
       endian::Writer<little> writer(out);
-      writer.write<data_type>(static_cast<uint32_t>(data));
+      writer.write<uint32_t>(static_cast<uint32_t>(data));
     }
   };
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -72,6 +72,19 @@ static constexpr bool declIDFitsIn32Bits() {
   return PtrIntInfo::digits - DeclIDTraits::NumLowBitsAvailable <= Int32Info::digits;
 }
 
+/// Used for static_assert.
+static constexpr bool bitOffsetFitsIn32Bits() {
+  // FIXME: Considering BitOffset is a _bit_ offset, and we're storing it in 31
+  // bits of a PointerEmbeddedInt, the maximum offset inside a modulefile we can
+  // handle happens at 2**28 _bytes_, which is only 268MB. Considering
+  // Swift.swiftmodule is itself 25MB, it seems entirely possible users will
+  // exceed this limit.
+  using Int32Info = std::numeric_limits<uint32_t>;
+  using PtrIntInfo = std::numeric_limits<uintptr_t>;
+  using BitOffsetTraits = llvm::PointerLikeTypeTraits<BitOffset>;
+  return PtrIntInfo::digits - BitOffsetTraits::NumLowBitsAvailable <= Int32Info::digits;
+}
+
 namespace {
   /// Used to serialize the on-disk decl hash table.
   class DeclTableInfo {
@@ -282,6 +295,109 @@ namespace {
       for (auto entry : data) {
         writer.write<uint32_t>(entry.first);
         writer.write<uint32_t>(entry.second);
+      }
+    }
+  };
+
+  class DeclMemberNamesTableInfo {
+  public:
+    using key_type = DeclBaseName;
+    using key_type_ref = const key_type &;
+    using data_type = BitOffset; // Offsets to sub-tables
+    using data_type_ref = const data_type &;
+    using hash_value_type = uint32_t;
+    using offset_type = unsigned;
+
+    hash_value_type ComputeHash(key_type_ref key) {
+      switch (key.getKind()) {
+      case DeclBaseName::Kind::Normal:
+        assert(!key.empty());
+        return llvm::HashString(key.getIdentifier().str());
+      case DeclBaseName::Kind::Subscript:
+        return static_cast<uint8_t>(DeclNameKind::Subscript);
+      case DeclBaseName::Kind::Destructor:
+        return static_cast<uint8_t>(DeclNameKind::Destructor);
+      }
+    }
+
+    std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
+                                                    key_type_ref key,
+                                                    data_type_ref data) {
+      uint32_t keyLength = sizeof(uint8_t); // For the flag of the name's kind
+      if (key.getKind() == DeclBaseName::Kind::Normal) {
+        keyLength += key.getIdentifier().str().size(); // The name's length
+      }
+      uint32_t dataLength = sizeof(data_type);
+      endian::Writer<little> writer(out);
+      writer.write<uint16_t>(keyLength);
+      writer.write<uint16_t>(dataLength);
+      return { keyLength, dataLength };
+    }
+
+    void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
+      endian::Writer<little> writer(out);
+      switch (key.getKind()) {
+      case DeclBaseName::Kind::Normal:
+        writer.write<uint8_t>(static_cast<uint8_t>(DeclNameKind::Normal));
+        writer.OS << key.getIdentifier().str();
+        break;
+      case DeclBaseName::Kind::Subscript:
+        writer.write<uint8_t>(static_cast<uint8_t>(DeclNameKind::Subscript));
+        break;
+      case DeclBaseName::Kind::Destructor:
+        writer.write<uint8_t>(static_cast<uint8_t>(DeclNameKind::Destructor));
+        break;
+      }
+    }
+
+    void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
+                  unsigned len) {
+      static_assert(bitOffsetFitsIn32Bits(), "BitOffset too large");
+      endian::Writer<little> writer(out);
+      writer.write<data_type>(static_cast<uint32_t>(data));
+    }
+  };
+
+  class DeclMembersTableInfo {
+  public:
+    using key_type = DeclID;
+    using key_type_ref = const key_type &;
+    using data_type = Serializer::DeclMembersData; // Vector of DeclIDs
+    using data_type_ref = const data_type &;
+    using hash_value_type = uint32_t;
+    using offset_type = unsigned;
+
+    hash_value_type ComputeHash(key_type_ref key) {
+      return llvm::hash_value(static_cast<uint32_t>(key));
+    }
+
+    std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
+                                                    key_type_ref key,
+                                                    data_type_ref data) {
+      // This will trap if a single ValueDecl has more than 16383 members
+      // with the same DeclBaseName. Seems highly unlikely.
+      assert((data.size() < (1 << 14)) && "Too many members");
+      uint32_t keyLength = sizeof(uint32_t); // key DeclID
+      uint32_t dataLength = sizeof(uint32_t) * data.size(); // value DeclIDs
+      endian::Writer<little> writer(out);
+      writer.write<uint16_t>(keyLength);
+      writer.write<uint16_t>(dataLength);
+      return { keyLength, dataLength };
+    }
+
+    void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
+      static_assert(declIDFitsIn32Bits(), "DeclID too large");
+      assert(len == sizeof(uint32_t));
+      endian::Writer<little> writer(out);
+      writer.write<uint32_t>(key);
+    }
+
+    void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
+                  unsigned len) {
+      static_assert(declIDFitsIn32Bits(), "DeclID too large");
+      endian::Writer<little> writer(out);
+      for (auto entry : data) {
+        writer.write<uint32_t>(entry);
       }
     }
   };
@@ -1613,7 +1729,8 @@ static bool shouldSerializeMember(Decl *D) {
   llvm_unreachable("Unhandled DeclKind in switch.");
 }
 
-void Serializer::writeMembers(DeclRange members, bool isClass) {
+void Serializer::writeMembers(DeclID parentID,
+                              DeclRange members, bool isClass) {
   using namespace decls_block;
 
   unsigned abbrCode = DeclTypeAbbrCodes[MembersLayout::Code];
@@ -1625,8 +1742,18 @@ void Serializer::writeMembers(DeclRange members, bool isClass) {
     DeclID memberID = addDeclRef(member);
     memberIDs.push_back(memberID);
 
-    if (isClass) {
-      if (auto VD = dyn_cast<ValueDecl>(member)) {
+    if (auto VD = dyn_cast<ValueDecl>(member)) {
+
+      // Record parent->members in subtable of DeclMemberNames.
+      std::unique_ptr<DeclMembersTable> &memberTable =
+        DeclMemberNames[VD->getBaseName()].second;
+      if (!memberTable) {
+        memberTable = llvm::make_unique<DeclMembersTable>();
+      }
+      (*memberTable)[parentID].push_back(memberID);
+
+      // Possibly add a record to ClassMembersForDynamicLookup too.
+      if (isClass) {
         if (VD->canBeAccessedByDynamicLookup()) {
           auto &list = ClassMembersForDynamicLookup[VD->getBaseName()];
           list.push_back({getKindForTable(VD), memberID});
@@ -2562,7 +2689,7 @@ void Serializer::writeDecl(const Decl *D) {
     for (auto *genericParams : allGenericParams)
       writeGenericParams(genericParams);
 
-    writeMembers(extension->getMembers(), isClassExtension);
+    writeMembers(id, extension->getMembers(), isClassExtension);
     writeConformances(conformances, DeclTypeAbbrCodes);
     break;
   }
@@ -2770,7 +2897,7 @@ void Serializer::writeDecl(const Decl *D) {
 
 
     writeGenericParams(theStruct->getGenericParams());
-    writeMembers(theStruct->getMembers(), false);
+    writeMembers(id, theStruct->getMembers(), false);
     writeConformances(conformances, DeclTypeAbbrCodes);
     break;
   }
@@ -2817,7 +2944,7 @@ void Serializer::writeDecl(const Decl *D) {
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theEnum->getGenericParams());
-    writeMembers(theEnum->getMembers(), false);
+    writeMembers(id, theEnum->getMembers(), false);
     writeConformances(conformances, DeclTypeAbbrCodes);
     break;
   }
@@ -2855,7 +2982,7 @@ void Serializer::writeDecl(const Decl *D) {
                             inheritedTypes);
 
     writeGenericParams(theClass->getGenericParams());
-    writeMembers(theClass->getMembers(), true);
+    writeMembers(id, theClass->getMembers(), true);
     writeConformances(conformances, DeclTypeAbbrCodes);
     break;
   }
@@ -2889,7 +3016,7 @@ void Serializer::writeDecl(const Decl *D) {
     writeGenericParams(proto->getGenericParams());
     writeGenericRequirements(
       proto->getRequirementSignature(), DeclTypeAbbrCodes);
-    writeMembers(proto->getMembers(), true);
+    writeMembers(id, proto->getMembers(), true);
     writeDefaultWitnessTable(proto, DeclTypeAbbrCodes);
     break;
   }
@@ -3954,6 +4081,51 @@ writeNestedTypeDeclsTable(const index_block::NestedTypeDeclsLayout &declList,
   declList.emit(scratch, tableOffset, hashTableBlob);
 }
 
+static void
+writeDeclMemberNamesTable(const index_block::DeclMemberNamesLayout &declNames,
+                          const Serializer::DeclMemberNamesTable &table) {
+  SmallVector<uint64_t, 8> scratch;
+  llvm::SmallString<4096> hashTableBlob;
+  uint32_t tableOffset;
+  {
+    llvm::OnDiskChainedHashTableGenerator<DeclMemberNamesTableInfo> generator;
+    // Emit the offsets of the sub-tables; the tables themselves have been
+    // separately emitted into DECL_MEMBER_TABLES_BLOCK by now.
+    for (auto &entry : table) {
+      // Or they _should_ have been; check for nonzero offsets.
+      assert(static_cast<unsigned>(entry.second.first) != 0);
+      generator.insert(entry.first, entry.second.first);
+    }
+
+    llvm::raw_svector_ostream blobStream(hashTableBlob);
+    // Make sure that no bucket is at offset 0
+    endian::Writer<little>(blobStream).write<uint32_t>(0);
+    tableOffset = generator.Emit(blobStream);
+  }
+
+  declNames.emit(scratch, tableOffset, hashTableBlob);
+}
+
+static void
+writeDeclMembersTable(const decl_member_tables_block::DeclMembersLayout &mems,
+                      const Serializer::DeclMembersTable &table) {
+  SmallVector<uint64_t, 8> scratch;
+  llvm::SmallString<4096> hashTableBlob;
+  uint32_t tableOffset;
+  {
+    llvm::OnDiskChainedHashTableGenerator<DeclMembersTableInfo> generator;
+    for (auto &entry : table)
+      generator.insert(entry.first, entry.second);
+
+    llvm::raw_svector_ostream blobStream(hashTableBlob);
+    // Make sure that no bucket is at offset 0
+    endian::Writer<little>(blobStream).write<uint32_t>(0);
+    tableOffset = generator.Emit(blobStream);
+  }
+
+  mems.emit(scratch, tableOffset, hashTableBlob);
+}
+
 namespace {
 
 struct DeclCommentTableData {
@@ -4491,7 +4663,8 @@ static void collectInterestingNestedDeclarations(
 }
 
 void Serializer::writeAST(ModuleOrSourceFile DC,
-                          bool enableNestedTypeLookupTable) {
+                          bool enableNestedTypeLookupTable,
+                          bool enableDeclMemberNamesTable) {
   DeclTable topLevelDecls, operatorDecls, operatorMethodDecls;
   DeclTable precedenceGroupDecls;
   ObjCMethodTable objcMethods;
@@ -4625,6 +4798,25 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
       index_block::EntryPointLayout EntryPoint(Out);
       EntryPoint.emit(ScratchRecord, entryPointClassID.getValue());
     }
+
+    if (enableDeclMemberNamesTable) {
+      {
+        // Write sub-tables to a skippable sub-block.
+        BCBlockRAII restoreBlock(Out, DECL_MEMBER_TABLES_BLOCK_ID, 4);
+        decl_member_tables_block::DeclMembersLayout DeclMembersTable(Out);
+        for (auto &entry : DeclMemberNames) {
+          // Save BitOffset we're writing sub-table to.
+          static_assert(bitOffsetFitsIn32Bits(), "BitOffset too large");
+          assert(Out.GetCurrentBitNo() < (1ull << 32));
+          entry.second.first = Out.GetCurrentBitNo();
+          // Write sub-table.
+          writeDeclMembersTable(DeclMembersTable, *entry.second.second);
+        }
+      }
+      // Write top-level table mapping names to sub-tables.
+      index_block::DeclMemberNamesLayout DeclMemberNamesTable(Out);
+      writeDeclMemberNamesTable(DeclMemberNamesTable, DeclMemberNames);
+    }
   }
 }
 
@@ -4657,7 +4849,8 @@ void Serializer::writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
     S.writeHeader(options);
     S.writeInputBlock(options);
     S.writeSIL(SILMod, options.SerializeAllSIL);
-    S.writeAST(DC, options.EnableNestedTypeLookupTable);
+    S.writeAST(DC, options.EnableNestedTypeLookupTable,
+               options.EnableDeclMemberNamesTable);
   }
 
   S.writeToStream(os);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1744,13 +1744,16 @@ void Serializer::writeMembers(DeclID parentID,
 
     if (auto VD = dyn_cast<ValueDecl>(member)) {
 
-      // Record parent->members in subtable of DeclMemberNames.
-      std::unique_ptr<DeclMembersTable> &memberTable =
-        DeclMemberNames[VD->getBaseName()].second;
-      if (!memberTable) {
-        memberTable = llvm::make_unique<DeclMembersTable>();
+      // Record parent->members in subtable of DeclMemberNames
+      if (VD->hasName() &&
+          !VD->getBaseName().empty()) {
+        std::unique_ptr<DeclMembersTable> &memberTable =
+          DeclMemberNames[VD->getBaseName()].second;
+        if (!memberTable) {
+          memberTable = llvm::make_unique<DeclMembersTable>();
+        }
+        (*memberTable)[parentID].push_back(memberID);
       }
-      (*memberTable)[parentID].push_back(memberID);
 
       // Possibly add a record to ClassMembersForDynamicLookup too.
       if (isClass) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -330,7 +330,7 @@ namespace {
       uint32_t dataLength = sizeof(data_type);
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
-      writer.write<uint16_t>(dataLength);
+      // No need to write dataLength, it's constant.
       return { keyLength, dataLength };
     }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -137,7 +137,7 @@ private:
   /// A map from identifiers to methods and properties with the given name.
   ///
   /// This is used for id-style lookup.
-  DeclTable ClassMembersByName;
+  DeclTable ClassMembersForDynamicLookup;
 
   /// The queue of types and decls that need to be serialized.
   ///

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -132,7 +132,7 @@ public:
   using DeclMembersData = SmallVector<DeclID, 2>;
   // In-memory representation of what will eventually be an on-disk
   // hash table of all ValueDecl-members of a paticular DeclBaseName.
-  using DeclMembersTable = llvm::MapVector<DeclID, DeclMembersData>;
+  using DeclMembersTable = llvm::MapVector<uint32_t, DeclMembersData>;
 
   using DeclMemberNamesData = std::pair<serialization::BitOffset,
                                         std::unique_ptr<DeclMembersTable>>;

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -129,6 +129,17 @@ public:
   // hash table of all defined Objective-C methods.
   using NestedTypeDeclsTable = llvm::MapVector<Identifier, NestedTypeDeclsData>;
 
+  using DeclMembersData = SmallVector<DeclID, 2>;
+  // In-memory representation of what will eventually be an on-disk
+  // hash table of all ValueDecl-members of a paticular DeclBaseName.
+  using DeclMembersTable = llvm::MapVector<DeclID, DeclMembersData>;
+
+  using DeclMemberNamesData = std::pair<serialization::BitOffset,
+                                        std::unique_ptr<DeclMembersTable>>;
+  // In-memory representation of what will eventually be an on-disk
+  // hash table mapping DeclBaseNames to DeclMembersData tables.
+  using DeclMemberNamesTable = llvm::MapVector<DeclBaseName, DeclMemberNamesData>;
+
   using ExtensionTableData =
       SmallVector<std::pair<const NominalTypeDecl *, DeclID>, 4>;
   using ExtensionTable = llvm::MapVector<Identifier, ExtensionTableData>;
@@ -138,6 +149,11 @@ private:
   ///
   /// This is used for id-style lookup.
   DeclTable ClassMembersForDynamicLookup;
+
+  /// A map from DeclBaseNames of members to Decl->members sub-tables.
+  ///
+  /// This is for Named Lazy Member Loading.
+  DeclMemberNamesTable DeclMemberNames;
 
   /// The queue of types and decls that need to be serialized.
   ///
@@ -289,10 +305,11 @@ private:
 
   /// Writes an array of members for a decl context.
   ///
-  /// \param members The decls within the context
+  /// \param parentID The DeclID of the context.
+  /// \param members The decls within the context.
   /// \param isClass True if the context could be a class context (class,
   ///        class extension, or protocol).
-  void writeMembers(DeclRange members, bool isClass);
+  void writeMembers(DeclID parentID, DeclRange members, bool isClass);
 
   /// Write a default witness table for a protocol.
   ///
@@ -369,7 +386,9 @@ private:
   void writeSIL(const SILModule *M, bool serializeAllSIL);
 
   /// Top-level entry point for serializing a module.
-  void writeAST(ModuleOrSourceFile DC, bool enableNestedTypeLookupTable);
+  void writeAST(ModuleOrSourceFile DC,
+                bool enableNestedTypeLookupTable,
+                bool enableDeclMemberNamesTable);
 
   void writeToStream(raw_ostream &os);
 

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
@@ -30,5 +30,23 @@
 + (SimpleDoer*)Doer;
 + (SimpleDoer*)DoerOfNoWork;
 
+- (void)simplyDoSomeWork;
+- (void)simplyDoSomeWorkWithSpeed:(int)s;
+- (void)simplyDoSomeWorkWithSpeed:(int)s thoroughness:(int)t
+  NS_SWIFT_NAME(simplyDoVeryImportantWork(speed:thoroughness:));
+- (void)simplyDoSomeWorkWithSpeed:(int)s alacrity:(int)a
+  NS_SWIFT_NAME(simplyDoSomeWorkWithSpeed(speed:levelOfAlacrity:));
+
+// These we are generally trying to not-import, via laziness.
+- (void)simplyGoForWalk;
+- (void)simplyTakeNap;
+- (void)simplyEatMeal;
+- (void)simplyTidyHome;
+- (void)simplyCallFamily;
+- (void)simplySingSong;
+- (void)simplyReadBook;
+- (void)simplyAttendLecture;
+- (void)simplyWriteLetter;
+
 @end
 

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.swift
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.swift
@@ -1,8 +1,84 @@
-public class FooClass {
-  public func member1() -> Int { return 1; }
-  public func member2() -> Int { return 1; }
-  public func member3() -> Int { return 1; }
-  public func member4() -> Int { return 1; }
-  public func member5() -> Int { return 1; }
-  public func member6() -> Int { return 1; }
+public class BaseClass {
+  public func memberFunc1() -> Int { return 1; }
+  public func memberFunc2() -> Int { return 1; }
+  public func memberFunc3() -> Int { return 1; }
+  public func memberFunc4() -> Int { return 1; }
+  public func memberFunc5() -> Int { return 1; }
+  public typealias memberType1 = Int
+  public typealias memberType2 = Int
+  public typealias memberType3 = Int
+  public typealias memberType4 = Int
+  public typealias memberType5 = Int
 }
+
+public class DerivedClass : BaseClass {
+  public func derivedMemberFunc1() -> Int { return 1; }
+  public func derivedMemberFunc2() -> Int { return 1; }
+  public func derivedMemberFunc3() -> Int { return 1; }
+  public func derivedMemberFunc4() -> Int { return 1; }
+  public func derivedMemberFunc5() -> Int { return 1; }
+  public typealias derivedMemberType1 = Int
+  public typealias derivedMemberType2 = Int
+  public typealias derivedMemberType3 = Int
+  public typealias derivedMemberType4 = Int
+  public typealias derivedMemberType5 = Int
+}
+
+public class OverrideDerivedClass : BaseClass {
+  override public func memberFunc1() -> Int { return 1; }
+  override public func memberFunc2() -> Int { return 1; }
+  override public func memberFunc3() -> Int { return 1; }
+  override public func memberFunc4() -> Int { return 1; }
+  override public func memberFunc5() -> Int { return 1; }
+}
+
+public struct BaseStruct {
+  public func memberFunc1() -> Int { return 1; }
+  public func memberFunc2() -> Int { return 1; }
+  public func memberFunc3() -> Int { return 1; }
+  public func memberFunc4() -> Int { return 1; }
+  public func memberFunc5() -> Int { return 1; }
+}
+
+public enum BaseEnum {
+  case member1
+  case member2
+  case member3
+  case member4
+  case member5
+}
+
+public protocol BaseProto {
+  func protoMemberFunc1() -> Int
+  func protoMemberFunc2() -> Int
+  func protoMemberFunc3() -> Int
+  func protoMemberFunc4() -> Int
+  func protoMemberFunc5() -> Int
+}
+
+public struct BaseExt {
+  public func memberFunc1() -> Int { return 1; }
+  public func memberFunc2() -> Int { return 1; }
+  public func memberFunc3() -> Int { return 1; }
+  public func memberFunc4() -> Int { return 1; }
+  public func memberFunc5() -> Int { return 1; }
+  public typealias memberType1 = Int
+  public typealias memberType2 = Int
+  public typealias memberType3 = Int
+  public typealias memberType4 = Int
+  public typealias memberType5 = Int
+}
+
+extension BaseExt {
+  public func extMemberFunc1() -> Int { return 1; }
+  public func extMemberFunc2() -> Int { return 1; }
+  public func extMemberFunc3() -> Int { return 1; }
+  public func extMemberFunc4() -> Int { return 1; }
+  public func extMemberFunc5() -> Int { return 1; }
+  public typealias extMemberType1 = Int
+  public typealias extMemberType2 = Int
+  public typealias extMemberType3 = Int
+  public typealias extMemberType4 = Int
+  public typealias extMemberType5 = Int
+}
+

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.swift
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.swift
@@ -1,0 +1,8 @@
+public class FooClass {
+  public func member1() -> Int { return 1; }
+  public func member2() -> Int { return 1; }
+  public func member3() -> Int { return 1; }
+  public func member4() -> Int { return 1; }
+  public func member5() -> Int { return 1; }
+  public func member6() -> Int { return 1; }
+}

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -6,21 +6,18 @@
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s
 //
 // Check that without lazy named member loading, we're importing too much.
-// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck -stats-output-dir %t/stats-pre %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 35' %t/stats-pre
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-pre %s
+// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 20' %t/stats-pre
 //
 // Check that with lazy named member loading, we're importing less.
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 20' %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 10' %t/stats-post
 
 import NamedLazyMembers
 
-public func foo(d: Doer) {
-  d.doSomeWork()
-  d.doSomeWork(withSpeed:10)
-  d.doVeryImportantWork(speed:10, thoroughness:12)
-  d.doSomeWorkWithSpeed(speed:10, levelOfAlacrity:12)
-
-  let _ = SimpleDoer()
-  let _ = SimpleDoer.ofNoWork()
+public func foo(d: SimpleDoer) {
+  let _ = d.simplyDoSomeWork()
+  let _ = d.simplyDoSomeWork(withSpeed:10)
+  let _ = d.simplyDoVeryImportantWork(speed:10, thoroughness:12)
+  let _ = d.simplyDoSomeWorkWithSpeed(speed:10, levelOfAlacrity:12)
 }

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -5,13 +5,10 @@
 // Prime module cache
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s
 //
-// Check that without lazy named member loading, we're importing too much.
+// Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-pre %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 20' %t/stats-pre
-//
-// Check that with lazy named member loading, we're importing less.
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 10' %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
@@ -5,13 +5,10 @@
 // Prime module cache
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s
 //
-// Check that without lazy named member loading, we're importing too much.
-// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck -stats-output-dir %t/stats-pre %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities > 35' %t/stats-pre
-//
-// Check that with lazy named member loading, we're importing less.
+// Check that named-lazy-member-loading reduces the number of Decls deserialized
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumTotalClangImportedEntities < 20' %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class.swift
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+//
+// Compile swiftmodule with decl member name tables
+// RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule -enable-named-lazy-member-loading %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift
+//
+// Check that without lazy named member loading, we're importing too much.
+// RUN: %target-swift-frontend -typecheck -I %t -typecheck -stats-output-dir %t/stats-pre %s
+// RUN: %utils/process-stats-dir.py --evaluate 'NumDeclsDeserialized > 140' %t/stats-pre
+//
+// Check that with lazy named member loading, we're importing less.
+// RUN: %target-swift-frontend -typecheck -I %t -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
+// RUN: %utils/process-stats-dir.py --evaluate 'NumDeclsDeserialized < 125' %t/stats-post
+
+import NamedLazyMembers
+
+public func foo(f: FooClass) {
+  let _ = f.member1()
+}

--- a/test/NameBinding/named_lazy_member_loading_swift_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class.swift
@@ -3,13 +3,10 @@
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule -enable-named-lazy-member-loading %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift
 //
-// Check that without lazy named member loading, we're importing too much.
+// Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -typecheck -stats-output-dir %t/stats-pre %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumDeclsDeserialized > 140' %t/stats-pre
-//
-// Check that with lazy named member loading, we're importing less.
 // RUN: %target-swift-frontend -typecheck -I %t -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate 'NumDeclsDeserialized < 125' %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class_type.swift
@@ -10,6 +10,6 @@
 
 import NamedLazyMembers
 
-public func test(b: BaseClass) {
-  let _ = b.memberFunc1()
+public func test(b: BaseClass.memberType1) -> BaseClass.memberType1 {
+  return b
 }

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class.swift
@@ -10,6 +10,6 @@
 
 import NamedLazyMembers
 
-public func test(b: BaseClass) {
-  let _ = b.memberFunc1()
+public func test(d: DerivedClass) {
+  let _ = d.derivedMemberFunc1()
 }

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
@@ -10,6 +10,6 @@
 
 import NamedLazyMembers
 
-public func test(b: BaseClass) {
-  let _ = b.memberFunc1()
+public func test(i: DerivedClass.derivedMemberType1) -> DerivedClass.derivedMemberType1 {
+  return i
 }

--- a/test/NameBinding/named_lazy_member_loading_swift_enum.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_enum.swift
@@ -10,6 +10,6 @@
 
 import NamedLazyMembers
 
-public func test(b: BaseClass) {
-  let _ = b.memberFunc1()
+public func test(b: BaseEnum) -> Bool {
+  return b == .member1
 }

--- a/test/NameBinding/named_lazy_member_loading_swift_enum.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_enum.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_struct.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct.swift
@@ -10,6 +10,6 @@
 
 import NamedLazyMembers
 
-public func test(b: BaseClass) {
+public func test(b: BaseStruct) {
   let _ = b.memberFunc1()
 }

--- a/test/NameBinding/named_lazy_member_loading_swift_struct.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
+// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_struct_ext.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct_ext.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+//
+// Compile swiftmodule with decl member name tables
+// RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule -enable-named-lazy-member-loading %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift
+//
+// Check that named-lazy-member-loading reduces the number of Decls deserialized
+// RUN: %target-swift-frontend -typecheck -I %t -typecheck -stats-output-dir %t/stats-pre %s
+// RUN: %target-swift-frontend -typecheck -I %t -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
+// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
+
+import NamedLazyMembers
+
+public func test(b: BaseExt) {
+  let _ = b.memberFunc1()
+}

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -434,6 +434,37 @@ def evaluate(args):
         print(e)
         return 1
 
+# Evaluate a boolean expression in terms of deltas between the provided two
+# stats-dirs; works like evaluate() above but on absolute differences
+def evaluate_delta(args):
+    if len(args.remainder) != 2:
+        raise ValueError("Expected exactly 2 stats-dirs to evaluate-delta")
+
+    (old, new) = args.remainder
+    vargs = vars_of_args(args)
+    old_stats = merge_all_jobstats(load_stats_dir(old, **vargs), **vargs)
+    new_stats = merge_all_jobstats(load_stats_dir(new, **vargs), **vargs)
+
+    env = {}
+    ident = re.compile('(\w+)$')
+    for r in compare_stats(args, old_stats.stats, new_stats.stats):
+        if r.name.startswith("time.") or '.time.' in r.name:
+            continue
+        m = re.search(ident, r.name)
+        if m:
+            i = m.groups()[0]
+            if args.verbose:
+                print("%s => %s" % (i, r.delta))
+            env[i] = r.delta
+    try:
+        if eval(args.evaluate_delta, env):
+            return 0
+        else:
+            print("evaluate-delta condition failed: '%s'" % args.evaluate_delta)
+            return 1
+    except Exception as e:
+        print(e)
+        return 1
 
 def main():
     parser = argparse.ArgumentParser()
@@ -528,6 +559,8 @@ def main():
                        help="Emit an LNT-compatible test summary")
     modes.add_argument("--evaluate", type=str, default=None,
                        help="evaluate an expression of stat-names")
+    modes.add_argument("--evaluate-delta", type=str, default=None,
+                       help="evaluate an expression of stat-deltas")
     parser.add_argument('remainder', nargs=argparse.REMAINDER,
                         help="stats-dirs to process")
 
@@ -552,6 +585,8 @@ def main():
         write_lnt_values(args)
     elif args.evaluate:
         return evaluate(args)
+    elif args.evaluate_delta:
+        return evaluate_delta(args)
     return None
 
 

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -434,6 +434,7 @@ def evaluate(args):
         print(e)
         return 1
 
+
 # Evaluate a boolean expression in terms of deltas between the provided two
 # stats-dirs; works like evaluate() above but on absolute differences
 def evaluate_delta(args):
@@ -460,11 +461,13 @@ def evaluate_delta(args):
         if eval(args.evaluate_delta, env):
             return 0
         else:
-            print("evaluate-delta condition failed: '%s'" % args.evaluate_delta)
+            print("evaluate-delta condition failed: '%s'" %
+                  args.evaluate_delta)
             return 1
     except Exception as e:
         print(e)
         return 1
+
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Picking up where #12647 left off: implementing named lazy member loading from swiftmodule files.

This is now working to the point of passing its first test -- writing a class into a swiftmodule and doing named lazy member loading on it, and checking that we're deserializing strictly fewer decls than before -- though it's still likely wrong in a bunch of places, and there are some peculiarities around datatypes I'd like to discuss. I'll test more through the week, but I think this approach seems viable-ish?