### PR TITLE
Code size: copy_addr outline part 2 - Support Archetypes

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -83,10 +83,10 @@ Globals
   global ::= type 'We' // Outlined Consume Function Type
   global ::= type 'Wr' // Outlined Retain Function Type
   global ::= type 'Ws' // Outlined Release Function Type
-  global ::= type 'Wb' // Outlined InitializeWithTake Function Type
-  global ::= type 'Wc' // Outlined InitializeWithCopy Function Type
-  global ::= type 'Wd' // Outlined AssignWithTake Function Type
-  global ::= type 'Wf' // Outlined AssignWithCopy Function Type
+  global ::= type 'Wb' INDEX // Outlined InitializeWithTake Function Type
+  global ::= type 'Wc' INDEX // Outlined InitializeWithCopy Function Type
+  global ::= type 'Wd' INDEX // Outlined AssignWithTake Function Type
+  global ::= type 'Wf' INDEX // Outlined AssignWithCopy Function Type
 
   assoc_type_path ::= identifier '_' identifier*
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1688,20 +1688,24 @@ NodePointer Demangler::demangleWitness() {
                              popNode(Node::Kind::Type));
     }
     case 'b': {
-      return createWithChild(Node::Kind::OutlinedInitializeWithTake,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedInitializeWithTake,
+                                popNode(Node::Kind::Type), IndexChild);
     }
     case 'c': {
-      return createWithChild(Node::Kind::OutlinedInitializeWithCopy,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedInitializeWithCopy,
+                                popNode(Node::Kind::Type), IndexChild);
     }
     case 'd': {
-      return createWithChild(Node::Kind::OutlinedAssignWithTake,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedAssignWithTake,
+                                popNode(Node::Kind::Type), IndexChild);
     }
     case 'f': {
-      return createWithChild(Node::Kind::OutlinedAssignWithCopy,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedAssignWithCopy,
+                                popNode(Node::Kind::Type), IndexChild);
     }
 
     default:

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1748,23 +1748,27 @@ void Remangler::mangleOutlinedRelease(Node *node) {
 }
 
 void Remangler::mangleOutlinedInitializeWithTake(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wb";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedInitializeWithCopy(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wc";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedAssignWithTake(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wd";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedAssignWithCopy(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wf";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedVariable(Node *node) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -476,6 +476,17 @@ namespace {
                                          getSingletonType(IGF.IGM, T));
     }
 
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      if (!getSingleton())
+        return;
+      getSingleton()->collectArchetypeMetadata(IGF, typeToMetadataVec,
+                                               getSingletonType(IGF.IGM, T));
+    }
+
     void reexplode(IRGenFunction &IGF, Explosion &src, Explosion &dest)
     const override {
       if (getLoadableSingleton()) getLoadableSingleton()->reexplode(IGF, src, dest);
@@ -873,6 +884,16 @@ namespace {
       // primitive copy.
       llvm::Value *val = IGF.Builder.CreateLoad(src);
       IGF.Builder.CreateStore(val, dest);
+    }
+
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      auto canType = T.getSwiftRValueType();
+      assert(!canType->hasArchetype() &&
+             "collectArchetypeMetadata: no archetype expected here");
     }
 
     static constexpr IsPOD_t IsScalarPOD = IsPOD;
@@ -1300,6 +1321,14 @@ namespace {
       payload.store(IGF, projectPayload(IGF, addr));
       if (ExtraTagBitCount > 0)
         IGF.Builder.CreateStore(e.claimNext(), projectExtraTagBits(IGF, addr));
+    }
+
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      assert(TIK >= Loadable);
     }
 
     void reexplode(IRGenFunction &IGF, Explosion &src, Explosion &dest)
@@ -2596,8 +2625,15 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedAssignWithCopyFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
@@ -2609,8 +2645,15 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedAssignWithTakeFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
@@ -2622,8 +2665,15 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedInitializeWithCopyFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
@@ -2635,13 +2685,38 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedInitializeWithTakeFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
             IGF, *TI, dest, src, T,
             &IRGenModule::getOrCreateOutlinedInitializeWithTakeFunction);
