### PR TITLE
[Stats] Add a pair of counters to track failed processes.

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -105,6 +105,8 @@ public:
   };
 
 private:
+  bool currentProcessExitStatusSet;
+  int currentProcessExitStatus;
   SmallString<128> StatsFilename;
   SmallString<128> TraceFilename;
   llvm::TimeRecord StartedTime;
@@ -140,6 +142,7 @@ public:
   AlwaysOnDriverCounters &getDriverCounters();
   AlwaysOnFrontendCounters &getFrontendCounters();
   AlwaysOnFrontendRecursiveSharedTimers &getFrontendRecursiveSharedTimers();
+  void noteCurrentProcessExitStatus(int);
   FrontendStatsTracer getStatsTracer(StringRef N,
                                      SourceRange const &R);
   void saveAnyFrontendStatsEvents(FrontendStatsTracer const& T,

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -40,6 +40,10 @@ DRIVER_STATISTIC(NumDriverJobsRun)
 /// run-over-run.
 DRIVER_STATISTIC(NumDriverJobsSkipped)
 
+/// Total number of driver processes that exited with EXIT_FAILURE / not with
+/// EXIT_SUCCESS.
+DRIVER_STATISTIC(NumProcessFailures)
+
 /// Next 10 statistics count dirtying-events in the driver's dependency graph,
 /// which it uses to decide which files are invalid (and thus which files to
 /// build). There are two dimensions to each dirtying event:
@@ -68,6 +72,10 @@ DRIVER_STATISTIC(ChildrenMaxRSS)
 
 /// Driver statistics are collected for frontend processes
 #ifdef FRONTEND_STATISTIC
+
+/// Total number of frontend processes that exited with EXIT_FAILURE / not with
+/// EXIT_SUCCESS.
+FRONTEND_STATISTIC(Frontend, NumProcessFailures)
 
 /// Number of source buffers visible in the source manager.
 FRONTEND_STATISTIC(AST, NumSourceBuffers)

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -934,7 +934,8 @@ int Compilation::performJobs() {
         (void)llvm::sys::fs::remove(pathPair.getKey());
     }
   }
-
+  if (Stats)
+    Stats->noteCurrentProcessExitStatus(result);
   return result;
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1467,7 +1467,10 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     }
   }
 
-  return finishDiagProcessing(HadError ? 1 : ReturnValue);
+  auto r = finishDiagProcessing(HadError ? 1 : ReturnValue);
+  if (StatsReporter)
+    StatsReporter->noteCurrentProcessExitStatus(r);
+  return r;
 }
 
 void FrontendObserver::parsedArgs(CompilerInvocation &invocation) {}

--- a/test/Misc/stats_dir_failure_count.swift
+++ b/test/Misc/stats_dir_failure_count.swift
@@ -1,0 +1,25 @@
+// Check that a failed process-tree emits nonzero failure counters
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: echo zzz >%t/other.swift
+// RUN: not %target-swiftc_driver -D BROKEN -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
+// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
+// RUN: %FileCheck -input-file %t/stats.csv -check-prefix=FAILURE %s
+// FAILURE: {{"Driver.NumProcessFailures"	1$}}
+// FAILURE: {{"Frontend.NumProcessFailures"	2$}}
+
+// Check that a successful process-tree emits no failure counters
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: echo 'let x : Int = 1' >%t/other.swift
+// RUN: %target-swiftc_driver -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
+// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
+// RUN: %FileCheck -input-file %t/stats.csv -check-prefix=SUCCESS %s
+// SUCCESS-NOT: {{"Driver.NumProcessFailures"}}
+// SUCCESS-NOT: {{"Frontend.NumProcessFailures"}}
+
+func foo() {
+#if BROKEN
+  print(bar)
+#else
+  print(1)
+#endif
+}


### PR DESCRIPTION
This gives us a little signal in the -stats-output-dir files concerning any failures that occurred in the process tree. The purpose is to enable higher levels of stats processing to differentiate runs with diminished counters (because of differences in _performance_) from runs that have partial failures within them (because of _bugs or configuration changes_).
