### PR TITLE
[SIL] Make @_silgen_name and @_cdecl functions immune to some optimizations

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -160,9 +160,14 @@ private:
   /// The linkage of the function.
   unsigned Linkage : NumSILLinkageBits;
 
-  /// This flag indicates if a function can be eliminated by dead function
-  /// elimination. If it is unset, DFE will preserve the function and make
-  /// it public.
+  /// Set if the function may be referenced from C code and should thus be
+  /// preserved and exported more widely than its Swift linkage and usage
+  /// would indicate.
+  unsigned HasCReferences : 1;
+
+  /// Set if the function should be preserved and changed to public linkage
+  /// during dead function elimination. This is used for some generic
+  /// pre-specialization.
   unsigned KeepAsPublic : 1;
 
   /// This is the number of uses of this SILFunction inside the SIL.
@@ -401,7 +406,7 @@ public:
   }
 
   /// Helper method which returns true if the linkage of the SILFunction
-  /// indicates that the objects definition might be required outside the
+  /// indicates that the object's definition might be required outside the
   /// current SILModule.
   bool isPossiblyUsedExternally() const;
 
@@ -409,6 +414,10 @@ public:
   /// is a (private or internal) vtable method which can be referenced by
   /// vtables of derived classes outside the compilation unit.
   bool isExternallyUsedSymbol() const;
