### PR TITLE
SILGen: Fix block to func reabstraction thunks block argument handling

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -795,7 +795,9 @@ static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
   // Add the block argument.
   SILValue blockV =
       entry->createFunctionArgument(SILType::getPrimitiveObjectType(blockTy));
-  ManagedValue block = SGF.emitManagedRValueWithCleanup(blockV);
+  ManagedValue block = SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts
+                           ? SGF.emitManagedRetain(loc, blockV)
+                           : SGF.emitManagedRValueWithCleanup(blockV);
 
   CanType formalResultType = formalFuncTy.getResult();
 

--- a/test/SILGen/lit.local.cfg
+++ b/test/SILGen/lit.local.cfg
@@ -1,12 +1,12 @@
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 
-config.substitutions.insert(0, ('%build-silgen-test-overlays',
-  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/ObjectiveC.swift && '
-  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Dispatch.swift && '
-  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Foundation.swift'))
-
 config.substitutions.insert(0, ('%build-silgen-test-overlays-guaranteed-closure-contexts',
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-guaranteed-closure-contexts -emit-module -o %t %S/Inputs/ObjectiveC.swift && '
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-guaranteed-closure-contexts -emit-module -o %t %S/Inputs/Dispatch.swift && '
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-guaranteed-closure-contexts -emit-module -o %t %S/Inputs/Foundation.swift'))
+
+config.substitutions.insert(0, ('%build-silgen-test-overlays',
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/ObjectiveC.swift && '
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Dispatch.swift && '
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Foundation.swift'))

--- a/test/SILGen/lit.local.cfg
+++ b/test/SILGen/lit.local.cfg
@@ -5,3 +5,8 @@ config.substitutions.insert(0, ('%build-silgen-test-overlays',
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/ObjectiveC.swift && '
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Dispatch.swift && '
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Foundation.swift'))
+
+config.substitutions.insert(0, ('%build-silgen-test-overlays-guaranteed-closure-contexts',
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-guaranteed-closure-contexts -emit-module -o %t %S/Inputs/ObjectiveC.swift && '
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-guaranteed-closure-contexts -emit-module -o %t %S/Inputs/Dispatch.swift && '
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-guaranteed-closure-contexts -emit-module -o %t %S/Inputs/Foundation.swift'))

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership %s | %FileCheck %s
 // RUN: %empty-directory(%t)
-// RUN: %build-silgen-test-overlays-enable-guaranteed-closure-contexts
+// RUN: %build-silgen-test-overlays-guaranteed-closure-contexts
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership -enable-guaranteed-closure-contexts %s | %FileCheck %s --check-prefix=GUARANTEED
 
 // REQUIRES: objc_interop

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership %s | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %build-silgen-test-overlays-enable-guaranteed-closure-contexts
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership -enable-guaranteed-closure-contexts %s | %FileCheck %s --check-prefix=GUARANTEED
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
The block parameter is passed @guaranteed if we use a @callee_guaranteed
convention.

SR-5441
rdar://33255593