### PR TITLE
Temporarily disable sanitizers tests on Linux on swift-4.0

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -922,10 +922,11 @@ def check_runtime_feature(name):
             return
 
 check_runtime_feature('profile')
-check_runtime_feature('asan')
 check_runtime_feature('ubsan')
-check_runtime_feature('tsan')
 check_runtime_feature('safestack')
+if config.target_sdk_name != "linux":
+    check_runtime_feature('asan')
+    check_runtime_feature('tsan')
 
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift = (


### PR DESCRIPTION
As recent kernel update broke them.
Cf. google/sanitizers#837
Tracked in https://bugs.swift.org/browse/SR-6257