### PR TITLE
Change many uses of OSX to macOS (mostly in @available messages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1477,14 +1477,14 @@ Swift 2.0
   For example:
 
   ```swift
-  @available(iOS 8.0, OSX 10.10, *)
+  @available(iOS 8.0, macOS 10.10, *)
   func startUserActivity() -> NSUserActivity {
     ...
   }
   ```
 
   This code fragment indicates that the `startUserActivity()` method is
-  available on iOS 8.0+, on OS X v10.10+, and on all versions of any other
+  available on iOS 8.0+, on macOS v10.10+, and on all versions of any other
   platform. **(20938565)**
 
 * A new `@nonobjc` attribute is introduced to selectively suppress ObjC export
@@ -1529,7 +1529,7 @@ Swift 2.0
   the new `#available()` condition in an if or guard statement. For example:
 
   ```swift
-  if #available(iOS 8.0, OSX 10.10, *) {
+  if #available(iOS 8.0, macOS 10.10, *) {
     // Use Handoff APIs when available.
     let activity =
       NSUserActivity(activityType:"com.example.ShoppingList.view")
@@ -2962,7 +2962,7 @@ Swift 1.1
   unintentionally allowed in previous versions, now cause a
   compilation error.
 
-* OS X apps can now apply the `@NSApplicationMain` attribute to their app delegate
+* macOS apps can now apply the `@NSApplicationMain` attribute to their app delegate
   class in order to generate an implicit `main` for the app. This works like
   the `@UIApplicationMain` attribute for iOS apps.
 
@@ -3801,7 +3801,7 @@ Swift 1.0
 * Swift now supports a `#elseif` form for build configurations, e.g.:
 
     ```swift
-    #if os(OSX)
+    #if os(macOS)
       typealias SKColor = NSColor
     #elseif os(iOS)
       typealias SKColor = UIColor
@@ -4683,7 +4683,7 @@ Swift 1.0
   The argument represents certain static build-time information.
 
   There are currently two supported target configurations:
-    `os`, which can have the values `OSX` or `iOS`
+    `os`, which can have the values `macOS` or `iOS`
     `arch`, which can have the values `i386`, `x86_64`, `arm` and `arm64`
 
   Within the context of an `#if` block's conditional expression, a target
@@ -4699,13 +4699,13 @@ Swift 1.0
     #endif
 
     class C {
-    #if os(OSX)
+    #if os(macOS)
       func foo() {
-        // OSX stuff goes here
+        // macOS stuff goes here
       }
     #else
       func foo() {
-        // non-OSX stuff goes here
+        // non-macOS stuff goes here
       }
     #endif
     }

--- a/docs/ErrorHandling.rst
+++ b/docs/ErrorHandling.rst
@@ -726,7 +726,7 @@ more likely, we'd need to wrap them all in an overlay.
 
 In both cases, it is possible to pull these into the Swift error
 handling model, but because this is likely to require massive SDK
-annotations it is considered out of scope for iOS 9/OS X 10.11 & Swift 2.0.
+annotations it is considered out of scope for iOS 9/macOS 10.11 & Swift 2.0.
 
 Unexpected and universal errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/LibraryEvolution.rst
+++ b/docs/LibraryEvolution.rst
@@ -1433,9 +1433,9 @@ Related to the concept of a resilience domain is a *deployment.* While a
 resilience domain allows related libraries to be compiled more efficiently,
 a deployment groups related libraries together to present semantic version
 information to clients. The simplest example of this might be an OS release:
-OS X 10.10.0 contains Foundation version 1151.16 and AppKit version 1343. A
+macOS 10.10.0 contains Foundation version 1151.16 and AppKit version 1343. A
 deployment thus acts as a "virtual dependency": clients that depend on
-OS X 10.10 can rely on the presence of both of the library versions above.
+macOS 10.10 can rely on the presence of both of the library versions above.
 
 The use of deployments allows clients to only have to think about aggregate
 dependencies, instead of listing every library they might depend on. It also
@@ -1448,9 +1448,9 @@ __ https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundat
 There are lots of details to figure out here, including how to distribute this
 information. In particular, just like libraries publish the history of their
 own APIs, a deployment must publish the history of their included library
-versions, i.e. not just that OS X 10.10 contains Foundation 1151.16 and AppKit
-1343, but also that OS X 10.9 contains Foundation 1056 and AppKit 1265, and that
-OS X 10.8 contains Foundation 945.0 and AppKit 1187, and so on, back to the
+versions, i.e. not just that macOS 10.10 contains Foundation 1151.16 and AppKit
+1343, but also that macOS 10.9 contains Foundation 1056 and AppKit 1265, and that
+macOS 10.8 contains Foundation 945.0 and AppKit 1187, and so on, back to the
 earliest version of the deployment that is supported.
 
 

--- a/docs/Modules.rst
+++ b/docs/Modules.rst
@@ -115,7 +115,7 @@ to the declarations in the re-exported modules. ::
 
   @exported import AmericanCheckers
 
-As an example, the "Cocoa" `framework` on OS X exists only to re-export three
+As an example, the "Cocoa" `framework` on macOS exists only to re-export three
 other frameworks: AppKit, Foundation, and CoreData.
 
 Just as certain declarations can be selectively imported from a module, so too
@@ -418,7 +418,7 @@ Glossary
     __ http://clang.llvm.org/docs/Modules.html
 
   framework
-    A mechanism for library distribution on OS X. Traditionally contains header
+    A mechanism for library distribution on macOS. Traditionally contains header
     files describing the library's API, a binary file containing the
     implementation, and a directory containing any resources the library may
     need.

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -59,7 +59,7 @@ public:
 };
 
 /// \brief An availability specification that guards execution based on the
