### PR TITLE
SILGen: Conditionally use @callee_guaranteed contexts

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3415,6 +3415,12 @@ public:
   bool isCalleeConsumed() const {
     return getCalleeConvention() == ParameterConvention::Direct_Owned;
   }
+  bool isCalleeUnowned() const {
+    return getCalleeConvention() == ParameterConvention::Direct_Unowned;
+  }
+  bool isCalleeGuaranteed() const {
+    return getCalleeConvention() == ParameterConvention::Direct_Guaranteed;
+  }
 
   /// Return the array of all result information. This may contain inter-mingled
   /// direct and indirect results.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1687,9 +1687,11 @@ static SILValue emitRawApply(SILGenFunction &SGF,
                              ArrayRef<SILValue> indirectResultAddrs) {
   SILFunctionConventions substFnConv(substFnType, SGF.SGM.M);
   // Get the callee value.
-  SILValue fnValue = substFnType->isCalleeConsumed()
-    ? fn.forward(SGF)
-    : fn.getValue();
+  bool isConsumed = substFnType->isCalleeConsumed();
+  bool isUnowned = substFnType->isCalleeUnowned();
+  SILValue fnValue =
+      isUnowned ? fn.getValue()
+                : isConsumed ? fn.forward(SGF) : fn.borrow(SGF, loc).getValue();
 
   SmallVector<SILValue, 4> argValues;
 
@@ -4372,9 +4374,11 @@ CallEmission::applyPartiallyAppliedSuperMethod(unsigned uncurryLevel,
                                                 functionTy);
     }
   }
+  auto calleeConvention = SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts
+                              ? ParameterConvention::Direct_Guaranteed
+                              : ParameterConvention::Direct_Owned;
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
-      constantInfo.getSILType(), 1, SGF.B.getModule(), subs,
-      ParameterConvention::Direct_Owned);
+      constantInfo.getSILType(), 1, SGF.B.getModule(), subs, calleeConvention);
 
   auto &module = SGF.getFunction().getModule();
 
