### PR TITLE
[IRGen] Improve function type metadata representation (attempt #2).

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -550,11 +550,11 @@ enum class FunctionMetadataConvention: uint8_t {
 template <typename int_type>
 class TargetFunctionTypeFlags {
   enum : int_type {
-    NumArgumentsMask = 0x00FFFFFFU,
-    ConventionMask   = 0x0F000000U,
-    ConventionShift  = 25U,
-    ThrowsMask       = 0x10000000U,
-    ParamFlagsMask   = 0x01000000U,
+    NumParametersMask = 0x00FFFFFFU,
+    ConventionMask    = 0x0F000000U,
+    ConventionShift   = 25U,
+    ThrowsMask        = 0x10000000U,
+    ParamFlagsMask    = 0x01000000U,
   };
   int_type Data;
   
@@ -562,8 +562,9 @@ class TargetFunctionTypeFlags {
 public:
   constexpr TargetFunctionTypeFlags() : Data(0) {}
 
-  constexpr TargetFunctionTypeFlags withNumArguments(unsigned numArguments) const {
-    return TargetFunctionTypeFlags((Data & ~NumArgumentsMask) | numArguments);
+  constexpr TargetFunctionTypeFlags
+  withNumParameters(unsigned numParams) const {
+    return TargetFunctionTypeFlags((Data & ~NumParametersMask) | numParams);
   }
   
   constexpr TargetFunctionTypeFlags<int_type>
@@ -584,10 +585,8 @@ public:
                                              (hasFlags ? ParamFlagsMask : 0));
   }
 
-  unsigned getNumArguments() const {
-    return Data & NumArgumentsMask;
-  }
-  
+  unsigned getNumParameters() const { return Data & NumParametersMask; }
+
   FunctionMetadataConvention getConvention() const {
     return FunctionMetadataConvention((Data&ConventionMask) >> ConventionShift);
   }

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -551,10 +551,10 @@ template <typename int_type>
 class TargetFunctionTypeFlags {
   enum : int_type {
     NumArgumentsMask = 0x00FFFFFFU,
-    ConventionMask = 0x0F000000U,
-    ConventionShift = 24U,
-    ThrowsMask = 0x10000000U,
-    ParamFlagsMask = 0x01000000U,
+    ConventionMask   = 0x0F000000U,
+    ConventionShift  = 25U,
+    ThrowsMask       = 0x10000000U,
+    ParamFlagsMask   = 0x01000000U,
   };
   int_type Data;
   
@@ -614,6 +614,56 @@ public:
   }
 };
 using FunctionTypeFlags = TargetFunctionTypeFlags<size_t>;
+
+template <typename int_type>
+class TargetParameterTypeFlags {
+  enum : int_type {
+    InOutMask    = 1 << 0,
+    SharedMask   = 1 << 1,
+    VariadicMask = 1 << 2,
+  };
+  int_type Data;
+
+  constexpr TargetParameterTypeFlags(int_type Data) : Data(Data) {}
+
+public:
+  constexpr TargetParameterTypeFlags() : Data(0) {}
+
+  constexpr TargetParameterTypeFlags<int_type> withInOut(bool isInOut) const {
+    return TargetParameterTypeFlags<int_type>((Data & ~InOutMask) |
+                                              (isInOut ? InOutMask : 0));
+  }
+
+  constexpr TargetParameterTypeFlags<int_type> withShared(bool isShared) const {
+    return TargetParameterTypeFlags<int_type>((Data & ~SharedMask) |
+                                              (isShared ? SharedMask : 0));
+  }
+
+  constexpr TargetParameterTypeFlags<int_type>
+  withVariadic(bool isVariadic) const {
+    return TargetParameterTypeFlags<int_type>((Data & ~VariadicMask) |
+                                              (isVariadic ? VariadicMask : 0));
+  }
+
+  bool isNone() const { return Data == 0; }
+  bool isInOut() const { return Data & InOutMask; }
+  bool isShared() const { return Data & SharedMask; }
+  bool isVariadic() const { return Data & VariadicMask; }
+
+  int_type getIntValue() const { return Data; }
+
+  static TargetParameterTypeFlags<int_type> fromIntValue(int_type Data) {
+    return TargetParameterTypeFlags(Data);
+  }
+
+  bool operator==(TargetParameterTypeFlags<int_type> other) const {
+    return Data == other.Data;
+  }
+  bool operator!=(TargetParameterTypeFlags<int_type> other) const {
+    return Data != other.Data;
+  }
+};
+using ParameterFlags = TargetParameterTypeFlags<uint32_t>;
 
 /// Field types and flags as represented in a nominal type's field/case type
 /// vector.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -551,9 +551,10 @@ template <typename int_type>
 class TargetFunctionTypeFlags {
   enum : int_type {
     NumArgumentsMask = 0x00FFFFFFU,
-    ConventionMask   = 0x0F000000U,
-    ConventionShift  = 24U,
-    ThrowsMask       = 0x10000000U,
+    ConventionMask = 0x0F000000U,
+    ConventionShift = 24U,
+    ThrowsMask = 0x10000000U,
+    ParamFlagsMask = 0x01000000U,
   };
   int_type Data;
   
@@ -576,7 +577,13 @@ public:
     return TargetFunctionTypeFlags<int_type>((Data & ~ThrowsMask) |
                                              (throws ? ThrowsMask : 0));
   }
-  
+
+  constexpr TargetFunctionTypeFlags<int_type>
+  withParameterFlags(bool hasFlags) const {
+    return TargetFunctionTypeFlags<int_type>((Data & ~ParamFlagsMask) |
+                                             (hasFlags ? ParamFlagsMask : 0));
+  }
+
   unsigned getNumArguments() const {
     return Data & NumArgumentsMask;
   }
@@ -588,7 +595,9 @@ public:
   bool throws() const {
     return bool(Data & ThrowsMask);
   }
-  
+
+  bool hasParameterFlags() const { return bool(Data & ParamFlagsMask); }
+
   int_type getIntValue() const {
     return Data;
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1452,26 +1452,11 @@ public:
                                        : value - ParameterTypeFlags::Shared);
   }
 
-  ParameterTypeFlags withAutoClosure(bool isAutoClosure) const {
-    return ParameterTypeFlags(isAutoClosure
-                                  ? value | ParameterTypeFlags::AutoClosure
-                                  : value - ParameterTypeFlags::AutoClosure);
-  }
-
   bool operator ==(const ParameterTypeFlags &other) const {
     return value.toRaw() == other.value.toRaw();
   }
 
   uint8_t toRaw() const { return value.toRaw(); }
-
-  static ParameterTypeFlags fromRaw(uint8_t value) {
-    return ParameterTypeFlags()
-        .withVariadic(value & Variadic)
-        .withAutoClosure(value & AutoClosure)
-        .withEscaping(value & Escaping)
-        .withInOut(value & InOut)
-        .withShared(value & Shared);
-  }
 };
 
 /// ParenType - A paren type is a type that's been written in parentheses.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1452,11 +1452,26 @@ public:
                                        : value - ParameterTypeFlags::Shared);
   }
 
+  ParameterTypeFlags withAutoClosure(bool isAutoClosure) const {
+    return ParameterTypeFlags(isAutoClosure
+                                  ? value | ParameterTypeFlags::AutoClosure
+                                  : value - ParameterTypeFlags::AutoClosure);
+  }
+
   bool operator ==(const ParameterTypeFlags &other) const {
     return value.toRaw() == other.value.toRaw();
   }
 
   uint8_t toRaw() const { return value.toRaw(); }
