### PR TITLE
SILCombine and SIL adjustFunctionType fix for @callee_guaranteed

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -79,18 +79,22 @@ adjustFunctionType(CanSILFunctionType type, SILFunctionType::ExtInfo extInfo,
 }
 inline CanSILFunctionType
 adjustFunctionType(CanSILFunctionType t, SILFunctionType::Representation rep,
-                   Optional<ProtocolConformanceRef> witnessMethodConformance) {
+                   Optional<ProtocolConformanceRef> witnessMethodConformance,
+                   bool UseGuaranteedClosures) {
   if (t->getRepresentation() == rep) return t;
   auto extInfo = t->getExtInfo().withRepresentation(rep);
-
-  return adjustFunctionType(
-      t, extInfo, extInfo.hasContext() ? DefaultThickCalleeConvention
-                                       : ParameterConvention::Direct_Unowned,
-      witnessMethodConformance);
+  auto contextConvention = UseGuaranteedClosures
+                               ? ParameterConvention::Direct_Guaranteed
+                               : DefaultThickCalleeConvention;
+  return adjustFunctionType(t, extInfo,
+                            extInfo.hasContext()
+                                ? contextConvention
+                                : ParameterConvention::Direct_Unowned,
+                            witnessMethodConformance);
 }
 inline CanSILFunctionType
