### PR TITLE
libSyntax: root parsing context should hold a reference to the current token in the parser, NFC.

### DIFF
--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -58,11 +58,12 @@ enum class SyntaxParsingContextKind: uint8_t {
 /// create syntax nodes.
 class SyntaxParsingContext {
 protected:
-  SyntaxParsingContext(SourceFile &SF, unsigned BufferID);
+  SyntaxParsingContext(SourceFile &SF, unsigned BufferID, Token &Tok);
   SyntaxParsingContext(SyntaxParsingContext &Another);
 public:
   struct ContextInfo;
   ContextInfo &ContextData;
+  const Token &Tok;
 
   // Add a token syntax at the given source location to the context; this
   // token node can be used to build more complex syntax nodes in later call
@@ -86,8 +87,8 @@ public:
 class SyntaxParsingContextRoot: public SyntaxParsingContext {
   SourceFile &File;
 public:
-  SyntaxParsingContextRoot(SourceFile &File, unsigned BufferID):
-    SyntaxParsingContext(File, BufferID), File(File) {}
+  SyntaxParsingContextRoot(SourceFile &File, unsigned BufferID, Token &Tok):
+    SyntaxParsingContext(File, BufferID, Tok), File(File) {}
   ~SyntaxParsingContextRoot();
   void addTokenSyntax(SourceLoc Loc) override {};
   void makeNode(SyntaxKind Kind) override {};
@@ -109,10 +110,9 @@ class SyntaxParsingContextChild: public SyntaxParsingContext {
   SyntaxParsingContext *Parent;
   SyntaxParsingContext *&ContextHolder;
   const SyntaxContextKind Kind;
-  Token &Tok;
 public:
   SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-                            SyntaxContextKind Kind, Token &Tok);
+                            SyntaxContextKind Kind);
   ~SyntaxParsingContextChild();
   void makeNode(SyntaxKind Kind) override;
   void addTokenSyntax(SourceLoc Loc) override;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2148,7 +2148,7 @@ ParserResult<Decl>
 Parser::parseDecl(ParseDeclOptions Flags,
                   llvm::function_ref<void(Decl*)> Handler) {
   SyntaxParsingContextChild DeclParsingContext(SyntaxContext,
-                                               SyntaxContextKind::Decl, Tok);
+                                               SyntaxContextKind::Decl);
   if (Tok.is(tok::pound_if)) {
     auto IfConfigResult = parseIfConfig(
       [&](SmallVectorImpl<ASTNode> &Decls, bool IsActive) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -41,7 +41,7 @@ using namespace swift::syntax;
 ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
   // Start a context for creating expression syntax.
   SyntaxParsingContextChild ExprParsingContext(SyntaxContext,
-                                               SyntaxContextKind::Expr, Tok);
+                                               SyntaxContextKind::Expr);
 
   // If we are parsing a refutable pattern, check to see if this is the start
   // of a let/var/is pattern.  If so, parse it to an UnresolvedPatternExpr and
@@ -1806,7 +1806,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
   SyntaxContext->addTokenSyntax(Tok.getLoc());
   SyntaxContext->makeNode(SyntaxKind::StringLiteralExpr);
   SyntaxParsingContextChild LocalContext(SyntaxContext,
-                                         SyntaxContextKind::Expr, Tok);
+                                         SyntaxContextKind::Expr);
 
   // FIXME: Avoid creating syntax nodes for string interpolation.
   LocalContext.disable();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -434,7 +434,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     TokReceiver(SF.shouldKeepTokens() ?
                 new TokenRecorder(SF) :
                 new ConsumeTokenReceiver()),
-    SyntaxContext(new syntax::SyntaxParsingContextRoot(SF, L->getBufferID())) {
+    SyntaxContext(new syntax::SyntaxParsingContextRoot(SF, L->getBufferID(), Tok)) {
 
   State = PersistentState;
   if (!State) {

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -180,12 +180,13 @@ SyntaxParsingContext::ContextInfo::createFromBack(SyntaxKind Kind, unsigned N) {
   assert(Size - N + 1 == PendingSyntax.size());
 }
 
-SyntaxParsingContext::SyntaxParsingContext(SourceFile &SF, unsigned BufferID):
-  ContextData(*new ContextInfo(SF, BufferID)) {}
+SyntaxParsingContext::
+SyntaxParsingContext(SourceFile &SF, unsigned BufferID, Token &Tok):
+  ContextData(*new ContextInfo(SF, BufferID)), Tok(Tok) {}
 
 SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext &Another):
   ContextData(*new ContextInfo(Another.ContextData.allTokens(),
-                               Another.ContextData.Enabled)) {}
+                               Another.ContextData.Enabled)), Tok(Another.Tok) {}
 
 SyntaxParsingContext::~SyntaxParsingContext() { delete &ContextData; }
 
@@ -240,9 +241,9 @@ SyntaxParsingContextRoot &SyntaxParsingContextChild::getRoot() {
 
 SyntaxParsingContextChild::
 SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-                          SyntaxContextKind Kind, Token &Tok):
+                          SyntaxContextKind Kind):
     SyntaxParsingContext(*ContextHolder), Parent(ContextHolder),
-    ContextHolder(ContextHolder), Kind(Kind), Tok(Tok) {
+    ContextHolder(ContextHolder), Kind(Kind) {
   ContextHolder = this;
   if (ContextData.Enabled)
     ContextData.setContextStart(Tok.getLoc());


### PR DESCRIPTION
Since all parsing contexts need a reference to the current token of the
parser, we should pass the token reference to the root context. Therefore, the derived
sub-contexts can just copy it while being spawned.