### PR TITLE
libSyntax: fix a memory leak issue because of non-virtual destructor. rdar://35116413

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -212,6 +212,8 @@ struct RawSyntax : public llvm::ThreadSafeRefCountedBase<RawSyntax> {
             const SourcePresence Presence)
       : Kind(Kind), Layout(Layout), Presence(Presence) {}
 
+  virtual ~RawSyntax() = default;
+
   /// Returns a raw syntax node of the given Kind, specified Layout,
   /// and source presence.
   static RC<RawSyntax> make(const SyntaxKind Kind, const LayoutList Layout,


### PR DESCRIPTION
RawTokenSyntax is a derived class from RawSyntax, which is reference
counted with its own destructor function registered. Unfortunately, the destructor
function of RawSyntax is non-virtual before this patch. This means when reference counter
releases a pointer of RawSyntax, it won't clean-up the additional stuff in RawTokenSyntax if that is
the pointee.