-/// run-time platform and version, e.g., OS X >= 10.10.
+/// run-time platform and version, e.g., macOS >= 10.10.
 class PlatformVersionConstraintAvailabilitySpec : public AvailabilitySpec {
   PlatformKind Platform;
   SourceLoc PlatformLoc;

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -33,7 +33,7 @@ enum class PlatformKind {
 };
 
 /// Returns the short string representing the platform, suitable for
-/// use in availability specifications (e.g., "OSX").
+/// use in availability specifications (e.g., "macOS").
 StringRef platformString(PlatformKind platform);
   
 /// Returns the platform kind corresponding to the passed-in short platform name
@@ -41,15 +41,15 @@ StringRef platformString(PlatformKind platform);
 Optional<PlatformKind> platformFromString(StringRef Name);
 
 /// Returns a human-readable version of the platform name as a string, suitable
-/// for emission in diagnostics (e.g., "OS X").
+/// for emission in diagnostics (e.g., "macOS").
 StringRef prettyPlatformString(PlatformKind platform);
 
 /// Returns whether the passed-in platform is active, given the language
 /// options. A platform is active if either it is the target platform or its
-/// AppExtension variant is the target platform. For example, OS X is
-/// considered active when the target operating system is OS X and app extension
-/// restrictions are enabled, but OSXApplicationExtension is not considered
-/// active when the target platform is OS X and app extension restrictions are
+/// AppExtension variant is the target platform. For example, macOS is
+/// considered active when the target operating system is macOS and app extension
+/// restrictions are enabled, but macOSApplicationExtension is not considered
+/// active when the target platform is macOS and app extension restrictions are
 /// disabled. PlatformKind::none is always considered active.
 bool isPlatformActive(PlatformKind Platform, LangOptions &LangOpts);
   

--- a/include/swift/AST/PlatformKinds.def
+++ b/include/swift/AST/PlatformKinds.def
@@ -25,10 +25,10 @@
 AVAILABILITY_PLATFORM(iOS, "iOS")
 AVAILABILITY_PLATFORM(tvOS, "tvOS")
 AVAILABILITY_PLATFORM(watchOS, "watchOS")
-AVAILABILITY_PLATFORM(OSX, "OS X")
+AVAILABILITY_PLATFORM(macOS, "macOS")
 AVAILABILITY_PLATFORM(iOSApplicationExtension, "iOS application extension")
 AVAILABILITY_PLATFORM(tvOSApplicationExtension, "tvOS application extension")
 AVAILABILITY_PLATFORM(watchOSApplicationExtension, "watchOS application extension")
-AVAILABILITY_PLATFORM(OSXApplicationExtension, "OS X application extension")
+AVAILABILITY_PLATFORM(macOSApplicationExtension, "macOS application extension")
 
 #undef AVAILABILITY_PLATFORM

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -229,7 +229,7 @@ public:
   
 /// \brief An expression that guards execution based on whether the run-time
 /// configuration supports a given API, e.g.,
-/// #available(OSX >= 10.9, iOS >= 7.0).
+/// #available(macOS >= 10.9, iOS >= 7.0).
 class alignas(8) PoundAvailableInfo final :
     private llvm::TrailingObjects<PoundAvailableInfo, AvailabilitySpec *> {
   friend TrailingObjects;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -36,7 +36,7 @@ namespace swift {
 
   /// Kind of implicit platform conditions.
   enum class PlatformConditionKind {
-    /// The active os target (OSX, iOS, Linux, etc.)
+    /// The active os target (macOS, iOS, Linux, etc.)
     OS,
     /// The active arch target (x86_64, i386, arm, arm64, etc.)
     Arch,

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -48,7 +48,7 @@ namespace swift {
   /// Returns the platform name for a given target triple.
   ///
   /// For example, the iOS simulator has the name "iphonesimulator", while real
-  /// iOS uses "iphoneos". OS X is "macosx". (These names are intended to be
+  /// iOS uses "iphoneos". macOS is "macosx". (These names are intended to be
   /// compatible with Xcode's SDKs.)
   ///
   /// If the triple does not correspond to a known platform, the empty string is

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -38,7 +38,7 @@ struct HeapObject;
 
 // Redeclare APIs from the Objective-C runtime.
 // These functions are not available through public headers, but are guaranteed
-// to exist on OS X >= 10.9 and iOS >= 7.0.
+// to exist on macOS >= 10.9 and iOS >= 7.0.
 
 OBJC_EXPORT id objc_retain(id);
 OBJC_EXPORT void objc_release(id);

--- a/include/swift/Runtime/Once.h
+++ b/include/swift/Runtime/Once.h
@@ -24,7 +24,7 @@ namespace swift {
 
 #ifdef __APPLE__
 
-// On OS X and iOS, swift_once_t matches dispatch_once_t.
+// On macOS and iOS, swift_once_t matches dispatch_once_t.
 typedef long swift_once_t;
 
 #elif defined(__CYGWIN__)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -221,10 +221,10 @@ static bool isShortAvailable(const DeclAttribute *DA) {
 /// Print the short-form @available() attribute for an array of long-form
 /// AvailableAttrs that can be represented in the short form.
 /// For example, for:
-///   @available(OSX, introduced: 10.10)
+///   @available(macOS, introduced: 10.10)
 ///   @available(iOS, introduced: 8.0)
 /// this will print:
-///   @available(OSX 10.10, iOS 8.0, *)
+///   @available(macOS 10.10, iOS 8.0, *)
 static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
                                     ASTPrinter &Printer,
                                     const PrintOptions &Options) {

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -51,8 +51,8 @@ Optional<PlatformKind> swift::platformFromString(StringRef Name) {
   return llvm::StringSwitch<Optional<PlatformKind>>(Name)
 #define AVAILABILITY_PLATFORM(X, PrettyName) .Case(#X, PlatformKind::X)
 #include "swift/AST/PlatformKinds.def"
-      .Case("macOS", PlatformKind::OSX)
-      .Case("macOSApplicationExtension", PlatformKind::OSXApplicationExtension)
+      .Case("OSX", PlatformKind::macOS)
+      .Case("OSXApplicationExtension", PlatformKind::macOSApplicationExtension)
       .Default(Optional<PlatformKind>());
 }
 
@@ -60,15 +60,15 @@ bool swift::isPlatformActive(PlatformKind Platform, LangOptions &LangOpts) {
   if (Platform == PlatformKind::none)
     return true;
   
-  if (Platform == PlatformKind::OSXApplicationExtension ||
+  if (Platform == PlatformKind::macOSApplicationExtension ||
       Platform == PlatformKind::iOSApplicationExtension)
     if (!LangOpts.EnableAppExtensionRestrictions)
       return false;
   
   // FIXME: This is an awful way to get the current OS.
   switch (Platform) {
-    case PlatformKind::OSX:
-    case PlatformKind::OSXApplicationExtension:
+    case PlatformKind::macOS:
+    case PlatformKind::macOSApplicationExtension:
       return LangOpts.Target.isMacOSX();
     case PlatformKind::iOS:
     case PlatformKind::iOSApplicationExtension:
@@ -88,8 +88,8 @@ bool swift::isPlatformActive(PlatformKind Platform, LangOptions &LangOpts) {
 PlatformKind swift::targetPlatform(LangOptions &LangOpts) {
   if (LangOpts.Target.isMacOSX()) {
     return (LangOpts.EnableAppExtensionRestrictions
-                ? PlatformKind::OSXApplicationExtension
-                : PlatformKind::OSX);
+                ? PlatformKind::macOSApplicationExtension
+                : PlatformKind::macOS);
   }
 
   if (LangOpts.Target.isTvOS()) {

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -119,9 +119,9 @@ LangOptions::getPlatformConditionValue(PlatformConditionKind Kind) const {
 
 bool LangOptions::
 checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
-  // Check a special case that "macOS" is an alias of "OSX".
-  if (Kind == PlatformConditionKind::OS && Value == "macOS")
-    return checkPlatformCondition(Kind, "OSX");
+  // Check a special case that "OSX" is an alias of "macOS".
+  if (Kind == PlatformConditionKind::OS && Value == "OSX")
+    return checkPlatformCondition(Kind, "macOS");
 
   for (auto &Opt : reversed(PlatformConditionValues)) {
     if (Opt.first == Kind)
@@ -163,7 +163,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
 
   // Set the "os" platform condition.
   if (Target.isMacOSX())
-    addPlatformConditionValue(PlatformConditionKind::OS, "OSX");
+    addPlatformConditionValue(PlatformConditionKind::OS, "macOS");
   else if (triple.isTvOS())
     addPlatformConditionValue(PlatformConditionKind::OS, "tvOS");
   else if (triple.isWatchOS())

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -483,7 +483,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       "-DSWIFT_ENUM_EXTRA=__attribute__((annotate(\""
         SWIFT_NATIVE_ANNOTATION_STRING "\")))",
 
-      // Avoid including the iso646.h header because some headers from OS X
+      // Avoid including the iso646.h header because some headers from macOS
       // frameworks are broken by it.
       "-D_ISO646_H_", "-D__ISO646_H",
 
@@ -1649,7 +1649,7 @@ PlatformAvailability::PlatformAvailability(LangOptions &langOpts) {
              (major == 10 && (!minor.hasValue() || minor.getValue() <= 9));
     };
     deprecatedAsUnavailableMessage =
-        "APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift";
+        "APIs deprecated as of macOS 10.9 and earlier are unavailable in Swift";
   }
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7018,12 +7018,12 @@ void ClangImporter::Implementation::importAttributes(
       auto platformK =
         llvm::StringSwitch<Optional<PlatformKind>>(Platform)
           .Case("ios", PlatformKind::iOS)
-          .Case("macos", PlatformKind::OSX)
+          .Case("macos", PlatformKind::macOS)
           .Case("tvos", PlatformKind::tvOS)
           .Case("watchos", PlatformKind::watchOS)
           .Case("ios_app_extension", PlatformKind::iOSApplicationExtension)
           .Case("macos_app_extension",
-                PlatformKind::OSXApplicationExtension)
+                PlatformKind::macOSApplicationExtension)
           .Case("tvos_app_extension",
                 PlatformKind::tvOSApplicationExtension)
           .Case("watchos_app_extension",
@@ -7079,8 +7079,8 @@ void ClangImporter::Implementation::importAttributes(
       if (C.LangOpts.isSwiftVersion3() && isa<EnumElementDecl>(MappedDecl)) {
         bool downgradeExhaustivity = false;
         switch (*platformK) {
-        case PlatformKind::OSX:
-        case PlatformKind::OSXApplicationExtension:
+        case PlatformKind::macOS:
+        case PlatformKind::macOSApplicationExtension:
           downgradeExhaustivity = (introduced.getMajor() == 10 &&
                                    introduced.getMinor() &&
                                    *introduced.getMinor() == 13);

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -97,7 +97,7 @@ void EnumInfo::classifyEnum(ASTContext &ctx, const clang::EnumDecl *decl,
     }
   }
 
-  // Hardcode a particular annoying case in the OS X headers.
+  // Hardcode a particular annoying case in the macOS headers.
   if (decl->getName() == "DYLD_BOOL") {
     kind = EnumKind::Enum;
     return;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -130,7 +130,7 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &Args) {
     if (triple.isMacOSX()) {
       if (triple.isMacOSXVersionLT(10, 9))
         diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                       "OS X 10.9");
+                       "macOS 10.9");
     } else if (triple.isiOS()) {
       if (triple.isTvOS()) {
         if (triple.isOSVersionLT(9, 0)) {

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -159,7 +159,7 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
             + toStringRef(SanitizerKind::Thread)).toStringRef(b2));
   }
 
-  // Thread Sanitizer only works on OS X and the simulators. It's only supported
+  // Thread Sanitizer only works on macOS and the simulators. It's only supported
   // on 64 bit architectures.
   if ((sanitizerSet & SanitizerKind::Thread) &&
       !isTSanSupported(Triple, sanitizerRuntimeLibExists)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -919,10 +919,10 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       // For each platform version spec in the spec list, create an
       // implicit AvailableAttr for the platform with the introduced
       // version from the spec. For example, if we have
-      //   @available(iOS 8.0, OSX 10.10, *):
+      //   @available(iOS 8.0, macOS 10.10, *):
       // we will synthesize:
       //  @available(iOS, introduced: 8.0)
-      //  @available(OSX, introduced: 10.10)
+      //  @available(macOS, introduced: 10.10)
       //
       // Similarly if we have a language version spec in the spec
       // list, create an implicit AvailableAttr with the specified

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1046,7 +1046,7 @@ static void validateAvailabilitySpecList(Parser &P,
     if (!Inserted) {
       // Rule out multiple version specs referring to the same platform.
       // For example, we emit an error for
-      /// #available(OSX 10.10, OSX 10.11, *)
+      /// #available(macOS 10.10, macOS 10.11, *)
       PlatformKind Platform = VersionSpec->getPlatform();
       P.diagnose(VersionSpec->getPlatformLoc(),
                  diag::availability_query_repeated_platform,

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -776,7 +776,7 @@ private:
 
       const char *plat;
       switch (AvAttr->Platform) {
-      case PlatformKind::OSX:
+      case PlatformKind::macOS:
         plat = "macos";
         break;
       case PlatformKind::iOS:
@@ -788,7 +788,7 @@ private:
       case PlatformKind::watchOS:
         plat = "watchos";
         break;
-      case PlatformKind::OSXApplicationExtension:
+      case PlatformKind::macOSApplicationExtension:
         plat = "macos_app_extension";
         break;
       case PlatformKind::iOSApplicationExtension:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -545,9 +545,9 @@ private:
         continue;
 
       // FIXME: This is not quite right: we want to handle AppExtensions
-      // properly. For example, on the OSXApplicationExtension platform
-      // we want to chose the OS X spec unless there is an explicit
-      // OSXApplicationExtension spec.
+      // properly. For example, on the macOSApplicationExtension platform
+      // we want to chose the macOS spec unless there is an explicit
+      // macOSApplicationExtension spec.
       if (isPlatformActive(VersionSpec->getPlatform(), TC.getLangOpts())) {
         return VersionSpec;
       }
@@ -1220,8 +1220,8 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     auto Platform = targetPlatform(TC.Context.LangOpts);
     if (RunningVers.getMajor() != RequiredVers.getMajor())
       return false;
-    if ((Platform == PlatformKind::OSX ||
-         Platform == PlatformKind::OSXApplicationExtension) &&
+    if ((Platform == PlatformKind::macOS ||
+         Platform == PlatformKind::macOSApplicationExtension) &&
         !(RunningVers.getMinor().hasValue() &&
           RequiredVers.getMinor().hasValue() &&
           RunningVers.getMinor().getValue() ==

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -361,7 +361,7 @@ FileUnit *SerializedModuleLoader::loadAST(
     StringRef osName;
     unsigned major, minor, micro;
     if (moduleTarget.isMacOSX()) {
-      osName = swift::prettyPlatformString(PlatformKind::OSX);
+      osName = swift::prettyPlatformString(PlatformKind::macOS);
       moduleTarget.getMacOSXVersion(major, minor, micro);
     } else {
       osName = moduleTarget.getOSName();

--- a/test/ClangImporter/availability_implicit_macosx.swift
+++ b/test/ClangImporter/availability_implicit_macosx.swift
@@ -29,11 +29,11 @@ func useClassThatTriggersImportOfPotentiallyUnavailableOptions() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in OS X 10.51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 10.51: Use a different API}}
 }
 
-func useInSignature(_ options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
+func useInSignature(_ options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
 }
 
 class SuperClassWithDeprecatedInitializer {
@@ -49,7 +49,7 @@ class SubClassWithSynthesizedDesignedInitializerOverride : SuperClassWithDepreca
 }
 
 func callImplicitInitializerOnSubClassWithSynthesizedDesignedInitializerOverride() {
-  _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in OS X 10.51}}
+  _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.9, deprecated: 10.51)
@@ -57,7 +57,7 @@ class NSDeprecatedSuperClass {
   var i : Int = 7 // Causes initializer to be synthesized
 }
 
-class NotDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass { // expected-warning {{'NSDeprecatedSuperClass' was deprecated in OS X 10.51}}
+class NotDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass { // expected-warning {{'NSDeprecatedSuperClass' was deprecated in macOS 10.51}}
 }
 
 func callImplicitInitializerOnNotDeprecatedSubClassOfDeprecatedSuperClass() {

--- a/test/ClangImporter/availability_macosx.swift
+++ b/test/ClangImporter/availability_macosx.swift
@@ -6,7 +6,7 @@ import Foundation
 import AvailabilityExtras
 
 func test_unavailable_because_deprecated() {
-  _ = NSRealMemoryAvailable() // expected-error {{APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift}}
+  _ = NSRealMemoryAvailable() // expected-error {{APIs deprecated as of macOS 10.9 and earlier are unavailable in Swift}}
 }
 
 func test_swift_unavailable_wins() {

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -43,27 +43,27 @@ func testFactoryWithLaterIntroducedInit() {
 
   // Don't prefer more available convenience factory initializer over less
   // available designated initializer
-  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flim:5) // expected-error {{'init(flim:)' is only available on OS X 10.52 or newer}} 
+  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flim:5) // expected-error {{'init(flim:)' is only available on macOS 10.52 or newer}} 
     // expected-note @-1 {{add 'if #available' version check}}
   
-  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5) // expected-error {{'init(flam:)' is only available on OS X 10.52 or newer}}
-  // expected-note @-1 {{add 'if #available' version check}}  {{3-63=if #available(OSX 10.52, *) {\n      _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5)\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5) // expected-error {{'init(flam:)' is only available on macOS 10.52 or newer}}
+  // expected-note @-1 {{add 'if #available' version check}}  {{3-63=if #available(macOS 10.52, *) {\n      _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5)\n  \} else {\n      // Fallback on earlier versions\n  \}}}
 
   
   // Don't prefer more available factory initializer over less
   // available designated initializer
-  _ = NSHavingFactoryAndLaterConvenienceInit(flim:5) // expected-error {{'init(flim:)' is only available on OS X 10.52 or newer}} 
+  _ = NSHavingFactoryAndLaterConvenienceInit(flim:5) // expected-error {{'init(flim:)' is only available on macOS 10.52 or newer}} 
   // expected-note @-1 {{add 'if #available' version check}}
   
 
-  _ = NSHavingFactoryAndLaterConvenienceInit(flam:5) // expected-error {{'init(flam:)' is only available on OS X 10.52 or newer}} 
+  _ = NSHavingFactoryAndLaterConvenienceInit(flam:5) // expected-error {{'init(flam:)' is only available on macOS 10.52 or newer}} 
   // expected-note @-1 {{add 'if #available' version check}}
 
 
   // When both a convenience factory and a convenience initializer have the
   // same availability, choose the convenience initializer.
-  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flim:5) // expected-warning {{'init(flim:)' was deprecated in OS X 10.51: ConvenienceInit}}
-  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flam:5) // expected-warning {{'init(flam:)' was deprecated in OS X 10.51: ConvenienceInit}}
+  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flim:5) // expected-warning {{'init(flim:)' was deprecated in macOS 10.51: ConvenienceInit}}
+  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flam:5) // expected-warning {{'init(flam:)' was deprecated in macOS 10.51: ConvenienceInit}}
 
   _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flotsam:5) // expected-warning {{'init(flotsam:)' is deprecated: ConvenienceInit}}
   _ = NSHavingConvenienceFactoryAndSameConvenienceInit(jetsam:5) // expected-warning {{'init(jetsam:)' is deprecated: ConvenienceInit}}

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -1,5 +1,5 @@
 // UNSUPPORTED: objc_interop
-// Apple's "System Integrity Protection" makes this test fail on OS X.
+// Apple's "System Integrity Protection" makes this test fail on macOS.
 
 // RUN: %swift_driver -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s
 

--- a/test/Driver/os-deployment.swift
+++ b/test/Driver/os-deployment.swift
@@ -13,7 +13,7 @@
 // RUN: %swiftc_driver -target arm64-apple-ios11.0 %s -### >/dev/null
 
 
-// CHECK-OSX: Swift requires a minimum deployment target of OS X 10.9
+// CHECK-OSX: Swift requires a minimum deployment target of macOS 10.9
 // CHECK-IOS: Swift requires a minimum deployment target of iOS 7
 // CHECK-tvOS: Swift requires a minimum deployment target of tvOS 9.0
 // CHECK-watchOS: Swift requires a minimum deployment target of watchOS 2.0

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -13,11 +13,11 @@
 // AVAILABILITY1-NEXT: Keyword/None:                       iOS[#Platform#]; name=iOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       tvOS[#Platform#]; name=tvOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       watchOS[#Platform#]; name=watchOS{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       OSX[#Platform#]; name=OSX{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macOS[#Platform#]; name=macOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       iOSApplicationExtension[#Platform#]; name=iOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       tvOSApplicationExtension[#Platform#]; name=tvOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       watchOSApplicationExtension[#Platform#]; name=watchOSApplicationExtension{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       OSXApplicationExtension[#Platform#]; name=OSXApplicationExtension{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: End completions
 
 @available(*, #^AVAILABILITY2^#)

--- a/test/IDE/print_clang_framework.swift
+++ b/test/IDE/print_clang_framework.swift
@@ -32,10 +32,10 @@
 // RUN: %FileCheck %s -check-prefix=FOUNDATION -strict-whitespace < %t.printed.txt
 
 // This test is in general platform-independent, but it happens to check
-// printing of @available attributes for OS X, and those are not printed on
+// printing of @available attributes for macOS, and those are not printed on
 // iOS.
 //
-// FIXME: split OS X parts into a separate test.
+// FIXME: split macOS parts into a separate test.
 //
 // REQUIRES: OS=macosx
 

--- a/test/IRGen/weak_import.swift
+++ b/test/IRGen/weak_import.swift
@@ -2,7 +2,7 @@
 // RUN: %build-irgen-test-overlays
 //
 // Specify explicit target triples for the deployment target to test weak
-// linking for a symbol introduced in OS X 10.51.
+// linking for a symbol introduced in macOS 10.51.
 //
 // RUN: %target-swift-frontend(mock-sdk: -target x86_64-apple-macosx10.50 -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECK-10_50 %s
 // RUN: %target-swift-frontend(mock-sdk: -target x86_64-apple-macosx10.51 -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECK-10_51 %s

--- a/test/Interpreter/availability_host_os.swift
+++ b/test/Interpreter/availability_host_os.swift
@@ -12,9 +12,9 @@
 
 print(mavericks()) // CHECK: {{^9$}}
 print(yosemite()) // CHECK-NEXT: {{^10$}}
-// CHECK-NOT-INFERRED: 'yosemite()' is only available on OS X 10.10 or newer
+// CHECK-NOT-INFERRED: 'yosemite()' is only available on macOS 10.10 or newer
 
 #if FAIL
-print(todosSantos()) // expected-error {{'todosSantos()' is only available on OS X 10.99 or newer}}
+print(todosSantos()) // expected-error {{'todosSantos()' is only available on macOS 10.99 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
 #endif

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -45,7 +45,7 @@ if #available(iDishwasherOS 10.51) { // expected-error {{unrecognized platform n
 if #available(iDishwasherOS 10.51, *) { // expected-error {{unrecognized platform name 'iDishwasherOS'}}
 }
 
-if #available(OSX 10.51, OSX 10.52, *) {  // expected-error {{version for 'OSX' already specified}}
+if #available(macOS 10.51, macOS 10.52, *) {  // expected-error {{version for 'macOS' already specified}}
 }
 
 if #available(OSX 10.52) { }  // expected-error {{must handle potential future platforms with '*'}} {{24-24=, *}}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -8,21 +8,21 @@ func availableSince10_6() {}
 @available(OSX, introduced: 10.0, deprecated: 10.12) // no error
 func introducedFollowedByDeprecated() {}
 
-@available(OSX 10.0, deprecated: 10.12)
-// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
-// expected-note@-2 {{did you mean to specify an introduction version?}} {{15-15=, introduced:}}
+@available(macOS 10.0, deprecated: 10.12)
+// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'macOS 10.0'}}
+// expected-note@-2 {{did you mean to specify an introduction version?}} {{17-17=, introduced:}}
 // expected-error@-3 {{expected declaration}}
 func shorthandFollowedByDeprecated() {}
 
-@available(OSX 10.0, introduced: 10.12)
-// expected-error@-1 {{'introduced' can't be combined with shorthand specification 'OSX 10.0'}}
+@available(macOS 10.0, introduced: 10.12)
+// expected-error@-1 {{'introduced' can't be combined with shorthand specification 'macOS 10.0'}}
 // expected-error@-2 {{expected declaration}}
 func shorthandFollowedByIntroduced() {}
 
 @available(iOS 6.0, OSX 10.8, *) // no error
 func availableOnMultiplePlatforms() {}
 
-@available(iOS 6.0, OSX 10.0, deprecated: 10.12)
-// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
+@available(iOS 6.0, macOS 10.0, deprecated: 10.12)
+// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'macOS 10.0'}}
 // expected-error@-2 {{expected declaration}}
 func twoShorthandsFollowedByDeprecated() {}

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -2401,7 +2401,7 @@ runAllTests()
 public func run_UTF8Decode(_ N: Int) {
   // 1-byte sequences
   // This test case is the longest as it's the most performance sensitive.
-  let ascii = "Swift is a multi-paradigm, compiled programming language created for iOS, OS X, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
+  let ascii = "Swift is a multi-paradigm, compiled programming language created for iOS, macOS, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
   // 2-byte sequences
   let russian = "Ру́сский язы́к один из восточнославянских языков, национальный язык русского народа."
   // 3-byte sequences

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -15,7 +15,7 @@ if #available(OSX 10.53.8, iOS 7.1, *) {
 
 // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_br [[TRUE]]
-// Since we are compiling for an unmentioned platform (OS X), we check against the minimum
+// Since we are compiling for an unmentioned platform (macOS), we check against the minimum
 // deployment target, which is 10.50
 if #available(iOS 7.1, *) {
 }

--- a/test/SILGen/inherited_protocol_conformance_multi_file_2.swift
+++ b/test/SILGen/inherited_protocol_conformance_multi_file_2.swift
@@ -14,7 +14,7 @@
 // baC
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift %s -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
 
-// OS X 10.9
+// macOS 10.9
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -primary-file %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_C
 // cAb
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %S/Inputs/inherited_protocol_conformance_other_file_2_c.swift -primary-file %s %S/Inputs/inherited_protocol_conformance_other_file_2_b.swift -module-name main | %FileCheck %s --check-prefix=FILE_A

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -1,7 +1,7 @@
 // This file is used by Sema/availability_versions_multi.swift to
 // test that we build enough of the type refinement context as needed to
 // validate declarations when resolving declaration signatures.
-// This file relies on the minimum deployment target for OS X being 10.9.
+// This file relies on the minimum deployment target for macOS being 10.9.
 
 @available(OSX, introduced: 10.52)
 private class PrivateIntroduced10_52 { }
@@ -20,7 +20,7 @@ class OtherIntroduced10_51 {
 
   // This method uses a 10_52 only type in its signature, so validating
   // the declaration should produce an availability error
-  func returns10_52() -> OtherIntroduced10_52 { // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+  func returns10_52() -> OtherIntroduced10_52 { // expected-error {{'OtherIntroduced10_52' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     // Body is not type checked (by design) so no error is expected for unavailable type used in return.
@@ -66,7 +66,7 @@ class SubOtherIntroduced10_51 : OtherIntroduced10_51 {
 class OtherIntroduced10_52 : OtherIntroduced10_51 {
 }
 
-extension OtherIntroduced10_51 { // expected-error {{'OtherIntroduced10_51' is only available on OS X 10.51 or newer}}
+extension OtherIntroduced10_51 { // expected-error {{'OtherIntroduced10_51' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing extension}}
 }
 
@@ -87,5 +87,5 @@ extension OtherIntroduced10_51 {
 class OtherIntroduced10_53 {
 }
 
-var globalFromOtherOn10_52 : OtherIntroduced10_52? = nil // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+var globalFromOtherOn10_52 : OtherIntroduced10_52? = nil // expected-error {{'OtherIntroduced10_52' is only available on macOS 10.52 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing var}}

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -8,22 +8,22 @@
 
 func markUsed<T>(_ t: T) {}
 
-@available(OSX, introduced: 10.9)
+@available(macOS, introduced: 10.9)
 func globalFuncAvailableOn10_9() -> Int { return 9 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 func globalFuncAvailableOn10_51() -> Int { return 10 }
 
-@available(OSX, introduced: 10.52)
+@available(macOS, introduced: 10.52)
 func globalFuncAvailableOn10_52() -> Int { return 11 }
 
 // Top level should reflect the minimum deployment target.
 let ignored1: Int = globalFuncAvailableOn10_9()
 
-let ignored2: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+let ignored2: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let ignored3: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+let ignored3: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Functions without annotations should reflect the minimum deployment target.
@@ -32,92 +32,92 @@ func functionWithoutAvailability() {
 
   let _: Int = globalFuncAvailableOn10_9()
 
-  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Functions with annotations should refine their bodies.
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 func functionAvailableOn10_51() {
   let _: Int = globalFuncAvailableOn10_9()
   let _: Int = globalFuncAvailableOn10_51()
 
   // Nested functions should get their own refinement context.
-  @available(OSX, introduced: 10.52)
+  @available(macOS, introduced: 10.52)
   func innerFunctionAvailableOn10_52() {
     let _: Int = globalFuncAvailableOn10_9()
     let _: Int = globalFuncAvailableOn10_51()
     let _: Int = globalFuncAvailableOn10_52()
   }
 
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Don't allow script-mode globals to marked potentially unavailable. Their
 // initializers are eagerly executed.
-@available(OSX, introduced: 10.51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
+@available(macOS, introduced: 10.51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
 var potentiallyUnavailableGlobalInScriptMode: Int = globalFuncAvailableOn10_51()
 
 // Still allow other availability annotations on script-mode globals
-@available(OSX, deprecated: 10.51)
+@available(macOS, deprecated: 10.51)
 var deprecatedGlobalInScriptMode: Int = 5
 
-if #available(OSX 10.51, *) {
+if #available(macOS 10.51, *) {
   let _: Int = globalFuncAvailableOn10_51()
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-if #available(OSX 10.51, *) {
+if #available(macOS 10.51, *) {
   let _: Int = globalFuncAvailableOn10_51()
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 } else {
   let _: Int = globalFuncAvailableOn10_9()
-  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 @available(iOS, introduced: 8.0)
 func globalFuncAvailableOnOSX10_51AndiOS8_0() -> Int { return 10 }
 
-if #available(OSX 10.51, iOS 8.0, *) {
+if #available(macOS 10.51, iOS 8.0, *) {
   let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0()
 }
 
 if #available(iOS 9.0, *) {
-  let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0() // expected-error {{'globalFuncAvailableOnOSX10_51AndiOS8_0()' is only available on OS X 10.51 or newer}}
+  let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0() // expected-error {{'globalFuncAvailableOnOSX10_51AndiOS8_0()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Multiple unavailable references in a single statement
 
-let ignored4: (Int, Int) = (globalFuncAvailableOn10_51(), globalFuncAvailableOn10_52()) // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}  expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+let ignored4: (Int, Int) = (globalFuncAvailableOn10_51(), globalFuncAvailableOn10_52()) // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}  expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
     // expected-note@-1 2{{add 'if #available' version check}}
 
 
 _ = globalFuncAvailableOn10_9()
 
-let ignored5 = globalFuncAvailableOn10_51 // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+let ignored5 = globalFuncAvailableOn10_51 // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-_ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+_ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Overloaded global functions
-@available(OSX, introduced: 10.9)
+@available(macOS, introduced: 10.9)
 func overloadedFunction() {}
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 func overloadedFunction(_ on1010: Int) {}
 
 overloadedFunction()
-overloadedFunction(0) // expected-error {{'overloadedFunction' is only available on OS X 10.51 or newer}}
+overloadedFunction(0) // expected-error {{'overloadedFunction' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Unavailable methods
@@ -125,20 +125,20 @@ overloadedFunction(0) // expected-error {{'overloadedFunction' is only available
 class ClassWithUnavailableMethod {
     // expected-note@-1 {{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   func methAvailableOn10_9() {}
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func methAvailableOn10_51() {}
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   class func classMethAvailableOn10_51() {}
   
   func someOtherMethod() {
     // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     methAvailableOn10_9()
-    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -149,13 +149,13 @@ func callUnavailableMethods(_ o: ClassWithUnavailableMethod) {
   let m10_9 = o.methAvailableOn10_9
   m10_9()
   
-  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   m10_51()
   
   o.methAvailableOn10_9()
-  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -165,24 +165,24 @@ func callUnavailableMethodsViaIUO(_ o: ClassWithUnavailableMethod!) {
   let m10_9 = o.methAvailableOn10_9
   m10_9()
   
-  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       
       // expected-note@-2 {{add 'if #available' version check}}
 
   m10_51()
   
   o.methAvailableOn10_9()
-  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func callUnavailableClassMethod() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
-  ClassWithUnavailableMethod.classMethAvailableOn10_51() // expected-error {{'classMethAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  ClassWithUnavailableMethod.classMethAvailableOn10_51() // expected-error {{'classMethAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  let m10_51 = ClassWithUnavailableMethod.classMethAvailableOn10_51 // expected-error {{'classMethAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let m10_51 = ClassWithUnavailableMethod.classMethAvailableOn10_51 // expected-error {{'classMethAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   m10_51()
@@ -194,7 +194,7 @@ class SubClassWithUnavailableMethod : ClassWithUnavailableMethod {
         // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     methAvailableOn10_9()
-    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -205,13 +205,13 @@ class SubClassOverridingUnavailableMethod : ClassWithUnavailableMethod {
   override func methAvailableOn10_51() {
         // expected-note@-1 2{{add @available attribute to enclosing instance method}}
     methAvailableOn10_9()
-    super.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    super.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     let m10_9 = super.methAvailableOn10_9
     m10_9()
     
-    let m10_51 = super.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+    let m10_51 = super.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     m10_51()
   }
@@ -224,10 +224,10 @@ class SubClassOverridingUnavailableMethod : ClassWithUnavailableMethod {
 }
 
 class ClassWithUnavailableOverloadedMethod {
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   func overloadedMethod() {}
 
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func overloadedMethod(_ on1010: Int) {}
 }
 
@@ -235,7 +235,7 @@ func callUnavailableOverloadedMethod(_ o: ClassWithUnavailableOverloadedMethod) 
       // expected-note@-1 {{add @available attribute to enclosing global function}}
 
   o.overloadedMethod()
-  o.overloadedMethod(0) // expected-error {{'overloadedMethod' is only available on OS X 10.51 or newer}}
+  o.overloadedMethod(0) // expected-error {{'overloadedMethod' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -244,20 +244,20 @@ func callUnavailableOverloadedMethod(_ o: ClassWithUnavailableOverloadedMethod) 
 class ClassWithUnavailableInitializer {
     // expected-note@-1 {{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   required init() {  }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   required init(_ val: Int) {  }
   
   convenience init(s: String) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
     
-    self.init(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+    self.init(5) // expected-error {{'init' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   convenience init(onlyOn1010: String) {
     self.init(5)
   }
@@ -267,20 +267,20 @@ func callUnavailableInitializer() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
   _ = ClassWithUnavailableInitializer()
-  _ = ClassWithUnavailableInitializer(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+  _ = ClassWithUnavailableInitializer(5) // expected-error {{'init' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let i = ClassWithUnavailableInitializer.self 
   _ = i.init()
-  _ = i.init(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+  _ = i.init(5) // expected-error {{'init' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 class SuperWithWithUnavailableInitializer {
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   init() {  }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   init(_ val: Int) {  }
 }
 
@@ -290,7 +290,7 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
   override init(_ val: Int) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
 
-    super.init(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+    super.init(5) // expected-error {{'init' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -298,7 +298,7 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
     super.init()
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   init(on1010: Int) {
     super.init(22)
   }
@@ -309,32 +309,32 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
 class ClassWithUnavailableProperties {
     // expected-note@-1 4{{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced: 10.9) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  @available(macOS, introduced: 10.9) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   var nonLazyAvailableOn10_9Stored: Int = 9
 
-  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  @available(macOS, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   var nonLazyAvailableOn10_51Stored : Int = 10
 
-  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  @available(macOS, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   let nonLazyLetAvailableOn10_51Stored : Int = 10
 
   // Make sure that we don't emit a Fix-It to mark a stored property as potentially unavailable.
   // We don't support potentially unavailable stored properties yet.
-  var storedPropertyOfUnavailableType: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  var storedPropertyOfUnavailableType: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
 
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   lazy var availableOn10_9Stored: Int = 9
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   lazy var availableOn10_51Stored : Int = 10
 
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   var availableOn10_9Computed: Int {
     get {
-      let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
+      let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       
-      if #available(OSX 10.51, *) {
+      if #available(macOS 10.51, *) {
         let _: Int = availableOn10_51Stored
       }
       
@@ -345,7 +345,7 @@ class ClassWithUnavailableProperties {
     }
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   var availableOn10_51Computed: Int {
     get {
       return availableOn10_51Stored
@@ -358,11 +358,11 @@ class ClassWithUnavailableProperties {
   var propWithSetterOnlyAvailableOn10_51 : Int {
       // expected-note@-1 {{add @available attribute to enclosing var}}
     get {
-      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       return 0
     }
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     set(newVal) {
     _ = globalFuncAvailableOn10_51()
     }
@@ -370,23 +370,23 @@ class ClassWithUnavailableProperties {
   
   var propWithGetterOnlyAvailableOn10_51 : Int {
       // expected-note@-1 {{add @available attribute to enclosing var}}
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     get {
       _ = globalFuncAvailableOn10_51()
       return 0
     }
     set(newVal) {
-      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
     }
   }
   
   var propWithGetterAndSetterOnlyAvailableOn10_51 : Int {
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     get {
       return 0
     }
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     set(newVal) {
     }
   }
@@ -395,13 +395,13 @@ class ClassWithUnavailableProperties {
     get {
       return ClassWithUnavailableProperties()
     }
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     set(newVal) {
     }
   }
   
   var propWithGetterOnlyAvailableOn10_51ForNestedMemberRef : ClassWithUnavailableProperties {
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     get {
       return ClassWithUnavailableProperties()
     }
@@ -410,15 +410,15 @@ class ClassWithUnavailableProperties {
   }
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class ClassWithReferencesInInitializers {
   var propWithInitializer10_51: Int = globalFuncAvailableOn10_51()
 
-  var propWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  var propWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
 
   lazy var lazyPropWithInitializer10_51: Int = globalFuncAvailableOn10_51()
 
-  lazy var lazyPropWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  lazy var lazyPropWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing var}}
 }
 
@@ -426,38 +426,38 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
       // expected-note@-1 17{{add @available attribute to enclosing global function}}
   // Stored properties
   let _: Int = o.availableOn10_9Stored
-  let _: Int = o.availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
+  let _: Int = o.availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o.availableOn10_9Stored = 9
-  o.availableOn10_51Stored = 10 // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
+  o.availableOn10_51Stored = 10 // expected-error {{'availableOn10_51Stored' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Computed Properties
   let _: Int = o.availableOn10_9Computed
-  let _: Int = o.availableOn10_51Computed // expected-error {{'availableOn10_51Computed' is only available on OS X 10.51 or newer}}
+  let _: Int = o.availableOn10_51Computed // expected-error {{'availableOn10_51Computed' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o.availableOn10_9Computed = 9
-  o.availableOn10_51Computed = 10 // expected-error {{'availableOn10_51Computed' is only available on OS X 10.51 or newer}}
+  o.availableOn10_51Computed = 10 // expected-error {{'availableOn10_51Computed' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   // Getter allowed on 10.9 but setter is not
   let _: Int = o.propWithSetterOnlyAvailableOn10_51
-  o.propWithSetterOnlyAvailableOn10_51 = 5 // expected-error {{setter for 'propWithSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  o.propWithSetterOnlyAvailableOn10_51 = 5 // expected-error {{setter for 'propWithSetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  if #available(OSX 10.51, *) {
+  if #available(macOS 10.51, *) {
     // Setter is allowed on 10.51 and greater
     o.propWithSetterOnlyAvailableOn10_51 = 5
   }
   
   // Setter allowed on 10.9 but getter is not
   o.propWithGetterOnlyAvailableOn10_51 = 5
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) {
+  if #available(macOS 10.51, *) {
     // Getter is allowed on 10.51 and greater
     let _: Int = o.propWithGetterOnlyAvailableOn10_51
   }
@@ -465,15 +465,15 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
   // Tests for nested member refs
   
   // Both getters are potentially unavailable.
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on OS X 10.51 or newer}} expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on macOS 10.51 or newer}} expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
   // Nested getter is potentially unavailable, outer getter is available
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithSetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithSetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Nested getter is available, outer getter is potentially unavailable
-  let _:Int = o.propWithSetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _:Int = o.propWithSetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Both getters are always available.
@@ -483,93 +483,93 @@ func accessUnavailableProperties(_ o: ClassWithUnavailableProperties) {
   // Nesting in source of assignment
   var v: Int
   
-  v = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  v = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  v = (o.propWithGetterOnlyAvailableOn10_51) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  v = (o.propWithGetterOnlyAvailableOn10_51) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   // Inout requires access to both getter and setter
   
   func takesInout(_ i : inout Int) { }
   
-  takesInout(&o.propWithGetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithGetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  takesInout(&o.propWithSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because setter for 'propWithSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because setter for 'propWithSetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  takesInout(&o.propWithGetterAndSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}} expected-error {{cannot pass as inout because setter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithGetterAndSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}} expected-error {{cannot pass as inout because setter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
   takesInout(&o.availableOn10_9Computed)
-  takesInout(&o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.availableOn10_9Computed) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on OS X 10.51 or newer}}
+  takesInout(&o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.availableOn10_9Computed) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // _silgen_name
 
 @_silgen_name("SomeName")
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 func funcWith_silgen_nameAvailableOn10_51(_ p: ClassAvailableOn10_51?) -> ClassAvailableOn10_51
 
 // Enums
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 enum EnumIntroducedOn10_51 {
  case Element
 }
 
-@available(OSX, introduced: 10.52)
+@available(macOS, introduced: 10.52)
 enum EnumIntroducedOn10_52 {
  case Element
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 enum CompassPoint {
   case North
   case South
   case East
 
-  @available(OSX, introduced: 10.52)
+  @available(macOS, introduced: 10.52)
   case West
 
   case WithAvailableByEnumPayload(p : EnumIntroducedOn10_51)
 
-  @available(OSX, introduced: 10.52)
+  @available(macOS, introduced: 10.52)
   case WithAvailableByEnumElementPayload(p : EnumIntroducedOn10_52)
 
-  @available(OSX, introduced: 10.52)
+  @available(macOS, introduced: 10.52)
   case WithAvailableByEnumElementPayload1(p : EnumIntroducedOn10_52), WithAvailableByEnumElementPayload2(p : EnumIntroducedOn10_52)
 
-  case WithUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
+  case WithUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing case}}
 
-    case WithUnavailablePayload1(p : EnumIntroducedOn10_52), WithUnavailablePayload2(p : EnumIntroducedOn10_52) // expected-error 2{{'EnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
+    case WithUnavailablePayload1(p : EnumIntroducedOn10_52), WithUnavailablePayload2(p : EnumIntroducedOn10_52) // expected-error 2{{'EnumIntroducedOn10_52' is only available on macOS 10.52 or newer}}
       // expected-note@-1 2{{add @available attribute to enclosing case}}
 }
 
-@available(OSX, introduced: 10.52)
+@available(macOS, introduced: 10.52)
 func functionTakingEnumIntroducedOn10_52(_ e: EnumIntroducedOn10_52) { }
 
 func useEnums() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available on OS X 10.51 or newer}}
+  let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) {
+  if #available(macOS 10.51, *) {
     let _: CompassPoint = .North
 
-    let _: CompassPoint = .West // expected-error {{'West' is only available on OS X 10.52 or newer}}
+    let _: CompassPoint = .West // expected-error {{'West' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 
-  if #available(OSX 10.52, *) {
+  if #available(macOS 10.52, *) {
     let _: CompassPoint = .West
   }
 
   // Pattern matching on an enum element does not require it to be definitely available
-  if #available(OSX 10.51, *) {
+  if #available(macOS 10.51, *) {
     let point: CompassPoint = .North
     switch (point) {
       case .North, .South, .East:
@@ -595,7 +595,7 @@ func useEnums() {
 
         // For the moment, we do not incorporate enum element availability into 
         // TRC construction. Perhaps we should?
-        functionTakingEnumIntroducedOn10_52(p)  // expected-error {{'functionTakingEnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
+        functionTakingEnumIntroducedOn10_52(p)  // expected-error {{'functionTakingEnumIntroducedOn10_52' is only available on macOS 10.52 or newer}}
           
           // expected-note@-2 {{add 'if #available' version check}}
     }
@@ -604,14 +604,14 @@ func useEnums() {
 
 // Classes
 
-@available(OSX, introduced: 10.9)
+@available(macOS, introduced: 10.9)
 class ClassAvailableOn10_9 {
   func someMethod() {}
   class func someClassMethod() {}
   var someProp : Int = 22
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
   func someMethod() {}
   class func someClassMethod() {
@@ -619,12 +619,12 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
   }
   var someProp : Int = 22
 
-  @available(OSX, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
+  @available(macOS, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
   func someMethodAvailableOn10_9() { }
 
-  @available(OSX, introduced: 10.52)
+  @available(macOS, introduced: 10.52)
   var propWithGetter: Int { // expected-note{{enclosing scope here}}
-    @available(OSX, introduced: 10.51) // expected-error {{declaration cannot be more available than enclosing scope}}
+    @available(macOS, introduced: 10.51) // expected-error {{declaration cannot be more available than enclosing scope}}
     get { return 0 }
   }
 }
@@ -632,15 +632,15 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
 func classAvailability() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
   ClassAvailableOn10_9.someClassMethod()
-  ClassAvailableOn10_51.someClassMethod() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  ClassAvailableOn10_51.someClassMethod() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   _ = ClassAvailableOn10_9.self
-  _ = ClassAvailableOn10_51.self // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = ClassAvailableOn10_51.self // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let o10_9 = ClassAvailableOn10_9()
-  let o10_51 = ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let o10_51 = ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o10_9.someMethod()
@@ -652,13 +652,13 @@ func classAvailability() {
 
 func castingUnavailableClass(_ o : AnyObject) {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  let _ = o as! ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o as! ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o as? ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o as? ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o is ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o is ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -666,7 +666,7 @@ protocol Creatable {
   init()
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class ClassAvailableOn10_51_Creatable : Creatable {
   required init() {}
 }
@@ -681,30 +681,30 @@ class ClassWithTwoGenericTypeParameter<T, S> { }
 
 func classViaTypeParameter() {
   // expected-note@-1 9{{add @available attribute to enclosing global function}}
-  let _ : ClassAvailableOn10_51_Creatable = // expected-error {{'ClassAvailableOn10_51_Creatable' is only available on OS X 10.51 or newer}}
+  let _ : ClassAvailableOn10_51_Creatable = // expected-error {{'ClassAvailableOn10_51_Creatable' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
       create()
       
   let _ = create() as
-      ClassAvailableOn10_51_Creatable // expected-error {{'ClassAvailableOn10_51_Creatable' is only available on OS X 10.51 or newer}}
+      ClassAvailableOn10_51_Creatable // expected-error {{'ClassAvailableOn10_51_Creatable' is only available on macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = [ClassAvailableOn10_51]() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = [ClassAvailableOn10_51]() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithGenericTypeParameter<ClassAvailableOn10_51> = ClassWithGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithGenericTypeParameter<ClassAvailableOn10_51> = ClassWithGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, String> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, String> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<String, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<String, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error 2{{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error 2{{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
-  let _: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
 }
@@ -714,56 +714,56 @@ func classViaTypeParameter() {
 class ClassWithDeclarationsOfUnavailableClasses {
       // expected-note@-1 5{{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   init() {
     unavailablePropertyOfUnavailableType = ClassAvailableOn10_51()
     unavailablePropertyOfUnavailableType = ClassAvailableOn10_51()
   }
 
-  var propertyOfUnavailableType: ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  var propertyOfUnavailableType: ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
 
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   lazy var unavailablePropertyOfUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   lazy var unavailablePropertyOfOptionalUnavailableType: ClassAvailableOn10_51? = nil
 
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   lazy var unavailablePropertyOfUnavailableTypeWithInitializer: ClassAvailableOn10_51 = ClassAvailableOn10_51()
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   static var unavailableStaticPropertyOfUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
 
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   static var unavailableStaticPropertyOfOptionalUnavailableType: ClassAvailableOn10_51?
 
-  func methodWithUnavailableParameterType(_ o : ClassAvailableOn10_51) { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func methodWithUnavailableParameterType(_ o : ClassAvailableOn10_51) { // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func unavailableMethodWithUnavailableParameterType(_ o : ClassAvailableOn10_51) {
   }
   
-  func methodWithUnavailableReturnType() -> ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func methodWithUnavailableReturnType() -> ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 2{{add @available attribute to enclosing instance method}}
 
-    return ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+    return ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func unavailableMethodWithUnavailableReturnType() -> ClassAvailableOn10_51 {
     return ClassAvailableOn10_51()
   }
 
   func methodWithUnavailableLocalDeclaration() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
-    let _ : ClassAvailableOn10_51 = methodWithUnavailableReturnType() // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+    let _ : ClassAvailableOn10_51 = methodWithUnavailableReturnType() // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func unavailableMethodWithUnavailableLocalDeclaration() {
     let _ : ClassAvailableOn10_51 = methodWithUnavailableReturnType()
   }
@@ -771,15 +771,15 @@ class ClassWithDeclarationsOfUnavailableClasses {
 
 func referToUnavailableStaticProperty() {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = ClassWithDeclarationsOfUnavailableClasses.unavailableStaticPropertyOfUnavailableType // expected-error {{'unavailableStaticPropertyOfUnavailableType' is only available on OS X 10.51 or newer}}
+  let _ = ClassWithDeclarationsOfUnavailableClasses.unavailableStaticPropertyOfUnavailableType // expected-error {{'unavailableStaticPropertyOfUnavailableType' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-class ClassExtendingUnavailableClass : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class ClassExtendingUnavailableClass : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class UnavailableClassExtendingUnavailableClass : ClassAvailableOn10_51 {
 }
 
@@ -806,11 +806,11 @@ class SuperWithAlwaysAvailableMembers {
 }
 
 class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   override var shouldAlwaysBeAvailableProperty: Int { // expected-error {{overriding 'shouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     get { return 10 }
     set(newVal) {}
@@ -818,24 +818,24 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
 
   override var setterShouldAlwaysBeAvailableProperty: Int {
     get { return 9 }
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     set(newVal) {} // expected-error {{overriding setter for 'setterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     // This is a terrible diagnostic. rdar://problem/20427938
   }
 
   override var getterShouldAlwaysBeAvailableProperty: Int {
-    @available(OSX, introduced: 10.51)
+    @available(macOS, introduced: 10.51)
     get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     set(newVal) {}
   }
 }
 
 class SuperWithLimitedMemberAvailability {
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func someMethod() {
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   var someProperty: Int {
     get { return 10 }
     set(newVal) {}
@@ -844,23 +844,23 @@ class SuperWithLimitedMemberAvailability {
 
 class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
         // expected-note@-1 2{{add @available attribute to enclosing class}}
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   override func someMethod() {
-    super.someMethod() // expected-error {{'someMethod()' is only available on OS X 10.51 or newer}}
+    super.someMethod() // expected-error {{'someMethod()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
-    if #available(OSX 10.51, *) {
+    if #available(macOS 10.51, *) {
       super.someMethod()
     }
   }
   
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   override var someProperty: Int {
     get { 
-      let _ = super.someProperty // expected-error {{'someProperty' is only available on OS X 10.51 or newer}}
+      let _ = super.someProperty // expected-error {{'someProperty' is only available on macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       
-      if #available(OSX 10.51, *) {
+      if #available(macOS 10.51, *) {
         let _ = super.someProperty
       }
       
@@ -872,28 +872,28 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
 
 // Inheritance and availability
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 protocol ProtocolAvailableOn10_9 {
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 protocol ProtocolAvailableOn10_51 {
 }
 
-@available(OSX, introduced: 10.9)
+@available(macOS, introduced: 10.9)
 protocol ProtocolAvailableOn10_9InheritingFromProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 {
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 protocol ProtocolAvailableOn10_51InheritingFromProtocolAvailableOn10_9 : ProtocolAvailableOn10_9 {
 }
 
-@available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+@available(macOS, introduced: 10.9)
+class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
 }
 
 // We allow nominal types to conform to protocols that are less available than the types themselves.
-@available(OSX, introduced: 10.9)
+@available(macOS, introduced: 10.9)
 class ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 {
 }
 
@@ -901,54 +901,54 @@ func castToUnavailableProtocol() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
   let o: ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51 = ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51()
 
-  let _: ProtocolAvailableOn10_51 = o // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _: ProtocolAvailableOn10_51 = o // expected-error {{'ProtocolAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o as ProtocolAvailableOn10_51 // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = o as ProtocolAvailableOn10_51 // expected-error {{'ProtocolAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+@available(macOS, introduced: 10.9)
+class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
 }
 
 class SomeGenericClass<T> { }
 
-@available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+@available(macOS, introduced: 10.9)
+class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available on macOS 10.51 or newer}}
 }
 
-func GenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn10_51 { // expected-error * {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+func GenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn10_51 { // expected-error * {{'ProtocolAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing global function}}
 }
 
-func GenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) { // expected-error * {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
+func GenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) { // expected-error * {{'ProtocolAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing global function}}
 }
 
 // Extensions
 
-extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing extension}}
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 extension ClassAvailableOn10_51 {
   func m() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
     let _ = globalFuncAvailableOn10_51()
-    let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+    let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
 }
 
 class ClassToExtend { }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 extension ClassToExtend {
 
   func extensionMethod() { }
 
-  @available(OSX, introduced: 10.52)
+  @available(macOS, introduced: 10.52)
   func extensionMethod10_52() { }
 
   class ExtensionClass { }
@@ -965,9 +965,9 @@ extension ClassToExtend : ProtocolAvailableOn10_51 {
 
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 extension ClassToExtend { // expected-note {{enclosing scope here}}
-  @available(OSX, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
+  @available(macOS, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
   func extensionMethod10_9() { }
 }
 
@@ -975,13 +975,13 @@ func useUnavailableExtension() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
   let o = ClassToExtend()
 
-  o.extensionMethod() // expected-error {{'extensionMethod()' is only available on OS X 10.51 or newer}}
+  o.extensionMethod() // expected-error {{'extensionMethod()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = ClassToExtend.ExtensionClass() // expected-error {{'ExtensionClass' is only available on OS X 10.51 or newer}}
+  let _ = ClassToExtend.ExtensionClass() // expected-error {{'ExtensionClass' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  o.extensionMethod10_52() // expected-error {{'extensionMethod10_52()' is only available on OS X 10.52 or newer}}
+  o.extensionMethod10_52() // expected-error {{'extensionMethod10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -990,30 +990,30 @@ func useUnavailableExtension() {
 func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
 // Default availability reflects minimum deployment: 10.9 and up
 
-  if #available(OSX 10.9, *) { // no-warning
+  if #available(macOS 10.9, *) { // no-warning
     let _ = globalFuncAvailableOn10_9()
   }
   
-  if #available(OSX 10.51, *) { // expected-note {{enclosing scope here}}
+  if #available(macOS 10.51, *) { // expected-note {{enclosing scope here}}
     let _ = globalFuncAvailableOn10_51()
     
-    if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
       let _ = globalFuncAvailableOn10_51()
     }
   }
 
-  if #available(OSX 10.9, *) { // expected-note {{enclosing scope here}}
+  if #available(macOS 10.9, *) { // expected-note {{enclosing scope here}}
   } else {
     // Make sure we generate a warning about an unnecessary check even if the else branch of if is dead.
-    if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     }
   }
 
   // This 'if' is strictly to limit the scope of the guard fallthrough
   if p {
-    guard #available(OSX 10.9, *) else { // expected-note {{enclosing scope here}}
+    guard #available(macOS 10.9, *) else { // expected-note {{enclosing scope here}}
       // Make sure we generate a warning about an unnecessary check even if the else branch of guard is dead.
-      if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+      if #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
       }
     }
   }
@@ -1023,14 +1023,14 @@ func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
   if #available(iOS 8.0, *) {
   }
 
-  if #available(OSX 10.51, *) {
+  if #available(macOS 10.51, *) {
     // Similarly do not want '*' to generate a warning in a refined TRC.
     if #available(iOS 8.0, *) {
     }
   }
 }
 
-@available(OSX, unavailable)
+@available(macOS, unavailable)
 func explicitlyUnavailable() { } // expected-note 2{{'explicitlyUnavailable()' has been explicitly marked unavailable here}}
 
 func functionWithUnavailableInDeadBranch() {
@@ -1040,7 +1040,7 @@ func functionWithUnavailableInDeadBranch() {
     // This branch is dead on OSX, so we shouldn't a warning about use of potentially unavailable APIs in it.
     _ = globalFuncAvailableOn10_51() // no-warning
 
-    @available(OSX 10.51, *)
+    @available(macOS 10.51, *)
     func localFuncAvailableOn10_51() {
       _ = globalFuncAvailableOn10_52() // no-warning
     }
@@ -1057,13 +1057,13 @@ func functionWithUnavailableInDeadBranch() {
   }
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 func functionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note 2{{enclosing scope here}}
-  if #available(OSX 10.9, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+  if #available(macOS 10.9, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     let _ = globalFuncAvailableOn10_9()
   }
   
-  if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+  if #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     let _ = globalFuncAvailableOn10_51()
   }
 }
@@ -1075,40 +1075,40 @@ func injectToOptional<T>(_ v: T) -> T? {
 }
 
 
-if let _ = injectToOptional(5), #available(OSX 10.52, *) {}  // ok
+if let _ = injectToOptional(5), #available(macOS 10.52, *) {}  // ok
 
 
 // Refining context inside guard
 
-if #available(OSX 10.51, *),
+if #available(macOS 10.51, *),
    let _ = injectToOptional(globalFuncAvailableOn10_51()),
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   let _ = globalFuncAvailableOn10_51()
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
-if let _ = injectToOptional(5), #available(OSX 10.51, *),
+if let _ = injectToOptional(5), #available(macOS 10.51, *),
    let _ = injectToOptional(globalFuncAvailableOn10_51()),
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   let _ = globalFuncAvailableOn10_51()
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
-if let _ = injectToOptional(globalFuncAvailableOn10_51()), #available(OSX 10.51, *), // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+if let _ = injectToOptional(globalFuncAvailableOn10_51()), #available(macOS 10.51, *), // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
 }
 
-if let _ = injectToOptional(5), #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
-   let _ = injectToOptional(6), #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+if let _ = injectToOptional(5), #available(macOS 10.51, *), // expected-note {{enclosing scope here}}
+   let _ = injectToOptional(6), #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
 }
 
 
@@ -1117,66 +1117,66 @@ if let _ = injectToOptional(5), #available(OSX 10.51, *), // expected-note {{enc
 func useGuardAvailable() {
         // expected-note@-1 3{{add @available attribute to enclosing global function}}
   // Guard fallthrough should refine context
-  guard #available(OSX 10.51, *) else { // expected-note {{enclosing scope here}}
-    let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  guard #available(macOS 10.51, *) else { // expected-note {{enclosing scope here}}
+    let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     return
   }
 
   let _ = globalFuncAvailableOn10_51()
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+  if #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   }
 
   if globalFuncAvailableOn10_51() > 0 {
-    guard #available(OSX 10.52, *),
+    guard #available(macOS 10.52, *),
             let x = injectToOptional(globalFuncAvailableOn10_52()) else { return }
     _ = x
   }
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func twoGuardsInSameBlock(_ p: Int) {
         // expected-note@-1 {{add @available attribute to enclosing global function}}
   if (p > 0) {
-    guard #available(OSX 10.51, *) else { return }
+    guard #available(macOS 10.51, *) else { return }
 
     let _ = globalFuncAvailableOn10_51()
 
-    guard #available(OSX 10.52, *) else { return }
+    guard #available(macOS 10.52, *) else { return }
 
     let _ = globalFuncAvailableOn10_52()
   }
 
-  let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Refining while loops
 
-while globalFuncAvailableOn10_51() > 10 { } // expected-error {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+while globalFuncAvailableOn10_51() > 10 { } // expected-error {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
+while #available(macOS 10.51, *), // expected-note {{enclosing scope here}}
       globalFuncAvailableOn10_51() > 10 {
 
   let _ = globalFuncAvailableOn10_51()
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
   while globalFuncAvailableOn10_51() > 11,
         let _ = injectToOptional(5),
-        #available(OSX 10.52, *) {
+        #available(macOS 10.52, *) {
     let _ = globalFuncAvailableOn10_52();
   }
 
-  while #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+  while #available(macOS 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   }
 }
 
@@ -1187,34 +1187,34 @@ while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
 // take whatever indentation was there before and add 4 spaces to it).
 
 functionAvailableOn10_51()
-    // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-    // expected-note@-2 {{add 'if #available' version check}} {{1-27=if #available(OSX 10.51, *) {\n    functionAvailableOn10_51()\n} else {\n    // Fallback on earlier versions\n}}}
+    // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}} {{1-27=if #available(macOS 10.51, *) {\n    functionAvailableOn10_51()\n} else {\n    // Fallback on earlier versions\n}}}
 
 let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{1-57=if #available(OSX 10.51, *) {\n    let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil\n} else {\n    // Fallback on earlier versions\n}}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{1-57=if #available(macOS 10.51, *) {\n    let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil\n} else {\n    // Fallback on earlier versions\n}}}
 
 func fixitForReferenceInGlobalFunction() {
-      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.51, *)\n}}
+      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.51, *)\n}}
   functionAvailableOn10_51()
-      // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(OSX 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
+      // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(macOS 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
 
 public func fixitForReferenceInGlobalFunctionWithDeclModifier() {
-      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.51, *)\n}}
+      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.51, *)\n}}
   functionAvailableOn10_51()
-      // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(OSX 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
+      // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(macOS 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
 
 func fixitForReferenceInGlobalFunctionWithAttribute() -> Never {
-    // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.51, *)\n}}
+    // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.51, *)\n}}
   functionAvailableOn10_51()
-    // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-    // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(OSX 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
+    // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(macOS 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
     
 }
 
@@ -1222,97 +1222,97 @@ func takesAutoclosure(_ c : @autoclosure () -> ()) {
 }
 
 class ClassForFixit {
-        // expected-note@-1 12{{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
+        // expected-note@-1 12{{add @available attribute to enclosing class}} {{1-1=@available(macOS 10.51, *)\n}}
   func fixitForReferenceInMethod() {
-        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
+        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
     functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-        // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(OSX 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+        // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(macOS 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 
   func fixitForReferenceNestedInMethod() {
-          // expected-note@-1 3{{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
+          // expected-note@-1 3{{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
     func inner() {
       functionAvailableOn10_51()
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-          // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(OSX 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
+          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+          // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(macOS 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
     }
 
     let _: () -> () = { () in
       functionAvailableOn10_51()
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-          // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(OSX 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
+          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+          // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(macOS 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
     }
 
     takesAutoclosure(functionAvailableOn10_51())
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-          // expected-note@-2 {{add 'if #available' version check}} {{5-49=if #available(OSX 10.51, *) {\n        takesAutoclosure(functionAvailableOn10_51())\n    } else {\n        // Fallback on earlier versions\n    }}}
+          // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+          // expected-note@-2 {{add 'if #available' version check}} {{5-49=if #available(macOS 10.51, *) {\n        takesAutoclosure(functionAvailableOn10_51())\n    } else {\n        // Fallback on earlier versions\n    }}}
           
   }
 
   var fixitForReferenceInPropertyAccessor: Int {
-        // expected-note@-1 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
+        // expected-note@-1 {{add @available attribute to enclosing var}} {{3-3=@available(macOS 10.51, *)\n  }}
     get {
       functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-        // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(OSX 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
+        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+        // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(macOS 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
         
       return 5
     }
   }
 
   var fixitForReferenceInPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
 
   lazy var fixitForReferenceInLazyPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(macOS 10.51, *)\n  }}
 
   private lazy var fixitForReferenceInPrivateLazyPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(macOS 10.51, *)\n  }}
 
   lazy private var fixitForReferenceInLazyPrivatePropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(macOS 10.51, *)\n  }}
 
   static var fixitForReferenceInStaticPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing static var}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing static var}} {{3-3=@available(macOS 10.51, *)\n  }}
 
   var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn10_51? = nil, other: Int = 7
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
 
   func fixitForRefInGuardOfIf() {
-        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
+        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
     if (globalFuncAvailableOn10_51() > 1066) {
       let _ = 5
       let _ = 6
     }
-        // expected-error@-4 {{'globalFuncAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-        // expected-note@-5 {{add 'if #available' version check}} {{5-6=if #available(OSX 10.51, *) {\n        if (globalFuncAvailableOn10_51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-error@-4 {{'globalFuncAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+        // expected-note@-5 {{add 'if #available' version check}} {{5-6=if #available(macOS 10.51, *) {\n        if (globalFuncAvailableOn10_51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
 
 extension ClassToExtend {
         // expected-note@-1 {{add @available attribute to enclosing extension}}
   func fixitForReferenceInExtensionMethod() {
-        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(OSX 10.51, *)\n  }}
+        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
     functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
-        // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(OSX 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-error@-1 {{'functionAvailableOn10_51()' is only available on macOS 10.51 or newer}}
+        // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(macOS 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
 
 enum EnumForFixit {
-      // expected-note@-1 2{{add @available attribute to enclosing enum}} {{1-1=@available(OSX 10.51, *)\n}}
+      // expected-note@-1 2{{add @available attribute to enclosing enum}} {{1-1=@available(macOS 10.51, *)\n}}
   case CaseWithUnavailablePayload(p: ClassAvailableOn10_51)
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing case}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing case}} {{3-3=@available(macOS 10.51, *)\n  }}
 
   case CaseWithUnavailablePayload2(p: ClassAvailableOn10_51), WithoutPayload
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing case}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-error@-1 {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing case}} {{3-3=@available(macOS 10.51, *)\n  }}
       
 }
 
@@ -1327,18 +1327,18 @@ class X {
 }
 
 func testForFixitWithNestedMemberRefExpr() {
-    // expected-note@-1 2{{add @available attribute to enclosing global function}} {{1-1=@available(OSX 10.52, *)\n}}
+    // expected-note@-1 2{{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.52, *)\n}}
   let x = X()
 
   x.y.z = globalFuncAvailableOn10_52()
-      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-39=if #available(OSX 10.52, *) {\n      x.y.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
+      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-39=if #available(macOS 10.52, *) {\n      x.y.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
 
   // Access via dynamic member reference
   let anyX: AnyObject = x
   anyX.y?.z = globalFuncAvailableOn10_52()
-      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available on OS X 10.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-43=if #available(OSX 10.52, *) {\n      anyX.y?.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
+      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available on macOS 10.52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-43=if #available(macOS 10.52, *) {\n      anyX.y?.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
 
@@ -1346,14 +1346,14 @@ func testForFixitWithNestedMemberRefExpr() {
 
 protocol ProtocolWithRequirementMentioningUnavailable {
       // expected-note@-1 4{{add @available attribute to enclosing protocol}}
-  func hasUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func hasUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
       
 
-  func hasUnavailableReturn() -> ClassAvailableOn10_51 // expected-error * {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  func hasUnavailableReturn() -> ClassAvailableOn10_51 // expected-error * {{'ClassAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
 
-  @available(OSX 10.51, *)
+  @available(macOS 10.51, *)
   func hasUnavailableWithAnnotation(_ p: ClassAvailableOn10_51) -> ClassAvailableOn10_51
 }
 
@@ -1363,28 +1363,28 @@ protocol HasMethodF {
 }
 
 class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  @available(macOS, introduced: 10.51)
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on macOS 10.50.0 and newer}}
 }
 
 
 class ConformsWithFunctionIntroducedOnMinimumDeploymentTarget : HasMethodF {
   // Even though this function is less available than its requirement,
   // it is available on a deployment targets, so the conformance is safe.
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   func f(_ p: Int) { }
 }
 
 class SuperHasMethodF {
-  @available(OSX, introduced: 10.51)
-    func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  @available(macOS, introduced: 10.51)
+    func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on macOS 10.50.0 and newer}}
 }
 
 class TriesToConformWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-note {{conformance introduced here}}
   // The conformance here is generating an error on f in the super class.
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class ConformsWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF {
   // Limiting this class to only be available on 10.51 and newer means that
   // the witness in SuperHasMethodF is safe for the requirement on HasMethodF.
@@ -1403,69 +1403,69 @@ class ConformsByOverridingFunctionInSuperClass : SuperHasMethodF, HasMethodF {
 // in extension
 class HasNoMethodF1 { }
 extension HasNoMethodF1 : HasMethodF { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  @available(macOS, introduced: 10.51)
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on macOS 10.50.0 and newer}}
 }
 
 class HasNoMethodF2 { }
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 extension HasNoMethodF2 : HasMethodF { // expected-note {{conformance introduced here}}
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on macOS 10.50.0 and newer}}
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class HasNoMethodF3 { }
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 extension HasNoMethodF3 : HasMethodF {
   // We expect this conformance to succeed because on every version where HasNoMethodF3
   // is available, HasNoMethodF3's f() is as available as the protocol requirement
   func f(_ p: Int) { }
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 protocol HasMethodFOn10_51 {
   func f(_ p: Int) // expected-note {{protocol requirement here}}
 }
 
 class ConformsToUnavailableProtocolWithUnavailableWitness : HasMethodFOn10_51 {
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func f(_ p: Int) { }
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 class HasNoMethodF4 { }
-@available(OSX, introduced: 10.52)
+@available(macOS, introduced: 10.52)
 extension HasNoMethodF4 : HasMethodFOn10_51 { // expected-note {{conformance introduced here}}
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available on OS X 10.51 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available on macOS 10.51 and newer}}
 }
 
-@available(OSX, introduced: 10.51)
+@available(macOS, introduced: 10.51)
 protocol HasTakesClassAvailableOn10_51 {
   func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) // expected-note 2{{protocol requirement here}}
 }
 
 class AttemptsToConformToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced: 10.52)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
+  @available(macOS, introduced: 10.52)
+  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on macOS 10.51 and newer}}
   }
 }
 
 class ConformsToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) {
   }
 }
 
 class TakesClassAvailableOn10_51_A { }
 extension TakesClassAvailableOn10_51_A : HasTakesClassAvailableOn10_51 { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced: 10.52)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
