### PR TITLE
Temporarily disable sanitizers tests on Linux, as recent kernel updat…

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -925,20 +925,26 @@ source_compiler_rt_libs(os.path.join(test_resource_dir, 'clang', 'lib',
 
 def check_runtime_libs(features_to_check):
     for lib in config.compiler_rt_libs:
-        for (libname, feature) in features_to_check:
+        for (libname, feature) in features_to_check.iteritems():
             if lib.startswith("libclang_rt." + libname + "_"):
                 config.available_features.add(feature)
 
-runtime_libs = [
-    ('profile', 'profile_runtime'),
-    ('asan', 'asan_runtime'),
-    ('ubsan', 'ubsan_runtime'),
-    ('safestack', 'safestack_runtime'),
-    ('fuzzer', 'fuzzer_runtime')
-]
+runtime_libs = {
+    'profile': 'profile_runtime',
+    'asan': 'asan_runtime',
+    'ubsan': 'ubsan_runtime',
+    'safestack': 'safestack_runtime',
+    'fuzzer': 'fuzzer_runtime'
+}
 
 if run_ptrsize != "32":
-    runtime_libs.append(('tsan', 'tsan_runtime'))
+    runtime_libs['tsan'] = 'tsan_runtime'
+
+# TODO: remove these lines once sanitizers start working on Linux again:
+# Tracked in https://bugs.swift.org/browse/SR-6257.
+if config.target_sdk_name == "linux":
+    runtime_libs.pop('asan')
+    runtime_libs.pop('tsan')
 
 check_runtime_libs(runtime_libs)
 


### PR DESCRIPTION
…e breaks them.

Cf. https://github.com/google/sanitizers/issues/837
Tracked in https://bugs.swift.org/browse/SR-6257