### PR TITLE
Argparse "Overlay" Module

### DIFF
--- a/utils/build_swift/README.md
+++ b/utils/build_swift/README.md
@@ -8,5 +8,5 @@ the Swift build-script.
 You may run the unit test suite using the command:
 
 ```sh
-$ python -m unittest discover -s utils/build_swift
+$ python -m unittest discover -s utils/build_swift -t utils/
 ```

--- a/utils/build_swift/README.md
+++ b/utils/build_swift/README.md
@@ -8,5 +8,5 @@ the Swift build-script.
 You may run the unit test suite using the command:
 
 ```sh
-$ python -m unittest discover -s utils/build_swift -t utils/
+$ python -m unittest discover -s utils/build_swift/ -t utils/
 ```

--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -6,6 +6,13 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+"""
+Wrapper module around the standard argparse that extends the default
+functionality with support for multi-destination actions, an expressive DSL for
+constructing parsers and more argument types. This module exposes a strict
+super-set of the argparse API and is meant to be used as a drop-in replacement.
+"""
+
 
 from argparse import (ArgumentDefaultsHelpFormatter, ArgumentError,
                       ArgumentTypeError, FileType, HelpFormatter,

--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -12,11 +12,11 @@ from argparse import (ArgumentDefaultsHelpFormatter, ArgumentError,
                       Namespace, RawDescriptionHelpFormatter,
                       RawTextHelpFormatter)
 
-from argparse import SUPPRESS, OPTIONAL, ZERO_OR_MORE, ONE_OR_MORE
+from argparse import ONE_OR_MORE, OPTIONAL, SUPPRESS, ZERO_OR_MORE
 
 from .actions import Action, Nargs
 from .parser import ArgumentParser
-from .types import PathType, RegexType, ClangVersionType, SwiftVersionType
+from .types import ClangVersionType, PathType, RegexType, SwiftVersionType
 
 
 __all__ = [

--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -6,6 +6,7 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+
 """
 Wrapper module around the standard argparse that extends the default
 functionality with support for multi-destination actions, an expressive DSL for
@@ -22,7 +23,8 @@ from argparse import ONE_OR_MORE, OPTIONAL, SUPPRESS, ZERO_OR_MORE
 
 from .actions import Action, Nargs
 from .parser import ArgumentParser
-from .types import ClangVersionType, PathType, RegexType, SwiftVersionType
+from .types import (BoolType, ClangVersionType, PathType, RegexType,
+                    SwiftVersionType)
 
 
 __all__ = [
@@ -37,6 +39,7 @@ __all__ = [
     'RawDescriptionHelpFormatter',
     'RawTextHelpFormatter',
 
+    'BoolType',
     'FileType',
     'PathType',
     'RegexType',

--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -1,0 +1,44 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from argparse import (ArgumentDefaultsHelpFormatter, ArgumentError,
+                      ArgumentTypeError, FileType, HelpFormatter,
+                      Namespace, RawDescriptionHelpFormatter,
+                      RawTextHelpFormatter)
+
+from argparse import SUPPRESS, OPTIONAL, ZERO_OR_MORE, ONE_OR_MORE
+
+from .actions import Action, Nargs
+from .parser import ArgumentParser
+from .types import PathType, RegexType, ClangVersionType, SwiftVersionType
+
+
+__all__ = [
+    'Action',
+    'ArgumentDefaultsHelpFormatter',
+    'ArgumentError',
+    'ArgumentParser',
+    'ArgumentTypeError',
+    'HelpFormatter',
+    'Namespace',
+    'Nargs',
+    'RawDescriptionHelpFormatter',
+    'RawTextHelpFormatter',
+
+    'FileType',
+    'PathType',
+    'RegexType',
+    'ClangVersionType',
+    'SwiftVersionType',
+
+    'SUPPRESS',
+    'OPTIONAL',
+    'ZERO_OR_MORE',
+    'ONE_OR_MORE',
+]

--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -11,7 +11,6 @@ from argparse import (ArgumentDefaultsHelpFormatter, ArgumentError,
                       ArgumentTypeError, FileType, HelpFormatter,
                       Namespace, RawDescriptionHelpFormatter,
                       RawTextHelpFormatter)
-
 from argparse import ONE_OR_MORE, OPTIONAL, SUPPRESS, ZERO_OR_MORE
 
 from .actions import Action, Nargs

--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -1,0 +1,330 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import argparse
+import copy
+
+from .types import PathType
+
+
+__all__ = [
+    'Action',
+    'Nargs',
+
+    'AppendAction',
+    'CustomCallAction',
+    'StoreAction',
+    'StoreIntAction',
+    'StoreTrueAction',
+    'StoreFalseAction',
+    'StorePathAction',
+    'ToggleTrueAction',
+    'ToggleFalseAction',
+    'UnsupportedAction',
+]
+
+
+# -----------------------------------------------------------------------------
+
+class Nargs(object):
+    """Container class holding valid values for the number of arguments
+    actions can accept. Other possible values include integer literals.
+    """
+
+    ZERO = 0
+    SINGLE = None
+    OPTIONAL = argparse.OPTIONAL
+    ZERO_OR_MORE = argparse.ZERO_OR_MORE
+    ONE_OR_MORE = argparse.ONE_OR_MORE
+
+
+# -----------------------------------------------------------------------------
+
+class Action(argparse.Action):
+    """Slightly modified version of the Action class from argparse which has
+    support for multiple destinations available rather than just a single one.
+    """
+
+    def __init__(self,
+                 option_strings,
+                 dests=None,
+                 nargs=Nargs.SINGLE,
+                 const=None,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar=None,
+                 dest=None):  # exists for compatibility purposes
+
+        if dests is None and dest is None:
+            raise TypeError('action must supply either dests or dest')
+
+        dests = dests or dest
+        if dests == argparse.SUPPRESS:
+            dests = []
+        elif isinstance(dests, str):
+            dests = [dests]
+
+        super(Action, self).__init__(
+            option_strings=option_strings,
+            dest=argparse.SUPPRESS,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+        self.dests = dests
+
+    def _get_kwargs(self):
+        """Unofficial method used for pretty-printing out actions.
+        """
+
+        names = [
+            'option_strings',
+            'dests',
+            'nargs',
+            'const',
+            'default',
+            'type',
+            'choices',
+            'required',
+            'help',
+            'metavar',
+        ]
+
+        return [(name, getattr(self, name)) for name in names]
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        raise NotImplementedError('__call__ not defined')
+
+
+# -----------------------------------------------------------------------------
+
+class AppendAction(Action):
+    """Action that appends
+    """
+
+    def __init__(self, option_strings, join=None, **kwargs):
+
+        kwargs['nargs'] = Nargs.SINGLE
+        kwargs.setdefault('default', [])
+
+        super(AppendAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        for dest in self.dests:
+            if getattr(namespace, dest) is None:
+                setattr(namespace, dest, [])
+
+            items = copy.copy(getattr(namespace, dest))
+            items.append(values)
+
+            setattr(namespace, dest, items)
+
+
+# -----------------------------------------------------------------------------
+
+class CustomCallAction(Action):
+    """Action that allows for instances to implement custom call functionality.
+    The call_func must follow the same calling convention as implementing the
+    __call__ method for an Action.
+    """
+
+    def __init__(self, option_strings, call_func, **kwargs):
+
+        if not callable(call_func):
+            raise TypeError('call_func must be callable')
+
+        super(CustomCallAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+        self.call_func = call_func
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        self.call_func(self, parser, namespace, values, option_string)
+
+
+# -----------------------------------------------------------------------------
+
+class StoreAction(Action):
+    """Action that stores a string.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+
+        if 'choices' in kwargs:
+            kwargs['nargs'] = Nargs.OPTIONAL
+        if 'const' in kwargs:
+            kwargs['nargs'] = Nargs.ZERO
+
+        super(StoreAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        for dest in self.dests:
+            if self.nargs == Nargs.ZERO and self.const is not None:
+                values = self.const
+
+            setattr(namespace, dest, values)
+
+
+class StoreIntAction(StoreAction):
+    """Action that stores an int.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+        kwargs['nargs'] = Nargs.SINGLE
+        kwargs['type'] = int
+        kwargs.setdefault('metavar', 'N')
+
+        super(StoreAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+
+class StoreTrueAction(StoreAction):
+    """Action that stores True when called and False by default.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+        kwargs['nargs'] = Nargs.ZERO
+        kwargs['const'] = True
+        kwargs['default'] = False
+
+        super(StoreTrueAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+
+class StoreFalseAction(StoreAction):
+    """Action that stores False when called and True by default.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+        kwargs['nargs'] = Nargs.ZERO
+        kwargs['const'] = False
+        kwargs['default'] = True
+
+        super(StoreFalseAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+
+class StorePathAction(StoreAction):
+    """Action that stores a path, which it will attempt to expand.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+        kwargs['nargs'] = Nargs.SINGLE
+        kwargs['type'] = PathType()
+
+        super(StorePathAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+
+# -----------------------------------------------------------------------------
+
+class _ToggleAction(Action):
+    """Action that can be toggled on or off, either implicitly when called or
+    explicitly when an optional boolean value is parsed.
+    """
+
+    TRUE_VALUES = [True, 1, 'TRUE', 'True', 'true', '1']
+    FALSE_VALUES = [False, 0, 'FALSE', 'False', 'false', '0']
+
+    def __init__(self, option_strings, on_value, off_value, **kwargs):
+        kwargs['nargs'] = Nargs.OPTIONAL
+        kwargs.setdefault('default', off_value)
+        kwargs.setdefault('metavar', 'BOOL')
+
+        super(_ToggleAction, self).__init__(
+            option_strings=option_strings,
+            **kwargs)
+
+        self.on_value = on_value
+        self.off_value = off_value
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values is None:
+            values = self.on_value
+        elif values in _ToggleAction.TRUE_VALUES:
+            values = self.on_value
+        elif values in _ToggleAction.FALSE_VALUES:
+            values = self.off_value
+        else:
+            raise argparse.ArgumentTypeError(
+                '{} is not a boolean value'.format(values))
+
+        for dest in self.dests:
+            setattr(namespace, dest, values)
+
+
+class ToggleTrueAction(_ToggleAction):
+    """Action that toggles True when called or False otherwise, with the
+    option to explicitly override the value.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+
+        super(ToggleTrueAction, self).__init__(
+            option_strings=option_strings,
+            on_value=True,
+            off_value=False,
+            **kwargs)
+
+
+class ToggleFalseAction(_ToggleAction):
+    """Action that toggles False when called or True otherwise, with the
+    option to explicitly override the value.
+    """
+
+    def __init__(self, option_strings, **kwargs):
+
+        super(ToggleFalseAction, self).__init__(
+            option_strings=option_strings,
+            on_value=False,
+            off_value=True,
+            **kwargs)
+
+
+# -----------------------------------------------------------------------------
+
+class UnsupportedAction(Action):
+    """Action that denotes an unsupported argument or opiton and subsequently
+    raises an ArgumentError.
+    """
+
+    def __init__(self, option_strings, message=None, **kwargs):
+        kwargs['nargs'] = Nargs.ZERO
+        kwargs['default'] = argparse.SUPPRESS
+
+        super(UnsupportedAction, self).__init__(
+            option_strings=option_strings,
+            dests=argparse.SUPPRESS,
+            **kwargs)
+
+        self.message = message
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if self.message is not None:
+            parser.error(self.message)
+
+        arg = option_string or str(values)
+        parser.error('unsupported argument: {}'.format(arg))

--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -126,12 +126,15 @@ class AppendAction(Action):
             **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
+        if isinstance(values, str):
+            values = [values]
+
         for dest in self.dests:
             if getattr(namespace, dest) is None:
                 setattr(namespace, dest, [])
 
             items = copy.copy(getattr(namespace, dest))
-            items.append(values)
+            items += values
 
             setattr(namespace, dest, items)
 

--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -16,7 +16,7 @@ default actions provided by the standard argparse.
 import argparse
 import copy
 
-from .types import PathType
+from .types import BoolType, PathType
 
 
 __all__ = [
@@ -255,11 +255,9 @@ class _ToggleAction(Action):
     explicitly when an optional boolean value is parsed.
     """
 
-    TRUE_VALUES = [True, 1, 'TRUE', 'True', 'true', '1']
-    FALSE_VALUES = [False, 0, 'FALSE', 'False', 'false', '0']
-
     def __init__(self, option_strings, on_value, off_value, **kwargs):
         kwargs['nargs'] = Nargs.OPTIONAL
+        kwargs['type'] = BoolType()
         kwargs.setdefault('default', off_value)
         kwargs.setdefault('metavar', 'BOOL')
 
@@ -273,9 +271,9 @@ class _ToggleAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if values is None:
             values = self.on_value
-        elif values in _ToggleAction.TRUE_VALUES:
+        elif values is True:
             values = self.on_value
-        elif values in _ToggleAction.FALSE_VALUES:
+        elif values is False:
             values = self.off_value
         else:
             raise argparse.ArgumentTypeError(

--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -7,6 +7,12 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
+"""
+Hierarchy of action classes which support multiple destinations, similar to the
+default actions provided by the standard argparse.
+"""
+
+
 import argparse
 import copy
 

--- a/utils/build_swift/argparse/parser.py
+++ b/utils/build_swift/argparse/parser.py
@@ -7,6 +7,13 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
+"""
+Extensions to the standard argparse ArgumentParer class to support multiple
+destination actions as well as a new builder DSL for declaratively
+constructing complex parsers.
+"""
+
+
 import argparse
 from contextlib import contextmanager
 

--- a/utils/build_swift/argparse/parser.py
+++ b/utils/build_swift/argparse/parser.py
@@ -17,7 +17,7 @@ constructing complex parsers.
 import argparse
 from contextlib import contextmanager
 
-from . import actions
+from . import Namespace, SUPPRESS, actions
 from .actions import Action
 
 
@@ -199,7 +199,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """
 
         if namespace is None:
-            namespace = argparse.Namespace()
+            namespace = Namespace()
 
         # Add action defaults not present in namespace
         for action in self._actions:
@@ -209,7 +209,7 @@ class ArgumentParser(argparse.ArgumentParser):
             for dest in action.dests:
                 if hasattr(namespace, dest):
                     continue
-                if action.default is argparse.SUPPRESS:
+                if action.default is SUPPRESS:
                     continue
 
                 setattr(namespace, dest, action.default)

--- a/utils/build_swift/argparse/parser.py
+++ b/utils/build_swift/argparse/parser.py
@@ -7,9 +7,8 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from contextlib import contextmanager
-
 import argparse
+from contextlib import contextmanager
 
 from . import actions
 from .actions import Action

--- a/utils/build_swift/argparse/parser.py
+++ b/utils/build_swift/argparse/parser.py
@@ -149,14 +149,14 @@ class _Builder(object):
 
         return self._add_argument(option_strings, *actions, **kwargs)
 
-    def set_defaults(self, dests=None, value=None, **kwargs):
-        if dests is None:
-            dests = []
-        elif isinstance(dests, str):
-            dests = [dests]
+    def set_defaults(self, *args, **kwargs):
+        if len(args) == 1:
+            raise TypeError('set_defaults takes at least 2 arguments')
 
-        for dest in dests:
-            kwargs[dest] = value
+        if len(args) >= 2:
+            dests, value = args[:-1], args[-1]
+            for dest in dests:
+                kwargs[dest] = value
 
         self._defaults.update(**kwargs)
 
@@ -192,9 +192,15 @@ class ArgumentParser(argparse.ArgumentParser):
 
     @classmethod
     def builder(cls, **kwargs):
+        """Create a new builder instance using this parser class.
+        """
+
         return _Builder(parser=cls(**kwargs))
 
     def to_builder(self):
+        """Construct and return a builder instance with this parser.
+        """
+
         return _Builder(parser=self)
 
     def parse_known_args(self, args=None, namespace=None):

--- a/utils/build_swift/argparse/parser.py
+++ b/utils/build_swift/argparse/parser.py
@@ -1,0 +1,211 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from contextlib import contextmanager
+
+import argparse
+
+from . import actions
+from .actions import Action
+
+
+__all__ = [
+    'ArgumentParser',
+]
+
+
+# -----------------------------------------------------------------------------
+
+class _ActionContainer(object):
+    """Container object holding partially applied actions used as a part of the
+    builder DSL.
+    """
+
+    def __init__(self):
+        self.append = _PartialAction(actions.AppendAction)
+        self.custom_call = _PartialAction(actions.CustomCallAction)
+        self.store = _PartialAction(actions.StoreAction)
+        self.store_int = _PartialAction(actions.StoreIntAction)
+        self.store_true = _PartialAction(actions.StoreTrueAction)
+        self.store_false = _PartialAction(actions.StoreFalseAction)
+        self.store_path = _PartialAction(actions.StorePathAction)
+        self.toggle_true = _PartialAction(actions.ToggleTrueAction)
+        self.toggle_false = _PartialAction(actions.ToggleFalseAction)
+        self.unsupported = _PartialAction(actions.UnsupportedAction)
+
+
+class _CompoundAction(Action):
+    """Action composed of multiple actions. Default attributes are derived
+    from the first action.
+    """
+
+    def __init__(self, actions, **kwargs):
+        _actions = []
+        for action in actions:
+            _actions.append(action(**kwargs))
+
+        kwargs.setdefault('nargs', kwargs[0].nargs)
+        kwargs.setdefault('metavar', kwargs[0].metavar)
+        kwargs.setdefault('choices', kwargs[0].choices)
+
+        super(_CompoundAction, self).__init__(**kwargs)
+
+        self.actions = _actions
+
+    def __call__(self, *args):
+        for action in self.actions:
+            action(*args)
+
+
+class _PartialAction(Action):
+    """Action that is partially applied, creating a factory closure used to
+    defer initialization of acitons in the builder DSL.
+    """
+
+    def __init__(self, action_class):
+        self.action_class = action_class
+
+    def __call__(self, dests=None, *call_args, **call_kwargs):
+        def factory(**kwargs):
+            kwargs.update(call_kwargs)
+            if dests is not None:
+                return self.action_class(dests=dests, *call_args, **kwargs)
+            return self.action_class(*call_args, **kwargs)
+
+        return factory
+
+
+# -----------------------------------------------------------------------------
+
+class _Builder(object):
+    """Builder object for constructing complex ArgumentParser instances with
+    a more friendly and descriptive DSL.
+    """
+
+    def __init__(self, parser, **kwargs):
+        assert isinstance(parser, ArgumentParser)
+
+        self._parser = parser
+        self._current_group = self._parser
+        self._defaults = dict()
+
+        self.actions = _ActionContainer()
+
+    def build(self):
+        self._parser.set_defaults(**self._defaults)
+        return self._parser
+
+    def _add_argument(self, option_strings, *actions, **kwargs):
+        # Unwrap partial actions
+        _actions = []
+        for action in actions:
+            if isinstance(action, _PartialAction):
+                action = action()
+            _actions.append(action)
+
+        if len(_actions) == 0:
+            # Default to store action
+            action = actions.StoreAction
+        elif len(_actions) == 1:
+            action = _actions[0]
+        else:
+            def thunk(**kwargs):
+                return _CompoundAction(_actions, **kwargs)
+            action = thunk
+
+        return self._current_group.add_argument(
+            *option_strings, action=action, **kwargs)
+
+    def add_positional(self, option_strings, *actions, **kwargs):
+        if isinstance(option_strings, str):
+            option_strings = [option_strings]
+
+        if any(o.startswith('-') for o in option_strings):
+            raise ValueError("add_option can't add optional arguments")
+
+        return self._add_argument(option_strings, *actions, **kwargs)
+
+    def add_option(self, option_strings, *actions, **kwargs):
+        if isinstance(option_strings, str):
+            option_strings = [option_strings]
+
+        if not all(o.startswith('-') for o in option_strings):
+            raise ValueError("add_option can't add positional arguments")
+
+        return self._add_argument(option_strings, *actions, **kwargs)
+
+    def set_defaults(self, dests=None, value=None, **kwargs):
+        if dests is None:
+            dests = []
+        elif isinstance(dests, str):
+            dests = [dests]
+
+        for dest in dests:
+            kwargs[dest] = value
+
+        self._defaults.update(**kwargs)
+
+    def in_group(self, description):
+        self._current_group = self._parser.add_argument_group(description)
+        return self._current_group
+
+    def reset_group(self):
+        self._current_group = self._parser
+
+    @contextmanager
+    def argument_group(self, description):
+        previous_group = self._current_group
+        self._current_group = self._parser.add_argument_group(description)
+        yield self._current_group
+        self._current_group = previous_group
+
+    @contextmanager
+    def mutually_exclusive_group(self):
+        previous_group = self._current_group
+        self._current_group = previous_group.add_mutually_exclusive_group()
+        yield self._current_group
+        self._current_group = previous_group
+
+
+# -----------------------------------------------------------------------------
+
+class ArgumentParser(argparse.ArgumentParser):
+    """A thin extension class to the standard ArgumentParser which incluldes
+    methods to interact with a builder instance.
+    """
+
+    @staticmethod
+    def builder(**kwargs):
+        return _Builder(parser=ArgumentParser(**kwargs))
+
+    def to_builder(self):
+        return _Builder(parser=self)
+
+    def parse_known_args(self, args=None, namespace=None):
+        """Thin wrapper around parse_known_args which shims-in support for
+        actions with multiple destinations.
+        """
+
+        if namespace is None:
+            namespace = argparse.Namespace()
+
+        # Add action defaults not present in namespace
+        for action in self._actions:
+            if not hasattr(action, 'dests'):
+                continue
+
+            for dest in action.dests:
+                if hasattr(namespace, dest):
+                    continue
+                if action.default is argparse.SUPPRESS:
+                    continue
+
+                setattr(namespace, dest, action.default)
+
+        return super(ArgumentParser, self).parse_known_args(args, namespace)

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -7,6 +7,12 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
+"""
+Argument types useful for enforcing data-integrity and form when parsing
+arguments.
+"""
+
+
 import os.path
 import re
 import shlex

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -21,6 +21,7 @@ from . import ArgumentTypeError
 
 
 __all__ = [
+    'BoolType',
     'PathType',
     'RegexType',
     'ClangVersionType',
@@ -29,6 +30,30 @@ __all__ = [
 
 
 # -----------------------------------------------------------------------------
+
+class BoolType(object):
+    """Argument type used to validate an input string as a bool-like type.
+    Callers are able to override valid true and false values.
+    """
+
+    TRUE_VALUES = [True, 1, 'TRUE', 'True', 'true', '1']
+    FALSE_VALUES = [False, 0, 'FALSE', 'False', 'false', '0']
+
+    def __init__(self, true_values=None, false_values=None):
+        true_values = true_values or BoolType.TRUE_VALUES
+        false_values = false_values or BoolType.FALSE_VALUES
+
+        self._true_values = set(true_values)
+        self._false_values = set(false_values)
+
+    def __call__(self, value):
+        if value in self._true_values:
+            return True
+        elif value in self._false_values:
+            return False
+        else:
+            raise ArgumentTypeError('{} is not a boolean value'.format(value))
+
 
 class PathType(object):
     """PathType denotes a valid path-like object. When called paths will be

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -1,0 +1,110 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import os.path
+import re
+import shlex
+
+from . import ArgumentTypeError
+
+
+__all__ = [
+    'PathType',
+    'RegexType',
+    'ClangVersionType',
+    'SwiftVersionType',
+]
+
+
+# -----------------------------------------------------------------------------
+
+class PathType(object):
+    """PathType denotes a valid path-like object. When called paths will be
+    fully expanded with the option to assert the file or directory referenced
+    by the path exists.
+    """
+
+    def __init__(self, assert_exists=False):
+        self.assert_exists = assert_exists
+
+    def __call__(self, path):
+        path = os.path.expanduser(path)
+        path = os.path.abspath(path)
+        path = os.path.realpath(path)
+
+        if self.assert_exists:
+            assert os.path.exists(path)
+
+        return path
+
+
+class RegexType(object):
+    """Argument type used to validate an input string against a regular
+    expression.
+    """
+
+    def __init__(self, regex, error_message=None):
+        self._regex = regex
+        self._error_message = error_message or 'Invalid value'
+
+    def __call__(self, value):
+        matches = re.match(self._regex, value)
+        if matches is None:
+            raise ArgumentTypeError(self._error_message, value)
+
+        return value
+
+
+class ClangVersionType(RegexType):
+    """Argument type used to validate Clang version strings.
+    """
+
+    ERROR_MESSAGE = ('Invalid version value, must be '
+                     '"MAJOR.MINOR.PATCH" or "MAJOR.MINOR.PATCH.PATCH"')
+
+    VERSION_REGEX = r'^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$'
+
+    def __init__(self):
+        super(ClangVersionType, self).__init__(
+            ClangVersionType.VERSION_REGEX,
+            ClangVersionType.ERROR_MESSAGE)
+
+
+class SwiftVersionType(RegexType):
+    """Argument type used to validate Swift version strings.
+    """
+
+    ERROR_MESSAGE = ('Invalid version value, must be "MAJOR.MINOR" '
+                     'or "MAJOR.MINOR.PATCH"')
+    VERSION_REGEX = r'^(\d+)\.(\d+)(\.(\d+))?$'
+
+    def __init__(self):
+        super(SwiftVersionType, self).__init__(
+            SwiftVersionType.VERSION_REGEX,
+            SwiftVersionType.ERROR_MESSAGE)
+
+
+class ShellSplitType(object):
+    """Parse and split shell arguments into a list of strings. Recognizes `,`
+    as a separator as well as white spaces.
+
+    For example it converts the following:
+
+    '-BAR="foo bar" -BAZ="foo,bar",-QUX 42'
+
+    into
+
+    ['-BAR=foo bar', '-BAZ=foo,bar', '-QUX', '42']
+    """
+
+    def __call__(self, value):
+        lex = shlex.shlex(value, posix=True)
+        lex.whitespace_split = True
+        lex.whitespace += ','
+        return list(lex)

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -6,6 +6,7 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+
 import argparse
 import multiprocessing
 
@@ -14,7 +15,6 @@ import android.adb.commands
 from swift_build_support.swift_build_support import arguments
 from swift_build_support.swift_build_support import host
 from swift_build_support.swift_build_support import targets
-
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
 

--- a/utils/build_swift/tests/argparse/__init__.py
+++ b/utils/build_swift/tests/argparse/__init__.py
@@ -1,0 +1,7 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -1,0 +1,419 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from build_swift import argparse
+from build_swift.argparse import actions, ArgumentParser, Nargs
+from build_swift.tests.utils import redirect_stderr, TestCase
+
+
+# -----------------------------------------------------------------------------
+
+class TestAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.Action(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.option_strings, ['--foo'])
+        self.assertEqual(action.dests, ['foo'])
+        self.assertEqual(action.const, None)
+        self.assertEqual(action.default, None)
+        self.assertEqual(action.type, None)
+        self.assertEqual(action.choices, None)
+        self.assertEqual(action.required, False)
+        self.assertEqual(action.help, None)
+        self.assertEqual(action.metavar, None)
+        self.assertEqual(action.dest, argparse.SUPPRESS)
+
+    def test_single_destination(self):
+        action = actions.Action(['--foo'], 'foo')
+
+        self.assertEqual(action.dests, ['foo'])
+
+    def test_multiple_destinations(self):
+        action = actions.Action(['--foo'], ['foo', 'bar'])
+
+        self.assertEqual(action.dests, ['foo', 'bar'])
+
+    def test_supports_dest_argument(self):
+        with self.assertNotRaises(Exception):
+            action = actions.Action([], [], dest='foo')
+
+            self.assertEqual(action.dest, argparse.SUPPRESS)
+
+    def test_call_not_implemented(self):
+        action = actions.Action([], [])
+
+        with self.assertRaises(NotImplementedError):
+            action(None, None, None, None)
+
+
+class TestAppendAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.AppendAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.SINGLE)
+        self.assertEqual(action.default, [])
+
+    def test_default_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.AppendAction)
+
+        args = parser.parse_args([])
+        self.assertEqual(args.foo, [])
+
+    def test_append(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.AppendAction)
+
+        args = parser.parse_args(['--foo', 'bar', '--foo', 'baz'])
+        self.assertEqual(args.foo, ['bar', 'baz'])
+
+
+class TestCustomCallAction(TestCase):
+
+    def test_non_callable(self):
+        with self.assertRaises(TypeError):
+            actions.CustomCallAction('--foo', dests=['foo'], call_func=None)
+
+    def test_custom_call_func(self):
+        def test_func(action, parser, namespace, values, option_string=None):
+            for dest in action.dests:
+                setattr(namespace, dest, values)
+
+        parser = ArgumentParser()
+        parser.add_argument(
+            '--foo',
+            action=actions.CustomCallAction,
+            call_func=test_func,
+            nargs=Nargs.SINGLE)
+
+        args = parser.parse_args(['--foo', 'boo'])
+
+        self.assertEqual(args.foo, 'boo')
+
+
+class TestStoreAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.StoreAction(['--foo'], dests=['foo'], choices=['bar'])
+        self.assertEqual(action.nargs, Nargs.OPTIONAL)
+
+        action = actions.StoreAction(['--foo'], dests=['foo'], const='bar')
+        self.assertEqual(action.nargs, Nargs.ZERO)
+
+    def test_choices(self):
+        parser = ArgumentParser()
+        action = parser.add_argument(
+            '--foo',
+            action=actions.StoreAction,
+            choices=['bar', 'baz'])
+
+        self.assertEqual(action.nargs, Nargs.OPTIONAL)
+
+        with self.quietOutput(), self.assertRaises(SystemExit):
+            parser.parse_args(['--foo', 'qux'])
+
+        args = parser.parse_args(['--foo', 'bar'])
+
+        self.assertEqual(args.foo, 'bar')
+
+    def test_store_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreAction)
+
+        args = parser.parse_args(['--foo', 'bar'])
+
+        self.assertEqual(args.foo, 'bar')
+
+    def test_store_const(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreAction, const='bar')
+
+        args = parser.parse_args(['--foo'])
+
+        self.assertEqual(args.foo, 'bar')
+
+    def test_store_value_multiple_destinations(self):
+        parser = ArgumentParser()
+        parser.add_argument(
+            '--foo',
+            dests=['foo', 'bar'],
+            action=actions.StoreAction)
+
+        args = parser.parse_args(['--foo', 'baz'])
+
+        self.assertEqual(args.foo, 'baz')
+        self.assertEqual(args.bar, 'baz')
+
+    def test_store_const_multiple_destinations(self):
+        parser = ArgumentParser()
+        parser.add_argument(
+            '--foo',
+            dests=['foo', 'bar'],
+            action=actions.StoreAction,
+            const='baz')
+
+        args = parser.parse_args(['--foo'])
+
+        self.assertEqual(args.foo, 'baz')
+        self.assertEqual(args.bar, 'baz')
+
+
+class TestStoreIntAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.StoreIntAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.SINGLE)
+        self.assertEqual(action.type, int)
+        self.assertEqual(action.metavar, 'N')
+
+    def test_valid_int(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreIntAction)
+
+        for i in [0, 1, 42, -64]:
+            args = parser.parse_args(['--foo', str(i)])
+            self.assertEqual(args.foo, i)
+
+    def test_invalid_int(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreIntAction)
+
+        for i in [0.0, True, 'bar']:
+            with self.quietOutput(), self.assertRaises(SystemExit):
+                parser.parse_args(['--foo', str(i)])
+
+
+class TestStoreTrueAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.StoreTrueAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.ZERO)
+        self.assertEqual(action.const, True)
+        self.assertEqual(action.default, False)
+
+    def test_default_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreTrueAction)
+
+        args = parser.parse_args([])
+
+        self.assertFalse(args.foo)
+
+    def test_store_true(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreTrueAction)
+
+        args = parser.parse_args(['--foo'])
+
+        self.assertTrue(args.foo)
+
+
+class TestStoreFalseAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.StoreFalseAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.ZERO)
+        self.assertEqual(action.const, False)
+        self.assertEqual(action.default, True)
+
+    def test_default_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreFalseAction)
+
+        args = parser.parse_args([])
+
+        self.assertTrue(args.foo)
+
+    def test_store_false(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StoreFalseAction)
+
+        args = parser.parse_args(['--foo'])
+
+        self.assertFalse(args.foo)
+
+
+class TestStorePathAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.StorePathAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.SINGLE)
+        self.assertIsInstance(action.type, argparse.PathType)
+
+
+class TestToggleTrueAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.ToggleTrueAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.OPTIONAL)
+        self.assertEqual(action.on_value, True)
+        self.assertEqual(action.off_value, False)
+        self.assertEqual(action.metavar, 'BOOL')
+
+    def test_default_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleTrueAction)
+
+        args = parser.parse_args([])
+
+        self.assertFalse(args.foo)
+
+    def test_with_no_arg(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleTrueAction)
+
+        args = parser.parse_args(['--foo'])
+
+        self.assertTrue(args.foo)
+
+    def test_with_optional_true_arg(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleTrueAction)
+
+        for value in actions.ToggleTrueAction.TRUE_VALUES:
+            args = parser.parse_args(['--foo', str(value)])
+            self.assertTrue(args.foo)
+
+            args = parser.parse_args(['--foo={}'.format(value)])
+            self.assertTrue(args.foo)
+
+    def test_with_optional_false_arg(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleTrueAction)
+
+        for value in actions.ToggleTrueAction.FALSE_VALUES:
+            args = parser.parse_args(['--foo', str(value)])
+            self.assertFalse(args.foo)
+
+            args = parser.parse_args(['--foo={}'.format(value)])
+            self.assertFalse(args.foo)
+
+    def test_last_wins(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleTrueAction)
+
+        args = parser.parse_args(['--foo=TRUE', '--foo', 'FALSE'])
+        self.assertFalse(args.foo)
+
+        args = parser.parse_args(['--foo=FALSE', '--foo'])
+        self.assertTrue(args.foo)
+
+        args = parser.parse_args(['--foo=FALSE', '--foo', 'TRUE'])
+        self.assertTrue(args.foo)
+
+
+class TestToggleFalseAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.ToggleFalseAction(['--foo'], dests=['foo'])
+
+        self.assertEqual(action.nargs, Nargs.OPTIONAL)
+        self.assertEqual(action.on_value, False)
+        self.assertEqual(action.off_value, True)
+        self.assertEqual(action.metavar, 'BOOL')
+
+    def test_default_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleFalseAction)
+
+        args = parser.parse_args([])
+
+        self.assertTrue(args.foo)
+
+    def test_with_no_arg(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleFalseAction)
+
+        args = parser.parse_args(['--foo'])
+
+        self.assertFalse(args.foo)
+
+    def test_with_optional_true_arg(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleFalseAction)
+
+        for value in actions.ToggleFalseAction.TRUE_VALUES:
+            args = parser.parse_args(['--foo', str(value)])
+            self.assertFalse(args.foo)
+
+            args = parser.parse_args(['--foo={}'.format(value)])
+            self.assertFalse(args.foo)
+
+    def test_with_optional_false_arg(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleFalseAction)
+
+        for value in actions.ToggleFalseAction.FALSE_VALUES:
+            args = parser.parse_args(['--foo', str(value)])
+            self.assertTrue(args.foo)
+
+            args = parser.parse_args(['--foo={}'.format(value)])
+            self.assertTrue(args.foo)
+
+    def test_last_wins(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.ToggleFalseAction)
+
+        args = parser.parse_args(['--foo=TRUE', '--foo', 'FALSE'])
+        self.assertTrue(args.foo)
+
+        args = parser.parse_args(['--foo=FALSE', '--foo'])
+        self.assertFalse(args.foo)
+
+        args = parser.parse_args(['--foo=FALSE', '--foo', 'TRUE'])
+        self.assertFalse(args.foo)
+
+
+class TestUnuspportedAction(TestCase):
+
+    def test_default_attributes(self):
+        action = actions.UnsupportedAction(['--foo'])
+
+        self.assertEqual(action.dests, [])
+        self.assertEqual(action.nargs, Nargs.ZERO)
+        self.assertEqual(action.default, argparse.SUPPRESS)
+        self.assertEqual(action.message, None)
+
+    def test_suppressed_default_value(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.UnsupportedAction)
+
+        args = parser.parse_args([])
+
+        self.assertFalse(hasattr(args, 'foo'))
+
+    def test_raises_parser_error(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.UnsupportedAction)
+
+        with self.quietOutput(), self.assertRaises(SystemExit):
+            parser.parse_args(['--foo'])
+
+    def test_custom_error_message(self):
+        message = 'custom error message'
+
+        parser = ArgumentParser()
+        action = parser.add_argument(
+            '--foo',
+            action=actions.UnsupportedAction,
+            message=message)
+
+        self.assertEqual(action.message, message)
+
+        with redirect_stderr() as stderr, self.assertRaises(SystemExit):
+            parser.parse_args(['--foo'])
+
+            self.assertIn(message, stderr)

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -8,8 +8,8 @@
 
 
 from build_swift import argparse
