### PR TITLE
Convert ActionType from "enum" to "enum class".

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -299,7 +299,7 @@ public:
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 
-  enum ActionType {
+  enum class ActionType {
     NoneAction, ///< No specific action
     Parse, ///< Parse only
     Typecheck, ///< Parse and type-check only
@@ -336,10 +336,10 @@ public:
     EmitObject, ///< Emit object file
   };
 
-  bool isCreatingSIL() { return RequestedAction >= EmitSILGen; }
+  bool isCreatingSIL() { return RequestedAction >= ActionType::EmitSILGen; }
 
   /// Indicates the action the user requested that the frontend perform.
-  ActionType RequestedAction = NoneAction;
+  ActionType RequestedAction = ActionType::NoneAction;
 
   /// Indicates that the input(s) should be parsed as the Swift stdlib.
   bool ParseStdlib = false;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -300,14 +300,14 @@ public:
   std::string VerifyGenericSignaturesInModule;
 
   enum class ActionType {
-    NoneAction, ///< No specific action
-    Parse, ///< Parse only
-    Typecheck, ///< Parse and type-check only
-    DumpParse, ///< Parse only and dump AST
+    NoneAction,        ///< No specific action
+    Parse,             ///< Parse only
+    Typecheck,         ///< Parse and type-check only
+    DumpParse,         ///< Parse only and dump AST
     DumpInterfaceHash, ///< Parse and dump the interface token hash.
-    EmitSyntax, ///< Parse and dump Syntax tree as JSON
-    DumpAST, ///< Parse, type-check, and dump AST
-    PrintAST, ///< Parse, type-check, and pretty-print AST
+    EmitSyntax,        ///< Parse and dump Syntax tree as JSON
+    DumpAST,           ///< Parse, type-check, and dump AST
+    PrintAST,          ///< Parse, type-check, and pretty-print AST
 
     /// Parse and dump scope map.
     DumpScopeMaps,
@@ -316,24 +316,24 @@ public:
     DumpTypeRefinementContexts,
 
     EmitImportedModules, ///< Emit the modules that this one imports
-    EmitPCH, ///< Emit PCH of imported bridging header
+    EmitPCH,             ///< Emit PCH of imported bridging header
 
     EmitSILGen, ///< Emit raw SIL
-    EmitSIL, ///< Emit canonical SIL
+    EmitSIL,    ///< Emit canonical SIL
 
     EmitModuleOnly, ///< Emit module only
-    MergeModules, ///< Merge modules only
+    MergeModules,   ///< Merge modules only
 
     EmitSIBGen, ///< Emit serialized AST + raw SIL
-    EmitSIB, ///< Emit serialized AST + canonical SIL
+    EmitSIB,    ///< Emit serialized AST + canonical SIL
 
     Immediate, ///< Immediate mode
-    REPL, ///< REPL mode
+    REPL,      ///< REPL mode
 
     EmitAssembly, ///< Emit assembly
-    EmitIR, ///< Emit LLVM IR
-    EmitBC, ///< Emit LLVM BC
-    EmitObject, ///< Emit object file
+    EmitIR,       ///< Emit LLVM IR
+    EmitBC,       ///< Emit LLVM BC
+    EmitObject,   ///< Emit object file
   };
 
   bool isCreatingSIL() { return RequestedAction >= ActionType::EmitSILGen; }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -335,7 +335,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   bool TreatAsLLVM = Opts.Inputs.shouldTreatAsLLVM();
 
   if (Opts.Inputs.verifyInputs(
-          Diags, TreatAsSIL, Opts.RequestedAction == FrontendOptions::ActionType::REPL,
+          Diags, TreatAsSIL,
+          Opts.RequestedAction == FrontendOptions::ActionType::REPL,
           Opts.RequestedAction == FrontendOptions::ActionType::NoneAction)) {
     return true;
   }
@@ -542,16 +543,16 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Opts.FixitsOutputPath = A->getValue();
   }
 
-  bool IsSIB =
-    Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB ||
-    Opts.RequestedAction == FrontendOptions::ActionType::EmitSIBGen;
+  bool IsSIB = Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB ||
+               Opts.RequestedAction == FrontendOptions::ActionType::EmitSIBGen;
   bool canUseMainOutputForModule =
