### PR TITLE
[4.1] Use the concrete type parameter passed to JSON/plist decode

### DIFF
--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -478,6 +478,22 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Double], as: [Bool].self)
   }
 
+  func testDecodingConcreteTypeParameter() {
+      let encoder = JSONEncoder()
+      guard let json = try? encoder.encode(Employee.testValue) else {
+          expectUnreachable("Unable to encode Employee.")
+          return
+      }
+
+      let decoder = JSONDecoder()
+      guard let decoded = try? decoder.decode(Employee.self as Person.Type, from: json) else {
+          expectUnreachable("Failed to decode Employee as Person from JSON.")
+          return
+      }
+
+      expectEqual(type(of: decoded), Employee.self, "Expected decoded value to be of type Employee; got \(type(of: decoded)) instead.")
+  }
+
   // MARK: - Helper Functions
   private var _jsonEmptyDictionary: Data {
     return "{}".data(using: .utf8)!
@@ -1104,5 +1120,6 @@ JSONEncoderTests.test("testSuperEncoderCodingPaths") { TestJSONEncoder().testSup
 JSONEncoderTests.test("testInterceptDecimal") { TestJSONEncoder().testInterceptDecimal() }
 JSONEncoderTests.test("testInterceptURL") { TestJSONEncoder().testInterceptURL() }
 JSONEncoderTests.test("testTypeCoercion") { TestJSONEncoder().testTypeCoercion() }
+JSONEncoderTests.test("testDecodingConcreteTypeParameter") { TestJSONEncoder().testDecodingConcreteTypeParameter() }
 runAllTests()
 #endif

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -198,6 +198,22 @@ class TestPropertyListEncoder : TestPropertyListEncoderSuper {
     _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Double], as: [Bool].self)
   }
 
+  func testDecodingConcreteTypeParameter() {
+      let encoder = PropertyListEncoder()
+      guard let plist = try? encoder.encode(Employee.testValue) else {
+          expectUnreachable("Unable to encode Employee.")
+          return
+      }
+
+      let decoder = PropertyListDecoder()
+      guard let decoded = try? decoder.decode(Employee.self as Person.Type, from: plist) else {
+          expectUnreachable("Failed to decode Employee as Person from plist.")
+          return
+      }
+
+      expectEqual(type(of: decoded), Employee.self, "Expected decoded value to be of type Employee; got \(type(of: decoded)) instead.")
+  }
+
   // MARK: - Helper Functions
   private var _plistEmptyDictionaryBinary: Data {
     return Data(base64Encoded: "YnBsaXN0MDDQCAAAAAAAAAEBAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAJ")!
@@ -731,5 +747,6 @@ PropertyListEncoderTests.test("testEncodingTopLevelData") { TestPropertyListEnco
 PropertyListEncoderTests.test("testInterceptData") { TestPropertyListEncoder().testInterceptData() }
 PropertyListEncoderTests.test("testInterceptDate") { TestPropertyListEncoder().testInterceptDate() }
 PropertyListEncoderTests.test("testTypeCoercion") { TestPropertyListEncoder().testTypeCoercion() }
+PropertyListEncoderTests.test("testDecodingConcreteTypeParameter") { TestPropertyListEncoder().testDecodingConcreteTypeParameter() }
 runAllTests()
 #endif


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #12844 against `swift-4.1-branch`. Resolves https://github.com/apple/swift-corelibs-foundation/issues/4416.