+  @available(macOS, introduced: 10.52)
+  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on macOS 10.51 and newer}}
   }
 }
 
 class TakesClassAvailableOn10_51_B { }
 extension TakesClassAvailableOn10_51_B : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) {
   }
 }
@@ -1480,56 +1480,56 @@ class TestAvailabilityDoesNotAffectWitnessCandidacy : HasMethodF { // expected-n
   // less available than the protocol requires and there is a less specialized
   // witness that has suitable availability.
 
-  @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+  @available(macOS, introduced: 10.51)
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on macOS 10.50.0 and newer}}
 
   func f<T>(_ p: T) { }
 }
 
 protocol HasUnavailableMethodF {
-  @available(OSX, introduced: 10.51)
+  @available(macOS, introduced: 10.51)
   func f(_ p: String)
 }
 
 class ConformsWithUnavailableFunction : HasUnavailableMethodF {
-  @available(OSX, introduced: 10.9)
+  @available(macOS, introduced: 10.9)
   func f(_ p: String) { }
 }
 
 func useUnavailableProtocolMethod(_ h: HasUnavailableMethodF) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  h.f("Foo") // expected-error {{'f' is only available on OS X 10.51 or newer}}
+  h.f("Foo") // expected-error {{'f' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func useUnavailableProtocolMethod<H : HasUnavailableMethodF> (_ h: H) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  h.f("Foo") // expected-error {{'f' is only available on OS X 10.51 or newer}}
+  h.f("Foo") // expected-error {{'f' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 
 // Short-form @available() annotations
 
