### PR TITLE
test: modernise nullability attributes (NFC)

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/CoreCooling.h
+++ b/test/ClangImporter/Inputs/custom-modules/CoreCooling.h
@@ -40,13 +40,18 @@ CCOpaqueTypeRef CCRetain(CCOpaqueTypeRef typeRef);
 void CCRelease(CCOpaqueTypeRef typeRef);
 
 // Nullability
-void CCRefrigeratorOpenDoSomething(__nonnull CCRefrigeratorRef fridge);
-void CCRefrigeratorOpenMaybeDoSomething(__nullable CCRefrigeratorRef fridge);
+void CCRefrigeratorOpenDoSomething(_Nonnull CCRefrigeratorRef fridge);
+void CCRefrigeratorOpenMaybeDoSomething(_Nullable CCRefrigeratorRef fridge);
 
 // Out parameters
-void CCRefrigeratorCreateIndirect(CCRefrigeratorRef * __nullable __attribute__((cf_returns_retained)) outFridge);
+void CCRefrigeratorCreateIndirect(CCRefrigeratorRef *_Nullable
+                                  __attribute__((cf_returns_retained))
+                                  outFridge);
 // Note that the fridge parameter is incorrectly annotated.
-void CCRefrigeratorGetPowerSupplyIndirect(CCRefrigeratorRef __attribute__((cf_returns_not_retained)) fridge, CCPowerSupplyRef * __nonnull __attribute__((cf_returns_not_retained)) outPower);
+void CCRefrigeratorGetPowerSupplyIndirect(
+    CCRefrigeratorRef __attribute__((cf_returns_not_retained)) fridge,
+    CCPowerSupplyRef *_Nonnull __attribute__((cf_returns_not_retained))
+    outPower);
 void CCRefrigeratorGetItemUnaudited(CCRefrigeratorRef fridge, unsigned index, CCItemRef *outItem);
 
 typedef void *CFNonConstVoidRef __attribute__((objc_bridge(id)));

--- a/test/ClangImporter/Inputs/custom-modules/Newtype.h
+++ b/test/ClangImporter/Inputs/custom-modules/Newtype.h
@@ -1,7 +1,7 @@
 @import Foundation;
 @import CoreFoundation;
 
-typedef NSString *__nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
+typedef NSString *_Nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
 __attribute((swift_name("ErrorDomain")));
 
 extern void SNTErrorDomainProcess(SNTErrorDomain d)
@@ -19,7 +19,7 @@ extern const SNTErrorDomain SNTFive
 extern const SNTErrorDomain SNTElsewhere
     __attribute((swift_name("Food.err")));
 
-typedef NSString *__nullable SNTClosedEnum __attribute((swift_newtype(enum)))
+typedef NSString *_Nullable SNTClosedEnum __attribute((swift_newtype(enum)))
 __attribute((swift_name("ClosedEnum")));
 
 extern const SNTClosedEnum SNTFirstClosedEntryEnum;
@@ -83,16 +83,16 @@ extern MyABIOldType getMyABIOldType(void);
 extern void takeMyABINewType(MyABINewType);
 extern void takeMyABIOldType(MyABIOldType);
 
-extern void takeMyABINewTypeNonNull(__nonnull MyABINewType);
-extern void takeMyABIOldTypeNonNull(__nonnull MyABIOldType);
+extern void takeMyABINewTypeNonNull(_Nonnull MyABINewType);
+extern void takeMyABIOldTypeNonNull(_Nonnull MyABIOldType);
 _Pragma("clang arc_cf_code_audited end")
 
 typedef NSString *MyABINewTypeNS __attribute((swift_newtype(struct)));
 typedef NSString *MyABIOldTypeNS;
 extern MyABINewTypeNS getMyABINewTypeNS(void);
 extern MyABIOldTypeNS getMyABIOldTypeNS(void);
-extern void takeMyABINewTypeNonNullNS(__nonnull MyABINewTypeNS);
-extern void takeMyABIOldTypeNonNullNS(__nonnull MyABIOldTypeNS);
+extern void takeMyABINewTypeNonNullNS(_Nonnull MyABINewTypeNS);
+extern void takeMyABIOldTypeNonNullNS(_Nonnull MyABIOldTypeNS);
 
 // Nested types
 typedef struct {int i;} NSSomeContext;

