### PR TITLE
KeyPath: Fix out-of-bounds access when instantiating keypaths with optional chaining components.

### DIFF
--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -666,5 +666,25 @@ keyPath.test("subscripts") {
   expectEqual(base[keyPath: ints_be], (17 + 38).bigEndian)
 }
 
+// SR-6096
+
+protocol Protocol6096 {}
+struct Value6096<ValueType> {}
+extension Protocol6096 {
+    var asString: String? {
+        return self as? String
+    }
+}
+extension Value6096 where ValueType: Protocol6096 {
+    func doSomething() {
+        _ = \ValueType.asString?.endIndex
+    }
+}
+extension Int: Protocol6096 {}
+
+keyPath.test("optional chaining component that needs generic instantiation") {
+  Value6096<Int>().doSomething()
+}
+
 runAllTests()
 


### PR DESCRIPTION
When we pre-scan the components of a key path pattern to determine its runtime type and instance size, we would short-circuit upon seeing an optional-chaining component, since that makes a key path definitely read-only, but the loop also accumulates the size of the instance we're supposed to allocate, so…bad stuff happened. Leave out the short-circuit, fixing SR-6096 | rdar://problem/34889333 .