### PR TITLE
[WIP experiment]Change ReversedCollection.Index.base to point to same point in Base

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -66,6 +66,37 @@ public struct ReversedCollection<
 > : BidirectionalCollection {
   public let base: Base
 
+  @_fixed_layout
+  public struct Iterator: IteratorProtocol, Sequence {
+    @_inlineable
+    @inline(__always)
+    /// Creates an iterator over the given collection.
+    public /// @testable
+    init(elements: Base, position: Base.Index) {
+      self._elements = elements
+      self._position = position
+    }
+
+    @_inlineable
+    @inline(__always)
+    public mutating func next() -> Base.Element? {
+      guard _fastPath(_position != _elements.startIndex) else { return nil }
+      _position = _elements.index(before: _position)
+      return _elements[_position]
+    }
+  
+    @_versioned
+    internal let _elements: Base
+    @_versioned
+    internal var _position: Base.Index
+  }
+  
+  @_inlineable
+  @inline(__always)
+  public func makeIterator() -> Iterator {
+    return Iterator(elements: base, position: base.endIndex)
+  }
+
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
@@ -193,6 +224,37 @@ public struct ReversedRandomAccessCollection<
   Base : RandomAccessCollection
 > : RandomAccessCollection {
   public let base: Base
+
+  @_fixed_layout
+  public struct Iterator: IteratorProtocol, Sequence {
+    @_inlineable
+    @inline(__always)
+    /// Creates an iterator over the given collection.
+    public /// @testable
+    init(elements: Base, position: Base.Index) {
+      self._elements = elements
+      self._position = position
+    }
+  
+    @_inlineable
+    @inline(__always)
+    public mutating func next() -> Base.Element? {
+      guard _fastPath(_position != _elements.startIndex) else { return nil }
+      _position = _elements.index(before: _position)
+      return _elements[_position]
+    }
+  
+    @_versioned
+    internal let _elements: Base
+    @_versioned
+    internal var _position: Base.Index
+  }
+  
+  @_inlineable
+  @inline(__always)
+  public func makeIterator() -> Iterator {
+    return Iterator(elements: base, position: base.endIndex)
+  }
 
   /// A type that represents a valid position in the collection.
   ///

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -153,8 +153,7 @@ extension Unicode.DefaultScalarView : BidirectionalCollection {
   public func index(before i: Index) -> Index {
     var parser = Encoding.ReverseParser()
     
-    var more = _ReverseIndexingIterator(
-      _elements: codeUnits, _position: i.codeUnitIndex)
+    var more = codeUnits[..<i.codeUnitIndex].reversed().makeIterator()
     
     switch parser.parseScalar(from: &more) {
     case .valid(let scalarContent):

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -166,7 +166,7 @@ LazyTestSuite.test("CollectionOfOne/${name}/Trap")
   ] as [Range<Int>]) {
   r in
   var c = CollectionOfOne<OpaqueValue<Int>>(OpaqueValue(42))
-  let slice = r.count == 0 ? c[0..<0] : c[0..<1]
+  var slice = r.count == 0 ? c[0..<0] : c[0..<1]
   expectCrashLater()
   ${operation}
 }
@@ -597,7 +597,7 @@ extension ReversedCollection where Base : TestProtocol1 {
 //===----------------------------------------------------------------------===//
 
 // Check that the generic parameter is called 'Base'.
-extension ReversedIndex where Base : TestProtocol1 {
+extension ReversedCollection.Index where Base : TestProtocol1 {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
@@ -619,7 +619,7 @@ extension ReversedRandomAccessCollection where Base : TestProtocol1 {
 //===----------------------------------------------------------------------===//
 
 // Check that the generic parameter is called 'Base'.
-extension ReversedRandomAccessIndex where Base : TestProtocol1 {
+extension ReversedRandomAccessCollection.Index where Base : TestProtocol1 {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
@@ -964,14 +964,14 @@ tests.test("ReversedCollection") {
   }
 
   checkBidirectionalCollection(
-    "raboof".characters,
-    "foobar".characters.reversed())
+    "raboof",
+    "foobar".reversed())
 
   // Check that the reverse collection is still eager
   do {
     var calls = 0
-    _ = "foobar".characters.reversed().map { _ in calls += 1 }
-    expectEqual("foobar".characters.count, calls)
+    _ = "foobar".reversed().map { _ in calls += 1 }
+    expectEqual("foobar".count, calls)
   }
 }
 
@@ -1007,12 +1007,12 @@ tests.test("ReversedCollection/Lazy") {
 
   do {
     typealias Expected = LazyBidirectionalCollection<
-      ReversedCollection<String.CharacterView>
+      ReversedCollection<String>
     >
 
-    let base = "foobar".characters.lazy.map { $0 }
+    let base = "foobar".lazy.map { $0 }
     typealias Base = LazyMapBidirectionalCollection<
-      String.CharacterView, Character>
+      String, Character>
     ExpectType<Base>.test(base)
 
     typealias LazyReversedBase = LazyBidirectionalCollection<
@@ -1024,7 +1024,7 @@ tests.test("ReversedCollection/Lazy") {
     var calls = 0
     let reversedAndMapped = reversed.map { (x) -> Character in calls += 1; return x }
     expectEqual(0, calls)
-    checkBidirectionalCollection("raboof".characters, reversedAndMapped)
+    checkBidirectionalCollection("raboof", reversedAndMapped)
     expectNotEqual(0, calls)
   }
 }
@@ -1165,7 +1165,7 @@ tests.test("LazyFilterCollection/AssociatedTypes") {
     collectionType: Subject.self,
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
     subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
-    indexType: LazyFilterIndex<Base>.self,
+    indexType: Base.Index.self,
     indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultIndices<Subject>.self)
 }
@@ -1177,7 +1177,7 @@ tests.test("LazyFilterBidirectionalCollection/AssociatedTypes") {
     collectionType: Subject.self,
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
     subSequenceType: LazyFilterBidirectionalCollection<Base.SubSequence>.self,
-    indexType: LazyFilterIndex<Base>.self,
+    indexType: Base.Index.self,
     indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
 }


### PR DESCRIPTION
Current reverse views use the C++ reverse iterator technique of point to the element adjacent to the same position in the base. This is a version that vends an index that points to the same position, and uses an enum with a `.end` case to indicate "one past the start". Mainly an experiment at this point to see impact on performance.