### PR TITLE
[SE-NNNN] [WIP] [stdlib] Rename Sequence.elementsEqual

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -47,7 +47,7 @@ public struct DropLastTest {
   }
 }
 
-public struct ElementsEqualTest {
+public struct ElementsEqualInIterationOrderTest {
   public let expected: Bool
   public let sequence: [Int]
   public let other: [Int]
@@ -70,8 +70,8 @@ public struct ElementsEqualTest {
     self.loc = SourceLoc(file, line, comment: "test data" + comment)
   }
 
-  func flip() -> ElementsEqualTest {
-    return ElementsEqualTest(
+  func flip() -> ElementsEqualInIterationOrderTest {
+    return ElementsEqualInIterationOrderTest(
       expected, other, sequence,
       expectedLeftoverOther, expectedLeftoverSequence,
       file: loc.file, line: loc.line, comment: " (flipped)")
@@ -437,17 +437,17 @@ public struct ZipTest {
 }
 
 
-public let elementsEqualTests: [ElementsEqualTest] = [
-  ElementsEqualTest(true, [], [], [], []),
+public let elementsEqualInIterationOrderTests = [
+  ElementsEqualInIterationOrderTest(true, [], [], [], []),
 
-  ElementsEqualTest(false, [ 1 ], [], [], []),
-  ElementsEqualTest(false, [], [ 1 ], [], []),
+  ElementsEqualInIterationOrderTest(false, [ 1 ], [], [], []),
+  ElementsEqualInIterationOrderTest(false, [], [ 1 ], [], []),
 
-  ElementsEqualTest(false, [ 1, 2 ], [], [ 2 ], []),
-  ElementsEqualTest(false, [], [ 1, 2 ], [], [ 2 ]),
+  ElementsEqualInIterationOrderTest(false, [ 1, 2 ], [], [ 2 ], []),
+  ElementsEqualInIterationOrderTest(false, [], [ 1, 2 ], [], [ 2 ]),
 
-  ElementsEqualTest(false, [ 1, 2, 3, 4 ], [ 1, 2 ], [ 4 ], []),
-  ElementsEqualTest(false, [ 1, 2 ], [ 1, 2, 3, 4 ], [], [ 4 ]),
+  ElementsEqualInIterationOrderTest(false, [ 1, 2, 3, 4 ], [ 1, 2 ], [ 4 ], []),
+  ElementsEqualInIterationOrderTest(false, [ 1, 2 ], [ 1, 2, 3, 4 ], [], [ 4 ]),
 ].flatMap { [ $0, $0.flip() ] }
 
 public let enumerateTests = [

--- a/stdlib/private/StdlibUnicodeUnittest/Collation.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/Collation.swift
@@ -203,7 +203,7 @@ public func == <Element>(
   lhs: HashableArray<Element>,
   rhs: HashableArray<Element>
 ) -> Bool {
-  return lhs._elements.elementsEqual(rhs._elements)
+  return lhs._elements.elementsEqualInIterationOrder(rhs._elements)
 }
 
 extension HashableArray : ExpressibleByArrayLiteral {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2382,7 +2382,7 @@ public func expectEqualSequence<
 ) where
   Expected.Iterator.Element == Actual.Iterator.Element {
 
-  if !expected.elementsEqual(actual, by: sameValue) {
+  if !expected.elementsEqualInIterationOrder(actual, by: sameValue) {
     expectationFailure("expected elements: \"\(expected)\"\n"
       + "actual: \"\(actual)\" (of type \(String(reflecting: type(of: actual))))",
       trace: ${trace})
@@ -2546,7 +2546,7 @@ public func expectEqualUnicodeScalars(
   let actualUnicodeScalars = Array(
     actual.unicodeScalars.lazy.map { $0.value })
 
-  if !expected.elementsEqual(actualUnicodeScalars) {
+  if !expected.elementsEqualInIterationOrder(actualUnicodeScalars) {
     expectationFailure(
       "expected elements: \"\(asHex(expected))\"\n"
       + "actual: \"\(asHex(actualUnicodeScalars))\"",

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -289,7 +289,7 @@ ${equivalenceExplanation}
 % end
 
 //===----------------------------------------------------------------------===//
-// elementsEqual()
+// elementsEqualInIterationOrder()
 //===----------------------------------------------------------------------===//
 
 % # Generate two versions: with explicit predicates and with
@@ -325,9 +325,9 @@ ${equivalenceExplanation}
   ///     let a = 1...3
   ///     let b = 1...10
   ///
-  ///     print(a.elementsEqual(b))
+  ///     print(a.elementsEqualInIterationOrder(b))
   ///     // Prints "false"
-  ///     print(a.elementsEqual([1, 2, 3]))
+  ///     print(a.elementsEqualInIterationOrder([1, 2, 3]))
   ///     // Prints "true"
   ///
   /// - Parameter other: A sequence to compare to this sequence.
@@ -335,14 +335,14 @@ ${equivalenceExplanation}
   ///   in the same order.
 %   end
   @_inlineable
-  public func elementsEqual<OtherSequence>(
+  public func elementsEqualInIterationOrder<OtherSequence>(
     _ other: OtherSequence${"," if preds else ""}
 %   if preds:
     by areEquivalent: (Element, Element) throws -> Bool
 %   end
   ) ${rethrows_}-> Bool
     where
-    OtherSequence: Sequence,
+    OtherSequence : Sequence,
     OtherSequence.Element == Element {
 
     var iter1 = self.makeIterator()
@@ -360,6 +360,21 @@ ${equivalenceExplanation}
         return true
       }
     }
+  }
+
+  @_inlineable
+  @available(swift, deprecated: 5, renamed: "elementsEqualInIterationOrder(_:)")
+  public func elementsEqual<OtherSequence>(
+    _ other: OtherSequence${"," if preds else ""}
+%   if preds:
+    by areEquivalent: (Element, Element) throws -> Bool
+%   end
+  ) ${rethrows_}-> Bool
+    where
+    OtherSequence : Sequence,
+    OtherSequence.Element == Element {
+
+    return elementsEqualInIterationOrder(other)
   }
 }
 

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -170,7 +170,7 @@ func testArchetypeReplacement3 (_ a : [Int]) {
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceVar]/Super:            first[#Int?#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         map({#(transform): (Int) throws -> T##(Int) throws -> T#})[' rethrows'][#[T]#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         dropLast({#(n): Int#})[#ArraySlice<Int>#]
-// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         elementsEqual({#(other): Sequence#}, {#by: (Int, Int) throws -> Bool##(Int, Int) throws -> Bool#})[' rethrows'][#Bool#]
+// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         elementsEqualInIterationOrder({#(other): Sequence#}, {#by: (Int, Int) throws -> Bool##(Int, Int) throws -> Bool#})[' rethrows'][#Bool#]
 
 
 protocol P2 {

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -559,7 +559,7 @@ extension ${Collection} {
   ///
   ///     let a = [10, 20, 30, 40, 50, 60, 70]
   ///     let r = a.rotated(shiftingToStart: 3)
-  ///     // r.elementsEqual([40, 50, 60, 70, 10, 20, 30])
+  ///     // r.elementsEqualInIterationOrder([40, 50, 60, 70, 10, 20, 30])
   ///
   /// - Parameter i: The position in the collection that should be first in the
   ///   result. `i` must be a valid index of the collection.

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -242,7 +242,7 @@ func checkDecodeUTF<Codec : UnicodeCodec>(
   func check<C: Collection>(_ expected: C, _ description: String)
   where C.Element == UInt32
   {
-    if !expected.elementsEqual(decoded) {
+    if !expected.elementsEqualInIterationOrder(decoded) {
       if result.description == "" { result = assertionFailure()  }
       result = result.withDescription(" [\(description)]\n")
         .withDescription("expected: \(asHex(expectedHead))\n")

--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -200,9 +200,9 @@ ErrorHandlingTests.test("ErrorHandling/starts(with:)") {
   } catch {}
 }
 
-ErrorHandlingTests.test("ErrorHandling/elementsEqual") {
+ErrorHandlingTests.test("ErrorHandling/elementsEqualInIterationOrder") {
   do {
-    let x: Bool = try [1, 2, 3].elementsEqual([1, 2, 3]) { _, _ in
+    let x: Bool = try [1, 2, 3].elementsEqualInIterationOrder([1, 2, 3]) { _, _ in
       throw SillyError.JazzHands
       return false
     }

--- a/test/stdlib/Inputs/ArrayTypesAndHelpers.swift
+++ b/test/stdlib/Inputs/ArrayTypesAndHelpers.swift
@@ -88,7 +88,7 @@ func _equalsWithoutElementIdentity(
     return list.map { ExpectedArrayElement(value: $0.value) }
   }
 
-  return stripIdentity(lhs).elementsEqual(stripIdentity(rhs))
+  return stripIdentity(lhs).elementsEqualInIterationOrder(stripIdentity(rhs))
 }
 
 struct ExpectedArrayElement : Comparable, CustomStringConvertible {

--- a/test/stdlib/Inputs/DictionaryKeyValueTypes.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypes.swift
@@ -15,14 +15,14 @@ func equalsUnordered<T : Comparable>(
     return [ lhs.0, lhs.1 ].lexicographicallyPrecedes([ rhs.0, rhs.1 ])
   }
   return lhs.sorted(by: areInAscendingOrder)
-    .elementsEqual(rhs.sorted(by: areInAscendingOrder)) {
+    .elementsEqualInIterationOrder(rhs.sorted(by: areInAscendingOrder)) {
     (lhs: (T, T), rhs: (T, T)) -> Bool in
     lhs.0 == rhs.0 && lhs.1 == rhs.1
   }
 }
 
 func equalsUnordered<T : Comparable>(_ lhs: [T], _ rhs: [T]) -> Bool {
-  return lhs.sorted().elementsEqual(rhs.sorted())
+  return lhs.sorted().elementsEqualInIterationOrder(rhs.sorted())
 }
 
 var _keyCount = _stdlib_AtomicInt(0)
@@ -207,7 +207,7 @@ func _equalsWithoutElementIdentity(
     return list.map { ExpectedArrayElement(value: $0.value) }
   }
 
-  return stripIdentity(lhs).elementsEqual(stripIdentity(rhs))
+  return stripIdentity(lhs).elementsEqualInIterationOrder(stripIdentity(rhs))
 }
 
 func _makeExpectedArrayContents(

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -961,7 +961,8 @@ func testEquals(_ a: UnsafeRawPointer,
                 _ count: Int) -> Bool {
   numberOfEqualsOperations += 1
   return UnsafeRawBufferPointer(start: a, count: count)
-    .elementsEqual(UnsafeRawBufferPointer(start: b, count: count))
+    .elementsEqualInIterationOrder(
+      UnsafeRawBufferPointer(start: b, count: count))
 }
 
 var numberOfHashOperations = 0

--- a/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
+++ b/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
@@ -895,7 +895,7 @@ func checkDecodeUTF<Codec : UnicodeCodec & UnicodeEncoding>(
   func check<C: Collection>(_ expected: C, _ description: String)
   where C.Iterator.Element == UInt32
   {
-    if !expected.elementsEqual(decoded) {
+    if !expected.elementsEqualInIterationOrder(decoded) {
       if result.description == "" { result = assertionFailure()  }
       result = result.withDescription(" [\(description)]\n")
         .withDescription("expected: \(asHex(expectedHead))\n")

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -79,7 +79,7 @@ func checkEqual<
 where
 S1.Iterator.Element == S2.Iterator.Element, 
 S1.Iterator.Element : Equatable {
-  if a1.elementsEqual(a2) != expected {
+  if a1.elementsEqualInIterationOrder(a2) != expected {
     let un = expected ? "un" : ""
     print("unexpectedly \(un)equal sequences!")
   }

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -375,8 +375,8 @@ SequenceTypeTests.test("starts(with:)/Predicate") {
 // equal()
 //===----------------------------------------------------------------------===//
 
-SequenceTypeTests.test("elementsEqual/WhereElementIsEquatable") {
-  for test in elementsEqualTests {
+SequenceTypeTests.test("elementsEqualInIterationOrder/WhereElementIsEquatable") {
+  for test in elementsEqualInIterationOrderTests {
     do {
       let s = MinimalSequence<MinimalEquatableValue>(
         elements: test.sequence.map(MinimalEquatableValue.init))
@@ -384,7 +384,7 @@ SequenceTypeTests.test("elementsEqual/WhereElementIsEquatable") {
         elements: test.other.map(MinimalEquatableValue.init))
       expectEqual(
         test.expected,
-        s.elementsEqual(other),
+        s.elementsEqualInIterationOrder(other),
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.expectedLeftoverSequence, s.map { $0.value },
@@ -402,7 +402,7 @@ SequenceTypeTests.test("elementsEqual/WhereElementIsEquatable") {
         elements: test.other.map(MinimalEquatableValue.init))
       expectEqual(
         test.expected,
-        s.elementsEqual(other),
+        s.elementsEqualInIterationOrder(other),
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.sequence, s.map { $0.value },
@@ -414,8 +414,8 @@ SequenceTypeTests.test("elementsEqual/WhereElementIsEquatable") {
   }
 }
 
-SequenceTypeTests.test("elementsEqual/Predicate") {
-  for test in elementsEqualTests {
+SequenceTypeTests.test("elementsEqualInIterationOrder/Predicate") {
+  for test in elementsEqualInIterationOrderTests {
     do {
       let s = MinimalSequence<OpaqueValue<Int>>(
         elements: test.sequence.map(OpaqueValue.init))
@@ -423,7 +423,7 @@ SequenceTypeTests.test("elementsEqual/Predicate") {
         elements: test.other.map(OpaqueValue.init))
       expectEqual(
         test.expected,
-        s.elementsEqual(other) { $0.value == $1.value },
+        s.elementsEqualInIterationOrder(other) { $0.value == $1.value },
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.expectedLeftoverSequence, s.map { $0.value },
@@ -441,7 +441,7 @@ SequenceTypeTests.test("elementsEqual/Predicate") {
         elements: test.other.map(OpaqueValue.init))
       expectEqual(
         test.expected,
-        s.elementsEqual(other) { $0.value == $1.value },
+        s.elementsEqualInIterationOrder(other) { $0.value == $1.value },
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.sequence, s.map { $0.value },

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -117,7 +117,7 @@ func pickRandom<T>(_ a: [T]) -> T {
 }
 
 func equalsUnordered(_ lhs: Set<Int>, _ rhs: Set<Int>) -> Bool {
-  return lhs.sorted().elementsEqual(rhs.sorted()) {
+  return lhs.sorted().elementsEqualInIterationOrder(rhs.sorted()) {
     $0 == $1
   }
 }


### PR DESCRIPTION
A PR to support a pending [proposal](https://github.com/apple/swift-evolution/pull/766) to rename `Sequence.elementsEqual`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #48657.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->