### PR TITLE
Finish up parent pointer removal

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -253,16 +253,6 @@ namespace {
       if (theClass->isGenericContext())
         ClassMetadataRequiresDynamicInitialization = true;
 
-      if (!ClassMetadataRequiresDynamicInitialization) {
-        if (auto parentType =
-              theClass->getDeclContext()->getDeclaredTypeInContext()) {
-          if (!tryEmitConstantTypeMetadataRef(IGM,
-                                              parentType->getCanonicalType(),
-                                              SymbolReferenceKind::Absolute))
-            ClassMetadataRequiresDynamicInitialization = true;
-        }
-      }
-
       if (theClass->hasSuperclass()) {
         SILType superclassType = classType.getSuperclass();
         auto superclass = superclassType.getClassOrBoundGenericClass();

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -398,15 +398,15 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
   // access if it contains a resilient type.
   if (isa<StructType>(type) || isa<EnumType>(type)) {
     auto nominalType = cast<NominalType>(type);
+    auto *nominalDecl = nominalType->getDecl();
 
     // Imported type metadata always requires an accessor.
-    if (isa<ClangModuleUnit>(nominalType->getDecl()->getModuleScopeContext()))
+    if (isa<ClangModuleUnit>(nominalDecl->getModuleScopeContext()))
       return false;
 
-    // Metadata with a non-trivial parent node always requires an accessor.
-    if (auto parent = nominalType.getParent())
-      if (!isTypeMetadataAccessTrivial(IGM, parent))
-        return false;
+    // Generic type metadata always requires an accessor.
+    if (nominalDecl->isGenericContext())
+      return false;
 
     // Resiliently-sized metadata access always requires an accessor.
     return (IGM.getTypeInfoForUnlowered(type).isFixedSize());

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -162,18 +162,7 @@ namespace {
     }
 
     void collect(IRGenFunction &IGF, CanType type) {
-      NominalTypeDecl *decl;
-      CanType parentType;
-
-      if (auto nominalType = dyn_cast<NominalType>(type)) {
-        decl = nominalType->getDecl();
-        parentType = nominalType.getParent();
-      } else {
-        auto boundType = cast<BoundGenericType>(type);
-        decl = boundType->getDecl();
-        parentType = boundType.getParent();
-      }
-
+      auto *decl = type.getNominalOrBoundGenericNominal();
       GenericTypeRequirements requirements(IGF.IGM, decl);
 
       auto subs =

--- a/test/IRGen/nested_types.sil
+++ b/test/IRGen/nested_types.sil
@@ -4,6 +4,9 @@ sil_stage canonical
 
 import Builtin
 
+// Note: This test is trivial now that structs inside classes don't require dynamic
+// metadata instantiation.
+
 class Outer {
   struct Inner {
   }
@@ -17,20 +20,8 @@ bb0(%0 : $@thick Outer.Inner.Type):
   return %1 : $@thick Outer.Type
 }
 // CHECK-LABEL: define{{ | protected }}swiftcc %swift.type* @test0(%swift.type*)
-//   TODO: it would be more efficient to get this type from the parent metadata field
 // CHECK:      [[T0:%.*]] = call %swift.type* @_T012nested_types5OuterCMa()
 // CHECK-NEXT: ret %swift.type* [[T0]]
 
 // CHECK-LABEL: define hidden %swift.type* @_T012nested_types5OuterC5InnerVMa()
-// CHECK:      [[T0:%.*]] = load %swift.type*, %swift.type** @_T012nested_types5OuterC5InnerVML
-// CHECK-NEXT: [[T1:%.*]] = icmp eq %swift.type* [[T0]], null
-// CHECK-NEXT: br i1 [[T1]]
-// CHECK:      call void @swift_once({{.*}}* @_T012nested_types5OuterC5InnerVMa.once_token, i8* bitcast (void (i8*)* @initialize_metadata_Inner to i8*), i8* undef)
-// CHECK-NEXT: [[T2:%.*]] = load %swift.type*, %swift.type** @_T012nested_types5OuterC5InnerVML
-// CHECK-NEXT: br label
-// CHECK:      [[T4:%.*]] = phi %swift.type* [ [[T0]], {{.*}} ], [ [[T2]], {{.*}} ]
-// CHECK-NEXT: ret %swift.type* [[T4]]
-
-// CHECK-LABEL: define private void @initialize_metadata_Inner
-// CHECK:      store atomic %swift.type* bitcast ({{.*}} @_T012nested_types5OuterC5InnerVMf{{.*}} to %swift.type*), %swift.type** @_T012nested_types5OuterC5InnerVML release, align
-// CHECK-NEXT: ret void
+// CHECK:      ret %swift.type* bitcast {{.*}} @_T012nested_types5OuterC5InnerVMf

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -17,17 +17,17 @@ import objc_extension_base
 // CHECK: [[METHOD_TYPE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 
 // CHECK-LABEL: @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions" = private constant
-// CHECK:   i64 1,
-// CHECK:   @_PROTOCOL__TtP15objc_extensions11NewProtocol_
+// CHECK-SAME:   i64 1,
+// CHECK-SAME:   @_PROTOCOL__TtP15objc_extensions11NewProtocol_
 
 // CHECK-LABEL: @"_CATEGORY_Gizmo_$_objc_extensions" = private constant
-// CHECK:   i8* getelementptr inbounds ([16 x i8], [16 x i8]* [[CATEGORY_NAME]], i64 0, i64 0),
-// CHECK:   %objc_class* @"OBJC_CLASS_$_Gizmo",
-// CHECK:   @"_CATEGORY_INSTANCE_METHODS_Gizmo_$_objc_extensions",
-// CHECK:   @"_CATEGORY_CLASS_METHODS_Gizmo_$_objc_extensions",
-// CHECK:   @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions",
-// CHECK:   i8* null
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME:   i8* getelementptr inbounds ([16 x i8], [16 x i8]* [[CATEGORY_NAME]], i64 0, i64 0),
+// CHECK-SAME:   %objc_class* @"OBJC_CLASS_$_Gizmo",
+// CHECK-SAME:   @"_CATEGORY_INSTANCE_METHODS_Gizmo_$_objc_extensions",
+// CHECK-SAME:   @"_CATEGORY_CLASS_METHODS_Gizmo_$_objc_extensions",
+// CHECK-SAME:   @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions",
+// CHECK-SAME:   i8* null
+// CHECK-SAME: }, section "__DATA, __objc_const", align 8
 
 @objc protocol NewProtocol {
   func brandNewInstanceMethod()
@@ -149,6 +149,21 @@ extension NSObject {
   public func needMetadataOfSomeEnum() {
     print(NSObject.SomeEnum.X)
   }
+}
+
+
+// CHECK-LABEL: @"_CATEGORY__TtCC15objc_extensions5Outer5Inner_$_objc_extensions" = private constant
+// CHECK-SAME:   i8* getelementptr inbounds ([16 x i8], [16 x i8]* [[CATEGORY_NAME]], i64 0, i64 0),
+// CHECK-SAME:   @"_CATEGORY_INSTANCE_METHODS__TtCC15objc_extensions5Outer5Inner_$_objc_extensions",
+// CHECK-SAME:   i8* null
+// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+
+class Outer : NSObject {
+  class Inner : NSObject {}
+}
+
+extension Outer.Inner {
+  @objc func innerExtensionMethod() {}
 }
 
 

--- a/test/Interpreter/objc_extensions.swift
+++ b/test/Interpreter/objc_extensions.swift
@@ -1,0 +1,19 @@
+// RUN: %target-run-simple-swift %s | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+class OuterClass {
+  class InnerClass: NSObject {}
+}
+
+extension OuterClass.InnerClass {
+  @objc static let propertyInExtension = "foo"
+}
+
+let x = OuterClass.InnerClass()
+
+// CHECK: foo
+print(type(of: x).propertyInExtension)
+

--- a/test/Interpreter/objc_extensions_jit.swift
+++ b/test/Interpreter/objc_extensions_jit.swift
@@ -1,0 +1,5 @@
+// RUN: %target-jit-run %S/objc_extensions.swift | %FileCheck %S/objc_extensions.swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// REQUIRES: swift_interpreter


### PR DESCRIPTION
I recently removed the parent field from type metadata in #12052, but forgot to fix up a few places in IRGen where we were continuing to force runtime metadata instantiation for nested types if the parent was not trivial.

This removes some restrictions on @objc classes nested inside other classes, since the properties of the parent type metadata no longer have any bearing on the nested type's metadata.

Fixes <rdar://problem/35221915>, <https://bugs.swift.org/browse/SR-6238>.