-from build_swift.argparse import actions, ArgumentParser, Nargs
-from build_swift.tests.utils import redirect_stderr, TestCase
+from build_swift.argparse import ArgumentParser, Nargs, actions
+from build_swift.tests.utils import TestCase, redirect_stderr
 
 
 # -----------------------------------------------------------------------------

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -7,9 +7,9 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from build_swift import argparse
-from build_swift.argparse import ArgumentParser, Nargs, actions
-from build_swift.tests.utils import TestCase, redirect_stderr
+from ..utils import TestCase, redirect_stderr
+from ...argparse import (ArgumentParser, BoolType, Nargs, PathType, SUPPRESS,
+                         actions)
 
 
 # -----------------------------------------------------------------------------
@@ -28,7 +28,7 @@ class TestAction(TestCase):
         self.assertEqual(action.required, False)
         self.assertEqual(action.help, None)
         self.assertEqual(action.metavar, None)
-        self.assertEqual(action.dest, argparse.SUPPRESS)
+        self.assertEqual(action.dest, SUPPRESS)
 
     def test_single_destination(self):
         action = actions.Action(['--foo'], 'foo')
@@ -44,7 +44,7 @@ class TestAction(TestCase):
         with self.assertNotRaises(Exception):
             action = actions.Action([], [], dest='foo')
 
