### PR TITLE
Fix more places where were allowing IUOs but shouldn't.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4252,7 +4252,6 @@ public:
                                      &resolver);
     TypeResolutionOptions options;
     options |= TR_SubscriptParameters;
-    options |= TR_AllowIUO;
 
     isInvalid |= TC.typeCheckParameterList(SD->getIndices(), SD,
                                            options,
@@ -4792,8 +4791,8 @@ public:
                              GenericTypeResolver &resolver) {
     bool hadError = false;
     for (auto paramList : fd->getParameterLists()) {
-      hadError |=
-          TC.typeCheckParameterList(paramList, fd, TR_AllowIUO, resolver);
+      hadError |= TC.typeCheckParameterList(paramList, fd,
+                                            TypeResolutionOptions(), resolver);
     }
 
     return hadError;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -457,7 +457,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   // Check the parameter patterns.
   for (auto params : func->getParameterLists()) {
     // Check the pattern.
-    if (tc.typeCheckParameterList(params, func, TR_AllowIUO,
+    if (tc.typeCheckParameterList(params, func, TypeResolutionOptions(),
                                   resolver))
       badType = true;
 
@@ -932,8 +932,7 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
 
   // Check the element type.
   badType |= tc.validateType(subscript->getElementTypeLoc(), subscript,
-                             TypeResolutionOptions(),
-                             &resolver);
+                             TR_AllowIUO, &resolver);
 
   // Infer requirements from it.
   if (genericParams && builder) {
@@ -951,7 +950,6 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
 
   TypeResolutionOptions options;
   options |= TR_SubscriptParameters;
-  options |= TR_AllowIUO;
 
   badType |= tc.typeCheckParameterList(params, subscript,
                                        options,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -691,6 +691,9 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
   auto elementOptions = (options |
                          (decl->isVariadic() ? TR_VariadicFunctionInput
                                              : TR_FunctionInput));
+  if (!decl->isVariadic())
+    elementOptions |= TR_AllowIUO;
+
   bool hadError = false;
 
   // We might have a null typeLoc if this is a closure parameter list,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -557,6 +557,7 @@ withoutContext(TypeResolutionOptions options, bool preserveSIL = false) {
   options -= TR_VariadicFunctionInput;
   options -= TR_EnumCase;
   options -= TR_ImmediateOptionalTypeArgument;
+  options -= TR_AllowIUO;
   if (!preserveSIL) options -= TR_SILType;
   return options;
 }

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -1,19 +1,69 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5
 
+// These are all legal uses of '!'.
+struct Fine {
+  var value: Int!
+
+  func m(_ unnamed: Int!, named: Int!) -> Int! { return unnamed }
+  static func s(_ unnamed: Int!, named: Int!) -> Int! { return named }
+
+  init(_ value: Int) { self.value = value }
+  init!() { return nil }
+
+  subscript (
+    index: Int!
+  )     -> Int! {
+    return index
+  }
+
+  subscript<T> (
+    index: T!
+  )     -> T! {
+    return index
+  }
+}
+
 let _: ImplicitlyUnwrappedOptional<Int> = 1 // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{8-36=}}{{39-39=!}}{{39-40=}}
 let _: ImplicitlyUnwrappedOptional = 1 // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' in unsupported; use an explicit type followed by '!'}}
 
 extension ImplicitlyUnwrappedOptional {} // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 
-func function(
+func functionSpelling(
   _: ImplicitlyUnwrappedOptional<Int> // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{6-34=}}{{37-37=!}}{{37-38=}}
 ) -> ImplicitlyUnwrappedOptional<Int> { // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{6-34=}}{{37-37=!}}{{37-38=}}
   return 1
 }
 
+// Okay, like in the method case.
+func functionSigil(
+  _: Int!
+) -> Int! {
+  return 1
+}
+
+// Not okay because '!' is not at the top level of the type.
+func functionSigilArray(
+  _: [Int!] // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+) -> [Int!] { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  return [1]
+}
+
 func genericFunction<T>(
   iuo: ImplicitlyUnwrappedOptional<T> // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{8-36=}}{{37-37=!}}{{37-38=}}
 ) -> ImplicitlyUnwrappedOptional<T> { // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{6-34=}}{{35-35=!}}{{35-36=}}
+  return iuo
+}
+
+// Okay, like in the non-generic case.
+func genericFunctionSigil<T>(
+  iuo: T!
+) -> T! {
+  return iuo
+}
+
+func genericFunctionSigilArray<T>(
+  iuo: [T!] // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+) -> [T!] { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
   return iuo
 }
 
@@ -26,9 +76,21 @@ struct S : P {
   typealias T = ImplicitlyUnwrappedOptional<Int> // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
   typealias U = Optional<ImplicitlyUnwrappedOptional<Int>> // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 
+  typealias V = Int!  // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  typealias W = Int!? // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+
+  var x: V
+  var y: W
+
   subscript (
     index: ImplicitlyUnwrappedOptional<Int> // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{12-40=}}{{43-43=!}}{{43-44=}}
   )     -> ImplicitlyUnwrappedOptional<Int> { // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{12-40=}}{{43-43=!}}{{43-44=}}
+    return index
+  }
+
+  subscript<T> (
+    index: ImplicitlyUnwrappedOptional<T> // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{12-40=}}{{41-41=!}}{{41-42=}}
+  )     -> ImplicitlyUnwrappedOptional<T> { // expected-error {{the spelling 'ImplicitlyUnwrappedOptional' is unsupported; use '!' after the type name}}{{12-40=}}{{41-41=!}}{{41-42=}}
     return index
   }
 }
@@ -45,16 +107,33 @@ func testClosure() -> Int {
 }
 
 _ = Array<Int!>() // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+let _: Array<Int!> = [1] // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 _ = [Int!]() // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+let _: [Int!] = [1] // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 _ = Optional<Int!>(nil) // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+let _: Optional<Int!> = nil // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 _ = Int!?(0) // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+let _: Int!? = 0 // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 _ = (
   Int!, // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
-  Float!, // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
-  String! // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  Float!,
+  String!
 )(1, 2.0, "3")
+let _: (
+  Int!, // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  Float!,
+  String!
+) = (1, 2.0, "3")
 
-struct Generic<T, U, C> {}
+struct Generic<T, U, C> {
+  init(_ t: T, _ u: U, _ c: C) {}
+}
 _ = Generic<Int!, // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
-            Float!, // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
-            String!>() // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+            Float!,
+            String!>(1, 2.0, "3")
+let _: Generic<Int!, // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+               Float!,
+               String!> = Generic(1, 2.0, "3")
+
+func vararg(_ first: Int, more: Int!...) { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+}


### PR DESCRIPTION
My previous commit, f9b82bccb783492cf94639d1203d8e38feab46e5, failed to
ensure that IUOs could not be nested inside of other types in all
positions.
