### PR TITLE
Fix the value of `Float80.pi`

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -559,11 +559,11 @@ extension ${Self}: BinaryFloatingPoint {
     // in angles in the wrong quadrant if users aren't careful.  This is
     // not a problem for Double or Float80, as pi rounds down in both of
     // those formats.
-    return 0x1.921fb4p1 as Float
+    return 0x1.921fb4p1
 %elif bits == 64:
-    return 0x1.921fb54442d18p1 as Double
+    return 0x1.921fb54442d18p1
 %elif bits == 80:
-    return 0x1.921fb54442d1846ap1 as Float80
+    return 0x1.921fb54442d1846ap1
 %end
   }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -559,11 +559,11 @@ extension ${Self}: BinaryFloatingPoint {
     // in angles in the wrong quadrant if users aren't careful.  This is
     // not a problem for Double or Float80, as pi rounds down in both of
     // those formats.
-    return Float(0x1.921fb4p1)
+    return 0x1.921fb4p1 as Float
 %elif bits == 64:
-    return Double(0x1.921fb54442d18p1)
+    return 0x1.921fb54442d18p1 as Double
 %elif bits == 80:
-    return Float80(0x1.921fb54442d1846ap1)
+    return 0x1.921fb54442d1846ap1 as Float80
 %end
   }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently this is implemented as `Float80(literal)`, which gets interpreted as `Float80(Double(literal))`, unfortunately. Switch to the correct spelling: `literal as Float80`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves <rdar://problem/35459284>

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->