### PR TITLE
[WIP] Update pred memopt for ownership

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -296,25 +296,17 @@ public:
     });
   }
 
-  using SuccessorBlockListTy =
-    TransformRange<SuccessorListTy,
-                   std::function<SILBasicBlock *(const SILSuccessor &)>>;
-  using ConstSuccessorBlockListTy =
-    TransformRange<ConstSuccessorListTy,
-                   std::function<const SILBasicBlock *(const SILSuccessor &)>>;
+  using SuccessorBlockListTy = TermInst::SuccessorBlockListTy;
+  using ConstSuccessorBlockListTy = TermInst::ConstSuccessorBlockListTy;
 
   /// Return the range of SILBasicBlocks that are successors of this block.
   SuccessorBlockListTy getSuccessorBlocks() {
-    using FuncTy = std::function<SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformRange(getSuccessors(), F);
+    return getTerminator()->getSuccessorBlocks();
   }
 
   /// Return the range of SILBasicBlocks that are successors of this block.
   ConstSuccessorBlockListTy getSuccessorBlocks() const {
-    using FuncTy = std::function<const SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformRange(getSuccessors(), F);
+    return getTerminator()->getSuccessorBlocks();
   }
 
   using pred_iterator = SILSuccessor::pred_iterator;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6161,10 +6161,35 @@ public:
   using ConstSuccessorListTy = ArrayRef<SILSuccessor>;
   using SuccessorListTy = MutableArrayRef<SILSuccessor>;
 
+  bool succ_empty() const { return getSuccessors().empty(); }
+
+  unsigned getNumSuccessors() const { return getSuccessors().size(); }
+
   /// The successor basic blocks of this terminator.
   SuccessorListTy getSuccessors();
   ConstSuccessorListTy getSuccessors() const {
     return const_cast<TermInst*>(this)->getSuccessors();
+  }
+
+  using SuccessorBlockListTy =
+      TransformRange<SuccessorListTy,
+                     std::function<SILBasicBlock *(const SILSuccessor &)>>;
+  using ConstSuccessorBlockListTy =
+      TransformRange<ConstSuccessorListTy, std::function<const SILBasicBlock *(
+                                               const SILSuccessor &)>>;
+
+  /// Return the range of SILBasicBlocks that are successors of this block.
+  SuccessorBlockListTy getSuccessorBlocks() {
+    using FuncTy = std::function<SILBasicBlock *(const SILSuccessor &)>;
+    FuncTy F(&SILSuccessor::getBB);
+    return makeTransformRange(getSuccessors(), F);
+  }
+
+  /// Return the range of SILBasicBlocks that are successors of this block.
+  ConstSuccessorBlockListTy getSuccessorBlocks() const {
+    using FuncTy = std::function<const SILBasicBlock *(const SILSuccessor &)>;
+    FuncTy F(&SILSuccessor::getBB);
+    return makeTransformRange(getSuccessors(), F);
   }
 
   DEFINE_ABSTRACT_NON_VALUE_INST_BOILERPLATE(TermInst)

