### PR TITLE
[Mangling] Preserve all parameter flags in single parameter function mangling

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -349,7 +349,8 @@ Types
 
   function-signature ::= params-type params-type throws? // results and parameters
 
-  params-type := type                        // tuple in case of multiple parameters or a single parameter with a single tuple type
+  params-type := type 'z'? 'h'?              // tuple in case of multiple parameters or a single parameter with a single tuple type
+                                             // with optional inout convention, shared convention
   params-type := empty-list                  // shortcut for no parameters
 
   throws ::= 'K'                             // 'throws' annotation on function types

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1497,7 +1497,7 @@ void ASTMangler::appendFunctionInputType(
     // it as a single type dropping sugar.
     if (!param.hasLabel() && !param.isVariadic() &&
         !isa<TupleType>(type.getPointer())) {
-      appendType(type);
+      appendTypeListElement(param.getLabel(), type, param.getParameterFlags());
       break;
     }
 

--- a/test/Reflection/Inputs/ConcreteTypes.swift
+++ b/test/Reflection/Inputs/ConcreteTypes.swift
@@ -17,6 +17,7 @@ public class C {
   public let aFunctionWithInout1: (inout C) -> Void = { _ in }
   public let aFunctionWithInout2: (C, inout Int) -> Void = { _,_ in }
   public let aFunctionWithInout3: (inout C, inout Int) -> Void = { _,_ in }
+  public let aFunctionWithShared: (__shared C) -> Void = { _ in }
   public init(aClass: C, aStruct: S, anEnum: E, aTuple: (C, S, E, Int), aTupleWithLabels: (a: C, s: S, e: E), aMetatype: C.Type, aFunction: @escaping (C, S, E, Int) -> Int, aFunctionWithVarArgs: @escaping (C, S...) -> ()) {
     self.aClass = aClass
     self.aStruct = aStruct

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -84,6 +84,14 @@
 // CHECK:  (result
 // CHECK:    (tuple))
 
+// CHECK: aFunctionWithShared: (__shared TypesToReflect.C) -> ()
+// CHECK: (function
+// CHECK:  (parameters
+// CHECK:    (shared
+// CHECK:      (class TypesToReflect.C))
+// CHECK:  (result
+// CHECK:    (tuple))
+
 // CHECK: TypesToReflect.S.NestedS
 // CHECK: ------------------------
 // CHECK: aField: Swift.Int

--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -138,5 +138,5 @@ func owned_to_shared_conversion(_ f : (Int, ValueAggregate, RefAggregate) -> Voi
   return owned_to_shared_conversion { (trivial : __shared Int, val : __shared ValueAggregate, ref : __shared RefAggregate) in }
 }
 
-// CHECK-LABEL: sil hidden @_T06shared0A17_closure_loweringyySi_AA14ValueAggregateVAA03RefE0CtcF : $@convention(thin) (@guaranteed @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+// CHECK-LABEL: sil hidden @_T06shared0A17_closure_loweringyySi_AA14ValueAggregateVAA03RefE0CtchF : $@convention(thin) (@guaranteed @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
 func shared_closure_lowering(_ f : __shared (Int, ValueAggregate, RefAggregate) -> Void) {}


### PR DESCRIPTION
Currently if function has a single parameter we'd skip mangling some of the
parameter flags e.g. __shared, `inout` still works because it's part of the
type itself (currently) but would be broken too if that were to change.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
