### PR TITLE
Revert "Re-enable test failing due to the (now-removed) -F /S/L/Priva…

### DIFF
--- a/test/stdlib/MediaPlayer.swift
+++ b/test/stdlib/MediaPlayer.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: OS=ios
+// REQUIRES: rdar34462543
 
 import MediaPlayer
 import StdlibUnittest


### PR DESCRIPTION
…teFrameworks"

This test still fails on a bot
rdar://problem/35284791

This reverts commit 9daf89cec58d50bb7358ac527d3f78de479c5e34.