+
+  static ParameterTypeFlags fromRaw(uint8_t value) {
+    return ParameterTypeFlags()
+        .withVariadic(value & Variadic)
+        .withAutoClosure(value & AutoClosure)
+        .withEscaping(value & Escaping)
+        .withInOut(value & InOut)
+        .withShared(value & Shared);
+  }
 };
 
 /// ParenType - A paren type is a type that's been written in parentheses.

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -344,7 +344,7 @@ class FunctionTypeRef final : public TypeRef {
     for (const auto &Param : Parameters) {
       ID.addString(Param.getLabel().str());
       ID.addPointer(Param.getType());
-      ID.addInteger(static_cast<uint32_t>(Param.getFlags().toRaw()));
+      ID.addInteger(static_cast<uint32_t>(Param.getFlags().getIntValue()));
     }
     ID.addPointer(Result);
     ID.addInteger(static_cast<uint64_t>(Flags.getIntValue()));

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -798,38 +798,17 @@ public:
     }
     case MetadataKind::Function: {
       auto Function = cast<TargetFunctionTypeMetadata<Runtime>>(Meta);
-      auto numParameters = Function->getNumParameters();
 
       std::vector<FunctionParam<BuiltType>> Parameters;
-      StoredPointer ArgumentAddress = MetadataAddress +
-        sizeof(TargetFunctionTypeMetadata<Runtime>);
-      StoredPointer ParameterFlagsAddress =
-                    ArgumentAddress + (numParameters * sizeof(StoredPointer));
-
-      for (unsigned i = 0; i < numParameters; ++i,
-           ArgumentAddress += sizeof(StoredPointer),
-           ParameterFlagsAddress += sizeof(uint32_t)) {
-        StoredPointer ParamMetadata;
-        if (!Reader->readInteger(RemoteAddress(ArgumentAddress),
-                                 &ParamMetadata))
+      for (unsigned i = 0, n = Function->getNumParameters(); i != n; ++i) {
+        auto ParamTypeRef = readTypeFromMetadata(Function->getParameter(i));
+        if (!ParamTypeRef)
           return BuiltType();
 
-        if (auto ParamTypeRef = readTypeFromMetadata(ParamMetadata)) {
-          FunctionParam<BuiltType> Param;
-          Param.setType(ParamTypeRef);
-
-          if (Function->hasParameterFlags()) {
-            uint32_t ParameterFlags;
-            if (!Reader->readInteger(RemoteAddress(ParameterFlagsAddress),
-                                     &ParameterFlags))
-              return BuiltType();
-              Param.setFlags(ParameterFlags::fromIntValue(ParameterFlags));
-          }
-
-          Parameters.push_back(std::move(Param));
-        } else {
-          return BuiltType();
-        }
+        FunctionParam<BuiltType> Param;
+        Param.setType(ParamTypeRef);
+        Param.setFlags(Function->getParameterFlags(i));
+        Parameters.push_back(std::move(Param));
       }
 
       auto Result = readTypeFromMetadata(Function->ResultType);
@@ -1203,8 +1182,26 @@ protected:
         return _readMetadata<TargetExistentialMetatypeMetadata>(address);
       case MetadataKind::ForeignClass:
         return _readMetadata<TargetForeignClassMetadata>(address);
-      case MetadataKind::Function:
-        return _readMetadata<TargetFunctionTypeMetadata>(address);
+      case MetadataKind::Function: {
+        StoredSize flagsValue;
+        auto flagsAddr =
+            address + TargetFunctionTypeMetadata<Runtime>::OffsetToFlags;
+        if (!Reader->readInteger(RemoteAddress(flagsAddr), &flagsValue))
+          return nullptr;
+
+        auto flags =
+            TargetFunctionTypeFlags<StoredSize>::fromIntValue(flagsValue);
+
+        using Parameter =
+            ConstTargetMetadataPointer<Runtime, swift::TargetMetadata>;
+        auto totalSize = sizeof(TargetFunctionTypeMetadata<Runtime>) +
+                         flags.getNumParameters() * sizeof(Parameter);
+
+        if (flags.hasParameterFlags())
+          totalSize += flags.getNumParameters() * sizeof(uint32_t);
+
+        return _readMetadata(address, totalSize);
+      }
       case MetadataKind::HeapGenericLocalVariable:
         return _readMetadata<TargetGenericBoxHeapMetadata>(address);
       case MetadataKind::HeapLocalVariable:

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -798,7 +798,7 @@ public:
     }
     case MetadataKind::Function: {
       auto Function = cast<TargetFunctionTypeMetadata<Runtime>>(Meta);
-      auto numParameters = Function->getNumArguments();
+      auto numParameters = Function->getNumParameters();
 
       std::vector<FunctionParam<BuiltType>> Parameters;
       StoredPointer ArgumentAddress = MetadataAddress +
@@ -836,8 +836,10 @@ public:
       if (!Result)
         return BuiltType();
 
-      auto flags = FunctionTypeFlags().withConvention(Function->getConvention())
-                                      .withThrows(Function->throws());
+      auto flags = FunctionTypeFlags()
+                       .withConvention(Function->getConvention())
+                       .withThrows(Function->throws())
+                       .withParameterFlags(Function->hasParameterFlags());
       auto BuiltFunction =
           Builder.createFunctionType(Parameters, Result, flags);
       TypeCache[MetadataAddress] = BuiltFunction;

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1760,12 +1760,19 @@ struct TargetFunctionTypeMetadata : public TargetMetadata<Runtime> {
     return reinterpret_cast<TargetPointer<Runtime, const Argument>>(this + 1);
   }
 
+  TargetPointer<Runtime, uint32_t> getParameterFlags() {
+    return reinterpret_cast<TargetPointer<Runtime, uint32_t>>(
+        reinterpret_cast<Argument *>(this + 1) + getNumArguments());
+  }
+
+  TargetPointer<Runtime, const uint32_t> getParameterFlags() const {
+    return reinterpret_cast<TargetPointer<Runtime, const uint32_t>>(
+        reinterpret_cast<const Argument *>(this + 1) + getNumArguments());
+  }
+
   uint32_t getParameterFlags(unsigned index) const {
-    auto numParams = getNumArguments();
-    assert(index < numParams);
-    auto *flags = reinterpret_cast<const uint32_t *>(this + 1 +
-                                                  numParams * sizeof(Argument));
-    return flags[index];
+    assert(index <= getNumArguments());
+    return hasParameterFlags() ? getParameterFlags()[index] : 0;
   }
 
   StoredSize getNumArguments() const {
@@ -1775,6 +1782,7 @@ struct TargetFunctionTypeMetadata : public TargetMetadata<Runtime> {
     return Flags.getConvention();
   }
   bool throws() const { return Flags.throws(); }
+  bool hasParameterFlags() const { return Flags.hasParameterFlags(); }
 
   static constexpr StoredSize OffsetToFlags = sizeof(TargetMetadata<Runtime>);
 
@@ -2645,35 +2653,39 @@ swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
 /// \brief Fetch a uniqued metadata for a function type.
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
-swift_getFunctionTypeMetadata(const void *flagsArgsAndResult[]);
+swift_getFunctionTypeMetadata(FunctionTypeFlags flags,
+                              const Metadata **parameters,
+                              const uint32_t *parameterFlags,
+                              const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                const Metadata *arg0,
-                               const Metadata *resultMetadata);
+                               const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
                                         const Metadata *arg0,
-                                        const uint32_t *paramFlags,
-                                        const Metadata *resultMetadata);
+                                        const uint32_t flags0,
+                                        const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                const Metadata *arg0,
                                const Metadata *arg1,
-                               const Metadata *resultMetadata);
+                               const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
                                         const Metadata *arg0,
+                                        const uint32_t flags0,
                                         const Metadata *arg1,
-                                        const uint32_t *paramFlags,
-                                        const Metadata *resultMetadata);
+                                        const uint32_t flags1,
+                                        const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *swift_getFunctionTypeMetadata3(
@@ -2681,16 +2693,18 @@ const FunctionTypeMetadata *swift_getFunctionTypeMetadata3(
                                                 const Metadata *arg0,
                                                 const Metadata *arg1,
                                                 const Metadata *arg2,
-                                                const Metadata *resultMetadata);
+                                                const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *swift_getFunctionTypeMetadata3WithFlags(
                                                 FunctionTypeFlags flags,
                                                 const Metadata *arg0,
+                                                const uint32_t flags0,
                                                 const Metadata *arg1,
+                                                const uint32_t flags1,
                                                 const Metadata *arg2,
-                                                const uint32_t *paramFlags,
-                                                const Metadata *resultMetadata);
+                                                const uint32_t flags2,
+                                                const Metadata *result);
 
 /// \brief Fetch a uniqued metadata for a thin function type.
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1762,17 +1762,18 @@ struct TargetFunctionTypeMetadata : public TargetMetadata<Runtime> {
 
   TargetPointer<Runtime, uint32_t> getParameterFlags() {
     return reinterpret_cast<TargetPointer<Runtime, uint32_t>>(
-        reinterpret_cast<Argument *>(this + 1) + getNumArguments());
+                    reinterpret_cast<Argument *>(this + 1) + getNumArguments());
   }
 
   TargetPointer<Runtime, const uint32_t> getParameterFlags() const {
     return reinterpret_cast<TargetPointer<Runtime, const uint32_t>>(
-        reinterpret_cast<const Argument *>(this + 1) + getNumArguments());
+              reinterpret_cast<const Argument *>(this + 1) + getNumArguments());
   }
 
