### PR TITLE
SILOptimizer: Fix convert_function -> apply peephole for metatype conversions

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -489,13 +489,10 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
       assert(NewOpType.isAddress() && "Addresses should map to addresses.");
       auto UAC = Builder.createUncheckedAddrCast(AI.getLoc(), Op, NewOpType);
       Args.push_back(UAC);
-    } else if (SILType::canRefCast(OldOpType, NewOpType, AI.getModule())) {
-      auto URC = Builder.createUncheckedRefCast(AI.getLoc(), Op, NewOpType);
+    } else if (OldOpType.getSwiftRValueType() != NewOpType.getSwiftRValueType()) {
+      auto URC = Builder.createUncheckedBitCast(AI.getLoc(), Op, NewOpType);
       Args.push_back(URC);
     } else {
-      assert((!OldOpType.isHeapObjectReferenceType()
-              && !NewOpType.isHeapObjectReferenceType()) &&
-             "ref argument types should map to refs.");
       Args.push_back(Op);
     }
   }

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -497,3 +497,25 @@ bb11(%128 : $Error):
 bb99:
   return %closure : $@callee_guaranteed (@guaranteed C) -> @error Error
 }
+
+// Make sure convert_function -> apply does the right thing with metatypes
+class Base {}
+class Derived {}
+
+sil @takesMetatype : $@convention(thin) (@thick Base.Type) -> ()
+
+// CHECK-LABEL: sil @passesMetatype
+// CHECK: [[METATYPE:%.*]] = metatype $@thick Derived.Type
+// CHECK: [[FN:%.*]] = function_ref @takesMetatype
+// CHECK: [[CONVERTED:%.*]] = unchecked_trivial_bit_cast [[METATYPE]] : $@thick Derived.Type to $@thick Base.Type
+// CHECK: [[RESULT:%.*]] = apply [[FN]]([[CONVERTED]])
+
+sil @passesMetatype : $@convention(thin) () -> () {
+bb0:
+  %metatype = metatype $@thick Derived.Type
+  %fn = function_ref @takesMetatype : $@convention(thin) (@thick Base.Type) -> ()
+  %converted = convert_function %fn : $@convention(thin) (@thick Base.Type) -> () to $@convention(thin) (@thick Derived.Type) -> ()
+  %result = apply %converted(%metatype) : $@convention(thin) (@thick Derived.Type) -> ()
+  %return = tuple ()
+  return %return : $()
+}

--- a/validation-test/Evolution/test_superclass_methods.swift
+++ b/validation-test/Evolution/test_superclass_methods.swift
@@ -1,9 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// rdar://35492775
-// REQUIRES: swift_test_mode_optimize_none
-
 import StdlibUnittest
 import superclass_methods
 

--- a/validation-test/Evolution/test_superclass_properties.swift
+++ b/validation-test/Evolution/test_superclass_properties.swift
@@ -1,9 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// rdar://35492775
-// REQUIRES: swift_test_mode_optimize_none
-
 import StdlibUnittest
 import superclass_properties
 


### PR DESCRIPTION
Fixes <rdar://problem/35492775>.