### PR TITLE
SIL: Kill completely bogus getTypeLinkage() function

### DIFF
--- a/include/swift/SIL/FormalLinkage.h
+++ b/include/swift/SIL/FormalLinkage.h
@@ -21,19 +21,6 @@ class ValueDecl;
 enum class SILLinkage : unsigned char;
 enum ForDefinition_t : bool;
 
-// Bits useful in defining the below.
-enum {
-  // Bottom bit is uniqueness.
-  FormalLinkage_Unique    = 0x0,
-  FormalLinkage_NonUnique = 0x1,
-
-  // Higher bits are visibility, with greater values being more
-  // restrictive.
-  FormalLinkage_Public    = 0 << 1,
-  FormalLinkage_Hidden    = 1 << 1,
-  FormalLinkage_Private   = 2 << 1,
-};
-
 /// Formal linkage is a property of types and declarations that
 /// informs, but is not completely equivalent to, the linkage of
 /// symbols corresponding to those types and declarations.
@@ -42,52 +29,27 @@ enum {
 enum class FormalLinkage {
   /// This entity is visible in multiple Swift modules and has a
   /// unique file that is known to define it.
-  PublicUnique     = FormalLinkage_Public | FormalLinkage_Unique,
+  PublicUnique,
 
   /// This entity is visible in multiple Swift modules, but does not
   /// have a unique file that is known to define it.
-  PublicNonUnique  = FormalLinkage_Public | FormalLinkage_NonUnique,
+  PublicNonUnique,
 
   /// This entity is visible in only a single Swift module and has a
   /// unique file that is known to define it.
-  HiddenUnique     = FormalLinkage_Hidden | FormalLinkage_Unique,
+  HiddenUnique,
 
   /// This entity is visible in only a single Swift module but does not
   /// have a unique file that is known to define it.
-  HiddenNonUnique  = FormalLinkage_Hidden | FormalLinkage_NonUnique,
+  HiddenNonUnique,
 
   /// This entity is visible in only a single Swift file.
   //
   // In reality, these are by definition unique, but we use the
   // non-unique flag to make merging more efficient.
-  Private          = FormalLinkage_Private | FormalLinkage_NonUnique,
-
-  /// The top of the semilattice: (a ^ Top) == a.
-  Top = PublicUnique,
-
-  /// The bottom of the semilattice: (a ^ Bottom) == Bottom.
-  Bottom = Private,
+  Private,
 };
 
-/// Merge two linkages to get the more restrictive.
-inline FormalLinkage operator^(FormalLinkage lhs, FormalLinkage rhs) {
-  // Semantically, we want the more restrictive visibility; if that's
-  // private, it's unique, and otherwise it's non-unique if either is
-  // non-unique.  This is more efficient if we define away the
-  // special case for private by representing Private as non-unique.
-  if (lhs < rhs) {
-    return FormalLinkage(unsigned(rhs) | 
-                         (unsigned(lhs) & FormalLinkage_NonUnique));
-  } else {
-    return FormalLinkage(unsigned(lhs) | 
-                         (unsigned(rhs) & FormalLinkage_NonUnique));
-  }
-}
-inline FormalLinkage &operator^=(FormalLinkage &lhs, FormalLinkage rhs) {
-  return (lhs = lhs ^ rhs);
-}
-
-FormalLinkage getTypeLinkage(CanType type);
 FormalLinkage getDeclLinkage(const ValueDecl *decl);
 SILLinkage getSILLinkage(FormalLinkage linkage,
                          ForDefinition_t forDefinition);

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -65,23 +65,6 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
   llvm_unreachable("Unhandled access level in switch.");
 }
 
-FormalLinkage swift::getTypeLinkage(CanType type) {
-  FormalLinkage result = FormalLinkage::Top;
-
-  // Merge all nominal types from the structural type.
-  (void) type.findIf([&](Type _type) {
-    CanType type = CanType(_type);
-
-    // For any nominal type reference, look at the type declaration.
-    if (auto nominal = type->getAnyNominal())
-      result ^= getDeclLinkage(nominal);
-
-    return false; // continue searching
-  });
-
-  return result;
-}
-
 SILLinkage swift::getSILLinkage(FormalLinkage linkage,
                                 ForDefinition_t forDefinition) {
   switch (linkage) {

--- a/test/IRGen/extension_type_metadata_linking.swift
+++ b/test/IRGen/extension_type_metadata_linking.swift
@@ -1,28 +1,49 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -c  %S/Inputs/simple.swift %s -O  -num-threads 1 -o %t/simple.o -o %t/extension_type_metadata_linking.o
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -c  %S/Inputs/main.swift -o %t/main.o
-// RUN: %target-build-swift %t/extension_type_metadata_linking.o %t/simple.o %t/main.o -o %t/main.out
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 
 // Check that type metadata defined inside extensions of files imported from
-// other modules is emitted properly and there no linking errors.
+// other modules is emitted with the right linkage.
+//
 // In particular, it should be possible to define types inside extensions of
 // types imported from Foundation (rdar://problem/27245620).
 
 import Foundation
 
-extension NSNumber {
-    class Base : CustomStringConvertible {
-        public var description: String {
-            return "Base"
-        }
-    }
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE4BaseCMm = global
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE4BaseCMn = constant
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE4BaseCMf = internal global
 
-    class Derived: Base {
-        override public var description: String {
-            return "Derived"
-        }
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE7DerivedCMm = global
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE7DerivedCMn = constant
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE7DerivedCMf = internal global
+
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE6StructVMn = constant
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE6StructVMf = internal constant
+
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE4BaseCN = alias
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE7DerivedCN = alias
+// CHECK-LABEL: @_T0So8NSNumberC31extension_type_metadata_linkingE6StructVN = alias
+
+// CHECK-LABEL: define %swift.type* @_T0So8NSNumberC31extension_type_metadata_linkingE4BaseCMa()
+// CHECK-LABEL: define %swift.type* @_T0So8NSNumberC31extension_type_metadata_linkingE7DerivedCMa
+
+// FIXME: Not needed
+// CHECK-LABEL: define %swift.type* @_T0So8NSNumberC31extension_type_metadata_linkingE6StructVMa
+
+extension NSNumber {
+  public class Base : CustomStringConvertible {
+    public var description: String {
+      return "Base"
     }
+  }
+
+  public class Derived : Base {
+    override public var description: String {
+      return "Derived"
+    }
+  }
+
+  public struct Struct {}
 }
 


### PR DESCRIPTION
- The overload of operator^ on FormalLinkage, while cute, was only used
  in this one place, and does not behave like an XOR.

- The structural type walk was totally unnecessary in the first place,
  because we were only ever calling getTypeLinkage() with builtin types
  and nominal types.

- Furthermore, the structural type walk was doing the wrong thing with
  nested nominal types, because the linkage of a nested type A.B
  should not be the intersection of the linkage of A and A.B. If A is an
  imported type and A.B is defined in an extension of A, we would give
  the metadata of A.B shared linkage, which is wrong.