### PR TITLE
[4.1] Handle labeled singleton tuples in the setter value argument

### DIFF
--- a/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -89,3 +89,7 @@ void escapeNonnullBlock(void (^_Nonnull block)(void));
 void noescapeBlockAlias(__attribute__((noescape)) dispatch_block_t block);
 void noescapeNonnullBlockAlias(__attribute__((noescape)) _Nonnull dispatch_block_t block);
 void escapeBlockAlias(dispatch_block_t block);
+
+@interface ObjectWithSplitProperty : NSObject
+@property (nonatomic, setter=private_setFlagForSomething:) BOOL flagForSomething;
+@end

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -253,6 +253,6 @@ class HasLazyProperty : NSObject, HasProperty {
 //   which can cause fits for SILGenApply the way it's currently implemented.
 // CHECK-LABEL: sil hidden @_T015objc_properties26testPropSetWithPreposition
 func testPropSetWithPreposition(object: ObjectWithSplitProperty?) {
-  // CHECK: #ObjectWithSplitProperty.flagForSomething!setter.1.foreign : (ObjectWithSplitProperty) -> (Bool) -> (), $@convention(objc_method) (ObjCBool, ObjectWithSplitProperty) -> ()
+  // CHECK: #ObjectWithSplitProperty.flagForSomething!setter.1.foreign : (ObjectWithSplitProperty) -> (Bool) -> (), $@convention(objc_method) ({{Bool|ObjCBool}}, ObjectWithSplitProperty) -> ()
   object?.flagForSomething = false
 }

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -248,3 +248,11 @@ class HasLazyProperty : NSObject, HasProperty {
 // CHECK-LABEL: sil hidden @_T015objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgvg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {
 // CHECK: class_method %0 : $HasLazyProperty, #HasLazyProperty.instanceMethod!1 : (HasLazyProperty) -> () -> NSObject?
 // CHECK: return
+
+//   The way we import this setter splits the name into the parameter list,
+//   which can cause fits for SILGenApply the way it's currently implemented.
+// CHECK-LABEL: sil hidden @_T015objc_properties26testPropSetWithPreposition
+func testPropSetWithPreposition(object: ObjectWithSplitProperty?) {
+  // CHECK: #ObjectWithSplitProperty.flagForSomething!setter.1.foreign : (ObjectWithSplitProperty) -> (Bool) -> (), $@convention(objc_method) (ObjCBool, ObjectWithSplitProperty) -> ()
+  object?.flagForSomething = false
+}


### PR DESCRIPTION
This can get introduced by somewhat pathological behavior in the importer combined with SILGenApply's reliance on parallel tuple destructuring.  Both of these should be fixed, but this patch is much simpler.

rdar://34913800. 4.1 version of #12646.