-            self.assertEqual(action.dest, argparse.SUPPRESS)
+            self.assertEqual(action.dest, SUPPRESS)
 
     def test_call_not_implemented(self):
         action = actions.Action([], [])
@@ -250,7 +250,7 @@ class TestStorePathAction(TestCase):
         action = actions.StorePathAction(['--foo'], dests=['foo'])
 
         self.assertEqual(action.nargs, Nargs.SINGLE)
-        self.assertIsInstance(action.type, argparse.PathType)
+        self.assertIsInstance(action.type, PathType)
 
 
 class TestToggleTrueAction(TestCase):
@@ -283,7 +283,7 @@ class TestToggleTrueAction(TestCase):
         parser = ArgumentParser()
         parser.add_argument('--foo', action=actions.ToggleTrueAction)
 
-        for value in actions.ToggleTrueAction.TRUE_VALUES:
+        for value in BoolType.TRUE_VALUES:
             args = parser.parse_args(['--foo', str(value)])
             self.assertTrue(args.foo)
 
@@ -294,7 +294,7 @@ class TestToggleTrueAction(TestCase):
         parser = ArgumentParser()
         parser.add_argument('--foo', action=actions.ToggleTrueAction)
 
-        for value in actions.ToggleTrueAction.FALSE_VALUES:
+        for value in BoolType.FALSE_VALUES:
             args = parser.parse_args(['--foo', str(value)])
             self.assertFalse(args.foo)
 
