### PR TITLE
[refactoring] Made min func consistent with max

### DIFF
--- a/include/swift/Basic/Algorithm.h
+++ b/include/swift/Basic/Algorithm.h
@@ -22,7 +22,7 @@ namespace swift {
   /// Returns the minimum of `a` and `b`, or `a` if they are equivalent.
   template <typename T>
   constexpr const T &min(const T &a, const T &b) {
-    return !(b < a) ? a : b;
+    return (a > b) ? b : a;
   }
   
   /// Returns the maximum of `a` and `b`, or `a` if they are equivalent.


### PR DESCRIPTION
<!-- What's in this pull request? -->
The previous implementation of the min function was the following:
```C++
return !(b < a) ? a : b;
```
While this implementation works, this is inconsistent with the max function, which compares the elements differently. Thus, I had the choice of either changing the min or the max function, and I changed the min, since the current implementation that I made seems clearer IMO.

