### PR TITLE
Disable ModelIO test on ios

### DIFF
--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -6,6 +6,7 @@
 // Currently crashes on iphonesimulator.
 // rdar://35490456
 // UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
 
 import StdlibUnittest
 

--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -3,6 +3,10 @@
 // UNSUPPORTED: OS=watchos
 // REQUIRES: objc_interop
 
+// Currently crashes on iphonesimulator.
+// rdar://35490456
+// UNSUPPORTED: OS=ios
+
 import StdlibUnittest
 
 import Foundation


### PR DESCRIPTION
This test fails on the iphonesimulator x86_64

rdar://35490456