@@ -345,7 +345,7 @@ class TestToggleFalseAction(TestCase):
         parser = ArgumentParser()
         parser.add_argument('--foo', action=actions.ToggleFalseAction)
 
-        for value in actions.ToggleFalseAction.TRUE_VALUES:
+        for value in BoolType.TRUE_VALUES:
             args = parser.parse_args(['--foo', str(value)])
             self.assertFalse(args.foo)
 
@@ -356,7 +356,7 @@ class TestToggleFalseAction(TestCase):
         parser = ArgumentParser()
         parser.add_argument('--foo', action=actions.ToggleFalseAction)
 
-        for value in actions.ToggleFalseAction.FALSE_VALUES:
+        for value in BoolType.FALSE_VALUES:
             args = parser.parse_args(['--foo', str(value)])
             self.assertTrue(args.foo)
 
@@ -384,7 +384,7 @@ class TestUnuspportedAction(TestCase):
 
         self.assertEqual(action.dests, [])
         self.assertEqual(action.nargs, Nargs.ZERO)
-        self.assertEqual(action.default, argparse.SUPPRESS)
+        self.assertEqual(action.default, SUPPRESS)
         self.assertEqual(action.message, None)
 
     def test_suppressed_default_value(self):

--- a/utils/build_swift/tests/argparse/test_parser.py
+++ b/utils/build_swift/tests/argparse/test_parser.py
@@ -1,0 +1,151 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import argparse as std_argparse
+
+from build_swift.argparse import actions, ArgumentParser
+from build_swift.tests.utils import TestCase
+
+
+# -----------------------------------------------------------------------------
+
+class TestBuilder(TestCase):
+
+    def test_build(self):
+        builder = ArgumentParser.builder()
+
+        self.assertEqual(builder._parser, builder.build())
+
+    def test_add_positional(self):
+        # Setup builder and DSL
+        builder = ArgumentParser.builder()
+        positional = builder.add_positional
+
+        store = builder.actions.store
+        store_int = builder.actions.store_int
+
+        # Create test parser
+        positional('foo', store)
+        positional('bar', store_int(['bar', 'baz']))
+
+        parser = builder.build()
+
+        args = parser.parse_args(['Foo', '1'])
+
+        self.assertEqual(args.foo, 'Foo')
+        self.assertEqual(args.bar, 1)
+        self.assertEqual(args.baz, 1)
+
+    def test_add_option(self):
+        # Setup builder and DSL
+        builder = ArgumentParser.builder()
+        option = builder.add_option
+
+        append = builder.actions.append
+        store_true = builder.actions.store_true
+        toggle_false = builder.actions.toggle_false
+        unsupported = builder.actions.unsupported
+
+        # Create test parser
+        option('--foo', append)
+        option('--bar', store_true(['bar', 'foobar']))
+        option('--baz', toggle_false)
+        option('--qux', unsupported)
+
+        parser = builder.build()
+
+        args = parser.parse_args([])
+        self.assertEqual(args.foo, [])
+        self.assertFalse(args.bar)
+        self.assertFalse(args.foobar)
+        self.assertTrue(args.baz)
+        self.assertFalse(hasattr(args, 'qux'))
+
+        args = parser.parse_args(['--foo', 'Foo'])
+        self.assertEqual(args.foo, ['Foo'])
+
+        args = parser.parse_args(['--bar'])
+        self.assertTrue(args.bar)
+        self.assertTrue(args.foobar)
+
+        args = parser.parse_args(['--baz', '--baz=FALSE'])
+        self.assertTrue(args.baz)
+
+        with self.quietOutput(), self.assertRaises(SystemExit):
+            parser.parse_args(['--qux'])
+
+    def test_set_defaults(self):
+        builder = ArgumentParser.builder()
+
+        builder.set_defaults(foo=True, bar=False, baz=[])
+        builder.set_defaults('qux', 'Lorem ipsum set dolor')
+
+        self.assertEqual(builder._defaults, {
+            'foo': True,
+            'bar': False,
+            'baz': [],
+            'qux': 'Lorem ipsum set dolor',
+        })
+
+    def test_in_group(self):
+        builder = ArgumentParser.builder()
+        self.assertEqual(builder._current_group, builder._parser)
+
+        group = builder.in_group('First Group')
+        self.assertEqual(group, builder._current_group)
+        self.assertNotEqual(group, builder._parser)
+
+    def test_reset_group(self):
+        builder = ArgumentParser.builder()
+        self.assertEqual(builder._current_group, builder._parser)
+
+        group = builder.in_group('First Group')
+        builder.reset_group()
+        self.assertNotEqual(group, builder._current_group)
+        self.assertEqual(builder._current_group, builder._parser)
+
+    def test_argument_group(self):
+        builder = ArgumentParser.builder()
+
+        with builder.argument_group('First Group') as group:
+            self.assertEqual(builder._current_group, group)
+            self.assertIsInstance(group, std_argparse._ArgumentGroup)
+
+        self.assertEqual(builder._current_group, builder._parser)
+
+    def test_mutually_exclusive_group(self):
+        builder = ArgumentParser.builder()
+
+        with builder.mutually_exclusive_group() as group:
+            self.assertEqual(builder._current_group, group)
+            self.assertIsInstance(group, std_argparse._MutuallyExclusiveGroup)
+
+        self.assertEqual(builder._current_group, builder._parser)
+
+
+class TestArgumentParser(TestCase):
+
+    def test_to_builder(self):
+        parser = ArgumentParser()
+        builder = parser.to_builder()
+
+        self.assertEqual(parser, builder._parser)
+
+    def test_parse_known_args_adds_defaults_to_dests(self):
+        parser = ArgumentParser()
+        parser.add_argument(
+            '--foo',
+            action=actions.StoreAction,
+            dests=['foo', 'bar'],
+            default='FooBar')
+
+        # parse_args calls parse_known_args under the hood
+        args = parser.parse_args([])
+        self.assertEqual(args.foo, 'FooBar')
+        self.assertEqual(args.bar, 'FooBar')

