### PR TITLE
runtime: Fix swift_deallocBox

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -248,6 +248,8 @@ BoxPair::Return SWIFT_RT_ENTRY_IMPL(swift_allocBox)(const Metadata *type) {
 
 void swift::swift_deallocBox(HeapObject *o) {
   auto metadata = static_cast<const GenericBoxHeapMetadata *>(o->metadata);
+  // Move the object to the deallocating state (+1 -> +0).
+  o->refCounts.decrementFromOneNonAtomic();
   SWIFT_RT_ENTRY_CALL(swift_deallocObject)(o, metadata->getAllocSize(),
                                            metadata->getAllocAlignMask());
 }

--- a/test/Interpreter/closures.swift
+++ b/test/Interpreter/closures.swift
@@ -48,3 +48,37 @@ map({()})
 
 map({(x: Int) -> Int in x})
 // CHECK: Non-void overload
+
+// This used to assert in runtime assert builds.
+protocol Initializable {
+  init()
+}
+
+func f2<T: Initializable>(_ x: T) -> T? { return nil }
+
+func c<T: Initializable>(_ x: T) {
+
+({
+  guard var b = f2(x) else { print("success") ; return }
+  let c = { b = T() }
+  _ = (b, c)
+})()
+
+}
+extension Bool : Initializable {
+  init() {
+    self = true
+  }
+}
+// CHECK: success
+c(true)
+
+
+func f() -> Bool? { return nil }
+
+// CHECK: success
+({
+  guard var b = f() else { print("success") ; return }
+  let c = { b = true }
+  _ = (b, c)
+})()


### PR DESCRIPTION
We need to set the object into deallocating state (+1 -> +0).