-  uint32_t getParameterFlags(unsigned index) const {
-    assert(index <= getNumArguments());
-    return hasParameterFlags() ? getParameterFlags()[index] : 0;
+  ParameterFlags getParameterFlags(unsigned index) const {
+    assert(index < getNumArguments());
+    auto flags = hasParameterFlags() ? getParameterFlags()[index] : 0;
+    return ParameterFlags::fromIntValue(flags);
   }
 
   StoredSize getNumArguments() const {
@@ -2654,7 +2655,7 @@ swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata(FunctionTypeFlags flags,
-                              const Metadata **parameters,
+                              const Metadata *const *parameters,
                               const uint32_t *parameterFlags,
                               const Metadata *result);
 
@@ -2668,7 +2669,7 @@ SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
                                         const Metadata *arg0,
-                                        const uint32_t flags0,
+                                        ParameterFlags flags0,
                                         const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
@@ -2682,9 +2683,9 @@ SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
                                         const Metadata *arg0,
-                                        const uint32_t flags0,
+                                        ParameterFlags flags0,
                                         const Metadata *arg1,
-                                        const uint32_t flags1,
+                                        ParameterFlags flags1,
                                         const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
@@ -2699,11 +2700,11 @@ SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *swift_getFunctionTypeMetadata3WithFlags(
                                                 FunctionTypeFlags flags,
                                                 const Metadata *arg0,
-                                                const uint32_t flags0,
+                                                ParameterFlags flags0,
                                                 const Metadata *arg1,
-                                                const uint32_t flags1,
+                                                ParameterFlags flags1,
                                                 const Metadata *arg2,
-                                                const uint32_t flags2,
+                                                ParameterFlags flags2,
                                                 const Metadata *result);
 
 /// \brief Fetch a uniqued metadata for a thin function type.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1745,39 +1745,39 @@ using EnumMetadata = TargetEnumMetadata<InProcess>;
 template <typename Runtime>
 struct TargetFunctionTypeMetadata : public TargetMetadata<Runtime> {
   using StoredSize = typename Runtime::StoredSize;
-  using Argument = const TargetMetadata<Runtime> *;
+  using Parameter = const TargetMetadata<Runtime> *;
 
   TargetFunctionTypeFlags<StoredSize> Flags;
 
   /// The type metadata for the result type.
   ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> ResultType;
 
-  TargetPointer<Runtime, Argument> getArguments() {
-    return reinterpret_cast<TargetPointer<Runtime, Argument>>(this + 1);
+  TargetPointer<Runtime, Parameter> getParameters() {
+    return reinterpret_cast<TargetPointer<Runtime, Parameter>>(this + 1);
   }
 
-  TargetPointer<Runtime, const Argument> getArguments() const {
-    return reinterpret_cast<TargetPointer<Runtime, const Argument>>(this + 1);
+  TargetPointer<Runtime, const Parameter> getParameters() const {
+    return reinterpret_cast<TargetPointer<Runtime, const Parameter>>(this + 1);
   }
 
   TargetPointer<Runtime, uint32_t> getParameterFlags() {
     return reinterpret_cast<TargetPointer<Runtime, uint32_t>>(
-                    reinterpret_cast<Argument *>(this + 1) + getNumArguments());
+                  reinterpret_cast<Parameter *>(this + 1) + getNumParameters());
   }
 
   TargetPointer<Runtime, const uint32_t> getParameterFlags() const {
     return reinterpret_cast<TargetPointer<Runtime, const uint32_t>>(
-              reinterpret_cast<const Argument *>(this + 1) + getNumArguments());
+            reinterpret_cast<const Parameter *>(this + 1) + getNumParameters());
   }
 
   ParameterFlags getParameterFlags(unsigned index) const {
-    assert(index < getNumArguments());
+    assert(index < getNumParameters());
     auto flags = hasParameterFlags() ? getParameterFlags()[index] : 0;
     return ParameterFlags::fromIntValue(flags);
   }
 
-  StoredSize getNumArguments() const {
-    return Flags.getNumArguments();
+  StoredSize getNumParameters() const {
+    return Flags.getNumParameters();
   }
   FunctionMetadataConvention getConvention() const {
     return Flags.getConvention();

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2650,45 +2650,45 @@ swift_getFunctionTypeMetadata(const void *flagsArgsAndResult[]);
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
-                               const void *arg0,
+                               const Metadata *arg0,
                                const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
-                                        const void *arg0,
+                                        const Metadata *arg0,
                                         const uint32_t *paramFlags,
                                         const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
-                               const void *arg0,
-                               const void *arg1,
+                               const Metadata *arg0,
+                               const Metadata *arg1,
                                const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
-                                        const void *arg0,
-                                        const void *arg1,
+                                        const Metadata *arg0,
+                                        const Metadata *arg1,
                                         const uint32_t *paramFlags,
                                         const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *swift_getFunctionTypeMetadata3(
                                                 FunctionTypeFlags flags,
-                                                const void *arg0,
-                                                const void *arg1,
-                                                const void *arg2,
+                                                const Metadata *arg0,
+                                                const Metadata *arg1,
+                                                const Metadata *arg2,
                                                 const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *swift_getFunctionTypeMetadata3WithFlags(
                                                 FunctionTypeFlags flags,
-                                                const void *arg0,
-                                                const void *arg1,
-                                                const void *arg2,
+                                                const Metadata *arg0,
+                                                const Metadata *arg1,
+                                                const Metadata *arg2,
                                                 const uint32_t *paramFlags,
                                                 const Metadata *resultMetadata);
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -766,65 +766,69 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
-//                                          const void *arg0,
+//                                          const Metadata *arg0,
 //                                          const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1, DefaultCC,
         RETURNS(TypeMetadataPtrTy),
-        ARGS(SizeTy, Int8PtrTy, TypeMetadataPtrTy),
+        ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata1WithFlags(unsigned long flags,
-//                                                   const void *arg0,
+//                                                   const Metadata *arg0,
 //                                                   const uint32_t *paramFlags,
 //                                                   const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata1WithFlags, swift_getFunctionTypeMetadata1WithFlags,
          DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, Int8PtrTy, Int32Ty->getPointerTo(), TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty->getPointerTo(),
+              TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata2(unsigned long flags,
-//                                          const void *arg0,
-//                                          const void *arg1,
+//                                          const Metadata *arg0,
+//                                          const Metadata *arg1,
 //                                          const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
         DefaultCC,
         RETURNS(TypeMetadataPtrTy),
-        ARGS(SizeTy, Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
+        ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata2WithFlags(unsigned long flags,
-//                                                   const void *arg0,
-//                                                   const void *arg1,
+//                                                   const Metadata *arg0,
+//                                                   const Metadata *arg1,
 //                                                   const uint32_t *paramFlags,
 //                                                   const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata2WithFlags, swift_getFunctionTypeMetadata2WithFlags,
          DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int32Ty->getPointerTo(), TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
+              Int32Ty->getPointerTo(), TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata3(unsigned long flags,
-//                                          const void *arg0,
-//                                          const void *arg1,
-//                                          const void *arg2,
+//                                          const Metadata *arg0,
+//                                          const Metadata *arg1,
+//                                          const Metadata *arg2,
 //                                          const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
         DefaultCC,
         RETURNS(TypeMetadataPtrTy),
-        ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
+        ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
+             TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata3WithFlags(unsigned long flags,
-//                                                   const void *arg0,
-//                                                   const void *arg1,
-//                                                   const void *arg2,
+//                                                   const Metadata *arg0,
+//                                                   const Metadata *arg1,
+//                                                   const Metadata *arg2,
 //                                                   const uint32_t *paramFlags,
 //                                                   const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata3WithFlags, swift_getFunctionTypeMetadata3WithFlags,
          DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty->getPointerTo(), TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
+              Int32Ty->getPointerTo(), TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -765,22 +765,66 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
          ARGS(Int8PtrTy->getPointerTo(0)),
          ATTRS(NoUnwind, ReadNone))
 
-// Metadata *swift_getFunctionTypeMetadata1(unsigned long flags, const void *arg0, const Metadata *resultMetadata);
+// Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
+//                                          const void *arg0,
+//                                          const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1, DefaultCC,
+        RETURNS(TypeMetadataPtrTy),
+        ARGS(SizeTy, Int8PtrTy, TypeMetadataPtrTy),
+        ATTRS(NoUnwind, ReadNone))
+
+// Metadata *swift_getFunctionTypeMetadata1WithFlags(unsigned long flags,
+//                                                   const void *arg0,
+//                                                   const uint32_t *paramFlags,
+//                                                   const Metadata *resultMetadata);
+FUNCTION(GetFunctionMetadata1WithFlags, swift_getFunctionTypeMetadata1WithFlags,
+         DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, Int8PtrTy, TypeMetadataPtrTy),
+         ARGS(SizeTy, Int8PtrTy, Int32Ty->getPointerTo(), TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
-// Metadata *swift_getFunctionTypeMetadata2(unsigned long flags, const void *arg0, const void *arg1, const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2, DefaultCC,
+// Metadata *swift_getFunctionTypeMetadata2(unsigned long flags,
+//                                          const void *arg0,
+//                                          const void *arg1,
+//                                          const Metadata *resultMetadata);
+FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
+        DefaultCC,
+        RETURNS(TypeMetadataPtrTy),
+        ARGS(SizeTy, Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
+        ATTRS(NoUnwind, ReadNone))
+
+// Metadata *swift_getFunctionTypeMetadata2WithFlags(unsigned long flags,
+//                                                   const void *arg0,
+//                                                   const void *arg1,
+//                                                   const uint32_t *paramFlags,
+//                                                   const Metadata *resultMetadata);
+FUNCTION(GetFunctionMetadata2WithFlags, swift_getFunctionTypeMetadata2WithFlags,
+         DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
+         ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int32Ty->getPointerTo(), TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
-// Metadata *swift_getFunctionTypeMetadata3(unsigned long flags, const void *arg0, const void *arg1, const void *arg2, const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3, DefaultCC,
+// Metadata *swift_getFunctionTypeMetadata3(unsigned long flags,
+//                                          const void *arg0,
+//                                          const void *arg1,
+//                                          const void *arg2,
+//                                          const Metadata *resultMetadata);
+FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
+        DefaultCC,
+        RETURNS(TypeMetadataPtrTy),
+        ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
+        ATTRS(NoUnwind, ReadNone))
+
+// Metadata *swift_getFunctionTypeMetadata3WithFlags(unsigned long flags,
+//                                                   const void *arg0,
+//                                                   const void *arg1,
+//                                                   const void *arg2,
+//                                                   const uint32_t *paramFlags,
+//                                                   const Metadata *resultMetadata);
+FUNCTION(GetFunctionMetadata3WithFlags, swift_getFunctionTypeMetadata3WithFlags,
+         DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
+         ARGS(SizeTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty->getPointerTo(), TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -759,10 +759,14 @@ FUNCTION(ArrayDestroy, swift_arrayDestroy, DefaultCC,
          ARGS(OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
-// Metadata *swift_getFunctionTypeMetadata(const void **args);
+// Metadata *swift_getFunctionTypeMetadata(unsigned long flags,
+//                                         const Metadata **parameters,
+//                                         const uint32_t *parameterFlags,
+//                                         const Metadata *result);
 FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(Int8PtrTy->getPointerTo(0)),
+         ARGS(SizeTy, TypeMetadataPtrTy->getPointerTo(), Int32Ty->getPointerTo(),
+              TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
@@ -775,13 +779,12 @@ FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1, DefaultCC,
 
 // Metadata *swift_getFunctionTypeMetadata1WithFlags(unsigned long flags,
 //                                                   const Metadata *arg0,
-//                                                   const uint32_t *paramFlags,
+//                                                   const uint32_t paramFlags,
 //                                                   const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata1WithFlags, swift_getFunctionTypeMetadata1WithFlags,
          DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty->getPointerTo(),
-              TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata2(unsigned long flags,
@@ -796,14 +799,15 @@ FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
 
 // Metadata *swift_getFunctionTypeMetadata2WithFlags(unsigned long flags,
 //                                                   const Metadata *arg0,
+//                                                   const uint32_t flags0,
 //                                                   const Metadata *arg1,
-//                                                   const uint32_t *paramFlags,
+//                                                   const uint32_t flags1,
 //                                                   const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata2WithFlags, swift_getFunctionTypeMetadata2WithFlags,
          DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
-              Int32Ty->getPointerTo(), TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy, Int32Ty,
+              TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata3(unsigned long flags,
@@ -820,15 +824,17 @@ FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
 
 // Metadata *swift_getFunctionTypeMetadata3WithFlags(unsigned long flags,
 //                                                   const Metadata *arg0,
+//                                                   const uint32_t flags0,
 //                                                   const Metadata *arg1,
+//                                                   const uint32_t flags1,
 //                                                   const Metadata *arg2,
-//                                                   const uint32_t *paramFlags,
+//                                                   const uint32_t flags2,
 //                                                   const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata3WithFlags, swift_getFunctionTypeMetadata3WithFlags,
          DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
-              Int32Ty->getPointerTo(), TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy, Int32Ty,
+              TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -765,7 +765,9 @@ FUNCTION(ArrayDestroy, swift_arrayDestroy, DefaultCC,
 //                                         const Metadata *result);
 FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy->getPointerTo(), Int32Ty->getPointerTo(),
+         ARGS(SizeTy,
+              TypeMetadataPtrTy->getPointerTo(0),
+              Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -749,7 +749,7 @@ namespace {
       }
 
       auto flagsVal = FunctionTypeFlags()
-                          .withNumArguments(numParams)
+                          .withNumParameters(numParams)
                           .withConvention(metadataConvention)
                           .withThrows(type->throws())
                           .withParameterFlags(hasFlags);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -758,12 +758,19 @@ namespace {
                                           flagsVal.getIntValue());
 
       auto collectParameters =
-          [&](llvm::function_ref<void(unsigned, llvm::Value *, uint8_t)>
+          [&](llvm::function_ref<void(unsigned, llvm::Value *,
+                                      ParameterFlags flags)>
                   processor) {
             for (auto index : indices(params)) {
               auto param = params[index];
               auto flags = param.getParameterFlags();
-              processor(index, getFunctionParameterRef(param), flags.toRaw());
+
+              auto parameterFlags = ParameterFlags()
+                                        .withInOut(flags.isInOut())
+                                        .withShared(flags.isShared())
+                                        .withVariadic(flags.isVariadic());
+
+              processor(index, getFunctionParameterRef(param), parameterFlags);
             }
           };
 
@@ -772,10 +779,12 @@ namespace {
           -> llvm::Constant * {
         arguments.push_back(flags);
 
-        collectParameters([&](unsigned i, llvm::Value *typeRef, uint8_t flags) {
+        collectParameters([&](unsigned i, llvm::Value *typeRef,
+                              ParameterFlags flags) {
           arguments.push_back(typeRef);
           if (hasFlags)
-            arguments.push_back(llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags));
+            arguments.push_back(
+                llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()));
         });
 
         arguments.push_back(result);
@@ -832,12 +841,12 @@ namespace {
           ConstantInitBuilder paramFlags(IGF.IGM);
           auto flagsArr = paramFlags.beginArray();
           collectParameters([&](unsigned i, llvm::Value *typeRef,
-                                uint8_t flags) {
+                                ParameterFlags flags) {
             auto argPtr = IGF.Builder.CreateStructGEP(parameters, i,
                                                       IGF.IGM.getPointerSize());
             IGF.Builder.CreateStore(typeRef, argPtr);
             if (hasFlags)
-              flagsArr.addInt32(flags);
+              flagsArr.addInt32(flags.getIntValue());
           });
 
           auto parametersPtr =

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -334,7 +334,12 @@ public:
 
       auto label = Ctx.getIdentifier(param.getLabel());
       auto flags = param.getFlags();
-      funcParams.push_back(AnyFunctionType::Param(type, label, flags));
+      auto parameterFlags = ParameterTypeFlags()
+                                .withInOut(flags.isInOut())
+                                .withShared(flags.isShared())
+                                .withVariadic(flags.isVariadic());
+
+      funcParams.push_back(AnyFunctionType::Param(type, label, parameterFlags));
     }
 
     return FunctionType::get(funcParams, output, einfo);

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -147,9 +147,6 @@ public:
       if (flags.isShared())
         printHeader("shared");
 
-      if (flags.isEscaping())
-        printHeader("escaping");
-
       printRec(param.getType());
 
       if (!flags.isNone()) {

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1927,7 +1927,7 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
       return _fail(src, srcType, targetType, flags);
 
     for (unsigned i = 0, e = srcFn->getNumParameters(); i < e; ++i) {
-      if (srcFn->getParameters()[i] != targetFn->getParameters()[i] ||
+      if (srcFn->getParameter(i) != targetFn->getParameter(i) ||
           srcFn->getParameterFlags(i) != targetFn->getParameterFlags(i))
         return _fail(src, srcType, targetType, flags);
     }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1922,11 +1922,16 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
       return _fail(src, srcType, targetType, flags);
     if (srcFn->getNumArguments() != targetFn->getNumArguments())
       return _fail(src, srcType, targetType, flags);
-    for (unsigned i = 0, e = srcFn->getNumArguments(); i < e; ++i)
+
+    if (srcFn->hasParameterFlags() != targetFn->hasParameterFlags())
+      return _fail(src, srcType, targetType, flags);
+
+    for (unsigned i = 0, e = srcFn->getNumArguments(); i < e; ++i) {
       if (srcFn->getArguments()[i] != targetFn->getArguments()[i] ||
           srcFn->getParameterFlags(i) != targetFn->getParameterFlags(i))
         return _fail(src, srcType, targetType, flags);
-    
+    }
+
     return _succeed(dest, src, srcType, flags);
   }
   

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1920,14 +1920,14 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
     // The result and argument types must match.
     if (srcFn->ResultType != targetFn->ResultType)
       return _fail(src, srcType, targetType, flags);
-    if (srcFn->getNumArguments() != targetFn->getNumArguments())
+    if (srcFn->getNumParameters() != targetFn->getNumParameters())
       return _fail(src, srcType, targetType, flags);
 
     if (srcFn->hasParameterFlags() != targetFn->hasParameterFlags())
       return _fail(src, srcType, targetType, flags);
 
-    for (unsigned i = 0, e = srcFn->getNumArguments(); i < e; ++i) {
-      if (srcFn->getArguments()[i] != targetFn->getArguments()[i] ||
+    for (unsigned i = 0, e = srcFn->getNumParameters(); i < e; ++i) {
+      if (srcFn->getParameters()[i] != targetFn->getParameters()[i] ||
           srcFn->getParameterFlags(i) != targetFn->getParameterFlags(i))
         return _fail(src, srcType, targetType, flags);
     }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1923,7 +1923,8 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
     if (srcFn->getNumArguments() != targetFn->getNumArguments())
       return _fail(src, srcType, targetType, flags);
     for (unsigned i = 0, e = srcFn->getNumArguments(); i < e; ++i)
-      if (srcFn->getArguments()[i] != targetFn->getArguments()[i])
+      if (srcFn->getArguments()[i] != targetFn->getArguments()[i] ||
+          srcFn->getParameterFlags(i) != targetFn->getParameterFlags(i))
         return _fail(src, srcType, targetType, flags);
     
     return _succeed(dest, src, srcType, flags);

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -320,7 +320,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     
     std::vector<NodePointer> inputs;
     for (unsigned i = 0, e = func->getNumParameters(); i < e; ++i) {
-      auto param = func->getParameters()[i];
+      auto param = func->getParameter(i);
       auto flags = func->getParameterFlags(i);
       auto input = _swift_buildDemanglingForMetadata(param, Dem);
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/Types.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Strings.h"
 #include "Private.h"
@@ -321,11 +322,17 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     std::vector<NodePointer> inputs;
     for (unsigned i = 0, e = func->getNumArguments(); i < e; ++i) {
       auto arg = func->getArguments()[i];
-      auto input = _swift_buildDemanglingForMetadata(arg.getPointer(), Dem);
-      if (arg.getFlag()) {
+      auto flags = ParameterTypeFlags::fromRaw(func->getParameterFlags(i));
+      auto input = _swift_buildDemanglingForMetadata(arg, Dem);
+
+      if (flags.isInOut()) {
         NodePointer inout = Dem.createNode(Node::Kind::InOut);
         inout->addChild(input, Dem);
         input = inout;
+      } else if (flags.isShared()) {
+        NodePointer shared = Dem.createNode(Node::Kind::Shared);
+        shared->addChild(input, Dem);
+        input = shared;
       }
       inputs.push_back(input);
     }

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/Types.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Strings.h"
 #include "Private.h"
@@ -322,7 +321,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     std::vector<NodePointer> inputs;
     for (unsigned i = 0, e = func->getNumArguments(); i < e; ++i) {
       auto arg = func->getArguments()[i];
-      auto flags = ParameterTypeFlags::fromRaw(func->getParameterFlags(i));
+      auto flags = func->getParameterFlags(i);
       auto input = _swift_buildDemanglingForMetadata(arg, Dem);
 
       if (flags.isInOut()) {

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -319,10 +319,10 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     }
     
     std::vector<NodePointer> inputs;
-    for (unsigned i = 0, e = func->getNumArguments(); i < e; ++i) {
-      auto arg = func->getArguments()[i];
+    for (unsigned i = 0, e = func->getNumParameters(); i < e; ++i) {
+      auto param = func->getParameters()[i];
       auto flags = func->getParameterFlags(i);
-      auto input = _swift_buildDemanglingForMetadata(arg, Dem);
+      auto input = _swift_buildDemanglingForMetadata(param, Dem);
 
       if (flags.isInOut()) {
         NodePointer inout = Dem.createNode(Node::Kind::InOut);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -337,7 +337,10 @@ public:
         Result(result) {}
 
     FunctionTypeFlags getFlags() const { return Flags; }
-    const Metadata *const *getParameters() const { return Parameters; }
+    const Metadata *getParameter(unsigned index) const {
+      assert(index < Flags.getNumParameters());
+      return Parameters[index];
+    }
     const Metadata *getResult() const { return Result; }
 
     const uint32_t *getParameterFlags() const {
@@ -367,8 +370,8 @@ public:
       return result;
 
     for (unsigned i = 0, e = keyFlags.getNumParameters(); i != e; ++i) {
-      if (auto result = comparePointers(key.getParameters()[i],
-                                        Data.getParameters()[i]))
+      if (auto result =
+              comparePointers(key.getParameter(i), Data.getParameter(i)))
         return result;
 
       if (auto result =
@@ -537,7 +540,7 @@ FunctionCacheEntry::FunctionCacheEntry(Key key) {
   Data.ResultType = key.getResult();
 
   for (unsigned i = 0; i < numParameters; ++i) {
-    Data.getParameters()[i] = key.getParameters()[i];
+    Data.getParameters()[i] = key.getParameter(i);
     if (flags.hasParameterFlags())
       Data.getParameterFlags()[i] = key.getParameterFlags(i).getIntValue();
   }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -345,7 +345,7 @@ public:
     }
 
     ::ParameterFlags getParameterFlags(unsigned index) const {
-      assert(index < Flags.getNumArguments());
+      assert(index < Flags.getNumParameters());
       auto flags = Flags.hasParameterFlags() ? ParameterFlags[index] : 0;
       return ParameterFlags::fromIntValue(flags);
     }
@@ -366,9 +366,9 @@ public:
     if (auto result = comparePointers(key.getResult(), Data.ResultType))
       return result;
 
-    for (unsigned i = 0, e = keyFlags.getNumArguments(); i != e; ++i) {
+    for (unsigned i = 0, e = keyFlags.getNumParameters(); i != e; ++i) {
       if (auto result = comparePointers(key.getParameters()[i],
-                                        Data.getArguments()[i]))
+                                        Data.getParameters()[i]))
         return result;
 
       if (auto result =
@@ -388,8 +388,8 @@ public:
   }
 
   static size_t getExtraAllocationSize(const FunctionTypeFlags flags) {
-    const auto numParams = flags.getNumArguments();
-    auto size = numParams * sizeof(FunctionTypeMetadata::Argument);
+    const auto numParams = flags.getNumParameters();
+    auto size = numParams * sizeof(FunctionTypeMetadata::Parameter);
     if (flags.hasParameterFlags())
       size += numParams * sizeof(uint32_t);
 
@@ -407,7 +407,7 @@ const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                       const Metadata *arg0,
                                       const Metadata *result) {
-  assert(flags.getNumArguments() == 1
+  assert(flags.getNumParameters() == 1
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0 };
   return swift_getFunctionTypeMetadata(flags, parameters, nullptr, result);
@@ -418,7 +418,7 @@ swift::swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
                                                const Metadata *arg0,
                                                ParameterFlags flags0,
                                                const Metadata *result) {
-  assert(flags.getNumArguments() == 1
+  assert(flags.getNumParameters() == 1
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0 };
   const uint32_t parameterFlags[] = { flags0.getIntValue() };
@@ -433,7 +433,7 @@ swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                       const Metadata *arg0,
                                       const Metadata *arg1,
                                       const Metadata *result) {
-  assert(flags.getNumArguments() == 2
+  assert(flags.getNumParameters() == 2
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1 };
   return swift_getFunctionTypeMetadata(flags, parameters, nullptr, result);
@@ -446,7 +446,7 @@ swift::swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
                                                const Metadata *arg1,
                                                ParameterFlags flags1,
                                                const Metadata *result) {
-  assert(flags.getNumArguments() == 2
+  assert(flags.getNumParameters() == 2
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1 };
   const uint32_t parameterFlags[] = {
@@ -465,7 +465,7 @@ swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
                                       const Metadata *arg1,
                                       const Metadata *arg2,
                                       const Metadata *result) {
-  assert(flags.getNumArguments() == 3
+  assert(flags.getNumParameters() == 3
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1, arg2 };
   return swift_getFunctionTypeMetadata(flags, parameters, nullptr, result);
@@ -480,7 +480,7 @@ swift::swift_getFunctionTypeMetadata3WithFlags(FunctionTypeFlags flags,
                                                const Metadata *arg2,
                                                ParameterFlags flags2,
                                                const Metadata *result) {
-  assert(flags.getNumArguments() == 3
+  assert(flags.getNumParameters() == 3
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1, arg2 };
   const uint32_t parameterFlags[] = {
@@ -530,14 +530,14 @@ FunctionCacheEntry::FunctionCacheEntry(Key key) {
     break;
   }
 
-  unsigned numArguments = flags.getNumArguments();
+  unsigned numParameters = flags.getNumParameters();
 
   Data.setKind(MetadataKind::Function);
   Data.Flags = flags;
   Data.ResultType = key.getResult();
 
-  for (unsigned i = 0; i < numArguments; ++i) {
-    Data.getArguments()[i] = key.getParameters()[i];
+  for (unsigned i = 0; i < numParameters; ++i) {
+    Data.getParameters()[i] = key.getParameters()[i];
     if (flags.hasParameterFlags())
       Data.getParameterFlags()[i] = key.getParameterFlags(i).getIntValue();
   }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -394,14 +394,14 @@ static SimpleGlobalCache<FunctionCacheEntry> FunctionTypes;
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
-                                      const void *arg0,
+                                      const Metadata *arg0,
                                       const Metadata *result) {
   return swift_getFunctionTypeMetadata1WithFlags(flags, arg0, nullptr, result);
 }
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
-                                               const void *arg0,
+                                               const Metadata *arg0,
                                                const uint32_t *paramFlags,
                                                const Metadata *result) {
   assert(flags.getNumArguments() == 1
@@ -414,8 +414,8 @@ swift::swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
-                                      const void *arg0,
-                                      const void *arg1,
+                                      const Metadata *arg0,
+                                      const Metadata *arg1,
                                       const Metadata *result) {
   return swift_getFunctionTypeMetadata2WithFlags(
                                             flags, arg0, arg1, nullptr, result);
@@ -423,8 +423,8 @@ swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
-                                               const void *arg0,
-                                               const void *arg1,
+                                               const Metadata *arg0,
+                                               const Metadata *arg1,
                                                const uint32_t *paramFlags,
                                                const Metadata *result) {
   assert(flags.getNumArguments() == 2
@@ -437,9 +437,9 @@ swift::swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
-                                      const void *arg0,
-                                      const void *arg1,
-                                      const void *arg2,
+                                      const Metadata *arg0,
+                                      const Metadata *arg1,
+                                      const Metadata *arg2,
                                       const Metadata *result) {
   return swift_getFunctionTypeMetadata3WithFlags(flags, arg0, arg1, arg2,
                                                  nullptr, result);
@@ -447,9 +447,9 @@ swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata3WithFlags(FunctionTypeFlags flags,
-                                               const void *arg0,
-                                               const void *arg1,
-                                               const void *arg2,
+                                               const Metadata *arg0,
+                                               const Metadata *arg1,
+                                               const Metadata *arg2,
                                                const uint32_t *paramFlags,
                                                const Metadata *result) {
   assert(flags.getNumArguments() == 3

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -325,24 +325,29 @@ public:
   struct Key {
     const FunctionTypeFlags Flags;
 
-    const Metadata **const Parameters;
-    const uint32_t *const ParameterFlags;
-    const Metadata *const Result;
+    const Metadata *const *Parameters;
+    const uint32_t *ParameterFlags;
+    const Metadata *Result;
 
     Key(FunctionTypeFlags flags,
-        const Metadata **params,
+        const Metadata *const *params,
         const uint32_t *paramFlags,
         const Metadata *result)
       : Flags(flags), Parameters(params), ParameterFlags(paramFlags),
         Result(result) {}
 
     FunctionTypeFlags getFlags() const { return Flags; }
-    const Metadata **getParameters() const { return Parameters; }
+    const Metadata *const *getParameters() const { return Parameters; }
     const Metadata *getResult() const { return Result; }
 
-    uint32_t getParameterFlags(unsigned index) const {
+    const uint32_t *getParameterFlags() const {
+      return ParameterFlags;
+    }
+
+    ::ParameterFlags getParameterFlags(unsigned index) const {
       assert(index < Flags.getNumArguments());
-      return Flags.hasParameterFlags() ? ParameterFlags[index] : 0;
+      auto flags = Flags.hasParameterFlags() ? ParameterFlags[index] : 0;
+      return ParameterFlags::fromIntValue(flags);
     }
   };
 
@@ -366,20 +371,30 @@ public:
                                         Data.getArguments()[i]))
         return result;
 
-      if (auto result = compareIntegers(key.getParameterFlags(i),
-                                        Data.getParameterFlags(i)))
+      if (auto result =
+              compareIntegers(key.getParameterFlags(i).getIntValue(),
+                              Data.getParameterFlags(i).getIntValue()))
         return result;
     }
 
     return 0;
   }
   static size_t getExtraAllocationSize(Key key) {
-    return key.getFlags().getNumArguments()
-         * (sizeof(FunctionTypeMetadata::Argument) + sizeof(uint32_t));
+    return getExtraAllocationSize(key.Flags);
   }
+
   size_t getExtraAllocationSize() const {
-    return Data.getNumArguments() *
-           (sizeof(FunctionTypeMetadata::Argument) + sizeof(uint32_t));
+    return getExtraAllocationSize(Data.Flags);
+  }
+
+  static size_t getExtraAllocationSize(const FunctionTypeFlags flags) {
+    const auto numParams = flags.getNumArguments();
+    auto size = numParams * sizeof(FunctionTypeMetadata::Argument);
+    if (flags.hasParameterFlags())
+      size += numParams * sizeof(uint32_t);
+
+    const auto alignment = sizeof(void *);
+    return (size + alignment - 1) & ~(alignment - 1);
   }
 };
 
@@ -401,12 +416,12 @@ swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
                                                const Metadata *arg0,
-                                               const uint32_t flags0,
+                                               ParameterFlags flags0,
                                                const Metadata *result) {
   assert(flags.getNumArguments() == 1
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0 };
-  const uint32_t parameterFlags[] = { flags0 };
+  const uint32_t parameterFlags[] = { flags0.getIntValue() };
   return swift_getFunctionTypeMetadata(flags,
                                        parameters,
                                        parameterFlags,
@@ -427,14 +442,17 @@ swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
                                                const Metadata *arg0,
-                                               const uint32_t flags0,
+                                               ParameterFlags flags0,
                                                const Metadata *arg1,
-                                               const uint32_t flags1,
+                                               ParameterFlags flags1,
                                                const Metadata *result) {
   assert(flags.getNumArguments() == 2
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1 };
-  const uint32_t parameterFlags[] = { flags0, flags1 };
+  const uint32_t parameterFlags[] = {
+    flags0.getIntValue(),
+    flags1.getIntValue()
+  };
   return swift_getFunctionTypeMetadata(flags,
                                        parameters,
                                        parameterFlags,
@@ -456,16 +474,20 @@ swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata3WithFlags(FunctionTypeFlags flags,
                                                const Metadata *arg0,
-                                               const uint32_t flags0,
+                                               ParameterFlags flags0,
                                                const Metadata *arg1,
-                                               const uint32_t flags1,
+                                               ParameterFlags flags1,
                                                const Metadata *arg2,
-                                               const uint32_t flags2,
+                                               ParameterFlags flags2,
                                                const Metadata *result) {
   assert(flags.getNumArguments() == 3
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1, arg2 };
-  const uint32_t parameterFlags[] = { flags0, flags1, flags2 };
+  const uint32_t parameterFlags[] = {
+    flags0.getIntValue(),
+    flags1.getIntValue(),
+    flags2.getIntValue()
+  };
   return swift_getFunctionTypeMetadata(flags,
                                        parameters,
                                        parameterFlags,
@@ -474,7 +496,7 @@ swift::swift_getFunctionTypeMetadata3WithFlags(FunctionTypeFlags flags,
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata(FunctionTypeFlags flags,
-                                     const Metadata **parameters,
+                                     const Metadata *const *parameters,
                                      const uint32_t *parameterFlags,
                                      const Metadata *result) {
   FunctionCacheEntry::Key key = { flags, parameters, parameterFlags, result };
@@ -514,10 +536,10 @@ FunctionCacheEntry::FunctionCacheEntry(Key key) {
   Data.Flags = flags;
   Data.ResultType = key.getResult();
 
-  for (size_t i = 0; i < numArguments; ++i) {
+  for (unsigned i = 0; i < numArguments; ++i) {
     Data.getArguments()[i] = key.getParameters()[i];
     if (flags.hasParameterFlags())
-      Data.getParameterFlags()[i] = key.getParameterFlags(i);
+      Data.getParameterFlags()[i] = key.getParameterFlags(i).getIntValue();
   }
 }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -14,22 +14,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/MathExtras.h"
-#include "swift/Demangling/Demangler.h"
+#include "swift/Runtime/Metadata.h"
+#include "MetadataCache.h"
 #include "swift/Basic/LLVM.h"
-#include "swift/Basic/Range.h"
 #include "swift/Basic/Lazy.h"
+#include "swift/Basic/Range.h"
+#include "swift/Demangling/Demangler.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/HeapObject.h"
-#include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Mutex.h"
 #include "swift/Strings.h"
-#include "MetadataCache.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/PointerLikeTypeTraits.h"
 #include <algorithm>
-#include <condition_variable>
-#include <new>
 #include <cctype>
+#include <condition_variable>
 #include <iostream>
+#include <new>
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 // Avoid defining macro max(), min() which conflict with std::max(), std::min()
@@ -329,13 +330,21 @@ public:
     }
 
     const Metadata *getResult() const {
-      auto opaqueResult = FlagsArgsAndResult[getFlags().getNumArguments() + 1];
+      auto opaqueResult = FlagsArgsAndResult[getFlags().getNumArguments() + 2];
       return reinterpret_cast<const Metadata *>(opaqueResult);
     }
 
     const void * const *getArguments() const {
       return getFlags().getNumArguments() == 0
               ? nullptr : &FlagsArgsAndResult[1];
+    }
+
+    uint32_t getParameterFlags(unsigned index) const {
+      auto numArguments = getFlags().getNumArguments();
+      assert(index < numArguments);
+      auto *flags = reinterpret_cast<const uint32_t *>(
+          FlagsArgsAndResult[numArguments + 1]);
+      return flags[index];
     }
   };
 
@@ -355,9 +364,13 @@ public:
       return result;
 
     for (unsigned i = 0, e = keyFlags.getNumArguments(); i != e; ++i) {
-      if (auto result =
-            comparePointers(key.getArguments()[i],
-                            Data.getArguments()[i].getOpaqueValue()))
+      if (auto result = compareIntegers(key.getParameterFlags(i),
+                                        Data.getParameterFlags(i)))
+        return result;
+
+      if (auto result = comparePointers(
+              key.getArguments()[i],
+              reinterpret_cast<const void *>(Data.getArguments()[i])))
         return result;
     }
 
@@ -383,45 +396,71 @@ const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                       const void *arg0,
                                       const Metadata *result) {
+  return swift_getFunctionTypeMetadata1WithFlags(flags, arg0, nullptr, result);
+}
+
+const FunctionTypeMetadata *
+swift::swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
+                                               const void *arg0,
+                                               const uint32_t *paramFlags,
+                                               const Metadata *result) {
   assert(flags.getNumArguments() == 1
          && "wrong number of arguments in function metadata flags?!");
   const void *flagsArgsAndResult[] = {
-    reinterpret_cast<const void*>(flags.getIntValue()),
-    arg0,
-    static_cast<const void *>(result)                      
-  };                                                       
+      reinterpret_cast<const void *>(flags.getIntValue()), arg0, paramFlags,
+      static_cast<const void *>(result)};
   return swift_getFunctionTypeMetadata(flagsArgsAndResult);
-}                                                          
-const FunctionTypeMetadata *                               
+}
+
+const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                       const void *arg0,
                                       const void *arg1,
                                       const Metadata *result) {
+  return swift_getFunctionTypeMetadata2WithFlags(
+                                            flags, arg0, arg1, nullptr, result);
+}
+
+const FunctionTypeMetadata *
+swift::swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
+                                               const void *arg0,
+                                               const void *arg1,
+                                               const uint32_t *paramFlags,
+                                               const Metadata *result) {
   assert(flags.getNumArguments() == 2
          && "wrong number of arguments in function metadata flags?!");
   const void *flagsArgsAndResult[] = {
-    reinterpret_cast<const void*>(flags.getIntValue()),
-    arg0,
-    arg1,                                                  
-    static_cast<const void *>(result)                      
-  };                                                       
+      reinterpret_cast<const void *>(flags.getIntValue()), arg0, arg1,
+      paramFlags, static_cast<const void *>(result)};
   return swift_getFunctionTypeMetadata(flagsArgsAndResult);
-}                                                          
-const FunctionTypeMetadata *                               
+}
+
+const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
                                       const void *arg0,
                                       const void *arg1,
                                       const void *arg2,
                                       const Metadata *result) {
+  return swift_getFunctionTypeMetadata3WithFlags(flags, arg0, arg1, arg2,
+                                                 nullptr, result);
+}
+
+const FunctionTypeMetadata *
+swift::swift_getFunctionTypeMetadata3WithFlags(FunctionTypeFlags flags,
+                                               const void *arg0,
+                                               const void *arg1,
+                                               const void *arg2,
+                                               const uint32_t *paramFlags,
+                                               const Metadata *result) {
   assert(flags.getNumArguments() == 3
          && "wrong number of arguments in function metadata flags?!");
   const void *flagsArgsAndResult[] = {
-    reinterpret_cast<const void*>(flags.getIntValue()),
-    arg0,                                                  
-    arg1,                                                  
-    arg2,                                                  
-    static_cast<const void *>(result)                      
-  };                                                       
+      reinterpret_cast<const void *>(flags.getIntValue()),
+      arg0,
+      arg1,
+      arg2,
+      paramFlags,
+      static_cast<const void *>(result)};
   return swift_getFunctionTypeMetadata(flagsArgsAndResult);
 }
 
@@ -466,8 +505,8 @@ FunctionCacheEntry::FunctionCacheEntry(Key key) {
 
   for (size_t i = 0; i < numArguments; ++i) {
     auto opaqueArg = key.getArguments()[i];
-    auto arg = FunctionTypeMetadata::Argument::getFromOpaqueValue(opaqueArg);
-    Data.getArguments()[i] = arg;
+    Data.getArguments()[i] =
+        reinterpret_cast<FunctionTypeMetadata::Argument>(opaqueArg);
   }
 }
 

--- a/test/IRGen/c_function_pointer.sil
+++ b/test/IRGen/c_function_pointer.sil
@@ -27,5 +27,4 @@ entry:
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0yyXCMa()
 // --                                                                               0x3000001 -- C convention, 1 argument
-// CHECK:         call %swift.type* @swift_getFunctionTypeMetadata(i8** %3)
-
+// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 100663296, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))

--- a/test/IRGen/dynamic_cast_functions.swift
+++ b/test/IRGen/dynamic_cast_functions.swift
@@ -48,3 +48,29 @@ let t2: Any.Type = (((Int, Int)) -> ()).self
 
 // CHECK: ok
 print((t1 == t2) ? "fail" : "ok")
+
+let i: (inout Int) -> Void = { _ in }
+let j: (__shared Int) -> Void = { _ in }
+let k: (Int, inout Int) -> Void = { _,_ in }
+let l: (inout Int, Float, inout String) -> Void = { _,_,_ in }
+let m: (__shared Int, String, inout Float, Double) -> Void = { _,_,_,_ in }
+
+let i_any: Any = i
+let j_any: Any = j
+let k_any: Any = k
+let l_any: Any = l
+let m_any: Any = m
+
+// CHECK: ok
+print((i_any as? (Int) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((i_any as? (__shared Int) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((i_any as? (inout Int) -> Void) != nil ? "ok" : "fail")
+
+// CHECK: ok
+print((j_any as? (Int) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((j_any as? (inout Int) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((j_any as? (__shared Int) -> Void) != nil ? "ok" : "fail")

--- a/test/IRGen/dynamic_cast_functions.swift
+++ b/test/IRGen/dynamic_cast_functions.swift
@@ -74,3 +74,46 @@ print((j_any as? (Int) -> Void) != nil ? "fail" : "ok")
 print((j_any as? (inout Int) -> Void) != nil ? "fail" : "ok")
 // CHECK: ok
 print((j_any as? (__shared Int) -> Void) != nil ? "ok" : "fail")
+
+// CHECK: ok
+print((k_any as? (Int, Int) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((k_any as? (Int, inout Int) -> Void) != nil ? "ok" : "fail")
+// CHECK: ok
+print((k_any as? (inout Int, Int) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((k_any as? (inout Int, __shared Int) -> Void) != nil ? "fail" : "ok")
+
+// CHECK: ok
+print((l_any as? (Int, Float, String) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((l_any as? (Int, Float, inout String) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((l_any as? (Int, inout Float, String) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((l_any as? (inout Int, Float, String) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((l_any as? (inout Int, inout Float, String) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((l_any as? (inout Int, Float, __shared String) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((l_any as? (inout Int, Float, inout String) -> Void) != nil ? "ok" : "fail")
+
+// CHECK: ok
+print((m_any as? (Int, String, Float, Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (Int, String, Float, inout Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (Int, String, Float, __shared Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (Int, String, inout Float, Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (Int, __shared String, Float, Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (inout Int, String, __shared Float, Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (__shared Int, String, Float, inout Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (Int, __shared String, inout Float, Double) -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((m_any as? (__shared Int, String, inout Float, Double) -> Void) != nil ? "ok" : "fail")

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -4,7 +4,7 @@ func arch<F>(_ f: F) {}
 
 // CHECK: define hidden swiftcc void @_T017function_metadata9test_archyyF()
 func test_arch() {
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata(i8** %3) {{#[0-9]+}}
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 0, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch( {() -> () in } )
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD:i(32|64)]] 1, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)) {{#[0-9]+}}
@@ -13,39 +13,33 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(_: ()) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 1, %swift.type* @_T0SiN, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 16777217, %swift.type* @_T0SiN, i32 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* %2, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: (Int, Float)) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 2, %swift.type* @_T0SiN, %swift.type* @_T0SiN, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 16777218, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SiN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 3, %swift.type* @_T0SiN, %swift.type* @_T0SfN, %swift.type* @_T0SSN, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 16777219, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SfN, i32 0, %swift.type* @_T0SSN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, %swift.type* @_T0SfN, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Float, c: Int) -> () in })
 
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 0
-  // CHECK: store [[WORD]] 4
-  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 1
-  // CHECK: store %swift.type* @_T0SiN, %swift.type** %6, align 8
-  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 2
-  // CHECK: store %swift.type* @_T0SdN, %swift.type** %8, align 8
-  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 3
-  // CHECK: store %swift.type* @_T0SSN, %swift.type** %10, align 8
-  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 4
-  // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** %12, align 8
-  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 5
-  // CHECK: store i8* bitcast ([4 x i32]* @parameter-flags.31 to i8*), i8** %13, align 8
-  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 6
-  // CHECK: bitcast i8** %14 to %swift.type**
-  // CHECK: store %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata(i8** [[T0]]) {{#[0-9]+}}
+  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
+  // CHECK: store %swift.type* @_T0SiN, %swift.type** [[T0:%.*]], align 8
+  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 1
+  // CHECK: store %swift.type* @_T0SdN, %swift.type** [[T0:%.*]], align 8
+  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 2
+  // CHECK: store %swift.type* @_T0SSN, %swift.type** [[T0:%.*]], align 8
+  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 3
+  // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** [[T0:%.*]], align 8
+  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 16777220, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
 }

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -31,15 +31,15 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, %swift.type* @_T0SfN, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Float, c: Int) -> () in })
 
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
-  // CHECK: store %swift.type* @_T0SiN, %swift.type** [[T0:%.*]], align 8
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 1
-  // CHECK: store %swift.type* @_T0SdN, %swift.type** [[T0:%.*]], align 8
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 2
-  // CHECK: store %swift.type* @_T0SSN, %swift.type** [[T0:%.*]], align 8
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 3
-  // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** [[T0:%.*]], align 8
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
+  // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
+  // CHECK: store %swift.type* @_T0SiN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
+  // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 1
+  // CHECK: store %swift.type* @_T0SdN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
+  // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 2
+  // CHECK: store %swift.type* @_T0SSN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
+  // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 3
+  // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
+  // CHECK: [[T:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 16777220, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
 }

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -13,35 +13,38 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, i8* bitcast (%swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1) to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(_: ()) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, i8* inttoptr ([[WORD]] or ([[WORD]] ptrtoint (%swift.type* @_T0SiN to [[WORD]]), [[WORD]] 1) to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 1, i8* bitcast (%swift.type* @_T0SiN to i8*), i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, i8* %3, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: (Int, Float)) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, i8* inttoptr ([[WORD]] or ([[WORD]] ptrtoint (%swift.type* @_T0SiN to [[WORD]]), [[WORD]] 1) to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 2, i8* bitcast (%swift.type* @_T0SiN to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, i8* inttoptr ([[WORD]] or ([[WORD]] ptrtoint (%swift.type* @_T0SiN to [[WORD]]), [[WORD]] 1) to i8*), i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SSN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 3, i8* bitcast (%swift.type* @_T0SiN to i8*), i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SSN to i8*), i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Float, c: Int) -> () in })
 
-  // CHECK: [[T0:%.*]] = getelementptr inbounds [6 x i8*], [6 x i8*]* %function-arguments, i32 0, i32 0
+  // CHECK: [[T0:%.*]] = getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 0
   // CHECK: store [[WORD]] 4
-  // CHECK: getelementptr inbounds [6 x i8*], [6 x i8*]* %function-arguments, i32 0, i32 1
-  // CHECK: store i8* inttoptr ([[WORD]] or ([[WORD]] ptrtoint (%swift.type* @_T0SiN to [[WORD]]), [[WORD]] 1) to i8*)
-  // CHECK: getelementptr inbounds [6 x i8*], [6 x i8*]* %function-arguments, i32 0, i32 2
+  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 1
+  // CHECK: store i8* bitcast (%swift.type* @_T0SiN to i8*), i8** %5, align 8
+  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 2
   // CHECK: store i8* bitcast (%swift.type* @_T0SdN to i8*)
-  // CHECK: getelementptr inbounds [6 x i8*], [6 x i8*]* %function-arguments, i32 0, i32 3
+  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 3
   // CHECK: store i8* bitcast (%swift.type* @_T0SSN to i8*)
-  // CHECK: getelementptr inbounds [6 x i8*], [6 x i8*]* %function-arguments, i32 0, i32 4
+  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 4
   // CHECK: store i8* bitcast (%swift.type* @_T0s4Int8VN to i8*)
-  // CHECK: getelementptr inbounds [6 x i8*], [6 x i8*]* %function-arguments, i32 0, i32 5
+  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 5
+  // CHECK: store i8* bitcast ([4 x i32]* @parameter-flags.31 to i8*), i8** %9, align 8
+  // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 6
+  // CHECK: bitcast i8** %10 to %swift.type**
   // CHECK: store %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata(i8** [[T0]]) {{#[0-9]+}}
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -7,44 +7,44 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata(i8** %3) {{#[0-9]+}}
   arch( {() -> () in } )
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD:i(32|64)]] 1, i8* bitcast (%swift.type* @_T0SiN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)) {{#[0-9]+}}
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD:i(32|64)]] 1, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)) {{#[0-9]+}}
   arch({(x: Int) -> () in  })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, i8* bitcast (%swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1) to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(_: ()) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 1, i8* bitcast (%swift.type* @_T0SiN to i8*), i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 1, %swift.type* @_T0SiN, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, i8* %3, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* %2, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: (Int, Float)) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 2, i8* bitcast (%swift.type* @_T0SiN to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 2, %swift.type* @_T0SiN, %swift.type* @_T0SiN, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 3, i8* bitcast (%swift.type* @_T0SiN to i8*), i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SSN to i8*), i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 3, %swift.type* @_T0SiN, %swift.type* @_T0SfN, %swift.type* @_T0SSN, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SfN to i8*), i8* bitcast (%swift.type* @_T0SiN to i8*), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, %swift.type* @_T0SfN, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Float, c: Int) -> () in })
 
   // CHECK: [[T0:%.*]] = getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 0
   // CHECK: store [[WORD]] 4
   // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 1
-  // CHECK: store i8* bitcast (%swift.type* @_T0SiN to i8*), i8** %5, align 8
+  // CHECK: store %swift.type* @_T0SiN, %swift.type** %6, align 8
   // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 2
-  // CHECK: store i8* bitcast (%swift.type* @_T0SdN to i8*)
+  // CHECK: store %swift.type* @_T0SdN, %swift.type** %8, align 8
   // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 3
-  // CHECK: store i8* bitcast (%swift.type* @_T0SSN to i8*)
+  // CHECK: store %swift.type* @_T0SSN, %swift.type** %10, align 8
   // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 4
-  // CHECK: store i8* bitcast (%swift.type* @_T0s4Int8VN to i8*)
+  // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** %12, align 8
   // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 5
-  // CHECK: store i8* bitcast ([4 x i32]* @parameter-flags.31 to i8*), i8** %9, align 8
+  // CHECK: store i8* bitcast ([4 x i32]* @parameter-flags.31 to i8*), i8** %13, align 8
   // CHECK: getelementptr inbounds [7 x i8*], [7 x i8*]* %function-arguments, i32 0, i32 6
-  // CHECK: bitcast i8** %10 to %swift.type**
+  // CHECK: bitcast i8** %14 to %swift.type**
   // CHECK: store %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata(i8** [[T0]]) {{#[0-9]+}}
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -38,5 +38,4 @@ entry(%b : $*@convention(block) () -> ()):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
 // --                                                                               0x100_0001 = block convention, 1 arg
-// CHECK:         call %swift.type* @swift_getFunctionTypeMetadata(i8** %3)
-
+// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 33554432, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))

--- a/test/RemoteAST/structural_types.swift
+++ b/test/RemoteAST/structural_types.swift
@@ -54,3 +54,11 @@ printType(Tuple2.self)
 typealias Tuple3 = (x: Int, Float, y: Int.Type)
 printType(Tuple3.self)
 // CHECK: found type: (x: Int, Float, y: Int.Type)
+
+func foo<T>(_: T) {
+  var f = T.self
+  printType(f)
+}
+
+foo() { (x: Int) -> Int in return x }
+// CHECK: found type: (Int) -> Int

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -147,7 +147,7 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
   EXPECT_NE(F4, F1);
 
   // Test parameter with and without inout/shared/variadic and/or label.
-  ParameterTypeFlags paramFlags;
+  ParameterFlags paramFlags;
   auto inoutFlags = paramFlags.withInOut(true);
   auto variadicFlags = paramFlags.withVariadic(true);
   auto sharedFlags = paramFlags.withShared(true);


### PR DESCRIPTION
This brings back all of the previously reverted commits with small change to MetadataReader to make LLDB happy and added test to make sure we do not regress like that again.

Problem with LLDB was related to `MetadataReader`, where my changes in `_readMetadata` to read whole `TargetFunctionTypeMetadata` and use its accessors mistakenly, made it so it attempted to read data from the pointer and then use as pointer when calling `readTypeFroMetadata`, which shouldn't be done because elements of `TargetFunctionTypeMetadata::getParameters` point to direct locations of parameters already.

Resolves: rdar://problem/31408030

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
