### PR TITLE
[ABI/Metadata] Re-arrange space allocation of function metadata flags

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -121,20 +121,22 @@ Function Metadata
 In addition to the `common metadata layout`_ fields, function metadata records
 contain the following fields:
 
-- The function flags are stored at **offset 1**, information contained by flags
-  includes 'throws' indicator (8 bits), metadata convention (8 bits)
-  and number of arguments (remaining N bits).
-- The **argument vector** begins at **offset 2** and consists of pointers to
-  metadata records of the function's arguments.
-- A reference to the **result type** metadata record is stored after the end
-  of **argument vector**. If the function has multiple returns, this references a
-  `tuple metadata`_ record.
+- The function flags are stored at **offset 1**, information contained by function
+  flags includes flags (8 bits) which _currently_ consists of 'throws' bit and
+  'parameter flags' bit, function convention (8 bits), and number of parameters (16 bits).
+- A reference to the **result type** metadata record is stored after function
+  flags. If the function has multiple returns, this references a `tuple metadata`_
+  record.
+- The **parameter type vector** follows the result type and consists of
+  NumParameters type metadata pointers corresponding to the types of the parameters.
+- The optional **parameter flags vector** begins after the end of **parameter type vector**
+  and consists of NumParameters unsigned 32-bit integer values representing flags
+  for each parameter such as inout, __shared, variadic and possibly others. This
+  vector is present only if the hasParameterFlags() function flag is set; otherwise
+  all of the parameter flags are assumed to be zero.
 
-  A pointer to each argument's metadata record will be appended separately,
-  the lowest bit being set if it is **inout**. Because of pointer alignment,
-  the lowest bit will always be free to hold this tag.
-
-  If the function takes no arguments, **argument vector** is going to be empty.
+  If the function takes no arguments, **parameter type vector** as well as
+  **parameter flags vector** are going to be empty.
 
 Protocol Metadata
 ~~~~~~~~~~~~~~~~~

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -549,12 +549,15 @@ enum class FunctionMetadataConvention: uint8_t {
 /// Flags in a function type metadata record.
 template <typename int_type>
 class TargetFunctionTypeFlags {
+  // If we were ever to run out of space for function flags (8 bits)
+  // one of the flag bits could be used to identify that the rest of
+  // the flags is going to be stored somewhere else in the metadata.
   enum : int_type {
-    NumParametersMask = 0x00FFFFFFU,
-    ConventionMask    = 0x0F000000U,
-    ConventionShift   = 25U,
-    ThrowsMask        = 0x10000000U,
-    ParamFlagsMask    = 0x01000000U,
+    NumParametersMask = 0x0000FFFFU,
+    ConventionMask    = 0x00FF0000U,
+    ConventionShift   = 16U,
+    ThrowsMask        = 0x01000000U,
+    ParamFlagsMask    = 0x02000000U,
   };
   int_type Data;
   

--- a/test/IRGen/c_function_pointer.sil
+++ b/test/IRGen/c_function_pointer.sil
@@ -27,4 +27,4 @@ entry:
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0yyXCMa()
 // --                                                                               0x3000001 -- C convention, 1 argument
-// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 100663296, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 196608, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -13,19 +13,19 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(_: ()) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 16777217, %swift.type* @_T0SiN, i32 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 33554433, %swift.type* @_T0SiN, i32 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* %2, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: (Int, Float)) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 16777218, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SiN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 33554434, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SiN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 16777219, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SfN, i32 0, %swift.type* @_T0SSN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 33554435, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SfN, i32 0, %swift.type* @_T0SSN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, %swift.type* @_T0SfN, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
@@ -40,6 +40,6 @@ func test_arch() {
   // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 3
   // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
   // CHECK: [[T:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 16777220, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554436, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
 }

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -38,4 +38,4 @@ entry(%b : $*@convention(block) () -> ()):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
 // --                                                                               0x100_0001 = block convention, 1 arg
-// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 33554432, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 65536, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))


### PR DESCRIPTION
This changes layout of the `TargetFunctionTypeFlags` to allocate
8 bits for flags, 8 bits for convesion and 16 bits for number of
parameters. Documentation is updated accordingly.

Resolves: rdar://problem/31408030

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
