### PR TITLE
vim: improve syntax highlighting for SIL attributes

### DIFF
--- a/utils/vim/syntax/sil.vim
+++ b/utils/vim/syntax/sil.vim
@@ -32,6 +32,29 @@ syn match silFunctionType skipwhite
 syn match silMetatypeType skipwhite
       \ /@\(\<thick\>\|\<thin\>\|\<objc\>\)/
 
+" TODO: handle [tail_elems sil-type * sil-operand]
+syn region silAttribute contains=silAttributes
+      \ start="\[" end="\]"
+syn keyword silAttributes contained containedin=silAttribute
+      \ abort
+      \ deinit
+      \ delegatingself
+      \ derivedself
+      \ derivedselfonly
+      \ dynamic
+      \ exact
+      \ init
+      \ modify
+      \ objc
+      \ read
+      \ rootself
+      \ stack
+      \ static
+      \ strict
+      \ unknown
+      \ unsafe
+      \ var
+
 syn keyword swiftImport import skipwhite nextgroup=swiftImportModule
 syn match swiftImportModule /\<[A-Za-z_][A-Za-z_0-9]*\>/ contained nextgroup=swiftImportComponent
 syn match swiftImportComponent /\.\<[A-Za-z_][A-Za-z_0-9]*\>/ contained nextgroup=swiftImportComponent
@@ -132,5 +155,6 @@ hi def link silConventions Type
 hi def link silIdentifier Identifier
 hi def link silFunctionType Special
 hi def link silMetatypeType Special
+hi def link silAttribute PreProc
 
 let b:current_syntax = "sil"


### PR DESCRIPTION
Add rules to highlight the SIL attributes currently emitted by the swift
compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
