### PR TITLE
[WIP] [stdlib] Require collection indices to be Hashable

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -323,7 +323,7 @@ public func expectGE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
 extension Range
 %   if 'Countable' in OtherRange:
   where
-  Bound : _Strideable, Bound.Stride : SignedInteger
+  Bound : _Strideable & Hashable, Bound.Stride : SignedInteger
 %   end
 {
   internal func _contains(_ other: ${OtherRange}<Bound>) -> Bool {
@@ -2430,7 +2430,7 @@ public func expectEqualsUnordered<T : Comparable>(
 }
 
 public func expectEqualsUnordered<
-  T : Strideable
+  T : Strideable & Hashable
 >(
   _ expected: Range<T>, _ actual: [T], ${TRACE}
 ) where T.Stride : SignedInteger {

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -33,6 +33,10 @@ extension IndexSet.Index {
     public static func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
         return lhs.value >= rhs.value
     }
+  
+    public var hashValue: Int {
+        return value.hashValue
+    }
 }
 
 extension IndexSet.RangeView {
@@ -94,7 +98,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
     
     /// The mechanism for accessing the integers stored in an IndexSet.
-    public struct Index : CustomStringConvertible, Comparable {
+    public struct Index : CustomStringConvertible, Comparable, Hashable {
         fileprivate var value: IndexSet.Element
         fileprivate var extent: Range<IndexSet.Element>
         fileprivate var rangeIndex: Int

--- a/stdlib/public/core/CharacterUnicodeScalars.swift
+++ b/stdlib/public/core/CharacterUnicodeScalars.swift
@@ -96,6 +96,13 @@ extension Character.UnicodeScalarView.Index : Comparable {
   }
 }
 
+extension Character.UnicodeScalarView.Index : Hashable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public var hashValue: Int {
+    return _encodedOffset.hashValue
+  }
+}
+
 extension Character.UnicodeScalarView : Collection {
   @_inlineable // FIXME(sil-serialize-all)
   public var startIndex: Index {

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -34,8 +34,8 @@ public struct ClosedRangeIndex<Bound>
   // swift-3-indexing-model: should conform to _Strideable, otherwise
   // CountableClosedRange is not interchangeable with CountableRange in all
   // contexts.
-  Bound : _Strideable & Comparable,
-  Bound.Stride : SignedNumeric {
+  Bound : _Strideable & Comparable & Hashable,
+  Bound.Stride : SignedInteger {
   /// Creates the "past the end" position.
   @_inlineable
   @_versioned
@@ -90,6 +90,17 @@ extension ClosedRangeIndex : Comparable {
   }
 }
 
+extension ClosedRangeIndex : Hashable {
+  public var hashValue: Int {
+    switch self._value {
+    case .inRange(let value):
+      return value.hashValue
+    case .pastEnd:
+      return .max
+    }
+  }
+}
+
 // FIXME(ABI)#175 (Type checker)
 // WORKAROUND: needed because of rdar://25584401
 /// An iterator over the elements of a `CountableClosedRange` instance.
@@ -98,7 +109,7 @@ public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
   where
   // FIXME(ABI)#176 (Type checker)
   // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
+  Bound : _Strideable & Comparable & Hashable,
   Bound.Stride : SignedInteger {
 
   @_inlineable
@@ -178,7 +189,7 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
   where
   // FIXME(ABI)#176 (Type checker)
   // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
+  Bound : _Strideable & Comparable & Hashable,
   Bound.Stride : SignedInteger {
 
   /// The range's lower bound.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -355,7 +355,7 @@ public protocol Collection : Sequence
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript
   /// argument.
-  associatedtype Index : Comparable
+  associatedtype Index : Comparable, Hashable
  
   /// The position of the first element in a nonempty collection.
   ///

--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -183,7 +183,7 @@ public struct DoubleWidth<Base : FixedWidthInteger> :
     }
     
     @_fixed_layout // FIXME(sil-serialize-all)
-    public struct Index : Comparable {
+    public struct Index : Comparable, Hashable {
       public var _value: _IndexValue
 
       @_inlineable // FIXME(sil-serialize-all)
@@ -205,6 +205,13 @@ public struct DoubleWidth<Base : FixedWidthInteger> :
         case (.low(_), .high(_)): return true
         case (.high(_), .low(_)): return false
         case let (.high(l), .high(r)): return l < r
+        }
+      }
+
+      public var hashValue: Int {
+        switch _value {
+        case .low(let v): return v.hashValue
+        case .high(let v): return v.hashValue
         }
       }
     }

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -115,7 +115,7 @@ extension LazySequenceProtocol {
 /// A position in a `LazyDropWhileCollection` or
 /// `LazyDropWhileBidirectionalCollection` instance.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct LazyDropWhileIndex<Base : Collection> : Comparable {
+public struct LazyDropWhileIndex<Base : Collection> : Comparable, Hashable {
   /// The position corresponding to `self` in the underlying collection.
   public let base: Base.Index
 

--- a/stdlib/public/core/Existential.swift
+++ b/stdlib/public/core/Existential.swift
@@ -17,7 +17,7 @@
 @_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal struct _CollectionOf<
-  IndexType : Strideable, Element
+  IndexType : Strideable & Hashable, Element
 > : Collection {
 
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -897,17 +897,19 @@ extension Any${Kind} {
 internal protocol _AnyIndexBox : class {
   var _typeID: ObjectIdentifier { get }
 
-  func _unbox<T : Comparable>() -> T?
+  func _unbox<T : Comparable & Hashable>() -> T?
 
   func _isEqual(to rhs: _AnyIndexBox) -> Bool
 
   func _isLess(than rhs: _AnyIndexBox) -> Bool
+
+  var _hashValue: Int { get }
 }
 
 @_fixed_layout
 @_versioned
 internal final class _IndexBox<
-  BaseIndex : Comparable
+  BaseIndex : Comparable & Hashable
 > : _AnyIndexBox {
   @_versioned
   internal var _base: BaseIndex
@@ -932,7 +934,7 @@ internal final class _IndexBox<
 
   @_versioned
   @_inlineable
-  internal func _unbox<T : Comparable>() -> T? {
+  internal func _unbox<T : Comparable & Hashable>() -> T? {
     return (self as _AnyIndexBox as? _IndexBox<T>)?._base
   }
 
@@ -947,6 +949,12 @@ internal final class _IndexBox<
   internal func _isLess(than rhs: _AnyIndexBox) -> Bool {
     return _base < _unsafeUnbox(rhs)
   }
+
+  @_versioned
+  @_inlineable
+  internal var _hashValue: Int {
+    return _base.hashValue
+  }
 }
 
 /// A wrapper over an underlying index that hides the specific underlying type.
@@ -954,7 +962,7 @@ internal final class _IndexBox<
 public struct AnyIndex {
   /// Creates a new index wrapping `base`.
   @_inlineable
-  public init<BaseIndex : Comparable>(_ base: BaseIndex) {
+  public init<BaseIndex : Comparable & Hashable>(_ base: BaseIndex) {
     self._box = _IndexBox(_base: base)
   }
 
@@ -974,7 +982,7 @@ public struct AnyIndex {
   internal var _box: _AnyIndexBox
 }
 
-extension AnyIndex : Comparable {
+extension AnyIndex : Comparable, Hashable {
   /// Returns a Boolean value indicating whether two indices wrap equal
   /// underlying indices.
   ///
@@ -1001,6 +1009,11 @@ extension AnyIndex : Comparable {
   public static func < (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
     _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isLess(than: rhs._box)
+  }
+
+  @_inlineable
+  public var hashValue: Int {
+    return _box._hashValue
   }
 }
 

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -188,7 +188,7 @@ public struct ${Index}<BaseElements>
   internal let _inner: BaseElements.Element.Index?
 }
 
-extension ${Index} : Comparable {
+extension ${Index} : Comparable, Hashable {
   @_inlineable // FIXME(sil-serialize-all)
   public static func == (
     lhs: ${Index}<BaseElements>,
@@ -217,6 +217,12 @@ extension ${Index} : Comparable {
     _precondition(lhs._inner == nil && rhs._inner == nil)
 
     return false
+  }
+
+  public var hashValue: Int {
+    var hash = _inner?.hashValue ?? 0
+    hash ^= _mixInt(_outer.hashValue)
+    return hash
   }
 }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -5892,7 +5892,7 @@ elif Self == 'Dictionary':
 
 ${SubscriptingWithIndexDoc}
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct Index : Comparable {
+public struct Index : Comparable, Hashable {
   // Index for native buffer is efficient.  Index for bridged NS${Self} is
   // not, because neither NSEnumerator nor fast enumeration support moving
   // backwards.  Even if they did, there is another issue: NSEnumerator does
@@ -6011,6 +6011,22 @@ extension ${Self}.Index {
       return lhsCocoa < rhsCocoa
     default:
       _preconditionFailure("Comparing indexes from different sets")
+  #endif
+    }
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public var hashValue: Int {
+    if _fastPath(_guaranteedNative) {
+      return _nativeIndex.offset
+    }
+
+    switch _value {
+    case ._native(let nativeIndex):
+      return nativeIndex.offset
+  #if _runtime(_ObjC)
+    case ._cocoa(let cocoaIndex):
+      return cocoaIndex.currentKeyIndex
   #endif
     }
   }

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -103,7 +103,7 @@ extension LazySequenceProtocol {
 
 /// A position in the base collection of a `LazyPrefixWhileCollection` or the
 /// end of that collection.
-public enum _LazyPrefixWhileIndexRepresentation<Base : Collection> {
+public enum _LazyPrefixWhileIndexRepresentation<Base : Collection> : Hashable {
   case index(Base.Index)
   case pastEnd
 }
@@ -111,7 +111,7 @@ public enum _LazyPrefixWhileIndexRepresentation<Base : Collection> {
 /// A position in a `LazyPrefixWhileCollection` or
 /// `LazyPrefixWhileBidirectionalCollection` instance.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct LazyPrefixWhileIndex<Base : Collection> : Comparable {
+public struct LazyPrefixWhileIndex<Base : Collection> : Comparable, Hashable {
   /// The position corresponding to `self` in the underlying collection.
   @_versioned // FIXME(sil-serialize-all)
   internal let _value: _LazyPrefixWhileIndexRepresentation<Base>

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -151,7 +151,7 @@ public struct CountableRange<Bound> : RandomAccessCollection
   where
   // FIXME(ABI)#176 (Type checker)
   // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
+  Bound : _Strideable & Comparable & Hashable,
   Bound.Stride : SignedInteger {
 
   /// The range's lower bound.
@@ -310,7 +310,7 @@ extension CountableRange {
 
 extension CountableRange
   where
-  Bound._DisabledRangeIndex : Strideable,
+  Bound._DisabledRangeIndex : Strideable & Hashable,
   Bound._DisabledRangeIndex.Stride : SignedInteger {
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -479,7 +479,8 @@ extension ${Self}
 %   if ('Countable' in OtherSelf or 'Closed' in OtherSelf or 'Closed' in Self) \
 %   and not 'Countable' in Self:
   where
-  Bound : _Strideable, Bound.Stride : SignedInteger
+  Bound : _Strideable & Hashable, Bound.Stride : SignedInteger
+  // FIXME: It doesn't seem like the Hashable constraint should be necessary here.
 %   end
 {
   /// Creates an instance equivalent to the given range.
@@ -506,7 +507,7 @@ ${get_init_warning(Self, OtherSelf)}
 extension ${Self}
 %   if 'Countable' in OtherSelf and not 'Countable' in Self:
   where
-  Bound : _Strideable, Bound.Stride : SignedInteger
+  Bound : _Strideable & Hashable, Bound.Stride : SignedInteger
 %   end
 {
   /// Returns a Boolean value indicating whether this range and the given range

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -76,7 +76,7 @@ public struct _ReverseIndexingIterator<
 /// An index that traverses the same positions as an underlying index,
 /// with inverted traversal direction.
 @_fixed_layout
-public struct ReversedIndex<Base : Collection> : Comparable {
+public struct ReversedIndex<Base : Collection> : Comparable, Hashable {
   /// Creates a new index into a reversed collection for the position before
   /// the specified index.
   ///
@@ -274,7 +274,7 @@ public struct ReversedCollection<
 @_fixed_layout
 public struct ReversedRandomAccessIndex<
   Base : RandomAccessCollection
-> : Comparable {
+> : Comparable, Hashable {
   /// Creates a new index into a reversed collection for the position before
   /// the specified index.
   ///

--- a/stdlib/public/core/SentinelCollection.swift
+++ b/stdlib/public/core/SentinelCollection.swift
@@ -74,7 +74,7 @@ where IsSentinel.Input == Base.Iterator.Element {
   
   @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal struct Index : Comparable {
+  internal struct Index : Comparable, Hashable {
     @_inlineable // FIXME(sil-serialize-all)
     @_versioned // FIXME(sil-serialize-all)
     internal init(
@@ -98,6 +98,10 @@ where IsSentinel.Input == Base.Iterator.Element {
     internal static func < (lhs: Index, rhs: Index) -> Bool {
       if rhs._impl == nil { return lhs._impl != nil }
       return lhs._impl != nil && rhs._impl!.position < lhs._impl!.position
+    }
+    
+    internal var hashValue: Int {
+      return _impl?.position.hashValue ?? 0
     }
   }
 

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -67,6 +67,13 @@ extension String.Index : Comparable {
   }
 }
 
+extension String.Index : Hashable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public var hashValue: Int {
+    return _compoundOffset.hashValue
+  }
+}
+
 extension String.Index {
   internal typealias _Self = String.Index
   

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -69,7 +69,7 @@ extension _UIntBuffer : Sequence {
 
 extension _UIntBuffer : Collection {  
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct Index : Comparable {
+  public struct Index : Comparable, Hashable {
     @_versioned
     internal var bitOffset: UInt8
     

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -70,7 +70,7 @@ extension _ValidUTF8Buffer : Collection {
   public typealias IndexDistance = Int
   
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct Index : Comparable {
+  public struct Index : Comparable, Hashable {
     @_versioned
     internal var _biasedBits: Storage
     
@@ -78,10 +78,6 @@ extension _ValidUTF8Buffer : Collection {
     @_versioned
     internal init(_biasedBits: Storage) { self._biasedBits = _biasedBits }
     
-    @_inlineable // FIXME(sil-serialize-all)
-    public static func == (lhs: Index, rhs: Index) -> Bool {
-      return lhs._biasedBits == rhs._biasedBits
-    }
     @_inlineable // FIXME(sil-serialize-all)
     public static func < (lhs: Index, rhs: Index) -> Bool {
       return lhs._biasedBits > rhs._biasedBits

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -77,6 +77,13 @@ DictionaryTestSuite.test("sizeof") {
 #endif
 }
 
+DictionaryTestSuite.test("Index.Hashable") {
+  let d = [1: "meow", 2: "meow", 3: "meow"]
+  let e = Dictionary(uniqueKeysWithValues: zip(d.indices, d))
+  expectEqual(d.count, e.count)
+  expectNotNil(e[d.startIndex])
+}
+
 DictionaryTestSuite.test("valueDestruction") {
   var d1 = Dictionary<Int, TestValueTy>()
   for i in 100...110 {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -334,6 +334,13 @@ SetTestSuite.test("sizeof") {
 #endif
 }
 
+SetTestSuite.test("Index.Hashable") {
+  let s: Set = [1, 2, 3, 4, 5]
+  let t = Set(s.indices)
+  expectEqual(s.count, t.count)
+  expectTrue(t.contains(s.startIndex))
+}
+
 SetTestSuite.test("COW.Smoke") {
   var s1 = Set<TestKeyTy>(minimumCapacity: 10)
   for i in [1010, 2020, 3030]{ s1.insert(TestKeyTy(i)) }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -148,7 +148,7 @@ StringTests.test("unicodeScalars") {
   checkUnicodeScalarViewIteration([ 0x10ffff ], "\u{0010ffff}")
 }
 
-StringTests.test("indexComparability") {
+StringTests.test("Index/Comparable") {
   let empty = ""
   expectTrue(empty.startIndex == empty.endIndex)
   expectFalse(empty.startIndex != empty.endIndex)
@@ -164,6 +164,13 @@ StringTests.test("indexComparability") {
   expectFalse(nonEmpty.startIndex >= nonEmpty.endIndex)
   expectFalse(nonEmpty.startIndex > nonEmpty.endIndex)
   expectTrue(nonEmpty.startIndex < nonEmpty.endIndex)
+}
+
+StringTests.test("Index/Hashable") {
+  let s = "abcdef"
+  let t = Set(s.indices)
+  expectEqual(s.count, t.count)
+  expectTrue(t.contains(s.startIndex))
 }
 
 StringTests.test("ForeignIndexes/Valid") {


### PR DESCRIPTION
Testing the impact of requiring `Collection.Index` to be `Hashable`.