### PR TITLE
[cfg] Add utility method completeJointPostDominanceSet.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -131,5 +131,36 @@ bool splitAllCriticalEdges(SILFunction &F, bool OnlyNonCondBr,
 bool mergeBasicBlockWithSuccessor(SILBasicBlock *BB, DominanceInfo *DT,
                                   SILLoopInfo *LI);
 
+/// Given a list of \p UserBlocks and a list of \p DefBlocks, find a set of
+/// blocks that together with \p UserBlocks joint-postdominate \p
+/// DefBlocks. This is in a sense finding a set of blocks that "complete" \p
+/// UserBlocks with respect to \p DefBlocks. As an example, for the following
+/// CFG:
+///
+///       +-----+
+///       | Def |
+///       +-----+
+///       |     |
+///       v     v
+/// +-----+     +-----+
+/// |     |     | Use |
+/// +-----+     +-----+
+///
+/// the completion of the joint post-dominance set would be the empty
+/// block. This has two main uses:
+///
+/// 1. This can tell you the places where if you were to sink the Def one would
+/// need to insert "compensating code".
+///
+/// 2. It can be used to prove ownership correctness of @owned values by
+/// asserting that the set of UserBlocks has an empty completion, implying they
+/// jointly-post dominate the def.
+///
+/// *NOTE* This completion may not be unique.
+void completeJointPostDominanceSet(
+    ArrayRef<SILBasicBlock *> UserBlocks, ArrayRef<SILBasicBlock *> DefBlocks,
+    llvm::SmallVectorImpl<SILBasicBlock *> &Completion);
+
 } // end namespace swift
+
 #endif

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -848,3 +848,85 @@ SILBasicBlock *swift::splitIfCriticalEdge(SILBasicBlock *From,
   }
   llvm_unreachable("Destination block not found");
 }
+
+void swift::completeJointPostDominanceSet(
+    ArrayRef<SILBasicBlock *> UserBlocks, ArrayRef<SILBasicBlock *> DefBlocks,
+    llvm::SmallVectorImpl<SILBasicBlock *> &Result) {
+  assert(!UserBlocks.empty() && "Must have at least 1 user block");
+  assert(!DefBlocks.empty() && "Must have at least 1 def block");
+
+  // If we have only one def block and one user block and they are the same
+  // block, then just return.
+  if (DefBlocks.size() == 1 && UserBlocks.size() == 1 &&
+      UserBlocks[0] == DefBlocks[0]) {
+    return;
+  }
+
+  // Some notes on the algorithm:
+  //
+  // 1. Our VisitedBlocks set just states that a value has been added to the
+  // worklist and should not be added to the worklist.
+  // 2. Our targets of the CFG block are DefBlockSet.
+  // 3. We find the missing post-domination blocks by finding successors of
+  // blocks on our walk that we have not visited by the end of the walk. For
+  // joint post-dominance to be true, no such successors should exist.
+
+  // Our set of target blocks where we stop walking.
+  llvm::SmallPtrSet<SILBasicBlock *, 8> DefBlockSet(DefBlocks.begin(),
+                                                    DefBlocks.end());
+
+  // The set of successor blocks of blocks that we visit. Any blocks still in
+  // this set at the end of the walk act as a post-dominating closure around our
+  // UserBlock set.
+  llvm::SmallSetVector<SILBasicBlock *, 16> MustVisitSuccessorBlocks;
+
+  // Add our user and def blocks to the VisitedBlock set. We never want to find
+  // these in our worklist.
+  llvm::SmallPtrSet<SILBasicBlock *, 32> VisitedBlocks(UserBlocks.begin(),
+                                                       UserBlocks.end());
+
+  // Finally setup our worklist by adding our user block predecessors. We only
+  // add the predecessors to the worklist once.
+  llvm::SmallVector<SILBasicBlock *, 32> Worklist;
+  for (auto *Block : UserBlocks) {
+    copy_if(Block->getPredecessorBlocks(), std::back_inserter(Worklist),
+            [&](SILBasicBlock *PredBlock) -> bool {
+              return VisitedBlocks.insert(PredBlock).second;
+            });
+  }
+
+  // Then until we reach a fix point.
+  while (!Worklist.empty()) {
+    // Grab the next block from the worklist.
+    auto *Block = Worklist.pop_back_val();
+    assert(VisitedBlocks.count(Block) && "All blocks from worklist should be "
+                                         "in the visited blocks set.");
+
+    // Since we are visiting this block now, we know that this block can not be
+    // apart of a the post-dominance closure of our UseBlocks.
+    MustVisitSuccessorBlocks.remove(Block);
+
+    // Then add each successor block of Block that has not been visited yet to
+    // the MustVisitSuccessorBlocks set.
+    for (auto *SuccBlock : Block->getSuccessorBlocks()) {
+      if (!VisitedBlocks.count(SuccBlock)) {
+        MustVisitSuccessorBlocks.insert(SuccBlock);
+      }
+    }
+
+    // If this is a def block, then do not add its predecessors to the
+    // worklist.
+    if (DefBlockSet.count(Block))
+      continue;
+
+    // Otherwise add all unvisited predecessors to the worklist.
+    copy_if(Block->getPredecessorBlocks(), std::back_inserter(Worklist),
+            [&](SILBasicBlock *Block) -> bool {
+              return VisitedBlocks.insert(Block).second;
+            });
+  }
+
+  // Now that we are done, add all remaining must visit blocks to our result
+  // list. These are the remaining parts of our joint post-dominance closure.
+  copy(MustVisitSuccessorBlocks, std::back_inserter(Result));
+}


### PR DESCRIPTION
This helper utility given a set of uses/defs determines the set of blocks that
together with the user blocks jointly post-dominate the def blocks. In a sense
this is completing the providing set of user blocks to a joint-post dominating
set. This completion is not unique.

I am adding this method because often times when working with Ownership SIL, one
needs to hoist/sink operations and then compensate to ensure that ownership
properties are still preserved.

I think with a little bit of work I can get the ownership model eliminator to
use this routine (since the condition for ownership to be correct on an @owned
value is an empty joint-post dominating completion. I wrote it b/c I need it in
pred-memopts and I expect it to be a general useful routine for Ownership SIL.

rdar://31521023
