### PR TITLE
Fix the debug locations of inserted operations in AvailableValueAggre…

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -519,8 +519,10 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType LoadTy,
   // case.
   ArrayRef<SILInstruction *> InsertPts = Val.getInsertionPoints();
   if (InsertPts.size() == 1) {
-    SavedInsertionPointRAII SavedInsertPt(B, InsertPts[0]);
-    SILValue EltVal = nonDestructivelyExtractSubElement(Val, B, Loc);
+    // Use the scope and location of the store at the insertion point.
+    SILBuilderWithScope Builder(InsertPts[0]);
+    SILLocation Loc = InsertPts[0]->getLoc();
+    SILValue EltVal = nonDestructivelyExtractSubElement(Val, Builder, Loc);
     assert(EltVal->getType() == LoadTy && "Subelement types mismatch");
     return EltVal;
   }
@@ -530,8 +532,10 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType LoadTy,
   SILSSAUpdater Updater;
   Updater.Initialize(LoadTy);
   for (auto *I : Val.getInsertionPoints()) {
-    SavedInsertionPointRAII SavedInsertPt(B, I);
-    SILValue EltVal = nonDestructivelyExtractSubElement(Val, B, Loc);
+    // Use the scope and location of the store at the insertion point.
+    SILBuilderWithScope Builder(I);
+    SILLocation Loc = I->getLoc();
+    SILValue EltVal = nonDestructivelyExtractSubElement(Val, Builder, Loc);
     Updater.AddAvailableValue(I->getParent(), EltVal);
   }
 

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -953,7 +953,7 @@ bool AllocOptimize::promoteLoad(SILInstruction *Inst) {
   }
   
   // Aggregate together all of the subelements into something that has the same
-  // type as the load did, and emit smaller) loads for any subelements that were
+  // type as the load did, and emit smaller loads for any subelements that were
   // not available.
   auto *Load = cast<LoadInst>(Inst);
   AvailableValueAggregator Agg(Load, AvailableValues, Uses);

--- a/test/SILOptimizer/predictable_memopt_locs.swift
+++ b/test/SILOptimizer/predictable_memopt_locs.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-debuginfo %s \
+// RUN:  | %FileCheck %s
+
+struct MyStruct {
+	var a = 12
+}
+
+public func use<T>(_ t : T){}
+
+public func main() {
+	var a = MyStruct() // line 11
+  // Verify that the inserted struct_extract has the same location as the store.
+  // CHECK:  %[[A:.*]] = apply {{.*}} -> MyStruct,
+  // CHECK-SAME: loc {{.*}}:11:10, scope [[S:[0-9]+]]
+  // CHECK-NEXT:  %[[I:.*]] = struct_extract %[[A]]
+  // CHECK-SAME:  loc {{.*}}:11:10, scope [[S]]
+  // CHECK-NEXT:  struct_extract %[[I]]
+  // CHECK-SAME:  loc {{.*}}:11:10, scope [[S]]
+  // CHECK:  store %[[A]] to %0 : $*MyStruct,
+  // CHECK-SAME:  loc {{.*}}:11:10, scope [[S]]
+	use(a.a)
+}


### PR DESCRIPTION
…gator.

This mandatory pass inserts struct_extract operations before earlier
stores to the aggregate but didn't set the debug location of those new
instructions to the location of the store, which caused unexpected
stepping behavior in the debugger.

Fixes a regression from e74367f.
<rdar://problem/35459092>