@@ -5572,11 +5576,14 @@ static ManagedValue emitDynamicPartialApply(SILGenFunction &SGF,
                                             SILValue self,
                                          CanAnyFunctionType foreignFormalType,
                                          CanAnyFunctionType nativeFormalType) {
-  auto partialApplyTy = SILBuilder::getPartialApplyResultType(method->getType(),
-                                            /*argCount*/1,
-                                            SGF.SGM.M,
-                                            /*subs*/{},
-                                            ParameterConvention::Direct_Owned);
+  auto calleeConvention = SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts
+                              ? ParameterConvention::Direct_Guaranteed
+                              : ParameterConvention::Direct_Owned;
+
+  auto partialApplyTy =
+      SILBuilder::getPartialApplyResultType(method->getType(),
+                                            /*argCount*/ 1, SGF.SGM.M,
+                                            /*subs*/ {}, calleeConvention);
 
   // Retain 'self' because the partial apply will take ownership.
   // We can't simply forward 'self' because the partial apply is conditional.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -210,7 +210,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         // Our 'let' binding can guarantee the lifetime for the callee,
         // if we don't need to do anything more to it.
         if (canGuarantee && !var->getType()->is<ReferenceStorageType>()) {
-          auto guaranteed = ManagedValue::forUnmanaged(Val);
+          auto guaranteed = ManagedValue::forUnmanaged(Val).borrow(*this, loc);
           capturedArgs.push_back(guaranteed);
           break;
         }
@@ -256,7 +256,8 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       if (vl.box) {
         // We can guarantee our own box to the callee.
         if (canGuarantee) {
-          capturedArgs.push_back(ManagedValue::forUnmanaged(vl.box));
+          capturedArgs.push_back(
+              ManagedValue::forUnmanaged(vl.box).borrow(*this, loc));
         } else {
           capturedArgs.push_back(emitManagedRetain(loc, vl.box));
         }
@@ -282,7 +283,11 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         ProjectBoxInst *boxAddress = B.createProjectBox(loc, allocBox, 0);
         B.createCopyAddr(loc, vl.value, boxAddress, IsNotTake,
                          IsInitialization);
-        capturedArgs.push_back(emitManagedRValueWithCleanup(allocBox));
+        if (canGuarantee)
+          capturedArgs.push_back(
+              emitManagedRValueWithCleanup(allocBox).borrow(*this, loc));
+        else
+          capturedArgs.push_back(emitManagedRValueWithCleanup(allocBox));
       }
 
       break;
@@ -357,11 +362,14 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
   for (auto capture : capturedArgs)
     forwardedArgs.push_back(capture.forward(*this));
 
-  SILType closureTy =
-    SILGenBuilder::getPartialApplyResultType(functionRef->getType(),
-                                             capturedArgs.size(), SGM.M,
-                                             subs,
-                                             ParameterConvention::Direct_Owned);
+  auto calleeConvention = SGM.M.getOptions().EnableGuaranteedClosureContexts
+                              ? ParameterConvention::Direct_Guaranteed
+                              : ParameterConvention::Direct_Owned;
+
+  SILType closureTy = SILGenBuilder::getPartialApplyResultType(
+      functionRef->getType(), capturedArgs.size(), SGM.M, subs,
+      calleeConvention);
+
   auto toClosure =
     B.createPartialApply(loc, functionRef, functionTy,
                          subs, forwardedArgs, closureTy);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2624,11 +2624,12 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
   // Add the rest of the arguments.
   forwardFunctionArguments(SGF, loc, fnType, args, argValues);
 
+  auto fun = fnType->isCalleeGuaranteed() ? fnValue.borrow(SGF, loc).getValue()
+                                          : fnValue.forward(SGF);
   SILValue innerResult =
-    SGF.emitApplyWithRethrow(loc, fnValue.forward(SGF),
-                             /*substFnType*/ fnValue.getType(),
-                             /*substitutions*/ {},
-                             argValues);
+      SGF.emitApplyWithRethrow(loc, fun,
+                               /*substFnType*/ fnValue.getType(),
+                               /*substitutions*/ {}, argValues);
 
   // Reabstract the result.
   SILValue outerResult = resultPlanner.execute(innerResult);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -396,6 +396,8 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     // temporary within the closure to provide this address.
     if (VD->isSettable(VD->getDeclContext())) {
       auto addr = SGF.emitTemporaryAllocation(VD, ty);
+      if (SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts)
+        val = SGF.B.createCopyValue(Loc, val);
       lowering.emitStore(SGF.B, VD, val, addr, StoreOwnershipQualifier::Init);
       val = addr;
     }

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -165,11 +165,13 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
   resultTy = F.mapTypeIntoContext(resultTy);
   auto substTy = toFn->getType().substGenericArgs(SGM.M,  subs);
 
+  auto calleeConvention = SGM.M.getOptions().EnableGuaranteedClosureContexts
+                              ? ParameterConvention::Direct_Guaranteed
+                              : ParameterConvention::Direct_Owned;
+
   // Partially apply the next uncurry level and return the result closure.
-  auto closureTy =
-    SILGenBuilder::getPartialApplyResultType(toFn->getType(), /*appliedParams=*/1,
-                                             SGM.M, subs,
-                                             ParameterConvention::Direct_Owned);
+  auto closureTy = SILGenBuilder::getPartialApplyResultType(
+      toFn->getType(), /*appliedParams=*/1, SGM.M, subs, calleeConvention);
   SILValue toClosure =
     B.createPartialApply(vd, toFn, substTy, subs, {selfArg}, closureTy);
   if (resultTy != closureTy)

--- a/test/SILGen/closures_callee_guaranteed.swift
+++ b/test/SILGen/closures_callee_guaranteed.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -parse-as-library -enable-guaranteed-closure-contexts -emit-silgen %s | %FileCheck %s
+import Swift
+
+// CHECK-LABEL: sil @{{.*}}apply{{.*}} : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Int)
+// bb0(%0 : @owned $@noescape @callee_guaranteed () -> Int):
+//   [[B1:%.*]] = begin_borrow %0 : $@noescape @callee_guaranteed () -> Int
+//   [[C1:%.*]] = copy_value %2 : $@noescape @callee_guaranteed () -> Int
+//
+//   The important part is that the call borrow's the function value -- we are
+//   @callee_guaranteed.
+//   [[B2:%.*]] = begin_borrow [[C1]] : $@noescape @callee_guaranteed () -> Int
+//   [[R:%.*]] = apply [[B2]]() : $@noescape @callee_guaranteed () -> Int
+//   end_borrow [[B2]] from [[C1]] : $@noescape @callee_guaranteed () -> Int, $@noescape @callee_guaranteed () -> Int
+//
+//   destroy_value [[C1]] : $@noescape @callee_guaranteed () -> Int
+//   end_borrow [[B1]] from %0 : $@noescape @callee_guaranteed () -> Int, $@noescape @callee_guaranteed () -> Int
+//   destroy_value %0 : $@noescape @callee_guaranteed () -> Int
+//   return [[R]] : $Int
+public func apply(_ f : () -> Int) -> Int {
+  return f()
+}
+
+// CHECK-LABEL: sil @{{.*}}test{{.*}} : $@convention(thin) () -> ()
+// CHECK:   [[A:%.*]] = function_ref @{{.*}}apply{{.*}} : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Int) -> Int
+// CHECK:   [[C1:%.*]] = function_ref @{{.*}}test{{.*}} : $@convention(thin) () -> Int
+// CHECK:   [[C2:%.*]] = convert_function [[C1]] : $@convention(thin) () -> Int to $@convention(thin) @noescape () -> Int
+// CHECK:   [[C3:%.*]] = thin_to_thick_function [[C2]] : $@convention(thin) @noescape () -> Int to $@noescape @callee_guaranteed () -> Int
+// CHECK:   apply [[A]]([[C3]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Int) -> Int
+public func test() {
+  let res = apply({ return 1 })
+}


### PR DESCRIPTION
We need to borrow guaranteed values with sil ownership and need to
distinguish between @callee_guaranteed and other context conventions in
a few places.

rdar://33255593
SR-5441