### PR TITLE
[4.1] Disable ModelIO test on ios on tvos

### DIFF
--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -3,6 +3,11 @@
 // UNSUPPORTED: OS=watchos
 // REQUIRES: objc_interop
 
+// Currently crashes on iphonesimulator.
+// rdar://35490456
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+
 import StdlibUnittest
 
 import Foundation


### PR DESCRIPTION
This test currently fails and blocks testing.

rdar://35490456