### PR TITLE
[stdlib] Make standard library index types Hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ CHANGELOG
 Swift 4.1
 ---------
 
+* [SE-0188][] 
+  
+  Index types for most standard library collections now conform to `Hashable`. 
+  These indices can now be used in key-path subscripts and hashed collections:
+  
+  ```swift
+  let s = "Hashable"
+  let p = \String.[s.startIndex]
+  s[keyPath: p] // "H"
+  ```
+
 * [SE-0143][] The standard library types `Optional`, `Array`, and
 	`Dictionary` now conform to the `Equatable` protocol when their element types
 	conform to `Equatable`. This allows the `==` operator to compose (e.g., one
@@ -6810,3 +6821,4 @@ Swift 1.0
 [SE-0184]: <https://github.com/apple/swift-evolution/blob/master/proposals/0184-unsafe-pointers-add-missing.md>
 [SE-0185]: <https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md>
 [SE-0186]: <https://github.com/apple/swift-evolution/blob/master/proposals/0186-remove-ownership-keyword-support-in-protocols.md>
+[SE-0188]: <https://github.com/apple/swift-evolution/blob/master/proposals/0188-stdlib-index-types-hashable.md>

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -85,6 +85,17 @@ extension ClosedRangeIndex : Comparable {
   }
 }
 
+extension ClosedRangeIndex : Hashable where Bound : Hashable {
+  public var hashValue: Int {
+    switch _value {
+    case .inRange(let value):
+      return value.hashValue
+    case .pastEnd:
+      return .max
+    }
+  }
+}
+
 /// A closed range that forms a collection of consecutive values.
 ///
 /// You create a `CountableClosedRange` instance by using the closed range

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -140,6 +140,12 @@ public struct LazyDropWhileIndex<Base : Collection> : Comparable {
   }
 }
 
+extension LazyDropWhileIndex : Hashable where Base.Index : Hashable {
+  public var hashValue: Int {
+    return base.hashValue
+  }
+}
+
 % for Traversal in ['Forward', 'Bidirectional']:
 %   Collection = collectionForTraversal(Traversal)
 %   Self = "LazyDropWhile" + Collection

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -220,6 +220,14 @@ extension ${Index} : Comparable {
   }
 }
 
+extension ${Index} : Hashable
+  where BaseElements.Index : Hashable, BaseElements.Element.Index : Hashable
+{
+  public var hashValue: Int {
+    return _mixInt(_inner?.hashValue ?? 0) ^ _outer.hashValue
+  }
+}
+
 /// A flattened view of a base collection of collections.
 ///
 /// The elements of this view are a concatenation of the elements of

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -5967,7 +5967,7 @@ elif Self == 'Dictionary':
 
 ${SubscriptingWithIndexDoc}
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct Index : Comparable {
+public struct Index : Comparable, Hashable {
   // Index for native buffer is efficient.  Index for bridged NS${Self} is
   // not, because neither NSEnumerator nor fast enumeration support moving
   // backwards.  Even if they did, there is another issue: NSEnumerator does
@@ -6086,6 +6086,22 @@ extension ${Self}.Index {
       return lhsCocoa < rhsCocoa
     default:
       _preconditionFailure("Comparing indexes from different sets")
+  #endif
+    }
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public var hashValue: Int {
+    if _fastPath(_guaranteedNative) {
+      return _nativeIndex.offset
+    }
+
+    switch _value {
+    case ._native(let nativeIndex):
+      return nativeIndex.offset
+  #if _runtime(_ObjC)
+    case ._cocoa(let cocoaIndex):
+      return cocoaIndex.currentKeyIndex
   #endif
     }
   }

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -161,6 +161,17 @@ public struct LazyPrefixWhileIndex<Base : Collection> : Comparable {
   }
 }
 
+extension LazyPrefixWhileIndex : Hashable where Base.Index : Hashable {
+  public var hashValue: Int {
+    switch _value {
+    case .index(let value):
+      return value.hashValue
+    case .pastEnd:
+      return .max
+    }
+  }
+}
+
 % for Traversal in ['Forward', 'Bidirectional']:
 %   Collection = collectionForTraversal(Traversal)
 %   Self = "LazyPrefixWhile" + Collection

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -149,6 +149,12 @@ public struct ReversedIndex<Base : Collection> : Comparable {
   }
 }
 
+extension ReversedIndex : Hashable where Base.Index : Hashable {
+  public var hashValue: Int {
+    return base.hashValue
+  }
+}
+
 /// A collection that presents the elements of its base collection
 /// in reverse order.
 ///
