### PR TITLE
Revert "[stdlib]Enable Swift 4 mode for the overlays"

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -256,14 +256,9 @@ function(_compile_swift_files
                             "-Xfrontend" "${GROUP_INFO_JSON_FILE}")
   endif()
 
-  # Force swift 3 compatibility mode for Standard Library.
-  if (SWIFTFILE_IS_STDLIB)
+  # Force swift 3 compatibility mode for Standard Library and overlay.
+  if (SWIFTFILE_IS_STDLIB OR SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-swift-version" "3")
-  endif()
-  
-  # Force swift 4 compatibility mode for overlays.
-  if (SWIFTFILE_IS_SDK_OVERLAY)
-    list(APPEND swift_flags "-swift-version" "4")
   endif()
 
   if(SWIFTFILE_IS_SDK_OVERLAY)

--- a/stdlib/public/SDK/AppKit/CMakeLists.txt
+++ b/stdlib/public/SDK/AppKit/CMakeLists.txt
@@ -8,7 +8,7 @@ add_swift_library(swiftAppKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OV
   NSGraphics.swift
   NSOpenGL.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreData CoreGraphics CoreImage Dispatch Foundation IOKit ObjectiveC QuartzCore XPC # auto-updated

--- a/stdlib/public/SDK/CoreGraphics/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreGraphics/CMakeLists.txt
@@ -6,7 +6,7 @@ add_swift_library(swiftCoreGraphics ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
   CGFloat.swift.gyb
   Private.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation Dispatch IOKit ObjectiveC # auto-updated
   SWIFT_MODULE_DEPENDS_IOS Darwin CoreFoundation Dispatch ObjectiveC # auto-updated

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -57,7 +57,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   UUID.swift
   CheckClass.mm
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation CoreGraphics Dispatch IOKit ObjectiveC # auto-updated

--- a/stdlib/public/SDK/Intents/INRideOption.swift
+++ b/stdlib/public/SDK/Intents/INRideOption.swift
@@ -26,7 +26,7 @@ public protocol _INRideOptionMeteredFare {
 extension _INRideOptionMeteredFare {
   @available(swift, obsoleted: 4)
   @nonobjc
-  public var usesMeteredFare: NSNumber? {
+  public final var usesMeteredFare: NSNumber? {
     get {
       return __usesMeteredFare
     }

--- a/stdlib/public/SDK/Metal/CMakeLists.txt
+++ b/stdlib/public/SDK/Metal/CMakeLists.txt
@@ -4,7 +4,7 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_library(swiftMetal ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Metal.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation CoreGraphics Dispatch Foundation IOKit ObjectiveC XPC # auto-updated

--- a/stdlib/public/SDK/MetalKit/CMakeLists.txt
+++ b/stdlib/public/SDK/MetalKit/CMakeLists.txt
@@ -4,7 +4,7 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_library(swiftMetalKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     MetalKit.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreFoundation CoreGraphics CoreImage Dispatch Foundation IOKit Metal ModelIO ObjectiveC QuartzCore simd XPC # auto-updated

--- a/stdlib/public/SDK/SceneKit/CMakeLists.txt
+++ b/stdlib/public/SDK/SceneKit/CMakeLists.txt
@@ -4,7 +4,7 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_library(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   SceneKit.swift.gyb
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreGraphics CoreImage Dispatch Foundation GLKit IOKit ObjectiveC QuartzCore simd XPC # auto-updated

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -42,7 +42,7 @@ public extension XCTContext {
 @available(macOS 10.11, *)
 public extension XCUIElement {
   /// Types a single key from the XCUIKeyboardKey enumeration with the specified modifier flags.
-  @nonobjc public func typeKey(_ key: XCUIKeyboardKey, modifierFlags: XCUIElement.KeyModifierFlags) {
+  @nonobjc public func typeKey(_ key: XCUIKeyboardKey, modifierFlags: XCUIKeyModifierFlags) {
     // Call the version of the method defined in XCTest.framework.
     typeKey(key.rawValue, modifierFlags: modifierFlags)
   }
@@ -55,11 +55,11 @@ public extension XCUIElement {
 func _XCTRegisterFailure(_ expected: Bool, _ condition: String, _ message: @autoclosure () -> String, _ file: StaticString, _ line: UInt) {
   // Call the real _XCTFailureHandler.
   let test = _XCTCurrentTestCase()
-  _XCTPreformattedFailureHandler(test, expected, file.description, Int(line), condition, message())
+  _XCTPreformattedFailureHandler(test, expected, file.description, line, condition, message())
 }
 
 /// Produce a failure description for the given assertion type.
-func _XCTFailureDescription(_ assertionType: _XCTAssertionType, _ formatIndex: Int, _ expressionStrings: CVarArg...) -> String {
+func _XCTFailureDescription(_ assertionType: _XCTAssertionType, _ formatIndex: UInt, _ expressionStrings: CVarArg...) -> String {
   // In order to avoid revlock/submission issues between XCTest and the Swift XCTest overlay,
   // we are using the convention with _XCTFailureFormat that (formatIndex >= 100) should be
   // treated just like (formatIndex - 100), but WITHOUT the expression strings. (Swift can't


### PR DESCRIPTION
Reverts apple/swift#12608

```
FAILED: lib/swift/macosx/x86_64/libswiftFoundation.dylib 
: && /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/llvm-macosx-x86_64/./bin/clang++  -Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector -stdlib=libc++ -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -std=c++11 -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wcovered-switch-default -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fcolor-diagnostics -Werror=switch -Wdocumentation -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fno-sanitize=all -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1 -O3 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -dynamiclib -Wl,-headerpad_max_install_names -stdlib=libc++   -target x86_64-apple-macosx10.9 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -arch x86_64 -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/../../../Developer/Library/Frameworks -mmacosx-version-min=10.9 -Wl,-sectcreate,__TEXT,__info_plist,/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swift-macosx-x86_64/stdlib/public/SDK/Foundation/Info.plist -Wl,-application_extension  "-L/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swift-macosx-x86_64/./lib/swift/macosx/x86_64" "-L/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swift-macosx-x86_64/./bin/../lib/swift/macosx/x86_64" "-L/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swift-macosx-x86_64/./bin/../lib/swift/macosx" -o lib/swift/macosx/x86_64/libswiftFoundation.dylib -install_name @rpath/libswiftFoundation.dylib stdlib/public/SDK/Foundation/macosx/x86_64/Foundation.o stdlib/public/SDK/Foundation/CMakeFiles/swiftFoundation-macosx-x86_64.dir/DataThunks.m.o stdlib/public/SDK/Foundation/CMakeFiles/swiftFoundation-macosx-x86_64.dir/CheckClass.mm.o -L/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/llvm-macosx-x86_64/./lib -framework Foundation lib/swift/macosx/x86_64/libswiftCoreGraphics.dylib lib/swift/macosx/x86_64/libswiftIOKit.dylib lib/swift/macosx/x86_64/libswiftCoreFoundation.dylib lib/swift/macosx/x86_64/libswiftCore.dylib -framework Foundation lib/swift/macosx/x86_64/libswiftDarwin.dylib -framework CoreFoundation lib/swift/macosx/x86_64/libswiftDispatch.dylib -framework IOKit lib/swift/macosx/x86_64/libswiftObjectiveC.dylib -framework CoreGraphics && :
Undefined symbols for architecture x86_64:
  "__T0So13DispatchQueueC0A0E10AttributesVN", referenced from:
      __T0s22_ContiguousArrayBufferVAByxGSi19_uninitializedCount_Si15minimumCapacitytcfCSo13DispatchQueueC0H0E10AttributesV_Tgq5Tf4nnd_n in Foundation.o
ld: symbol(s) not found for architecture x86_64
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
```