--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -66,6 +66,10 @@ void replaceBranchTarget(TermInst *T, SILBasicBlock *OldDest, SILBasicBlock *New
 /// \brief Check if the edge from the terminator is critical.
 bool isCriticalEdge(TermInst *T, unsigned EdgeIdx);
 
+/// \brief Get all critical edges from the terminator.
+bool gatherAllCriticalEdges(TermInst *T,
+                            llvm::SmallVectorImpl<unsigned> &EdgeIndices);
+
 /// \brief Splits the edge from terminator if it is critical.
 ///
 /// Updates dominance information and loop information if not null.

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -508,6 +508,27 @@ bool swift::isCriticalEdge(TermInst *T, unsigned EdgeIdx) {
   return true;
 }
 
+bool swift::gatherAllCriticalEdges(
+    TermInst *TI, llvm::SmallVectorImpl<unsigned> &EdgeIndices) {
+  if (TI->getNumSuccessors() <= 1)
+    return false;
+
+  bool FoundEdge = false;
+  unsigned Index = 0;
+  for (auto *DestBB : TI->getSuccessorBlocks()) {
+    assert(!DestBB->pred_empty() && "There should be a predecessor");
+    if (DestBB->getSinglePredecessorBlock()) {
+      ++Index;
+      continue;
+    }
+    EdgeIndices.emplace_back(Index);
+    FoundEdge = true;
+    ++Index;
+  }
+
+  return FoundEdge;
+}
+
 template<class SwitchInstTy>
 SILBasicBlock *getNthEdgeBlock(SwitchInstTy *S, unsigned EdgeIdx) {
   if (S->getNumCases() == EdgeIdx)

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -78,16 +78,29 @@ SILValue SILSSAUpdater::GetValueAtEndOfBlock(SILBasicBlock *BB) {
 
 /// Are all available values identicalTo each other.
 bool areIdentical(AvailableValsTy &Avails) {
-  // TODO: MultiValueInstruction
-  auto *First = dyn_cast<SingleValueInstruction>(Avails.begin()->second);
-  if (!First)
+  if (auto *First = dyn_cast<SingleValueInstruction>(Avails.begin()->second)) {
+    for (auto Avail : Avails) {
+      auto *Inst = dyn_cast<SingleValueInstruction>(Avail.second);
+      if (!Inst)
+        return false;
+      if (!Inst->isIdenticalTo(First))
+        return false;
+    }
+    return true;
+  }
+
+  auto *MVIR = dyn_cast<MultipleValueInstructionResult>(Avails.begin()->second);
+  if (!MVIR)
     return false;
+
   for (auto Avail : Avails) {
-    auto *Inst = dyn_cast<SingleValueInstruction>(Avail.second);
-    if (!Inst)
+    auto *Result = dyn_cast<MultipleValueInstructionResult>(Avail.second);
+    if (!Result)
       return false;
-    if (!Inst->isIdenticalTo(First))
+    if (!Result->getParent()->isIdenticalTo(MVIR->getParent()) ||
+        Result->getIndex() != MVIR->getIndex()) {
       return false;
+    }
   }
   return true;
 }
@@ -153,6 +166,7 @@ isEquivalentPHI(SILPHIArgument *PHI,
                 llvm::SmallDenseMap<SILBasicBlock *, SILValue, 8> &ValueMap) {
   SILBasicBlock *PhiBB = PHI->getParent();
   size_t Idx = PHI->getIndex();
+  // TODO: Should we check ownership here?
   for (auto *PredBB : PhiBB->getPredecessorBlocks()) {
     auto DesiredVal = ValueMap[PredBB];
     OperandValueArrayRef EdgeValues =

--- a/test/DebugInfo/linetable-cleanups.swift
+++ b/test/DebugInfo/linetable-cleanups.swift
@@ -27,7 +27,8 @@ func main() {
 // CHECK:  call void @swift_bridgeObjectRelease({{.*}}) {{#[0-9]+}}, !dbg ![[CLEANUPS:.*]]
 // CHECK-NEXT:  !dbg ![[CLEANUPS]]
 // CHECK-NEXT:  llvm.lifetime.end
-// CHECK-NEXT:  bitcast
+// CHECK-NEXT:  load
+// CHECK-NEXT:  swift_rt_swift_release
 // CHECK-NEXT:  bitcast
 // CHECK-NEXT:  llvm.lifetime.end
 // CHECK-NEXT:  ret void, !dbg ![[CLEANUPS]]

--- a/test/DebugInfo/return.swift
+++ b/test/DebugInfo/return.swift
@@ -7,16 +7,19 @@ class X {
 
 // CHECK: define {{.*}}ifelseexpr
 public func ifelseexpr() -> Int64 {
-  var x = X(i:0) 
+  var x = X(i:0)
+  // CHECK: [[ALLOCA:%.*]] = alloca %T6return1XC*
   // CHECK: [[META:%.*]] = call %swift.type* @_T06return1XCMa()
   // CHECK: [[X:%.*]] = call {{.*}}%T6return1XC* @_T06return1XCACs5Int64V1i_tcfC(
   // CHECK-SAME:                                  i64 0, %swift.type* swiftself [[META]])
+  // CHECK:  store %T6return1XC* [[X]], %T6return1XC** [[ALLOCA]]
   // CHECK:  @swift_rt_swift_release to void (%T6return1XC*)*)(%T6return1XC* [[X]])
   if true {
     x.x += 1
   } else {
     x.x -= 1
   }
+  // CHECK:  [[X:%.*]] = load %T6return1XC*, %T6return1XC** [[ALLOCA]]
   // CHECK:  @swift_rt_swift_release to void (%T6return1XC*)*)(%T6return1XC* [[X]])
   // CHECK-SAME:                    , !dbg ![[RELEASE:.*]]
 

--- a/test/IRGen/superclass_constraint.swift
+++ b/test/IRGen/superclass_constraint.swift
@@ -8,9 +8,9 @@ public class CVC<A1: AC> where A1: A {
   // CHECK-LABEL: define{{.*}} @_T021superclass_constraint3CVCCACyxGycfc
   public init() {
     // CHECK: [[A:%.*]] = alloca %T21superclass_constraint3CVCC*
-    // CHECK-NOT: ret
+    // CHECK-NOT: ret %T21superclass_constraint3CVCC*
     // CHECK: store %T21superclass_constraint3CVCC* %0, %T21superclass_constraint3CVCC** [[A]]
-    // CHECK: ret
+    // CHECK: ret %T21superclass_constraint3CVCC*
     var a = self
   }
 }

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -60,7 +60,7 @@ struct FailableStruct {
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
-// CHECK-NEXT:    strong_release [[CANARY]]
+// CHECK-NEXT:    destroy_addr [[X_ADDR]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
@@ -86,8 +86,7 @@ struct FailableStruct {
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
-// CHECK-NEXT:    [[SELF:%.*]] = struct $FailableStruct ([[CANARY1]] : $Canary, [[CANARY2]] : $Canary)
-// CHECK-NEXT:    release_value [[SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
@@ -108,7 +107,7 @@ struct FailableStruct {
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
-// CHECK-NEXT:    release_value [[CANARY]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
@@ -127,7 +126,7 @@ struct FailableStruct {
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
-// CHECK-NEXT:    release_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
@@ -153,7 +152,9 @@ struct FailableStruct {
 // CHECK:       [[SUCC_BB]]:
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
+// CHECK-NEXT:    retain_value [[SELF_VALUE]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableStruct>)
 //
@@ -346,6 +347,8 @@ struct ThrowStruct {
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_T035definite_init_failable_initializers11ThrowStructVACyt6noFail_tcfC
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]](%1)
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -366,6 +369,8 @@ struct ThrowStruct {
 // CHECK-NEXT:    try_apply [[INIT_FN]](%1)
 // CHECK:       bb2([[NEW_SELF:%.*]] : $ThrowStruct):
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb3([[ERROR:%.*]] : $Error):
@@ -410,6 +415,8 @@ struct ThrowStruct {
 // CHECK-NEXT:    try_apply [[INIT_FN]](%1)
 // CHECK:       bb1([[NEW_SELF:%.*]] : $ThrowStruct):
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -428,10 +435,12 @@ struct ThrowStruct {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
-// CHECK:         release_value [[NEW_SELF]]
+// CHECK:         destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]
   init(failAfterDelegation: Int) throws {
@@ -454,6 +463,8 @@ struct ThrowStruct {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
@@ -493,6 +504,8 @@ struct ThrowStruct {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
@@ -537,7 +550,9 @@ struct ThrowStruct {
 // CHECK:       [[SUCC_BB]]:
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
+// CHECK-NEXT:    retain_value [[SELF_VALUE]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<ThrowStruct>)
 //
@@ -591,6 +606,8 @@ struct ThrowStruct {
 // CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*ThrowStruct
 // CHECK-NEXT:    store [[NEW_SELF]] to [[WRITE]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*ThrowStruct
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -612,10 +629,12 @@ struct ThrowStruct {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    retain_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
-// CHECK-NEXT:    release_value [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]
   init(failAfterSelfReplacement: Int) throws {
@@ -782,7 +801,7 @@ class FailableBaseClass {
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
-// CHECK-NEXT:    strong_release [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
@@ -809,7 +828,9 @@ class FailableBaseClass {
 // CHECK:       [[SUCC_BB]]:
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[SELF_VALUE]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableBaseClass>)
 //
@@ -891,7 +912,9 @@ class FailableDerivedClass : FailableBaseClass {
 // CHECK-NEXT:    [[BASE_SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_ref_cast [[BASE_SELF_VALUE]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[SELF_VALUE]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableDerivedClass>)
 //
@@ -952,6 +975,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:       bb1([[NEW_SELF:%.*]] : $ThrowBaseClass):
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -977,6 +1002,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]]([[BASE_SELF]])
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]] : $ThrowDerivedClass
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -1007,6 +1034,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:       bb2([[NEW_SELF:%.*]] : $ThrowBaseClass):
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]]
@@ -1044,10 +1073,12 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
-// CHECK-NEXT:    strong_release [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]
   init(failAfterFullInitialization: Int) throws {
@@ -1073,6 +1104,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]]
@@ -1122,6 +1155,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%1)
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]]
@@ -1184,6 +1219,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%2)
 // CHECK:       bb3([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[DERIVED_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[DERIVED_SELF]]
@@ -1239,6 +1276,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_T035definite_init_failable_initializers17ThrowDerivedClassCACyt6noFail_tcfc
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]](%1)
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -1259,6 +1298,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-NEXT:    try_apply [[INIT_FN]](%1)
 // CHECK:       bb1([[NEW_SELF:%.*]] : $ThrowDerivedClass):
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -1284,6 +1325,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-NEXT:    try_apply [[INIT_FN]](%1)
 // CHECK:       bb2([[NEW_SELF:%.*]] : $ThrowDerivedClass):
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
@@ -1325,6 +1368,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-NEXT:    try_apply [[INIT_FN]]([[ARG]], %1)
 // CHECK:       bb2([[NEW_SELF:%.*]] : $ThrowDerivedClass):
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
@@ -1361,10 +1406,12 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
-// CHECK-NEXT:    strong_release [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]
   convenience init(failAfterDelegation: Int) throws {
@@ -1390,6 +1437,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
@@ -1437,6 +1486,8 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
+// CHECK-NEXT:    strong_retain [[NEW_SELF]]
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -456,29 +456,39 @@ struct ThrowStruct {
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_T035definite_init_failable_initializers11ThrowStructVACyt4fail_tKcfC
 // CHECK-NEXT:    try_apply [[INIT_FN]](%1)
+//
 // CHECK:       bb1([[NEW_SELF:.*]] : $ThrowStruct):
 // CHECK-NEXT:    [[BIT:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK-NEXT:    store [[BIT]] to [[BITMAP_BOX]]
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
+//
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
 // CHECK-NEXT:    retain_value [[NEW_SELF]]
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
+//
 // CHECK:       bb3([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
+//
 // CHECK:       bb4([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
+//
 // CHECK:       bb5([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    [[COND:%.*]] = load [[BITMAP_BOX]]
-// CHECK-NEXT:    cond_br [[COND]], bb6, bb7
+// CHECK-NEXT:    cond_br [[COND]], bb7, bb6
+//
 // CHECK:       bb6:
-// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
-// CHECK-NEXT:    br bb7
+// CHECK:         br bb8
+//
 // CHECK:       bb7:
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
+// CHECK-NEXT:    br bb8
+//
+// CHECK:       bb8:
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]
@@ -495,6 +505,7 @@ struct ThrowStruct {
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
+//
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_T035definite_init_failable_initializers11ThrowStructVACyt6noFail_tcfC
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]](%1)
@@ -503,23 +514,32 @@ struct ThrowStruct {
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
+//
 // CHECK:       bb2([[RESULT:%.*]] : $Int):
 // CHECK-NEXT:    retain_value [[NEW_SELF]]
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
+//
 // CHECK:       bb3([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
+//
 // CHECK:       bb4([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
+//
 // CHECK:       bb5([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    [[COND:%.*]] = load [[BITMAP_BOX]]
-// CHECK-NEXT:    cond_br [[COND]], bb6, bb7
+// CHECK-NEXT:    cond_br [[COND]], bb7, bb6
+//
 // CHECK:       bb6:
-// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
-// CHECK-NEXT:    br bb7
+// CHECK-NEXT:    br bb8
+//
 // CHECK:       bb7:
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
+// CHECK-NEXT:    br bb8
+//
+// CHECK:       bb8:
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -50,7 +50,10 @@ class Cat : FakeNSObject {
     // CHECK-NEXT: [[NEW_SUPER_SELF:%.*]] = apply [[SUPER_FN]]([[SUPER]]) : $@convention(objc_method) (@owned FakeNSObject) -> @owned FakeNSObject
     // CHECK-NEXT: [[NEW_SELF:%.*]] = unchecked_ref_cast [[NEW_SUPER_SELF]] : $FakeNSObject to $Cat
     // CHECK-NEXT: store [[NEW_SELF]] to [[SELF_BOX]] : $*Cat
+    // TODO: Once we re-enable arbitrary take promotion, this retain and the associated destroy_addr will go away.
+    // CHECK-NEXT: strong_retain [[NEW_SELF]]
     // CHECK-NEXT: [[RESULT:%.*]] = enum $Optional<Cat>, #Optional.some!enumelt.1, [[NEW_SELF]] : $Cat
+    // CHECK-NEXT: destroy_addr [[SELF_BOX]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
     // CHECK-NEXT: br bb4([[RESULT]] : $Optional<Cat>)
 

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -40,6 +40,9 @@ class TrivialClass : TriviallyConstructible {
   // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1
   // CHECK-NEXT:  dealloc_partial_ref %1 : $TrivialClass, [[METATYPE]] : $@thick TrivialClass.Type
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // TODO: Once we restore arbitrary takes, the strong_retain/destroy_addr pair below will go away.
+  // CHECK-NEXT:  strong_retain [[NEW_SELF]]
+  // CHECK-NEXT:  destroy_addr [[SELF_BOX]]
   // CHECK-NEXT:  dealloc_stack [[SELF_BOX]]
   // CHECK-NEXT:  return [[NEW_SELF]]
   convenience init(upper: Int) {

--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -793,3 +793,48 @@ bb5:
   dealloc_stack %2 : $*NativeObjectTriple
   return %14 : $NativeObjectPair
 }
+
+///////////////////////
+// Unreachable Tests //
+///////////////////////
+
+// Make sure that we can handle a dead allocation with a destroy_addr in an
+// unreachable block.
+//
+// TODO: We can support this with trivial changes to canPromoteDestroyAddr. We
+// just need to distinguish a promotion failure around lack of availability vs
+// promotion failure for other reasons.
+//
+//
+// CHECK-LABEL: sil @dead_allocation_with_unreachable_destroy_addr : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject):
+// CHECK-NEXT: alloc_stack
+// CHECK-NEXT: store
+// CHECK-NEXT: br bb1
+//
+// CHECK: bb1:
+// CHECK-NEXT: destroy_addr
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+//
+// CHECK: bb2:
+// CHECK-NEXT: destroy_addr
+// CHECK-NEXT: unreachable
+// CHECK: } // end sil function 'dead_allocation_with_unreachable_destroy_addr'
+sil @dead_allocation_with_unreachable_destroy_addr : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_stack $Builtin.NativeObject
+  store %0 to %1 : $*Builtin.NativeObject
+  br bb1
+
+bb1:
+  destroy_addr %1 : $*Builtin.NativeObject
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2:
+  destroy_addr %1 : $*Builtin.NativeObject
+  unreachable
+}

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -1,94 +1,106 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -predictable-memopt  | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all %s -predictable-memopt  | %FileCheck %s
 
 import Builtin
 import Swift
 
-
 // CHECK-LABEL: sil @simple_reg_promotion
-// CHECK: bb0(%0 : $Int):
+// CHECK: bb0(%0 : @trivial $Int):
 // CHECK-NEXT: return %0 : $Int
 sil @simple_reg_promotion : $@convention(thin) (Int) -> Int {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  store %0 to %1a : $*Int
+  store %0 to [trivial] %1a : $*Int
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  %4 = load %1a : $*Int
-  store %4 to %3a : $*Int
-  %6 = load %3a : $*Int
-  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Int>
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %4 = load [trivial] %1a : $*Int
+  store %4 to [trivial] %3a : $*Int
+  %6 = load [trivial] %3a : $*Int
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Int>
   return %6 : $Int
 }
 
+
+// CHECK-LABEL: sil @tuple_reg_promotion
+// CHECK: bb0([[ARG:%.*]] : @trivial $Int):
+//
 // Verify that promotion has promoted the tuple load away, and we know that
 // %0 is being returned through scalar instructions in SSA form.
-//
-// CHECK-LABEL: sil @tuple_reg_promotion
-// CHECK: bb0(%0 : $Int):
 // CHECK-NEXT: [[TUPLE:%[0-9]+]] = tuple ({{.*}} : $Int, {{.*}} : $Int)
 // CHECK-NEXT: [[TUPLE_ELT:%[0-9]+]] = tuple_extract [[TUPLE]] : $(Int, Int), 0
 // CHECK-NEXT: return [[TUPLE_ELT]] : $Int
+// CHECK: } // end sil function 'tuple_reg_promotion'
 sil @tuple_reg_promotion : $@convention(thin) (Int) -> Int {
-bb0(%0 : $Int):                         
+bb0(%0 : @trivial $Int):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <(Int, Int)>, 0
+
   %a = tuple_element_addr %1a : $*(Int, Int), 0
   %b = tuple_element_addr %1a : $*(Int, Int), 1
-  store %0 to %a : $*Int
-  store %0 to %b : $*Int
-  %c = load %1a : $*(Int, Int)
+  store %0 to [trivial] %a : $*Int
+  store %0 to [trivial] %b : $*Int
+
+  %c = load [trivial]  %1a : $*(Int, Int)
   %d = tuple_extract %c : $(Int, Int), 0
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+
   return %d : $Int
 }
 
-// CHECK-LABEL: sil @tuple_reg_ownership_promotion_1 : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject):
+// This pattern comes from:
+//
+// func test(c: C) -> C {
+//   var x = (c, c)
+//   let y = x
+//   return y.0
+// }
+//
+// CHECK-LABEL: sil @tuple_reg_ownership_promotion_1
+// CHECK: bb0([[ARG:%.*]] : @owned $Builtin.NativeObject):
 // CHECK:   [[BOX:%.*]] = alloc_box
-// CHECK:   [[PB_BOX:%.*]] = project_box
-// CHECK:   [[LHS_1:%.*]] = tuple_element_addr [[PB_BOX]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
-// CHECK:   [[RHS_1:%.*]] = tuple_element_addr [[PB_BOX]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
-// CHECK:   [[LHS_2:%.*]] = tuple_element_addr [[PB_BOX]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
-// CHECK:   [[RHS_2:%.*]] = tuple_element_addr [[PB_BOX]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
-// CHECK:   strong_retain [[ARG]]
-// CHECK:   store [[ARG]] to [[LHS_2]]
-// CHECK:   store [[ARG]] to [[RHS_2]]
-// CHECK:   [[LHS_LOAD:%.*]] = load [[LHS_1]]
-// CHECK:   [[RHS_LOAD:%.*]] = load [[RHS_1]]
-// CHECK:   [[TUP:%.*]] = tuple ([[LHS_LOAD]] : $Builtin.NativeObject, [[RHS_LOAD]] : $Builtin.NativeObject)
-// CHECK:   retain_value [[TUP]]
-// CHECK:   [[LHS_EXT_RESULT:%.*]] = tuple_extract [[TUP]]
-// CHECK:   strong_retain [[LHS_EXT_RESULT]]
-// CHECK:   release_value [[TUP]]
-// CHECK:   release_value [[BOX]]
-// CHECK:   return [[LHS_EXT_RESULT]]
+// CHECK:   [[PB_BOX:%.*]] = project_box [[BOX]]
+// CHECK:   [[LHS_TUP:%.*]] = tuple_element_addr [[PB_BOX]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK:   [[RHS_TUP:%.*]] = tuple_element_addr [[PB_BOX]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[LHS_COPY:%.*]] = copy_value [[ARG_COPY]]
+// CHECK:   store [[ARG_COPY]] to [init] [[LHS_TUP]]
+// CHECK:   [[RHS_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   store [[ARG]] to [init] [[RHS_TUP]]
+// CHECK:   [[TUPLE:%[0-9]+]] = tuple ([[LHS_COPY]] : $Builtin.NativeObject, [[RHS_COPY]] : $Builtin.NativeObject)
+// CHECK:   [[BORROWED_TUPLE:%.*]] = begin_borrow [[TUPLE]]
+// CHECK:   [[BORROWED_LHS_TUPLE:%.*]] = tuple_extract [[BORROWED_TUPLE]]
+// CHECK:   [[RESULT:%.*]] = copy_value [[BORROWED_LHS_TUPLE]]
+// CHECK:   end_borrow [[BORROWED_TUPLE]]
+// CHECK:   destroy_value [[TUPLE]]
+// CHECK:   destroy_value [[BOX]]
+// CHECK:   return [[RESULT]]
 // CHECK: } // end sil function 'tuple_reg_ownership_promotion_1'
 sil @tuple_reg_ownership_promotion_1 : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <(Builtin.NativeObject, Builtin.NativeObject)>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <(Builtin.NativeObject, Builtin.NativeObject)>, 0
 
   %a = tuple_element_addr %1a : $*(Builtin.NativeObject, Builtin.NativeObject), 0
   %b = tuple_element_addr %1a : $*(Builtin.NativeObject, Builtin.NativeObject), 1
-  strong_retain %0 : $Builtin.NativeObject
-  store %0 to %a : $*Builtin.NativeObject
-  store %0 to %b : $*Builtin.NativeObject
+  %0c = copy_value %0 : $Builtin.NativeObject
+  store %0c to [init] %a : $*Builtin.NativeObject
+  store %0 to [init] %b : $*Builtin.NativeObject
 
-  %c = load %1a : $*(Builtin.NativeObject, Builtin.NativeObject)
-  retain_value %c : $(Builtin.NativeObject, Builtin.NativeObject)
-  %d = tuple_extract %c : $(Builtin.NativeObject, Builtin.NativeObject), 0
-  strong_retain %d : $Builtin.NativeObject
-  release_value %c : $(Builtin.NativeObject, Builtin.NativeObject)
-  release_value %1 : $<τ_0_0> { var τ_0_0 } <(Builtin.NativeObject, Builtin.NativeObject)>
+  %c = load [copy] %1a : $*(Builtin.NativeObject, Builtin.NativeObject)
+  %cb = begin_borrow %c : $(Builtin.NativeObject, Builtin.NativeObject)
+  %d = tuple_extract %cb : $(Builtin.NativeObject, Builtin.NativeObject), 0
+  %dc = copy_value %d : $Builtin.NativeObject
+  end_borrow %cb from %c : $(Builtin.NativeObject, Builtin.NativeObject), $(Builtin.NativeObject, Builtin.NativeObject)
+  destroy_value %c : $(Builtin.NativeObject, Builtin.NativeObject)
 
-  return %d : $Builtin.NativeObject
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <(Builtin.NativeObject, Builtin.NativeObject)>
+
+  return %dc : $Builtin.NativeObject
 }
 
-
 sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
-sil @takes_NativeObject_inout : $@convention(thin) (@inout Builtin.NativeObject) -> ()
 
 // Verify that load promotion works properly with inout arguments.
 //
@@ -97,34 +109,28 @@ sil @takes_NativeObject_inout : $@convention(thin) (@inout Builtin.NativeObject)
 //  takes_Int_inout(&a)
 //  return (t, a)
 //}
-//
-// CHECK-LABEL: sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {
-// CHECK: bb0([[ARG:%.*]] : $Int):
+// CHECK-LABEL: sil @used_by_inout
 sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   // This alloc_stack can't be removed since it is used by an inout call.
-  // CHECK: [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  // CHECK: [[PB_BOX:%.*]] = project_box [[BOX]]
+  // CHECK: %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  store %0 to %1a : $*Int
+  store %0 to [trivial] %1a : $*Int
 
   // This load should be eliminated.
-  // CHECK-NOT: load
-  // CHECK: [[FUNC:%.*]] = function_ref @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
-  // CHECK: apply [[FUNC]]([[PB_BOX]])
-  %3 = load %1a : $*Int
+  %3 = load [trivial] %1a : $*Int
   %5 = function_ref @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
   %6 = apply %5(%1a) : $@convention(thin) (@inout Int) -> ()
 
   // This load is needed in case the callee modifies the allocation.
-  // CHECK: [[RES:%[0-9]+]] = load [[PB_BOX]]
-  %7 = load %1a : $*Int
+  // CHECK: [[RES:%[0-9]+]] = load
+  %7 = load [trivial] %1a : $*Int
 
   // This should use the incoming argument to the function.
-  // CHECK: tuple ([[ARG]] : $Int, [[RES]] : $Int)
+  // CHECK: tuple ({{.*}} : $Int, {{.*}} : $Int)
   %8 = tuple (%3 : $Int, %7 : $Int)
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Int>
   return %8 : $(Int, Int)
 }
 
@@ -139,50 +145,47 @@ sil @returns_generic_struct : $@convention(thin) () -> @out AddressOnlyStruct
 
 
 
-sil @takes_closure : $@convention(thin) (@callee_owned () -> ()) -> ()
+sil @takes_closure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
 sil @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
 
 
 // CHECK-LABEL: sil @closure_test2
 sil @closure_test2 : $@convention(thin) (Int) -> Int {
-bb0(%1 : $Int):
+bb0(%1 : @trivial $Int):
   %0 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %0a = project_box %0 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  store %1 to %0a : $*Int  // CHECK: store
+  store %1 to [trivial] %0a : $*Int  // CHECK: store
 
-  %5 = function_ref @takes_closure : $@convention(thin) (@callee_owned () -> ()) -> ()
+  %5 = function_ref @takes_closure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   %6 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
-  strong_retain %0 : $<τ_0_0> { var τ_0_0 } <Int>
-  %8 = partial_apply %6(%0) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
-  %9 = apply %5(%8) : $@convention(thin) (@callee_owned () -> ()) -> ()
-  strong_release %0 : $<τ_0_0> { var τ_0_0 } <Int>
+  %0c = copy_value %0 : $<τ_0_0> { var τ_0_0 } <Int>
+  %8 = partial_apply %6(%0c) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
+  %9 = apply %5(%8) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Int>
 
-  store %1 to %0a : $*Int // CHECK: store
+  store %1 to [trivial] %0a : $*Int // CHECK: store
 
   // In an escape region, we should not promote loads.
-  %r = load %0a : $*Int // CHECK: load
+  %r = load [trivial] %0a : $*Int // CHECK: load
   return %r : $Int
 }
-
-
 
 class SomeClass {}
 
 sil @getSomeClass : $@convention(thin) () -> @owned SomeClass
 
-
 // CHECK-LABEL: sil @assign_test_trivial
 sil @assign_test_trivial : $@convention(thin) (Int) -> Int {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
 
-  store %0 to %1a : $*Int
-  store %0 to %1a : $*Int
-  store %0 to %1a : $*Int
+  store %0 to [trivial] %1a : $*Int
+  store %0 to [trivial] %1a : $*Int
+  store %0 to [trivial] %1a : $*Int
 
-  %2 = load %1a : $*Int
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %2 = load [trivial] %1a : $*Int
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Int>
 
   // Verify that the load got forwarded from an assign.
   return %2 : $Int                        // CHECK: return %0 : $Int
@@ -196,20 +199,22 @@ struct ContainsNativeObject {
 }
 
 // CHECK-LABEL: sil @multiple_level_extract_1 : $@convention(thin) (@owned ContainsNativeObject) -> Builtin.Int32 {
-// CHECK: bb0([[ARG:%.*]] : $ContainsNativeObject):
-// CHECK:   [[FIELD1:%.*]] = struct_extract [[ARG]] : $ContainsNativeObject, #ContainsNativeObject.y
-// CHECK:   [[FIELD2:%.*]] = struct_extract [[FIELD1]] : $Int32, #Int32._value
-// CHECK:   release_value [[ARG]]
-// CHECK:   return [[FIELD2]]
+// CHECK: bb0([[ARG:%.*]] : @owned $ContainsNativeObject):
+// CHECK-NEXT:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT:   [[FIELD1:%.*]] = struct_extract [[BORROWED_ARG]] : $ContainsNativeObject, #ContainsNativeObject.y
+// CHECK-NEXT:   [[FIELD2:%.*]] = struct_extract [[FIELD1]] : $Int32, #Int32._value
+// CHECK-NEXT:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK-NEXT:   destroy_value [[ARG]]
+// CHECK-NEXT:   return [[FIELD2]]
 // CHECK: } // end sil function 'multiple_level_extract_1'
 sil @multiple_level_extract_1 : $@convention(thin) (@owned ContainsNativeObject) -> Builtin.Int32 {
-bb0(%0 : $ContainsNativeObject):
+bb0(%0 : @owned $ContainsNativeObject):
   %1 = alloc_stack $ContainsNativeObject
-  store %0 to %1 : $*ContainsNativeObject
+  store %0 to [init] %1 : $*ContainsNativeObject
 
   %2 = struct_element_addr %1 : $*ContainsNativeObject, #ContainsNativeObject.y
   %3 = struct_element_addr %2 : $*Int32, #Int32._value
-  %4 = load %3 : $*Builtin.Int32
+  %4 = load [trivial] %3 : $*Builtin.Int32
 
   destroy_addr %1 : $*ContainsNativeObject
   dealloc_stack %1 : $*ContainsNativeObject
@@ -223,32 +228,36 @@ struct ComplexStruct {
 }
 
 // CHECK-LABEL: sil @multiple_level_extract_2 : $@convention(thin) (@owned ComplexStruct) -> (@owned Builtin.NativeObject, @owned Builtin.NativeObject, Builtin.Int32) {
-// CHECK: bb0([[ARG:%.*]] : $ComplexStruct):
-// CHECK: [[f1:%.*]] = struct_extract [[ARG]] : $ComplexStruct, #ComplexStruct.f3
-// CHECK: [[f2:%.*]] = struct_extract [[ARG]] : $ComplexStruct, #ComplexStruct.f2
-// CHECK: [[f2_x:%.*]] = struct_extract [[f2]] : $ContainsNativeObject, #ContainsNativeObject.x
-// CHECK: [[f3:%.*]] = struct_extract [[ARG]] : $ComplexStruct, #ComplexStruct.f1
-// CHECK-NEXT: strong_retain [[f3]]
-// CHECK-NEXT: strong_retain [[f2_x]]
-// CHECK-NEXT: release_value [[ARG]]
-// CHECK: [[RESULT:%.*]] = tuple ([[f3]] : $Builtin.NativeObject, [[f2_x]] : $Builtin.NativeObject, [[f1]] : $Builtin.Int32)
+// CHECK: bb0([[ARG:%.*]] : @owned $ComplexStruct):
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: [[f1:%.*]] = struct_extract [[BORROWED_ARG]]
+// CHECK: end_borrow [[BORROWED_ARG]]
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: [[f2:%.*]] = struct_extract [[BORROWED_ARG]]
+// CHECK: [[f2_x:%.*]] = struct_extract [[f2]]
+// CHECK: [[f2_x_copy:%.*]] = copy_value [[f2_x]]
+// CHECK: end_borrow [[BORROWED_ARG]]
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: [[f3:%.*]] = struct_extract [[BORROWED_ARG]]
+// CHECK: [[f3_copy:%.*]] = copy_value [[f3]]
+// CHECK: end_borrow [[BORROWED_ARG]]
+// CHECK: destroy_value [[ARG]]
+// CHECK: [[RESULT:%.*]] = tuple ([[f3_copy]] : $Builtin.NativeObject, [[f2_x_copy]] : $Builtin.NativeObject, [[f1]] : $Builtin.Int32)
 // CHECK: return [[RESULT]]
 // CHECK: } // end sil function 'multiple_level_extract_2'
 sil @multiple_level_extract_2 : $@convention(thin) (@owned ComplexStruct) -> (@owned Builtin.NativeObject, @owned Builtin.NativeObject, Builtin.Int32) {
-bb0(%0 : $ComplexStruct):
+bb0(%0 : @owned $ComplexStruct):
   %1 = alloc_stack $ComplexStruct
-  store %0 to %1 : $*ComplexStruct
+  store %0 to [init] %1 : $*ComplexStruct
 
   %2 = struct_element_addr %1 : $*ComplexStruct, #ComplexStruct.f1
   %3 = struct_element_addr %1 : $*ComplexStruct, #ComplexStruct.f2
   %4 = struct_element_addr %3 : $*ContainsNativeObject, #ContainsNativeObject.x
   %5 = struct_element_addr %1 : $*ComplexStruct, #ComplexStruct.f3
 
-  %6 = load %2 : $*Builtin.NativeObject
-  strong_retain %6 : $Builtin.NativeObject
-  %7 = load %4 : $*Builtin.NativeObject
-  strong_retain %7 : $Builtin.NativeObject
-  %8 = load %5 : $*Builtin.Int32
+  %6 = load [copy] %2 : $*Builtin.NativeObject
+  %7 = load [copy] %4 : $*Builtin.NativeObject
+  %8 = load [trivial] %5 : $*Builtin.Int32
 
   destroy_addr %1 : $*ComplexStruct
   dealloc_stack %1 : $*ComplexStruct
@@ -260,62 +269,64 @@ bb0(%0 : $ComplexStruct):
 var int_global : Int
 
 // CHECK-LABEL: sil @promote_alloc_stack
+// CHECK: [[IL:%[0-9]+]] = integer_literal
+// CHECK-NOT: alloc_stack
+// CHECK-NEXT: return [[IL]]
+// CHECK: } // end sil function 'promote_alloc_stack'
 sil @promote_alloc_stack : $@convention(thin) (Int32) -> Builtin.Int32 {
-bb0(%0 : $Int32):
+bb0(%0 : @trivial $Int32):
   %5 = integer_literal $Builtin.Int32, 1
-  // CHECK: [[IL:%[0-9]+]] = integer_literal
-
   %18 = struct $Int32 (%5 : $Builtin.Int32)
   %22 = alloc_stack $Int32
-
-  // CHECK-NOT: alloc_stack
-
-  store %18 to %22 : $*Int32
+  store %18 to [trivial] %22 : $*Int32
   %24 = struct_element_addr %22 : $*Int32, #Int32._value
-  %25 = load %24 : $*Builtin.Int32
+  %25 = load [trivial] %24 : $*Builtin.Int32
   dealloc_stack %22 : $*Int32
-  // CHECK-NEXT: return [[IL]]
   return %25 : $Builtin.Int32
 }
 
 // CHECK-LABEL: sil @copy_addr_to_load
+// CHECK: bb0(%0 : @trivial $Int):
+// CHECK-NEXT: return %0
+// CHECK: } // end sil function 'copy_addr_to_load'
 sil @copy_addr_to_load : $@convention(thin) (Int) -> Int {
-bb0(%0 : $Int):               // CHECK: bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_stack $Int
-  store %0 to %1 : $*Int
+  store %0 to [trivial] %1 : $*Int
   %2 = alloc_stack $Int
 
   copy_addr %1 to [initialization] %2 : $*Int
 
-  %3 = load %2 : $*Int
+  %3 = load [trivial] %2 : $*Int
 
   dealloc_stack %2 : $*Int
   dealloc_stack %1 : $*Int
-  // CHECK-NEXT: return %0
   return %3 : $Int
 }
 
 // rdar://15170149
 // CHECK-LABEL: sil @store_to_copyaddr
 sil @store_to_copyaddr : $(Bool) -> Bool {
-bb0(%0 : $Bool):  // CHECK: bb0(%0 :
+bb0(%0 : @trivial $Bool):  // CHECK: bb0(%0 :
   %1 = alloc_stack $Bool
-  store %0 to %1 : $*Bool
+  store %0 to [trivial] %1 : $*Bool
   %3 = alloc_stack $Bool
   copy_addr %1 to [initialization] %3 : $*Bool
-  %5 = load %3 : $*Bool
+  %5 = load [trivial] %3 : $*Bool
   copy_addr %3 to %1 : $*Bool
-  %12 = load %1 : $*Bool
+  %12 = load [trivial] %1 : $*Bool
   dealloc_stack %3 : $*Bool
   dealloc_stack %1 : $*Bool
   return %12 : $Bool                              // CHECK-NEXT: return %0
 }
 
 // CHECK-LABEL: sil @cross_block_load_promotion
+// CHECK: return %0 : $Int
+// CHECK: } // end sil function 'cross_block_load_promotion'
 sil @cross_block_load_promotion : $@convention(thin) (Int) -> Int {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_stack $Int
-  store %0 to %1 : $*Int
+  store %0 to [trivial] %1 : $*Int
   %11 = integer_literal $Builtin.Int1, 1
   cond_br %11, bb1, bb2
 
@@ -326,11 +337,9 @@ bb2:
   br bb5
 
 bb5:
-  %15 = load %1 : $*Int
+  %15 = load [trivial] %1 : $*Int
   dealloc_stack %1 : $*Int
   return %15 : $Int
-
-// CHECK: return %0 : $Int
 }
 
 struct XYStruct { var x, y : Int }
@@ -338,84 +347,87 @@ sil @init_xy_struct : $@convention(thin) () -> XYStruct
 
 
 // CHECK-LABEL: sil @cross_block_load_promotion_struct
+// CHECK: return %0 : $Int
+// CHECK: } // end sil function 'cross_block_load_promotion_struct'
 sil @cross_block_load_promotion_struct : $@convention(thin) (Int, Int) -> Int {
-bb0(%0 : $Int, %2 : $Int):
+bb0(%0 : @trivial $Int, %2 : @trivial $Int):
   %1 = alloc_stack $XYStruct
 
   %7 = function_ref @init_xy_struct : $@convention(thin) () -> XYStruct
   %9 = apply %7() : $@convention(thin) () -> XYStruct
-  store %9 to %1 : $*XYStruct
+  store %9 to [trivial] %1 : $*XYStruct
 
   %11 = struct_element_addr %1 : $*XYStruct, #XYStruct.y
-  store %0 to %11 : $*Int
+  store %0 to [trivial] %11 : $*Int
 
   %12 = integer_literal $Builtin.Int1, 1          // user: %3
   cond_br %12, bb1, bb2
 
 bb1:                                              // Preds: bb3
   %13 = struct_element_addr %1 : $*XYStruct, #XYStruct.x
-  store %2 to %13 : $*Int
+  store %2 to [trivial] %13 : $*Int
   br bb5
 
 bb2:                                              // Preds: bb0
   br bb5
 
 bb5:                                              // Preds: bb4
-  %15 = load %11 : $*Int
+  %15 = load [trivial] %11 : $*Int
   dealloc_stack %1 : $*XYStruct
   return %15 : $Int
 
-// CHECK: return %0 : $Int
 }
 
 // CHECK-LABEL: sil @cross_block_load_promotion_struct2
+// CHECK: bb0([[ARG0:%.*]] : @trivial $Int,
+// CHECK: bb1:
+// CHECK-NEXT:   br bb3([[ARG0]] : $Int)
+// CHECK: bb2:
+// CHECK-NEXT:   br bb3([[ARG0]] : $Int)
+// CHECK: bb3([[PHI:%.*]] : @trivial $Int):
+// CHECK-NEXT: return [[PHI]] : $Int
 sil @cross_block_load_promotion_struct2 : $@convention(thin) (Int, Int) -> Int {
-bb0(%0 : $Int, %2 : $Int):
+bb0(%0 : @trivial $Int, %2 : @trivial $Int):
   %1 = alloc_stack $XYStruct
 
   %7 = function_ref @init_xy_struct : $@convention(thin) () -> XYStruct
   %9 = apply %7() : $@convention(thin) () -> XYStruct
-  store %9 to %1 : $*XYStruct
+  store %9 to [trivial] %1 : $*XYStruct
 
   %11 = struct_element_addr %1 : $*XYStruct, #XYStruct.x
-  store %0 to %11 : $*Int
+  store %0 to [trivial] %11 : $*Int
 
   %12 = integer_literal $Builtin.Int1, 1          // user: %3
   cond_br %12, bb1, bb2
 
 bb1:                                              // Preds: bb3
   %13 = struct_element_addr %1 : $*XYStruct, #XYStruct.x
-  store %0 to %13 : $*Int
+  store %0 to [trivial] %13 : $*Int
   br bb5
 
 bb2:                                              // Preds: bb0
   br bb5
 
 bb5:                                              // Preds: bb4
-  %15 = load %11 : $*Int
+  %15 = load [trivial] %11 : $*Int
   dealloc_stack %1 : $*XYStruct
   return %15 : $Int
-
-// CHECK: return %0 : $Int
 }
 
 
 // CHECK-LABEL: sil @destroy_addr_test
 sil @destroy_addr_test : $@convention(method) (@owned SomeClass) -> @owned SomeClass {
-bb0(%0 : $SomeClass):
+bb0(%0 : @owned $SomeClass):
   %1 = alloc_stack $SomeClass
   %2 = tuple ()
-  store %0 to %1 : $*SomeClass
-  %7 = load %1 : $*SomeClass
-  strong_retain %7 : $SomeClass
-  strong_release %7 : $SomeClass
-  %12 = load %1 : $*SomeClass                   // users: %16, %13
-  strong_retain %12 : $SomeClass                  // id: %13
+  store %0 to [init] %1 : $*SomeClass
+  %7 = load [copy] %1 : $*SomeClass
+  destroy_value %7 : $SomeClass
+  %12 = load [copy] %1 : $*SomeClass                   // users: %16, %13
   destroy_addr %1 : $*SomeClass                 // id: %14
   dealloc_stack %1 : $*SomeClass // id: %15
   return %12 : $SomeClass                         // id: %16
 }
-
 
 protocol P {}
 class C : P {}
@@ -423,6 +435,10 @@ class C : P {}
 sil @use : $@convention(thin) (@in P) -> ()
 
 // rdar://15492647
+//
+// Since we do not support arbitrary takes, we do not eliminate this
+// destroy_addr any more. But with future work we should be able to.
+//
 // CHECK-LABEL: sil @destroy_addr_removed
 sil @destroy_addr_removed : $@convention(thin) () -> () {
 bb0:
@@ -431,41 +447,70 @@ bb0:
   %9 = apply %f() : $@convention(thin) () -> @owned SomeClass
   // CHECK: [[CVAL:%[0-9]+]] = apply
 
-  store %9 to %3 : $*SomeClass
+  assign %9 to %3 : $*SomeClass
   destroy_addr %3 : $*SomeClass
   dealloc_stack %3 : $*SomeClass
   %15 = tuple ()
   return %15 : $()
-// CHECK-NEXT: strong_release [[CVAL]]
+// CHECK: destroy_addr %0
+// CHECK: } // end sil function 'destroy_addr_removed'
 }
 
 // <rdar://problem/17755462> Predictable memory opts removes refcount operation
-// CHECK-LABEL: sil @dead_allocation_1
-sil @dead_allocation_1 : $@convention(thin) (Optional<AnyObject>) -> () {
-  bb0(%0 : $Optional<AnyObject>):
-// CHECK: retain_value %0
+//
+// Don't remove otherwise dead allocations if there are uses that are the
+// destinations of copy_addr initializations that are not also takes of the
+// source. Doing so removes the retain of the source of the copy_addr.
+//   
+// CHECK-LABEL: sil @dead_allocation_1 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Optional<AnyObject>):
+// SEMANTIC ARC TODO: I think we are not processing this alloc_stack since we
+// just do a pass once over the CFG. This should be dead as well.
+// CHECK:   [[BOX:%.*]] = alloc_stack
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   store [[ARG_COPY]] to [init] [[BOX]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: copy_addr
+// CHECK:   destroy_addr [[BOX]]
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: copy_addr
+// CHECK:   dealloc_stack [[BOX]]
+// CHECK: } // end sil function 'dead_allocation_1'
+sil @dead_allocation_1 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+bb0(%0 : @owned $Optional<AnyObject>):
   %1 = alloc_stack $Optional<AnyObject>
   %2 = alloc_stack $Optional<AnyObject>
-  store %0 to %2 : $*Optional<AnyObject>
-// CHECK-NOT: copy_addr
+  store %0 to [init] %2 : $*Optional<AnyObject>
   copy_addr %2 to [initialization] %1 : $*Optional<AnyObject>
+  destroy_addr %2 : $*Optional<AnyObject>
   dealloc_stack %2 : $*Optional<AnyObject>
+  destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %3 = tuple ()
   return %3 : $()
 }
 
-// CHECK-LABEL: sil @dead_allocation_2
-sil @dead_allocation_2 : $@convention(thin) (Optional<AnyObject>) -> () {
-  bb0(%0 : $Optional<AnyObject>):
-// CHECK: retain_value %0
+// CHECK-LABEL: sil @dead_allocation_2 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Optional<AnyObject>):
 // CHECK-NOT: alloc_stack
+// CHECK-NOT: copy_addr
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: copy_addr
+// CHECK:   destroy_value [[ARG_COPY]]
+// CHECK-NOT: copy_addr
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function 'dead_allocation_2'
+sil @dead_allocation_2 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+bb0(%0 : @owned $Optional<AnyObject>):
   %1 = alloc_stack $Optional<AnyObject>
   %2 = alloc_stack $Optional<AnyObject>
-  store %0 to %1 : $*Optional<AnyObject>
-// CHECK-NOT: copy_addr
+  store %0 to [init] %1 : $*Optional<AnyObject>
   copy_addr %1 to [initialization] %2 : $*Optional<AnyObject>
+  destroy_addr %2 : $*Optional<AnyObject>
   dealloc_stack %2 : $*Optional<AnyObject>
+  destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %3 = tuple ()
   return %3 : $()
@@ -476,15 +521,15 @@ enum IndirectCase {
 }
 
 // CHECK-LABEL: sil @indirect_enum_box
-sil @indirect_enum_box : $@convention(thin) (Int) -> IndirectCase {
-// CHECK: bb0([[X:%.*]] : $Int):
-entry(%x : $Int):
+sil @indirect_enum_box : $@convention(thin) (Int) -> @owned IndirectCase {
+// CHECK: bb0([[X:%.*]] : @trivial $Int):
+entry(%x : @trivial $Int):
   // CHECK: [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  // CHECK: store [[X]] to [[PB]]
-  store %x to %ba : $*Int
+  // CHECK: store [[X]] to [trivial] [[PB]]
+  store %x to [trivial] %ba : $*Int
   // CHECK: [[E:%.*]] = enum $IndirectCase, #IndirectCase.X!enumelt.1, [[BOX]] : $<τ_0_0> { var τ_0_0 } <Int>
   %e = enum $IndirectCase, #IndirectCase.X!enumelt.1, %b : $<τ_0_0> { var τ_0_0 } <Int>
   // CHECK: return [[E]]
@@ -506,13 +551,13 @@ bb0:
   %b0 = struct $Bool (%0 : $Builtin.Int1)
   // CHECK: [[BV:%[0-9]+]] = struct_element_addr [[A]]
   %bv = struct_element_addr %a : $*Bool, #Bool._value
-  store %b0 to %a : $*Bool
+  store %b0 to [trivial] %a : $*Bool
 
   // CHECK: apply
   %ap = apply %f(%ump) : $@convention(c) (UnsafeMutablePointer<Bool>) -> Int32
 
-  // CHECK: [[L:%[0-9]+]] = load [[BV]]
-  %l = load %bv : $*Builtin.Int1
+  // CHECK: [[L:%[0-9]+]] = load [trivial] [[BV]]
+  %l = load [trivial] %bv : $*Builtin.Int1
   // CHECK: [[R:%[0-9]+]] = struct $Bool ([[L]]
   %r = struct $Bool (%l : $Builtin.Int1)
   dealloc_stack %a : $*Bool
@@ -544,22 +589,22 @@ struct NativeObjectPair {
 // CHECK-NOT: load
 // CHECK: } // end sil function 'diamond_test_1'
 sil @diamond_test_1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = alloc_stack $Builtin.NativeObject
   cond_br undef, bb1, bb2
 
 bb1:
-  store %0 to %1 : $*Builtin.NativeObject
+  store %0 to [init] %1 : $*Builtin.NativeObject
   br bb3
 
 bb2:
-  store %0 to %1 : $*Builtin.NativeObject
+  store %0 to [init] %1 : $*Builtin.NativeObject
   br bb3
 
 bb3:
-  %2 = load %1 : $*Builtin.NativeObject
-  strong_retain %2 : $Builtin.NativeObject
-  strong_release %2 : $Builtin.NativeObject
+  %2 = load [copy] %1 : $*Builtin.NativeObject
+  destroy_value %2 : $Builtin.NativeObject
+  destroy_addr %1 : $*Builtin.NativeObject
   dealloc_stack %1 : $*Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
@@ -568,42 +613,46 @@ bb3:
 // This test makes sure that we insert the tuple_extracts that we need before
 // the store in bb0, not at the load block.
 // CHECK-LABEL: sil @diamond_test_2 : $@convention(thin) (@owned NativeObjectPair) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[ARG:%.*]] : $NativeObjectPair):
-// CHECK:   [[LHS1:%.*]] = struct_extract [[ARG]] : $NativeObjectPair, #NativeObjectPair.f1
-// CHECK:   [[LHS2:%.*]] = struct_extract [[ARG]] : $NativeObjectPair, #NativeObjectPair.f1
+// CHECK: bb0([[ARG:%.*]] : @owned $NativeObjectPair):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[LHS1:%.*]] = struct_extract [[BORROWED_ARG]] : $NativeObjectPair, #NativeObjectPair.f1
+// CHECK:   [[LHS1_COPY:%.*]] = copy_value [[LHS1]]
+// CHECK:   end_borrow [[BORROWED_ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[LHS2:%.*]] = struct_extract [[BORROWED_ARG]] : $NativeObjectPair, #NativeObjectPair.f1
+// CHECK:   [[LHS2_COPY:%.*]] = copy_value [[LHS2]]
+// CHECK:   end_borrow [[BORROWED_ARG]]
 // CHECK:   cond_br undef, bb1, bb2
 //
 // CHECK: bb1:
-// CHECK:   strong_retain [[LHS2]]
-// CHECK:   br bb3([[LHS2]] :
+// CHECK:   destroy_value [[LHS1_COPY]]
+// CHECK:   br bb3([[LHS2_COPY]] :
 //
 // CHECK: bb2:
-// CHECK:   strong_retain [[LHS1]] : $Builtin.NativeObject
-// CHECK:   br bb3([[LHS1]] :
+// CHECK:   destroy_value [[LHS2_COPY]]
+// CHECK:   br bb3([[LHS1_COPY]] :
 //
-// CHECK: bb3([[PHI:%.*]] :
-// CHECK:   release_value [[ARG]]
+// CHECK: bb3([[PHI:%.*]] : @owned $Builtin.NativeObject):
+// CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[PHI]]
 // CHECK: } // end sil function 'diamond_test_2'
 sil @diamond_test_2 : $@convention(thin) (@owned NativeObjectPair) -> @owned Builtin.NativeObject {
-bb0(%0 : $NativeObjectPair):
+bb0(%0 : @owned $NativeObjectPair):
   %1 = alloc_stack $NativeObjectPair
-  store %0 to %1 : $*NativeObjectPair
+  store %0 to [init] %1 : $*NativeObjectPair
   cond_br undef, bb1, bb2
 
 bb1:
   %2 = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.f1
-  %3 = load %2 : $*Builtin.NativeObject
-  strong_retain %3 : $Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
   br bb3(%3 : $Builtin.NativeObject)
 
 bb2:
   %4 = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.f1
-  %5 = load %4 : $*Builtin.NativeObject
-  strong_retain %5 : $Builtin.NativeObject
+  %5 = load [copy] %4 : $*Builtin.NativeObject
   br bb3(%5 : $Builtin.NativeObject)
 
-bb3(%6 : $Builtin.NativeObject):
+bb3(%6 : @owned $Builtin.NativeObject):
   destroy_addr %1 : $*NativeObjectPair
   dealloc_stack %1 : $*NativeObjectPair
   return %6 : $Builtin.NativeObject
@@ -617,27 +666,25 @@ bb3(%6 : $Builtin.NativeObject):
 // CHECK-NOT: store
 // CHECK: } // end sil function 'diamond_test_3'
 sil @diamond_test_3 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %2 = alloc_stack $NativeObjectPair
   %3 = struct_element_addr %2 : $*NativeObjectPair, #NativeObjectPair.f1
   %4 = struct_element_addr %2 : $*NativeObjectPair, #NativeObjectPair.f2
-  store %0 to %3 : $*Builtin.NativeObject
-  store %1 to %4 : $*Builtin.NativeObject
+  store %0 to [init] %3 : $*Builtin.NativeObject
+  store %1 to [init] %4 : $*Builtin.NativeObject
   cond_br undef, bb1, bb2
 
 bb1:
   %tup_addr_1 = struct_element_addr %2 : $*NativeObjectPair, #NativeObjectPair.f1
-  %tup_val_1 = load %tup_addr_1 : $*Builtin.NativeObject
-  strong_retain %tup_val_1 : $Builtin.NativeObject
+  %tup_val_1 = load [copy] %tup_addr_1 : $*Builtin.NativeObject
   br bb3(%tup_val_1 : $Builtin.NativeObject)
 
 bb2:
   %tup_addr_2 = struct_element_addr %2 : $*NativeObjectPair, #NativeObjectPair.f1
-  %tup_val_2 = load %tup_addr_2 : $*Builtin.NativeObject
-  strong_retain %tup_val_2 : $Builtin.NativeObject
+  %tup_val_2 = load [copy] %tup_addr_2 : $*Builtin.NativeObject
   br bb3(%tup_val_2 : $Builtin.NativeObject)
 
-bb3(%result : $Builtin.NativeObject):
+bb3(%result : @owned $Builtin.NativeObject):
   destroy_addr %2 : $*NativeObjectPair
   dealloc_stack %2 : $*NativeObjectPair
   return %result : $Builtin.NativeObject
@@ -651,51 +698,54 @@ struct NativeObjectTriple {
 // Make sure we insert the struct_extracts in bb1, bb2.
 //
 // CHECK-LABEL: sil @diamond_test_4 : $@convention(thin) (@owned Builtin.NativeObject, @owned NativeObjectPair) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $NativeObjectPair):
+// CHECK: bb0([[ARG0:%.*]] : @owned $Builtin.NativeObject, [[ARG1:%.*]] : @owned $NativeObjectPair):
 // CHECK:   cond_br undef, bb1, bb2
 //
 // CHECK: bb1:
-// CHECK-NEXT: [[PAIR_LHS:%.*]] = struct_extract [[ARG1]]
-// CHECK-NEXT: br bb3([[PAIR_LHS]] :
+// CHECK-NEXT: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK-NEXT: [[PAIR_LHS:%.*]] = struct_extract [[BORROWED_ARG1]]
+// CHECK-NEXT: [[PAIR_LHS_COPY:%.*]] = copy_value [[PAIR_LHS]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG1]]
+// CHECK-NEXT: br bb3([[PAIR_LHS_COPY]] :
 //
 // CHECK: bb2:
-// CHECK-NEXT: [[PAIR_LHS:%.*]] = struct_extract [[ARG1]]
-// CHECK-NEXT: br bb3([[PAIR_LHS]] :
+// CHECK-NEXT: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK-NEXT: [[PAIR_LHS:%.*]] = struct_extract [[BORROWED_ARG1]]
+// CHECK-NEXT: [[PAIR_LHS_COPY:%.*]] = copy_value [[PAIR_LHS]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG1]]
+// CHECK-NEXT: br bb3([[PAIR_LHS_COPY]] :
 //
-// CHECK: bb3([[PHI:%.*]] : $Builtin.NativeObject):
-// CHECK-NOT: struct_extract
-// CHECK: strong_retain [[PHI]]
+// CHECK: bb3([[PHI:%.*]] : @owned $Builtin.NativeObject):
 // CHECK-NOT: struct_extract
 // CHECK: [[REFORMED:%.*]] = struct $NativeObjectTriple ([[ARG0]] : {{.*}}, [[ARG1]] : {{.*}})
 // CHECK-NOT: struct_extract
-// CHECK: release_value [[REFORMED]]
+// CHECK: destroy_value [[REFORMED]]
 // CHECK-NOT: struct_extract
 // CHECK: return [[PHI]]
 // CHECK: } // end sil function 'diamond_test_4'
 sil @diamond_test_4 : $@convention(thin) (@owned Builtin.NativeObject, @owned NativeObjectPair) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject, %1 : $NativeObjectPair):
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $NativeObjectPair):
   %2 = alloc_stack $NativeObjectTriple
   cond_br undef, bb1, bb2
 
 bb1:
   %3 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f1
   %4 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
-  store %0 to %3 : $*Builtin.NativeObject
-  store %1 to %4 : $*NativeObjectPair
+  store %0 to [init] %3 : $*Builtin.NativeObject
+  store %1 to [init] %4 : $*NativeObjectPair
   br bb3
 
 bb2:
   %5 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f1
   %6 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
-  store %0 to %5 : $*Builtin.NativeObject
-  store %1 to %6 : $*NativeObjectPair
+  store %0 to [init] %5 : $*Builtin.NativeObject
+  store %1 to [init] %6 : $*NativeObjectPair
   br bb3
 
 bb3:
   %11 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
   %12 = struct_element_addr %11 : $*NativeObjectPair, #NativeObjectPair.f1
-  %13 = load %12 : $*Builtin.NativeObject
-  strong_retain %13 : $Builtin.NativeObject
+  %13 = load [copy] %12 : $*Builtin.NativeObject
   destroy_addr %2 : $*NativeObjectTriple
   dealloc_stack %2 : $*NativeObjectTriple
   return %13 : $Builtin.NativeObject
@@ -705,145 +755,156 @@ bb3:
 // overridden along one path
 //
 // CHECK-LABEL: sil @diamond_test_5 : $@convention(thin) (@owned Builtin.NativeObject, @owned NativeObjectPair, @owned Builtin.NativeObject) -> @owned NativeObjectPair {
-// CHECK: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $NativeObjectPair, [[ARG2:%.*]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG0:%.*]] : @owned $Builtin.NativeObject, [[ARG1:%.*]] : @owned $NativeObjectPair, [[ARG2:%.*]] : @owned $Builtin.NativeObject):
 // CHECK:   [[BOX:%.*]] = alloc_stack $NativeObjectTriple
 // CHECK:   br bb1
 //
 // CHECK: bb1:
 // CHECK:   [[TRIPLE_LHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f1
 // CHECK:   [[TRIPLE_RHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f2
-// CHECK:   store [[ARG0]] to [[TRIPLE_LHS]]
-// CHECK:   [[TRIPLE_RHS_RHS_VAL:%.*]] = struct_extract [[ARG1]] : $NativeObjectPair, #NativeObjectPair.f2
-// CHECK:   store [[ARG1]] to [[TRIPLE_RHS]]
+// CHECK:   store [[ARG0]] to [init] [[TRIPLE_LHS]]
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK:   [[TRIPLE_RHS_RHS_VAL:%.*]] = struct_extract [[BORROWED_ARG1]] : $NativeObjectPair, #NativeObjectPair.f2
+// CHECK:   [[TRIPLE_RHS_RHS_VAL_COPY:%.*]] = copy_value [[TRIPLE_RHS_RHS_VAL]]
+// CHECK:   end_borrow [[BORROWED_ARG1]]
+// CHECK:   store [[ARG1]] to [init] [[TRIPLE_RHS]]
 // CHECK:   cond_br undef, bb2, bb3
 //
 // CHECK: bb2:
 // CHECK:   [[TRIPLE_RHS_LHS:%.*]] = struct_element_addr [[TRIPLE_RHS]]
-// CHECK:   store [[ARG2]] to [[TRIPLE_RHS_LHS]]
+// CHECK:   store [[ARG2]] to [assign] [[TRIPLE_RHS_LHS]]
 // CHECK:   br bb4
 //
 // CHECK: bb3:
+// CHECK:   destroy_value [[ARG2]]
 // CHECK:   br bb4
 //
 // CHECK: bb4:
 // CHECK:   [[TRIPLE_RHS_LHS:%.*]] = struct_element_addr [[TRIPLE_RHS]] : $*NativeObjectPair, #NativeObjectPair.f1
-// CHECK:   [[TRIPLE_RHS_LHS_VAL:%.*]] = load [[TRIPLE_RHS_LHS]] : $*Builtin.NativeObject
-// CHECK:   [[STRUCT:%.*]] = struct $NativeObjectPair ([[TRIPLE_RHS_LHS_VAL]] : {{.*}}, [[TRIPLE_RHS_RHS_VAL]] : {{.*}})
-// CHECK:   retain_value [[STRUCT]]
+// CHECK:   [[TRIPLE_RHS_LHS_VAL:%.*]] = load [copy] [[TRIPLE_RHS_LHS]] : $*Builtin.NativeObject
+// CHECK:   [[STRUCT:%.*]] = struct $NativeObjectPair ([[TRIPLE_RHS_LHS_VAL]] : {{.*}}, [[TRIPLE_RHS_RHS_VAL_COPY]] : {{.*}})
 // CHECK:   destroy_addr [[BOX]]
 // CHECK:   return [[STRUCT]]
 // CHECK: } // end sil function 'diamond_test_5'
 sil @diamond_test_5 : $@convention(thin) (@owned Builtin.NativeObject, @owned NativeObjectPair, @owned Builtin.NativeObject) -> @owned NativeObjectPair {
-bb0(%0 : $Builtin.NativeObject, %1 : $NativeObjectPair, %arg2 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $NativeObjectPair, %arg2 : @owned $Builtin.NativeObject):
   %2 = alloc_stack $NativeObjectTriple
   br bb1
 
 bb1:
   %5 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f1
   %6 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
-  store %0 to %5 : $*Builtin.NativeObject
-  store %1 to %6 : $*NativeObjectPair
+  store %0 to [init] %5 : $*Builtin.NativeObject
+  store %1 to [init] %6 : $*NativeObjectPair
   cond_br undef, bb2, bb3
 
 bb2:
   %11 = struct_element_addr %6 : $*NativeObjectPair, #NativeObjectPair.f1
-  store %arg2 to %11 : $*Builtin.NativeObject
+  store %arg2 to [assign] %11 : $*Builtin.NativeObject
   br bb4
 
 bb3:
+  destroy_value %arg2 : $Builtin.NativeObject
   br bb4
 
 bb4:
-  %13 = load %6 : $*NativeObjectPair
-  retain_value %13 : $NativeObjectPair
+  %13 = load [copy] %6 : $*NativeObjectPair
   destroy_addr %2 : $*NativeObjectTriple
   dealloc_stack %2 : $*NativeObjectTriple
   return %13 : $NativeObjectPair
 }
 
 // CHECK-LABEL: sil @diamond_test_6 : $@convention(thin) (@owned Builtin.NativeObject, @owned NativeObjectPair, @owned Builtin.NativeObject) -> @owned NativeObjectPair {
-// CHECK: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $NativeObjectPair, [[ARG2:%.*]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG0:%.*]] : @owned $Builtin.NativeObject, [[ARG1:%.*]] : @owned $NativeObjectPair, [[ARG2:%.*]] : @owned $Builtin.NativeObject):
 // CHECK:   [[BOX:%.*]] = alloc_stack $NativeObjectTriple
-// CHECK:   cond_br undef, bb1, bb4
+// CHECK:   cond_br {{.*}}, bb1, bb4
 //
 // CHECK: bb1:
 // CHECK:   [[TRIPLE_LHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f1
 // CHECK:   [[TRIPLE_RHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f2
-// CHECK:   store [[ARG0]] to [[TRIPLE_LHS]]
-// CHECK:   [[TRIPLE_RHS_RHS_VAL:%.*]] = struct_extract [[ARG1]] : $NativeObjectPair, #NativeObjectPair.f2
-// CHECK:   store [[ARG1]] to [[TRIPLE_RHS]]
-// CHECK:   cond_br undef, bb3, bb2
+// CHECK:   store [[ARG0]] to [init] [[TRIPLE_LHS]]
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK:   [[TRIPLE_RHS_RHS_VAL:%.*]] = struct_extract [[BORROWED_ARG1]] : $NativeObjectPair, #NativeObjectPair.f2
+// CHECK:   [[TRIPLE_RHS_RHS_VAL_COPY:%.*]] = copy_value [[TRIPLE_RHS_RHS_VAL]]
+// CHECK:   end_borrow [[BORROWED_ARG1]]
+// CHECK:   store [[ARG1]] to [init] [[TRIPLE_RHS]]
+// CHECK:   cond_br {{.*}}, bb3, bb2
 //
-// CHECK: bb2:
-// CHECK-NEXT:   br bb8([[TRIPLE_RHS_RHS_VAL]] : $Builtin.NativeObject)
+// CHECK:   bb2:
+// CHECK:     br bb8([[TRIPLE_RHS_RHS_VAL_COPY]]
 //
-// CHECK: bb3:
-// CHECK-NEXT:   br bb7([[TRIPLE_RHS_RHS_VAL]] : $Builtin.NativeObject)
+// CHECK:   bb3:
+// CHECK:     br bb7([[TRIPLE_RHS_RHS_VAL_COPY]]
 //
 // CHECK: bb4:
 // CHECK:   [[TRIPLE_LHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f1
 // CHECK:   [[TRIPLE_RHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f2
-// CHECK:   store [[ARG0]] to [[TRIPLE_LHS]]
-// CHECK:   [[TRIPLE_RHS_RHS_VAL:%.*]] = struct_extract [[ARG1]] : $NativeObjectPair, #NativeObjectPair.f2
-// CHECK:   store [[ARG1]] to [[TRIPLE_RHS]]
-// CHECK:   cond_br undef, bb6, bb5
+// CHECK:   store [[ARG0]] to [init] [[TRIPLE_LHS]]
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK:   [[TRIPLE_RHS_RHS_VAL:%.*]] = struct_extract [[BORROWED_ARG1]] : $NativeObjectPair, #NativeObjectPair.f2
+// CHECK:   [[TRIPLE_RHS_RHS_VAL_COPY:%.*]] = copy_value [[TRIPLE_RHS_RHS_VAL]]
+// CHECK:   store [[ARG1]] to [init] [[TRIPLE_RHS]]
+// CHECK:   cond_br {{.*}}, bb6, bb5
 //
 // CHECK: bb5:
-// CHECK-NEXT: br bb8([[TRIPLE_RHS_RHS_VAL]] : {{.*}})
+// CHECK:   br bb8([[TRIPLE_RHS_RHS_VAL_COPY]]
 //
 // CHECK: bb6:
-// CHECK-NEXT: br bb7([[TRIPLE_RHS_RHS_VAL]] : {{.*}})
+// CHECK:   br bb7([[TRIPLE_RHS_RHS_VAL_COPY]]
 //
-// CHECK: bb7([[PHI1:%.*]] : $Builtin.NativeObject):
+// CHECK: bb7([[PHI:%.*]] : @owned $Builtin.NativeObject):
 // CHECK:   [[TRIPLE_RHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f2
 // CHECK:   [[TRIPLE_RHS_LHS:%.*]] = struct_element_addr [[TRIPLE_RHS]]
-// CHECK:   store [[ARG2]] to [[TRIPLE_RHS_LHS]]
+// CHECK:   store [[ARG2]] to [assign] [[TRIPLE_RHS_LHS]]
 // CHECK:   br bb9([[PHI1:%.*]] : $Builtin.NativeObject)
 //
-// CHECK: bb8([[PHI:%.*]] : $Builtin.NativeObject):
+// CHECK: bb8([[PHI:%.*]] : @owned $Builtin.NativeObject):
+// CHECK:   destroy_value [[ARG2]]
 // CHECK:   br bb9([[PHI]] : {{.*}})
 //
-// CHECK: bb9([[PHI:%.*]] : $Builtin.NativeObject
+// CHECK: bb9([[PHI:%.*]] : @owned $Builtin.NativeObject):
 // CHECK:   [[TRIPLE_RHS:%.*]] = struct_element_addr [[BOX]] : $*NativeObjectTriple, #NativeObjectTriple.f2
 // CHECK:   [[TRIPLE_RHS_LHS:%.*]] = struct_element_addr [[TRIPLE_RHS]] : $*NativeObjectPair, #NativeObjectPair.f1
-// CHECK:   [[TRIPLE_RHS_LHS_VAL:%.*]] = load [[TRIPLE_RHS_LHS]] : $*Builtin.NativeObject
+// CHECK:   [[TRIPLE_RHS_LHS_VAL:%.*]] = load [copy] [[TRIPLE_RHS_LHS]] : $*Builtin.NativeObject
 // CHECK:   [[STRUCT:%.*]] = struct $NativeObjectPair ([[TRIPLE_RHS_LHS_VAL]] : {{.*}}, [[PHI]] : {{.*}})
-// CHECK:   retain_value [[STRUCT]]
 // CHECK:   destroy_addr [[BOX]]
 // CHECK:   return [[STRUCT]]
 // CHECK: } // end sil function 'diamond_test_6'
 sil @diamond_test_6 : $@convention(thin) (@owned Builtin.NativeObject, @owned NativeObjectPair, @owned Builtin.NativeObject) -> @owned NativeObjectPair {
-bb0(%0 : $Builtin.NativeObject, %1 : $NativeObjectPair, %arg2 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $NativeObjectPair, %arg2 : @owned $Builtin.NativeObject):
   %2 = alloc_stack $NativeObjectTriple
-  cond_br undef, bb1, bb2
+  %bool1 = integer_literal $Builtin.Int1, 0
+  cond_br %bool1, bb1, bb2
 
 bb1:
   %5 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f1
   %6 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
-  store %0 to %5 : $*Builtin.NativeObject
-  store %1 to %6 : $*NativeObjectPair
-  cond_br undef, bb3, bb4
+  store %0 to [init] %5 : $*Builtin.NativeObject
+  store %1 to [init] %6 : $*NativeObjectPair
+  %bool2 = integer_literal $Builtin.Int1, 0
+  cond_br %bool2, bb3, bb4
 
 bb2:
   %7 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f1
   %8 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
-  store %0 to %7 : $*Builtin.NativeObject
-  store %1 to %8 : $*NativeObjectPair
-  cond_br undef, bb3, bb4
+  store %0 to [init] %7 : $*Builtin.NativeObject
+  store %1 to [init] %8 : $*NativeObjectPair
+  %bool3 = integer_literal $Builtin.Int1, 0
+  cond_br %bool3, bb3, bb4
 
 bb3:
   %11 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
   %12 = struct_element_addr %11 : $*NativeObjectPair, #NativeObjectPair.f1
-  store %arg2 to %12 : $*Builtin.NativeObject
+  store %arg2 to [assign] %12 : $*Builtin.NativeObject
   br bb5
 
 bb4:
+  destroy_value %arg2 : $Builtin.NativeObject
   br bb5
 
 bb5:
   %13 = struct_element_addr %2 : $*NativeObjectTriple, #NativeObjectTriple.f2
-  %14 = load %13 : $*NativeObjectPair
-  retain_value %14 : $NativeObjectPair
+  %14 = load [copy] %13 : $*NativeObjectPair
   destroy_addr %2 : $*NativeObjectTriple
   dealloc_stack %2 : $*NativeObjectTriple
   return %14 : $NativeObjectPair
@@ -862,7 +923,7 @@ bb5:
 //
 //
 // CHECK-LABEL: sil @dead_allocation_with_unreachable_destroy_addr : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG:%.*]] : @owned $Builtin.NativeObject):
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: store
 // CHECK-NEXT: br bb1
@@ -878,9 +939,9 @@ bb5:
 // CHECK-NEXT: unreachable
 // CHECK: } // end sil function 'dead_allocation_with_unreachable_destroy_addr'
 sil @dead_allocation_with_unreachable_destroy_addr : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = alloc_stack $Builtin.NativeObject
-  store %0 to %1 : $*Builtin.NativeObject
+  store %0 to [init] %1 : $*Builtin.NativeObject
   br bb1
 
 bb1:


### PR DESCRIPTION
This PR updates pred mem opts for SIL Ownership.

Once this is done, we should be able to with a bit of work (i.e. updating tests) move the ownership eliminator into the performance pipeline and thus apply the ownership verifier to the other overlays.

rdar://31521023