### PR TITLE
Debug Info / SILGen: fix the source location of variable assignments

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1125,7 +1125,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
   // the initialization. Otherwise, mark it uninitialized for DI to resolve.
   if (auto *Init = entry.getInit()) {
     FullExpr Scope(Cleanups, CleanupLocation(Init));
-    emitExprInto(Init, initialization.get());
+    emitExprInto(Init, initialization.get(), SILLocation(PBD));
   } else {
     initialization->finishUninitialized(*this);
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -361,7 +361,8 @@ ManagedValue SILGenFunction::emitManagedBufferWithCleanup(SILValue v,
   return ManagedValue(v, enterDestroyCleanup(v));
 }
 
-void SILGenFunction::emitExprInto(Expr *E, Initialization *I) {
+void SILGenFunction::emitExprInto(Expr *E, Initialization *I,
+                                  Optional<SILLocation> L) {
   // Handle the special case of copying an lvalue.
   if (auto load = dyn_cast<LoadExpr>(E)) {
     FormalEvaluationScope writeback(*this);
@@ -372,7 +373,7 @@ void SILGenFunction::emitExprInto(Expr *E, Initialization *I) {
 
   RValue result = emitRValue(E, SGFContext(I));
   if (!result.isInContext())
-    std::move(result).forwardInto(*this, E, I);
+    std::move(result).forwardInto(*this, L ? *L : E, I);
 }
 
 namespace {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -952,7 +952,8 @@ public:
   /// Generate SIL for the given expression, storing the final result into the
   /// specified Initialization buffer(s). This avoids an allocation and copy if
   /// the result would be allocated into temporary memory normally.
-  void emitExprInto(Expr *E, Initialization *I);
+  /// The location defaults to \c E.
+  void emitExprInto(Expr *E, Initialization *I, Optional<SILLocation> L = None);
 
   /// Emit the given expression as an r-value.
   RValue emitRValue(Expr *E, SGFContext C = SGFContext());

--- a/test/DebugInfo/linetable-assign.swift
+++ b/test/DebugInfo/linetable-assign.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle %s \
+// RUN:   -emit-sil -emit-verbose-sil -Xllvm -sil-print-debuginfo -g -o - \
+// RUN:   | %FileCheck %s
+public func g<T>(_ t: T) {}
+public func f(_ i: Int32) {
+  // CHECK: function_ref @_T04main1fys5Int32VFyycfU_
+  // CHECK-SAME: loc "{{.*}}":13:3,
+  // CHECK: %[[CLOSURE:.*]] = partial_apply
+  // CHECK-SAME: loc "{{.*}}":13:3,{{.*}}auto_gen
+  // CHECK: store %[[CLOSURE]]
+  // CHECK-SAME: loc "{{.*}}":12:3,  
+  var closure = // line 12
+  {
+    g(i)
+  }
+  return closure() 
+}


### PR DESCRIPTION
by setting the location of the store emitted for a pattern binding
decl to the location of that PBD.

<rdar://problem/35430708>