### PR TITLE
Bridge the formal block type in a block-to-func thunk

### DIFF
--- a/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -93,3 +93,5 @@ void escapeBlockAlias(dispatch_block_t block);
 @interface ObjectWithSplitProperty : NSObject
 @property (nonatomic, setter=private_setFlagForSomething:) BOOL flagForSomething;
 @end
+
+extern NSString * __nonnull (^ const __nonnull GlobalBlock)(NSString * __nonnull);

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -188,3 +188,11 @@ struct GenericStruct<T> {
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ix_Ixx_IyB_IyBy_TR : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_owned (@owned @noescape @callee_owned () -> ()) -> (), @convention(block) @noescape () -> ()) -> ()
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0IyB_Ix_TR : $@convention(thin) (@owned @convention(block) @noescape () -> ()) -> ()
 
+// rdar://35402696
+func takeOptStringFunction(fn: (String) -> String?) {}
+func testGlobalBlock() {
+  takeOptStringFunction(fn: GlobalBlock)
+}
+// CHECK-LABEL: sil hidden @_T020objc_blocks_bridging15testGlobalBlockyyF
+// CHECK: global_addr @GlobalBlock : $*@convention(block) (NSString) -> @autoreleased Optional<NSString>
+// CHECK: function_ref @_T0So8NSStringCABSgIeyBya_S2SIexxo_TR : $@convention(thin) (@owned String, @owned @convention(block) (NSString) -> @autoreleased Optional<NSString>) -> @owned String


### PR DESCRIPTION
When building a block-to-func reabstraction thunk, be sure to bridge
the block's formal parameter and result types, because otherwise
the bridging code gets real confused.

Fixes rdar://35402696

Swift 4.1 version of #12941.