### PR TITLE
[stdlib] Adopt conditional conformance for Indices, Slice, ReversedCollection

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -276,7 +276,8 @@ self.test("\(testNamePrefix).subscript(_: Range)/Set/semantics") {
       // Call setter implicitly through an inout mutation.
       var c = makeWrappedCollection(test.collection)
 
-      _mapInPlace(&c[test.bounds(in: c)]) {
+      var s = c[test.bounds(in: c)]
+      _mapInPlace(&s) {
         wrapValue(OpaqueValue(extractValue($0).value + 90000))
       }
 

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -44,13 +44,19 @@ public typealias BidirectionalIndexable = BidirectionalCollection
 ///   `c.index(before: c.index(after: i)) == i`.
 /// - If `i > c.startIndex && i <= c.endIndex`
 ///   `c.index(after: c.index(before: i)) == i`.
-public protocol BidirectionalCollection : Collection 
-{
+public protocol BidirectionalCollection: Collection
+where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Index
+
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype SubSequence = Slice<Self>
+
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype Indices = DefaultIndices<Self>
 
   /// Returns the position immediately before the given index.
   ///
@@ -64,16 +70,6 @@ public protocol BidirectionalCollection : Collection
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   func formIndex(before i: inout Index)
-
-  /// A sequence that can represent a contiguous subrange of the collection's
-  /// elements.
-  associatedtype SubSequence : BidirectionalCollection
-    = BidirectionalSlice<Self>
-
-  /// A type that represents the indices that are valid for subscripting the
-  /// collection, in ascending order.
-  associatedtype Indices : BidirectionalCollection
-    = DefaultBidirectionalIndices<Self>
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
@@ -198,17 +194,6 @@ extension BidirectionalCollection {
     }
 
     return count
-  }
-}
-
-/// Supply the default "slicing" `subscript` for `BidirectionalCollection`
-/// models that accept the default associated `SubSequence`,
-/// `BidirectionalSlice<Self>`.
-extension BidirectionalCollection where SubSequence == BidirectionalSlice<Self> {
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(bounds: Range<Index>) -> BidirectionalSlice<Self> {
-    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-    return BidirectionalSlice(base: self, bounds: bounds)
   }
 }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -72,7 +72,7 @@ set(SWIFTLIB_ESSENTIAL
   HeapBuffer.swift
   ICU.swift
   ImplicitlyUnwrappedOptional.swift
-  Indices.swift.gyb
+  Indices.swift
   InputStream.swift
   IntegerParsing.swift
   Integers.swift.gyb
@@ -100,7 +100,7 @@ set(SWIFTLIB_ESSENTIAL
   Print.swift
   RandomAccessCollection.swift
   Range.swift.gyb
-  RangeReplaceableCollection.swift.gyb
+  RangeReplaceableCollection.swift
   ReflectionLegacy.swift
   Repeat.swift
   REPL.swift
@@ -115,7 +115,7 @@ set(SWIFTLIB_ESSENTIAL
   SetAlgebra.swift
   ShadowProtocols.swift
   Shims.swift
-  Slice.swift.gyb
+  Slice.swift
   Sort.swift.gyb
   StaticString.swift
   Stride.swift.gyb

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -261,8 +261,8 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
 
   @_inlineable
   public subscript(bounds: Range<Index>)
-    -> RandomAccessSlice<CountableClosedRange<Bound>> {
-    return RandomAccessSlice(base: self, bounds: bounds)
+    -> Slice<CountableClosedRange<Bound>> {
+    return Slice(base: self, bounds: bounds)
   }
 
   /// Creates an instance with the given bounds.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -82,9 +82,11 @@ public typealias Indexable = Collection
 ///     // Prints "15.0"
 ///     // Prints "20.0"
 @_fixed_layout
-public struct IndexingIterator<
-  Elements : Collection
-> : IteratorProtocol, Sequence {
+public struct IndexingIterator<Elements : Collection> {
+  @_versioned
+  internal let _elements: Elements
+  @_versioned
+  internal var _position: Elements.Index
 
   @_inlineable
   @inline(__always)
@@ -103,6 +105,12 @@ public struct IndexingIterator<
     self._elements = _elements
     self._position = _position
   }
+}
+
+extension IndexingIterator: IteratorProtocol, Sequence {
+  public typealias Element = Elements.Element
+  public typealias Iterator = IndexingIterator<Elements>
+  public typealias SubSequence = AnySequence<Element>
 
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
@@ -136,11 +144,6 @@ public struct IndexingIterator<
     _elements.formIndex(after: &_position)
     return element
   }
-  
-  @_versioned
-  internal let _elements: Elements
-  @_versioned
-  internal var _position: Elements.Index
 }
 
 /// A sequence whose elements can be traversed multiple times,
@@ -345,8 +348,7 @@ public struct IndexingIterator<
 /// or bidirectional collection must traverse the entire collection to count
 /// the number of contained elements, accessing its `count` property is an
 /// O(*n*) operation.
-public protocol Collection : Sequence
-{
+public protocol Collection: Sequence where SubSequence: Collection {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
 
@@ -403,7 +405,7 @@ public protocol Collection : Sequence
   /// This associated type appears as a requirement in the `Sequence`
   /// protocol, but it is restated here with stricter constraints. In a
   /// collection, the subsequence should also conform to `Collection`.
-  associatedtype SubSequence : Collection = Slice<Self>
+  associatedtype SubSequence = Slice<Self>
     where SubSequence.Index == Index,
           SubSequence.IndexDistance == IndexDistance
 

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -109,10 +109,10 @@ public struct CollectionOfOne<Element>
 
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(bounds: Range<Int>)
-    -> MutableRandomAccessSlice<CollectionOfOne<Element>> {
+    -> Slice<CollectionOfOne<Element>> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return MutableRandomAccessSlice(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
     set {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -362,8 +362,8 @@ public struct ${Collection}<Base> : ${collectionForTraversal(traversal)}
 
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(bounds: Range<Index>)
-    -> ${Slice}<${Collection}> {
-    return ${Slice}(base: self, bounds: bounds)
+    -> Slice<${Collection}> {
+    return Slice(base: self, bounds: bounds)
   }
 
   // To return any estimate of the number of elements, we have to start

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3208,7 +3208,7 @@ ${assignmentOperatorComment(x.operator, True)}
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Words : BidirectionalCollection {
     public typealias Indices = CountableRange<Int>
-    public typealias SubSequence = BidirectionalSlice<${Self}.Words>
+    public typealias SubSequence = Slice<${Self}.Words>
 
     @_versioned // FIXME(sil-serialize-all)
     internal var _value: ${Self}

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -162,8 +162,8 @@ extension ${Self} : ${TraversalCollection} {
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public subscript(bounds: Range<Index>) -> ${Slice}<${Self}<Base>> {
-    return ${Slice}(base: self, bounds: bounds)
+  public subscript(bounds: Range<Index>) -> Slice<${Self}<Base>> {
+    return Slice(base: self, bounds: bounds)
   }
 
   /// A Boolean value indicating whether the collection is empty.

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -65,7 +65,8 @@ public typealias MutableIndexable = MutableCollection
 ///     // Must be equivalent to:
 ///     a[i] = x
 ///     let y = x
-public protocol MutableCollection : Collection
+public protocol MutableCollection: Collection
+where SubSequence: MutableCollection
 {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
@@ -73,7 +74,8 @@ public protocol MutableCollection : Collection
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Index
 
-  associatedtype SubSequence : MutableCollection = MutableSlice<Self>
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype SubSequence = Slice<Self>
 
   /// Accesses the element at the specified position.
   ///
@@ -217,10 +219,10 @@ extension MutableCollection {
   /// - Parameter bounds: A range of the collection's indices. The bounds of
   ///   the range must be valid indices of the collection.
   @_inlineable
-  public subscript(bounds: Range<Index>) -> MutableSlice<Self> {
+  public subscript(bounds: Range<Index>) -> Slice<Self> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return MutableSlice(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
     set {
       _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
@@ -245,28 +247,4 @@ extension MutableCollection {
   }
 }
 
-extension MutableCollection where Self: BidirectionalCollection {
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(bounds: Range<Index>) -> MutableBidirectionalSlice<Self> {
-    get {
-      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return MutableBidirectionalSlice(base: self, bounds: bounds)
-    }
-    set {
-      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
-    }
-  }
-}
 
-extension MutableCollection where Self: RandomAccessCollection {
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(bounds: Range<Index>) -> MutableRandomAccessSlice<Self> {
-    get {
-      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return MutableRandomAccessSlice(base: self, bounds: bounds)
-    }
-    set {
-      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
-    }
-  }
-}

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -38,7 +38,8 @@ public typealias RandomAccessIndexable = RandomAccessCollection
 /// collection, either the index for your custom type must conform to the
 /// `Strideable` protocol or you must implement the `index(_:offsetBy:)` and
 /// `distance(from:to:)` methods with O(1) efficiency.
-public protocol RandomAccessCollection : BidirectionalCollection
+public protocol RandomAccessCollection: BidirectionalCollection
+where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
 {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
@@ -46,15 +47,11 @@ public protocol RandomAccessCollection : BidirectionalCollection
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Index
 
-  /// A collection that represents a contiguous subrange of the collection's
-  /// elements.
-  associatedtype SubSequence : RandomAccessCollection
-    = RandomAccessSlice<Self>
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype SubSequence = Slice<Self>
 
-  /// A type that represents the indices that are valid for subscripting the
-  /// collection, in ascending order.
-  associatedtype Indices : RandomAccessCollection
-    = DefaultRandomAccessIndices<Self>
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype Indices = DefaultIndices<Self>
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
@@ -106,38 +103,6 @@ public protocol RandomAccessCollection : BidirectionalCollection
 
   // FIXME(ABI): Associated type inference requires this.
   var endIndex: Index { get }
-}
-
-/// Supply the default "slicing" `subscript` for `RandomAccessCollection`
-/// models that accept the default associated `SubSequence`,
-/// `RandomAccessSlice<Self>`.
-extension RandomAccessCollection where SubSequence == RandomAccessSlice<Self> {
-  /// Accesses a contiguous subrange of the collection's elements.
-  ///
-  /// The accessed slice uses the same indices for the same elements as the
-  /// original collection uses. Always use the slice's `startIndex` property
-  /// instead of assuming that its indices start at a particular value.
-  ///
-  /// This example demonstrates getting a slice of an array of strings, finding
-  /// the index of one of the strings in the slice, and then using that index
-  /// in the original array.
-  ///
-  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
-  ///     let streetsSlice = streets[2 ..< streets.endIndex]
-  ///     print(streetsSlice)
-  ///     // Prints "["Channing", "Douglas", "Evarts"]"
-  ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
-  ///     print(streets[index!])
-  ///     // Prints "Evarts"
-  ///
-  /// - Parameter bounds: A range of the collection's indices. The bounds of
-  ///   the range must be valid indices of the collection.
-  @_inlineable
-  public subscript(bounds: Range<Index>) -> RandomAccessSlice<Self> {
-    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-    return RandomAccessSlice(base: self, bounds: bounds)
-  }
 }
 
 // TODO: swift-3-indexing-model - Make sure RandomAccessCollection has

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -1,4 +1,4 @@
-//===--- RangeReplaceableCollection.swift.gyb -----------------*- swift -*-===//
+//===--- RangeReplaceableCollection.swift ---------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -70,10 +70,11 @@ public typealias RangeReplaceableIndexable = RangeReplaceableCollection
 /// `replaceSubrange(_:with:)` with an empty collection for the `newElements` 
 /// parameter. You can override any of the protocol's required methods to 
 /// provide your own custom implementation.
-public protocol RangeReplaceableCollection : Collection
+public protocol RangeReplaceableCollection: Collection
+where SubSequence: RangeReplaceableCollection
 {
-  associatedtype SubSequence : RangeReplaceableCollection
-    = RangeReplaceableSlice<Self>
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype SubSequence = Slice<Self>
 
   //===--- Fundamental Requirements ---------------------------------------===//
 
@@ -366,8 +367,8 @@ public protocol RangeReplaceableCollection : Collection
 
 extension RangeReplaceableCollection {
   @_inlineable
-  public subscript(bounds: Range<Index>) -> RangeReplaceableSlice<Self> {
-    return RangeReplaceableSlice(base: self, bounds: bounds)
+  public subscript(bounds: Range<Index>) -> Slice<Self> {
+    return Slice(base: self, bounds: bounds)
   }
 
   /// Creates a new collection containing the specified number of a single,
@@ -654,40 +655,6 @@ extension RangeReplaceableCollection {
   @_inlineable
   public mutating func reserveCapacity(_ n: IndexDistance) {}
 }
-
-// Offer the most specific slice type available for each possible combination of
-// RangeReplaceable * (1 + Bidirectional + RandomAccess) * (1 + Mutable)
-// collections.
-
-% for capability in ['', 'Bidirectional', 'RandomAccess']:
-%   if capability:
-extension RangeReplaceableCollection where
-    Self.SubSequence == RangeReplaceable${capability}Slice<Self> {
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(bounds: Range<Index>)
-      -> RangeReplaceable${capability}Slice<Self> {
-    return RangeReplaceable${capability}Slice(base: self, bounds: bounds)
-  }
-}
-%   end
-
-extension RangeReplaceableCollection where
-  Self.SubSequence == MutableRangeReplaceable${capability}Slice<Self>
-{
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(bounds: Range<Index>)
-      -> MutableRangeReplaceable${capability}Slice<Self> {
-    get {
-      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return MutableRangeReplaceable${capability}Slice(base: self,
-                                                       bounds: bounds)
-    }
-    set {
-      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
-    }
-  }
-}
-% end
 
 extension RangeReplaceableCollection where SubSequence == Self {
   /// Removes and returns the first element of the collection.

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -366,11 +366,6 @@ where SubSequence: RangeReplaceableCollection
 //===----------------------------------------------------------------------===//
 
 extension RangeReplaceableCollection {
-  @_inlineable
-  public subscript(bounds: Range<Index>) -> Slice<Self> {
-    return Slice(base: self, bounds: bounds)
-  }
-
   /// Creates a new collection containing the specified number of a single,
   /// repeated value.
   ///

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -65,14 +65,6 @@ public struct _ReverseIndexingIterator<
   internal var _position: Elements.Index
 }
 
-// FIXME(ABI)#59 (Conditional Conformance): we should have just one type,
-// `ReversedCollection`, that has conditional conformances to
-// `RandomAccessCollection`, and possibly `MutableCollection` and
-// `RangeReplaceableCollection`.
-// rdar://problem/17144340
-
-// FIXME: swift-3-indexing-model - should gyb ReversedXxx & ReversedRandomAccessXxx
-
 /// An index that traverses the same positions as an underlying index,
 /// with inverted traversal direction.
 @_fixed_layout
@@ -172,9 +164,7 @@ extension ReversedIndex : Hashable where Base.Index : Hashable {
 ///
 /// - See also: `ReversedRandomAccessCollection`
 @_fixed_layout
-public struct ReversedCollection<
-  Base : BidirectionalCollection
-> : BidirectionalCollection {
+public struct ReversedCollection<Base: BidirectionalCollection>: BidirectionalCollection {
   /// Creates an instance that presents the elements of `base` in
   /// reverse order.
   ///
@@ -254,7 +244,8 @@ public struct ReversedCollection<
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
     // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
-    return _base.index(i.base, offsetBy: -n, limitedBy: limit.base).map { ReversedIndex($0) }
+    return _base.index(i.base, offsetBy: -n, limitedBy: limit.base)
+                .map(ReversedIndex.init)
   }
 
   @_inlineable
@@ -268,190 +259,17 @@ public struct ReversedCollection<
   }
 
   @_inlineable
-  public subscript(bounds: Range<Index>) -> BidirectionalSlice<ReversedCollection> {
-    return BidirectionalSlice(base: self, bounds: bounds)
+  public subscript(bounds: Range<Index>) -> Slice<ReversedCollection> {
+    return Slice(base: self, bounds: bounds)
   }
 
   public let _base: Base
 }
 
-/// An index that traverses the same positions as an underlying index,
-/// with inverted traversal direction.
-@_fixed_layout
-public struct ReversedRandomAccessIndex<
-  Base : RandomAccessCollection
-> : Comparable {
-  /// Creates a new index into a reversed collection for the position before
-  /// the specified index.
-  ///
-  /// When you create an index into a reversed collection using the index
-  /// passed as `base`, an index from the underlying collection, the resulting
-  /// index is the position of the element *before* the element referenced by
-  /// `base`. The following example creates a new `ReversedIndex` from the
-  /// index of the `"a"` character in a string's character view.
-  ///
-  ///     let name = "Horatio"
-  ///     let aIndex = name.index(of: "a")!
-  ///     // name[aIndex] == "a"
-  ///
-  ///     let reversedName = name.reversed()
-  ///     let i = ReversedIndex<String>(aIndex)
-  ///     // reversedName[i] == "r"
-  ///
-  /// The element at the position created using `ReversedIndex<...>(aIndex)` is
-  /// `"r"`, the character before `"a"` in the `name` string. Viewed from the
-  /// perspective of the `reversedCharacters` collection, of course, `"r"` is
-  /// the element *after* `"a"`.
-  ///
-  /// - Parameter base: The position after the element to create an index for.
-  @_inlineable
-  public init(_ base: Base.Index) {
-    self.base = base
-  }
+extension ReversedCollection: RandomAccessCollection where Base: RandomAccessCollection { }
 
-  /// The position after this position in the underlying collection.
-  ///
-  /// To find the position that corresponds with this index in the original,
-  /// underlying collection, use that collection's `index(before:)` method
-  /// with this index's `base` property.
-  ///
-  /// The following example declares a function that returns the index of the
-  /// last even number in the passed array, if one is found. First, the
-  /// function finds the position of the last even number as a `ReversedIndex`
-  /// in a reversed view of the array of numbers. Next, the function calls the
-  /// array's `index(before:)` method to return the correct position in the
-  /// passed array.
-  ///
-  ///     func indexOfLastEven(_ numbers: [Int]) -> Int? {
-  ///         let reversedNumbers = numbers.reversed()
-  ///         guard let i = reversedNumbers.index(where: { $0 % 2 == 0 })
-  ///             else { return nil }
-  ///
-  ///         return numbers.index(before: i.base)
-  ///     }
-  ///
-  ///     let numbers = [10, 20, 13, 19, 30, 52, 17, 40, 51]
-  ///     if let lastEven = indexOfLastEven(numbers) {
-  ///         print("Last even number: \(numbers[lastEven])")
-  ///     }
-  ///     // Prints "Last even number: 40"
-  public let base: Base.Index
-
-  @_inlineable
-  public static func == (
-    lhs: ReversedRandomAccessIndex<Base>,
-    rhs: ReversedRandomAccessIndex<Base>
-  ) -> Bool {
-    return lhs.base == rhs.base
-  }
-
-  @_inlineable
-  public static func < (
-    lhs: ReversedRandomAccessIndex<Base>,
-    rhs: ReversedRandomAccessIndex<Base>
-  ) -> Bool {
-    // Note ReversedRandomAccessIndex has inverted logic compared to base Base.Index
-    return lhs.base > rhs.base
-  }
-}
-
-extension ReversedRandomAccessIndex : Hashable where Base.Index : Hashable {
-  public var hashValue: Int {
-    return base.hashValue
-  }
-}
-
-/// A collection that presents the elements of its base collection
-/// in reverse order.
-///
-/// - Note: This type is the result of `x.reversed()` where `x` is a
-///   collection having random access indices.
-/// - See also: `ReversedCollection`
-@_fixed_layout
-public struct ReversedRandomAccessCollection<
-  Base : RandomAccessCollection
-> : RandomAccessCollection {
-  // FIXME: swift-3-indexing-model: tests for ReversedRandomAccessIndex and
-  // ReversedRandomAccessCollection.
-
-  /// Creates an instance that presents the elements of `base` in
-  /// reverse order.
-  ///
-  /// - Complexity: O(1)
-  @_versioned
-  @_inlineable
-  internal init(_base: Base) {
-    self._base = _base
-  }
-
-  /// A type that represents a valid position in the collection.
-  ///
-  /// Valid indices consist of the position of every element and a
-  /// "past the end" position that's not valid for use as a subscript.
-  public typealias Index = ReversedRandomAccessIndex<Base>
-
-  public typealias IndexDistance = Base.IndexDistance
-
-  public typealias Indices =
-    DefaultRandomAccessIndices<ReversedRandomAccessCollection<Base>>
-
-  /// A type that provides the sequence's iteration interface and
-  /// encapsulates its iteration state.
-  public typealias Iterator = IndexingIterator<
-    ReversedRandomAccessCollection
-  >
-
-  @_inlineable
-  public var startIndex: Index {
-    return ReversedRandomAccessIndex(_base.endIndex)
-  }
-
-  @_inlineable
-  public var endIndex: Index {
-    return ReversedRandomAccessIndex(_base.startIndex)
-  }
-
-  @_inlineable
-  public func index(after i: Index) -> Index {
-    return ReversedRandomAccessIndex(_base.index(before: i.base))
-  }
-
-  @_inlineable
-  public func index(before i: Index) -> Index {
-    return ReversedRandomAccessIndex(_base.index(after: i.base))
-  }
-
-  @_inlineable
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
-    // FIXME: swift-3-indexing-model: tests.
-    return ReversedRandomAccessIndex(_base.index(i.base, offsetBy: -n))
-  }
-
-  @_inlineable
-  public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
-  ) -> Index? {
-    // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
-    // FIXME: swift-3-indexing-model: tests.
-    return _base.index(i.base, offsetBy: -n, limitedBy: limit.base).map { Index($0) }
-  }
-
-  @_inlineable
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
-    // FIXME: swift-3-indexing-model: tests.
-    return _base.distance(from: end.base, to: start.base)
-  }
-
-  @_inlineable
-  public subscript(position: Index) -> Base.Element {
-    return _base[_base.index(before: position.base)]
-  }
-
-  // FIXME: swift-3-indexing-model: the rest of methods.
-
-  public let _base: Base
-}
+@available(*, deprecated, renamed: "ReversedCollection")
+public typealias ReversedRandomAccessCollection<T: RandomAccessCollection> = ReversedCollection<T>
 
 extension BidirectionalCollection {
   /// Returns a view presenting the elements of the collection in reverse
@@ -485,40 +303,6 @@ extension BidirectionalCollection {
   }
 }
 
-extension RandomAccessCollection {
-  /// Returns a view presenting the elements of the collection in reverse
-  /// order.
-  ///
-  /// You can reverse a collection without allocating new space for its
-  /// elements by calling this `reversed()` method. A
-  /// `ReversedRandomAccessCollection` instance wraps an underlying collection
-  /// and provides access to its elements in reverse order. This example
-  /// prints the elements of an array in reverse order:
-  ///
-  ///     let numbers = [3, 5, 7]
-  ///     for number in numbers.reversed() {
-  ///         print(number)
-  ///     }
-  ///     // Prints "7"
-  ///     // Prints "5"
-  ///     // Prints "3"
-  ///
-  /// If you need a reversed collection of the same type, you may be able to
-  /// use the collection's sequence-based or collection-based initializer. For
-  /// example, to get the reversed version of an array, initialize a new
-  /// `Array` instance from the result of this `reversed()` method.
-  ///
-  ///     let reversedNumbers = Array(numbers.reversed())
-  ///     print(reversedNumbers)
-  ///     // Prints "[7, 5, 3]"
-  ///
-  /// - Complexity: O(1)
-  @_inlineable
-  public func reversed() -> ReversedRandomAccessCollection<Self> {
-    return ReversedRandomAccessCollection(_base: self)
-  }
-}
-
 extension LazyCollectionProtocol
   where
   Self : BidirectionalCollection,
@@ -545,9 +329,9 @@ extension LazyCollectionProtocol
   /// - Complexity: O(1)
   @_inlineable
   public func reversed() -> LazyRandomAccessCollection<
-    ReversedRandomAccessCollection<Elements>
+    ReversedCollection<Elements>
   > {
-    return ReversedRandomAccessCollection(_base: elements).lazy
+    return ReversedCollection(_base: elements).lazy
   }
 }
 

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -274,7 +274,7 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
 extension StrideTo : RandomAccessCollection
 where Element.Stride : BinaryInteger {
   public typealias Index = Int
-  public typealias SubSequence = RandomAccessSlice<StrideTo<Element>>
+  public typealias SubSequence = Slice<StrideTo<Element>>
   public typealias Indices = CountableRange<Int>
 
   @_inlineable
@@ -295,11 +295,9 @@ where Element.Stride : BinaryInteger {
     return _start.advanced(by: Element.Stride(position) * _stride)
   }
 
-  public subscript(
-    bounds: Range<Index>
-  ) -> RandomAccessSlice<StrideTo<Element>> {
-    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-    return RandomAccessSlice(base: self, bounds: bounds)
+  public subscript(bounds: Range<Index>) -> Slice<StrideTo<Element>> {
+    _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
+    return Slice(base: self, bounds: bounds)
   }
 
   @_inlineable
@@ -448,7 +446,7 @@ extension StrideThrough : RandomAccessCollection
 where Element.Stride : BinaryInteger {
   public typealias Index = ClosedRangeIndex<Int>
   public typealias IndexDistance = Int
-  public typealias SubSequence = RandomAccessSlice<StrideThrough<Element>>
+  public typealias SubSequence = Slice<StrideThrough<Element>>
 
   @_inlineable
   public var startIndex: Index {
@@ -474,10 +472,8 @@ where Element.Stride : BinaryInteger {
     return _start.advanced(by: offset)
   }
 
-  public subscript(
-    bounds: Range<Index>
-  ) -> RandomAccessSlice<StrideThrough<Element>> {
-    return RandomAccessSlice(base: self, bounds: bounds)
+  public subscript(bounds: Range<Index>) -> Slice<StrideThrough<Element>> {
+    return Slice(base: self, bounds: bounds)
   }
 
   @_inlineable

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -94,17 +94,17 @@ public struct Substring : StringProtocol {
   public typealias SubSequence = Substring
 
   @_versioned // FIXME(sil-serialize-all)
-  internal var _slice: RangeReplaceableBidirectionalSlice<String>
+  internal var _slice: Slice<String>
 
   /// Creates an empty substring.
   @_inlineable // FIXME(sil-serialize-all)
   public init() {
-    _slice = RangeReplaceableBidirectionalSlice()
+    _slice = Slice()
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal init(_slice: RangeReplaceableBidirectionalSlice<String>) {
+  internal init(_slice: Slice<String>) {
     self._slice = _slice
   }
   
@@ -116,7 +116,7 @@ public struct Substring : StringProtocol {
   ///     upper bounds of `bounds` must be valid indices of `base`.
   @_inlineable // FIXME(sil-serialize-all)
   public init(_base base: String, _ bounds: Range<Index>) {
-    _slice = RangeReplaceableBidirectionalSlice(base: base, bounds: bounds)
+    _slice = Slice(base: base, bounds: bounds)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -434,7 +434,7 @@ extension Substring {
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct ${View} {
     @_versioned // FIXME(sil-serialize-all)
-    internal var _slice: ${RangeReplaceable}BidirectionalSlice<String.${View}>
+    internal var _slice: Slice<String.${View}>
   }
 }
 
@@ -446,7 +446,7 @@ extension Substring.${View} : BidirectionalCollection {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal init(_ base: String.${View}, _bounds: Range<Index>) {
-    _slice = ${RangeReplaceable}BidirectionalSlice(
+    _slice = Slice(
       base: String(base._core).${property},
       bounds: _bounds)
   }
@@ -537,7 +537,7 @@ extension String {
 // FIXME: The other String views should be RangeReplaceable too.
 extension Substring.UnicodeScalarView : RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
-  public init() { _slice = RangeReplaceableBidirectionalSlice.init() }
+  public init() { _slice = Slice.init() }
 
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func replaceSubrange<C : Collection>(
@@ -661,7 +661,7 @@ extension String {
   @available(swift, introduced: 4)
   public subscript(r: Range<Index>) -> Substring {
     return Substring(
-      _slice: RangeReplaceableBidirectionalSlice(base: self, bounds: r))
+      _slice: Slice(base: self, bounds: r))
   }
 
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -38,7 +38,7 @@ public struct _UIntBuffer<
 }
 
 extension _UIntBuffer : Sequence {
-  public typealias SubSequence = RangeReplaceableRandomAccessSlice<_UIntBuffer>
+  public typealias SubSequence = Slice<_UIntBuffer>
   
   @_fixed_layout
   public struct Iterator : IteratorProtocol, Sequence {

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -251,12 +251,12 @@ public struct Unsafe${Mutable}BufferPointer<Element>
 
   @_inlineable
   public subscript(bounds: Range<Int>)
-    -> ${Mutable}RandomAccessSlice<Unsafe${Mutable}BufferPointer<Element>>
+    -> Slice<Unsafe${Mutable}BufferPointer<Element>>
   {
     get {
       _debugPrecondition(bounds.lowerBound >= startIndex)
       _debugPrecondition(bounds.upperBound <= endIndex)
-      return ${Mutable}RandomAccessSlice(
+      return Slice(
         base: self, bounds: bounds)
     }
 %  if Mutable:
@@ -352,7 +352,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///
   /// - Parameter slice: The buffer slice to rebase.
   @_inlineable
-  public init(rebasing slice: RandomAccessSlice<UnsafeBufferPointer<Element>>) {
+  public init(rebasing slice: Slice<UnsafeBufferPointer<Element>>) {
     self.init(start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)
   }
@@ -381,7 +381,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   @_inlineable
   public init(
     rebasing slice:
-    MutableRandomAccessSlice<UnsafeMutableBufferPointer<Element>>
+    Slice<UnsafeMutableBufferPointer<Element>>
   ) {
     self.init(start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -100,7 +100,7 @@ public struct Unsafe${Mutable}RawBufferPointer
 
   public typealias Index = Int
   public typealias IndexDistance = Int
-  public typealias SubSequence = ${Mutable}RandomAccessSlice<${Self}>
+  public typealias SubSequence = ${Mutable}Slice<${Self}>
 
   /// An iterator over the bytes viewed by a raw buffer pointer.
   @_fixed_layout
@@ -386,7 +386,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///
   /// - Parameter slice: The raw buffer slice to rebase.
   @_inlineable
-  public init(rebasing slice: RandomAccessSlice<UnsafeRawBufferPointer>) {
+  public init(rebasing slice: Slice<UnsafeRawBufferPointer>) {
     self.init(start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)
   }
@@ -414,7 +414,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// - Parameter slice: The raw buffer slice to rebase.
   @_inlineable
   public init(
-    rebasing slice: MutableRandomAccessSlice<UnsafeMutableRawBufferPointer>
+    rebasing slice: Slice<UnsafeMutableRawBufferPointer>
   ) {
     self.init(start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)
@@ -471,11 +471,11 @@ public struct Unsafe${Mutable}RawBufferPointer
   @_inlineable
   public subscript(
     bounds: Range<Int>
-  ) -> ${Mutable}RandomAccessSlice<Unsafe${Mutable}RawBufferPointer> {
+  ) -> Slice<Unsafe${Mutable}RawBufferPointer> {
     get {
       _debugPrecondition(bounds.lowerBound >= startIndex)
       _debugPrecondition(bounds.upperBound <= endIndex)
-      return ${Mutable}RandomAccessSlice(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
 %  if mutable:
     nonmutating set {

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -42,7 +42,7 @@ public struct _ValidUTF8Buffer<
 }
 
 extension _ValidUTF8Buffer : Sequence {
-  public typealias SubSequence = RangeReplaceableRandomAccessSlice<_ValidUTF8Buffer>
+  public typealias SubSequence = Slice<_ValidUTF8Buffer>
   
 
   @_fixed_layout // FIXME(sil-serialize-all)

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -167,9 +167,9 @@ func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3
 // Note: a standard-library-based stress test to make sure we don't inject
 // any additional requirements.
 // CHECK-LABEL: RangeReplaceableCollection
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : MutableCollection, τ_0_0 : RangeReplaceableCollection, τ_0_0.SubSequence == MutableRangeReplaceableSlice<τ_0_0>>
-extension RangeReplaceableCollection where
-  Self.SubSequence == MutableRangeReplaceableSlice<Self>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : MutableCollection, τ_0_0 : RangeReplaceableCollection, τ_0_0.SubSequence == Slice<τ_0_0>>
+extension RangeReplaceableCollection
+  where Self: MutableCollection, Self.SubSequence == Slice<Self>
 {
 	func f() { }
 }

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -343,5 +343,5 @@ func takesRawBuffer(_ b: UnsafeRawBufferPointer) {}
 func f29586888(b: UnsafeRawBufferPointer) {
   takesRawBuffer(b[1..<2]) // expected-error {{'subscript' is unavailable: use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.}}
   let slice = b[1..<2]
-  takesRawBuffer(slice) // expected-error {{cannot convert value of type 'UnsafeRawBufferPointer.SubSequence' (aka 'RandomAccessSlice<UnsafeRawBufferPointer>') to expected argument type 'UnsafeRawBufferPointer'}}
+  takesRawBuffer(slice) // expected-error {{cannot convert value of type 'UnsafeRawBufferPointer.SubSequence' (aka 'Slice<UnsafeRawBufferPointer>') to expected argument type 'UnsafeRawBufferPointer'}}
 }

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
 // RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/out.swift
-// RUN: %line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out -Onone -swift-version 4
+// RUN: %line-directive %t/out.swift -- %target-build-swift -enable-experimental-conditional-conformances -parse-stdlib %t/out.swift -o %t/a.out -Onone -swift-version 4
 // RUN: %line-directive %t/out.swift -- %target-run %t/a.out
 
 // REQUIRES: executable_test

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -51,12 +51,7 @@ public protocol MutableCollectionAlgorithms : MutableCollection
 extension Array : MutableCollectionAlgorithms {  }
 extension ArraySlice : MutableCollectionAlgorithms {  }
 
-% for Traversal in TRAVERSALS:
-%   for RangeReplaceable in [ False, True ]:
-%     Slice = sliceTypeName(traversal=Traversal, mutable=True, rangeReplaceable=RangeReplaceable)
-extension ${Slice} : MutableCollectionAlgorithms {  }
-%   end
-% end
+extension Slice : MutableCollectionAlgorithms {  }
 
 /// In the stdlib, this would simply be MutableCollection
 extension MutableCollectionAlgorithms {

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -51,7 +51,7 @@ public protocol MutableCollectionAlgorithms : MutableCollection
 extension Array : MutableCollectionAlgorithms {  }
 extension ArraySlice : MutableCollectionAlgorithms {  }
 
-extension Slice : MutableCollectionAlgorithms {  }
+extension Slice : MutableCollectionAlgorithms where Base: MutableCollection { }
 
 /// In the stdlib, this would simply be MutableCollection
 extension MutableCollectionAlgorithms {

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -38,7 +38,7 @@ LazyTestSuite.test("Repeated/AssociatedTypes") {
   expectRandomAccessCollectionAssociatedTypes(
     collectionType: Subject.self,
     iteratorType: IndexingIterator<Subject>.self,
-    subSequenceType: RandomAccessSlice<Subject>.self,
+    subSequenceType: Slice<Subject>.self,
     indexType: Int.self,
     indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
@@ -121,7 +121,7 @@ LazyTestSuite.test("CollectionOfOne/AssociatedTypes") {
   expectRandomAccessCollectionAssociatedTypes(
     collectionType: Subject.self,
     iteratorType: IteratorOverOne<OpaqueValue<Int>>.self,
-    subSequenceType: MutableRandomAccessSlice<Subject>.self,
+    subSequenceType: Slice<Subject>.self,
     indexType: Int.self,
     indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
@@ -533,7 +533,7 @@ extension LazyCollection where Base : TestProtocol1 {
 %for (Traversal, ReversedType) in [
 %    ('Forward', None),
 %    ('Bidirectional', 'ReversedCollection'),
-%    ('RandomAccess', 'ReversedRandomAccessCollection')
+%    ('RandomAccess', 'ReversedCollection')
 %]:
 %  TraversalCollection = collectionForTraversal(Traversal)
 
@@ -608,18 +608,20 @@ extension ReversedIndex where Base : TestProtocol1 {
 //===----------------------------------------------------------------------===//
 
 // Check that the generic parameter is called 'Base'.
-extension ReversedRandomAccessCollection where Base : TestProtocol1 {
+extension ReversedCollection
+    where Base : TestProtocol1, Base : RandomAccessCollection {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
 }
 
 //===----------------------------------------------------------------------===//
-// ReversedRandomAccessIndex
+// ReversedIndex for RandomAccessCollections
 //===----------------------------------------------------------------------===//
 
 // Check that the generic parameter is called 'Base'.
-extension ReversedRandomAccessIndex where Base : TestProtocol1 {
+extension ReversedIndex
+    where Base : TestProtocol1, Base : RandomAccessCollection {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
@@ -993,7 +995,7 @@ tests.test("ReversedCollection/Lazy") {
     ExpectType<Base>.test(base)
 
     typealias LazyReversedBase = LazyRandomAccessCollection<
-      ReversedRandomAccessCollection<Base>>
+      ReversedCollection<Base>>
 
     let reversed = base.reversed()
     ExpectType<LazyReversedBase>.test(reversed)
@@ -1372,7 +1374,7 @@ tests.test("LazyPrefixWhileBidirectionalCollection/AssociatedTypes") {
     collectionType: Subject.self,
     iteratorType: LazyPrefixWhileIterator<Base.Iterator>.self,
     // FIXME(ABI)#82 (Associated Types with where clauses): SubSequence should be `LazyFilterBidirectionalCollection<Base.Slice>`.
-    subSequenceType: BidirectionalSlice<Subject>.self,
+    subSequenceType: Slice<Subject>.self,
     indexType: LazyPrefixWhileIndex<Base>.self,
     indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
@@ -1432,7 +1434,7 @@ tests.test("LazyDropWhileBidirectionalCollection/AssociatedTypes") {
     collectionType: Subject.self,
     iteratorType: LazyDropWhileIterator<Base.Iterator>.self,
     // FIXME(ABI)#83 (Associated Types with where clauses): SubSequence should be `LazyFilterBidirectionalCollection<Base.Slice>`.
-    subSequenceType: BidirectionalSlice<Subject>.self,
+    subSequenceType: Slice<Subject>.self,
     indexType: LazyDropWhileIndex<Base>.self,
     indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)


### PR DESCRIPTION
This PR refactors the variations of `Slice`, `DefaultIndices`, and `ReversedCollection` to be conditional conformances on each base type e.g.

```swift
ReversedRandomAccessCollection<Base: RandomAccessCollection>: RandomAccessCollection
```

becomes:

```swift
extension ReversedCollection: RandomAccessCollection where Base: RandomAccessCollection { }

@available(*, deprecated, renamed: "ReversedCollection")
public typealias ReversedRandomAccessCollection<T: RandomAccessCollection> = ReversedCollection<T>
```