### PR TITLE
fixed test case KeyPath.swift for s390x

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2390,8 +2390,8 @@ internal func _instantiateKeyPathBuffer(
         // offset within the metadata object.
         let metadataPtr = unsafeBitCast(base, to: UnsafeRawPointer.self)
         let offsetOfOffset = patternBuffer.pop(UInt32.self)
-        let offset = metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
-                                      as: UInt32.self)
+        let offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
+                                       as: UInt.self))
         // Rewrite the header for a resolved offset.
         var newHeader = header
         newHeader.payload = RawKeyPathComponent.Header.outOfLineOffsetPayload


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixed test case KeyPath.swift for s390x, need to use "UInt64" to load value for big-endian platform
Tested both s390x and x86_64 and passed

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
