### PR TITLE
stdlib: fixes depend targets

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -193,8 +193,8 @@ foreach(sdk ${ELFISH_SDKS})
       OUTPUT
           "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
       DEPENDS
-          "${section_magic_begin_obj}"
-          "${section_magic_loader_obj}")
+          "section_magic_begin-${arch_suffix}"
+          "section_magic_loader-${arch_suffix}")
 
     add_custom_command_target(section_magic_${arch_suffix}_end_object
       COMMAND
@@ -204,7 +204,7 @@ foreach(sdk ${ELFISH_SDKS})
       OUTPUT
           "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
       DEPENDS
-          "${section_magic_end_obj}")
+          "section_magic_end-${arch_suffix}")
 
     list(APPEND object_target_list
         "${section_magic_${arch_suffix}_begin_object}"
@@ -227,7 +227,7 @@ foreach(sdk ${ELFISH_SDKS})
         OUTPUT
             "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_begin.o"
         DEPENDS
-            "${section_magic_begin_obj}")
+            "section_magic_begin-${arch_suffix}")
 
       add_custom_command_target(static_section_magic_${arch_suffix}_end_object
         COMMAND
@@ -237,7 +237,7 @@ foreach(sdk ${ELFISH_SDKS})
         OUTPUT
             "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_end.o"
         DEPENDS
-            "${section_magic_end_obj}")
+            "section_magic_end-${arch_suffix}")
 
       list(APPEND object_target_list
             "${static_section_magic_${arch_suffix}_begin_object}"


### PR DESCRIPTION
this fixes such an error: No rule to make target
'stdlib/public/runtime/CMakeFiles/section_magic_end-haiku-x86-64.dir/swift_sections.S.o'.

Also seen here https://www.mail-archive.com/swift-dev@swift.org/msg04644.html
