### PR TITLE
Fixes for s390x

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -162,9 +162,21 @@ void EnumPayload::insertValue(IRGenFunction &IGF, llvm::Value *value,
         subvalue = IGF.Builder.CreateLShr(subvalue,
                                llvm::ConstantInt::get(valueIntTy, valueOffset));
       subvalue = IGF.Builder.CreateZExtOrTrunc(subvalue, payloadIntTy);
+#if defined(__BIG_ENDIAN__)
+      if ((valueBitWidth == 32 || valueBitWidth == 16 || valueBitWidth == 8 || valueBitWidth == 1) &&
+          payloadBitWidth > (payloadValueOffset + valueBitWidth)) {
+        unsigned shiftBitWidth = valueBitWidth;
+        if (valueBitWidth == 1) {
+          shiftBitWidth = 8;
+        }
+        subvalue = IGF.Builder.CreateShl(subvalue,
+          llvm::ConstantInt::get(payloadIntTy, (payloadBitWidth - shiftBitWidth) - payloadValueOffset));
+      }
+#else
       if (payloadValueOffset > 0)
         subvalue = IGF.Builder.CreateShl(subvalue,
                       llvm::ConstantInt::get(payloadIntTy, payloadValueOffset));
+#endif
       
       // If there hasn't yet been a value stored here, we can use the adjusted
       // value directly.
@@ -218,9 +230,21 @@ llvm::Value *EnumPayload::extractValue(IRGenFunction &IGF, llvm::Type *type,
         llvm::IntegerType::get(IGF.IGM.getLLVMContext(), payloadBitWidth);
 
       value = IGF.Builder.CreateBitOrPointerCast(value, payloadIntTy);
+#if defined(__BIG_ENDIAN__)
+      if ((valueBitWidth == 32 || valueBitWidth == 16 || valueBitWidth == 8 || valueBitWidth == 1) &&
+          payloadBitWidth > (payloadValueOffset + valueBitWidth)) {
+        unsigned shiftBitWidth = valueBitWidth;
+        if (valueBitWidth == 1) {
+          shiftBitWidth = 8;
+        }
+        value = IGF.Builder.CreateLShr(value,
+          llvm::ConstantInt::get(value->getType(), (payloadBitWidth - shiftBitWidth) - payloadValueOffset));
+      }
+#else
       if (payloadValueOffset > 0)
         value = IGF.Builder.CreateLShr(value,
                   llvm::ConstantInt::get(value->getType(), payloadValueOffset));
+#endif
       if (valueBitWidth > payloadBitWidth)
         value = IGF.Builder.CreateZExt(value, valueIntTy);
       if (valueOffset > 0)

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3903,6 +3903,12 @@ namespace {
       } else if (CommonSpareBits.size() > 0) {
         // Otherwise the payload is just the index.
         payload = EnumPayload::zero(IGM, PayloadSchema);
+#if defined(__BIG_ENDIAN__) && defined(__LP64__)
+        // Code produced above are of type IGM.Int32Ty
+        // However, payload is IGM.SizeTy in 64bit
+        if (numCaseBits >= 64)
+          tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
+#endif
         // We know we won't use more than numCaseBits from tagIndex's value:
         // We made sure of this in the logic above.
         payload.insertValue(IGF, tagIndex, 0,


### PR DESCRIPTION
In the first commit, we need to use Swift calling convention when dealing with BoxPair on s390x.  BoxPair is expected to be returned in 2 registers but there is no native C type that is returned in two registers by the default ABI on s390x.

The second commit fixes the way enum payloads are packed for big endian order.

Both of these commits resolve test failures on s390x therefore no new test cases are added. 