### PR TITLE
SILGen: Fix bug with vtable entries for allocating initializers

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -343,6 +343,10 @@ struct SILDeclRef {
   /// to foreign C or ObjC calling convention.
   bool isNativeToForeignThunk() const;
 
+  /// True if the decl ref references a method which introduces a new vtable
+  /// entry.
+  bool requiresNewVTableEntry() const;
+
   /// Return a SILDeclRef to the declaration overridden by this one, or
   /// a null SILDeclRef if there is no override.
   SILDeclRef getOverridden() const;

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -43,8 +43,8 @@ template <class T> class SILVTableVisitor {
   void maybeAddMethod(FuncDecl *fd) {
     assert(!fd->hasClangNode());
 
-    maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func),
-                  fd->needsNewVTableEntry());
+    SILDeclRef constant(fd, SILDeclRef::Kind::Func);
+    maybeAddEntry(constant, constant.requiresNewVTableEntry());
   }
 
   void maybeAddConstructor(ConstructorDecl *cd) {
@@ -53,18 +53,14 @@ template <class T> class SILVTableVisitor {
     // Required constructors (or overrides thereof) have their allocating entry
     // point in the vtable.
     if (cd->isRequired()) {
-      bool needsAllocatingEntry = cd->needsNewVTableEntry();
-      if (!needsAllocatingEntry)
-        if (auto *baseCD = cd->getOverriddenDecl())
-          needsAllocatingEntry = !baseCD->isRequired() || baseCD->hasClangNode();
-      maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator),
-                    needsAllocatingEntry);
+      SILDeclRef constant(cd, SILDeclRef::Kind::Allocator);
+      maybeAddEntry(constant, constant.requiresNewVTableEntry());
     }
 
     // All constructors have their initializing constructor in the
     // vtable, which can be used by a convenience initializer.
-    maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Initializer),
-                  cd->needsNewVTableEntry());
+    SILDeclRef constant(cd, SILDeclRef::Kind::Initializer);
+    maybeAddEntry(constant, constant.requiresNewVTableEntry());
   }
 
   void maybeAddEntry(SILDeclRef declRef, bool needsNewEntry) {

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -772,6 +772,22 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
   llvm_unreachable("bad entity kind!");
 }
 
+bool SILDeclRef::requiresNewVTableEntry() const {
+  if (cast<AbstractFunctionDecl>(getDecl())->needsNewVTableEntry())
+    return true;
+  if (kind == SILDeclRef::Kind::Allocator) {
+    auto *cd = cast<ConstructorDecl>(getDecl());
+    if (cd->isRequired()) {
+      auto *baseCD = cd->getOverriddenDecl();
+      if(!baseCD ||
+         !baseCD->isRequired() ||
+         baseCD->hasClangNode())
+        return true;
+    }
+  }
+  return false;
+}
+
 SILDeclRef SILDeclRef::getOverridden() const {
   if (!hasDecl())
     return SILDeclRef();

--- a/test/SILGen/objc_required_designated_init.swift
+++ b/test/SILGen/objc_required_designated_init.swift
@@ -1,19 +1,39 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-sil-ownership %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule -import-objc-header %S/Inputs/objc_required_designated_init.h
-// RUN: %target-swift-frontend -I %t -emit-silgen -enable-sil-ownership -verify %s -import-objc-header %S/Inputs/objc_required_designated_init.h
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-sil-ownership -verify %s -import-objc-header %S/Inputs/objc_required_designated_init.h | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir %s -import-objc-header %S/Inputs/objc_required_designated_init.h
 
 // REQUIRES: objc_interop
 
 import Booms
 
-class Baboom: Boom {
+class Baboom : Boom {
+  @objc dynamic required init() {
+    super.init()
+  }
+}
+
+class BigBadaBoom<V> : Badaboom<V> {
   required init() {
     super.init()
   }
 }
 
-class BigBadaBoom<V>: Badaboom<V> {
-  required init() {
-    super.init()
-  }
+class Root {
+  @objc dynamic required init() {}
 }
+
+// CHECK-LABEL: sil_vtable Baboom {
+// CHECK:   #Boom.init!allocator.1: (Boom.Type) -> () -> Boom : _T029objc_required_designated_init6BaboomCACycfC [override]
+// CHECK:   #Baboom.deinit!deallocator: _T029objc_required_designated_init6BaboomCfD
+// CHECK: }
+
+// CHECK-LABEL: sil_vtable BigBadaBoom {
+// CHECK:   #Badaboom.init!allocator.1: <U> (Badaboom<U>.Type) -> () -> Badaboom<U> : _T029objc_required_designated_init11BigBadaBoomCACyxGycfC [override]
+// CHECK:   #BigBadaBoom.deinit!deallocator: _T029objc_required_designated_init11BigBadaBoomCfD
+// CHECK: }
+
+// CHECK-LABEL: sil_vtable Root {
+// CHECK:   #Root.init!allocator.1: (Root.Type) -> () -> Root : _T029objc_required_designated_init4RootCACycfC
+// CHECK:   #Root.deinit!deallocator: _T029objc_required_designated_init4RootCfD
+// CHECK: }


### PR DESCRIPTION
Some changes I was working on uncovered a latent bug where we would
emit a class_method instruction to call an allocating initializer
that did not have a vtable entry.

Previously this wasn't caught because the only example of this in
our test suite was in test/SILGen/objc_bridging_any.swift, which
did not test with IRGen; if it did, an IRGen crash would have been
observed.

Factor out some code duplication to prevent this from happening
again, and add a SILGen test that we emit a vtable entry in this
case, and that the test case passes IRGen also.