### PR TITLE
split-cmdline: Correctly handle spaces in arguments.

### DIFF
--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# splitcmdline - Split swift compiler command lines -------------*- python -*-
+# split-cmdline - Split swift compiler command lines ------------*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -14,7 +14,19 @@
 # Split swift compiler command lines into multiple lines.
 #
 # Reads the command line from stdin an outputs the split line to stdout.
+# Example:
 #
+# $ swiftc -c hello.swift -### | split-cmdline
+# /path-to-swift/bin/swift \
+#   -frontend \
+#   -c \
+#   -primary-file hello.swift \
+#   -target x86_64-apple-macosx10.9 \
+#   -enable-objc-interop \
+#   -color-diagnostics \
+#   -module-name hello \
+#   -o hello.o
+# 
 # Example usage in vim:
 # *) make sure that split-cmdline is in the $PATH
 # *) copy-paste the swift command line the text buffer
@@ -29,16 +41,15 @@ from __future__ import print_function
 import re
 import sys
 import os
-
+import shlex
 
 def main():
   for line in sys.stdin:
     first = True
     is_arg_param = False
     # Handle escaped spaces
-    args = re.sub('\\\\ ', '@#space#@', line).split()
+    args = shlex.split(line)
     for arg in args:
-      arg = re.sub('@#space#@', '\\ ', arg)
       if arg == '':
         continue
       if not first:
@@ -59,7 +70,10 @@ def main():
         first = True
         continue
 
-      print(arg, end='')
+      if ' ' in arg:
+        print('"' + arg + '"', end='')
+      else:
+        print(arg, end='')
 
       # A hard-coded list of options which expect a parameter
       is_arg_param = (arg in [


### PR DESCRIPTION
Also add an example in the script header.
