### PR TITLE
Named lazy member loading write by default

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -37,7 +37,6 @@ namespace swift {
 
     bool AutolinkForceLoad = false;
     bool EnableNestedTypeLookupTable = false;
-    bool EnableDeclMemberNamesTable = false;
     bool SerializeAllSIL = false;
     bool SerializeOptionsForDebugging = false;
     bool IsSIB = false;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -835,8 +835,6 @@ static bool performCompile(CompilerInstance &Instance,
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
-      serializationOpts.EnableDeclMemberNamesTable =
-        Invocation.getLangOptions().NamedLazyMemberLoading;
 
       serialize(DC, serializationOpts, SM.get());
     }
@@ -901,8 +899,6 @@ static bool performCompile(CompilerInstance &Instance,
             Invocation.getClangImporterOptions().ExtraArgs;
         serializationOpts.EnableNestedTypeLookupTable =
             opts.EnableSerializationNestedTypeLookupTable;
-        serializationOpts.EnableDeclMemberNamesTable =
-          Invocation.getLangOptions().NamedLazyMemberLoading;
         if (!IRGenOpts.ForceLoadSymbolName.empty())
           serializationOpts.AutolinkForceLoad = true;
 
@@ -981,8 +977,6 @@ static bool performCompile(CompilerInstance &Instance,
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
-      serializationOpts.EnableDeclMemberNamesTable =
-        Invocation.getLangOptions().NamedLazyMemberLoading;
 
       serialize(DC, serializationOpts, SM.get());
     }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -387,8 +387,7 @@ private:
 
   /// Top-level entry point for serializing a module.
   void writeAST(ModuleOrSourceFile DC,
-                bool enableNestedTypeLookupTable,
-                bool enableDeclMemberNamesTable);
+                bool enableNestedTypeLookupTable);
 
   void writeToStream(raw_ostream &os);
 


### PR DESCRIPTION
This turns on @DougGregor's suggestion that we write the name lookup tables by default and only control their use by the command line flag.

Also fixes one class of bugs (of the ~35 remaining bugs) where named lazy loading doesn't quite work at runtime. Getting closer!