--- a/utils/build_swift/tests/argparse/test_parser.py
+++ b/utils/build_swift/tests/argparse/test_parser.py
@@ -122,14 +122,29 @@ class TestBuilder(TestCase):
     def test_mutually_exclusive_group(self):
         builder = ArgumentParser.builder()
 
-        with builder.mutually_exclusive_group() as group:
+        with builder.mutually_exclusive_group(required=True) as group:
             self.assertEqual(builder._current_group, group)
             self.assertIsInstance(group, _MutuallyExclusiveGroup)
+            self.assertTrue(group.required)
 
         self.assertEqual(builder._current_group, builder._parser)
 
 
 class TestArgumentParser(TestCase):
+
+    def test_builder(self):
+        builder = ArgumentParser.builder(usage='Totally useless help message')
+
+        self.assertIsInstance(builder._parser, ArgumentParser)
+        self.assertEqual(builder._parser.usage, 'Totally useless help message')
+
+    def test_builder_uses_subclass(self):
+        class _ArgumentParserSubclass(ArgumentParser):
+            pass
+
+        builder = _ArgumentParserSubclass.builder()
+
+        self.assertIsInstance(builder._parser, _ArgumentParserSubclass)
 
     def test_to_builder(self):
         parser = ArgumentParser()

--- a/utils/build_swift/tests/argparse/test_parser.py
+++ b/utils/build_swift/tests/argparse/test_parser.py
@@ -9,7 +9,7 @@
 
 import argparse as std_argparse
 