--- a/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
@@ -2,9 +2,9 @@
 @import SwiftName;
 
 @interface PointerWrapper
-@property void * __null_unspecified voidPtr;
-@property int * __null_unspecified intPtr;
-@property __null_unspecified id __autoreleasing * __null_unspecified idPtr;
+@property void *_Null_unspecified voidPtr;
+@property int *_Null_unspecified intPtr;
+@property _Null_unspecified id __autoreleasing *_Null_unspecified idPtr;
 @end
 
 #pragma clang assume_nonnull begin

--- a/test/ClangImporter/Inputs/mirror_import_overrides_1.h
+++ b/test/ClangImporter/Inputs/mirror_import_overrides_1.h
@@ -3,14 +3,14 @@
 @end
 
 @protocol A
-- (void) use: (nonnull void(^)(__nonnull id)) callback;
+- (void)use:(nonnull void (^)(_Nonnull id))callback;
 @end
 
 @protocol B<A>
 @end
 
 @protocol C<A>
-- (void) use: (nonnull void(^)(__nonnull id<Context>)) callback;
+- (void)use:(nonnull void (^)(_Nonnull id<Context>))callback;
 @end
 
 @protocol D<C, B>

--- a/test/ClangImporter/Inputs/mirror_import_overrides_2.h
+++ b/test/ClangImporter/Inputs/mirror_import_overrides_2.h
@@ -3,14 +3,14 @@
 @end
 
 @protocol A
-- (void) use: (nonnull void(^)(__nonnull id)) callback;
+- (void)use:(nonnull void (^)(_Nonnull id))callback;
 @end
 
 @protocol B<A>
 @end
 
 @protocol C<A>
-- (void) use: (nonnull void(^)(__nonnull id<Context>)) callback;
+- (void)use:(nonnull void (^)(_Nonnull id<Context>))callback;
 @end
 
 @protocol D<B, C>

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -62,9 +62,8 @@ SWIFT_PROTOCOL("SwiftProto")
 @property (nonatomic) long protoProperty;
 @end
 
-
-id <SwiftProtoWithCustomName> __nonnull convertToProto(SwiftClassWithCustomName * __nonnull obj);
-
+id<SwiftProtoWithCustomName> _Nonnull
+convertToProto(SwiftClassWithCustomName *_Nonnull obj);
 
 SWIFT_CLASS("BOGUS")
 @interface BogusClass

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -1,7 +1,7 @@
 @import Foundation;
 @import CoreFoundation;
 
-typedef NSString *__nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
+typedef NSString *_Nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
 __attribute((swift_name("ErrorDomain")));
 
 extern void SNTErrorDomainProcess(SNTErrorDomain d)
@@ -19,7 +19,7 @@ extern const SNTErrorDomain SNTFive
 extern const SNTErrorDomain SNTElsewhere
     __attribute((swift_name("Food.err")));
 
-typedef NSString *__nullable SNTClosedEnum __attribute((swift_newtype(enum)))
+typedef NSString *_Nullable SNTClosedEnum __attribute((swift_newtype(enum)))
 __attribute((swift_name("ClosedEnum")));
 
 extern const SNTClosedEnum SNTFirstClosedEntryEnum;
@@ -83,16 +83,16 @@ extern MyABIOldType getMyABIOldType(void);
 extern void takeMyABINewType(MyABINewType);
 extern void takeMyABIOldType(MyABIOldType);
 
-extern void takeMyABINewTypeNonNull(__nonnull MyABINewType);
-extern void takeMyABIOldTypeNonNull(__nonnull MyABIOldType);
+extern void takeMyABINewTypeNonNull(_Nonnull MyABINewType);
+extern void takeMyABIOldTypeNonNull(_Nonnull MyABIOldType);
 _Pragma("clang arc_cf_code_audited end")
 
 typedef NSString *MyABINewTypeNS __attribute((swift_newtype(struct)));
 typedef NSString *MyABIOldTypeNS;
 extern MyABINewTypeNS getMyABINewTypeNS(void);
 extern MyABIOldTypeNS getMyABIOldTypeNS(void);
