### PR TITLE
Make sure string benchmarks actually measure string operations

### DIFF
--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -31,7 +31,7 @@ let japanese = "日本語（にほんご、にっぽんご）は、主に日本�
 public func run_StringWithCString(_ N: Int) {
   let str = String(repeating: "x", count: 100 * (1 << 16))
   for _ in 0 ..< N {
-    str.withCString { _ in }
+    str.withCString { blackHole($0) }
   }
 }
 

--- a/benchmark/single-source/StringTests.swift
+++ b/benchmark/single-source/StringTests.swift
@@ -26,9 +26,7 @@ public func run_StringHasPrefix(_ N: Int) {
   let testString = "prefixedString"
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
-      if !testString.hasPrefix(prefix) {
-        CheckResults(false)
-      }
+      CheckResults(testString.hasPrefix(getString(prefix)))
     }
   }
 #endif
@@ -41,9 +39,7 @@ public func run_StringHasSuffix(_ N: Int) {
   let testString = "StringSuffixed"
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
-      if !testString.hasSuffix(suffix) {
-        CheckResults(false)
-      }
+      CheckResults(testString.hasSuffix(getString(suffix)))
     }
   }
 #endif
@@ -56,9 +52,7 @@ public func run_StringHasPrefixUnicode(_ N: Int) {
   let testString = "❄️prefixedString"
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
-      if !testString.hasPrefix(prefix) {
-        CheckResults(false)
-      }
+      CheckResults(testString.hasPrefix(getString(prefix)))
     }
   }
 #endif
@@ -71,9 +65,7 @@ public func run_StringHasSuffixUnicode(_ N: Int) {
   let testString = "String❄️Suffixed"
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
-      if !testString.hasSuffix(suffix) {
-        CheckResults(false)
-      }
+      CheckResults(testString.hasSuffix(getString(suffix)))
     }
   }
 #endif
@@ -89,9 +81,7 @@ public func run_StringEqualPointerComparison(_ N: Int) {
   let str2 = str1
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
-      if !compareEqual(str1, str2) {
-        CheckResults(false)
-      }
+      CheckResults(compareEqual(str1, str2))
     }
   }
 }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -183,7 +183,14 @@ public func someProtocolFactory() -> SomeProtocol { return MyStruct() }
 // Just consume the argument.
 // It's important that this function is in another module than the tests
 // which are using it.
+@inline(never)
 public func blackHole<T>(_ x: T) {
+}
+
+// Return the passed argument without letting the optimizer know that.
+@inline(never)
+public func identity<T>(_ x: T) -> T {
+  return x
 }
 
 // Return the passed argument without letting the optimizer know that.


### PR DESCRIPTION
Some of the benchmarks in the current benchmark suite do not protect against dead store elimination / invariant detection etc, so the compiler optimizes away the call that is supposed to be measured.

Affected benchmarks I found so far:

* `StringHasPrefix`
* `StringHasSuffix`
* `StringWithCString`

This PR fixes these (and a few other potentially fragile benchmarks) by adding calls to utility functions that were designed to help prevent such optimizations. 

I expect this PR will result in significant slowdowns for the affected benchmarks. However, this adjustment will make the benchmarks better reflect actual String performance in the future.