### PR TITLE
libSyntax: avoid copying token text when lexing token syntax nodes, NFC.

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -745,7 +745,7 @@ syntax::RawSyntaxInfo Lexer::fullLex() {
   }
   auto Loc = NextToken.getLoc();
   auto Result = syntax::RawTokenSyntax::make(NextToken.getKind(),
-                                        OwnedString(NextToken.getText()).copy(),
+                                        OwnedString(NextToken.getText()),
                                         syntax::SourcePresence::Present,
                                         {LeadingTrivia}, {TrailingTrivia});
   LeadingTrivia.clear();


### PR DESCRIPTION
This is likely the root cause for the memory surge when we always turn on
syntax token lexing. Since the underlying buffer outlives the syntax
tree, it's reasonable to refer the text instead of copying and owning it.