### PR TITLE
IRGen: properly handle deallocation of a boxed type

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1541,6 +1541,7 @@ public:
     auto size = layout.emitSize(IGF.IGM);
     auto alignMask = layout.emitAlignMask(IGF.IGM);
 
+    IGF.emitNativeSetDeallocating(box);
     emitDeallocateHeapObject(IGF, box, size, alignMask);
   }
 

--- a/test/IRGen/alloc_box.swift
+++ b/test/IRGen/alloc_box.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o - | %FileCheck %s
+
+func f() -> Bool? { return nil }
+
+({
+  guard var b = f() else { return }
+  let c = { b = true }
+  _ = (b, c)
+})()
+
+// CHECK-LABEL: @_T09alloc_boxyycfU_
+// CHECK: <label>:8:
+// CHECK: call void @swift_setDeallocating
+// CHECK: call void @swift_rt_swift_deallocObject
+


### PR DESCRIPTION
When a boxed type is destroyed, ensure that the object is marked as
deiniting first.  This was caught by an assertion in the runtime.

Addresses SR-6268 | rdar://problem/35296541

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->