### PR TITLE
Ignore missing foundation and libdispatch build directories when attempting to remove them on non-darwin platforms.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2484,7 +2484,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # FIXME: Always re-build foundation on non-darwin platforms.
                 # Remove this when products build in the CMake system.
                 echo "Cleaning the Foundation build directory"
-                call rm -r "${build_dir}"
+                call rm -rf "${build_dir}"
 
                 with_pushd "${FOUNDATION_SOURCE_DIR}" \
                     call env SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
@@ -2544,7 +2544,7 @@ for host in "${ALL_HOSTS[@]}"; do
                   # FIXME: Always re-build libdispatch on non-darwin platforms.
                   # Remove this when products build in the CMake system.
                   echo "Cleaning the libdispatch build directory"
-                  call rm -r "${LIBDISPATCH_BUILD_DIR}"
+                  call rm -rf "${LIBDISPATCH_BUILD_DIR}"
 
                   cmake_options=(
                     ${cmake_options[@]}


### PR DESCRIPTION
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04-long-test/1469/

rdar://35293576