### PR TITLE
[SR-2660][Driver] Pass .swiftmodule to linker

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1414,8 +1414,9 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       }
       case types::TY_SwiftModuleFile:
       case types::TY_SwiftModuleDocFile:
-        if (OI.ShouldGenerateModule) {
-          // When generating a .swiftmodule, treat .swiftmodule files as
+        if (OI.ShouldGenerateModule && !OI.shouldLink()) {
+          // When generating a .swiftmodule as a top-level output (as opposed
+          // to, for example, linking an image), treat .swiftmodule files as
           // inputs to a MergeModule action.
           AllModuleInputs.push_back(Current);
           break;

--- a/test/Driver/bindings.swift
+++ b/test/Driver/bindings.swift
@@ -50,5 +50,5 @@
 
 // RUN: touch %t/a.swiftmodule %t/b.swiftmodule
 // RUN: %swiftc_driver -driver-print-bindings -target x86_64-apple-macosx10.9 -g %t/a.o %t/b.o %t/a.swiftmodule %t/b.swiftmodule -o main 2>&1 | %FileCheck %s -check-prefix=DEBUG-LINK-ONLY
-// DEBUG-LINK-ONLY: # "x86_64-apple-macosx10.9" - "swift", inputs: ["{{.*}}/a.swiftmodule", "{{.*}}/b.swiftmodule"], output: {swiftmodule: "[[MERGED:.+\.swiftmodule]]", swiftdoc: "{{.+}}.swiftdoc"}
-// DEBUG-LINK-ONLY: # "x86_64-apple-macosx10.9" - "ld", inputs: ["{{.*}}/a.o", "{{.*}}/b.o", "[[MERGED]]"], output: {image: "main"}
+// DEBUG-LINK-ONLY-NOT: "swift"
+// DEBUG-LINK-ONLY: # "x86_64-apple-macosx10.9" - "ld", inputs: ["{{.*}}/a.o", "{{.*}}/b.o", "{{.*}}/a.swiftmodule", "{{.*}}/b.swiftmodule"], output: {image: "main"}


### PR DESCRIPTION
The following two invocations of `swiftc` behave differently, despite their only difference being the `-g` option:

```
swiftc foo.swift bar.o baz.swiftmodule -o foo
swiftc -g foo.swift bar.o baz.swiftmodule -o foo
```

The first invocation compiles `foo.swift`, links it with `bar.o`, and passes the AST information from `baz.swiftmodule` to the linker. The second invocation results in the following error:

```
<unknown>:0: error: cannot load module 'baz' as 'foo'
```

The source of the problem is that the driver determines whether to generate a module based on the debug info level that has been requested, and merges all .swiftmodule inputs if a module is being generated.

Modify this behavior to instead pass .swiftmodule inputs directly to the linker if our output is to be linked. This results in both the `swiftc` and the `swiftc -g` invocations above succeeding.

**Test Plan:**

1. `utils/build-script --test` passes.
2. After cloning https://github.com/modocache/SR-2660 and modifying its `build-driver.sh` to point at the local Swift source build directory, running `build-driver.sh` succeeds, and lldb is able to print descriptions with accurate debug info.

Addresses one aspect of [SR-2660](https://bugs.swift.org/browse/SR-2660).