### PR TITLE
[GSB] Don't infer requirements from types in the definitions of protocols

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2315,11 +2315,9 @@ static void addConditionalRequirements(GenericSignatureBuilder &builder,
   // Abstract conformances don't have associated decl-contexts/modules, but also
   // don't have conditional requirements.
   if (conformance.isConcrete()) {
-    auto mod = conformance.getConcrete()->getDeclContext()->getParentModule();
     auto source = FloatingRequirementSource::forInferred(nullptr);
     for (auto requirement : conformance.getConditionalRequirements()) {
-      builder.addRequirement(requirement, source,
-                             /*inferForModule=*/mod);
+      builder.addRequirement(requirement, source, /*inferForModule=*/nullptr);
       ++NumConditionalRequirementsAdded;
     }
   }
@@ -3370,8 +3368,6 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     return ConstraintResult::Resolved;
   }
 
-  auto protoModule = proto->getParentModule();
-
   if (!onlySameTypeConstraints) {
     // Add all of the inherited protocol requirements, recursively.
     if (auto resolver = getLazyResolver())
@@ -3379,7 +3375,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
     auto inheritedReqResult =
       addInheritedRequirements(proto, selfType.getUnresolvedType(), source,
-                               protoModule);
+                               /*inferForModule=*/nullptr);
     if (isErrorResult(inheritedReqResult))
       return inheritedReqResult;
   }
@@ -3394,7 +3390,8 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
       auto innerSource = FloatingRequirementSource::viaProtocolRequirement(
           source, proto, &req, /*inferred=*/false);
-      addRequirement(&req, innerSource, &protocolSubMap, protoModule);
+      addRequirement(&req, innerSource, &protocolSubMap,
+                     /*inferForModule=*/nullptr);
     }
   }
 
@@ -3516,7 +3513,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
       if (!onlySameTypeConstraints) {
         auto assocResult =
           addInheritedRequirements(assocTypeDecl, assocType, source,
-                                   protoModule);
+                                   /*inferForModule=*/nullptr);
         if (isErrorResult(assocResult))
           return assocResult;
       }
@@ -3533,7 +3530,8 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
           auto innerSource =
             FloatingRequirementSource::viaProtocolRequirement(
                                       source, proto, &req, /*inferred=*/false);
-          addRequirement(&req, innerSource, &protocolSubMap, protoModule);
+          addRequirement(&req, innerSource, &protocolSubMap,
+                         /*inferForModule=*/nullptr);
         }
       }
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -299,7 +299,7 @@ struct X22<T, U> {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X20<τ_0_0.B>, τ_0_0.B : P20>
 protocol P22 {
   associatedtype A
-  associatedtype B where A == X20<B>
+  associatedtype B: P20 where A == X20<B>
 }
 
 // CHECK: Generic signature: <Self where Self : P23>
@@ -327,7 +327,7 @@ struct X24<T: P20> : P24 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25a {
   associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A': 'P24'}}
-  associatedtype B where A == X24<B> // expected-note{{conformance constraint 'Self.A': 'P24' implied here}}
+  associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A': 'P24' implied here}}
 }
 
 // CHECK-LABEL: .P25b@
@@ -335,12 +335,17 @@ protocol P25a {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25b {
   associatedtype A
-  associatedtype B where A == X24<B>
+  associatedtype B: P20 where A == X24<B>
 }
 
 protocol P25c {
   associatedtype A: P24
   associatedtype B where A == X<B> // expected-error{{use of undeclared type 'X'}}
+}
+
+protocol P25d {
+  associatedtype A
+  associatedtype B where A == X24<B> // expected-error{{type 'Self.B' does not conform to protocol 'P20'}}
 }
 
 // Similar to the above, but with superclass constraints.
@@ -357,7 +362,7 @@ struct X26<T: X3> : P26 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A': 'P26'}}
-  associatedtype B where A == X26<B> // expected-note{{conformance constraint 'Self.A': 'P26' implied here}}
+  associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A': 'P26' implied here}}
 }
 
 // CHECK-LABEL: .P27b@
@@ -365,7 +370,7 @@ protocol P27a {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27b {
   associatedtype A
-  associatedtype B where A == X26<B>
+  associatedtype B: X3 where A == X26<B>
 }
 
 // ----------------------------------------------------------------------------

--- a/validation-test/compiler_crashers_fixed/28822-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers_fixed/28822-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -5,12 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func a<a{
-extension{{}
-{
-}
-class a<a{
-class a{protocol
-protocol{protocol A typealias e:A
+// RUN: not %target-swift-frontend %s -emit-ir
+extension CountableRange{{}func a<a:A
+protocol A{typealias e:a{}class a

--- a/validation-test/compiler_crashers_fixed/28853-result-second.swift
+++ b/validation-test/compiler_crashers_fixed/28853-result-second.swift
@@ -5,6 +5,12 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-extension CountableRange{{}func a<a:A
-protocol A{typealias e:a{}class a
+// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+func a<a{
+extension{{}
+{
+}
+class a<a{
+class a{protocol
+protocol{protocol A typealias e:A


### PR DESCRIPTION
Previously, we were inferring requirements from types within the definitions
of protocols, e.g., given something like:

    protocol P {
      associatedtype A: Collection
      associatedtype B where A.Element == Set<B>
    }

we would infer that `B: Hashable`. The code for doing this was actually
incorrect due to its mis-use of requirement sources, causing a few
crashers. Plus, it's not a good idea in general because it hides the
actual requirements on B. Stop doing this.

Also stop trying to infer requirements from conditional
requirements---those have already been canonicalized and minimized, so
there's nothing to infer from.
