### PR TITLE
[overlay] Use precondition instead of fatalError in DateInterval initializer

### DIFF
--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -54,10 +54,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable, Codable
     ///
     /// - precondition: `end >= start`
     public init(start: Date, end: Date) {
-        if end < start {
-            fatalError("Reverse intervals are not allowed")
-        }
-        
+        precondition(end >= start, "Reverse intervals are not allowed")
         self.start = start
         duration = end.timeIntervalSince(start)
     }


### PR DESCRIPTION
Comment of the function says:

> /// - precondition: `end >= start`

but it actually uses `if -> fatalError` instead of `precondition`,

Other functions of `DateInterval` use `precondition`-s, only this one uses `fatalError`, probably makes sense to change it as well.

Similar to https://github.com/apple/swift-corelibs-foundation/pull/1292

@parkera 