### PR TITLE
runtime: Add and use swift_deallocUninitializedObject for uninitialized objects

### DIFF
--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -78,6 +78,7 @@ Rename with a non-`stdlib` naming scheme.
 000000000001cd30 T _swift_deallocBox
 000000000001d490 T _swift_deallocClassInstance
 000000000001cd60 T _swift_deallocObject
+000000000001cd60 T _swift_deallocUninitializedObject
 000000000001d4c0 T _swift_deallocPartialClassInstance
 000000000001d400 T _swift_rootObjCDealloc
 000000000001c960 T _swift_slowAlloc

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -423,6 +423,22 @@ void swift_deallocObject(HeapObject *object, size_t allocatedSize,
                          size_t allocatedAlignMask)
     SWIFT_CC(RegisterPreservingCC);
 
+/// Deallocate an uninitialized object with a strong reference count of +1.
+///
+/// It must have been returned by swift_allocObject, but otherwise the object is
+/// in an unknown state.
+///
+/// \param object - never null
+/// \param allocatedSize - the allocated size of the object from the
+///   program's perspective, i.e. the value
+/// \param allocatedAlignMask - the alignment requirement that was passed
+///   to allocObject
+///
+SWIFT_RT_ENTRY_VISIBILITY
+void swift_deallocUninitializedObject(HeapObject *object, size_t allocatedSize,
+                                      size_t allocatedAlignMask)
+    SWIFT_CC(RegisterPreservingCC);
+
 /// Deallocate the given memory.
 ///
 /// It must have been returned by swift_allocObject, possibly used as an

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -111,6 +111,13 @@ FUNCTION(DeallocObject, swift_deallocObject, RegisterPreservingCC,
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
+// void swift_deallocUninitializedObject(HeapObject *obj, size_t size, size_t alignMask);
+FUNCTION(DeallocUninitializedObject, swift_deallocUninitializedObject,
+         RegisterPreservingCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy, SizeTy, SizeTy),
+         ATTRS(NoUnwind))
+
 // void swift_deallocClassInstance(HeapObject *obj, size_t size, size_t alignMask);
 FUNCTION(DeallocClassInstance, swift_deallocClassInstance, DefaultCC,
          RETURNS(VoidTy),

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -168,6 +168,14 @@ void irgen::emitDeallocateHeapObject(IRGenFunction &IGF,
                          {object, size, alignMask});
 }
 
+void emitDeallocateUninitializedHeapObject(IRGenFunction &IGF,
+                                           llvm::Value *object,
+                                           llvm::Value *size,
+                                           llvm::Value *alignMask) {
+  IGF.Builder.CreateCall(IGF.IGM.getDeallocUninitializedObjectFn(),
+                         {object, size, alignMask});
+}
+
 void irgen::emitDeallocateClassInstance(IRGenFunction &IGF,
                                         llvm::Value *object,
                                         llvm::Value *size,
@@ -1541,8 +1549,7 @@ public:
     auto size = layout.emitSize(IGF.IGM);
     auto alignMask = layout.emitAlignMask(IGF.IGM);
 
-    IGF.emitNativeSetDeallocating(box);
-    emitDeallocateHeapObject(IGF, box, size, alignMask);
+    emitDeallocateUninitializedHeapObject(IGF, box, size, alignMask);
   }
 
   Address

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -774,10 +774,15 @@ static inline void memset_pattern8(void *b, const void *pattern8, size_t len) {
 }
 #endif
 
-void swift::swift_deallocObject(HeapObject *object, size_t allocatedSize,
-                                size_t allocatedAlignMask)
-    SWIFT_CC(RegisterPreservingCC_IMPL) {
+static inline void swift_deallocObjectImpl(HeapObject *object,
+                                           size_t allocatedSize,
+                                           size_t allocatedAlignMask,
+                                           bool isDeiniting) {
   assert(isAlignmentMask(allocatedAlignMask));
+  if (!isDeiniting) {
+    assert(object->refCounts.isUniquelyReferenced());
+    object->refCounts.decrementFromOneNonAtomic();
+  }
   assert(object->refCounts.isDeiniting());
   SWIFT_RT_TRACK_INVOCATION(object, swift_deallocObject);
 #ifdef SWIFT_RUNTIME_CLOBBER_FREED_OBJECTS
@@ -869,6 +874,17 @@ void swift::swift_deallocObject(HeapObject *object, size_t allocatedSize,
     // object state DEINITING -> DEINITED
     SWIFT_RT_ENTRY_CALL(swift_unownedRelease)(object);
   }
+}
+
+void swift::swift_deallocObject(HeapObject *object, size_t allocatedSize,
+                                size_t allocatedAlignMask) {
+  swift_deallocObjectImpl(object, allocatedSize, allocatedAlignMask, true);
+}
+
+void swift::swift_deallocUninitializedObject(HeapObject *object,
+                                             size_t allocatedSize,
+                                             size_t allocatedAlignMask) {
+  swift_deallocObjectImpl(object, allocatedSize, allocatedAlignMask, false);
 }
 
 WeakReference *swift::swift_weakInit(WeakReference *ref, HeapObject *value) {

--- a/test/IRGen/alloc_box.swift
+++ b/test/IRGen/alloc_box.swift
@@ -10,6 +10,6 @@ func f() -> Bool? { return nil }
 
 // CHECK-LABEL: @_T09alloc_boxyycfU_
 // CHECK: <label>:8:
-// CHECK: call void @swift_setDeallocating
-// CHECK: call void @swift_rt_swift_deallocObject
+// CHECK-NOT: call void @swift_setDeallocating
+// CHECK: call void @swift_rt_swift_deallocUninitializedObject
 

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -15,7 +15,7 @@ entry:
   // CHECK-64: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 1
   // CHECK: [[BOX_DATA_1:%.*]] = bitcast [8 x i8]* [[BOX_DATA]] to i64*
   %b = project_box %a : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>, 0
-  // CHECK: call void @swift_rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
+  // CHECK: call void @swift_rt_swift_deallocUninitializedObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
   dealloc_box %a : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
   return undef : $()
 }
@@ -31,7 +31,7 @@ entry:
   // CHECK-64: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 1
   // CHECK: [[BOX_DATA_1:%.*]] = bitcast [8 x i8]* [[BOX_DATA]] to double*
   %b = project_box %a : $<τ_0_0> { var τ_0_0 } <Builtin.FPIEEE64>, 0
-  // CHECK: call void @swift_rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
+  // CHECK: call void @swift_rt_swift_deallocUninitializedObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
   dealloc_box %a : $<τ_0_0> { var τ_0_0 } <Builtin.FPIEEE64>
   return undef : $()
 }
@@ -51,7 +51,7 @@ entry:
   // CHECK: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_32_32_LAYOUT]], [[POD_32_32_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
   // CHECK: [[BOX_DATA_1:%.*]] = bitcast [32 x i8]* [[BOX_DATA]] to %T11typed_boxes11OverAlignedV*
   %b = project_box %a : $<τ_0_0> { var τ_0_0 } <OverAligned>, 0
-  // CHECK: call void @swift_rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 64, [[WORD]] 31)
+  // CHECK: call void @swift_rt_swift_deallocUninitializedObject(%swift.refcounted* [[BOX]], [[WORD]] 64, [[WORD]] 31)
   dealloc_box %a : $<τ_0_0> { var τ_0_0 } <OverAligned>
   return undef : $()
 }


### PR DESCRIPTION

This is different from swift_deallocObject in that it applies to objects
at +1 while swift_deallocObject actually only applies to objects whose
state is deiniting (swift_release was called).