+      }
+    }
+
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      auto canType = T.getSwiftRValueType();
+      if (irgen::mightContainMetadata(IGF.IGM, canType)) {
+        auto *metadata = IGF.emitTypeMetadataRef(canType);
+        assert(metadata && "Expected Type Metadata Ref");
+        typeToMetadataVec.push_back(std::make_pair(canType, metadata));
+      }
+      if (CopyDestroyKind == Normal) {
+        auto payloadT = getPayloadType(IGF.IGM, T);
+        getPayloadTypeInfo().collectArchetypeMetadata(IGF, typeToMetadataVec,
+                                                      payloadT);
       }
     }
 
@@ -4234,8 +4309,15 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedAssignWithCopyFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
@@ -4247,8 +4329,15 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedAssignWithTakeFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
@@ -4260,8 +4349,15 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedInitializeWithCopyFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
@@ -4273,13 +4369,42 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
+      if (IGF.isInOutlinedFunction()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake);
+      } else if (T.hasArchetype()) {
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            typeToMetadataVec;
+        collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+        IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+            IGF, *TI, dest, src, typeToMetadataVec, T,
+            &IRGenModule::getOrCreateGenericOutlinedInitializeWithTakeFunction);
       } else {
         // Create an outlined function to avoid explosion
         IGF.IGM.generateCallToOutlinedCopyAddr(
             IGF, *TI, dest, src, T,
             &IRGenModule::getOrCreateOutlinedInitializeWithTakeFunction);
+      }
+    }
+
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      auto canType = T.getSwiftRValueType();
+      if (irgen::mightContainMetadata(IGF.IGM, canType)) {
+        auto *metadata = IGF.emitTypeMetadataRef(canType);
+        assert(metadata && "Expected Type Metadata Ref");
+        typeToMetadataVec.push_back(std::make_pair(canType, metadata));
+      }
+      if (CopyDestroyKind != Normal) {
+        return;
+      }
+      for (auto &payloadCasePair : ElementsWithPayload) {
+        SILType PayloadT =
+            T.getEnumElementType(payloadCasePair.decl, IGF.getSILModule());
+        auto &payloadTI = *payloadCasePair.ti;
+        payloadTI.collectArchetypeMetadata(IGF, typeToMetadataVec, PayloadT);
       }
     }
 
@@ -4806,6 +4931,20 @@ namespace {
                                  dest, src);
     }
 
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      auto canType = T.getSwiftRValueType();
+      if (!irgen::mightContainMetadata(IGF.IGM, canType)) {
+        return;
+      }
+      auto *metadata = IGF.emitTypeMetadataRef(canType);
+      assert(metadata && "Expected Type Metadata Ref");
+      typeToMetadataVec.push_back(std::make_pair(canType, metadata));
+    }
+
     void destroy(IRGenFunction &IGF, Address addr, SILType T) const override {
       emitDestroyCall(IGF, T, addr);
     }
