### PR TITLE
Revert " Re-enable parse_stdlib tests."

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2233,6 +2233,11 @@ ERROR(autoclosure_function_type,none,
 ERROR(autoclosure_function_input_nonunit,none,
       "argument type of @autoclosure parameter must be '()'", ())
 
+// FIXME: drop these when we drop @noescape
+ERROR(noescape_implied_by_autoclosure,none,
+      "@noescape is implied by @autoclosure and should not be "
+      "redundantly specified", ())
+
 ERROR(escaping_non_function_parameter,none,
       "@escaping attribute may only be used in function parameter position", ())
 

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -82,7 +82,7 @@
 #include "swift/Basic/OwnedString.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <vector>
+#include <deque>
 
 namespace swift {
 namespace syntax {
@@ -204,7 +204,7 @@ struct TriviaPiece {
   }
 };
 
-using TriviaList = std::vector<TriviaPiece>;
+using TriviaList = std::deque<TriviaPiece>;
 
 /// A collection of leading or trailing trivia. This is the main data structure
 /// for thinking about trivia.
@@ -228,7 +228,7 @@ struct Trivia {
 
   /// Add a piece to the beginning of the collection.
   void push_front(const TriviaPiece &Piece) {
-    Pieces.insert(Pieces.begin(), Piece);
+    Pieces.push_front(Piece);
   }
 
   /// Return a reference to the first piece.

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -740,8 +740,7 @@ static bool rangeContainsPlaceholderEnd(const char *CurPtr,
 syntax::RawTokenInfo Lexer::fullLex() {
   if (NextToken.isEscapedIdentifier()) {
     LeadingTrivia.push_back(syntax::TriviaPiece::backtick());
-    TrailingTrivia.insert(TrailingTrivia.begin(),
-                          syntax::TriviaPiece::backtick());
+    TrailingTrivia.push_front(syntax::TriviaPiece::backtick());
   }
   auto Loc = NextToken.getLoc();
   auto Result = syntax::RawTokenSyntax::make(NextToken.getKind(),

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1663,7 +1663,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
             .fixItReplace(autoclosureEscapingParenRange, " @escaping ");
       }
       Attributes.setAttr(TAK_escaping, Loc);
-    } else if (Attributes.has(TAK_noescape) && !isInSILMode()) {
+    } else if (Attributes.has(TAK_noescape)) {
       diagnose(Loc, diag::attr_noescape_implied_by_autoclosure);
     }
     break;
@@ -1676,7 +1676,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
     }
 
     // @noescape after @autoclosure is redundant.
-    if (Attributes.has(TAK_autoclosure) && !isInSILMode()) {
+    if (Attributes.has(TAK_autoclosure)) {
       diagnose(Loc, diag::attr_noescape_implied_by_autoclosure);
     }
 

--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -18,6 +18,9 @@ for id in $(seq 0 $process_id_max); do
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322
 __EOF__
 
 done

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_11.sil
+++ b/validation-test/SIL/parse_stdlib_11.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -10,3 +10,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// FIXME: Re-enable when we're no longer running out of memory.
+// REQUIRES: rdar34771322


### PR DESCRIPTION
Reverts apple/swift#12700. We're still failing on Linux