-adjustFunctionType(CanSILFunctionType t, SILFunctionType::Representation rep) {
-  return adjustFunctionType(t, rep, t->getWitnessMethodConformanceOrNone());
+adjustFunctionType(CanSILFunctionType t, SILFunctionType::Representation rep, bool UseGuaranteedClosures) {
+  return adjustFunctionType(t, rep, t->getWitnessMethodConformanceOrNone(), UseGuaranteedClosures);
 }
   
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1890,9 +1890,11 @@ static ManagedValue convertFunctionRepresentation(SILGenFunction &SGF,
   case AnyFunctionType::Representation::Swift: {
     switch (sourceTy->getRepresentation()) {
     case SILFunctionType::Representation::Thin: {
-      auto v = SGF.B.createThinToThickFunction(loc, source.getValue(),
-        SILType::getPrimitiveObjectType(
-         adjustFunctionType(sourceTy, SILFunctionType::Representation::Thick)));
+      auto v = SGF.B.createThinToThickFunction(
+          loc, source.getValue(),
+          SILType::getPrimitiveObjectType(adjustFunctionType(
+              sourceTy, SILFunctionType::Representation::Thick,
+              SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts)));
       // FIXME: what if other reabstraction is required?
       return ManagedValue(v, source.getCleanup());
     }
@@ -1916,9 +1918,11 @@ static ManagedValue convertFunctionRepresentation(SILGenFunction &SGF,
     switch (sourceTy->getRepresentation()) {
     case SILFunctionType::Representation::Thin: {
       // Make thick first.
-      auto v = SGF.B.createThinToThickFunction(loc, source.getValue(),
-        SILType::getPrimitiveObjectType(
-         adjustFunctionType(sourceTy, SILFunctionType::Representation::Thick)));
+      auto v = SGF.B.createThinToThickFunction(
+          loc, source.getValue(),
+          SILType::getPrimitiveObjectType(adjustFunctionType(
+              sourceTy, SILFunctionType::Representation::Thick,
+              SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts)));
       source = ManagedValue(v, source.getCleanup());
       LLVM_FALLTHROUGH;
     }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2820,12 +2820,15 @@ CanSILFunctionType SILGenFunction::buildThunkType(
       extInfo = extInfo.withIsPseudogeneric();
 
   // Add the function type as the parameter.
+  auto contextConvention = SGM.M.getOptions().EnableGuaranteedClosureContexts
+                               ? ParameterConvention::Direct_Guaranteed
+                               : DefaultThickCalleeConvention;
   SmallVector<SILParameterInfo, 4> params;
   params.append(expectedType->getParameters().begin(),
                 expectedType->getParameters().end());
   params.push_back({sourceType,
                     sourceType->getExtInfo().hasContext()
-                      ? DefaultThickCalleeConvention
+                      ? contextConvention
                       : ParameterConvention::Direct_Unowned});
 
   // Map the parameter and expected types out of context to get the interface

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -251,8 +251,9 @@ SILFunction *CapturePropagation::specializeConstClosure(PartialApplyInst *PAI,
   // expressed as literals. So its callee signature will be the same as its
   // return signature.
   auto NewFTy = getPartialApplyInterfaceResultType(PAI);
-  NewFTy = Lowering::adjustFunctionType(NewFTy,
-                                        SILFunctionType::Representation::Thin);
+  NewFTy = Lowering::adjustFunctionType(
+      NewFTy, SILFunctionType::Representation::Thin,
+      OrigF->getModule().getOptions().EnableGuaranteedClosureContexts);
 
   GenericEnvironment *GenericEnv = nullptr;
   if (NewFTy->getGenericSignature())

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -328,7 +328,9 @@ bool PartialApplyCombiner::processSingleApply(FullApplySite AI) {
     for (auto Arg : ToBeReleasedArgs) {
       Builder.emitDestroyValueOperation(PAI->getLoc(), Arg);
     }
-    Builder.createStrongRelease(AI.getLoc(), PAI, Builder.getDefaultAtomicity());
+    if (!PAI->hasCalleeGuaranteedContext())
+      Builder.createStrongRelease(AI.getLoc(), PAI,
+                                  Builder.getDefaultAtomicity());
     Builder.setInsertionPoint(TAI->getErrorBB()->begin());
     // Release the non-consumed parameters.
     for (auto Arg : ToBeReleasedArgs) {

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -463,3 +463,37 @@ bb0(%0: $C):
   apply %closure() : $@callee_guaranteed () -> ()
   return %closure : $@callee_guaranteed () -> ()
 }
+
+sil @guaranteed_closure_throws : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @error Error
+
+// CHECK: sil @test_guaranteed_closure_try_apply
+// CHECK: bb0(%0 : $C, %1 : $Builtin.Int32):
+// CHECK:   strong_retain %0 : $C
+// CHECK:   [[FUN:%.*]] = function_ref @guaranteed_closure_throws
+// CHECK:   [[CL:%.*]] = partial_apply [callee_guaranteed] [[FUN]](%1)
+// CHECK:   try_apply [[FUN]](%0, %1)
+// CHECK: bb1({{.*}}):
+// CHECK-NOT:   strong_release
+// CHECK:   br bb3
+// CHECK: bb2({{.*}}):
+// CHECK-NOT:   strong_release
+// CHECK:   br bb3
+// CHECK: bb3:
+// CHECK:   return [[CL]]
+
+sil @test_guaranteed_closure_try_apply : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @owned @callee_guaranteed (@guaranteed C) -> @error Error {
+bb0(%0: $C, %1: $Builtin.Int32):
+  strong_retain %0 : $C
+  %closure_fun = function_ref @guaranteed_closure_throws : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @error Error
+  %closure = partial_apply [callee_guaranteed] %closure_fun(%1) : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @error Error
+  try_apply %closure(%0) : $@callee_guaranteed (@guaranteed C) -> @error Error, normal bb7, error bb11
+
+bb7(%callret : $()):
+  br bb99
+
+bb11(%128 : $Error):
+  br bb99
+
+bb99:
+  return %closure : $@callee_guaranteed (@guaranteed C) -> @error Error
+}


### PR DESCRIPTION
- SIL: Make adjustFunction type of closures parameterized on whether we use
guaranteed closures
This is going to go away once we change the default to guaranteed
closures.

- SILCombine: Fix @callee_guaranteed combine of try_apply
I missed another place where we were releasing the context.

SR-5441
rdar://33255593