-extern void takeMyABINewTypeNonNullNS(__nonnull MyABINewTypeNS);
-extern void takeMyABIOldTypeNonNullNS(__nonnull MyABIOldTypeNS);
+extern void takeMyABINewTypeNonNullNS(_Nonnull MyABINewTypeNS);
+extern void takeMyABIOldTypeNonNullNS(_Nonnull MyABIOldTypeNS);
 
 // Nested types
 typedef struct {int i;} NSSomeContext;
@@ -114,9 +114,9 @@ extern void mutate_TRef(TRef *) __attribute((swift_name("TRef.mutate(self:)")));
 extern void use_ConstT(ConstTRef)
     __attribute((swift_name("ConstTRef.use(self:)")));
 
-
-typedef struct T *__nonnull *TRefRef __attribute((swift_newtype(struct)));
-typedef struct T *__nonnull const *ConstTRefRef __attribute((swift_newtype(struct)));
+typedef struct T *_Nonnull *TRefRef __attribute((swift_newtype(struct)));
+typedef struct T *_Nonnull const *ConstTRefRef
+    __attribute((swift_newtype(struct)));
 extern _Nonnull TRefRef create_TRef(void);
 extern _Nonnull ConstTRefRef create_ConstTRef(void);
 extern void destroy_TRef(TRefRef);

--- a/test/IDE/Inputs/mock-sdk/BoolBridgingTests.framework/Headers/BoolBridgingTests.h
+++ b/test/IDE/Inputs/mock-sdk/BoolBridgingTests.framework/Headers/BoolBridgingTests.h
@@ -44,7 +44,7 @@ typedef __typeof(testObjCBoolFnToBlockTypedef) ObjCBoolFnToBlockType;
 typedef __typeof(testDarwinBooleanFnToBlockTypedef) DarwinBooleanFnToBlockType;
 
 extern ObjCBoolFnToBlockType *globalObjCBoolFnToBlockFP;
-extern ObjCBoolFnToBlockType * __nonnull * __nullable globalObjCBoolFnToBlockFPP;
+extern ObjCBoolFnToBlockType *_Nonnull *_Nullable globalObjCBoolFnToBlockFPP;
 extern ObjCBoolFnToBlockType ^globalObjCBoolFnToBlockBP;
 
 extern CBoolFn globalCBoolFn;
@@ -72,9 +72,10 @@ extern DarwinBooleanBlock globalDarwinBooleanBlock;
 - (BOOL (^)(BOOL))testObjCBoolFnToBlock:(BOOL (*)(BOOL))fp;
 - (Boolean (^)(Boolean))testDarwinBooleanFnToBlock:(Boolean (*)(Boolean))fp;
 
-- (void)produceCBoolBlockTypedef:(CBoolBlock __nullable * __nonnull)outBlock;
-- (void)produceObjCBoolBlockTypedef:(ObjCBoolBlock __nullable * __nonnull)outBlock;
-- (void)produceDarwinBooleanBlockTypedef:(DarwinBooleanBlock __nullable * __nonnull)outBlock;
+- (void)produceCBoolBlockTypedef:(CBoolBlock _Nullable *_Nonnull)outBlock;
+- (void)produceObjCBoolBlockTypedef:(ObjCBoolBlock _Nullable *_Nonnull)outBlock;
+- (void)produceDarwinBooleanBlockTypedef:
+    (DarwinBooleanBlock _Nullable *_Nonnull)outBlock;
 
 - (instancetype)init;
 @end

--- a/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -66,5 +66,5 @@ extern int weak_variable __attribute__((weak_import));
 
 @end
 
-typedef NSString *__nonnull NSNotificationName
+typedef NSString *_Nonnull NSNotificationName
     __attribute((swift_newtype(struct)));

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -95,7 +95,8 @@ __attribute__((availability(ios,introduced=8.0)))
 @interface NSArray<ObjectType> : NSObject
 - (nonnull ObjectType)objectAtIndexedSubscript:(NSUInteger)idx;
 - description;
-+ (instancetype)arrayWithObjects:(const ObjectType __nonnull [__nullable])objects count:(NSUInteger)count;
++ (instancetype)arrayWithObjects:(const ObjectType _Nonnull[_Nullable])objects
+                           count:(NSUInteger)count;
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector;
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector withObject:(nullable ObjectType)anObject;
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector withObject:(nullable ObjectType)anObject withObject:(nullable ObjectType)anotherObject;
@@ -124,9 +125,9 @@ __attribute__((availability(ios,introduced=8.0)))
 - (void) takeNullableString: (nullable NSString*) string;
 - (void) takeNullproneString: (null_unspecified NSString*) string;
 
