### PR TITLE
Generate opt-view for benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -211,6 +211,10 @@ set(SWIFT_BENCHMARK_NUM_ONONE_ITERATIONS "" CACHE STRING
 # Options for the default (= empty) configuration
 set(BENCHOPTS "-whole-module-optimization")
 
+option(SWIFT_BENCHMARK_GENERATE_OPT_VIEW
+  "Produce optimization view for benchmarks"
+  FALSE)
+
 # Options for other configurations
 set(BENCHOPTS_MULTITHREADED
     "-whole-module-optimization" "-num-threads" "4")


### PR DESCRIPTION
When the SWIFT_BENCHMARK_GENERATE_OPT_VIEW cmake flag is on, the benchmarks are compiled with -save-optimization-record which generate optimization remarks in external YAML files.  Then the opt-viewer tool from LLVM is invoked to generate the HTML pages that displays the remarks embedded in the source code.

I've only added it to single-source benchmarks for now.

This can be enabled by
passing --extra-cmake-options='-DSWIFT_BENCHMARK_GENERATE_OPT_VIEW=ON' to
build-script.