### PR TITLE
add JSONDecoder.decode(_:fromJSONObject:) method

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -865,12 +865,32 @@ open class JSONDecoder {
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: error))
         }
-
+        
+        return try _decode(type, topLevel: topLevel)
+    }
+    
+    /// Decodes a top-level value of the given type from the given Foundation object.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter fromJSONObject: The Foundation object to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if the given Foundation object is not valid JSON.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, fromJSONObject obj: Any) throws -> T {
+        guard JSONSerialization.isValidJSONObject(obj) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given object is not valid JSON.", underlyingError: nil))
+        }
+        
+        return try _decode(type, topLevel: obj)
+    }
+    
+    private func _decode<T : Decodable>(_ type: T.Type, topLevel: Any) throws -> T
+    {
         let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
         guard let value = try decoder.unbox(topLevel, as: T.self) else {
             throw DecodingError.valueNotFound(T.self, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
         }
-
+        
         return value
     }
 }

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -866,7 +866,7 @@ open class JSONDecoder {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: error))
         }
         
-        return try _decode(type, topLevel: topLevel)
+        return try _decode(topLevel: topLevel)
     }
     
     /// Decodes a top-level value of the given type from the given Foundation object.
@@ -881,10 +881,10 @@ open class JSONDecoder {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given object is not valid JSON.", underlyingError: nil))
         }
         
-        return try _decode(type, topLevel: obj)
+        return try _decode(topLevel: obj)
     }
     
-    private func _decode<T : Decodable>(_ type: T.Type, topLevel: Any) throws -> T
+    private func _decode<T : Decodable>(topLevel: Any) throws -> T
     {
         let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
         guard let value = try decoder.unbox(topLevel, as: T.self) else {


### PR DESCRIPTION
In some cases, it's possible to have a Foundation object (either NSArray or NSDictionary) that produce a valid JSON.
The current implementation of JSONDecoder allows decoding **only from `Data`**. This pull request adds the possibility to decode an object from the Foundation object.