### PR TITLE
libSyntax: Ensure round-trip printing when we build syntax tree from parser incrementally.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -83,7 +83,7 @@ namespace syntax {
   class SourceFileSyntax;
   class SyntaxParsingContext;
   class SyntaxParsingContextRoot;
-  struct RawTokenInfo;
+  struct RawSyntaxInfo;
 }
 
 /// Discriminator for file-units.
@@ -1092,7 +1092,7 @@ private:
   Optional<std::vector<Token>> AllCorrectedTokens;
 
   /// All of the raw token syntax nodes in the underlying source.
-  std::vector<syntax::RawTokenInfo> AllRawTokenSyntax;
+  std::vector<syntax::RawSyntaxInfo> AllRawTokenSyntax;
 
   SourceFileSyntaxInfo &SyntaxInfo;
 

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -246,7 +246,7 @@ public:
   }
 
   /// Lex a full token including leading and trailing trivia.
-  syntax::RawTokenInfo fullLex();
+  syntax::RawSyntaxInfo fullLex();
 
   bool isKeepingComments() const {
     return RetainComments == CommentRetentionMode::ReturnAsTokens;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1429,7 +1429,7 @@ tokenizeWithTrivia(const LangOptions &LangOpts,
 void populateTokenSyntaxMap(const LangOptions &LangOpts,
                             const SourceManager &SM,
                             unsigned BufferID,
-                            std::vector<syntax::RawTokenInfo> &Result);
+                            std::vector<syntax::RawSyntaxInfo> &Result);
 } // end namespace swift
 
 #endif

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -92,6 +92,7 @@ public:
 
 enum class SyntaxContextKind: uint8_t{
   Expr,
+  Decl,
 };
 
 // The base class for contexts that are created from a parent context.

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -27,9 +27,15 @@ namespace swift {
 
 namespace syntax {
 
+/// The handler for parser to generate libSyntax entities.
 struct RawSyntaxInfo {
+  /// Start location of this syntax node.
   SourceLoc StartLoc;
+
+  /// The number of tokens belong to the syntax node.
   unsigned TokCount;
+
+  /// The raw node.
   RC<RawSyntax> RawNode;
   RawSyntaxInfo(SourceLoc StartLoc, RC<RawSyntax> RawNode):
     RawSyntaxInfo(StartLoc, 1, RawNode) {}

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -737,7 +737,7 @@ static bool rangeContainsPlaceholderEnd(const char *CurPtr,
   return false;
 }
 
-syntax::RawTokenInfo Lexer::fullLex() {
+syntax::RawSyntaxInfo Lexer::fullLex() {
   if (NextToken.isEscapedIdentifier()) {
     LeadingTrivia.push_back(syntax::TriviaPiece::backtick());
     TrailingTrivia.push_front(syntax::TriviaPiece::backtick());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 
 using namespace swift;
+using namespace syntax;
 
 namespace {
   /// A RAII object for deciding whether this DeclKind needs special
@@ -2125,7 +2126,8 @@ void Parser::delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
 ParserResult<Decl>
 Parser::parseDecl(ParseDeclOptions Flags,
                   llvm::function_ref<void(Decl*)> Handler) {
-
+  SyntaxParsingContextChild DeclParsingContext(SyntaxContext,
+                                               SyntaxContextKind::Decl, Tok);
   if (Tok.is(tok::pound_if)) {
     auto IfConfigResult = parseIfConfig(
       [&](SmallVectorImpl<ASTNode> &Decls, bool IsActive) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -40,7 +40,8 @@ using namespace swift::syntax;
 /// \param isExprBasic Whether we're only parsing an expr-basic.
 ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
   // Start a context for creating expression syntax.
-  SyntaxParsingContextChild ExprParsingContext(SyntaxContext, SyntaxKind::Expr);
+  SyntaxParsingContextChild ExprParsingContext(SyntaxContext,
+                                               SyntaxContextKind::Expr, Tok);
 
   // If we are parsing a refutable pattern, check to see if this is the start
   // of a let/var/is pattern.  If so, parse it to an UnresolvedPatternExpr and
@@ -1804,7 +1805,8 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
   // Create a syntax node for string literal.
   SyntaxContext->addTokenSyntax(Tok.getLoc());
   SyntaxContext->makeNode(SyntaxKind::StringLiteralExpr);
-  SyntaxParsingContextChild LocalContext(SyntaxContext, SyntaxKind::Expr);
+  SyntaxParsingContextChild LocalContext(SyntaxContext,
+                                         SyntaxContextKind::Expr, Tok);
 
   // FIXME: Avoid creating syntax nodes for string interpolation.
   LocalContext.disable();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -268,7 +268,7 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts,
                         syntax::AbsolutePosition>> Tokens;
   syntax::AbsolutePosition RunningPos;
   do {
-    auto ThisToken = L.fullLex().Token;
+    auto ThisToken = L.fullLex().getRaw<syntax::RawTokenSyntax>();
     auto ThisTokenPos = ThisToken->accumulateAbsolutePosition(RunningPos);
     Tokens.push_back({ThisToken, ThisTokenPos});
   } while (Tokens.back().first->isNot(tok::eof));
@@ -279,7 +279,7 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts,
 void swift::populateTokenSyntaxMap(const LangOptions &LangOpts,
                                    const SourceManager &SM,
                                    unsigned BufferID,
-                                   std::vector<syntax::RawTokenInfo> &Result) {
+                                   std::vector<syntax::RawSyntaxInfo> &Result) {
   if (!Result.empty())
     return;
   Lexer L(LangOpts, SM, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
@@ -287,7 +287,7 @@ void swift::populateTokenSyntaxMap(const LangOptions &LangOpts,
           TriviaRetentionMode::WithTrivia);
   do {
     Result.emplace_back(L.fullLex());
-    if (Result.back().Token->is(tok::eof))
+    if (Result.back().getRaw<syntax::RawTokenSyntax>()->is(tok::eof))
       return;
   } while (true);
 }

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -299,5 +299,9 @@ SyntaxParsingContextChild::~SyntaxParsingContextChild() {
       Parent->ContextData.addPendingSyntax({Start, TokCount,
         makeUnknownSyntax(SyntaxKind::UnknownExpr, SyntaxNodes).getRaw()});
       return;
+    case SyntaxContextKind::Decl:
+      Parent->ContextData.addPendingSyntax({Start, TokCount,
+        makeUnknownSyntax(SyntaxKind::UnknownDecl, SyntaxNodes).getRaw()});
+      return;
   }
 }

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/Module.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Parse/Token.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Syntax/TokenSyntax.h"
 #include "swift/Syntax/SyntaxParsingContext.h"
@@ -22,112 +23,183 @@ using namespace swift::syntax;
 
 namespace {
 static Syntax makeUnknownSyntax(SyntaxKind Kind, ArrayRef<Syntax> SubExpr) {
+  assert(isUnknownKind(Kind));
   RawSyntax::LayoutList Layout;
   std::transform(SubExpr.begin(), SubExpr.end(), std::back_inserter(Layout),
                  [](const Syntax &S) { return S.getRaw(); });
   return make<Syntax>(RawSyntax::make(Kind, Layout, SourcePresence::Present));
 }
+
+static std::vector<Syntax> getSyntaxNodes(ArrayRef<RawSyntaxInfo> RawNodes) {
+  std::vector<Syntax> SyntaxParts;
+  std::transform(RawNodes.begin(), RawNodes.end(), std::back_inserter(SyntaxParts),
+    [](const RawSyntaxInfo &Info) { return Info.makeSyntax<Syntax>(); });
+  return SyntaxParts;
+}
+
+static unsigned countTokens(ArrayRef<RawSyntaxInfo> AllNodes) {
+  return std::accumulate(AllNodes.begin(), AllNodes.end(), 0,
+    [](unsigned Sum, const RawSyntaxInfo &Info) { return Sum + Info.TokCount; });
+}
 } // End of anonymous namespace
+
+RawSyntaxInfo::RawSyntaxInfo(SourceLoc StartLoc, unsigned TokCount,
+  RC<RawSyntax> RawNode): StartLoc(StartLoc), TokCount(TokCount), RawNode(RawNode) {
+    assert(StartLoc.isValid());
+}
 
 struct SyntaxParsingContext::ContextInfo {
   bool Enabled;
-  std::vector<Syntax> PendingSyntax;
+private:
+  SourceLoc ContextStartLoc;
+  SourceLoc ContextEndLoc;
+  std::vector<RawSyntaxInfo> PendingSyntax;
 
-  ContextInfo(bool Enabled): Enabled(Enabled) {}
+  // All tokens after the start of this context.
+  ArrayRef<RawSyntaxInfo> Tokens;
+
+  ArrayRef<RawSyntaxInfo>::const_iterator findTokenAt(SourceLoc Loc) {
+    for (auto It = Tokens.begin(); It != Tokens.end(); It ++) {
+      assert(It->TokCount == 1);
+      if (It->StartLoc == Loc)
+        return It;
+    }
+    llvm_unreachable("cannot find the token on the given location");
+  }
+
+public:
+  ContextInfo(SourceFile &File, unsigned BufferID):
+      Enabled(File.shouldKeepTokens()) {
+    if (Enabled) {
+      populateTokenSyntaxMap(File.getASTContext().LangOpts,
+                             File.getASTContext().SourceMgr,
+                             BufferID, File.AllRawTokenSyntax);
+      Tokens = File.AllRawTokenSyntax;
+      assert(Tokens.back().makeSyntax<TokenSyntax>().getTokenKind() == tok::eof);
+    }
+  }
+
+  ContextInfo(ArrayRef<RawSyntaxInfo> Tokens, bool Enabled): Enabled(Enabled) {
+    if (Enabled) {
+      this->Tokens = Tokens;
+    }
+  }
+
+  // Squash N syntax nodex from the back of the pending list into one.
+  void createFromBack(SyntaxKind Kind, unsigned N = 0);
+  std::vector<RawSyntaxInfo> collectAllSyntax();
+  ArrayRef<RawSyntaxInfo> allTokens() const { return Tokens; }
+  ArrayRef<RawSyntaxInfo> getPendingSyntax() const { return PendingSyntax; };
+
+  void addPendingSyntax(RawSyntaxInfo Info) {
+    assert(PendingSyntax.empty() || PendingSyntax.back().StartLoc.
+           getOpaquePointerValue() < Info.StartLoc.getOpaquePointerValue());
+    PendingSyntax.push_back(Info);
+  }
+
+  void setContextStart(SourceLoc Loc) {
+    assert(ContextStartLoc.isInvalid());
+    ContextStartLoc = Loc;
+    Tokens = Tokens.slice(findTokenAt(Loc) - Tokens.begin());
+  }
+
+  void setContextEnd(SourceLoc Loc) {
+    assert(ContextEndLoc.isInvalid());
+    ContextEndLoc = Loc;
+    Tokens = Tokens.take_front(findTokenAt(Loc) - Tokens.begin());
+  }
+
+  void promoteTokenAt(SourceLoc Loc) {
+    PendingSyntax.push_back(*findTokenAt(Loc));
+  }
 
   // Check if the pending syntax is a token syntax in the given kind.
   bool checkTokenFromBack(tok Kind, unsigned OffsetFromBack = 0) {
     if (PendingSyntax.size() - 1 < OffsetFromBack)
       return false;
     auto Back = PendingSyntax[PendingSyntax.size() - 1 - OffsetFromBack].
-      getAs<TokenSyntax>();
+      makeSyntax<Syntax>().getAs<TokenSyntax>();
     return Back.hasValue() && Back->getTokenKind() == Kind;
-  }
-
-  void addPendingSyntax(ArrayRef<Syntax> More) {
-    std::transform(More.begin(), More.end(), std::back_inserter(PendingSyntax),
-                 [](const Syntax &S) { return make<Syntax>(S.getRaw()); });
-  }
-
-  // Squash N syntax nodex from the back of the pending list into one.
-  void createFromBack(SyntaxKind Kind, unsigned N = 0) {
-    auto Size = PendingSyntax.size();
-    assert(Size >= N);
-    if (!N)
-      N = Size;
-    auto Parts = llvm::makeArrayRef(PendingSyntax).slice(Size - N);
-
-    // Try to create the node of the given syntax.
-    Optional<Syntax> Result = SyntaxFactory::createSyntax(Kind, Parts);
-    if (!Result) {
-
-      // If unable to create, we should create an unknown node.
-      Result.emplace(makeUnknownSyntax(SyntaxFactory::getUnknownKind(Kind),
-                                       Parts));
-    }
-
-    // Remove the building bricks and re-append the result.
-    for (unsigned I = 0; I < N; I ++)
-      PendingSyntax.pop_back();
-    addPendingSyntax({ *Result });
-    assert(Size - N + 1 == PendingSyntax.size());
   }
 };
 
-SyntaxParsingContext::SyntaxParsingContext(bool Enabled):
-  ContextData(*new ContextInfo(Enabled)) {}
+std::vector<RawSyntaxInfo>
+SyntaxParsingContext::ContextInfo::collectAllSyntax() {
+  std::vector<RawSyntaxInfo> Results;
+  auto CurSyntax = PendingSyntax.begin();
+  for (auto It = Tokens.begin(); It != Tokens.end();) {
+    auto Tok = *It;
+    if (CurSyntax == PendingSyntax.end()) {
+      Results.emplace_back(Tok);
+      It ++;
+    } else if (CurSyntax->StartLoc == Tok.StartLoc) {
+      auto Cur = *CurSyntax;
+      Results.emplace_back(*CurSyntax);
+      It += CurSyntax->TokCount;
+      CurSyntax ++;
+    } else {
+      auto Cur = *CurSyntax;
+      assert(Tok.StartLoc.getOpaquePointerValue() <
+             CurSyntax->StartLoc.getOpaquePointerValue());
+      Results.push_back(Tok);
+      It ++;
+    }
+  }
+  for (;CurSyntax != PendingSyntax.end(); CurSyntax ++) {
+    Results.emplace_back(*CurSyntax);
+  }
+  return Results;
+}
+
+void
+SyntaxParsingContext::ContextInfo::createFromBack(SyntaxKind Kind, unsigned N) {
+  auto Size = PendingSyntax.size();
+  assert(Size >= N);
+  if (!N)
+    N = Size;
+  auto Parts = llvm::makeArrayRef(PendingSyntax).slice(Size - N);
+  std::vector<Syntax> SyntaxParts = getSyntaxNodes(Parts);
+
+  // Try to create the node of the given syntax.
+  Optional<Syntax> Result = SyntaxFactory::createSyntax(Kind, SyntaxParts);
+  if (!Result) {
+
+    // If unable to create, we should create an unknown node.
+    Result.emplace(makeUnknownSyntax(SyntaxFactory::getUnknownKind(Kind),
+                                     SyntaxParts));
+  }
+
+  // Remove the building bricks and re-append the result.
+  for (unsigned I = 0; I < N; I ++)
+    PendingSyntax.pop_back();
+  addPendingSyntax({ Parts.front().StartLoc, countTokens(Parts),
+                     Result->getRaw()});
+  assert(Size - N + 1 == PendingSyntax.size());
+}
+
+SyntaxParsingContext::SyntaxParsingContext(SourceFile &SF, unsigned BufferID):
+  ContextData(*new ContextInfo(SF, BufferID)) {}
 
 SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext &Another):
-    SyntaxParsingContext(Another.ContextData.Enabled) {}
+  ContextData(*new ContextInfo(Another.ContextData.allTokens(),
+                               Another.ContextData.Enabled)) {}
 
 SyntaxParsingContext::~SyntaxParsingContext() { delete &ContextData; }
 
 void SyntaxParsingContext::disable() { ContextData.Enabled = false; }
 
-struct SyntaxParsingContextRoot::GlobalInfo {
-  // The source file under parsing.
-  SourceFile &File;
-
-  // All tokens in the source file. This list will shrink from the start when
-  // we start to build syntax nodes.
-  ArrayRef<RawTokenInfo> Tokens;
-
-  GlobalInfo(SourceFile &File) : File(File) {}
-  TokenSyntax retrieveTokenSyntax(SourceLoc Loc) {
-    auto TargetLoc = Loc.getOpaquePointerValue();
-    for (unsigned I = 0, N = Tokens.size(); I < N; I ++) {
-      auto Info = Tokens[I];
-      auto InfoLoc = Info.Loc.getOpaquePointerValue();
-      if (InfoLoc < TargetLoc)
-        continue;
-      assert(InfoLoc == TargetLoc);
-      Tokens = Tokens.slice(I + 1);
-      return make<TokenSyntax>(Info.Token);
-    }
-    llvm_unreachable("can not find token at Loc");
-  }
-};
-
-SyntaxParsingContextRoot::
-SyntaxParsingContextRoot(SourceFile &File, unsigned BufferID):
-    SyntaxParsingContext(File.shouldKeepTokens()),
-    GlobalData(*new GlobalInfo(File)) {
-  populateTokenSyntaxMap(File.getASTContext().LangOpts,
-                         File.getASTContext().SourceMgr,
-                         BufferID, File.AllRawTokenSyntax);
-  // Keep track of the raw tokens.
-  GlobalData.Tokens = llvm::makeArrayRef(File.AllRawTokenSyntax);
-}
-
 SyntaxParsingContextRoot::~SyntaxParsingContextRoot() {
+  if (!ContextData.Enabled)
+    return;
   std::vector<DeclSyntax> AllTopLevel;
-  if (GlobalData.File.hasSyntaxRoot()) {
-    for (auto It: GlobalData.File.getSyntaxRoot().getTopLevelDecls()) {
+  if (File.hasSyntaxRoot()) {
+    for (auto It: File.getSyntaxRoot().getTopLevelDecls()) {
       AllTopLevel.push_back(It);
     }
   }
-  for (auto S: ContextData.PendingSyntax) {
+  for (auto Info: ContextData.getPendingSyntax()) {
     std::vector<StmtSyntax> AllStmts;
+    auto S = Info.makeSyntax<Syntax>();
     if (S.isDecl()) {
       AllStmts.push_back(SyntaxFactory::makeDeclarationStmt(
         S.getAs<DeclSyntax>().getValue(), None));
@@ -148,12 +220,9 @@ SyntaxParsingContextRoot::~SyntaxParsingContextRoot() {
       SyntaxFactory::makeStmtList(AllStmts)));
   }
 
-  Trivia Leading = Trivia::newlines(1), Trailing;
-  GlobalData.File.setSyntaxRoot(
+  File.setSyntaxRoot(
     SyntaxFactory::makeSourceFile(SyntaxFactory::makeDeclList(AllTopLevel),
-      SyntaxFactory::makeToken(tok::eof, "", SourcePresence::Present,
-                               Leading, Trailing)));
-  delete &GlobalData;
+    ContextData.allTokens().back().makeSyntax<TokenSyntax>()));
 }
 
 SyntaxParsingContextRoot &SyntaxParsingContextChild::getRoot() {
@@ -165,10 +234,18 @@ SyntaxParsingContextRoot &SyntaxParsingContextChild::getRoot() {
   llvm_unreachable("can not find root");
 }
 
+SyntaxParsingContextChild::
+SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
+                          SyntaxContextKind Kind, Token &Tok):
+    SyntaxParsingContext(*ContextHolder), Parent(ContextHolder),
+    ContextHolder(ContextHolder), Kind(Kind), Tok(Tok) {
+  ContextHolder = this;
+  ContextData.setContextStart(Tok.getLoc());
+}
+
 void SyntaxParsingContextChild::addTokenSyntax(SourceLoc Loc) {
   if (ContextData.Enabled)
-    ContextData.PendingSyntax.push_back(getRoot().GlobalData.
-      retrieveTokenSyntax(Loc));
+    ContextData.promoteTokenAt(Loc);
 }
 
 void SyntaxParsingContextChild::makeNode(SyntaxKind Kind) {
@@ -196,16 +273,31 @@ void SyntaxParsingContextChild::makeNode(SyntaxKind Kind) {
 
 SyntaxParsingContextChild::~SyntaxParsingContextChild() {
   SWIFT_DEFER {
-    // Parent should take care of the created syntax.
-    Parent->ContextData.addPendingSyntax(ContextData.PendingSyntax);
-
     // Reset the context holder to be Parent.
     ContextHolder = Parent;
   };
+  if (!ContextData.Enabled)
+    return;
+  ContextData.setContextEnd(Tok.getLoc());
+  auto AllNodes = ContextData.collectAllSyntax();
+  assert(countTokens(AllNodes) == ContextData.allTokens().size());
+  RC<RawSyntax> FinalResult;
+  if (AllNodes.empty())
+    return;
 
-  // If we've created more than one syntax node, we should try building by using
-  // the final kind.
-  if (ContextData.PendingSyntax.size() > 1) {
-    ContextData.createFromBack(FinalKind);
+  if (AllNodes.size() == 1) {
+    // FIXME: Check kind
+    Parent->ContextData.addPendingSyntax(AllNodes.front());
+    return;
+  }
+
+  std::vector<Syntax> SyntaxNodes = getSyntaxNodes(AllNodes);
+  SourceLoc Start = AllNodes.front().StartLoc;
+  unsigned TokCount = countTokens(AllNodes);
+  switch (Kind) {
+    case SyntaxContextKind::Expr:
+      Parent->ContextData.addPendingSyntax({Start, TokCount,
+        makeUnknownSyntax(SyntaxKind::UnknownExpr, SyntaxNodes).getRaw()});
+      return;
   }
 }

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -244,7 +244,8 @@ SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
     SyntaxParsingContext(*ContextHolder), Parent(ContextHolder),
     ContextHolder(ContextHolder), Kind(Kind), Tok(Tok) {
   ContextHolder = this;
-  ContextData.setContextStart(Tok.getLoc());
+  if (ContextData.Enabled)
+    ContextData.setContextStart(Tok.getLoc());
 }
 
 void SyntaxParsingContextChild::addTokenSyntax(SourceLoc Loc) {

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -304,10 +304,10 @@ SyntaxParsingContextChild::~SyntaxParsingContextChild() {
   switch (Kind) {
     case SyntaxContextKind::Expr:
       UnknownKind = SyntaxKind::UnknownExpr;
-      return;
+      break;
     case SyntaxContextKind::Decl:
       UnknownKind = SyntaxKind::UnknownDecl;
-      return;
+      break;
   }
   // Create an unknown node and give it to the parent context.
   Parent->ContextData.addPendingSyntax({Start, TokCount,

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -1,10 +1,15 @@
-<StringLiteralExpr>// RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
-// RUN: diff %t %s
+<DeclarationStmt><UnknownDecl>// RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
+// RUN: diff -u %t %s
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
-// RUN: diff %t.withkinds %S/Outputs/round_trip_parse_gen.swift.withkinds
+// RUN: diff -u %t.withkinds %S/Outputs/round_trip_parse_gen.swift.withkinds
 
-"String Literal"</StringLiteralExpr><StringLiteralExpr>
-
-""</StringLiteralExpr><IntegerLiteralExpr>
-
-/*comments*/+3 // comments</IntegerLiteralExpr>
+class C {<UnknownDecl>
+  func bar(_ a: Int) {}</UnknownDecl><UnknownDecl>
+  func foo() {<UnknownDecl>
+    var a = /*comment*/<StringLiteralExpr>"abc"/*comment*/</StringLiteralExpr></UnknownDecl><UnknownDecl>
+    var b = /*comment*/<IntegerLiteralExpr>+2/*comment*/</IntegerLiteralExpr></UnknownDecl><UnknownExpr>
+    bar(<IntegerLiteralExpr>1</IntegerLiteralExpr>)</UnknownExpr><UnknownExpr>
+    bar(<IntegerLiteralExpr>+10</IntegerLiteralExpr>)</UnknownExpr><UnknownExpr>
+    bar(<IntegerLiteralExpr>-10</IntegerLiteralExpr>)</UnknownExpr>
+  }</UnknownDecl>
+}</UnknownDecl></DeclarationStmt>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -1,10 +1,15 @@
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
-// RUN: diff %t %s
+// RUN: diff -u %t %s
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
-// RUN: diff %t.withkinds %S/Outputs/round_trip_parse_gen.swift.withkinds
+// RUN: diff -u %t.withkinds %S/Outputs/round_trip_parse_gen.swift.withkinds
 
-"String Literal"
-
-""
-
-/*comments*/+3 // comments
+class C {
+  func bar(_ a: Int) {}
+  func foo() {
+    var a = /*comment*/"abc"/*comment*/
+    var b = /*comment*/+2/*comment*/
+    bar(1)
+    bar(+10)
+    bar(-10)
+  }
+}


### PR DESCRIPTION
This also disables raw syntax token lexing in non-IDE mode. We saw memory surge when keeping syntax token parsing enabled at regular builds.
cc @DougGregor 