@@ -5183,6 +5322,13 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest,
                             Address src, SILType T) const override {
       return Strategy.initializeWithTake(IGF, dest, src, T);
+    }
+    void collectArchetypeMetadata(
+        IRGenFunction &IGF,
+        llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+            &typeToMetadataVec,
+        SILType T) const override {
+      return Strategy.collectArchetypeMetadata(IGF, typeToMetadataVec, T);
     }
     void assignWithCopy(IRGenFunction &IGF, Address dest,
                         Address src, SILType T) const override {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2596,8 +2596,7 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -2610,8 +2609,7 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -2624,8 +2622,7 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -2638,8 +2635,7 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4238,8 +4234,7 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4252,8 +4247,7 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4266,8 +4260,7 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4280,8 +4273,7 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -429,6 +429,12 @@ public:
   virtual llvm::Value *loadRefcountedPtr(IRGenFunction &IGF, SourceLoc loc,
                                          Address addr) const;
 
+  virtual void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType T) const = 0;
+
 private:
   EnumImplStrategy(const EnumImplStrategy &) = delete;
   EnumImplStrategy &operator=(const EnumImplStrategy &) = delete;

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -307,6 +307,10 @@ namespace irgen {
   /// Get the runtime identifier for a special protocol, if any.
   SpecialProtocol getSpecialProtocolID(ProtocolDecl *P);
 
+  /// Use the argument as the 'self' type metadata.
+  void getArgAsLocalSelfTypeMetadata(IRGenFunction &IGF, llvm::Value *arg,
+                                     CanType abstractType);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -137,27 +137,45 @@ public:
 
   void assignWithCopy(IRGenFunction &IGF, Address dest,
                       Address src, SILType T) const override {
-    auto offsets = asImpl().getNonFixedOffsets(IGF, T);
-    for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
+    if (IGF.isInOutlinedFunction()) {
+      auto offsets = asImpl().getNonFixedOffsets(IGF, T);
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
 
-      Address destField = field.projectAddress(IGF, dest, offsets);
-      Address srcField = field.projectAddress(IGF, src, offsets);
-      field.getTypeInfo().assignWithCopy(IGF, destField, srcField,
-                                         field.getType(IGF.IGM, T));
+        Address destField = field.projectAddress(IGF, dest, offsets);
+        Address srcField = field.projectAddress(IGF, src, offsets);
+        field.getTypeInfo().assignWithCopy(IGF, destField, srcField,
+                                           field.getType(IGF.IGM, T));
+      }
+    } else {
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4> typeToMetadataVec;
+      collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+      IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+          IGF, *this, dest, src, typeToMetadataVec, T,
+          &IRGenModule::getOrCreateGenericOutlinedAssignWithCopyFunction);
     }
   }
 
   void assignWithTake(IRGenFunction &IGF, Address dest,
                       Address src, SILType T) const override {
-    auto offsets = asImpl().getNonFixedOffsets(IGF, T);
-    for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
+    if (IGF.isInOutlinedFunction()) {
+      auto offsets = asImpl().getNonFixedOffsets(IGF, T);
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
 
-      Address destField = field.projectAddress(IGF, dest, offsets);
-      Address srcField = field.projectAddress(IGF, src, offsets);
-      field.getTypeInfo().assignWithTake(IGF, destField, srcField,
-                                         field.getType(IGF.IGM, T));
+        Address destField = field.projectAddress(IGF, dest, offsets);
+        Address srcField = field.projectAddress(IGF, src, offsets);
+        field.getTypeInfo().assignWithTake(IGF, destField, srcField,
+                                           field.getType(IGF.IGM, T));
+      }
+    } else {
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4> typeToMetadataVec;
+      collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+      IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+          IGF, *this, dest, src, typeToMetadataVec, T,
+          &IRGenModule::getOrCreateGenericOutlinedAssignWithTakeFunction);
     }
   }
 
@@ -171,15 +189,23 @@ public:
                LoadableTypeInfo::initializeWithCopy(IGF, dest, src, T);
     }
 
-    auto offsets = asImpl().getNonFixedOffsets(IGF, T);
-    for (auto &field : getFields()) {
-      if (field.isEmpty())
-        continue;
+    if (IGF.isInOutlinedFunction()) {
+      auto offsets = asImpl().getNonFixedOffsets(IGF, T);
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
 
-      Address destField = field.projectAddress(IGF, dest, offsets);
-      Address srcField = field.projectAddress(IGF, src, offsets);
-      field.getTypeInfo().initializeWithCopy(IGF, destField, srcField,
-                                             field.getType(IGF.IGM, T));
+        Address destField = field.projectAddress(IGF, dest, offsets);
+        Address srcField = field.projectAddress(IGF, src, offsets);
+        field.getTypeInfo().initializeWithCopy(IGF, destField, srcField,
+                                               field.getType(IGF.IGM, T));
+      }
+    } else {
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4> typeToMetadataVec;
+      collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+      IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+          IGF, *this, dest, src, typeToMetadataVec, T,
+          &IRGenModule::getOrCreateGenericOutlinedInitializeWithCopyFunction);
     }
   }
   
