### PR TITLE
[Clang importer] Fix bridging of the underlying types of typedefs.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -684,18 +684,13 @@ namespace {
         auto typedefBridgeability = getTypedefBridgeability(underlyingType);
 
         // Figure out the typedef we should actually use.
-        auto underlyingBridgeability =
-          (Bridging == Bridgeability::Full
-             ? typedefBridgeability : Bridgeability::None);
-        SwiftTypeConverter innerConverter(Impl, AllowNSUIntegerAsInt,
-                                          underlyingBridgeability);
+        SwiftTypeConverter innerConverter(Impl, AllowNSUIntegerAsInt, Bridging);
         auto underlyingResult = innerConverter.Visit(underlyingType);
 
         // If we used different bridgeability than this typedef normally
-        // would because we're in a non-bridgeable context, and therefore
-        // the underlying type is different from the mapping of the typedef,
-        // use the underlying type.
-        if (underlyingBridgeability != typedefBridgeability &&
+        // would, and therefore the underlying type is different from the
+        // mapping of the typedef, use the underlying type.
+        if (Bridging != typedefBridgeability &&
             !underlyingResult.AbstractType->isEqual(mappedType)) {
           return underlyingResult;
         }

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -203,3 +203,9 @@ typedef SomeCell <NSCopying> *CopyableSomeCell;
 @property (class, readonly) InstancetypeAccessor *prop;
 + (instancetype)prop;
 @end
+
+typedef NSArray<NSString *> *NSStringArray;
+
+@interface BridgedTypedefs : NSObject
+@property (readonly,nonnull) NSArray<NSStringArray> *arrayOfArrayOfStrings;
+@end

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -638,3 +638,8 @@ func testTypeAndValue() {
   let _: () -> testStruct = testStruct.init
   let _: (CInt) -> testStruct = testStruct.init
 }
+
+// rdar://problem/34913507
+func testBridgedTypedef(bt: BridgedTypedefs) {
+  let _: Int = bt.arrayOfArrayOfStrings // expected-error{{'[[String]]'}}
+}


### PR DESCRIPTION
Typedefs tend to be imported without bridging the underlying
type. However, when a typedef is used within a bridging context, we
should bridge based on the underlying type. That wasn't being done
consistently, causing us to import various typedefs without bridging
at all. Update the logic to use the bridged underlying type whenever
the (often unbridged) typedef type itself doesn't line up.

Fixes rdar://problem/34913507.

(cherry picked from commit 687d753448f33a51b4499aed856d03da6c3b38bc)