-@property (readwrite) __nonnull NSString *nonnullStringProperty;
-@property (readwrite) __nullable NSString *nullableStringProperty;
-@property (readwrite) __null_unspecified NSString *nullproneStringProperty;
+@property(readwrite) _Nonnull NSString *nonnullStringProperty;
+@property(readwrite) _Nullable NSString *nullableStringProperty;
+@property(readwrite) _Null_unspecified NSString *nullproneStringProperty;
 
 @end
 
@@ -708,9 +709,8 @@ typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOnOSXOptions) {
 @end
 
 @interface NSClassWithExplicitlyUnavailableOptionsInMethodSignature (ActuallyUseOptions)
-  - (void)someMethodWithUnavailableOptions:(NSExplicitlyUnavailableOptions)options __attribute__((unavailable));
-
-  - (void)someMethodWithUnavailableOptionsOnOSX:(NSExplicitlyUnavailableOnOSXOptions)options __attribute__((availability(macosx, unavailable, message="Use a different API")));
+- (void)someMethodWithUnavailableOptions:(NSExplicitlyUnavailableOptions)options __attribute__((unavailable));
+- (void)someMethodWithUnavailableOptionsOnOSX:(NSExplicitlyUnavailableOnOSXOptions)options __attribute__((availability(macosx, unavailable, message="Use a different API")));
 @end
 
 @interface NSClassWithPotentiallyUnavailableOptionsInMethodSignature : NSObject
@@ -805,7 +805,7 @@ extern void CGColorRelease(CGColorRef color) __attribute__((availability(macosx,
 @property (readonly) Class classForPortCoder NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead");
 @end
 
-typedef NSString *__nonnull NSNotificationName
+typedef NSString *_Nonnull NSNotificationName
     __attribute((swift_newtype(struct)));
 
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
@@ -850,7 +850,8 @@ NS_SWIFT_UNAVAILABLE("NSInvocation and related APIs not available")
 @interface NSMethodSignature : NSObject
 @end
 /// Unavailable Global Functions
-extern void NSSetZoneName(NSZone * __nonnull zone, NSString * __nonnull name) NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
+extern void NSSetZoneName(NSZone *_Nonnull zone, NSString *_Nonnull name)
+    NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
 extern NSString *NSZoneName(NSZone *zone) NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
 extern NSZone *NSCreateZone(NSUInteger startSize, NSUInteger granularity, BOOL canFree) NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
 
@@ -859,7 +860,7 @@ extern NSZone *NSCreateZone(NSUInteger startSize, NSUInteger granularity, BOOL c
 @end
 
 typedef struct NonNilableReferences {
-  NSObject *__nonnull __unsafe_unretained obj;
+  NSObject *_Nonnull __unsafe_unretained obj;
 } NonNilableReferences;
 
 
@@ -872,26 +873,25 @@ typedef struct NonNilableReferences {
 -(void)optionalRequirement  __attribute__((availability(macosx, introduced=10.51)));
 @end
 
-__attribute__((availability(macosx,introduced=10.51)))
+__attribute__((availability(macosx, introduced = 10.51)))
 @interface AnnotatedFrameworkClass : NSObject
-
 @end
 
-__attribute__((availability(macosx,introduced=10.52)))
+__attribute__((availability(macosx, introduced = 10.52)))
 @interface AnnotatedLaterFrameworkClass : NSObject
-
 @end
 
 /// Aaa.  UnannotatedFrameworkProtocol.  Bbb.
 @protocol UnannotatedFrameworkProtocol
--(void)doSomethingWithClass:(AnnotatedFrameworkClass * __nullable)k;
--(void)doSomethingWithNonNullableClass:(AnnotatedFrameworkClass * __nonnull)k;
--(void)doSomethingWithIUOClass:(AnnotatedFrameworkClass * __null_unspecified)k;
--(AnnotatedFrameworkClass * __nullable)returnSomething;
+- (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nullable)k;
+- (void)doSomethingWithNonNullableClass:(AnnotatedFrameworkClass *_Nonnull)k;
+- (void)doSomethingWithIUOClass:(AnnotatedFrameworkClass *_Null_unspecified)k;
+- (AnnotatedFrameworkClass *_Nullable)returnSomething;
 
 -(void)noUnavailableTypesInSignature;
 
--(void)doSomethingWithClass:(AnnotatedFrameworkClass * __nonnull)k andLaterClass:(AnnotatedLaterFrameworkClass * __nonnull)lk;
+- (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nonnull)k
+               andLaterClass:(AnnotatedLaterFrameworkClass *_Nonnull)lk;
 
 -(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=10.53)));
 
@@ -900,25 +900,26 @@ __attribute__((availability(macosx,introduced=10.52)))
 @end
 
 /// Aaa.  AnnotatedFrameworkProtocol.  Bbb.
-__attribute__((availability(macosx,introduced=10.9)))
+__attribute__((availability(macosx, introduced = 10.9)))
 @protocol AnnotatedFrameworkProtocol
--(AnnotatedFrameworkClass * __nullable)returnSomething;
+- (AnnotatedFrameworkClass * _Nullable) returnSomething;
 @end
 
 /// Aaa.  FrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
-@interface FrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject <UnannotatedFrameworkProtocol>
+@interface FrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject<UnannotatedFrameworkProtocol>
 @end
 
 /// Aaa.  LaterFrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
-__attribute__((availability(macosx,introduced=10.52)))
-@interface LaterFrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject <UnannotatedFrameworkProtocol>
+__attribute__((availability(macosx, introduced = 10.52)))
+@interface LaterFrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject<UnannotatedFrameworkProtocol>
 @end
 
 /// Aaa.  LaterAnnotatedFrameworkProtocol.  Bbb.
-__attribute__((availability(macosx,introduced=10.52)))
+__attribute__((availability(macosx, introduced = 10.52)))
 @protocol LaterAnnotatedFrameworkProtocol
--(AnnotatedFrameworkClass * __nullable)returnSomething;
--(void)doSomethingWithClass:(AnnotatedFrameworkClass * __nonnull)k andLaterClass:(AnnotatedLaterFrameworkClass * __nonnull)lk;
+- (AnnotatedFrameworkClass * _Nullable) returnSomething;
+- (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nonnull)k
+               andLaterClass:(AnnotatedLaterFrameworkClass *_Nonnull)lk;
 -(void)noUnavailableTypesInSignature;
 -(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=10.53)));
 @property(nonnull) AnnotatedFrameworkClass *someProperty;
@@ -976,14 +977,11 @@ typedef NS_OPTIONS(NSUInteger, NSEnumerationOptions) {
                          usingBlock:(void (^)(id obj, NSUInteger idx,
                                               BOOL *stop))block;
 
-- (void)enumerateObjectsRandomlyWithBlock:(void (^ __nullable)(
-                                                  id obj,
-                                                  NSUInteger idx,
-                                                  BOOL *stop))block;
+- (void)enumerateObjectsRandomlyWithBlock:
+    (void (^_Nullable)(id obj, NSUInteger idx, BOOL *stop))block;
 
-- (void)enumerateObjectsHaphazardly:(void (^ __nullable)(id obj,
-                                                         NSUInteger idx,
-                                                         BOOL *stop))block;
+- (void)enumerateObjectsHaphazardly:(void (^_Nullable)(id obj, NSUInteger idx,
+                                                       BOOL *stop))block;
 
 - (void)optionallyEnumerateObjects:(NSEnumerationOptions)opts
                               body:(void (^)(id obj, NSUInteger idx,
@@ -997,14 +995,13 @@ typedef NS_OPTIONS(NSUInteger, NSEnumerationOptions) {
 - (void)doSomethingWithCopying:(nonnull id<NSCopying>)copying;
 - (void)doSomethingElseWithCopying:(nonnull NSObject<NSCopying> *)copying;
 
-- (void)enumerateObjectsWithNullableBlock:(void (^ __nullable)(
-                                                  id obj,
-                                                  NSUInteger idx,
-                                                  BOOL *stop))block;
+- (void)enumerateObjectsWithNullableBlock:
+    (void (^_Nullable)(id obj, NSUInteger idx, BOOL *stop))block;
 @end
 
 @interface NSMutableArray (Sorting)
-- (void)sortUsingFunction:(NSInteger (* __nonnull)(__nonnull id, __nonnull id))fimctopn;
+- (void)sortUsingFunction:(NSInteger (*_Nonnull)(_Nonnull id,
+                                                 _Nonnull id))fimctopn;
 @end
 
 @interface NSMutableArray (Removal)
@@ -1131,8 +1128,8 @@ typedef enum __attribute__((ns_error_domain(NSLaundryErrorDomain))) __attribute_
     NSLaundryErrorCatInWasher = 2
 };
 
-typedef void (*event_handler)(__nonnull id);
-void install_global_event_handler(__nullable event_handler handler);
+typedef void (*event_handler)(_Nonnull id);
+void install_global_event_handler(_Nullable event_handler handler);
 
 @interface NSObject ()
 - (void) addObserver: (id) observer

--- a/test/Inputs/clang-importer-sdk/usr/include/blocks.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/blocks.h
@@ -3,7 +3,8 @@
 
 @interface NSString ()
 
-- (void)enumerateLinesUsingBlock:(nonnull __attribute__((noescape)) void (^)(__nonnull NSString *line)) f;
+- (void)enumerateLinesUsingBlock:
+    (nonnull __attribute__((noescape)) void (^)(_Nonnull NSString *line))f;
 // FIXME: The importer drops this.
 //- (void)enumerateLinesUsingBlock:(void (^)(NSString *line, BOOL *b)) f;
 
@@ -12,9 +13,9 @@
 typedef void (^my_block_t)(void);
 
 my_block_t blockWithoutNullability();
-my_block_t __nonnull blockWithNonnull();
-my_block_t __null_unspecified blockWithNullUnspecified();
-my_block_t __nullable blockWithNullable();
+my_block_t _Nonnull blockWithNonnull();
+my_block_t _Null_unspecified blockWithNullUnspecified();
+my_block_t _Nullable blockWithNullable();
 
 void accepts_block(my_block_t) __attribute__((nonnull));
 void accepts_noescape_block(__attribute__((noescape)) my_block_t) __attribute__((nonnull));

--- a/test/Inputs/clang-importer-sdk/usr/include/nullability.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/nullability.h
@@ -3,9 +3,9 @@
 
 @import Foundation;
 
-__nullable id getId1(void);
+_Nullable id getId1(void);
 
-extern __nullable id global_id;
+extern _Nullable id global_id;
 
 @interface SomeClass
 - (nonnull id)methodA:(nullable SomeClass *)obj;

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -11,31 +11,31 @@ GenericOption const GenericOptionMultithreaded NS_SWIFT_NAME(multithreaded);
 
 @interface GenericClass<T> : NSObject
 - (id)initWithThing:(T)thing;
-- (id)initWithArrayOfThings:(NSArray<T> *__nonnull)things;
+- (id)initWithArrayOfThings:(NSArray<T> *_Nonnull)things;
 - (id)initWithOptions:(nullable NSDictionary<GenericOption, id> *)options;
 - (void)dealloc;
-- (__nullable T)thing;
+- (_Nullable T)thing;
 - (int)count;
-+ (__nullable T)classThing;
-- (__nonnull NSArray<T> *)arrayOfThings;
-- (void)setArrayOfThings:(NSArray<T> *__nonnull)things;
++ (_Nullable T)classThing;
+- (_Nonnull NSArray<T> *)arrayOfThings;
+- (void)setArrayOfThings:(NSArray<T> *_Nonnull)things;
 
-- (T __nonnull)objectAtIndexedSubscript:(uint16_t)i;
-- (void)setObject:(T __nonnull)object atIndexedSubscript:(uint16_t)i;
+- (T _Nonnull)objectAtIndexedSubscript:(uint16_t)i;
+- (void)setObject:(T _Nonnull)object atIndexedSubscript:(uint16_t)i;
 
-- (void)performBlockOnThings: (T __nonnull (^ __nonnull)(T __nonnull))block;
-- (T __nonnull (^ __nonnull)(T __nonnull))blockForPerformingOnThings;
+- (void)performBlockOnThings:(T _Nonnull (^_Nonnull)(T _Nonnull))block;
+- (T _Nonnull (^_Nonnull)(T _Nonnull))blockForPerformingOnThings;
 
-@property (nonatomic) __nullable T propertyThing;
-@property (nonatomic) __nullable NSArray<T> *propertyArrayOfThings;
+@property(nonatomic) _Nullable T propertyThing;
+@property(nonatomic) _Nullable NSArray<T> *propertyArrayOfThings;
 @end
 
-@interface GenericClass<T> (Private)
-- (__nullable T)otherThing;
-+ (__nullable T)otherClassThing;
+@interface GenericClass<T>(Private)
+- (_Nullable T)otherThing;
++ (_Nullable T)otherClassThing;
 @end
 
-void takeGenericClass(__nullable GenericClass<NSString *> *thing);
+void takeGenericClass(_Nullable GenericClass<NSString *> *thing);
 
 @interface GenericSubclass<T> : GenericClass<T>
 @end
@@ -72,23 +72,23 @@ void takeGenericClass(__nullable GenericClass<NSString *> *thing);
 @protocol Fungible
 @end
 
-@interface FungibleContainer<T: id<Fungible>> : NSObject
+@interface FungibleContainer<T : id<Fungible>> : NSObject
 @end
 
-@interface PettableContainer<T: id<Pettable>> : NSObject
+@interface PettableContainer<T : id<Pettable>> : NSObject
 @end
 
-@interface AnimalContainer<T: Animal *> : NSObject
+@interface AnimalContainer<T : Animal *> : NSObject
 @end
 
-@interface PettableAnimalContainer<T: Animal<Pettable> *> : NSObject
+@interface PettableAnimalContainer<T : Animal<Pettable> *> : NSObject
 @end
 
-@interface FungibleAnimalContainer<T: Animal<Fungible> *> : NSObject
+@interface FungibleAnimalContainer<T : Animal<Fungible> *> : NSObject
 @end
 
 @interface TestConstrainedTypeParam<T> : NSObject
-- (void)doThing:(__nonnull T<Pettable>)thing;
+- (void)doThing:(_Nonnull T<Pettable>)thing;
 @end
 
 typedef id <Fungible> FungibleObject;

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_structs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_structs.h
@@ -5,5 +5,5 @@ struct StructOfNSStrings {
 };
 
 struct StructOfBlocks {
-  void (^ __unsafe_unretained __nonnull block)(void);
+  void (^__unsafe_unretained _Nonnull block)(void);
 };

--- a/test/Interpreter/SDK/Inputs/Foundation_bridge.h
+++ b/test/Interpreter/SDK/Inputs/Foundation_bridge.h
@@ -1,8 +1,6 @@
 @import Foundation;
 
-static inline NSArray * __nullable getNullable() {
-  return nil;
-}
-static inline NSArray * __nonnull getNonnull() {
-  return (NSArray * __nonnull) nil;
+static inline NSArray *_Nullable getNullable() { return nil; }
+static inline NSArray *_Nonnull getNonnull() {
+  return (NSArray * _Nonnull) nil;
 }

--- a/test/Interpreter/SDK/Inputs/errors.h
+++ b/test/Interpreter/SDK/Inputs/errors.h
@@ -7,21 +7,21 @@
 - (nullable id)failAndReturnError:(NSError **)error;
 @end
 
-static id __nullable testSucceed(id <ErrorTest> __nonnull testObj) {
+static id _Nullable testSucceed(id<ErrorTest> _Nonnull testObj) {
   NSError *error = nil;
   return [testObj succeedAndReturnError:&error];
 }
 
-static id __nullable testSucceedIgnoringError(id <ErrorTest> __nonnull testObj) {
+static id _Nullable testSucceedIgnoringError(id<ErrorTest> _Nonnull testObj) {
   return [testObj succeedAndReturnError:NULL];
 }
 
-static id __nullable testFail(id <ErrorTest> __nonnull testObj) {
+static id _Nullable testFail(id<ErrorTest> _Nonnull testObj) {
   NSError *error = nil;
   return [testObj failAndReturnError:&error];
 }
 
-static id __nullable testFailIgnoringError(id <ErrorTest> __nonnull testObj) {
+static id _Nullable testFailIgnoringError(id<ErrorTest> _Nonnull testObj) {
   return [testObj failAndReturnError:NULL];
 }
 

--- a/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -30,8 +30,8 @@
 
 @interface Foo : NSObject
 
-- (__null_unspecified NSString*) foo;
-- (void) setFoo: (__null_unspecified NSString*)s;
+- (_Null_unspecified NSString*) foo;
+- (void)setFoo:(_Null_unspecified NSString *)s;
 
 - (BOOL) zim;
 - (void) setZim: (BOOL)b;
@@ -53,14 +53,14 @@
 
 @interface NSDraggingItem
 
-@property(copy, nullable) NSArray *__nonnull (^imageComponentsProvider)(void);
+@property(copy, nullable) NSArray *_Nonnull (^imageComponentsProvider)(void);
 
 @end
 
-__null_unspecified NSString *bar(void);
-void setBar(__null_unspecified NSString *s);
+_Null_unspecified NSString *bar(void);
+void setBar(_Null_unspecified NSString *s);
 
-__null_unspecified NSString *NSStringFromString(__null_unspecified NSString *s);
+_Null_unspecified NSString *NSStringFromString(_Null_unspecified NSString *s);
 NSString *NSStringFromClass(Class c);
 
 #define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type

--- a/test/SILGen/Inputs/usr/include/newtype.h
+++ b/test/SILGen/Inputs/usr/include/newtype.h
@@ -1,6 +1,6 @@
 @import Foundation;
 
-typedef NSString *__nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
+typedef NSString *_Nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
 __attribute((swift_name("ErrorDomain")));
 extern const SNTErrorDomain SNTErrTwo;
 extern const SNTErrorDomain SNTErrorDomainThree;

--- a/test/SourceKit/Inputs/libIDE-mock-sdk/BoolBridgingTests.framework/Headers/BoolBridgingTests.h
+++ b/test/SourceKit/Inputs/libIDE-mock-sdk/BoolBridgingTests.framework/Headers/BoolBridgingTests.h
@@ -68,9 +68,10 @@ extern DarwinBooleanBlock globalDarwinBooleanBlock;
 - (BOOL (^)(BOOL))testObjCBoolFnToBlock:(BOOL (*)(BOOL))fp;
 - (Boolean (^)(Boolean))testDarwinBooleanFnToBlock:(Boolean (*)(Boolean))fp;
 
-- (void)produceCBoolBlockTypedef:(CBoolBlock __nullable * __nonnull)outBlock;
-- (void)produceObjCBoolBlockTypedef:(ObjCBoolBlock __nullable * __nonnull)outBlock;
-- (void)produceDarwinBooleanBlockTypedef:(DarwinBooleanBlock __nullable * __nonnull)outBlock;
+- (void)produceCBoolBlockTypedef:(CBoolBlock _Nullable *_Nonnull)outBlock;
+- (void)produceObjCBoolBlockTypedef:(ObjCBoolBlock _Nullable *_Nonnull)outBlock;
+- (void)produceDarwinBooleanBlockTypedef:
+    (DarwinBooleanBlock _Nullable *_Nonnull)outBlock;
 
 - (instancetype)init;
 @end

--- a/test/SourceKit/Inputs/libIDE-mock-sdk/Mixed.framework/Headers/Mixed.h
+++ b/test/SourceKit/Inputs/libIDE-mock-sdk/Mixed.framework/Headers/Mixed.h
@@ -36,11 +36,11 @@ SWIFT_PROTOCOL_NAMED("CustomNameType")
 
 SWIFT_CLASS_NAMED("CustomNameClass")
 __attribute__((objc_root_class))
-@interface SwiftClassWithCustomName <SwiftProtoWithCustomName>
+@interface SwiftClassWithCustomName<SwiftProtoWithCustomName>
 @end
 
-id <SwiftProtoWithCustomName> __nonnull convertToProto(SwiftClassWithCustomName * __nonnull obj);
-
+id<SwiftProtoWithCustomName> _Nonnull
+convertToProto(SwiftClassWithCustomName *_Nonnull obj);
 
 SWIFT_CLASS("BOGUS")
 @interface BogusClass


### PR DESCRIPTION
Use the modern spelling for the nullability attributes in the test mock
headers.  Currently, this was relying on the predefined macros from
clang to work.  However, those are only available on Darwin targets.
This is needed to make the mock environments more portable.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