@@ -193,15 +219,24 @@ public:
                  std::min(dest.getAlignment(), src.getAlignment()).getValue());
       return;
     }
-    
-    auto offsets = asImpl().getNonFixedOffsets(IGF, T);
-    for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
-      
-      Address destField = field.projectAddress(IGF, dest, offsets);
-      Address srcField = field.projectAddress(IGF, src, offsets);
-      field.getTypeInfo().initializeWithTake(IGF, destField, srcField,
-                                             field.getType(IGF.IGM, T));
+
+    if (IGF.isInOutlinedFunction()) {
+      auto offsets = asImpl().getNonFixedOffsets(IGF, T);
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
+
+        Address destField = field.projectAddress(IGF, dest, offsets);
+        Address srcField = field.projectAddress(IGF, src, offsets);
+        field.getTypeInfo().initializeWithTake(IGF, destField, srcField,
+                                               field.getType(IGF.IGM, T));
+      }
+    } else {
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4> typeToMetadataVec;
+      collectArchetypeMetadata(IGF, typeToMetadataVec, T);
+      IGF.IGM.generateCallToGenericOutlinedCopyAddr(
+          IGF, *this, dest, src, typeToMetadataVec, T,
+          &IRGenModule::getOrCreateGenericOutlinedInitializeWithTakeFunction);
     }
   }
 
@@ -212,6 +247,26 @@ public:
 
       field.getTypeInfo().destroy(IGF, field.projectAddress(IGF, addr, offsets),
                                   field.getType(IGF.IGM, T));
+    }
+  }
+
+  void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType T) const override {
+    auto canType = T.getSwiftRValueType();
+    if (irgen::mightContainMetadata(IGF.IGM, canType)) {
+      auto *metadata = IGF.emitTypeMetadataRef(canType);
+      assert(metadata && "Expected Type Metadata Ref");
+      typeToMetadataVec.push_back(std::make_pair(canType, metadata));
+    }
+    for (auto &field : getFields()) {
+      if (field.isEmpty())
+        continue;
+      auto fType = field.getType(IGF.IGM, T);
+      field.getTypeInfo().collectArchetypeMetadata(IGF, typeToMetadataVec,
+                                                   fType);
     }
   }
 };

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -429,3 +429,8 @@ void IRGenFunction::setInOutlinedFunction() {
   assert(!isInOutlinedFunction() && "Expected inOutlinedFunction to be false");
   inOutlinedFunction = true;
 }
+
+void IRGenFunction::setNotInOutlinedFunction() {
+  assert(isInOutlinedFunction() && "Expected inOutlinedFunction to be true");
+  inOutlinedFunction = false;
+}

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -560,6 +560,7 @@ public:
 public:
   bool isInOutlinedFunction();
   void setInOutlinedFunction();
+  void setNotInOutlinedFunction();
 
 private:
   LocalTypeDataCache &getOrCreateLocalTypeData();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -715,10 +715,22 @@ public:
   typedef llvm::Constant *(IRGenModule::*OutlinedCopyAddrFunction)(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy);
 
+  typedef llvm::Constant *(IRGenModule::*GenericOutlinedCopyAddrFunction)(
+      const TypeInfo &objectTI, llvm::Type *llvmType,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType addrTy);
+
   void
   generateCallToOutlinedCopyAddr(IRGenFunction &IGF, const TypeInfo &objectTI,
                                  Address dest, Address src, SILType T,
                                  const OutlinedCopyAddrFunction MethodToCall);
+
+  void generateCallToGenericOutlinedCopyAddr(
+      IRGenFunction &IGF, const TypeInfo &objectTI, Address dest, Address src,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType T, const GenericOutlinedCopyAddrFunction MethodToCall);
 
   llvm::Constant *getOrCreateOutlinedInitializeWithTakeFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy);
