### PR TITLE
[stdlib] Various documentation revisions

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -178,7 +178,7 @@ if True:
 /// can store any kind of elements---from integers to strings to classes.
 ///
 /// Swift makes it easy to create arrays in your code using an array literal:
-/// simply surround a comma separated list of values with square brackets.
+/// simply surround a comma-separated list of values with square brackets.
 /// Without any other information, Swift creates an array that includes the
 /// specified values, automatically inferring the array's `Element` type. For
 /// example:

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -144,8 +144,13 @@ internal func != (lhs: Builtin.RawPointer, rhs: Builtin.RawPointer) -> Bool {
   return !(lhs == rhs)
 }
 
-/// Returns `true` iff `t0` is identical to `t1`; i.e. if they are both
-/// `nil` or they both represent the same type.
+/// Returns a Boolean value indicating whether two types are identical.
+///
+/// - Parameters:
+///   - t0: A type to compare.
+///   - t1: Another type to compare.
+/// - Returns: `true` if both `t0` and `t1` are `nil` or if they represent the
+///   same type; otherwise, `false`.
 @_inlineable
 public func == (t0: Any.Type?, t1: Any.Type?) -> Bool {
   switch (t0, t1) {
@@ -156,8 +161,13 @@ public func == (t0: Any.Type?, t1: Any.Type?) -> Bool {
   }
 }
 
-/// Returns `false` iff `t0` is identical to `t1`; i.e. if they are both
-/// `nil` or they both represent the same type.
+/// Returns a Boolean value indicating whether two types are not identical.
+///
+/// - Parameters:
+///   - t0: A type to compare.
+///   - t1: Another type to compare.
+/// - Returns: `true` if one, but not both, of `t0` and `t1` are `nil`, or if
+///   they represent different types; otherwise, `false`.
 @_inlineable
 public func != (t0: Any.Type?, t1: Any.Type?) -> Bool {
   return !(t0 == t1)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -42,17 +42,19 @@ public typealias CShort = Int16
 /// The C 'int' type.
 public typealias CInt = Int32
 
-/// The C 'long' type.
 #if os(Windows) && arch(x86_64)
+/// The C 'long' type.
 public typealias CLong = Int32
 #else
+/// The C 'long' type.
 public typealias CLong = Int
 #endif
 
-/// The C 'long long' type.
 #if os(Windows) && arch(x86_64)
+/// The C 'long long' type.
 public typealias CLongLong = Int
 #else
+/// The C 'long long' type.
 public typealias CLongLong = Int64
 #endif
 
@@ -200,7 +202,7 @@ extension OpaquePointer : Equatable {
   }
 }
 
-/// The corresponding Swift type to `va_list` in imported C APIs.
+/// A wrapper around a C `va_list` pointer.
 @_fixed_layout
 public struct CVaListPointer {
   @_versioned // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -1166,8 +1166,8 @@ public protocol KeyedDecodingContainerProtocol {
 
 // An implementation of _KeyedDecodingContainerBase and _KeyedDecodingContainerBox are given at the bottom of this file.
 
-/// A concrete container that provides a view into an decoder's storage, making
-/// the encoded properties of an decodable type accessible by keys.
+/// A concrete container that provides a view into a decoder's storage, making
+/// the encoded properties of a decodable type accessible by keys.
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
     public typealias Key = K
@@ -2307,7 +2307,8 @@ public protocol SingleValueEncodingContainer {
     mutating func encode<T : Encodable>(_ value: T) throws
 }
 
-/// A `SingleValueDecodingContainer` is a container which can support the storage and direct decoding of a single non-keyed value.
+/// A container that can support the storage and direct decoding of a single
+/// nonkeyed value.
 public protocol SingleValueDecodingContainer {
     /// The path of coding keys taken to get to this point in encoding.
     var codingPath: [CodingKey] { get }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1620,8 +1620,8 @@ func _projectKeyPathReferenceWritable<Root, Value>(
 // on `Self` to prevent dynamically-typed methods from being inherited by
 // statically-typed key paths.
 
-/// This protocol is an implementation detail of key path expressions; do not
-/// use it directly.
+/// An implementation detail of key path expressions; do not use this protocol
+/// directly.
 @_show_in_interface
 public protocol _AppendKeyPath {}
 

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -12,15 +12,31 @@
 // FIXME: ExistentialCollection needs to be supported before this will work
 // without the ObjC Runtime.
 
-/// Representation of the sub-structure and optional "display style"
-/// of any arbitrary subject instance.
+/// A representation of the substructure and display style of an instance of
+/// any type.
 ///
-/// Describes the parts---such as stored properties, collection
-/// elements, tuple elements, or the active enumeration case---that
-/// make up a particular instance.  May also supply a "display style"
-/// property that suggests how this structure might be rendered.
+/// A mirror describes the parts that make up a particular instance, such as
+/// the instance's stored properties, collection or tuple elements, or its
+/// active enumeration case. Mirrors also provide a "display style" property
+/// that suggests how this mirror might be rendered.
 ///
-/// Mirrors are used by playgrounds and the debugger.
+/// Playgrounds and the debugger use the `Mirror` type to display
+/// representations of values of any type. For example, when you pass an
+/// instance to the `dump(_:_:_:_:)` function, a mirror is used to render that
+/// instance's runtime contents.
+///
+///     struct Point {
+///         let x: Int, y: Int
+///     }
+///
+///     let p = Point(x: 21, y: 30)
+///     print(String(reflecting: p))
+///     // Prints "▿ Point
+///     //           - x: 21
+///     //           - y: 30"
+///
+/// To customize the mirror representation of a custom type, add conformance to
+/// the `CustomReflectable` protocol.
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct Mirror {
   /// Representation of descendant classes that don't override
@@ -46,56 +62,58 @@ public struct Mirror {
     case suppressed
   }
 
-  /// Representation of ancestor classes.
+  /// The representation to use for ancestor classes.
   ///
-  /// A `CustomReflectable` class can control how its mirror will
-  /// represent ancestor classes by initializing the mirror with a
-  /// `AncestorRepresentation`.  This setting has no effect on mirrors
+  /// A class that conforms to the `CustomReflectable` protocol can control how
+  /// its mirror represents ancestor classes by initializing the mirror
+  /// with an `AncestorRepresentation`. This setting has no effect on mirrors
   /// reflecting value type instances.
   public enum AncestorRepresentation {
 
-    /// Generate a default mirror for all ancestor classes.
+    /// Generates a default mirror for all ancestor classes.
     ///
-    /// This case is the default.
+    /// This case is the default when initializing a `Mirror` instance.
     ///
-    /// - Note: This option generates default mirrors even for
-    ///   ancestor classes that may implement `CustomReflectable`'s
-    ///   `customMirror` requirement.  To avoid dropping an ancestor class
-    ///   customization, an override of `customMirror` should pass
-    ///   `ancestorRepresentation: .Customized(super.customMirror)` when
-    ///   initializing its `Mirror`.
+    /// When you use this option, a subclass's mirror generates default mirrors
+    /// even for ancestor classes that conform to the `CustomReflectable`
+    /// protocol. To avoid dropping the customization provided by ancestor
+    /// classes, an override of `customMirror` should pass
+    /// `.customized({ super.customMirror })` as `ancestorRepresentation` when
+    /// initializing its mirror.
     case generated
 
-    /// Use the nearest ancestor's implementation of `customMirror` to
-    /// create a mirror for that ancestor.  Other classes derived from
-    /// such an ancestor are given a default mirror.
+    /// Uses the nearest ancestor's implementation of `customMirror` to create
+    /// a mirror for that ancestor.
     ///
-    /// The payload for this option should always be
-    /// "`{ super.customMirror }`":
+    /// Other classes derived from such an ancestor are given a default mirror.
+    /// The payload for this option should always be `{ super.customMirror }`:
     ///
     ///     var customMirror: Mirror {
-    ///       return Mirror(
-    ///         self,
-    ///         children: ["someProperty": self.someProperty],
-    ///         ancestorRepresentation: .Customized({ super.customMirror })) // <==
+    ///         return Mirror(
+    ///             self,
+    ///             children: ["someProperty": self.someProperty],
+    ///             ancestorRepresentation: .customized({ super.customMirror })) // <==
     ///     }
     case customized(() -> Mirror)
 
-    /// Suppress the representation of all ancestor classes.  The
-    /// resulting `Mirror`'s `superclassMirror` is `nil`.
+    /// Suppresses the representation of all ancestor classes.
+    ///
+    /// In a mirror created with this ancestor representation, the
+    /// `superclassMirror` property is `nil`.
     case suppressed
   }
 
-  /// Reflect upon the given `subject`.
+  /// Creates a mirror that reflects on the given instance.
   ///
-  /// If the dynamic type of `subject` conforms to `CustomReflectable`,
-  /// the resulting mirror is determined by its `customMirror` property.
+  /// If the dynamic type of `subject` conforms to `CustomReflectable`, the
+  /// resulting mirror is determined by its `customMirror` property.
   /// Otherwise, the result is generated by the language.
   ///
-  /// - Note: If the dynamic type of `subject` has value semantics,
-  ///   subsequent mutations of `subject` will not observable in
-  ///   `Mirror`.  In general, though, the observability of such
-  /// mutations is unspecified.
+  /// If the dynamic type of `subject` has value semantics, subsequent
+  /// mutations of `subject` will not observable in `Mirror`.  In general,
+  /// though, the observability of mutations is unspecified.
+  ///
+  /// - Parameter subject: The instance for which to create a mirror.
   @_inlineable // FIXME(sil-serialize-all)
   public init(reflecting subject: Any) {
     if case let customized as CustomReflectable = subject {
@@ -107,36 +125,33 @@ public struct Mirror {
     }
   }
 
-  /// An element of the reflected instance's structure.  The optional
-  /// `label` may be used when appropriate, e.g. to represent the name
-  /// of a stored property or of an active `enum` case, and will be
-  /// used for lookup when `String`s are passed to the `descendant`
-  /// method.
+  /// An element of the reflected instance's structure.
+  ///
+  /// When the `label` component in not `nil`, it may represent the name of a
+  /// stored property or an active `enum` case. If you pass strings to the
+  /// `descendant(_:_:)` method, labels are used for lookup.
   public typealias Child = (label: String?, value: Any)
 
-  /// The type used to represent sub-structure.
+  /// The type used to represent substructure.
   ///
-  /// Depending on your needs, you may find it useful to "upgrade"
-  /// instances of this type to `AnyBidirectionalCollection` or
-  /// `AnyRandomAccessCollection`.  For example, to display the last
-  /// 20 children of a mirror if they can be accessed efficiently, you
-  /// might write:
+  /// When working with a mirror that reflects a bidirectional or random access
+  /// collection, you may find it useful to "upgrade" instances of this type
+  /// to `AnyBidirectionalCollection` or `AnyRandomAccessCollection`. For
+  /// example, to display the last twenty children of a mirror if they can be
+  /// accessed efficiently, you write the following code:
   ///
   ///     if let b = AnyBidirectionalCollection(someMirror.children) {
-  ///       var i = xs.index(b.endIndex, offsetBy: -20,
-  ///         limitedBy: b.startIndex) ?? b.startIndex
-  ///       while i != xs.endIndex {
-  ///          print(b[i])
-  ///          b.formIndex(after: &i)
-  ///       }
+  ///         for element in b.suffix(20) {
+  ///             print(element)
+  ///         }
   ///     }
   public typealias Children = AnyCollection<Child>
 
-  /// A suggestion of how a `Mirror`'s `subject` is to be interpreted.
+  /// A suggestion of how a mirror's subject is to be interpreted.
   ///
   /// Playgrounds and the debugger will show a representation similar
   /// to the one used for instances of the kind indicated by the
-  /// `DisplayStyle` case name when the `Mirror` is used for display.
+  /// `DisplayStyle` case name when the mirror is used for display.
   @_fixed_layout // FIXME(sil-serialize-all)
   public enum DisplayStyle {
     case `struct`, `class`, `enum`, tuple, optional, collection
@@ -200,26 +215,31 @@ public struct Mirror {
     return Mirror._noSuperclassMirror
   }
   
-  /// Represent `subject` with structure described by `children`,
-  /// using an optional `displayStyle`.
+  /// Creates a mirror representing the given subject with a specified
+  /// structure.
   ///
-  /// If `subject` is not a class instance, `ancestorRepresentation`
-  /// is ignored.  Otherwise, `ancestorRepresentation` determines
+  /// You use this initializer from within your type's `customMirror`
+  /// implementation to create a customized mirror.
+  ///
+  /// If `subject` is a class instance, `ancestorRepresentation` determines
   /// whether ancestor classes will be represented and whether their
-  /// `customMirror` implementations will be used.  By default, a
-  /// representation is automatically generated and any `customMirror`
-  /// implementation is bypassed.  To prevent bypassing customized
-  /// ancestors, `customMirror` overrides should initialize the
-  /// `Mirror` with:
+  /// `customMirror` implementations will be used. By default, the
+  /// `customMirror` implementation of any ancestors is ignored. To prevent
+  /// bypassing customized ancestors, pass
+  /// `.customized({ super.customMirror })` as the `ancestorRepresentation`
+  /// parameter when implementing your type's `customMirror` property.
   ///
-  ///     ancestorRepresentation: .customized({ super.customMirror })
-  ///
-  /// - Note: The traversal protocol modeled by `children`'s indices
-  ///   (`ForwardIndex`, `BidirectionalIndex`, or
-  ///   `RandomAccessIndex`) is captured so that the resulting
-  /// `Mirror`'s `children` may be upgraded later.  See the failable
-  /// initializers of `AnyBidirectionalCollection` and
-  /// `AnyRandomAccessCollection` for details.
+  /// - Parameters:
+  ///   - subject: The instance to represent in the new mirror.
+  ///   - children: The structure to use for the mirror. The collection
+  ///     traversal modeled by `children` is captured so that the resulting
+  ///     mirror's children may be upgraded to a bidirectional or random
+  ///     access collection later. See the `children` property for details.
+  ///   - displayStyle: The preferred display style for the mirror when
+  ///     presented in the debugger or in a playground. The default is `nil`.
+  ///   - ancestorRepresentation: The means of generating the subject's
+  ///     ancestor representation. `ancestorRepresentation` is ignored if
+  ///     `subject` is not a class instance. The default is `.generated`.
   @_inlineable // FIXME(sil-serialize-all)
   public init<Subject, C : Collection>(
     _ subject: Subject,
@@ -239,36 +259,33 @@ public struct Mirror {
       = subject is CustomLeafReflectable ? .suppressed : .generated
   }
 
-  /// Represent `subject` with child values given by
-  /// `unlabeledChildren`, using an optional `displayStyle`.  The
-  /// result's child labels will all be `nil`.
+  /// Creates a mirror representing the given subject with unlabeled children.
   ///
-  /// This initializer is especially useful for the mirrors of
-  /// collections, e.g.:
+  /// You use this initializer from within your type's `customMirror`
+  /// implementation to create a customized mirror, particularly for custom
+  /// types that are collections. The labels of the resulting mirror's
+  /// `children` collection are all `nil`.
   ///
-  ///     extension MyArray : CustomReflectable {
-  ///       var customMirror: Mirror {
-  ///         return Mirror(self, unlabeledChildren: self, displayStyle: .collection)
-  ///       }
-  ///     }
-  ///
-  /// If `subject` is not a class instance, `ancestorRepresentation`
-  /// is ignored.  Otherwise, `ancestorRepresentation` determines
+  /// If `subject` is a class instance, `ancestorRepresentation` determines
   /// whether ancestor classes will be represented and whether their
-  /// `customMirror` implementations will be used.  By default, a
-  /// representation is automatically generated and any `customMirror`
-  /// implementation is bypassed.  To prevent bypassing customized
-  /// ancestors, `customMirror` overrides should initialize the
-  /// `Mirror` with:
+  /// `customMirror` implementations will be used. By default, the
+  /// `customMirror` implementation of any ancestors is ignored. To prevent
+  /// bypassing customized ancestors, pass
+  /// `.customized({ super.customMirror })` as the `ancestorRepresentation`
+  /// parameter when implementing your type's `customMirror` property.
   ///
-  ///     ancestorRepresentation: .Customized({ super.customMirror })
-  ///
-  /// - Note: The traversal protocol modeled by `children`'s indices
-  ///   (`ForwardIndex`, `BidirectionalIndex`, or
-  ///   `RandomAccessIndex`) is captured so that the resulting
-  /// `Mirror`'s `children` may be upgraded later.  See the failable
-  /// initializers of `AnyBidirectionalCollection` and
-  /// `AnyRandomAccessCollection` for details.
+  /// - Parameters:
+  ///   - subject: The instance to represent in the new mirror.
+  ///   - unlabeledChildren: The children to use for the mirror. The collection
+  ///     traversal modeled by `unlabeledChildren` is captured so that the
+  ///     resulting mirror's children may be upgraded to a bidirectional or
+  ///     random access collection later. See the `children` property for
+  ///     details.
+  ///   - displayStyle: The preferred display style for the mirror when
+  ///     presented in the debugger or in a playground. The default is `nil`.
+  ///   - ancestorRepresentation: The means of generating the subject's
+  ///     ancestor representation. `ancestorRepresentation` is ignored if
+  ///     `subject` is not a class instance. The default is `.generated`.
   @_inlineable // FIXME(sil-serialize-all)
   public init<Subject, C : Collection>(
     _ subject: Subject,
@@ -291,29 +308,35 @@ public struct Mirror {
       = subject is CustomLeafReflectable ? .suppressed : .generated
   }
 
-  /// Represent `subject` with labeled structure described by
-  /// `children`, using an optional `displayStyle`.
+  /// Creates a mirror representing the given subject using a dictionary
+  /// literal for the structure.
   ///
-  /// Pass a dictionary literal with `String` keys as `children`.  Be
-  /// aware that although an *actual* `Dictionary` is
-  /// arbitrarily-ordered, the ordering of the `Mirror`'s `children`
-  /// will exactly match that of the literal you pass.
+  /// You use this initializer from within your type's `customMirror`
+  /// implementation to create a customized mirror. Pass a dictionary literal
+  /// with string keys as `children`. Although an *actual* dictionary is
+  /// arbitrarily-ordered, when you create a mirror with a dictionary literal,
+  /// the ordering of the mirror's `children` will exactly match that of the
+  /// literal you pass.
   ///
-  /// If `subject` is not a class instance, `ancestorRepresentation`
-  /// is ignored.  Otherwise, `ancestorRepresentation` determines
+  /// If `subject` is a class instance, `ancestorRepresentation` determines
   /// whether ancestor classes will be represented and whether their
-  /// `customMirror` implementations will be used.  By default, a
-  /// representation is automatically generated and any `customMirror`
-  /// implementation is bypassed.  To prevent bypassing customized
-  /// ancestors, `customMirror` overrides should initialize the
-  /// `Mirror` with:
+  /// `customMirror` implementations will be used. By default, the
+  /// `customMirror` implementation of any ancestors is ignored. To prevent
+  /// bypassing customized ancestors, pass
+  /// `.customized({ super.customMirror })` as the `ancestorRepresentation`
+  /// parameter when implementing your type's `customMirror` property.
   ///
-  ///     ancestorRepresentation: .customized({ super.customMirror })
-  ///
-  /// - Note: The resulting `Mirror`'s `children` may be upgraded to
-  ///   `AnyRandomAccessCollection` later.  See the failable
-  ///   initializers of `AnyBidirectionalCollection` and
-  /// `AnyRandomAccessCollection` for details.
+  /// - Parameters:
+  ///   - subject: The instance to represent in the new mirror.
+  ///   - children: A dictionary literal to use as the structure for the
+  ///     mirror. The `children` collection of the resulting mirror may be
+  ///     upgraded to a random access collection later. See the `children`
+  ///     property for details.
+  ///   - displayStyle: The preferred display style for the mirror when
+  ///     presented in the debugger or in a playground. The default is `nil`.
+  ///   - ancestorRepresentation: The means of generating the subject's
+  ///     ancestor representation. `ancestorRepresentation` is ignored if
+  ///     `subject` is not a class instance. The default is `.generated`.
   @_inlineable // FIXME(sil-serialize-all)
   public init<Subject>(
     _ subject: Subject,
@@ -335,7 +358,7 @@ public struct Mirror {
 
   /// The static type of the subject being reflected.
   ///
-  /// This type may differ from the subject's dynamic type when `self`
+  /// This type may differ from the subject's dynamic type when this mirror
   /// is the `superclassMirror` of another mirror.
   public let subjectType: Any.Type
 
@@ -343,9 +366,10 @@ public struct Mirror {
   /// reflected subject.
   public let children: Children
 
-  /// Suggests a display style for the reflected subject.
+  /// A suggested display style for the reflected subject.
   public let displayStyle: DisplayStyle?
 
+  /// A mirror of the subject's superclass, if one exists.
   @_inlineable // FIXME(sil-serialize-all)
   public var superclassMirror: Mirror? {
     return _makeSuperclassMirror()
@@ -359,7 +383,7 @@ public struct Mirror {
 
 /// A type that explicitly supplies its own mirror.
 ///
-/// You can create a mirror for any type using the `Mirror(reflect:)`
+/// You can create a mirror for any type using the `Mirror(reflecting:)`
 /// initializer, but if you are not satisfied with the mirror supplied for
 /// your type by default, you can make it conform to `CustomReflectable` and
 /// return a custom `Mirror` instance.
@@ -383,9 +407,10 @@ public protocol CustomLeafReflectable : CustomReflectable {}
 ///
 /// Do not declare new conformances to this protocol; they will not
 /// work as expected.
-// FIXME(ABI)#49 (Sealed Protocols): this protocol should be "non-open" and you shouldn't be able to
-// create conformances.
-public protocol MirrorPath {}
+public protocol MirrorPath {
+  // FIXME(ABI)#49 (Sealed Protocols): this protocol should be "non-open" and
+  // you shouldn't be able to create conformances.
+}
 extension Int : MirrorPath {}
 extension String : MirrorPath {}
 
@@ -405,42 +430,50 @@ extension Mirror {
     internal var customMirror: Mirror { return mirror }
   }
 
-  /// Return a specific descendant of the reflected subject, or `nil`
-  /// Returns a specific descendant of the reflected subject, or `nil`
-  /// if no such descendant exists.
+  /// Returns a specific descendant of the reflected subject, or `nil` if no
+  /// such descendant exists.
   ///
-  /// A `String` argument selects the first `Child` with a matching label.
-  /// An integer argument *n* select the *n*th `Child`.  For example:
+  /// Pass a variadic list of string and integer arguments. Each string
+  /// argument selects the first child with a matching label. Each integer
+  /// argument selects the child at that offset. For example, passing
+  /// `1, "two", 3` as arguments to `myMirror.descendant(_:_:)` is equivalent
+  /// to:
   ///
-  ///     var d = Mirror(reflecting: x).descendant(1, "two", 3)
-  ///
-  /// is equivalent to:
-  ///
-  ///     var d = nil
-  ///     let children = Mirror(reflecting: x).children
-  ///     if let p0 = children.index(children.startIndex,
-  ///       offsetBy: 1, limitedBy: children.endIndex) {
-  ///       let grandChildren = Mirror(reflecting: children[p0].value).children
-  ///       SeekTwo: for g in grandChildren {
-  ///         if g.label == "two" {
-  ///           let greatGrandChildren = Mirror(reflecting: g.value).children
-  ///           if let p1 = greatGrandChildren.index(
-  ///             greatGrandChildren.startIndex,
-  ///             offsetBy: 3, limitedBy: greatGrandChildren.endIndex) {
-  ///             d = greatGrandChildren[p1].value
-  ///           }
-  ///           break SeekTwo
+  ///     var result: Any? = nil
+  ///     let children = myMirror.children
+  ///     if let i0 = children.index(
+  ///         children.startIndex, offsetBy: 1, limitedBy: children.endIndex),
+  ///         i0 != children.endIndex
+  ///     {
+  ///         let grandChildren = Mirror(reflecting: children[i0].value).children
+  ///         if let i1 = grandChildren.index(where: { $0.label == "two" }) {
+  ///             let greatGrandChildren =
+  ///                 Mirror(reflecting: grandChildren[i1].value).children
+  ///             if let i2 = greatGrandChildren.index(
+  ///                 greatGrandChildren.startIndex,
+  ///                 offsetBy: 3,
+  ///                 limitedBy: greatGrandChildren.endIndex),
+  ///                 i2 != greatGrandChildren.endIndex
+  ///             {
+  ///                 // Success!
+  ///                 result = greatGrandChildren[i2].value
+  ///             }
   ///         }
-  ///       }
   ///     }
   ///
-  /// As you can see, complexity for each element of the argument list
-  /// depends on the argument type and capabilities of the collection
-  /// used to initialize the corresponding subject's parent's mirror.
-  /// Each `String` argument results in a linear search.  In short,
-  /// this function is suitable for exploring the structure of a
-  /// `Mirror` in a REPL or playground, but don't expect it to be
-  /// efficient.
+  /// This function is suitable for exploring the structure of a mirror in a
+  /// REPL or playground, but is not intended to be efficient. The efficiency
+  /// of finding each element in the argument list depends on the argument
+  /// type and the capabilities of the each level of the mirror's `children`
+  /// collections. Each string argument requires a linear search, and unless
+  /// the underlying collection supports random-access traversal, each integer
+  /// argument also requires a linear operation.
+  ///
+  /// - Parameters:
+  ///   - first: The first mirror path component to access.
+  ///   - rest: Any remaining mirror path components.
+  /// - Returns: The descendant of this mirror specified by the given mirror
+  ///   path components if such a descendant exists; otherwise, `nil`.
   @_inlineable // FIXME(sil-serialize-all)
   public func descendant(
     _ first: MirrorPath, _ rest: MirrorPath...
@@ -698,19 +731,20 @@ public enum PlaygroundQuickLook {
 }
 
 extension PlaygroundQuickLook {
-  /// Initialize for the given `subject`.
+  /// Creates a new Quick Look for the given instance.
   ///
   /// If the dynamic type of `subject` conforms to
-  /// `CustomPlaygroundQuickLookable`, returns the result of calling
-  /// its `customPlaygroundQuickLook` property.  Otherwise, returns
-  /// a `PlaygroundQuickLook` synthesized for `subject` by the
-  /// language.  Note that in some cases the result may be
-  /// `.Text(String(reflecting: subject))`.
+  /// `CustomPlaygroundQuickLookable`, the result is found by calling its
+  /// `customPlaygroundQuickLook` property. Otherwise, the result is
+  /// synthesized by the language. In some cases, the synthesized result may
+  /// be `.text(String(reflecting: subject))`.
   ///
-  /// - Note: If the dynamic type of `subject` has value semantics,
-  ///   subsequent mutations of `subject` will not observable in
-  ///   `Mirror`.  In general, though, the observability of such
-  ///   mutations is unspecified.
+  /// - Note: If the dynamic type of `subject` has value semantics, subsequent
+  ///   mutations of `subject` will not observable in the Quick Look. In
+  ///   general, though, the observability of such mutations is unspecified.
+  ///
+  /// - Parameter subject: The instance to represent with the resulting Quick
+  ///   Look.
   @_inlineable // FIXME(sil-serialize-all)
   public init(reflecting subject: Any) {
     if let customized = subject as? CustomPlaygroundQuickLookable {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -15,8 +15,8 @@
 //===----------------------------------------------------------------------===//
 // Standardized uninhabited type
 //===----------------------------------------------------------------------===//
-/// The return type of functions that do not return normally; a type with no
-/// values.
+/// The return type of functions that do not return normally, that is, a type
+/// with no values.
 ///
 /// Use `Never` as the return type when declaring a closure, function, or
 /// method that unconditionally throws an error, traps, or otherwise does
@@ -31,16 +31,16 @@ public enum Never {}
 //===----------------------------------------------------------------------===//
 // Standardized aliases
 //===----------------------------------------------------------------------===//
-/// The return type of functions that don't explicitly specify a return type;
-/// an empty tuple (i.e., `()`).
+/// The return type of functions that don't explicitly specify a return type,
+/// that is, an empty tuple `()`.
 ///
 /// When declaring a function or method, you don't need to specify a return
 /// type if no value will be returned. However, the type of a function,
 /// method, or closure always includes a return type, which is `Void` if
 /// otherwise unspecified.
 ///
-/// Use `Void` or an empty tuple as the return type when declaring a
-/// closure, function, or method that doesn't return a value.
+/// Use `Void` or an empty tuple as the return type when declaring a closure,
+/// function, or method that doesn't return a value.
 ///
 ///     // No return type declared:
 ///     func logMessage(_ s: String) {

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -406,9 +406,15 @@ internal func _heapSort<C>(
 % end
 // for p in preds
 
-/// Exchange the values of `a` and `b`.
+/// Exchanges the values of the two arguments.
 ///
-/// - Precondition: `a` and `b` do not alias each other.
+/// The two arguments must not alias each other. To swap two elements of a
+/// mutable collection, use the `swapAt(_:_:)` method of that collection
+/// instead of this function.
+///
+/// - Parameters:
+///   - a: The first value to swap.
+///   - b: The second value to swap.
 @_inlineable
 public func swap<T>(_ a: inout T, _ b: inout T) {
   // Semantically equivalent to (a, b) = (b, a).

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -48,7 +48,7 @@ public protocol StringProtocol
   /// encoding.
   ///
   /// - Parameters:
-  ///   - codeUnits: A collection of code units encoded in the ecoding
+  ///   - codeUnits: A collection of code units encoded in the encoding
   ///     specified in `sourceEncoding`.
   ///   - sourceEncoding: The encoding in which `codeUnits` should be
   ///     interpreted.
@@ -280,7 +280,7 @@ extension String {
   /// encoding.
   ///
   /// - Parameters:
-  ///   - codeUnits: A collection of code units encoded in the ecoding
+  ///   - codeUnits: A collection of code units encoded in the encoding
   ///     specified in `sourceEncoding`.
   ///   - sourceEncoding: The encoding in which `codeUnits` should be
   ///     interpreted.
@@ -673,6 +673,12 @@ extension String {
 @_fixed_layout
 public struct String {
   /// Creates an empty string.
+  ///
+  /// Using this initializer is equivalent to initializing a string with an
+  /// empty string literal.
+  ///
+  ///     let empty = ""
+  ///     let alsoEmpty = String()
   @_inlineable // FIXME(sil-serialize-all)
   public init() {
     _core = _StringCore()

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -29,6 +29,11 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///     let zeroes = String(repeating: "0" as Character, count: 10)
   ///     print(zeroes)
   ///     // Prints "0000000000"
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The character to repeat.
+  ///   - count: The number of times to repeat `repeatedValue` in the 
+  ///     resulting string.
   @_inlineable // FIXME(sil-serialize-all)
   public init(repeating repeatedValue: Character, count: Int) {
     self.init(repeating: String(repeatedValue), count: count)
@@ -38,6 +43,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   // that String conforms to Collection:
   // - init<T>(_ value: T) where T : LosslessStringConvertible
   // - init<S>(_ characters: S) where S : Sequence, S.Element == Character
+  
+  /// Creates a new string containing the characters in the given sequence.
+  ///
+  /// You can use this initializer to create a new string from the result of
+  /// one or more collection operations on a string's characters. For example:
+  ///
+  ///     let str = "The rain in Spain stays mainly in the plain."
+  ///
+  ///     let vowels: Set<Character> = ["a", "e", "i", "o", "u"]
+  ///     let disemvoweled = String(str.lazy.filter { !vowels.contains($0) })
+  ///
+  ///     print(disemvoweled)
+  ///     // Prints "Th rn n Spn stys mnly n th pln."
+  ///
+  /// - Parameter other: A string instance or another sequence of 
+  ///   characters.
   @_inlineable // FIXME(sil-serialize-all)
   public init<S : Sequence & LosslessStringConvertible>(_ other: S)
   where S.Element == Character {
@@ -171,14 +192,16 @@ extension String : StringProtocol, RangeReplaceableCollection {
 
   /// Accesses the character at the given position.
   ///
-  /// Indices for a subscripting a string are shared with the string's
-  /// `characters` view. For example:
+  /// You can use the same indices for subscripting a string and its substring.
+  /// For example, this code finds the first letter after the first space:
   ///
-  ///     let greeting = "Hello, friend!"
-  ///     if let i = greeting.characters.index(where: { $0 >= "A" && $0 <= "Z" }) {
-  ///         print("First capital letter: \(greeting[i])")
+  ///     let str = "Greetings, friend! How are you?"
+  ///     let firstSpace = str.index(of: " ") ?? str.endIndex
+  ///     let substr = str[firstSpace...]
+  ///     if let nextCapital = substr.index(where: { $0 >= "A" && $0 <= "Z" }) {
+  ///         print("Capital after a space: \(str[nextCapital])")
   ///     }
-  ///     // Prints "First capital letter: H"
+  ///     // Prints "Capital after a space: H"
   ///
   /// - Parameter i: A valid index of the string. `i` must be less than the
   ///   string's end index.
@@ -190,17 +213,18 @@ extension String {
   /// Creates a new string containing the characters in the given sequence.
   ///
   /// You can use this initializer to create a new string from the result of
-  /// one or more operations on a string's `characters` view. For example:
+  /// one or more collection operations on a string's characters. For example:
   ///
   ///     let str = "The rain in Spain stays mainly in the plain."
   ///
   ///     let vowels: Set<Character> = ["a", "e", "i", "o", "u"]
-  ///     let disemvoweled = String(str.characters.lazy.filter { !vowels.contains($0) })
+  ///     let disemvoweled = String(str.lazy.filter { !vowels.contains($0) })
   ///
   ///     print(disemvoweled)
   ///     // Prints "Th rn n Spn stys mnly n th pln."
   ///
-  /// - Parameter characters: A sequence of characters.
+  /// - Parameter characters: A string instance or another sequence of 
+  ///   characters.
   @_inlineable // FIXME(sil-serialize-all)
   public init<S : Sequence>(_ characters: S)
     where S.Iterator.Element == Character {
@@ -326,7 +350,7 @@ extension String {
   /// removes the hyphen from the middle of a string.
   ///
   ///     var nonempty = "non-empty"
-  ///     if let i = nonempty.characters.index(of: "-") {
+  ///     if let i = nonempty.index(of: "-") {
   ///         nonempty.remove(at: i)
   ///     }
   ///     print(nonempty)

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -205,7 +205,7 @@ public struct Substring : StringProtocol {
   /// encoding.
   ///
   /// - Parameters:
-  ///   - codeUnits: A collection of code units encoded in the ecoding
+  ///   - codeUnits: A collection of code units encoded in the encoding
   ///     specified in `sourceEncoding`.
   ///   - sourceEncoding: The encoding in which `codeUnits` should be
   ///     interpreted.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -42,7 +42,7 @@ public struct UnsafeBufferPointerIterator<Element>
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
-/// A non-owning collection interface to a buffer of ${Mutable.lower()}
+/// A nonowning collection interface to a buffer of ${Mutable.lower()}
 /// elements stored contiguously in memory.
 ///
 /// You can use an `${Self}` instance in low level operations to eliminate

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -10,28 +10,30 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Instances of conforming types can be encoded, and appropriately
-/// passed, as elements of a C `va_list`.
+/// A type whose instances can be encoded, and appropriately passed, as
+/// elements of a C `va_list`.
 ///
-/// This protocol is useful in presenting C "varargs" APIs natively in
-/// Swift.  It only works for APIs that have a `va_list` variant, so
-/// for example, it isn't much use if all you have is:
+/// You use this protocol to present a native Swift interface to a C "varargs"
+/// API. For example, a program can import a C API like the one defined here:
 ///
-/// ~~~ c
-/// int c_api(int n, ...)
-/// ~~~
-///
-/// Given a version like this, though,
-///
-/// ~~~ c
+/// ~~~c
 /// int c_api(int, va_list arguments)
 /// ~~~
 ///
-/// you can write:
+/// To create a wrapper for the `c_api` function, write a function that takes
+/// `CVarArg` arguments, and then call the imported C function using the
+/// `withVaList(_:_:)` function:
 ///
 ///     func swiftAPI(_ x: Int, arguments: CVarArg...) -> Int {
-///       return withVaList(arguments) { c_api(x, $0) }
+///         return withVaList(arguments) { c_api(x, $0) }
 ///     }
+///
+/// Swift only imports C variadic functions that use a `va_list` for their
+/// arguments. C functions that use the `...` syntax for variadic arguments
+/// are not imported, and therefore can't be called using `CVarArg` arguments.
+///
+/// - Note: Declaring conformance to the `CVarArg` protocol for types defined
+///   outside the standard library is not supported.
 public protocol CVarArg {
   // Note: the protocol is public, but its requirement is stdlib-private.
   // That's because there are APIs operating on CVarArg instances, but


### PR DESCRIPTION
- Add missing docs & parameter lists
- Remove deprecated `characters` usage in examples
- Revise documentation for Mirror and CVarArg
- Revise documentation for swap(_:_:)
- Various typo and grammar fixes