-from build_swift.argparse import actions, ArgumentParser
+from build_swift.argparse import ArgumentParser, actions
 from build_swift.tests.utils import TestCase
 
 

--- a/utils/build_swift/tests/argparse/test_parser.py
+++ b/utils/build_swift/tests/argparse/test_parser.py
@@ -7,10 +7,10 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-import argparse as std_argparse
+from argparse import _ArgumentGroup, _MutuallyExclusiveGroup
 
-from build_swift.argparse import ArgumentParser, actions
-from build_swift.tests.utils import TestCase
+from ..utils import TestCase
+from ...argparse import ArgumentParser, actions
 
 
 # -----------------------------------------------------------------------------
@@ -115,7 +115,7 @@ class TestBuilder(TestCase):
 
         with builder.argument_group('First Group') as group:
             self.assertEqual(builder._current_group, group)
-            self.assertIsInstance(group, std_argparse._ArgumentGroup)
+            self.assertIsInstance(group, _ArgumentGroup)
 
         self.assertEqual(builder._current_group, builder._parser)
 
@@ -124,7 +124,7 @@ class TestBuilder(TestCase):
 
         with builder.mutually_exclusive_group() as group:
             self.assertEqual(builder._current_group, group)
-            self.assertIsInstance(group, std_argparse._MutuallyExclusiveGroup)
+            self.assertIsInstance(group, _MutuallyExclusiveGroup)
 
         self.assertEqual(builder._current_group, builder._parser)
 

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -9,11 +9,66 @@
 
 import os.path
 