@@ -732,12 +744,47 @@ public:
   llvm::Constant *getOrCreateOutlinedAssignWithCopyFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy);
 
+  llvm::Constant *getOrCreateGenericOutlinedInitializeWithTakeFunction(
+      const TypeInfo &objectTI, llvm::Type *llvmType,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType addrTy);
+
+  llvm::Constant *getOrCreateGenericOutlinedInitializeWithCopyFunction(
+      const TypeInfo &objectTI, llvm::Type *llvmType,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType addrTy);
+
+  llvm::Constant *getOrCreateGenericOutlinedAssignWithTakeFunction(
+      const TypeInfo &objectTI, llvm::Type *llvmType,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType addrTy);
+
+  llvm::Constant *getOrCreateGenericOutlinedAssignWithCopyFunction(
+      const TypeInfo &objectTI, llvm::Type *llvmType,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType addrTy);
+
+  unsigned getCanTypeID(const CanType type);
+
 private:
   llvm::Constant *getAddrOfClangGlobalDecl(clang::GlobalDecl global,
                                            ForDefinition_t forDefinition);
   llvm::Constant *getOrCreateOutlinedCopyAddrHelperFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy,
       std::string funcName,
+      llvm::function_ref<void(const TypeInfo &objectTI, IRGenFunction &IGF,
+                              Address dest, Address src, SILType T)>
+          Generate);
+
+  llvm::Constant *getOrCreateGenericOutlinedCopyAddrHelperFunction(
+      const TypeInfo &objectTI, llvm::Type *llvmType,
+      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType addrTy, std::string funcName,
       llvm::function_ref<void(const TypeInfo &objectTI, IRGenFunction &IGF,
                               Address dest, Address src, SILType T)>
           Generate);
@@ -824,6 +871,10 @@ private:
   /// A mapping from order numbers to the LLVM functions which we
   /// created for the SIL functions with those orders.
   SuccessorMap<unsigned, llvm::Function*> EmittedFunctionsByOrder;
+
+  /// Mapping from archetype-containing CanType to UniqueID (for outline)
+  llvm::DenseMap<const swift::TypeBase *, unsigned> typeToUniqueID;
+  unsigned currUniqueID = 0;
 
   ObjCProtocolPair getObjCProtocolGlobalVars(ProtocolDecl *proto);
   void emitLazyObjCProtocolDefinitions();

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -477,6 +477,14 @@ public:
                                    Address src, llvm::Value *count,
                                    SILType T) const;
 
+  /// Outlining helper function: recursively traverse the SILType:
+  /// When encountering an Archetype - add it to a type-metadata vec.
+  virtual void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType T) const;
+
   /// Get the native (abi) convention for a return value of this type.
   const NativeConventionSchema &nativeReturnValueSchema(IRGenModule &IGM) const;
 
@@ -489,6 +497,7 @@ public:
                       llvm::Value *typeMetadata,
                       SILType T) const;
 };