-@available(OSX 10.51, *)
+@available(macOS 10.51, *)
 class ClassWithShortFormAvailableOn10_51 {
 }
 
-@available(OSX 10.53, *)
+@available(macOS 10.53, *)
 class ClassWithShortFormAvailableOn10_53 {
 }
 
-@available(OSX 10.54, *)
+@available(macOS 10.54, *)
 class ClassWithShortFormAvailableOn10_54 {
 }
 
-@available(OSX 10.9, *)
+@available(macOS 10.9, *)
 func funcWithShortFormAvailableOn10_9() {
-  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX 10.51, *)
+@available(macOS 10.51, *)
 func funcWithShortFormAvailableOn10_51() {
   let _ = ClassWithShortFormAvailableOn10_51()
 }
@@ -1537,7 +1537,7 @@ func funcWithShortFormAvailableOn10_51() {
 @available(iOS 14.0, *)
 func funcWithShortFormAvailableOniOS14() {
   // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1548,23 +1548,23 @@ func funcWithShortFormAvailableOniOS14AndOSX10_53() {
 
 // Not idiomatic but we need to be able to handle it.
 @available(iOS 8.0, *)
-@available(OSX 10.51, *)
+@available(macOS 10.51, *)
 func funcWithMultipleShortFormAnnotationsForDifferentPlatforms() {
   let _ = ClassWithShortFormAvailableOn10_51()
 }
 
-@available(OSX 10.51, *)
-@available(OSX 10.53, *)
-@available(OSX 10.52, *)
+@available(macOS 10.51, *)
+@available(macOS 10.53, *)
+@available(macOS 10.52, *)
 func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
   let _ = ClassWithShortFormAvailableOn10_53()
 
-  let _ = ClassWithShortFormAvailableOn10_54() // expected-error {{'ClassWithShortFormAvailableOn10_54' is only available on OS X 10.54 or newer}}
+  let _ = ClassWithShortFormAvailableOn10_54() // expected-error {{'ClassWithShortFormAvailableOn10_54' is only available on macOS 10.54 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX 10.9, *)
-@available(OSX, unavailable)
+@available(macOS 10.9, *)
+@available(macOS, unavailable)
 func unavailableWins() { } // expected-note {{'unavailableWins()' has been explicitly marked unavailable here}}
 
 func useShortFormAvailable() {
@@ -1572,18 +1572,18 @@ func useShortFormAvailable() {
 
   funcWithShortFormAvailableOn10_9()
 
-  funcWithShortFormAvailableOn10_51() // expected-error {{'funcWithShortFormAvailableOn10_51()' is only available on OS X 10.51 or newer}}
+  funcWithShortFormAvailableOn10_51() // expected-error {{'funcWithShortFormAvailableOn10_51()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   funcWithShortFormAvailableOniOS14()
 
-  funcWithShortFormAvailableOniOS14AndOSX10_53() // expected-error {{'funcWithShortFormAvailableOniOS14AndOSX10_53()' is only available on OS X 10.53 or newer}}
+  funcWithShortFormAvailableOniOS14AndOSX10_53() // expected-error {{'funcWithShortFormAvailableOniOS14AndOSX10_53()' is only available on macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  funcWithMultipleShortFormAnnotationsForDifferentPlatforms() // expected-error {{'funcWithMultipleShortFormAnnotationsForDifferentPlatforms()' is only available on OS X 10.51 or newer}}
+  funcWithMultipleShortFormAnnotationsForDifferentPlatforms() // expected-error {{'funcWithMultipleShortFormAnnotationsForDifferentPlatforms()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available on OS X 10.53 or newer}}
+  funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available on macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   unavailableWins() // expected-error {{'unavailableWins()' is unavailable}}

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -17,10 +17,10 @@ var globalAvailableOn10_52: Int = 11
 // Top level should reflect the minimum deployment target.
 let ignored1: Int = globalAvailableOn10_9
 
-let ignored2: Int = globalAvailableOn10_51 // expected-error {{'globalAvailableOn10_51' is only available on OS X 10.51 or newer}}
+let ignored2: Int = globalAvailableOn10_51 // expected-error {{'globalAvailableOn10_51' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing let}}
 
-let ignored3: Int = globalAvailableOn10_52 // expected-error {{'globalAvailableOn10_52' is only available on OS X 10.52 or newer}}
+let ignored3: Int = globalAvailableOn10_52 // expected-error {{'globalAvailableOn10_52' is only available on macOS 10.52 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing let}}
 
 @available(OSX, introduced: 10.51)
@@ -32,16 +32,16 @@ func useFromOtherOn10_51() {
 
   let o10_9 = OtherIntroduced10_9()
   o10_9.extensionMethodOnOtherIntroduced10_9AvailableOn10_51(o10_51)
-  _ = o10_51.returns10_52Introduced10_52() // expected-error {{'returns10_52Introduced10_52()' is only available on OS X 10.52 or newer}}
+  _ = o10_51.returns10_52Introduced10_52() // expected-error {{'returns10_52Introduced10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = OtherIntroduced10_52() // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+  _ = OtherIntroduced10_52() // expected-error {{'OtherIntroduced10_52' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  o10_51.extensionMethodOnOtherIntroduced10_51AvailableOn10_52() // expected-error {{'extensionMethodOnOtherIntroduced10_51AvailableOn10_52()' is only available on OS X 10.52 or newer}}
+  o10_51.extensionMethodOnOtherIntroduced10_51AvailableOn10_52() // expected-error {{'extensionMethodOnOtherIntroduced10_51AvailableOn10_52()' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = OtherIntroduced10_51.NestedIntroduced10_52() // expected-error {{'NestedIntroduced10_52' is only available on OS X 10.52 or newer}}
+  _ = OtherIntroduced10_51.NestedIntroduced10_52() // expected-error {{'NestedIntroduced10_52' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -51,7 +51,7 @@ func useFromOtherOn10_52() {
 
   let n10_52 = OtherIntroduced10_51.NestedIntroduced10_52()
   _ = n10_52.returns10_52()
-  _ = n10_52.returns10_53() // expected-error {{'returns10_53()' is only available on OS X 10.53 or newer}}
+  _ = n10_52.returns10_53() // expected-error {{'returns10_53()' is only available on macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // This will trigger validation of the global in availability_in_multi_other.swift

--- a/test/Sema/availability_versions_objc_api.swift
+++ b/test/Sema/availability_versions_objc_api.swift
@@ -9,7 +9,7 @@ import Foundation
 // Tests for uses of version-based potential unavailability imported from ObjC APIs.
 func callUnavailableObjC() {
       // expected-note@-1 5{{add @available attribute to enclosing global function}}
-  _ = NSAvailableOn10_51() // expected-error {{'NSAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = NSAvailableOn10_51() // expected-error {{'NSAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   
@@ -17,30 +17,30 @@ func callUnavailableObjC() {
     let o = NSAvailableOn10_51()!
     
     // Properties
-    _ = o.propertyOn10_52 // expected-error {{'propertyOn10_52' is only available on OS X 10.52 or newer}}
+    _ = o.propertyOn10_52 // expected-error {{'propertyOn10_52' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    o.propertyOn10_52 = 22 // expected-error {{'propertyOn10_52' is only available on OS X 10.52 or newer}}
+    o.propertyOn10_52 = 22 // expected-error {{'propertyOn10_52' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     // Methods
-    o.methodAvailableOn10_52() // expected-error {{'methodAvailableOn10_52()' is only available on OS X 10.52 or newer}}
+    o.methodAvailableOn10_52() // expected-error {{'methodAvailableOn10_52()' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     // Initializers
     
-    _ = NSAvailableOn10_51(stringOn10_52:"Hi") // expected-error {{'init(stringOn10_52:)' is only available on OS X 10.52 or newer}}
+    _ = NSAvailableOn10_51(stringOn10_52:"Hi") // expected-error {{'init(stringOn10_52:)' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
 
 // Declarations with Objective-C-originated potentially unavailable APIs
 
-func functionWithObjCParam(o: NSAvailableOn10_51) { // expected-error {{'NSAvailableOn10_51' is only available on OS X 10.51 or newer}}
+func functionWithObjCParam(o: NSAvailableOn10_51) { // expected-error {{'NSAvailableOn10_51' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing global function}}
 }
 
-class ClassExtendingUnvailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available on OS X 10.51 or newer}}
+class ClassExtendingUnvailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 
@@ -55,42 +55,42 @@ extension SomeSoonToBeConformingClass : NSProtocolAvailableOn10_51 {
 
 // Enums from Objective-C
 
-let _: NSPotentiallyUnavailableOptions = .first // expected-error {{'NSPotentiallyUnavailableOptions' is only available on OS X 10.51 or newer}}
+let _: NSPotentiallyUnavailableOptions = .first // expected-error {{'NSPotentiallyUnavailableOptions' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSOptionsWithUnavailableElement = .third // expected-error {{'third' is only available on OS X 10.51 or newer}}
+let _: NSOptionsWithUnavailableElement = .third // expected-error {{'third' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSUnavailableEnum = .first // expected-error {{'NSUnavailableEnum' is only available on OS X 10.51 or newer}}
+let _: NSUnavailableEnum = .first // expected-error {{'NSUnavailableEnum' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSEnumWithUnavailableElement = .third // expected-error {{'third' is only available on OS X 10.51 or newer}}
+let _: NSEnumWithUnavailableElement = .third // expected-error {{'third' is only available on macOS 10.51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Differing availability on getters and setters imported from ObjC.
 
 func gettersAndSettersFromObjC(o: NSAvailableOn10_9) {
       // expected-note@-1 6{{add @available attribute to enclosing global function}}
-  let _: Int = o.propertyOn10_51WithSetterOn10_52After  // expected-error {{'propertyOn10_51WithSetterOn10_52After' is only available on OS X 10.51 or newer}}
+  let _: Int = o.propertyOn10_51WithSetterOn10_52After  // expected-error {{'propertyOn10_51WithSetterOn10_52After' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) {
     // Properties with unavailable accessors declared before property in Objective-C header
-    o.propertyOn10_51WithSetterOn10_52Before = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52Before' is only available on OS X 10.52 or newer}}
+    o.propertyOn10_51WithSetterOn10_52Before = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52Before' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    let _: Int = o.propertyOn10_51WithGetterOn10_52Before // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52Before' is only available on OS X 10.52 or newer}}
+    let _: Int = o.propertyOn10_51WithGetterOn10_52Before // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52Before' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
     // Properties with unavailable accessors declared after property in Objective-C header
-    o.propertyOn10_51WithSetterOn10_52After = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52After' is only available on OS X 10.52 or newer}}
+    o.propertyOn10_51WithSetterOn10_52After = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52After' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    let _: Int = o.propertyOn10_51WithGetterOn10_52After // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52After' is only available on OS X 10.52 or newer}}
+    let _: Int = o.propertyOn10_51WithGetterOn10_52After // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52After' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
     // Property with unavailable setter redeclared in Objective-C category
-    o.readOnlyRedeclaredWithSetterInCategory = 5 // expected-error {{setter for 'readOnlyRedeclaredWithSetterInCategory' is only available on OS X 10.52 or newer}}
+    o.readOnlyRedeclaredWithSetterInCategory = 5 // expected-error {{setter for 'readOnlyRedeclaredWithSetterInCategory' is only available on macOS 10.52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -99,13 +99,13 @@ func gettersAndSettersFromObjC(o: NSAvailableOn10_9) {
 
 func useGlobalsFromObjectiveC() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  _ = globalStringAvailableOn10_51 // expected-error {{'globalStringAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = globalStringAvailableOn10_51 // expected-error {{'globalStringAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = globalStringAvailableOn10_52 // expected-error {{'globalStringAvailableOn10_52' is only available on OS X 10.52 or newer}}
+  _ = globalStringAvailableOn10_52 // expected-error {{'globalStringAvailableOn10_52' is only available on macOS 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = globalClassInstanceAvailableOn10_51 // expected-error {{'globalClassInstanceAvailableOn10_51' is only available on OS X 10.51 or newer}}
+  _ = globalClassInstanceAvailableOn10_51 // expected-error {{'globalClassInstanceAvailableOn10_51' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   if #available(OSX 10.51, *) {
@@ -167,7 +167,7 @@ class UserClass : UnannotatedFrameworkProtocol {
 
 func callViaUnannotatedFrameworkProtocol(p: UnannotatedFrameworkProtocol) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = p.returnSomething() // expected-error {{'returnSomething()' is only available on OS X 10.51 or newer}}
+  let _ = p.returnSomething() // expected-error {{'returnSomething()' is only available on macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 

--- a/test/Sema/availability_versions_playgrounds.swift
+++ b/test/Sema/availability_versions_playgrounds.swift
@@ -23,19 +23,19 @@ func someFunction() {
     availableOn10_50() // no-warning
   }
 
-  if #available(OSX 10.50, *) { // expected-note {{enclosing scope here}}
+  if #available(macOS 10.50, *) { // expected-note {{enclosing scope here}}
     // Still warn if the check is useless because an enclosing #available rules
     // it out.
-    if #available(OSX 10.50, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+    if #available(macOS 10.50, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     }
   }
 }
 
-@available(OSX 10.50, *)
+@available(macOS 10.50, *)
 func availableOn10_50() { // expected-note {{enclosing scope here}}
   // Still warn if the check is useless because an enclosing @available rules
   // it out.
-  if #available(OSX 10.50, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
+  if #available(macOS 10.50, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   }
 }
 

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck -parse-as-library -target x86_64-apple-macosx10.51 %clang-importer-sdk -I %S/Inputs/custom-modules %s -verify
 // RUN: %swift -typecheck -parse-as-library -target x86_64-apple-macosx10.51 %clang-importer-sdk -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
 //
-// This test requires a target of OS X 10.51 or later to test deprecation
+// This test requires a target of macOS 10.51 or later to test deprecation
 // diagnostics because (1) we only emit deprecation warnings if a symbol is
 // deprecated on all deployment targets and (2) symbols deprecated on 10.9 and
 // earlier are imported as unavailable.
@@ -26,11 +26,11 @@ func useClassThatTriggersImportOfDeprecatedEnum() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in OS X 10.51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 10.51: Use a different API}}
 }
 