@@ -346,6 +352,12 @@ public struct ReversedRandomAccessIndex<
   ) -> Bool {
     // Note ReversedRandomAccessIndex has inverted logic compared to base Base.Index
     return lhs.base > rhs.base
+  }
+}
+
+extension ReversedRandomAccessIndex : Hashable where Base.Index : Hashable {
+  public var hashValue: Int {
+    return base.hashValue
   }
 }
 

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -67,6 +67,13 @@ extension String.Index : Comparable {
   }
 }
 
+extension String.Index : Hashable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public var hashValue: Int {
+    return _compoundOffset.hashValue
+  }
+}
+
 extension String.Index {
   internal typealias _Self = String.Index
   

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -77,6 +77,13 @@ DictionaryTestSuite.test("sizeof") {
 #endif
 }
 
+DictionaryTestSuite.test("Index.Hashable") {
+  let d = [1: "meow", 2: "meow", 3: "meow"]
+  let e = Dictionary(uniqueKeysWithValues: zip(d.indices, d))
+  expectEqual(d.count, e.count)
+  expectNotNil(e[d.startIndex])
+}
+
 DictionaryTestSuite.test("valueDestruction") {
   var d1 = Dictionary<Int, TestValueTy>()
   for i in 100...110 {

--- a/validation-test/stdlib/HashableIndices.swift
+++ b/validation-test/stdlib/HashableIndices.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var HashTests = TestSuite("HashableIndices")
+
+HashTests.test("ClosedRangeIndex") {
+  let a = 1...10
+  checkHashable(a.indices, equalityOracle: { $0 == $1 })
+}
+
+HashTests.test("FlattenIndex") {
+  let a = [1...10, 11...20, 21...30].joined()
+  checkHashable(a.indices, equalityOracle: { $0 == $1 })
+}
+
+HashTests.test("LazyDropWhileIndex") {
+  let a = (1...10).lazy.drop(while: { $0 < 5 })
+  checkHashable(a.indices, equalityOracle: { $0 == $1 })
+}
+
+HashTests.test("LazyPrefixWhileIndex") {
+  let a = (1...10).lazy.prefix(while: { $0 < 5 })
+  checkHashable(a.indices, equalityOracle: { $0 == $1 })
+}
+
+HashTests.test("ReversedIndex") {
+  let a = (1...10).lazy.filter({ $0 > 3 }).reversed()
+  checkHashable(a.indices, equalityOracle: { $0 == $1 })
+}
+
+HashTests.test("ReversedRandomAccessIndex") {
+  let a = (1...10).reversed()
+  checkHashable(a.indices, equalityOracle: { $0 == $1 })
+}
+
+runAllTests()

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -331,6 +331,13 @@ SetTestSuite.test("sizeof") {
 #endif
 }
 
+SetTestSuite.test("Index.Hashable") {
+  let s: Set = [1, 2, 3, 4, 5]
+  let t = Set(s.indices)
+  expectEqual(s.count, t.count)
+  expectTrue(t.contains(s.startIndex))
+}
+
 SetTestSuite.test("COW.Smoke") {
   var s1 = Set<TestKeyTy>(minimumCapacity: 10)
   for i in [1010, 2020, 3030]{ s1.insert(TestKeyTy(i)) }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -148,7 +148,7 @@ StringTests.test("unicodeScalars") {
   checkUnicodeScalarViewIteration([ 0x10ffff ], "\u{0010ffff}")
 }
 
-StringTests.test("indexComparability") {
+StringTests.test("Index/Comparable") {
   let empty = ""
   expectTrue(empty.startIndex == empty.endIndex)
   expectFalse(empty.startIndex != empty.endIndex)
@@ -164,6 +164,13 @@ StringTests.test("indexComparability") {
   expectFalse(nonEmpty.startIndex >= nonEmpty.endIndex)
   expectFalse(nonEmpty.startIndex > nonEmpty.endIndex)
   expectTrue(nonEmpty.startIndex < nonEmpty.endIndex)
+}
+
+StringTests.test("Index/Hashable") {
+  let s = "abcdef"
+  let t = Set(s.indices)
+  expectEqual(s.count, t.count)
+  expectTrue(t.contains(s.startIndex))
 }
 
 StringTests.test("ForeignIndexes/Valid") {


### PR DESCRIPTION
This adds `Hashable` conformance for the `String`, `Dictionary`, and `Set` index types.

Proposal here: https://github.com/apple/swift-evolution/pull/761