### PR TITLE
Add missing swift-syntax-generated-headers dependencies to ensure SyntaxKind.h is generated before it's used

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_library(swiftClangImporter STATIC
   ImportName.cpp
   ImportType.cpp
   SwiftLookupTable.cpp
+  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftAST
     swiftParse

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -16,7 +16,7 @@ set(swiftDriver_targetDefines)
 
 add_swift_library(swiftDriver STATIC
   ${swiftDriver_sources}
-  DEPENDS SwiftOptions
+  DEPENDS swift-syntax-generated-headers SwiftOptions
   LINK_LIBRARIES swiftAST swiftBasic swiftFrontend swiftOption)
 
 # Generate the static-stdlib-args.lnk file used by -static-stdlib option

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_library(swiftImmediate STATIC
   Immediate.cpp
   REPL.cpp
+  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftIDE
     swiftFrontend

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_library(swiftParseSIL STATIC
   ParseSIL.cpp
+  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftParse
     swiftSema

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_library(swiftPrintAsObjC STATIC
   PrintAsObjC.cpp
 
+  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftIDE
     swiftFrontend


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is breaking the build.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/35259197.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->