### PR TITLE
Disable coroutine verification tests in non-asserts builds for now

### DIFF
--- a/test/SIL/Parser/coroutines_failure_merge.sil
+++ b/test/SIL/Parser/coroutines_failure_merge.sil
@@ -1,4 +1,5 @@
 // RUN: not --crash %target-swift-frontend %s -emit-silgen -verify
+// REQUIRES: asserts
 
 sil_stage raw
 

--- a/test/SIL/Parser/coroutines_failure_unwind_return.sil
+++ b/test/SIL/Parser/coroutines_failure_unwind_return.sil
@@ -1,4 +1,5 @@
 // RUN: not --crash %target-swift-frontend %s -emit-silgen -verify
+// REQUIRES: asserts
 
 sil_stage raw
 

--- a/test/SIL/Parser/coroutines_failure_unwind_reuse.sil
+++ b/test/SIL/Parser/coroutines_failure_unwind_reuse.sil
@@ -1,4 +1,5 @@
 // RUN: not --crash %target-swift-frontend %s -emit-silgen -verify
+// REQUIRES: asserts
 
 sil_stage raw
 

--- a/test/SIL/Parser/coroutines_failure_yieldonce_return.sil
+++ b/test/SIL/Parser/coroutines_failure_yieldonce_return.sil
@@ -1,4 +1,5 @@
 // RUN: not --crash %target-swift-frontend %s -emit-silgen -verify
+// REQUIRES: asserts
 
 sil_stage canonical
 

--- a/test/SIL/Parser/coroutines_failure_yieldonce_twice.sil
+++ b/test/SIL/Parser/coroutines_failure_yieldonce_twice.sil
@@ -1,4 +1,5 @@
 // RUN: not --crash %target-swift-frontend %s -emit-silgen -verify
+// REQUIRES: asserts
 
 sil_stage canonical
 


### PR DESCRIPTION
Resolves [SR-6336](https://bugs.swift.org/browse/SR-6336).