### PR TITLE
[pred-memopt] Provide normal succ manipulation methods on TermInst in…

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -227,7 +227,7 @@ public:
   void dropAllArguments() { ArgumentList.clear(); }
 
   //===--------------------------------------------------------------------===//
-  // Predecessors and Successors
+  // Successors
   //===--------------------------------------------------------------------===//
 
   using SuccessorListTy = TermInst::SuccessorListTy;
@@ -242,80 +242,62 @@ public:
     return getTerminator()->getSuccessors();
   }
 
-  using const_succ_iterator = ConstSuccessorListTy::const_iterator;
-  using succ_iterator = SuccessorListTy::iterator;
+  using const_succ_iterator = TermInst::const_succ_iterator;
+  using succ_iterator = TermInst::succ_iterator;
 
-  bool succ_empty() const { return getSuccessors().empty(); }
-  succ_iterator succ_begin() { return getSuccessors().begin(); }
-  succ_iterator succ_end() { return getSuccessors().end(); }
-  const_succ_iterator succ_begin() const { return getSuccessors().begin(); }
-  const_succ_iterator succ_end() const { return getSuccessors().end(); }
+  bool succ_empty() const { return getTerminator()->succ_empty(); }
+  succ_iterator succ_begin() { return getTerminator()->succ_begin(); }
+  succ_iterator succ_end() { return getTerminator()->succ_end(); }
+  const_succ_iterator succ_begin() const {
+    return getTerminator()->succ_begin();
+  }
+  const_succ_iterator succ_end() const { return getTerminator()->succ_end(); }
 
-  using succblock_iterator =
-      TransformIterator<SILSuccessor *,
-                        std::function<SILBasicBlock *(const SILSuccessor &)>>;
-  using const_succblock_iterator = TransformIterator<
-      const SILSuccessor *,
-      std::function<const SILBasicBlock *(const SILSuccessor &)>>;
+  using succblock_iterator = TermInst::succblock_iterator;
+  using const_succblock_iterator = TermInst::const_succblock_iterator;
+
   succblock_iterator succblock_begin() {
-    using FuncTy = std::function<SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformIterator(getSuccessors().begin(), F);
+    return getTerminator()->succblock_begin();
   }
   succblock_iterator succblock_end() {
-    using FuncTy = std::function<SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformIterator(getSuccessors().end(), F);
+    return getTerminator()->succblock_end();
   }
   const_succblock_iterator succblock_begin() const {
-    using FuncTy = std::function<const SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformIterator(getSuccessors().begin(), F);
+    return getTerminator()->succblock_begin();
   }
   const_succblock_iterator succblock_end() const {
-    using FuncTy = std::function<const SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformIterator(getSuccessors().end(), F);
+    return getTerminator()->succblock_end();
   }
 
   SILBasicBlock *getSingleSuccessorBlock() {
-    if (succ_empty() || std::next(succ_begin()) != succ_end())
-      return nullptr;
-    return *succ_begin();
+    return getTerminator()->getSingleSuccessorBlock();
   }
 
   const SILBasicBlock *getSingleSuccessorBlock() const {
-    return const_cast<SILBasicBlock *>(this)->getSingleSuccessorBlock();
+    return getTerminator()->getSingleSuccessorBlock();
   }
 
   /// \brief Returns true if \p BB is a successor of this block.
-  bool isSuccessorBlock(SILBasicBlock *BB) const {
-    auto Range = getSuccessorBlocks();
-    return any_of(Range, [&BB](const SILBasicBlock *SuccBB) -> bool {
-      return BB == SuccBB;
-    });
+  bool isSuccessorBlock(SILBasicBlock *Block) const {
+    return getTerminator()->isSuccessorBlock(Block);
   }
 
-  using SuccessorBlockListTy =
-    TransformRange<SuccessorListTy,
-                   std::function<SILBasicBlock *(const SILSuccessor &)>>;
-  using ConstSuccessorBlockListTy =
-    TransformRange<ConstSuccessorListTy,
-                   std::function<const SILBasicBlock *(const SILSuccessor &)>>;
+  using SuccessorBlockListTy = TermInst::SuccessorBlockListTy;
+  using ConstSuccessorBlockListTy = TermInst::ConstSuccessorBlockListTy;
 
   /// Return the range of SILBasicBlocks that are successors of this block.
   SuccessorBlockListTy getSuccessorBlocks() {
-    using FuncTy = std::function<SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformRange(getSuccessors(), F);
+    return getTerminator()->getSuccessorBlocks();
   }
 
   /// Return the range of SILBasicBlocks that are successors of this block.
   ConstSuccessorBlockListTy getSuccessorBlocks() const {
-    using FuncTy = std::function<const SILBasicBlock *(const SILSuccessor &)>;
-    FuncTy F(&SILSuccessor::getBB);
-    return makeTransformRange(getSuccessors(), F);
+    return getTerminator()->getSuccessorBlocks();
   }
+
+  //===--------------------------------------------------------------------===//
+  // Predecessors
+  //===--------------------------------------------------------------------===//
 
   using pred_iterator = SILSuccessor::pred_iterator;
 


### PR DESCRIPTION
…stead of SILBasicBlock.

I am doing this for a few different reasons:

1. The code for manipulating successors was partially in TermInst (with
SILBasicBlock delegating to TermInst) and partly in SILBasicBlock itself. It
makes more sense to just be consistent and move all said functionality into
TermInst and just always delegate to SILBasicBlock.

2. I am preparing an API around gathering all critical edges. All of the
critical edge breaking APIs to take a TermInst. I wanted to use some of the
successor APIs, only to discover that we were not delegating to TermInst.  By
moving said functionality onto TermInst itself and delegating, we have it in
both places.

rdar://31521023

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