+bool mightContainMetadata(const IRGenModule &IGM, const CanType type);
 
 } // end namespace irgen
 } // end namespace swift

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -24,27 +24,42 @@ enum NullableRefcounted {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases18NullableRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases18NullableRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases18NullableRefcountedO* @_T034enum_value_semantics_special_cases18NullableRefcountedOWc(%T34enum_value_semantics_special_cases18NullableRefcountedO* %1, %T34enum_value_semantics_special_cases18NullableRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
+// CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %3, align 8
+// CHECK:   %5 = call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %4) #2
+// CHECK:   store %swift.refcounted* %4, %swift.refcounted** %2, align 8
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases18NullableRefcountedOwca(%swift.opaque* %dest, %swift.opaque* %src, %swift.type* %NullableRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases18NullableRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases18NullableRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases18NullableRefcountedO* @_T034enum_value_semantics_special_cases18NullableRefcountedOWf(%T34enum_value_semantics_special_cases18NullableRefcountedO* %1, %T34enum_value_semantics_special_cases18NullableRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
+// CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
+// CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
+// CHECK:   %6 = call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5) #2
+// CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) #2
+// CHECK:   %7 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %7
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases18NullableRefcountedOwta(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %NullableRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases18NullableRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases18NullableRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases18NullableRefcountedO* @_T034enum_value_semantics_special_cases18NullableRefcountedOWd(%T34enum_value_semantics_special_cases18NullableRefcountedO* %1, %T34enum_value_semantics_special_cases18NullableRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
+// CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
+// CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
+// CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) #2
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // Enums consisting of a retainable block pointer and a single empty case use
@@ -67,27 +82,42 @@ enum NullableBlockRefcounted {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
-// CHECK:   %2 =  call %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOWc(%T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1, %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %objc_block**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1 to %objc_block**
+// CHECK:   %4 = load %objc_block*, %objc_block** %3, align 8
+// CHECK:   %5 = call %objc_block* @_Block_copy(%objc_block* %4)
+// CHECK:   store %objc_block* %4, %objc_block** %2, align 8
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOwca(%swift.opaque* %dest, %swift.opaque* %src, %swift.type* %NullableBlockRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOWf(%T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1, %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %objc_block**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1 to %objc_block**
+// CHECK:   %4 = load %objc_block*, %objc_block** %2, align 8
+// CHECK:   %5 = load %objc_block*, %objc_block** %3, align 8
+// CHECK:   %6 = call %objc_block* @_Block_copy(%objc_block* %5)
+// CHECK:   store %objc_block* %5, %objc_block** %2, align 8
+// CHECK:   call void @_Block_release(%objc_block* %4) #2
+// CHECK:   %7 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %7
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOwta(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %NullableBlockRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOWd(%T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1, %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %objc_block**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1 to %objc_block**
+// CHECK:   %4 = load %objc_block*, %objc_block** %2, align 8
+// CHECK:   %5 = load %objc_block*, %objc_block** %3, align 8
+// CHECK:   store %objc_block* %5, %objc_block** %2, align 8
+// CHECK:   call void @_Block_release(%objc_block* %4) #2
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // With multiple empty cases, the nullable pointer semantics aren't used.
@@ -134,16 +164,6 @@ enum AllRefcounted {
   case None
 }
 
-// CHECK-LABEL: define linkonce_odr hidden %T34enum_value_semantics_special_cases13AllRefcountedO* @_T034enum_value_semantics_special_cases13AllRefcountedOWc(%T34enum_value_semantics_special_cases13AllRefcountedO*, %T34enum_value_semantics_special_cases13AllRefcountedO*)
-// --                              0x3fffffffffffffff
-// CHECK:         %4 = and i64 %3, 4611686018427387903
-// CHECK:         %5 = inttoptr i64 %4 to %swift.refcounted*
-// CHECK:         call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5)
-// CHECK:         %7 = bitcast %T34enum_value_semantics_special_cases13AllRefcountedO* %1 to i64*
-// -- NB: The original loaded value is stored, not the masked one.
-// CHECK:         store i64 %3, i64* %7, align 8
-// CHECK: }
-
 // CHECK-LABEL: define linkonce_odr hidden void @_T034enum_value_semantics_special_cases13AllRefcountedOwxx(%swift.opaque* noalias %object, %swift.type* %AllRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %object to %T34enum_value_semantics_special_cases13AllRefcountedO*
@@ -154,6 +174,16 @@ enum AllRefcounted {
 // CHECK:   %4 = inttoptr i64 %3 to %swift.refcounted*
 // CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK:   ret void
+// CHECK: }
+
+// CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases13AllRefcountedOwcp(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %AllRefcounted)
+// --                              0x3fffffffffffffff
+// CHECK:         %4 = and i64 %3, 4611686018427387903
+// CHECK:         %5 = inttoptr i64 %4 to %swift.refcounted*
+// CHECK:         call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5)
+// CHECK:         %6 = bitcast %T34enum_value_semantics_special_cases13AllRefcountedO* %0 to i64*
+// -- NB: The original loaded value is stored, not the masked one.
+// CHECK:         store i64 %3, i64* %6, align 8
 // CHECK: }
 
 enum AllRefcountedTwoSimple {

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -67,16 +67,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWb({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWb_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWd({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWd_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWc({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWc_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWf({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWf_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
 
   // CHECK: [[REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -39,10 +39,10 @@ bb0(%0 : $*Any, %1 : $*Any):
 }
 
 // CHECK-DAG:   define{{( protected)?}} swiftcc void @take_opaque_existential([[ANY:%Any]]* noalias nocapture sret, %Any* noalias nocapture dereferenceable({{.*}})) {{.*}} {
-// CHECK: call %Any* @_T0ypWb(%Any* %1, %Any* %0)
+// CHECK: call %Any* @_T0ypWb_(%Any* %1, %Any* %0)
 // CHECK-NEXT:    ret void
 
-// CHECK-DAG:   define{{( protected)?}} linkonce_odr hidden %Any* @_T0ypWb([[ANY:%Any]]*, %Any*)
+// CHECK-DAG:   define{{( protected)?}} linkonce_odr hidden %Any* @_T0ypWb_([[ANY:%Any]]*, %Any*)
 // CHECK:         [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[SRC:%0]], i32 0, i32 1
 // CHECK-NEXT:    [[TYPE:%.*]] = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[DEST:%1]], i32 0, i32 1
@@ -138,16 +138,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWb({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWb_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWd({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWd_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWc({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWc_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWf({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWf_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
 
   // CHECK: [[REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -432,7 +432,7 @@ bb0(%0 : $*Existential):
 // CHECK: define{{( protected)?}} swiftcc void @test_assignWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
-// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
+// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
 // CHECK:   ret void
 sil @test_assignWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -443,7 +443,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 // CHECK:   [[LOCAL_METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1
@@ -465,7 +465,7 @@ bb0(%0 : $*Existential):
 
 // CHECK: define{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
+// CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
 sil @test_initWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -478,9 +478,9 @@ bb0(%0 : $*Existential):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @test_initWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
+// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[TYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[ARG_TYPE:%.*]] = load %swift.type*, %swift.type** [[TYPE_ADDR]]
 // CHECK:   [[LOCAL_TYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -214,9 +214,7 @@ sil public_external @indirect_consumed_captured_class_pair_param : $@convention(
 
 // CHECK:       define internal swiftcc i64 [[PARTIAL_APPLY_FORWARDER]]
 // CHECK:         [[X_TMP:%.*]] = alloca
-// CHECK:         retain
-// CHECK:         retain
-// CHECK-NOT:     retain
+// CHECK:         call %T13partial_apply14SwiftClassPairV* @_T013partial_apply14SwiftClassPairVWc_
 // CHECK:         release{{.*}}%1)
 // CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_pair_param(i64 %0, %T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}) [[X_TMP]])
 // CHECK:         ret i64 [[RESULT]]

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -61,7 +61,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[PV:%0]])
   store_unowned %p to [initialization] %x : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWc({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWc_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr %x to [initialization] %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
@@ -73,7 +73,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call void @swift_unknownRelease([[UNKNOWN]]* [[TV]])
   strong_release %t0 : $P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWf({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWf_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr %x to %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
@@ -82,10 +82,10 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedAssign(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[QV:%2]])
   store_unowned %q to %y : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWd({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWd_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr [take] %x to %y : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWb({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWb_({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
   copy_addr [take] %y to [initialization] %x : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0


### PR DESCRIPTION
radar rdar://problem/33942466

Part two of `copy_addr`outlining: supports passing the Metatype information to the outlined function / outlining `CanType` that contain Archetypes