### PR TITLE
SILGen: Fix @callee_guaranteed prolog emission for captured l-values

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2987,9 +2987,8 @@ ManagedValue Transform::transformFunction(ManagedValue fn,
   // Apply any ABI-compatible conversions before doing thin-to-thick.
   if (fnType != newFnType) {
     SILType resTy = SILType::getPrimitiveObjectType(newFnType);
-    fn = ManagedValue(
-        SGF.B.createConvertFunction(Loc, fn.getValue(), resTy),
-        fn.getCleanup());
+    fn = SGF.emitManagedRValueWithCleanup(
+        SGF.B.createConvertFunction(Loc, fn.forward(SGF), resTy));
   }
 
   // Now do thin-to-thick if necessary.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -390,14 +390,20 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     SILType ty = lowering.getLoweredType();
     SILValue val = SGF.F.begin()->createFunctionArgument(ty, VD);
 
+    bool NeedToDestroyValueAtExit =
+        !SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts;
+
     // If the original variable was settable, then Sema will have treated the
     // VarDecl as an lvalue, even in the closure's use.  As such, we need to
     // allow formation of the address for this captured value.  Create a
     // temporary within the closure to provide this address.
     if (VD->isSettable(VD->getDeclContext())) {
       auto addr = SGF.emitTemporaryAllocation(VD, ty);
-      if (SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts)
+      if (SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts) {
+        // We have created a copy that needs to be destroyed.
         val = SGF.B.createCopyValue(Loc, val);
+        NeedToDestroyValueAtExit = true;
+      }
       lowering.emitStore(SGF.B, VD, val, addr, StoreOwnershipQualifier::Init);
       val = addr;
     }
@@ -409,8 +415,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
       SGF.B.createDebugValue(Loc, val, {/*Constant*/true, ArgNo});
 
     // TODO: Closure contexts should always be guaranteed.
-    if (!SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts
-        && !lowering.isTrivial())
+    if (NeedToDestroyValueAtExit && !lowering.isTrivial())
       SGF.enterDestroyCleanup(val);
     break;
   }

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -parse-as-library -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -parse-as-library -emit-silgen -enable-guaranteed-closure-contexts %s | %FileCheck %s --check-prefix=GUARANTEED
 
 import Swift
 
@@ -394,6 +395,17 @@ func closeOverLetLValue() {
 // CHECK:   return [[INT_IN_CLASS]]
 // CHECK: } // end sil function '_T08closures18closeOverLetLValueyyFSiycfU_'
 
+// GUARANTEED-LABEL: sil private @_T08closures18closeOverLetLValueyyFSiycfU_ : $@convention(thin) (@guaranteed ClassWithIntProperty) -> Int {
+// GUARANTEED: bb0(%0 : @guaranteed $ClassWithIntProperty):
+// GUARANTEED:   [[TMP:%.*]] = alloc_stack $ClassWithIntProperty
+// GUARANTEED:   [[COPY:%.*]] = copy_value %0 : $ClassWithIntProperty
+// GUARANTEED:   store [[COPY]] to [init] [[TMP]] : $*ClassWithIntProperty
+// GUARANTEED:   [[LOADED_COPY:%.*]] = load [copy] [[TMP]]
+// GUARANTEED:   [[BORROWED:%.*]] = begin_borrow [[LOADED_COPY]]
+// GUARANTEED:   end_borrow [[BORROWED]] from [[LOADED_COPY]]
+// GUARANTEED:   destroy_value [[LOADED_COPY]]
+// GUARANTEED:   destroy_addr [[TMP]]
+// GUARANTEED: } // end sil function '_T08closures18closeOverLetLValueyyFSiycfU_'
 
 
 // Use an external function so inout deshadowing cannot see its body.


### PR DESCRIPTION
We need to deallocate the copy we created in the temporary location.

... and properly forward cleanup after inserting a convert_function
instruction. This didn't come up before because closures where consumed
by the ultimate apply in the chain and no compensating destroy was
neccessary.

SR-5441
rdar://33255593