-    Opts.RequestedAction == FrontendOptions::ActionType::MergeModules ||
-    Opts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly ||
-    IsSIB;
+      Opts.RequestedAction == FrontendOptions::ActionType::MergeModules ||
+      Opts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly ||
+      IsSIB;
   auto ext = IsSIB ? SIB_EXTENSION : SERIALIZED_MODULE_EXTENSION;
-  auto sibOpt = Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB ?
-    OPT_emit_sib : OPT_emit_sibgen;
+  auto sibOpt = Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB
+                    ? OPT_emit_sib
+                    : OPT_emit_sibgen;
   determineOutputFilename(Opts.ModuleOutputPath,
                           IsSIB ? sibOpt : OPT_emit_module,
                           OPT_emit_module_path,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -238,39 +238,39 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(OPT_modes_Group)) {
     Option Opt = A->getOption();
     if (Opt.matches(OPT_emit_object)) {
-      Action = FrontendOptions::EmitObject;
+      Action = FrontendOptions::ActionType::EmitObject;
     } else if (Opt.matches(OPT_emit_assembly)) {
-      Action = FrontendOptions::EmitAssembly;
+      Action = FrontendOptions::ActionType::EmitAssembly;
     } else if (Opt.matches(OPT_emit_ir)) {
-      Action = FrontendOptions::EmitIR;
+      Action = FrontendOptions::ActionType::EmitIR;
     } else if (Opt.matches(OPT_emit_bc)) {
-      Action = FrontendOptions::EmitBC;
+      Action = FrontendOptions::ActionType::EmitBC;
     } else if (Opt.matches(OPT_emit_sil)) {
-      Action = FrontendOptions::EmitSIL;
+      Action = FrontendOptions::ActionType::EmitSIL;
     } else if (Opt.matches(OPT_emit_silgen)) {
-      Action = FrontendOptions::EmitSILGen;
+      Action = FrontendOptions::ActionType::EmitSILGen;
     } else if (Opt.matches(OPT_emit_sib)) {
-      Action = FrontendOptions::EmitSIB;
+      Action = FrontendOptions::ActionType::EmitSIB;
     } else if (Opt.matches(OPT_emit_sibgen)) {
-      Action = FrontendOptions::EmitSIBGen;
+      Action = FrontendOptions::ActionType::EmitSIBGen;
     } else if (Opt.matches(OPT_emit_pch)) {
-      Action = FrontendOptions::EmitPCH;
+      Action = FrontendOptions::ActionType::EmitPCH;
     } else if (Opt.matches(OPT_emit_imported_modules)) {
-      Action = FrontendOptions::EmitImportedModules;
+      Action = FrontendOptions::ActionType::EmitImportedModules;
     } else if (Opt.matches(OPT_parse)) {
-      Action = FrontendOptions::Parse;
+      Action = FrontendOptions::ActionType::Parse;
     } else if (Opt.matches(OPT_typecheck)) {
-      Action = FrontendOptions::Typecheck;
+      Action = FrontendOptions::ActionType::Typecheck;
     } else if (Opt.matches(OPT_dump_parse)) {
-      Action = FrontendOptions::DumpParse;
+      Action = FrontendOptions::ActionType::DumpParse;
     } else if (Opt.matches(OPT_dump_ast)) {
-      Action = FrontendOptions::DumpAST;
+      Action = FrontendOptions::ActionType::DumpAST;
     } else if (Opt.matches(OPT_emit_syntax)) {
-      Action = FrontendOptions::EmitSyntax;
+      Action = FrontendOptions::ActionType::EmitSyntax;
     } else if (Opt.matches(OPT_merge_modules)) {
-      Action = FrontendOptions::MergeModules;
+      Action = FrontendOptions::ActionType::MergeModules;
     } else if (Opt.matches(OPT_dump_scope_maps)) {
-      Action = FrontendOptions::DumpScopeMaps;
+      Action = FrontendOptions::ActionType::DumpScopeMaps;
 
       StringRef value = A->getValue();
       if (value == "expanded") {
@@ -300,16 +300,16 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
           Diags.diagnose(SourceLoc(), diag::error_no_source_location_scope_map);
       }
     } else if (Opt.matches(OPT_dump_type_refinement_contexts)) {
-      Action = FrontendOptions::DumpTypeRefinementContexts;
+      Action = FrontendOptions::ActionType::DumpTypeRefinementContexts;
     } else if (Opt.matches(OPT_dump_interface_hash)) {
-      Action = FrontendOptions::DumpInterfaceHash;
+      Action = FrontendOptions::ActionType::DumpInterfaceHash;
     } else if (Opt.matches(OPT_print_ast)) {
-      Action = FrontendOptions::PrintAST;
+      Action = FrontendOptions::ActionType::PrintAST;
     } else if (Opt.matches(OPT_repl) ||
                Opt.matches(OPT_deprecated_integrated_repl)) {
-      Action = FrontendOptions::REPL;
+      Action = FrontendOptions::ActionType::REPL;
     } else if (Opt.matches(OPT_interpret)) {
-      Action = FrontendOptions::Immediate;
+      Action = FrontendOptions::ActionType::Immediate;
     } else {
       llvm_unreachable("Unhandled mode option");
     }
@@ -319,11 +319,11 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       // We've been told to emit a module, but have no other mode indicators.
       // As a result, put the frontend into EmitModuleOnly mode.
       // (Setting up module output will be handled below.)
-      Action = FrontendOptions::EmitModuleOnly;
+      Action = FrontendOptions::ActionType::EmitModuleOnly;
     }
   }
 
