### PR TITLE
[GSB] Eliminate unnecessary walk over the associated types.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1639,13 +1639,6 @@ bool EquivalenceClass::recordConformanceConstraint(
       // superclass conforms to this protocol.
       (void)builder.resolveSuperConformance(type, proto);
     }
-
-    // Resolve any associated type members.
-    for (auto assocType : proto->getAssociatedTypeMembers()) {
-      type.realizePotentialArchetype(builder)->updateNestedTypeForConformance(
-                                        builder, assocType,
-                                        ArchetypeResolutionKind::AlreadyKnown);
-    }
   }
 
   // Record this conformance source.


### PR DESCRIPTION
We lazily resolve all of this information about nested potential archetypes
anyway; there's no need to do it eagerly.