-func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in OS X 10.51: Use a different API}}
+func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
 }
 
 
@@ -83,20 +83,20 @@ class ClassWithComputedPropertyDeprecatedIn10_51 {
     }
   }
 
-  var unannotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  var unannotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
     get {
-      return ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+      return ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
     }
     set(newValue) {
-      _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+      _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
     }
   }
 
-  var unannotatedStoredPropertyOfTypeDeprecatedIn10_51 : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  var unannotatedStoredPropertyOfTypeDeprecatedIn10_51 : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 func usesFunctionDeprecatedIn10_51() {
-  _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
@@ -104,34 +104,34 @@ func annotatedUsesFunctionDeprecatedIn10_51() {
   _ = ClassDeprecatedIn10_51()
 }
 
-func hasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+func hasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedHasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) {
 }
 
-func hasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+func hasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedHasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 {
 }
 
-var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
 var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51?
 
 
 enum EnumWithDeprecatedCasePayload {
-  case WithDeprecatedPayload(p: ClassDeprecatedIn10_51) // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  case WithDeprecatedPayload(p: ClassDeprecatedIn10_51) // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
   @available(OSX, introduced: 10.8, deprecated: 10.51)
   case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn10_51)
 }
 
-extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
 }
 
@@ -142,15 +142,15 @@ extension ClassDeprecatedIn10_51 {
 }
 
 func callMethodInDeprecatedExtension() {
-  let o = ClassDeprecatedIn10_51() // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
+  let o = ClassDeprecatedIn10_51() // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
 
-  o.methodInExtensionOfClassDeprecatedIn10_51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn10_51()' was deprecated in OS X 10.51}}
+  o.methodInExtensionOfClassDeprecatedIn10_51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn10_51()' was deprecated in macOS 10.51}}
 }
 
 func functionWithDeprecatedMethodInDeadElseBranch() {
   if #available(iOS 8.0, *) {
   } else {
-    // This branch is dead on OS X, so we shouldn't emit a deprecation warning in it.
+    // This branch is dead on macOS, so we shouldn't emit a deprecation warning in it.
     let _ = ClassDeprecatedIn10_9()  // no-warning
   }
 
