### PR TITLE
[Type checker] The term "layout constraint" is confusing; don't use it.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1733,13 +1733,13 @@ NOTE(superclass_redundancy_here,none,
      (unsigned, Type, Type))
 
 ERROR(conflicting_layout_constraints,none,
-      "%select{generic parameter |protocol |}0%1 has conflicting layout "
+      "%select{generic parameter |protocol |}0%1 has conflicting "
       "constraints %2 and %3",
       (unsigned, Type, LayoutConstraint, LayoutConstraint))
 WARNING(redundant_layout_constraint,none,
-        "redundant layout constraint %0 : %1", (Type, LayoutConstraint))
+        "redundant constraint %0 : %1", (Type, LayoutConstraint))
 NOTE(previous_layout_constraint, none,
-     "layout constraint constraint %1 : %2 %select{written here|implied here|"
+     "constraint %1 : %2 %select{written here|implied here|"
      "inferred from type here}0",
      (unsigned, Type, LayoutConstraint))
 

--- a/test/Compatibility/anyobject_class.swift
+++ b/test/Compatibility/anyobject_class.swift
@@ -3,5 +3,5 @@
 // RUN: not %target-swift-frontend -tyepcheck -swift-version 5
 
 protocol P : class, AnyObject { } // expected-warning{{redundant inheritance from 'AnyObject' and Swift 3 'class' keyword}}{{14-21=}}
-// expected-warning@-1{{redundant layout constraint 'Self' : 'AnyObject'}}
-// expected-note@-2{{layout constraint constraint 'Self' : 'AnyObject' written here}}
+// expected-warning@-1{{redundant constraint 'Self' : 'AnyObject'}}
+// expected-note@-2{{constraint 'Self' : 'AnyObject' written here}}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -161,16 +161,16 @@ func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 }
 
 @_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject)
-// expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial(64)' and '_Trivial(32)'}}
-// expected-error@-2{{generic parameter 'T' has conflicting layout constraints '_RefCountedObject' and '_Trivial(32)'}}
-// expected-warning@-3{{redundant layout constraint 'T' : '_Trivial'}}
-// expected-note@-4 3{{layout constraint constraint 'T' : '_Trivial(32)' written here}}
+// expected-error@-1{{generic parameter 'T' has conflicting constraints '_Trivial(64)' and '_Trivial(32)'}}
+// expected-error@-2{{generic parameter 'T' has conflicting constraints '_RefCountedObject' and '_Trivial(32)'}}
+// expected-warning@-3{{redundant constraint 'T' : '_Trivial'}}
+// expected-note@-4 3{{constraint 'T' : '_Trivial(32)' written here}}
 @_specialize(where T: _Trivial, T: _Trivial(64))
-// expected-warning@-1{{redundant layout constraint 'T' : '_Trivial'}}
-// expected-note@-2 1{{layout constraint constraint 'T' : '_Trivial(64)' written here}}
+// expected-warning@-1{{redundant constraint 'T' : '_Trivial'}}
+// expected-note@-2 1{{constraint 'T' : '_Trivial(64)' written here}}
 @_specialize(where T: _RefCountedObject, T: _NativeRefCountedObject)
-// expected-warning@-1{{redundant layout constraint 'T' : '_RefCountedObject'}}
-// expected-note@-2 1{{layout constraint constraint 'T' : '_NativeRefCountedObject' written here}}
+// expected-warning@-1{{redundant constraint 'T' : '_RefCountedObject'}}
+// expected-note@-2 1{{constraint 'T' : '_NativeRefCountedObject' written here}}
 @_specialize(where Array<T> == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
 // expected-error@-1{{generic signature requires types 'Array<T>' and 'Int' to be the same}}
 @_specialize(where T.Element == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
@@ -183,9 +183,9 @@ public protocol Proto: class {
 
 @_specialize(where T: _RefCountedObject)
 @_specialize(where T: _Trivial)
-// expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial' and '_NativeClass'}}
+// expected-error@-1{{generic parameter 'T' has conflicting constraints '_Trivial' and '_NativeClass'}}
 @_specialize(where T: _Trivial(64))
-// expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial(64)' and '_NativeClass'}}
+// expected-error@-1{{generic parameter 'T' has conflicting constraints '_Trivial(64)' and '_NativeClass'}}
 public func funcWithABaseClassRequirement<T>(t: T) -> Int where T: C1 {
   return 44444
 }

--- a/test/decl/protocol/req/class.swift
+++ b/test/decl/protocol/req/class.swift
@@ -5,7 +5,7 @@ protocol P1 : class { }
 protocol P2 : class, class { } // expected-error{{redundant 'class' requirement}}{{20-27=}}
 
 protocol P3 : P2, class { } // expected-error{{'class' must come first in the requirement list}}{{15-15=class, }}{{17-24=}}
-// expected-warning@-1 {{redundant layout constraint 'Self' : 'AnyObject'}}
-// expected-note@-2 {{layout constraint constraint 'Self' : 'AnyObject' implied here}}
+// expected-warning@-1 {{redundant constraint 'Self' : 'AnyObject'}}
+// expected-note@-2 {{constraint 'Self' : 'AnyObject' implied here}}
 
 struct X : class { } // expected-error{{'class' constraint can only appear on protocol declarations}}


### PR DESCRIPTION
Within the compiler, we use the term "layout constraint" for any
constraint that affects the layout of a type parameter that has that
constraint. However, the only user-visible constraint is "AnyObject",
and calling that a layout constraint is confusing. Drop the term
"layout" from diagnostics.

Fixes rdar://problem/35295372.