-  if (Opts.RequestedAction == FrontendOptions::Immediate &&
+  if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate &&
       Opts.Inputs.hasPrimaryInput()) {
     Diags.diagnose(SourceLoc(), diag::error_immediate_mode_primary_file);
     return true;
@@ -335,12 +335,12 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   bool TreatAsLLVM = Opts.Inputs.shouldTreatAsLLVM();
 
   if (Opts.Inputs.verifyInputs(
-          Diags, TreatAsSIL, Opts.RequestedAction == FrontendOptions::REPL,
-          Opts.RequestedAction == FrontendOptions::NoneAction)) {
+          Diags, TreatAsSIL, Opts.RequestedAction == FrontendOptions::ActionType::REPL,
+          Opts.RequestedAction == FrontendOptions::ActionType::NoneAction)) {
     return true;
   }
 
-  if (Opts.RequestedAction == FrontendOptions::Immediate) {
+  if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate) {
     Opts.ImmediateArgv.push_back(
         Opts.Inputs.getFilenameOfFirstInput()); // argv[0]
     if (const Arg *A = Args.getLastArg(OPT__DASH_DASH)) {
@@ -356,7 +356,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Opts.InputKind = InputFileKind::IFK_LLVM_IR;
   else if (Args.hasArg(OPT_parse_as_library))
     Opts.InputKind = InputFileKind::IFK_Swift_Library;
-  else if (Action == FrontendOptions::REPL)
+  else if (Action == FrontendOptions::ActionType::REPL)
     Opts.InputKind = InputFileKind::IFK_Swift_REPL;
   else
     Opts.InputKind = InputFileKind::IFK_Swift;
@@ -376,28 +376,28 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
     StringRef Suffix;
     switch (Opts.RequestedAction) {
-    case FrontendOptions::NoneAction:
+    case FrontendOptions::ActionType::NoneAction:
       break;
 
-    case FrontendOptions::Parse:
-    case FrontendOptions::Typecheck:
-    case FrontendOptions::DumpParse:
-    case FrontendOptions::DumpInterfaceHash:
-    case FrontendOptions::DumpAST:
-    case FrontendOptions::EmitSyntax:
-    case FrontendOptions::PrintAST:
-    case FrontendOptions::DumpScopeMaps:
-    case FrontendOptions::DumpTypeRefinementContexts:
+    case FrontendOptions::ActionType::Parse:
+    case FrontendOptions::ActionType::Typecheck:
+    case FrontendOptions::ActionType::DumpParse:
+    case FrontendOptions::ActionType::DumpInterfaceHash:
+    case FrontendOptions::ActionType::DumpAST:
+    case FrontendOptions::ActionType::EmitSyntax:
+    case FrontendOptions::ActionType::PrintAST:
+    case FrontendOptions::ActionType::DumpScopeMaps:
+    case FrontendOptions::ActionType::DumpTypeRefinementContexts:
       // Textual modes.
       Opts.setOutputFilenameToStdout();
       break;
 
-    case FrontendOptions::EmitPCH:
+    case FrontendOptions::ActionType::EmitPCH:
       Suffix = PCH_EXTENSION;
       break;
 
-    case FrontendOptions::EmitSILGen:
-    case FrontendOptions::EmitSIL: {
+    case FrontendOptions::ActionType::EmitSILGen:
+    case FrontendOptions::ActionType::EmitSIL: {
       if (Opts.OutputFilenames.empty())
         Opts.setOutputFilenameToStdout();
       else
@@ -405,23 +405,23 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       break;
     }
 
-    case FrontendOptions::EmitSIBGen:
-    case FrontendOptions::EmitSIB:
+    case FrontendOptions::ActionType::EmitSIBGen:
+    case FrontendOptions::ActionType::EmitSIB:
       Suffix = SIB_EXTENSION;
       break;
 
-    case FrontendOptions::MergeModules:
-    case FrontendOptions::EmitModuleOnly:
+    case FrontendOptions::ActionType::MergeModules:
+    case FrontendOptions::ActionType::EmitModuleOnly:
       Suffix = SERIALIZED_MODULE_EXTENSION;
       break;
 
-    case FrontendOptions::Immediate:
-    case FrontendOptions::REPL:
+    case FrontendOptions::ActionType::Immediate:
+    case FrontendOptions::ActionType::REPL:
       // These modes have no frontend-generated output.
       Opts.OutputFilenames.clear();
       break;
 
-    case FrontendOptions::EmitAssembly: {
+    case FrontendOptions::ActionType::EmitAssembly: {
       if (Opts.OutputFilenames.empty())
         Opts.setOutputFilenameToStdout();
       else
@@ -429,7 +429,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       break;
     }
 
-    case FrontendOptions::EmitIR: {
+    case FrontendOptions::ActionType::EmitIR: {
       if (Opts.OutputFilenames.empty())
         Opts.setOutputFilenameToStdout();
       else
@@ -437,16 +437,16 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       break;
     }
 
-    case FrontendOptions::EmitBC: {
+    case FrontendOptions::ActionType::EmitBC: {
       Suffix = "bc";
       break;
     }
 
-    case FrontendOptions::EmitObject:
+    case FrontendOptions::ActionType::EmitObject:
       Suffix = "o";
       break;
 
-    case FrontendOptions::EmitImportedModules:
+    case FrontendOptions::ActionType::EmitImportedModules:
       if (Opts.OutputFilenames.empty())
         Opts.setOutputFilenameToStdout();
       else
@@ -474,9 +474,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     }
 
     if (Opts.OutputFilenames.empty()) {
-      if (Opts.RequestedAction != FrontendOptions::REPL &&
-          Opts.RequestedAction != FrontendOptions::Immediate &&
-          Opts.RequestedAction != FrontendOptions::NoneAction) {
+      if (Opts.RequestedAction != FrontendOptions::ActionType::REPL &&
+          Opts.RequestedAction != FrontendOptions::ActionType::Immediate &&
+          Opts.RequestedAction != FrontendOptions::ActionType::NoneAction) {
         Diags.diagnose(SourceLoc(), diag::error_no_output_filename_specified);
         return true;
       }
@@ -543,14 +543,14 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   }
 
   bool IsSIB =
-    Opts.RequestedAction == FrontendOptions::EmitSIB ||
-    Opts.RequestedAction == FrontendOptions::EmitSIBGen;
+    Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB ||
+    Opts.RequestedAction == FrontendOptions::ActionType::EmitSIBGen;
   bool canUseMainOutputForModule =
-    Opts.RequestedAction == FrontendOptions::MergeModules ||
-    Opts.RequestedAction == FrontendOptions::EmitModuleOnly ||
+    Opts.RequestedAction == FrontendOptions::ActionType::MergeModules ||
+    Opts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly ||
     IsSIB;
   auto ext = IsSIB ? SIB_EXTENSION : SERIALIZED_MODULE_EXTENSION;
-  auto sibOpt = Opts.RequestedAction == FrontendOptions::EmitSIB ?
+  auto sibOpt = Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB ?
     OPT_emit_sib : OPT_emit_sibgen;
   determineOutputFilename(Opts.ModuleOutputPath,
                           IsSIB ? sibOpt : OPT_emit_module,
@@ -566,97 +566,97 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   if (!Opts.DependenciesFilePath.empty()) {
     switch (Opts.RequestedAction) {
-    case FrontendOptions::NoneAction:
-    case FrontendOptions::DumpParse:
-    case FrontendOptions::DumpInterfaceHash:
-    case FrontendOptions::DumpAST:
-    case FrontendOptions::EmitSyntax:
-    case FrontendOptions::PrintAST:
-    case FrontendOptions::DumpScopeMaps:
-    case FrontendOptions::DumpTypeRefinementContexts:
-    case FrontendOptions::Immediate:
-    case FrontendOptions::REPL:
+    case FrontendOptions::ActionType::NoneAction:
+    case FrontendOptions::ActionType::DumpParse:
+    case FrontendOptions::ActionType::DumpInterfaceHash:
+    case FrontendOptions::ActionType::DumpAST:
+    case FrontendOptions::ActionType::EmitSyntax:
+    case FrontendOptions::ActionType::PrintAST:
+    case FrontendOptions::ActionType::DumpScopeMaps:
+    case FrontendOptions::ActionType::DumpTypeRefinementContexts:
+    case FrontendOptions::ActionType::Immediate:
+    case FrontendOptions::ActionType::REPL:
       Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_dependencies);
       return true;
-    case FrontendOptions::Parse:
-    case FrontendOptions::Typecheck:
-    case FrontendOptions::MergeModules:
-    case FrontendOptions::EmitModuleOnly:
-    case FrontendOptions::EmitPCH:
-    case FrontendOptions::EmitSILGen:
-    case FrontendOptions::EmitSIL:
-    case FrontendOptions::EmitSIBGen:
-    case FrontendOptions::EmitSIB:
-    case FrontendOptions::EmitIR:
-    case FrontendOptions::EmitBC:
-    case FrontendOptions::EmitAssembly:
-    case FrontendOptions::EmitObject:
-    case FrontendOptions::EmitImportedModules:
+    case FrontendOptions::ActionType::Parse:
+    case FrontendOptions::ActionType::Typecheck:
+    case FrontendOptions::ActionType::MergeModules:
+    case FrontendOptions::ActionType::EmitModuleOnly:
+    case FrontendOptions::ActionType::EmitPCH:
+    case FrontendOptions::ActionType::EmitSILGen:
+    case FrontendOptions::ActionType::EmitSIL:
+    case FrontendOptions::ActionType::EmitSIBGen:
+    case FrontendOptions::ActionType::EmitSIB:
+    case FrontendOptions::ActionType::EmitIR:
+    case FrontendOptions::ActionType::EmitBC:
+    case FrontendOptions::ActionType::EmitAssembly:
+    case FrontendOptions::ActionType::EmitObject:
+    case FrontendOptions::ActionType::EmitImportedModules:
       break;
     }
   }
 
   if (!Opts.ObjCHeaderOutputPath.empty()) {
     switch (Opts.RequestedAction) {
-    case FrontendOptions::NoneAction:
-    case FrontendOptions::DumpParse:
-    case FrontendOptions::DumpInterfaceHash:
-    case FrontendOptions::DumpAST:
-    case FrontendOptions::EmitSyntax:
-    case FrontendOptions::PrintAST:
-    case FrontendOptions::EmitPCH:
-    case FrontendOptions::DumpScopeMaps:
-    case FrontendOptions::DumpTypeRefinementContexts:
-    case FrontendOptions::Immediate:
-    case FrontendOptions::REPL:
+    case FrontendOptions::ActionType::NoneAction:
+    case FrontendOptions::ActionType::DumpParse:
+    case FrontendOptions::ActionType::DumpInterfaceHash:
+    case FrontendOptions::ActionType::DumpAST:
+    case FrontendOptions::ActionType::EmitSyntax:
+    case FrontendOptions::ActionType::PrintAST:
+    case FrontendOptions::ActionType::EmitPCH:
+    case FrontendOptions::ActionType::DumpScopeMaps:
+    case FrontendOptions::ActionType::DumpTypeRefinementContexts:
+    case FrontendOptions::ActionType::Immediate:
+    case FrontendOptions::ActionType::REPL:
       Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_header);
       return true;
-    case FrontendOptions::Parse:
-    case FrontendOptions::Typecheck:
-    case FrontendOptions::MergeModules:
-    case FrontendOptions::EmitModuleOnly:
-    case FrontendOptions::EmitSILGen:
-    case FrontendOptions::EmitSIL:
-    case FrontendOptions::EmitSIBGen:
-    case FrontendOptions::EmitSIB:
-    case FrontendOptions::EmitIR:
-    case FrontendOptions::EmitBC:
-    case FrontendOptions::EmitAssembly:
-    case FrontendOptions::EmitObject:
-    case FrontendOptions::EmitImportedModules:
+    case FrontendOptions::ActionType::Parse:
+    case FrontendOptions::ActionType::Typecheck:
+    case FrontendOptions::ActionType::MergeModules:
+    case FrontendOptions::ActionType::EmitModuleOnly:
+    case FrontendOptions::ActionType::EmitSILGen:
+    case FrontendOptions::ActionType::EmitSIL:
+    case FrontendOptions::ActionType::EmitSIBGen:
+    case FrontendOptions::ActionType::EmitSIB:
+    case FrontendOptions::ActionType::EmitIR:
+    case FrontendOptions::ActionType::EmitBC:
+    case FrontendOptions::ActionType::EmitAssembly:
+    case FrontendOptions::ActionType::EmitObject:
+    case FrontendOptions::ActionType::EmitImportedModules:
       break;
     }
   }
 
   if (!Opts.LoadedModuleTracePath.empty()) {
     switch (Opts.RequestedAction) {
-    case FrontendOptions::NoneAction:
-    case FrontendOptions::Parse:
-    case FrontendOptions::DumpParse:
-    case FrontendOptions::DumpInterfaceHash:
-    case FrontendOptions::DumpAST:
-    case FrontendOptions::EmitSyntax:
-    case FrontendOptions::PrintAST:
-    case FrontendOptions::DumpScopeMaps:
-    case FrontendOptions::DumpTypeRefinementContexts:
-    case FrontendOptions::Immediate:
-    case FrontendOptions::REPL:
+    case FrontendOptions::ActionType::NoneAction:
+    case FrontendOptions::ActionType::Parse:
+    case FrontendOptions::ActionType::DumpParse:
+    case FrontendOptions::ActionType::DumpInterfaceHash:
+    case FrontendOptions::ActionType::DumpAST:
+    case FrontendOptions::ActionType::EmitSyntax:
+    case FrontendOptions::ActionType::PrintAST:
+    case FrontendOptions::ActionType::DumpScopeMaps:
+    case FrontendOptions::ActionType::DumpTypeRefinementContexts:
+    case FrontendOptions::ActionType::Immediate:
+    case FrontendOptions::ActionType::REPL:
       Diags.diagnose(SourceLoc(),
                      diag::error_mode_cannot_emit_loaded_module_trace);
       return true;
-    case FrontendOptions::Typecheck:
-    case FrontendOptions::MergeModules:
-    case FrontendOptions::EmitModuleOnly:
-    case FrontendOptions::EmitPCH:
-    case FrontendOptions::EmitSILGen:
-    case FrontendOptions::EmitSIL:
-    case FrontendOptions::EmitSIBGen:
-    case FrontendOptions::EmitSIB:
-    case FrontendOptions::EmitIR:
-    case FrontendOptions::EmitBC:
-    case FrontendOptions::EmitAssembly:
-    case FrontendOptions::EmitObject:
-    case FrontendOptions::EmitImportedModules:
+    case FrontendOptions::ActionType::Typecheck:
+    case FrontendOptions::ActionType::MergeModules:
+    case FrontendOptions::ActionType::EmitModuleOnly:
+    case FrontendOptions::ActionType::EmitPCH:
+    case FrontendOptions::ActionType::EmitSILGen:
+    case FrontendOptions::ActionType::EmitSIL:
+    case FrontendOptions::ActionType::EmitSIBGen:
+    case FrontendOptions::ActionType::EmitSIB:
+    case FrontendOptions::ActionType::EmitIR:
+    case FrontendOptions::ActionType::EmitBC:
+    case FrontendOptions::ActionType::EmitAssembly:
+    case FrontendOptions::ActionType::EmitObject:
+    case FrontendOptions::ActionType::EmitImportedModules:
       break;
     }
   }
@@ -664,35 +664,35 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (!Opts.ModuleOutputPath.empty() ||
       !Opts.ModuleDocOutputPath.empty()) {
     switch (Opts.RequestedAction) {
-    case FrontendOptions::NoneAction:
-    case FrontendOptions::Parse:
-    case FrontendOptions::Typecheck:
-    case FrontendOptions::DumpParse:
-    case FrontendOptions::DumpInterfaceHash:
-    case FrontendOptions::DumpAST:
-    case FrontendOptions::EmitSyntax:
-    case FrontendOptions::PrintAST:
-    case FrontendOptions::EmitPCH:
-    case FrontendOptions::DumpScopeMaps:
-    case FrontendOptions::DumpTypeRefinementContexts:
-    case FrontendOptions::EmitSILGen:
-    case FrontendOptions::Immediate:
-    case FrontendOptions::REPL:
+    case FrontendOptions::ActionType::NoneAction:
+    case FrontendOptions::ActionType::Parse:
+    case FrontendOptions::ActionType::Typecheck:
+    case FrontendOptions::ActionType::DumpParse:
+    case FrontendOptions::ActionType::DumpInterfaceHash:
+    case FrontendOptions::ActionType::DumpAST:
+    case FrontendOptions::ActionType::EmitSyntax:
+    case FrontendOptions::ActionType::PrintAST:
+    case FrontendOptions::ActionType::EmitPCH:
+    case FrontendOptions::ActionType::DumpScopeMaps:
+    case FrontendOptions::ActionType::DumpTypeRefinementContexts:
+    case FrontendOptions::ActionType::EmitSILGen:
+    case FrontendOptions::ActionType::Immediate:
+    case FrontendOptions::ActionType::REPL:
       if (!Opts.ModuleOutputPath.empty())
         Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_module);
       else
         Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_module_doc);
       return true;
-    case FrontendOptions::MergeModules:
-    case FrontendOptions::EmitModuleOnly:
-    case FrontendOptions::EmitSIL:
-    case FrontendOptions::EmitSIBGen:
-    case FrontendOptions::EmitSIB:
-    case FrontendOptions::EmitIR:
-    case FrontendOptions::EmitBC:
-    case FrontendOptions::EmitAssembly:
-    case FrontendOptions::EmitObject:
-    case FrontendOptions::EmitImportedModules:
+    case FrontendOptions::ActionType::MergeModules:
+    case FrontendOptions::ActionType::EmitModuleOnly:
+    case FrontendOptions::ActionType::EmitSIL:
+    case FrontendOptions::ActionType::EmitSIBGen:
+    case FrontendOptions::ActionType::EmitSIB:
+    case FrontendOptions::ActionType::EmitIR:
+    case FrontendOptions::ActionType::EmitBC:
+    case FrontendOptions::ActionType::EmitAssembly:
+    case FrontendOptions::ActionType::EmitObject:
+    case FrontendOptions::ActionType::EmitImportedModules:
       break;
     }
   }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -170,33 +170,33 @@ void FrontendInputs::readInputFileList(DiagnosticEngine &diags,
 
 bool FrontendOptions::actionHasOutput() const {
   switch (RequestedAction) {
-  case NoneAction:
-  case Parse:
-  case Typecheck:
-  case DumpParse:
-  case DumpAST:
-  case EmitSyntax:
-  case DumpInterfaceHash:
-  case PrintAST:
-  case DumpScopeMaps:
-  case DumpTypeRefinementContexts:
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::Typecheck:
+  case ActionType::DumpParse:
+  case ActionType::DumpAST:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
     return false;
-  case EmitPCH:
-  case EmitSILGen:
-  case EmitSIL:
-  case EmitSIBGen:
-  case EmitSIB:
-  case EmitModuleOnly:
-  case MergeModules:
+  case ActionType::EmitPCH:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::EmitModuleOnly:
+  case ActionType::MergeModules:
     return true;
-  case Immediate:
-  case REPL:
+  case ActionType::Immediate:
+  case ActionType::REPL:
     return false;
-  case EmitAssembly:
-  case EmitIR:
-  case EmitBC:
-  case EmitObject:
-  case EmitImportedModules:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+  case ActionType::EmitImportedModules:
     return true;
   }
   llvm_unreachable("Unknown ActionType");
@@ -204,32 +204,32 @@ bool FrontendOptions::actionHasOutput() const {
 
 bool FrontendOptions::actionIsImmediate() const {
   switch (RequestedAction) {
-  case NoneAction:
-  case Parse:
-  case Typecheck:
-  case DumpParse:
-  case DumpAST:
-  case EmitSyntax:
-  case DumpInterfaceHash:
-  case PrintAST:
-  case DumpScopeMaps:
-  case DumpTypeRefinementContexts:
-  case EmitPCH:
-  case EmitSILGen:
-  case EmitSIL:
-  case EmitSIBGen:
-  case EmitSIB:
-  case EmitModuleOnly:
-  case MergeModules:
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::Typecheck:
+  case ActionType::DumpParse:
+  case ActionType::DumpAST:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::EmitPCH:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::EmitModuleOnly:
+  case ActionType::MergeModules:
     return false;
-  case Immediate:
-  case REPL:
+  case ActionType::Immediate:
+  case ActionType::REPL:
     return true;
-  case EmitAssembly:
-  case EmitIR:
-  case EmitBC:
-  case EmitObject:
-  case EmitImportedModules:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+  case ActionType::EmitImportedModules:
     return false;
   }
   llvm_unreachable("Unknown ActionType");
@@ -237,8 +237,8 @@ bool FrontendOptions::actionIsImmediate() const {
 
 void FrontendOptions::forAllOutputPaths(
     std::function<void(const std::string &)> fn) const {
-  if (RequestedAction != FrontendOptions::EmitModuleOnly &&
-      RequestedAction != FrontendOptions::MergeModules) {
+  if (RequestedAction != FrontendOptions::ActionType::EmitModuleOnly &&
+      RequestedAction != FrontendOptions::ActionType::MergeModules) {
     for (const std::string &OutputFileName : OutputFilenames) {
       fn(OutputFileName);
     }
@@ -299,7 +299,7 @@ StringRef FrontendOptions::determineFallbackModuleName() const {
   // Note: this code path will only be taken when running the frontend
   // directly; the driver should always pass -module-name when invoking the
   // frontend.
-  if (RequestedAction == FrontendOptions::REPL) {
+  if (RequestedAction == FrontendOptions::ActionType::REPL) {
     // Default to a module named "REPL" if we're in REPL mode.
     return "REPL";
   }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -690,7 +690,8 @@ static bool performCompile(CompilerInstance &Instance,
 
       // Print the resulting map.
       scope.print(llvm::errs());
-    } else if (Action == FrontendOptions::ActionType::DumpTypeRefinementContexts)
+    } else if (Action ==
+               FrontendOptions::ActionType::DumpTypeRefinementContexts)
       SF->getTypeRefinementContext()->dump(llvm::errs(), Context.SourceMgr);
     else if (Action == FrontendOptions::ActionType::DumpInterfaceHash)
       SF->dumpInterfaceHash(llvm::errs());
@@ -910,7 +911,7 @@ static bool performCompile(CompilerInstance &Instance,
     SharedTimer timer("SIL optimization");
     if (Action != FrontendOptions::ActionType::MergeModules &&
         Invocation.getSILOptions().Optimization >
-          SILOptions::SILOptMode::None) {
+            SILOptions::SILOptMode::None) {
 
       runSILOptPreparePasses(*SM);
 
@@ -1326,7 +1327,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   }
 
   if (Invocation.getFrontendOptions().RequestedAction ==
-        FrontendOptions::ActionType::NoneAction) {
+      FrontendOptions::ActionType::NoneAction) {
     Instance->getDiags().diagnose(SourceLoc(),
                                  diag::error_missing_frontend_action);
     return finishDiagProcessing(1);


### PR DESCRIPTION
<!-- What's in this pull request? -->
Convert ActionType from "enum" to "enum class".
Helps with my upcoming PRs.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->