### PR TITLE
[Cross compile] Add missing standard include from C++

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #endif
 #include <climits>
+#include <clocale>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
This should be totally harmless.