-from build_swift.argparse import ArgumentTypeError, types
-from build_swift.tests.utils import TestCase
+from ..utils import TestCase
+from ...argparse import ArgumentTypeError, types
 
 
 # -----------------------------------------------------------------------------
+
+class TestBoolType(TestCase):
+
+    def test_true_values(self):
+        bool_type = types.BoolType()
+
+        self.assertTrue(bool_type(True))
+        self.assertTrue(bool_type(1))
+        self.assertTrue(bool_type('TRUE'))
+        self.assertTrue(bool_type('True'))
+        self.assertTrue(bool_type('true'))
+        self.assertTrue(bool_type('1'))
+
+    def test_false_values(self):
+        bool_type = types.BoolType()
+
+        self.assertFalse(bool_type(False))
+        self.assertFalse(bool_type(0))
+        self.assertFalse(bool_type('FALSE'))
+        self.assertFalse(bool_type('False'))
+        self.assertFalse(bool_type('false'))
+        self.assertFalse(bool_type('0'))
+
+    def test_custom_true_values(self):
+        bool_type = types.BoolType(true_values=['TRUE', 'ON', '1'])
+
+        self.assertTrue(bool_type('TRUE'))
+        self.assertTrue(bool_type('ON'))
+        self.assertTrue(bool_type('1'))
+
+        self.assertRaises(ArgumentTypeError, bool_type, True)
+        self.assertRaises(ArgumentTypeError, bool_type, 1)
+        self.assertRaises(ArgumentTypeError, bool_type, 'True')
+        self.assertRaises(ArgumentTypeError, bool_type, 'true')
+
+    def test_custom_false_values(self):
+        bool_type = types.BoolType(false_values=['FALSE', 'OFF', '0'])
+
+        self.assertFalse(bool_type('FALSE'))
+        self.assertFalse(bool_type('OFF'))
+        self.assertFalse(bool_type('0'))
+
+        self.assertRaises(ArgumentTypeError, bool_type, False)
+        self.assertRaises(ArgumentTypeError, bool_type, 0)
+        self.assertRaises(ArgumentTypeError, bool_type, 'False')
+        self.assertRaises(ArgumentTypeError, bool_type, 'false')
+
+    def test_invalid_values(self):
+        bool_type = types.BoolType()
+
+        self.assertRaises(ArgumentTypeError, bool_type, None)
+        self.assertRaises(ArgumentTypeError, bool_type, 2)
+        self.assertRaises(ArgumentTypeError, bool_type, 2.71828)
+        self.assertRaises(ArgumentTypeError, bool_type, 'Invalid')
+
 
 class TestPathType(TestCase):
 

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -1,0 +1,120 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import os.path
+
+from build_swift.argparse import types, ArgumentTypeError
+from build_swift.tests.utils import TestCase
+
+
+# -----------------------------------------------------------------------------
+
+class TestPathType(TestCase):
+
+    def setUp(self):
+        self.home_dir = os.path.expanduser('~')
+
+    def test_expands_path(self):
+        path_type = types.PathType()
+
+        path = path_type('/some/random/path/../')
+        self.assertEqual('/some/random', path)
+
+        path = path_type('~/path/to/some/file.txt')
+        self.assertEqual(self.home_dir + '/path/to/some/file.txt', path)
+
+        path = path_type('~/path/to/some/../file.txt')
+        self.assertEqual(self.home_dir + '/path/to/file.txt', path)
+
+    def test_assert_exists(self):
+        path_type = types.PathType(assert_exists=True)
+
+        with self.assertNotRaises(AssertionError):
+            path_type(__file__)
+
+        with self.assertRaises(AssertionError):
+            path_type('/nonsensisal/path/')
+            path_type('~/not-a-real/path to a file')
+
+
+class TestRegexType(TestCase):
+
+    def test_regex_match(self):
+        regex_type = types.RegexType(r'a+b*')
+
+        with self.assertNotRaises(ArgumentTypeError):
+            regex_type('a')
+            regex_type('aab')
+            regex_type('abbbbbbb')
+
+    def test_raises_argument_error(self):
+        regex_type = types.RegexType(r'a+b*')
+
+        with self.assertRaises(ArgumentTypeError):
+            regex_type('')
+            regex_type('b')
+            regex_type('baaaa')
+
+
+class TestClangVersionType(TestCase):
+
+    def test_valid_clang_version(self):
+        clang_version_type = types.ClangVersionType()
+
+        with self.assertNotRaises(ArgumentTypeError):
+            clang_version_type('1.0.0')
+            clang_version_type('3.0.2.1')
+            clang_version_type('200.0.56.3')
+            clang_version_type('100000.0.0.1')
+
+    def test_invalid_clang_version(self):
+        clang_version_type = types.ClangVersionType()
+
+        with self.assertRaises(ArgumentTypeError):
+            clang_version_type('2')
+            clang_version_type('3.0')
+            clang_version_type('1.8.0.2')
+            clang_version_type('100.0.56.1')
+
+
+class TestSwiftVersionType(TestCase):
+
+    def test_valid_swift_version(self):
+        swift_version_type = types.SwiftVersionType()
+
+        with self.assertNotRaises(ArgumentTypeError):
+            swift_version_type('1.0')
+            swift_version_type('3.0.2')
+            swift_version_type('200.0.56')
+            swift_version_type('100000.0.1')
+
+    def test_invalid_swift_version(self):
+        swift_version_type = types.SwiftVersionType()
+
+        with self.assertRaises(ArgumentTypeError):
+            swift_version_type('2')
+            swift_version_type('1.8.0.2')
+            swift_version_type('100.0.56.1')
+
+
+class TestShellSplitType(object):
+
+    def test_split(self):
+        shell_split_type = types.ShellSplitType()
+
+        split = shell_split_type('-BAR="foo bar"')
+        self.assertEqual(split, ['-BAR="foo bar"'])
+
+        split = shell_split_type('-BAR="foo bar" -BAZ="foo,bar",-QUX 42')
+        self.assertEqual(split, [
+            '-BAR="foo bar"',
+            '-BAZ="foo,bar"',
+            '-QUX',
+            '42',
+        ])

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -9,7 +9,7 @@
 
 import os.path
 