+
+  /// Return whether this function may be referenced by C code.
+  bool hasCReferences() const { return HasCReferences; }
+  void setHasCReferences(bool value) { HasCReferences = value; }
 
   /// Get the DeclContext of this function. (Debug info only).
   DeclContext *getDeclContext() const {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -832,10 +832,9 @@ void IRGenerator::emitGlobalTopLevel() {
   PrimaryIGM->emitCoverageMapping();
   
   // Emit SIL functions.
-  bool isWholeModule = PrimaryIGM->getSILModule().isWholeModule();
   for (SILFunction &f : PrimaryIGM->getSILModule()) {
     // Only eagerly emit functions that are externally visible.
-    if (!isPossiblyUsedExternally(f.getLinkage(), isWholeModule))
+    if (!f.isPossiblyUsedExternally())
       continue;
 
     CurrentIGMPtr IGM = getGenModule(&f);
@@ -934,8 +933,7 @@ void IRGenerator::emitLazyDefinitions() {
     while (!LazyFunctionDefinitions.empty()) {
       SILFunction *f = LazyFunctionDefinitions.pop_back_val();
       CurrentIGMPtr IGM = getGenModule(f);
-      assert(!isPossiblyUsedExternally(f->getLinkage(),
-                                       IGM->getSILModule().isWholeModule())
+      assert(!f->isPossiblyUsedExternally()
              && "function with externally-visible linkage emitted lazily?");
       IGM->emitSILFunction(f);
     }
@@ -1872,9 +1870,7 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(SILFunction *f,
     }
 
   // Otherwise, if we have a lazy definition for it, be sure to queue that up.
-  } else if (isDefinition && !forDefinition &&
-             !isPossiblyUsedExternally(f->getLinkage(),
-                                       getSILModule().isWholeModule())) {
+  } else if (isDefinition && !forDefinition && !f->isPossiblyUsedExternally()) {
     IRGen.addLazyFunction(f);
   }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -454,17 +454,12 @@ SILFunction::isPossiblyUsedExternally() const {
   if (linkage == SILLinkage::Hidden && hasCReferences())
     return true;
 
-  if (getModule().isWholeModule())
-    return linkage <= SILLinkage::Public;
-  else
-    return linkage <= SILLinkage::Hidden;
+  return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
 }
 
 bool SILFunction::isExternallyUsedSymbol() const {
-  if (getModule().isWholeModule())
-    return getEffectiveSymbolLinkage() <= SILLinkage::Public;
-  else
-    return getEffectiveSymbolLinkage() <= SILLinkage::Hidden;
+  return swift::isPossiblyUsedExternally(getEffectiveSymbolLinkage(),
+                                         getModule().isWholeModule());
 }
 
 void SILFunction::convertToDeclaration() {

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -96,7 +96,8 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
       Serialized(isSerialized), Thunk(isThunk),
       ClassSubclassScope(unsigned(classSubclassScope)), GlobalInitFlag(false),
       InlineStrategy(inlineStrategy), Linkage(unsigned(Linkage)),
-      KeepAsPublic(false), EffectsKindAttr(E), EntryCount(entryCount) {
+      HasCReferences(false), KeepAsPublic(false), EffectsKindAttr(E),
+      EntryCount(entryCount) {
   if (InsertBefore)
     Module.functions.insert(SILModule::iterator(InsertBefore), this);
   else
@@ -445,18 +446,25 @@ bool SILFunction::hasValidLinkageForFragileRef() const {
   return hasPublicVisibility(getLinkage());
 }
 
-/// Helper method which returns true if the linkage of the SILFunction
-/// indicates that the objects definition might be required outside the
-/// current SILModule.
 bool
 SILFunction::isPossiblyUsedExternally() const {
-  return swift::isPossiblyUsedExternally(getLinkage(),
-                                         getModule().isWholeModule());
+  auto linkage = getLinkage();
+
+  // Hidden functions may be referenced by other C code in the linkage unit.
+  if (linkage == SILLinkage::Hidden && hasCReferences())
+    return true;
+
+  if (getModule().isWholeModule())
+    return linkage <= SILLinkage::Public;
+  else
+    return linkage <= SILLinkage::Hidden;
 }
 
 bool SILFunction::isExternallyUsedSymbol() const {
-  return swift::isPossiblyUsedExternally(getEffectiveSymbolLinkage(),
-                                         getModule().isWholeModule());
+  if (getModule().isWholeModule())
+    return getEffectiveSymbolLinkage() <= SILLinkage::Public;
+  else
+    return getEffectiveSymbolLinkage() <= SILLinkage::Hidden;
 }
 
 void SILFunction::convertToDeclaration() {

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -333,10 +333,12 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
 
+    // Propagate @_semantics.
     auto Attrs = decl->getAttrs();
     for (auto *A : Attrs.getAttributes<SemanticsAttr>())
       F->addSemanticsAttr(cast<SemanticsAttr>(A)->Value);
 
+    // Propagate @_specialize.
     for (auto *A : Attrs.getAttributes<SpecializeAttr>()) {
       auto *SA = cast<SpecializeAttr>(A);
       auto kind = SA->getSpecializationKind() ==
@@ -346,6 +348,11 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
       F->addSpecializeAttr(SILSpecializeAttr::create(
           *this, SA->getRequirements(), SA->isExported(), kind));
     }
+
+    // @_silgen_name and @_cdecl functions may be called from C code somewhere.
+    if (Attrs.hasAttribute<SILGenNameAttr>() ||
+        Attrs.hasAttribute<CDeclAttr>())
+      F->setHasCReferences(true);
   }
 
   // If this function has a self parameter, make sure that it has a +0 calling

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -112,7 +112,7 @@ protected:
   bool isAnchorFunction(SILFunction *F) {
 
     // Functions that may be used externally cannot be removed.
-    if (isPossiblyUsedExternally(F->getLinkage(), Module->isWholeModule()))
+    if (F->isPossiblyUsedExternally())
       return true;
 
     // ObjC functions are called through the runtime and are therefore alive

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -607,8 +607,6 @@ class MandatoryInlining : public SILModuleTransform {
     if (!ShouldCleanup)
       return;
 
-    bool isWholeModule = M->isWholeModule();
-    
     // Now that we've inlined some functions, clean up.  If there are any
     // transparent functions that are deserialized from another module that are
     // now unused, just remove them from the module.
@@ -629,7 +627,7 @@ class MandatoryInlining : public SILModuleTransform {
       // We discard functions that don't have external linkage,
       // e.g. deserialized functions, internal functions, and thunks.
       // Being marked transparent controls this.
-      if (isPossiblyUsedExternally(F.getLinkage(), isWholeModule)) continue;
+      if (F.isPossiblyUsedExternally()) continue;
 
       // ObjC functions are called through the runtime and are therefore alive
       // even if not referenced inside SIL.

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -1,9 +1,50 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -whole-module-optimization | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 
+
+// Non-Swift _silgen_name definitions
+
 @_silgen_name("atan2") func atan2test(_ a: Double, _ b: Double) -> Double
-
-atan2test(0.0, 0.0)
-
+_ = atan2test(0.0, 0.0)
 // CHECK: call swiftcc double @atan2(double {{.*}}, double {{.*}})
+
+
+// Ordinary Swift definitions
+// WMO is expected to eliminate the unused internal and private functions.
+
+public   func PlainPublic()   { }
+internal func PlainInternal() { }
+private  func PlainPrivate()  { }
+// CHECK: define swiftcc void @_T07asmname11PlainPublic
+// CHECK-NOT: PlainInternal
+// CHECK-NOT: PlainPrivate
+
+
+// Swift _silgen_name definitions
+// WMO is expected to eliminate the private function
+// but the internal function must survive for C use.
+// Only the C-named definition is emitted.
+
+@_silgen_name("silgen_name_public")   public   func SilgenNamePublic()   { }
+@_silgen_name("silgen_name_internal") internal func SilgenNameInternal() { }
+@_silgen_name("silgen_name_private")  private  func SilgenNamePrivate()  { }
+// CHECK: define swiftcc void @silgen_name_public
+// CHECK: define hidden swiftcc void @silgen_name_internal
+// CHECK-NOT: silgen_name_private
+// CHECK-NOT: SilgenName
+
+
+// Swift cdecl definitions
+// WMO is expected to eliminate the private functions
+// but the internal functions must survive for C use.
+// Both a C-named definition and a Swift-named definition are emitted.
+
+@_cdecl("cdecl_public")   public   func CDeclPublic()   { }
+@_cdecl("cdecl_internal") internal func CDeclInternal() { }
+@_cdecl("cdecl_private")  private  func CDeclPrivate()  { }
+// CHECK: define void @cdecl_public
+// CHECK: define swiftcc void @_T07asmname11CDeclPublic
+// CHECK: define hidden void @cdecl_internal
+// CHECK: define hidden swiftcc void @_T07asmname13CDeclInternal
+// CHECK-NOT: cdecl_private

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -16,7 +16,7 @@ _ = atan2test(0.0, 0.0)
 public   func PlainPublic()   { }
 internal func PlainInternal() { }
 private  func PlainPrivate()  { }
-// CHECK: define{{( protected|)}} swiftcc void @_T07asmname11PlainPublic
+// CHECK: define{{( protected)?}} swiftcc void @_T07asmname11PlainPublic
 // CHECK-NOT: PlainInternal
 // CHECK-NOT: PlainPrivate
 
@@ -29,7 +29,7 @@ private  func PlainPrivate()  { }
 @_silgen_name("silgen_name_public")   public   func SilgenNamePublic()   { }
 @_silgen_name("silgen_name_internal") internal func SilgenNameInternal() { }
 @_silgen_name("silgen_name_private")  private  func SilgenNamePrivate()  { }
-// CHECK: define{{( protected|)}} swiftcc void @silgen_name_public
+// CHECK: define{{( protected)?}} swiftcc void @silgen_name_public
 // CHECK: define hidden swiftcc void @silgen_name_internal
 // CHECK-NOT: silgen_name_private
 // CHECK-NOT: SilgenName
@@ -43,8 +43,8 @@ private  func PlainPrivate()  { }
 @_cdecl("cdecl_public")   public   func CDeclPublic()   { }
 @_cdecl("cdecl_internal") internal func CDeclInternal() { }
 @_cdecl("cdecl_private")  private  func CDeclPrivate()  { }
-// CHECK: define{{( protected|)}} void @cdecl_public
-// CHECK: define{{( protected|)}} swiftcc void @_T07asmname11CDeclPublic
+// CHECK: define{{( protected)?}} void @cdecl_public
+// CHECK: define{{( protected)?}} swiftcc void @_T07asmname11CDeclPublic
 // CHECK: define hidden void @cdecl_internal
 // CHECK: define hidden swiftcc void @_T07asmname13CDeclInternal
 // CHECK-NOT: cdecl_private

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -16,7 +16,7 @@ _ = atan2test(0.0, 0.0)
 public   func PlainPublic()   { }
 internal func PlainInternal() { }
 private  func PlainPrivate()  { }
-// CHECK: define swiftcc void @_T07asmname11PlainPublic
+// CHECK: define{{( protected|)}} swiftcc void @_T07asmname11PlainPublic
 // CHECK-NOT: PlainInternal
 // CHECK-NOT: PlainPrivate
 
@@ -29,7 +29,7 @@ private  func PlainPrivate()  { }
 @_silgen_name("silgen_name_public")   public   func SilgenNamePublic()   { }
 @_silgen_name("silgen_name_internal") internal func SilgenNameInternal() { }
 @_silgen_name("silgen_name_private")  private  func SilgenNamePrivate()  { }
-// CHECK: define swiftcc void @silgen_name_public
+// CHECK: define{{( protected|)}} swiftcc void @silgen_name_public
 // CHECK: define hidden swiftcc void @silgen_name_internal
 // CHECK-NOT: silgen_name_private
 // CHECK-NOT: SilgenName
@@ -43,8 +43,8 @@ private  func PlainPrivate()  { }
 @_cdecl("cdecl_public")   public   func CDeclPublic()   { }
 @_cdecl("cdecl_internal") internal func CDeclInternal() { }
 @_cdecl("cdecl_private")  private  func CDeclPrivate()  { }
-// CHECK: define void @cdecl_public
-// CHECK: define swiftcc void @_T07asmname11CDeclPublic
+// CHECK: define{{( protected|)}} void @cdecl_public
+// CHECK: define{{( protected|)}} swiftcc void @_T07asmname11CDeclPublic
 // CHECK: define hidden void @cdecl_internal
 // CHECK: define hidden swiftcc void @_T07asmname13CDeclInternal
 // CHECK-NOT: cdecl_private


### PR DESCRIPTION
@_silgen_name and @_cdecl functions are assumed to be referenced from
C code. Public and internal functions marked as such must not be deleted
by the optimizer, and their C symbols must be public or hidden respectively.

rdar://33924873, SR-6209
