### PR TITLE
Add opt remarks to Generic Specializer pass

### DIFF
--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -40,6 +40,7 @@ struct Argument {
   SourceLoc Loc;
 
   explicit Argument(StringRef Str = "") : Key("String"), Val(Str) {}
+  Argument(StringRef Key, StringRef Val) : Key(Key), Val(Val) {}
 
   Argument(StringRef Key, int N);
   Argument(StringRef Key, long N);
@@ -53,6 +54,13 @@ struct Argument {
 
 /// Shorthand to insert named-value pairs.
 using NV = Argument;
+
+/// Inserting this into a Remark indents the text when printed as a debug
+/// message.
+struct IndentDebug {
+  explicit IndentDebug(unsigned Width) : Width(Width) {}
+  unsigned Width;
+};
 
 /// The base class for remarks.  This can be created by optimization passed to
 /// report successful and unsuccessful optimizations. CRTP is used to preserve
@@ -75,6 +83,9 @@ template <typename DerivedT> class Remark {
   /// The function for the diagnostics.
   SILFunction *Function;
 
+  /// Indentation used if this remarks is printed as a debug message.
+  unsigned IndentDebugWidth = 0;
+
 protected:
   Remark(StringRef Identifier, SILInstruction &I)
       : Identifier(Identifier), Location(I.getLoc().getSourceLoc()),
@@ -91,11 +102,17 @@ public:
     return *static_cast<DerivedT *>(this);
   }
 
+  DerivedT &operator<<(IndentDebug ID) {
+    IndentDebugWidth = ID.Width;
+    return *static_cast<DerivedT *>(this);
+  }
+
   StringRef getPassName() const { return PassName; }
   StringRef getIdentifier() const { return Identifier; }
   SILFunction *getFunction() const { return Function; }
   SourceLoc getLocation() const { return Location; }
   std::string getMsg() const;
+  std::string getDebugMsg() const;
   Remark<DerivedT> &getRemark() { return *this; }
   SmallVector<Argument, 4> &getArgs() { return Args; }
 
@@ -119,8 +136,11 @@ class Emitter {
   bool PassedEnabled;
   bool MissedEnabled;
 
+  // Making these non-generic allows out-of-line definition.
   void emit(const RemarkPassed &R);
   void emit(const RemarkMissed &R);
+  static void emitDebug(const RemarkPassed &R);
+  static void emitDebug(const RemarkMissed &R);
 
   template <typename RemarkT> bool isEnabled();
 
@@ -140,7 +160,37 @@ public:
       emit(R);
     }
   }
+
+  /// Emit an optimization remark or debug message.
+  template <typename T>
+  static void emitOrDebug(const char *PassName, Emitter *ORE, T RemarkBuilder,
+                          decltype(RemarkBuilder()) * = nullptr) {
+    using RemarkT = decltype(RemarkBuilder());
+    // Avoid building the remark unless remarks are enabled.
+    bool EmitRemark =
+        ORE && (ORE->isEnabled<RemarkT>() || ORE->Module.getOptRecordStream());
+    // Same for DEBUG.
+    bool EmitDebug = false
+#ifndef _NDEBUG
+                     || (llvm::DebugFlag && llvm::isCurrentDebugType(PassName));
+#endif // _NDEBUG
+
+    if (EmitRemark || EmitDebug) {
+      auto R = RemarkBuilder();
+      if (EmitDebug)
+        emitDebug(R);
+      if (EmitRemark) {
+        // If we have ORE use the PassName that was set up with ORE. DEBUG_TYPE
+        // may be different if a pass is calling other modules.
+        R.setPassName(ORE->PassName);
+        ORE->emit(R);
+      }
+    }
+  }
 };