@@ -161,7 +161,7 @@ func functionWithDeprecatedMethodInDeadElseBranch() {
   }
 
   guard #available(iOS 8.0, *) else {
-    // This branch is dead because our platform is OS X, so the wildcard always matches.
+    // This branch is dead because our platform is macOS, so the wildcard always matches.
     let _ = ClassDeprecatedIn10_9()  // no-warning
   }
 }

--- a/test/Serialization/target-too-new.swift
+++ b/test/Serialization/target-too-new.swift
@@ -7,5 +7,5 @@
 
 // REQUIRES: OS=macosx
 
-// CHECK: :[[@LINE+1]]:8: error: module file's minimum deployment target is OS X v10.50: {{.*}}empty.swiftmodule{{$}}
+// CHECK: :[[@LINE+1]]:8: error: module file's minimum deployment target is macOS v10.50: {{.*}}empty.swiftmodule{{$}}
 import empty

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -7220,7 +7220,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.attribute.availability,
             key.platform: source.availability.platform.osx,
             key.is_unavailable: 1,
-            key.message: "APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift",
+            key.message: "APIs deprecated as of macOS 10.9 and earlier are unavailable in Swift",
             key.deprecated: "10.1"
           }
         ],

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -9,13 +9,13 @@ func foo() { }
 
 func useFoo() {
   if #available(macOS 10.12.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{23-30=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}} {{23-30=10.12.2}}
   }
 }
 
 func useFooDifferentSpelling() {
   if #available(OSX 10.12.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{21-28=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}} {{21-28=10.12.2}}
   }
 }
 
