### PR TITLE
Re-enable sanitizer tests on Linux.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -940,12 +940,6 @@ runtime_libs = {
 if run_ptrsize != "32":
     runtime_libs['tsan'] = 'tsan_runtime'
 
-# TODO: remove these lines once sanitizers start working on Linux again:
-# Tracked in https://bugs.swift.org/browse/SR-6257.
-if config.target_sdk_name == "linux":
-    runtime_libs.pop('asan')
-    runtime_libs.pop('tsan')
-
 check_runtime_libs(runtime_libs)
 
 if not getattr(config, 'target_run_simple_swift', None):


### PR DESCRIPTION
Tests pass again after latest Ubuntu kernel update.