+
+#define REMARK_OR_DEBUG(...)                                                   \
+  OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, __VA_ARGS__)
 
 template <> inline bool Emitter::isEnabled<RemarkMissed>() {
   return MissedEnabled;

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -29,6 +29,10 @@ namespace swift {
 
 class FunctionSignaturePartialSpecializer;
 
+namespace OptRemark {
+class Emitter;
+} // namespace OptRemark
+
 /// Tries to specialize an \p Apply of a generic function. It can be a full
 /// apply site or a partial apply.
 /// Replaced and now dead instructions are returned in \p DeadApplies.
@@ -38,7 +42,8 @@ class FunctionSignaturePartialSpecializer;
 /// This is the top-level entry point for specializing an existing call site.
 void trySpecializeApplyOfGeneric(
     ApplySite Apply, DeadInstructionSet &DeadApplies,
-    llvm::SmallVectorImpl<SILFunction *> &NewFunctions);
+    llvm::SmallVectorImpl<SILFunction *> &NewFunctions,
+    OptRemark::Emitter &ORE);
 
 /// Helper class to describe re-abstraction of function parameters done during
 /// specialization.
@@ -117,7 +122,8 @@ class ReabstractionInfo {
 
   void createSubstitutedAndSpecializedTypes();
   bool prepareAndCheck(ApplySite Apply, SILFunction *Callee,
-                       SubstitutionList ParamSubs);
+                       SubstitutionList ParamSubs,
+                       OptRemark::Emitter *ORE = nullptr);
   void performFullSpecializationPreparation(SILFunction *Callee,
                                             SubstitutionList ParamSubs);
   void performPartialSpecializationPreparation(SILFunction *Caller,
@@ -134,7 +140,8 @@ public:
   /// invalid type.
   ReabstractionInfo(ApplySite Apply, SILFunction *Callee,
                     SubstitutionList ParamSubs,
-                    bool ConvertIndirectToDirect = true);
+                    bool ConvertIndirectToDirect = true,
+                    OptRemark::Emitter *ORE = nullptr);
 
   /// Constructs the ReabstractionInfo for generic function \p Callee with
   /// additional requirements. Requirements may contain new layout,

--- a/lib/SIL/OptimizationRemark.cpp
+++ b/lib/SIL/OptimizationRemark.cpp
@@ -63,6 +63,20 @@ template <typename DerivedT> std::string Remark<DerivedT>::getMsg() const {
   return OS.str();
 }
 
+template <typename DerivedT> std::string Remark<DerivedT>::getDebugMsg() const {
+  std::string Str;
+  llvm::raw_string_ostream OS(Str);
+
+  if (IndentDebugWidth)
+    OS << std::string(" ", IndentDebugWidth);
+
+  for (const Argument &Arg : Args)
+    OS << Arg.Val;
+
+  OS << "\n";
+  return OS.str();
+}
+
 Emitter::Emitter(StringRef PassName, SILModule &M)
     : Module(M), PassName(PassName),
       PassedEnabled(
@@ -92,6 +106,14 @@ void Emitter::emit(const RemarkPassed &R) {
 
 void Emitter::emit(const RemarkMissed &R) {
   emitRemark(Module, R, diag::opt_remark_missed, isEnabled<RemarkMissed>());
+}
+
+void Emitter::emitDebug(const RemarkPassed &R) {
+  llvm::dbgs() << R.getDebugMsg();
+}
+
+void Emitter::emitDebug(const RemarkMissed &R) {
+  llvm::dbgs() << R.getDebugMsg();
 }
 
 namespace llvm {

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -17,6 +17,7 @@
 
 #define DEBUG_TYPE "sil-generic-specializer"
 
+#include "swift/SIL/OptimizationRemark.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
@@ -49,6 +50,7 @@ class GenericSpecializer : public SILFunctionTransform {
 bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
   DeadInstructionSet DeadApplies;
   llvm::SmallSetVector<SILInstruction *, 8> Applies;
+  OptRemark::Emitter ORE(DEBUG_TYPE, F.getModule());
 
   bool Changed = false;
   for (auto &BB : F) {
@@ -67,8 +69,17 @@ bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
         continue;
 
       auto *Callee = Apply.getReferencedFunction();
-      if (!Callee || !Callee->isDefinition())
+      if (!Callee)
         continue;
+      if (!Callee->isDefinition()) {
+        ORE.emit([&]() {
+          using namespace OptRemark;
+          return RemarkMissed("NoDef", *I)
+                 << "Unable to specialize generic function "
+                 << NV("Callee", Callee) << " since definition is not visible";
+        });
+        continue;
+      }
 
       Applies.insert(Apply.getInstruction());
     }
@@ -87,7 +98,7 @@ bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
       // We have a call that can potentially be specialized, so
       // attempt to do so.
       llvm::SmallVector<SILFunction *, 2> NewFunctions;
-      trySpecializeApplyOfGeneric(Apply, DeadApplies, NewFunctions);
+      trySpecializeApplyOfGeneric(Apply, DeadApplies, NewFunctions, ORE);
 
       // Remove all the now-dead applies. We must do this immediately
       // rather than defer it in order to avoid problems with cloning

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/TypeMatcher.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/OptimizationRemark.h"
 #include "swift/SILOptimizer/Utils/GenericCloner.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
@@ -368,7 +369,8 @@ static bool shouldNotSpecializeCallee(SILFunction *Callee,
 /// Returns false, if the current function cannot be specialized.
 /// Returns true otherwise.
 bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
-                                        SubstitutionList ParamSubs) {
+                                        SubstitutionList ParamSubs,
+                                        OptRemark::Emitter *ORE) {
   if (shouldNotSpecializeCallee(Callee))
     return false;
 
@@ -387,6 +389,7 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   if (CalleeGenericSig)
     InterfaceSubs = CalleeGenericSig->getSubstitutionMap(ParamSubs);
 
+  using namespace OptRemark;
   // We do not support partial specialization.
   if (!EnablePartialSpecialization && InterfaceSubs.hasArchetypes()) {
     DEBUG(llvm::dbgs() << "    Partial specialization is not supported.\n");
@@ -396,7 +399,10 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
 
   // Perform some checks to see if we need to bail.
   if (InterfaceSubs.hasDynamicSelf()) {
-    DEBUG(llvm::dbgs() << "    Cannot specialize with dynamic self.\n");
+    REMARK_OR_DEBUG(ORE, [&]() {
+      return RemarkMissed("DynamicSelf", *Apply.getInstruction())
+             << IndentDebug(4) << "Cannot specialize with dynamic self";
+    });
     return false;
   }
 
@@ -406,8 +412,11 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   for (auto Sub : ParamSubs) {
     auto Replacement = Sub.getReplacement();
     if (isTypeTooComplex(Replacement)) {
-      DEBUG(llvm::dbgs()
-            << "    Cannot specialize because the generic type is too deep.\n");
+      REMARK_OR_DEBUG(ORE, [&]() {
+        return RemarkMissed("TypeTooDeep", *Apply.getInstruction())
+               << IndentDebug(4)
+               << "Cannot specialize because the generic type is too deep";
+      });
       NumPreventedTooComplexGenericSpecializations++;
       return false;
     }
@@ -481,11 +490,14 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   // Check if specializing this call site would create in an infinite generic
   // specialization loop.
   if (createsInfiniteSpecializationLoop(Apply)) {
-    DEBUG(llvm::dbgs() << "    Generic specialization is not supported if "
-                          "it would result in a generic specialization of "
-                          "infinite depth.\n");
-    DEBUG(llvm::dbgs() << "Callee " << Callee->getName()
-                       << " occurs multiple times on the call chain\n");
+    REMARK_OR_DEBUG(ORE, [&]() {
+      return RemarkMissed("SpecializationLoop", *Apply.getInstruction())
+             << IndentDebug(4)
+             << "Generic specialization is not supported if it would result in "
+                "a generic specialization of infinite depth. Callee "
+             << NV("Callee", Callee)
+             << " occurs multiple times on the call chain";
+    });
     if (PrintGenericSpecializationLoops)
       llvm::errs() << "Detected and prevented an infinite "
                       "generic specialization loop for callee: "
@@ -505,8 +517,9 @@ bool ReabstractionInfo::canBeSpecialized(ApplySite Apply, SILFunction *Callee,
 
 ReabstractionInfo::ReabstractionInfo(ApplySite Apply, SILFunction *Callee,
                                      ArrayRef<Substitution> ParamSubs,
-                                     bool ConvertIndirectToDirect) {
-  if (!prepareAndCheck(Apply, Callee, ParamSubs))
+                                     bool ConvertIndirectToDirect,
+                                     OptRemark::Emitter *ORE) {
+  if (!prepareAndCheck(Apply, Callee, ParamSubs, ORE))
     return;
 
   this->ConvertIndirectToDirect = ConvertIndirectToDirect;
@@ -2252,7 +2265,8 @@ SILArgument *ReabstractionThunkGenerator::convertReabstractionThunkArguments(
 
 void swift::trySpecializeApplyOfGeneric(
     ApplySite Apply, DeadInstructionSet &DeadApplies,
-    llvm::SmallVectorImpl<SILFunction *> &NewFunctions) {
+    llvm::SmallVectorImpl<SILFunction *> &NewFunctions,
+    OptRemark::Emitter &ORE) {
   assert(Apply.hasSubstitutions() && "Expected an apply with substitutions!");
   auto *F = Apply.getFunction();
   auto *RefF = cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunction();
@@ -2286,7 +2300,8 @@ void swift::trySpecializeApplyOfGeneric(
   if (Apply.getModule().isOptimizedOnoneSupportModule())
     Serialized = IsNotSerialized;
 
-  ReabstractionInfo ReInfo(Apply, RefF, Apply.getSubstitutions());
+  ReabstractionInfo ReInfo(Apply, RefF, Apply.getSubstitutions(),
+                           /*ConvertIndirectToDirect=*/true, &ORE);
   if (!ReInfo.canBeSpecialized())
     return;
 
@@ -2347,6 +2362,18 @@ void swift::trySpecializeApplyOfGeneric(
     assert(SpecializedF->hasUnqualifiedOwnership());
     NewFunctions.push_back(SpecializedF);
   }
+
+  ORE.emit([&]() {
+    std::string Str;
+    llvm::raw_string_ostream OS(Str);
+    SpecializedF->getLoweredFunctionType().print(
+        OS, PrintOptions::printQuickHelpDeclaration());
+
+    using namespace OptRemark;
+    return RemarkPassed("Specialized", *Apply.getInstruction())
+           << "Specialized function " << NV("Function", RefF) << " with type "
+           << NV("FuncType", OS.str());
+  });
 
   assert(ReInfo.getSpecializedType()
          == SpecializedF->getLoweredFunctionType() &&

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -1,4 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-partial-specialization -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-partial-specialization -generic-specializer -save-optimization-record-path=%t.yaml %s | %FileCheck %s
+// RUN: %FileCheck -check-prefix=YAML %s < %t.yaml
 
 sil_stage canonical
 
@@ -17,6 +18,43 @@ import Swift
 // CHECK: apply [[ACCEPTS_INT]]
 // CHECK: return
 // CHEcK: sil @exp2 : $@convention(thin) () -> () {
+
+// YAML:      --- !Passed
+// YAML-NEXT: Pass:            sil-generic-specializer
+// YAML-NEXT: Name:            Specialized
+// YAML-NEXT: DebugLoc:
+// YAML-NEXT:   File:            {{.*}}/specialize.sil
+// YAML-NEXT:   Line:            132
+// YAML-NEXT:   Column:          8
+// YAML-NEXT: Function:        exp1
+// YAML-NEXT: Args:
+// YAML-NEXT:   - String:          'Specialized function '
+// YAML-NEXT:   - Function:        '"XXX_init"'
+// YAML-NEXT:     DebugLoc:
+// YAML-NEXT:       File:            {{.*}}/specialize.sil
+// YAML-NEXT:       Line:            73
+// YAML-NEXT:       Column:          17
+// YAML-NEXT:   - String:          ' with type '
+// YAML-NEXT:   - FuncType:        '(Int32, @thin XXX<Int32>.Type) -> XXX<Int32>'
+// YAML-NEXT: ...
+// YAML-NEXT: --- !Passed
+// YAML-NEXT: Pass:            sil-generic-specializer
+// YAML-NEXT: Name:            Specialized
+// YAML-NEXT: DebugLoc:
+// YAML-NEXT:   File:            {{.*}}/specialize.sil
+// YAML-NEXT:   Line:            142
+// YAML-NEXT:   Column:          9
+// YAML-NEXT: Function:        exp1
+// YAML-NEXT: Args:
+// YAML-NEXT:   - String:          'Specialized function '
+// YAML-NEXT:   - Function:        '"XXX_foo"'
+// YAML-NEXT:     DebugLoc:
+// YAML-NEXT:       File:            {{.*}}/specialize.sil
+// YAML-NEXT:       Line:            90
+// YAML-NEXT:       Column:          17
+// YAML-NEXT:   - String:          ' with type '
+// YAML-NEXT:   - FuncType:        '(Int32, @inout XXX<Int32>) -> Int32'
+// YAML-NEXT: ...
 
 struct XXX<T> {
   init(t: T)
@@ -243,6 +281,20 @@ bb0(%0 : $Base):
 // CHECK-LABEL: sil shared @{{.*}}generic_upcast{{.*}}Tg5 : $@convention(thin) (@owned Base) -> @owned Base {
 // CHECK: bb0(%0 : $Base):
 // CHECK:  return %0 : $Base
+
+// YAML:      Line:            277
+// YAML-NEXT:   Column:          8
+// YAML-NEXT: Function:        specialize_generic_upcast
+// YAML-NEXT: Args:
+// YAML-NEXT:   - String:          'Specialized function '
+// YAML-NEXT:   - Function:        '"generic_upcast"'
+// YAML-NEXT:     DebugLoc:
+// YAML-NEXT:       File:            {{.*}}/specialize.sil
+// YAML-NEXT:       Line:            268
+// YAML-NEXT:       Column:          6
+// YAML-NEXT:   - String:          ' with type '
+// YAML-NEXT:   - FuncType:        '(@owned Base) -> @owned Base'
+// YAML-NEXT: ...
 
 
 // Check generic specialization of partial_apply

--- a/test/SILOptimizer/specialize_no_definition.sil
+++ b/test/SILOptimizer/specialize_no_definition.sil
@@ -1,0 +1,43 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer -save-optimization-record-path=%t.yaml -o /dev/null %s
+// RUN: %FileCheck %s < %t.yaml
+
+import Builtin
+import Swift
+
+sil_stage canonical
+
+// CHECK:      --- !Missed
+// CHECK-NEXT: Pass:            sil-generic-specializer
+// CHECK-NEXT: Name:            NoDef
+// CHECK-NEXT: DebugLoc:
+// CHECK-NEXT:   File:            {{.*}}/specialize_no_definition.sil
+// CHECK-NEXT:   Line:            36
+// CHECK-NEXT:   Column:          8
+// CHECK-NEXT: Function:        foo
+// CHECK-NEXT: Args:
+// CHECK-NEXT:   - String:          'Unable to specialize generic function '
+// CHECK-NEXT:   - Callee:          '"bar"'
+// CHECK-NEXT:     DebugLoc:
+// CHECK-NEXT:       File:            {{.*}}/specialize_no_definition.sil
+// CHECK-NEXT:       Line:            35
+// CHECK-NEXT:       Column:          21
+// CHECK-NEXT:   - String:          ' since definition is not visible'
+// CHECK-NEXT: ...
+
+// foo()
+sil hidden @foo : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 2          // user: %1
+  %1 = struct $Int (%0 : $Builtin.Int64)          // user: %3
+  %2 = alloc_stack $Int                           // users: %3, %6, %5
+  store %1 to %2 : $*Int                          // id: %3
+  // function_ref bar<A>(_:)
+  %4 = function_ref @bar : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () // user: %5
+  %5 = apply %4<Int>(%2) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+  dealloc_stack %2 : $*Int                        // id: %6
+  %7 = tuple ()                                   // user: %8
+  return %7 : $()                                 // id: %8
+} // end sil function 'foo'
+
+// bar<A>(_:)
+sil hidden_external @bar : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()


### PR DESCRIPTION
Adds a combined API to output both debug message and optimization remarks.

The previously added test partial_specialization_debug.sil ensures that it's an
NFC for debug output.
