### PR TITLE
Check if the checkout has been --clone'd yet

### DIFF
--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -479,9 +479,13 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
                                                             skip_history,
                                                             skip_repo_list)
 
-    if len([p for p in os.listdir(SWIFT_SOURCE_ROOT) if os.path.isdir(p)]) == 1:
-        # If there's only one folder in the root directory, it means they still have to clone all the other projects.
-        print("You only have the /swift directory. You may want to call this script with --clone to get the rest.")
+    # Quick check whether somebody is calling update in an empty directory
+    directory_contents = os.listdir(SWIFT_SOURCE_ROOT)
+    if not ('cmark' in directory_contents and 
+        'llvm' in directory_contents and
+        'clang' in directory_contents):
+        print("You don't have all swift sources. "
+        "Call this script with --clone to get them.")
 
     update_results = update_all_repositories(args, config, scheme,
                                              cross_repos_pr)

--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -479,6 +479,10 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
                                                             skip_history,
                                                             skip_repo_list)
 
+    if len([p for p in os.listdir(SWIFT_SOURCE_ROOT) if os.path.isdir(p)]) == 1:
+        # If there's only one folder in the root directory, it means they still have to clone all the other projects.
+        print("You only have the /swift directory. You may want to call this script with --clone to get the rest.")
+
     update_results = update_all_repositories(args, config, scheme,
                                              cross_repos_pr)
     fail_count = 0

--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -481,8 +481,8 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
     # Quick check whether somebody is calling update in an empty directory
     directory_contents = os.listdir(SWIFT_SOURCE_ROOT)
-    if not ('cmark' in directory_contents and 
-        'llvm' in directory_contents and
+    if not ('cmark' in directory_contents or 
+        'llvm' in directory_contents or
         'clang' in directory_contents):
         print("You don't have all swift sources. "
         "Call this script with --clone to get them.")

--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -482,10 +482,10 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     # Quick check whether somebody is calling update in an empty directory
     directory_contents = os.listdir(SWIFT_SOURCE_ROOT)
     if not ('cmark' in directory_contents or 
-        'llvm' in directory_contents or
-        'clang' in directory_contents):
+            'llvm' in directory_contents or
+            'clang' in directory_contents):
         print("You don't have all swift sources. "
-        "Call this script with --clone to get them.")
+              "Call this script with --clone to get them.")
 
     update_results = update_all_repositories(args, config, scheme,
                                              cross_repos_pr)


### PR DESCRIPTION
As requested in SR-6312 a simple diagnostic to catch the error of not passing --clone the first time you run update-checkout. Checks whether there is just one directory (i.e. the swift/ directory) in SWIFT_SOURCE_ROOT and prints a message.

Resolves [SR-6312](https://bugs.swift.org/browse/SR-6312)

This doesn't touch Swift itself, so I'm not sure whether it requires a CI test.