### PR TITLE
[pred-memopts] Eliminate all dead references to AssignInst.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -324,7 +324,7 @@ updateAvailableValues(SILInstruction *Inst, llvm::SmallBitVector &RequiredElts,
                       SmallVectorImpl<std::pair<SILValue, unsigned>> &Result,
                       llvm::SmallBitVector &ConflictingValues) {
   // Handle store and assign.
-  if (isa<StoreInst>(Inst) || isa<AssignInst>(Inst)) {
+  if (isa<StoreInst>(Inst)) {
     unsigned StartSubElt = computeSubelement(Inst->getOperand(1), TheMemory);
     assert(StartSubElt != ~0U && "Store within enum projection not handled");
     SILType ValTy = Inst->getOperand(0)->getType();

--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -327,7 +327,7 @@ bb0:
   %9 = apply %f() : $@convention(thin) () -> @owned SomeClass
   // CHECK: [[CVAL:%[0-9]+]] = apply
 
-  assign %9 to %3 : $*SomeClass
+  store %9 to %3 : $*SomeClass
   destroy_addr %3 : $*SomeClass
   dealloc_stack %3 : $*SomeClass
   %15 = tuple ()


### PR DESCRIPTION
AssignInst is eliminated by DI so we should /never/ see any AssignInst once DI
runs. So this code is dead.

Just shaved off of a larger commit to make it easier to review the larger
commit.

rdar://31521023