### PR TITLE
Remove redundant inlineable declarations

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3668,6 +3668,9 @@ ERROR(versioned_attr_with_explicit_access,
 ERROR(versioned_attr_in_protocol,none,
       "'@_versioned' attribute cannot be used in protocols", ())
 
+ERROR(versioned_dynamic_not_supported,none,
+      "'@_versioned' attribute cannot be applied to 'dynamic' declarations", ())
+
 #define FRAGILE_FUNC_KIND \
   "%select{a '@_transparent' function|" \
   "an '@inline(__always)' function|" \
@@ -3707,6 +3710,9 @@ ERROR(class_designated_init_inlineable_resilient,none,
 
 ERROR(inlineable_stored_property,
       none, "'@_inlineable' attribute cannot be applied to stored properties", ())
+
+ERROR(inlineable_dynamic_not_supported,
+      none, "'@_inlineable' attribute cannot be applied to 'dynamic' declarations", ())
 
 ERROR(inlineable_decl_not_public,
       none, "'@_inlineable' attribute can only be applied to public declarations, "

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -98,11 +98,16 @@ bool TypeChecker::diagnoseInlineableDeclRef(SourceLoc loc,
   // Enum cases are handled as part of their containing enum.
   if (isa<EnumElementDecl>(D))
     return false;
-    
+
   // Protocol requirements are not versioned because there's no
   // global entry point.
   if (isa<ProtocolDecl>(D->getDeclContext()) &&
       D->isProtocolRequirement())
+    return false;
+
+  // Dynamic declarations are not versioned because there's no
+  // global entry point.
+  if (D->isDynamic())
     return false;
 
   // FIXME: Figure out what to do with typealiases

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -613,21 +613,19 @@ internal class _stdlib_ReturnAutoreleasedDummy {
   @_versioned // FIXME(sil-serialize-all)
   @objc
   internal init() {}
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   deinit {}
+
   // Use 'dynamic' to force Objective-C dispatch, which uses the
   // return-autoreleased call sequence.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_versioned // FIXME(sil-serialize-all)
   @objc
   internal dynamic func returnsAutoreleased(_ x: AnyObject) -> AnyObject {
     return x
   }
 
   // Use 'dynamic' to prevent this call to be duplicated into other modules.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_versioned // FIXME(sil-serialize-all)
   @objc
   internal dynamic func initializeReturnAutoreleased() {
     // On x86_64 it is sufficient to perform one cycle of return-autoreleased

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -67,14 +67,10 @@ internal class _SwiftNativeNSArrayWithContiguousStorage
 
 // Implement the APIs required by NSArray 
 extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
-  @_inlineable
-  @_versioned
   @objc internal var count: Int {
     return withUnsafeBufferOfObjects { $0.count }
   }
 
-  @_inlineable
-  @_versioned
   @objc(objectAtIndex:)
   internal func objectAt(_ index: Int) -> AnyObject {
     return withUnsafeBufferOfObjects {
@@ -86,8 +82,6 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
     }
   }
 
-  @_inlineable
-  @_versioned
   @objc internal func getObjects(
     _ aBuffer: UnsafeMutablePointer<AnyObject>, range: _SwiftNSRange
   ) {
@@ -113,8 +107,6 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
     }
   }
 
-  @_inlineable
-  @_versioned
   @objc(countByEnumeratingWithState:objects:count:)
   internal func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
@@ -137,8 +129,6 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
     }
   }
 
-  @_inlineable
-  @_versioned
   @objc(copyWithZone:)
   internal func copy(with _: _SwiftNSZone?) -> AnyObject {
     return self
@@ -258,8 +248,6 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
   ///
   /// This override allows the count to be read without triggering
   /// bridging of array elements.
-  @_inlineable
-  @_versioned
   @objc
   internal override var count: Int {
     if let bridgedStorage = _heapBufferBridged {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2282,3 +2282,12 @@ class User: NSObject {
     }
   }
 }
+
+// 'dynamic' methods cannot be @_inlineable or @_versioned
+class BadClass {
+  @_inlineable @objc dynamic func badMethod1() {}
+  // expected-error@-1 {{'@_inlineable' attribute cannot be applied to 'dynamic' declarations}}
+
+  @_versioned @objc dynamic func badMethod2() {}
+  // expected-error@-1 {{'@_versioned' attribute cannot be applied to 'dynamic' declarations}}
+}


### PR DESCRIPTION
There's nothing to be gained from declaring 'dynamic' members as '@_inlineable' or '@_versioned', so let's just ban this.