### PR TITLE
Another fix for an initialization using a cast involving an IUO.

### DIFF
--- a/stdlib/public/Platform/Glibc.swift.gyb
+++ b/stdlib/public/Platform/Glibc.swift.gyb
@@ -12,8 +12,7 @@
 
 @_exported import SwiftGlibc // Clang module
 
-public let MAP_FAILED =
-  UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!
+public let MAP_FAILED: UnsafeMutableRawPointer! = UnsafeMutableRawPointer(bitPattern: -1)
 
 //  Constants defined by <math.h>
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")


### PR DESCRIPTION
Like the change in cbca1f23f67fe00cb31f5bccba5f9e6032b43919, this is not
allowed under SE-0054.
