### PR TITLE
IRGen: emitObjCPartialApplicationForwarder support @callee_guaranteed

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -908,7 +908,8 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
       subIGF.emitObjCAutoreleaseCall(self);
     }
     // Release the context.
-    subIGF.emitNativeStrongRelease(context, subIGF.getDefaultAtomicity());
+    if (!resultType->isCalleeGuaranteed())
+      subIGF.emitNativeStrongRelease(context, subIGF.getDefaultAtomicity());
   };
   
    // Emit the call and produce the return value.

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -225,3 +225,49 @@ entry(%c : $Gizmo):
   %p = partial_apply %m(%c) : $@convention(objc_method) (Fob,  Gizmo) -> ()
   return %p : $@callee_owned (Fob) -> ()
 }
+
+// CHECK-LABEL: define {{.*}}@objc_partial_apply_callee_guaranteed
+// CHECK:  [[CONTEXT:%.*]] = call {{.*}}@swift_rt_swift_allocObject
+// CHECK:  store
+// CHECK:  [[CLOSURE:%.*]] = insertvalue {{.*}}@_T0Ta.20{{.*}}, {{.*}}[[CONTEXT]], 1
+// CHECK: ret {{.*}}[[CLOSURE]]
+
+sil @objc_partial_apply_callee_guaranteed : $@convention(thin) ObjCClass -> @callee_guaranteed Int -> () {
+entry(%c : $ObjCClass):
+  %m = objc_method %c : $ObjCClass, #ObjCClass.method!1.foreign : (ObjCClass) -> (Int) -> (), $@convention(objc_method) (Int, ObjCClass) -> ()
+  %p = partial_apply [callee_guaranteed] %m(%c) : $@convention(objc_method) (Int, ObjCClass) -> ()
+  return %p : $@callee_guaranteed Int -> ()
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @_T0Ta.20(i64, %swift.refcounted* swiftself)
+// CHECK: entry:
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK:   call {{.*}}@objc_msgSend
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK:   ret void
+// CHECK: }
+
+// CHECK-LABEL: define {{.*}}@objc_partial_apply_2_callee_guaranteed
+// CHECK:  [[CONTEXT:%.*]] = call {{.*}}@swift_rt_swift_allocObject
+// CHECK: store
+// CHECK:  [[CLOSURE:%.*]] = insertvalue {{.*}}@_T0Ta.23{{.*}}, {{.*}}[[CONTEXT]], 1
+// CHECK: ret {{.*}}[[CLOSURE]]
+
+sil @objc_partial_apply_2_callee_guaranteed : $@convention(thin) Gizmo -> @callee_guaranteed (Fob) -> () {
+entry(%c : $Gizmo):
+  %m = objc_method %c : $Gizmo, #Gizmo.test!1.foreign : (Gizmo) -> (Fob) -> (), $@convention(objc_method) (Fob,  Gizmo) -> ()
+  %p = partial_apply [callee_guaranteed] %m(%c) : $@convention(objc_method) (Fob,  Gizmo) -> ()
+  return %p : $@callee_guaranteed (Fob) -> ()
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @_T0Ta.23(i64, i64, i64, %swift.refcounted* swiftself)
+// CHECK: entry:
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK:   call {{.*}}@objc_msgSend
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK:   ret void
+// CHECK: }


### PR DESCRIPTION
@callee_guaranteed closure applications don't own their context.

SR-5441
rdar://33255593