### PR TITLE
[NamedLazyMemberLoading] Don't self-add extn members to partial tables.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1176,7 +1176,8 @@ void ExtensionDecl::addedMember(Decl *member) {
       return;
 
     auto nominal = getExtendedType()->getAnyNominal();
-    if (nominal->LookupTable.getPointer()) {
+    if (nominal->LookupTable.getPointer() &&
+        nominal->LookupTable.getInt()) {
       // Make sure we have the complete list of extensions.
       // FIXME: This is completely unnecessary. We want to determine whether
       // our own extension has already been included in the lookup table.


### PR DESCRIPTION
This fixes a vexing edge case that I was worried about back when I pushed the initial NLML-support for extensions (see foolishly naive comment in https://github.com/apple/swift/pull/12741#issuecomment-341886732). Of course, there's a case that's _not_ guarded by E->wasDeserialized(), which is the extensions-from-source-files that are (apparently!) lazily-loaded too. Those need to be inhibited from adding their members to partial lookup tables, which is what this patch does.

(As for why they were self-adding to lookup tables in the first place -- see the "FIXME: This is completely unnecessary" comment -- I do not actually know, for certain. But this makes the potentially unnecessary codepath here strictly more correct in the face of NLML so I think it's worth taking!)