### PR TITLE
[GSB] Add verification of all generic signatures within a module. 

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -802,6 +802,16 @@ public:
   /// Determine whether the two given types are in the same equivalence class.
   bool areInSameEquivalenceClass(Type type1, Type type2);
 
+  /// Verify the correctness of the given generic signature.
+  ///
+  /// This routine will test that the given generic signature is both minimal
+  /// and canonical, emitting errors if it is not.
+  static void verifyGenericSignature(ASTContext &context,
+                                     GenericSignature *sig);
+
+  /// Verify all of the generic sigantures in the given module.
+  static void verifyGenericSignaturesInModule(ModuleDecl *module);
+
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump(),

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1173,6 +1173,15 @@ public:
 
   virtual bool isSystemModule() const { return false; }
 
+  /// Retrieve the set of generic signatures stored within this module.
+  ///
+  /// \returns \c true if this module file supports retrieving all of the
+  /// generic signatures, \c false otherwise.
+  virtual bool getAllGenericSignatures(
+                 SmallVectorImpl<GenericSignature*> &genericSignatures) {
+    return false;
+  }
+
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST ||
            file->getKind() == FileUnitKind::ClangModule;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -296,6 +296,9 @@ public:
   /// too complex.
   unsigned SolverExpressionTimeThreshold = 0;
 
+  /// The module for which we should verify all of the generic signatures.
+  std::string VerifyGenericSignaturesInModule;
+
   enum ActionType {
     NoneAction, ///< No specific action
     Parse, ///< Parse only

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -76,6 +76,9 @@ def verify_apply_fixes : Flag<["-"], "verify-apply-fixes">,
   HelpText<"Like -verify, but updates the original source file">;
 def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,
   HelpText<"Allow diagnostics for '<unknown>' location in verify mode">;
+def verify_generic_signatures : Separate<["-"], "verify-generic-signatures">,
+  MetaVarName<"<module-name>">,
+  HelpText<"Verify the generic signatures in the given module">;
 
 def show_diagnostics_after_fatal : Flag<["-"], "show-diagnostics-after-fatal">,
   HelpText<"Keep emitting subsequent diagnostics after a fatal error">;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -195,6 +195,10 @@ public:
 
   virtual const clang::Module *getUnderlyingClangModule() const override;
 
+  virtual bool getAllGenericSignatures(
+                   SmallVectorImpl<GenericSignature*> &genericSignatures)
+                override;
+
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -229,6 +229,10 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);
 
+  if (const Arg *A = Args.getLastArg(OPT_verify_generic_signatures)) {
+    Opts.VerifyGenericSignaturesInModule = A->getValue();
+  }
+
   // Determine what the user has asked the frontend to do.
   FrontendOptions::ActionType &Action = Opts.RequestedAction;
   if (const Arg *A = Args.getLastArg(OPT_modes_Group)) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -30,6 +30,7 @@
 #include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/LegacyASTTransformer.h"
@@ -629,6 +630,14 @@ static bool performCompile(CompilerInstance &Instance,
     debugFailWithCrash();
 
   ASTContext &Context = Instance.getASTContext();
+
+
+  auto verifyGenericSignaturesInModule =
+    Invocation.getFrontendOptions().VerifyGenericSignaturesInModule;
+  if (!verifyGenericSignaturesInModule.empty()) {
+    if (auto module = Context.getModuleByName(verifyGenericSignaturesInModule))
+      GenericSignatureBuilder::verifyGenericSignaturesInModule(module);
+  }
 
   if (Invocation.getMigratorOptions().shouldRunMigrator()) {
     migrator::updateCodeAndEmitRemap(&Instance, Invocation);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2175,6 +2175,17 @@ bool SerializedASTFile::hasEntryPoint() const {
   return File.Bits.HasEntryPoint;
 }
 
+bool SerializedASTFile::getAllGenericSignatures(
+                       SmallVectorImpl<GenericSignature*> &genericSignatures) {
+  genericSignatures.clear();
+  for (unsigned index : indices(File.GenericSignatures)) {
+    if (auto genericSig = File.getGenericSignature(index + 1))
+      genericSignatures.push_back(genericSig);
+  }
+
+  return true;
+}
+
 ClassDecl *SerializedASTFile::getMainClass() const {
   assert(hasEntryPoint());
   return cast_or_null<ClassDecl>(File.getDecl(File.Bits.EntryPointDeclID));

--- a/test/Generics/validate_stdlib_generic_signatures.swift
+++ b/test/Generics/validate_stdlib_generic_signatures.swift
@@ -1,0 +1,6 @@
+// Verifies that all of the generic signatures in the standard library are
+// minimal and canonical.
+
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify-generic-signatures Swift
+
+// expected-no-diagnostics


### PR DESCRIPTION
Add a verification pass to ensure that all of the generic signatures in
a module are both minimal and canonical. The approach taken is quite
direct: for every (canonical) generic signature in the module, try
removing a single requirement and forming a new generic signature from
the result. If that new generic signature that provide the removed
requirement, then the original signature was not minimal.

Also canonicalize each resulting signature, to ensure that it meets the
requirements for a canonical signature.

Add a test to ensure that all of the generic signatures in the Swift
module are minimal and canonical, since they are ABI.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3733](https://bugs.swift.org/browse/SR-3733) / rdar://problem/31412994