### PR TITLE
Ban IUOs in more places.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2845,6 +2845,9 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   // ImmediateFunctionInput marker and install a FunctionInput one instead.
   auto elementOptions = options;
   if (repr->isParenType()) {
+    // We also want to disallow IUO within even a paren.
+    elementOptions -= TR_AllowIUO;
+
     // If we have a single ParenType, don't clear the context bits; we
     // still want to parse the type contained therein as if it were in
     // parameter position, meaning function types are not @escaping by

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -137,3 +137,19 @@ let _: Generic<Int!, // expected-error {{implicitly unwrapped optionals are only
 
 func vararg(_ first: Int, more: Int!...) { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
 }
+
+func iuoInTuple() -> (Int!) { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  return 1
+}
+
+func iuoInTuple2() -> (Float, Int!) { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  return 1
+}
+
+func takesFunc(_ fn: (Int!) -> Int) -> Int { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  return fn(0)
+}
+
+func returnsFunc() -> (Int!) -> Int { // expected-error {{implicitly unwrapped optionals are only allowed at top level and as function results}}
+  return { $0 }
+}


### PR DESCRIPTION
We were allowing them in tuples in some contexts, but shouldn't have.

Also added tests for function types to ensure we're not allowing them there.
