### PR TITLE
Update SwiftSyntax's expectations now that -emit-syntax is emitting a SourceFileSyntax

### DIFF
--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -37,12 +37,10 @@ extension Syntax {
       throw ParserError.swiftcFailed(result.exitCode, result.stderr)
     }
     let decoder = JSONDecoder()
-    let raw = try decoder.decode([RawSyntax].self, from: result.stdoutData)
-    let topLevelNodes = raw.map { Syntax.fromRaw($0) }
-    let eof = topLevelNodes.last! as! TokenSyntax
-    let decls = Array(topLevelNodes.dropLast()) as! [DeclSyntax]
-    let declList = SyntaxFactory.makeDeclList(decls)
-    return SyntaxFactory.makeSourceFile(topLevelDecls: declList,
-                                        eofToken: eof)
+    let raw = try decoder.decode(RawSyntax.self, from: result.stdoutData)
+    guard let file = Syntax.fromRaw(raw) as? SourceFileSyntax else {
+      throw ParserError.invalidFile
+    }
+    return file
   }
 }


### PR DESCRIPTION
Prior to this patch, SwiftSyntax expected an array of top-level decls, plus an EOF token, as the output of `swiftc -c -emit-syntax`. Since #12850, the JSON is now just a `SourceFileSyntax` node, which simplifies the logic throughout. This patch updates SwiftSyntax so it properly deserializes.