@@ -27,14 +27,14 @@ func useFooAlreadyOkRange() {
 
 func useFooUnaffectedSimilarText() {
   if #available(iOS 10.12.10, OSX 10.12.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{35-42=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}} {{35-42=10.12.2}}
   }
 }
 
 func useFooWayOff() {
     // expected-note@-1{{add @available attribute to enclosing global function}}
   if #available(OSX 10.10, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}}
     // expected-note@-1{{add 'if #available' version check}}
   }
 }
@@ -42,14 +42,14 @@ func useFooWayOff() {
 @available(OSX 10.12, *)
 class FooUser {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{16-21=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}} {{16-21=10.12.2}}
   }
 }
 
 @available(OSX, introduced: 10.12, obsoleted: 10.12.4)
 class FooUser2 {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{29-34=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}} {{29-34=10.12.2}}
   }
 }
 
@@ -57,7 +57,7 @@ class FooUser2 {
 @objc
 class FooUser3 : NSObject {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{29-34=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on macOS 10.12.2 or newer}} {{29-34=10.12.2}}
   }
 }
 

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -3,7 +3,7 @@
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9,
               message: "you don't want to do that anyway")
 func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in OS X 10.9}}
+// expected-note @-1{{'doSomething()' was obsoleted in macOS 10.9}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable: you don't want to do that anyway}}
 