-from build_swift.argparse import types, ArgumentTypeError
+from build_swift.argparse import ArgumentTypeError, types
 from build_swift.tests.utils import TestCase
 
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -9,6 +9,9 @@
 
 import multiprocessing
 
+from swift_build_support.swift_build_support import host
+from swift_build_support.swift_build_support import targets
+
 from .. import argparse
 from .. import defaults
 
@@ -123,12 +126,9 @@ EXPECTED_DEFAULTS = {
     'host_cxx': None,
     'host_libtool': None,
     'host_lipo': None,
-    # FIXME: determine actual default value rather than hardcode
-    'host_target': 'macosx-x86_64',
+    'host_target': targets.StdlibDeploymentTarget.host_target().name,
     'host_test': False,
-    # FIXME: determine actual default value rather than hardcode
-    'install_prefix': '/Applications/Xcode.app/Contents/Developer/Toolchains/'
-                      'XcodeDefault.xctoolchain/usr',
+    'install_prefix': targets.install_prefix(),
     'install_symroot': None,
     'ios': False,
     'ios_all': False,
@@ -140,7 +140,8 @@ EXPECTED_DEFAULTS = {
     'lldb_build_variant': 'Debug',
     'llvm_assertions': True,
     'llvm_build_variant': 'Debug',
-    'llvm_max_parallel_lto_link_jobs': 0,
+    'llvm_max_parallel_lto_link_jobs':
+        host.max_lto_link_job_counts()['llvm'],
     'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips',
     'long_test': False,
     'lto_type': None,
@@ -153,7 +154,8 @@ EXPECTED_DEFAULTS = {
     'swift_compiler_version': None,
     'swift_stdlib_assertions': True,
     'swift_stdlib_build_variant': 'Debug',
-    'swift_tools_max_parallel_lto_link_jobs': 0,
+    'swift_tools_max_parallel_lto_link_jobs':
+        host.max_lto_link_job_counts()['swift'],
     'swift_user_visible_version': defaults.SWIFT_USER_VISIBLE_VERSION,
     'symbols_package': None,
     'test': None,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -6,10 +6,11 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-import argparse
+
 import multiprocessing
 
-from build_swift import defaults
+from .. import argparse
+from .. import defaults
 
 
 __all__ = [

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -6,24 +6,23 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-from __future__ import print_function
 
-import argparse
 import os
 import sys
 import unittest
-
 from contextlib import contextmanager
 from io import StringIO
-
-from build_swift import driver_arguments
-from build_swift.tests import expected_options as eo
 
 from swift_build_support.swift_build_support import migration
 from swift_build_support.swift_build_support.SwiftBuildSupport import (
     get_all_preset_names,
     get_preset_options,
 )
+
+from . import expected_options as eo
+from .. import argparse
+from .. import driver_arguments
+
 
 FILE_PATH = os.path.abspath(__file__)
 TESTS_PATH = os.path.abspath(os.path.join(FILE_PATH, os.pardir))

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from contextlib import contextmanager
-
 try:
     from StringIO import StringIO
 except ImportError:
@@ -17,6 +15,7 @@ except ImportError:
 import os
 import sys
 import unittest
+from contextlib import contextmanager
 
 
 __all__ = [

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -1,0 +1,69 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from contextlib import contextmanager
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import os
+import sys
+import unittest
+
+
+__all__ = [
+    'redirect_stderr',
+    'redirect_stdout',
+    'TestCase',
+]
+
+
+# -----------------------------------------------------------------------------
+
+@contextmanager
+def redirect_stderr(stream=None):
+    stream = stream or StringIO()
+    old_stderr, sys.stderr = sys.stderr, stream
+    try:
+        yield stream
+    finally:
+        sys.stderr = old_stderr
+
+
+@contextmanager
+def redirect_stdout(stream=None):
+    stream = stream or StringIO()
+    old_stdout, sys.stdout = sys.stdout, stream
+    try:
+        yield stream
+    finally:
+        sys.stdout = old_stdout
+
+
+# -----------------------------------------------------------------------------
+
+class TestCase(unittest.TestCase):
+
+    @contextmanager
+    def quietOutput(self):
+        with open(os.devnull, 'w') as devnull:
+            with redirect_stderr(devnull), redirect_stdout(devnull):
+                yield
+
+    @contextmanager
+    def assertNotRaises(self, exception=BaseException):
+        assert issubclass(exception, BaseException)
+
+        try:
+            yield
+        except exception as e:
+            message = '{} raised: {}'.format(exception.__name__, str(e))
+            raise self.failureException(message)

--- a/validation-test/Python/build_swift.swift
+++ b/validation-test/Python/build_swift.swift
@@ -1,0 +1,7 @@
+// RUN: %{python} -m unittest discover -s utils/build_swift/ -t utils/
+
+// Continuous integration for the OS X Platform also runs the tests in the iPhone, Apple TV and Apple Watch simulators.
+// We only need to run python linting once per OSX Platform test run, rather than once for each supported Apple device.
+// UNSUPPORTED: OS=watchos
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos

--- a/validation-test/Python/build_swift.swift
+++ b/validation-test/Python/build_swift.swift
@@ -1,7 +1,10 @@
-// RUN: %{python} -m unittest discover -s %utils/build_swift/ -t %utils/
+// Continuous integration for the OS X Platform also runs the tests in the
+// iPhone, Apple TV and Apple Watch simulators. We only need to run the
+// build_swift module unit-tests once per OSX Platform test run, rather than
+// once for each supported Apple device.
 
-// Continuous integration for the OS X Platform also runs the tests in the iPhone, Apple TV and Apple Watch simulators.
-// We only need to run python linting once per OSX Platform test run, rather than once for each supported Apple device.
-// UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
+// UNSUPPORTED: OS=watchos
+
+// RUN: %{python} -m unittest discover -s %utils/build_swift/ -t %utils/

--- a/validation-test/Python/build_swift.swift
+++ b/validation-test/Python/build_swift.swift
@@ -1,4 +1,4 @@
-// RUN: %{python} -m unittest discover -s utils/build_swift/ -t utils/
+// RUN: %{python} -m unittest discover -s %utils/build_swift/ -t %utils/
 
 // Continuous integration for the OS X Platform also runs the tests in the iPhone, Apple TV and Apple Watch simulators.
 // We only need to run python linting once per OSX Platform test run, rather than once for each supported Apple device.


### PR DESCRIPTION
# Purpose

This PR is meant to supersede #11827. Rather than one large PR that introduces an entire DSL and refactors the _very_ large argument parsing logic all at once, it seemed better to introduce the argument parsing DSL separately and then in follow-up PRs complete the refactoring. I've used @rintaro's work from #2190 to construct a wrapper module, or overlay if you will, around the standard python `argparse` which exposes the exact same API with some extras on top. Specifically there's now a bunch of new action classes which handle multiple destinations, a new builder class on the `ArgumentParser` and lastly a handful of new `*Type` classes.

The entire module is thoroughly tested and I'll be following this up with subsequent PRs to convert the argument parser piece-wise.

rdar://34336890