### PR TITLE
[Exclusivity] Diagnose when noescape closure is passed via reabstraction thunk

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -94,7 +94,7 @@ ERROR(inout_argument_alias,none,
 NOTE(previous_inout_alias,none,
       "previous aliasing argument", ())
 
-WARNING(exclusivity_access_required_swift3,none,
+WARNING(exclusivity_access_required_warn,none,
         "overlapping accesses to %0, but "
         "%select{initialization|read|modification|deinitialization}1 requires "
         "exclusive access; "
@@ -115,7 +115,7 @@ ERROR(exclusivity_access_required_unknown_decl,none,
         "%select{initialization|read|modification|deinitialization}0 requires "
         "exclusive access; consider copying to a local variable", (unsigned))
 
-WARNING(exclusivity_access_required_unknown_decl_swift3,none,
+WARNING(exclusivity_access_required_unknown_decl_warn,none,
         "overlapping accesses, but "
         "%select{initialization|read|modification|deinitialization}0 requires "
 "exclusive access; consider copying to a local variable", (unsigned))

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -406,6 +406,12 @@ using StorageMap = llvm::SmallDenseMap<AccessedStorage, AccessInfo, 4>;
 
 /// Represents two accesses that conflict and their underlying storage.
 struct ConflictingAccess {
+private:
+
+  /// If true, always diagnose this conflict as a warning. This is useful for
+  /// staging in fixes for false negatives without affecting source
+  /// compatibility.
+  bool AlwaysDiagnoseAsWarning = false;
 public:
   /// Create a conflict for two begin_access instructions in the same function.
   ConflictingAccess(const AccessedStorage &Storage, const RecordedAccess &First,
@@ -415,6 +421,11 @@ public:
   const AccessedStorage Storage;
   const RecordedAccess FirstAccess;
   const RecordedAccess SecondAccess;
+
+  bool getAlwaysDiagnoseAsWarning() const { return AlwaysDiagnoseAsWarning; }
+  void setAlwaysDiagnoseAsWarning(bool AlwaysDiagnoseAsWarning) {
+    this->AlwaysDiagnoseAsWarning = AlwaysDiagnoseAsWarning;
+  }
 };
 
 } // end anonymous namespace
@@ -693,10 +704,15 @@ static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
   unsigned AccessKindForMain =
       static_cast<unsigned>(MainAccess.getAccessKind());
 
+  // For now, all exclusivity violations are warning in Swift 3 mode.
+  // Also treat some violations as warnings to allow them to be staged in.
+  bool DiagnoseAsWarning = Violation.getAlwaysDiagnoseAsWarning() ||
+      Ctx.LangOpts.isSwiftVersion3();
+
   if (const ValueDecl *VD = Storage.getStorageDecl()) {
     // We have a declaration, so mention the identifier in the diagnostic.
-    auto DiagnosticID = (Ctx.LangOpts.isSwiftVersion3() ?
-                         diag::exclusivity_access_required_swift3 :
+    auto DiagnosticID = (DiagnoseAsWarning ?
+                         diag::exclusivity_access_required_warn :
                          diag::exclusivity_access_required);
     SILType BaseType = FirstAccess.getInstruction()->getType().getAddressType();
     SILModule &M = FirstAccess.getInstruction()->getModule();
@@ -724,8 +740,8 @@ static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
       addSwapAtFixit(D, CallToReplace, Base, SwapIndex1, SwapIndex2,
                      Ctx.SourceMgr);
   } else {
-    auto DiagnosticID = (Ctx.LangOpts.isSwiftVersion3() ?
-                         diag::exclusivity_access_required_unknown_decl_swift3 :
+    auto DiagnosticID = (DiagnoseAsWarning ?
+                         diag::exclusivity_access_required_unknown_decl_warn :
                          diag::exclusivity_access_required_unknown_decl);
     diagnose(Ctx, MainAccess.getAccessLoc().getSourceLoc(), DiagnosticID,
              AccessKindForMain)
@@ -902,6 +918,7 @@ findConflictingArgumentAccess(const AccessSummaryAnalysis::ArgumentSummary &AS,
 static void checkForViolationWithCall(
     const StorageMap &Accesses, SILFunction *Callee, unsigned StartingAtIndex,
     OperandValueArrayRef Arguments, AccessSummaryAnalysis *ASA,
+    bool DiagnoseAsWarning,
     llvm::SmallVectorImpl<ConflictingAccess> &ConflictingAccesses) {
   const AccessSummaryAnalysis::FunctionSummary &FS =
       ASA->getOrCreateSummary(Callee);
@@ -934,6 +951,7 @@ static void checkForViolationWithCall(
 
     const AccessInfo &Info = AccessIt->getSecond();
     if (auto Conflict = findConflictingArgumentAccess(AS, Storage, Info)) {
+      Conflict->setAlwaysDiagnoseAsWarning(DiagnoseAsWarning);
       ConflictingAccesses.push_back(*Conflict);
     }
   }
@@ -964,34 +982,88 @@ static PartialApplyInst *lookThroughForPartialApply(SILValue V) {
 /// via @block_storage convention. To enforce this case, we should statically
 /// recognize when the apply takes a block argument that has been initialized to
 /// a non-escaping closure.
-static void checkForViolationsInNoEscapeClosures(
-    const StorageMap &Accesses, FullApplySite FAS, AccessSummaryAnalysis *ASA,
-    llvm::SmallVectorImpl<ConflictingAccess> &ConflictingAccesses) {
-
-  SILFunction *Callee = FAS.getCalleeFunction();
-  if (Callee && !Callee->empty()) {
-    // Check for violation with directly called closure
-    checkForViolationWithCall(Accesses, Callee, 0, FAS.getArguments(), ASA,
-                              ConflictingAccesses);
-  }
+static void checkForViolationsInNoEscapeClosureArguments(
+    const StorageMap &Accesses, ApplySite AS, AccessSummaryAnalysis *ASA,
+    llvm::SmallVectorImpl<ConflictingAccess> &ConflictingAccesses,
+    bool DiagnoseAsWarning) {
 
   // Check for violation with closures passed as arguments
-  for (SILValue Argument : FAS.getArguments()) {
+  for (SILValue Argument : AS.getArguments()) {
+    auto ArgumentFnType = Argument->getType().getAs<SILFunctionType>();
+    if (!ArgumentFnType)
+      continue;
+
+    if (!ArgumentFnType->isNoEscape())
+      continue;
+
     auto *PAI = lookThroughForPartialApply(Argument);
     if (!PAI)
       continue;
 
-    SILFunction *Closure = PAI->getCalleeFunction();
-    if (!Closure || Closure->empty())
+    SILFunction *Callee = PAI->getCalleeFunction();
+    if (!Callee)
+      continue;
+
+    if (Callee->isThunk() == IsReabstractionThunk) {
+      // For source compatibility reasons, treat conflicts found by
+      // looking through reabstraction thunks as warnings. A future compiler
+      // will upgrade these to errors;
+      bool WarnOnThunkConflict = true;
+      // Recursively check any arguments to the partial apply that are
+      // themselves noescape closures. This detects violations when a noescape
+      // closure is captured by a reabstraction thunk which is itself then passed
+      // to an apply.
+      checkForViolationsInNoEscapeClosureArguments(Accesses, PAI, ASA,
+                                                   ConflictingAccesses,
+                                                   WarnOnThunkConflict);
+      continue;
+    }
+    // The callee is not a reabstraction thunk, so check its captures directly.
+
+    if (Callee->empty())
       continue;
 
     // Check the closure's captures, which are a suffix of the closure's
     // parameters.
     unsigned StartIndex =
-        Closure->getArguments().size() - PAI->getNumArguments();
-    checkForViolationWithCall(Accesses, Closure, StartIndex,
-                              PAI->getArguments(), ASA, ConflictingAccesses);
+        Callee->getArguments().size() - PAI->getNumArguments();
+    checkForViolationWithCall(Accesses, Callee, StartIndex,
+                              PAI->getArguments(), ASA, DiagnoseAsWarning,
+                              ConflictingAccesses);
   }
+}
+
+/// Given a full apply site, diagnose if the apply either calls a closure
+/// directly that conflicts with an in-progress access or takes a noescape
+/// argument that, when called, would conflict with an in-progress access.
+static void checkForViolationsInNoEscapeClosures(
+    const StorageMap &Accesses, FullApplySite FAS, AccessSummaryAnalysis *ASA,
+    llvm::SmallVectorImpl<ConflictingAccess> &ConflictingAccesses) {
+  // Check to make sure that calling a closure immediately will not result in
+  // a conflict. This diagnoses in cases where there is a conflict between an
+  // argument passed inout to the closure and an access inside the closure to a
+  // captured variable:
+  //
+  //  var i = 7
+  //  ({ (p: inout Int) in i = 8})(&i) // Overlapping access to 'i'
+  //
+  SILFunction *Callee = FAS.getCalleeFunction();
+  if (Callee && !Callee->empty()) {
+    // Check for violation with directly called closure
+    checkForViolationWithCall(Accesses, Callee, 0, FAS.getArguments(), ASA,
+                              /*DiagnoseAsWarning=*/false, ConflictingAccesses);
+  }
+
+  // Check to make sure that any arguments to the apply are not themselves
+  // noescape closures that -- when called -- might conflict with an in-progress
+  // access. For example, this will diagnose on the following:
+  //
+  // var i = 7
+  // takesInoutAndClosure(&i) { i = 8 } // Overlapping access to 'i'
+  //
+  checkForViolationsInNoEscapeClosureArguments(Accesses, FAS, ASA,
+                                               ConflictingAccesses,
+                                               /*DiagnoseAsWarning=*/false);
 }
 
 static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -9,8 +9,9 @@ import Swift
 sil @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
 sil @takesOneInout : $@convention(thin) (@inout Int) -> ()
 sil @makesInt : $@convention(thin) () -> Int
-sil @takesInoutAndNoEscapeClosure : $@convention(thin) (@inout Int, @owned @callee_owned () -> ()) -> ()
-sil @takesInoutAndNoEscapeClosureTakingArgument : $@convention(thin) (@inout Int, @owned @callee_owned (Int) -> ()) -> ()
+sil @takesInoutAndNoEscapeClosure : $@convention(thin) (@inout Int, @noescape @owned @callee_owned () -> ()) -> ()
+sil @takesInoutAndNoEscapeClosureTakingArgument : $@convention(thin) (@inout Int, @noescape @owned @callee_owned (Int) -> ()) -> ()
+sil @takesInoutAndNoEscapeClosureWithGenericReturn : $@convention(thin) <T> (@inout Int, @owned @noescape @callee_owned (Int) -> @out T) -> ()
 
 // CHECK-LABEL: sil hidden @twoLocalInoutsDisaliased
 sil hidden @twoLocalInoutsDisaliased : $@convention(thin) (Int) -> () {
@@ -588,11 +589,12 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
-  %4 = function_ref @takesInoutAndNoEscapeClosureTakingArgument : $@convention(thin) (@inout Int, @owned @callee_owned (Int) -> ()) -> ()
+  %4 = function_ref @takesInoutAndNoEscapeClosureTakingArgument : $@convention(thin) (@inout Int, @noescape @owned @callee_owned (Int) -> ()) -> ()
   %5 = function_ref @closureWithArgument_1 : $@convention(thin) (Int, @inout_aliasable Int) -> ()
   %6 = partial_apply %5(%3) : $@convention(thin) (Int, @inout_aliasable Int) -> ()
+  %conv = convert_function %6 : $@callee_owned (Int) -> () to $@callee_owned @noescape (Int) -> ()
   %7 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
-  %8 = apply %4(%3, %6) : $@convention(thin) (@inout Int, @owned @callee_owned (Int) -> ()) -> ()
+  %8 = apply %4(%3, %conv) : $@convention(thin) (@inout Int, @noescape @owned @callee_owned (Int) -> ()) -> ()
   end_access %7: $*Int
   destroy_value %2 : ${ var Int }
   %9 = tuple ()
@@ -613,15 +615,46 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
-  %4 = function_ref @takesInoutAndNoEscapeClosure : $@convention(thin) (@inout Int, @owned @callee_owned () -> ()) -> ()
+  %4 = function_ref @takesInoutAndNoEscapeClosure : $@convention(thin) (@inout Int, @noescape @owned @callee_owned () -> ()) -> ()
   %5 = function_ref @closureThatModifiesCapture_2 : $@convention(thin) (@inout_aliasable Int) -> ()
   %6 = partial_apply %5(%3) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %conv = convert_function %6 : $@callee_owned () -> () to $@callee_owned @noescape () -> ()
   %7 = begin_access [read] [unknown] %3 : $*Int // expected-note {{conflicting access is here}}
-  %8 = apply %4(%3, %6) : $@convention(thin) (@inout Int, @owned @callee_owned () -> ()) -> ()
+  %8 = apply %4(%3, %conv) : $@convention(thin) (@inout Int, @noescape @owned @callee_owned () -> ()) -> ()
   end_access %7: $*Int
   destroy_value %2 : ${ var Int }
   %9 = tuple ()
   return %9 : $()
+}
+
+sil hidden @closureWithConcreteReturn : $@convention(thin) (Int, @inout_aliasable Int) -> (Int) {
+bb0(%0 : $Int, %1 : $*Int):
+  %2 = begin_access [modify] [unknown] %1 : $*Int // expected-note {{conflicting access is here}}
+  end_access %2 : $*Int
+  return %0 : $Int
+}
+
+sil [reabstraction_thunk] @thunkForClosureWithConcreteReturn : $@convention(thin) (Int, @owned @noescape @callee_owned (Int) -> Int) -> @out Int
+
+// CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeClosureWithReabstractionThunk
+sil hidden @inProgressConflictWithNoEscapeClosureWithReabstractionThunk : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesInoutAndNoEscapeClosureWithGenericReturn : $@convention(thin) <T_0> (@inout Int, @owned @noescape @callee_owned (Int) -> @out T_0) -> ()
+  %5 = function_ref @closureWithConcreteReturn : $@convention(thin) (Int, @inout_aliasable Int) -> (Int)
+  %6 = partial_apply %5(%3) : $@convention(thin) (Int, @inout_aliasable Int) -> (Int)
+  %7 = convert_function %6 : $@callee_owned (Int) -> Int to $@noescape @callee_owned (Int) -> Int
+  %8 = function_ref @thunkForClosureWithConcreteReturn : $@convention(thin) (Int, @owned @noescape @callee_owned (Int) -> Int) -> @out Int
+  %9 = partial_apply %8(%7) : $@convention(thin) (Int, @owned @noescape @callee_owned (Int) -> Int) -> @out Int
+  %10 = convert_function %9 : $@callee_owned (Int) -> @out Int to $@noescape @callee_owned (Int) -> @out Int
+  %11 = begin_access [modify] [unknown] %3 : $*Int // expected-warning {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %12 = apply %4<Int>(%11, %10) : $@convention(thin) <T_0> (@inout Int, @owned @noescape @callee_owned (Int) -> @out T_0) -> ()
+  end_access %11: $*Int
+  destroy_value %2 : ${ var Int }
+  %13 = tuple ()
+  return %13 : $()
 }
 
 // Stored property relaxation.


### PR DESCRIPTION
This fixes a serious false negative in static exclusivity enforcement when
a noescape closure performs an access that conflicts with an in-progress access
but is not reported because the closure is passed via a reabstraction thunk.

When diagnosing at a call site, the enforcement now looks through partial
applies that are passed as noescape arguments. If the partial apply takes
an argument that is itself a noescape partial apply, it recursively checks
the captures for that partial apply for conflicts and diagnoses if it finds one.

This means, for example, that the compiler will now diagnose when there is a
conflict involving a closure with a concrete return type that is passed to a
function that expects a closure returning a generic type. To preserve source
compatibility these diagnostics are emitted as warnings for now. The intent is
that they will be upgraded to errors in a future version of Swift.

rdar://problem/35215926, SR-6103