@@ -11,14 +11,14 @@ doSomething() // expected-error{{'doSomething()' is unavailable: you don't want 
 // Preservation of major.minor.micro
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9.1)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in OS X 10.9.1}}
+// expected-note @-1{{'doSomethingElse()' was obsoleted in macOS 10.9.1}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
 
 // Preservation of minor-only version
 @available(OSX, introduced: 8.0, deprecated: 8.5, obsoleted: 10)
 func doSomethingReallyOld() { }
-// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in OS X 10}}
+// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in macOS 10}}
 
 doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable}}
 
@@ -28,19 +28,19 @@ doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailabl
               message: "Use another function")
 func deprecatedFunctionWithMessage() { }
 
-deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in OS X 10.10: Use another function}}
+deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in macOS 10.10: Use another function}}
 
 
 @available(OSX, introduced: 10.5, deprecated: 10.10)
 func deprecatedFunctionWithoutMessage() { }
 
-deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in OS X 10.10}}
+deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in macOS 10.10}}
 
 @available(OSX, introduced: 10.5, deprecated: 10.10,
               message: "Use BetterClass instead")
 class DeprecatedClass { }
 
-func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in OS X 10.10: Use BetterClass instead}}
+func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in macOS 10.10: Use BetterClass instead}}
 
 @available(OSX, introduced: 10.5, deprecated: 10.11,
               message: "Use BetterClass instead")
@@ -65,7 +65,7 @@ doSomethingNotOniOS() // okay
 @available(OSX, deprecated)
 func doSomethingDeprecatedOnOSX() { }
 
-doSomethingDeprecatedOnOSX() // expected-warning{{'doSomethingDeprecatedOnOSX()' is deprecated on OS X}}
+doSomethingDeprecatedOnOSX() // expected-warning{{'doSomethingDeprecatedOnOSX()' is deprecated on macOS}}
 
 @available(iOS, deprecated)
 func doSomethingDeprecatedOniOS() { }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -654,8 +654,8 @@ if run_vendor == 'apple':
                              'Perhaps the simulator is not working.')
 
     elif run_os == 'macosx':
-        # OS X
-        lit_config.note("Testing OS X " + config.variant_triple)
+        # macOS
+        lit_config.note("Testing macOS " + config.variant_triple)
 
         xcrun_sdk_name = "macosx"
         config.target_cc_options = (

--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -1563,7 +1563,7 @@ NSStringAPIs.test("removingPercentEncoding") {
 }
 
 NSStringAPIs.test("removingPercentEncoding/OSX 10.9")
-  .xfail(.osxMinor(10, 9, reason: "looks like a bug in Foundation in OS X 10.9"))
+  .xfail(.osxMinor(10, 9, reason: "looks like a bug in Foundation in macOS 10.9"))
   .xfail(.iOSMajor(7, reason: "same bug in Foundation in iOS 7.*"))
   .skip(.iOSSimulatorAny("same bug in Foundation in iOS Simulator 7.*"))
   .code {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -598,7 +598,7 @@ static void reportAttributes(ASTContext &Ctx,
         PlatformUID = UIdent(); break;
       case PlatformKind::iOS:
         PlatformUID = PlatformIOS; break;
-      case PlatformKind::OSX:
+      case PlatformKind::macOS:
         PlatformUID = PlatformOSX; break;
       case PlatformKind::tvOS:
         PlatformUID = PlatformtvOS; break;
@@ -606,7 +606,7 @@ static void reportAttributes(ASTContext &Ctx,
         PlatformUID = PlatformWatchOS; break;
       case PlatformKind::iOSApplicationExtension:
         PlatformUID = PlatformIOSAppExt; break;
-      case PlatformKind::OSXApplicationExtension:
+      case PlatformKind::macOSApplicationExtension:
         PlatformUID = PlatformOSXAppExt; break;
       case PlatformKind::tvOSApplicationExtension:
         PlatformUID = PlatformtvOSAppExt; break;


### PR DESCRIPTION
It's been pointed out that swiftc still uses 'OSX' or 'OS X' in a lot of places it ought to be saying 'macOS' now. This change switches many, but not all, of those cases. In particular it fixes those cases where the compiler gives feedback about availability guards (the original report was about these) as well as switching internal symbols and docs.

Notably: this change does not eliminate support for 'OSX' in availability checks (it's still a synonym) nor does it change all of the tests that _use_ 'OSX' in those checks; I figured there was no point since the synonym is likely to be supported in perpetuity and it's good to test that fact too. Moreover this change does not alter the terminology in any of the configury or build system; it's my _hope_ that by avoiding that, I can avoid unintentional breakage, though I suspect I'll still be breaking something.

Opinions welcome on how else to stage this.

rdar://35127522