### PR TITLE
fixed test case: tuple_arguments.swift for s390x

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2420,8 +2420,8 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
   // Extract names of the tuple elements and preserve the structure
   // of the tuple (with any nested tuples inside) to be able to use
   // it in the fix-it without any type information provided by user.
-  std::function<StringRef(const TypeRepr *)> getTupleNames =
-      [&](const TypeRepr *typeRepr) -> StringRef {
+  std::function<std::string (const TypeRepr *)> getTupleNames =
+      [&](const TypeRepr *typeRepr) -> std::string  {
     if (!typeRepr)
       return "";
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixed test case: tuple_arguments.swift, the root reason is that there are invalid chars in the results of `getTupleNames` and `tupleRepr->getElementName`, solved it by introducing a `std::string` varible.

Note: the master branch changed this part code and no errors found. The fixing is applied to only  this 4.0 branch.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
