### PR TITLE
[DeadFunctionElimination] Pass on keypaths to foreign DeclRef properties.

### DIFF
--- a/test/SILOptimizer/Inputs/keypaths_objc.h
+++ b/test/SILOptimizer/Inputs/keypaths_objc.h
@@ -1,0 +1,14 @@
+@import Foundation;
+
+@interface ObjCFoo
+
+@property(readonly) NSString *_Nonnull objcProp;
+
+@end
+
+
+@interface ObjCFoo (Extras)
+
+@property(readonly) NSString *_Nonnull objcExtraProp;
+
+@end

--- a/test/SILOptimizer/dead_func_objc_extension_keypath.swift
+++ b/test/SILOptimizer/dead_func_objc_extension_keypath.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -O -emit-sil -import-objc-header %S/Inputs/keypaths_objc.h
+// REQUIRES: objc_interop
+
+import Foundation
+public func test_nocrash_rdar34913689() {
+  _ = \ObjCFoo.objcExtraProp
+}


### PR DESCRIPTION
Cherry-pick of 3ef686bf9220f2451521a95c09c2b303a4985e70 from master.

-- original message --

    [DeadFunctionElimination] Pass on keypaths to foreign DeclRef properties.
    
    These show up specifically when someone forms a keypath to an ObjC
    property in a category. They're no-ops from the perspective of
    DFE but the code has to intentionally skip the case if it wants to
    avoid the subsequent llvm_unreachable.
    
    rdar://34913689
