### PR TITLE
Force foundation and libdispatch to re-build always on non-darwin platforms. (#12736)

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2488,7 +2488,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # FIXME: Always re-build foundation on non-darwin platforms.
                 # Remove this when products build in the CMake system.
                 echo "Cleaning the Foundation build directory"
-                call rm -r "${build_dir}"
+                call rm -rf "${build_dir}"
 
                 with_pushd "${FOUNDATION_SOURCE_DIR}" \
                     call env SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
@@ -2548,7 +2548,7 @@ for host in "${ALL_HOSTS[@]}"; do
                   # FIXME: Always re-build libdispatch on non-darwin platforms.
                   # Remove this when products build in the CMake system.
                   echo "Cleaning the libdispatch build directory"
-                  call rm -r "${LIBDISPATCH_BUILD_DIR}"
+                  call rm -rf "${LIBDISPATCH_BUILD_DIR}"
 
                   cmake_options=(
                     ${cmake_options[@]}

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2485,6 +2485,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
 
+                # FIXME: Always re-build foundation on non-darwin platforms.
+                # Remove this when products build in the CMake system.
+                echo "Cleaning the Foundation build directory"
+                call rm -r "${build_dir}"
+
                 with_pushd "${FOUNDATION_SOURCE_DIR}" \
                     call env SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
                       SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="$(get_host_install_destdir ${host})" PREFIX="$(get_host_install_prefix ${host})" ./configure "${FOUNDATION_BUILD_TYPE}" ${FOUNDATION_BUILD_ARGS[@]} -DXCTEST_BUILD_DIR=${XCTEST_BUILD_DIR} $LIBDISPATCH_BUILD_ARGS
@@ -2530,6 +2535,7 @@ for host in "${ALL_HOSTS[@]}"; do
                   else
                       echo "Skipping reconfiguration of libdispatch"
                   fi
+
                   with_pushd "${LIBDISPATCH_BUILD_DIR}" \
                       call make
                   with_pushd "${LIBDISPATCH_BUILD_DIR}/tests" \
@@ -2539,6 +2545,11 @@ for host in "${ALL_HOSTS[@]}"; do
                   continue
                 ;;
                 *)
+                  # FIXME: Always re-build libdispatch on non-darwin platforms.
+                  # Remove this when products build in the CMake system.
+                  echo "Cleaning the libdispatch build directory"
+                  call rm -r "${LIBDISPATCH_BUILD_DIR}"
+
                   cmake_options=(
                     ${cmake_options[@]}
                     -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"


### PR DESCRIPTION
(cherry picked from commit bef1e6d0f1627c8720426e579f8752b5ca264a2a)
