### PR TITLE
Revert "Use conditional conformances to implement Equatable for Optional, Array and Dictionary"

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -474,6 +474,9 @@ namespace {
               tc.conformsToProtocol(baseTy, proto, cs.DC,
                                     (ConformanceCheckFlags::InExpression|
                                          ConformanceCheckFlags::Used));
+            assert((!conformance ||
+                    conformance->getConditionalRequirements().empty()) &&
+                   "unhandled conditional conformance");
             if (conformance && conformance->isConcrete()) {
               if (auto witness =
                         conformance->getConcrete()->getWitnessDecl(decl, &tc)) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4844,7 +4844,7 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
     AFD = dyn_cast<AbstractFunctionDecl>(candidate);
   }
 
-  if (!AFD || !AFD->getGenericSignature() || !AFD->hasInterfaceType())
+  if (!AFD || !AFD->isGeneric() || !AFD->hasInterfaceType())
     return false;
 
   auto env = AFD->getGenericEnvironment();

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1036,6 +1036,16 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
       continue;
     }
 
+    // A concrete type is better than an archetype.
+    // FIXME: Total hack.
+    if (type1->is<ArchetypeType>() != type2->is<ArchetypeType>()) {
+      if (type1->is<ArchetypeType>())
+        ++score2;
+      else
+        ++score1;
+      continue;
+    }
+    
     // FIXME:
     // This terrible hack is in place to support equality comparisons of non-
     // equatable option types to 'nil'. Until we have a way to constrain a type

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1418,15 +1418,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     ///       x == nil    // also !=
     ///
     void checkOptionalPromotions(ApplyExpr *call) {
-      // We only care about binary expressions.
-      if (!isa<BinaryExpr>(call)) return;
-
-      // Dig out the function we're calling.
-      auto fnExpr = call->getSemanticFn();
-      if (auto dotSyntax = dyn_cast<DotSyntaxCallExpr>(fnExpr))
-        fnExpr = dotSyntax->getSemanticFn();
-
-      auto DRE = dyn_cast<DeclRefExpr>(fnExpr);
+      auto DRE = dyn_cast<DeclRefExpr>(call->getSemanticFn());
       auto args = dyn_cast<TupleExpr>(call->getArg());
       if (!DRE || !DRE->getDecl()->isOperator() ||
           !args || args->getNumElements() != 2)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2181,55 +2181,57 @@ extension _ArrayBufferProtocol {
 // that are the same, e.g. Array<Int> and Array<Int>, not
 // ArraySlice<Int> and Array<Int>.
 
-extension ${Self} : Equatable where Element : Equatable {
-  /// Returns `true` if these arrays contain the same elements.
-  @_inlineable
-  public static func ==(lhs: ${Self}<Element>, rhs: ${Self}<Element>) -> Bool {
-    let lhsCount = lhs.count
-    if lhsCount != rhs.count {
-      return false
-    }
+/// Returns `true` if these arrays contain the same elements.
+@_inlineable
+public func == <Element : Equatable>(
+  lhs: ${Self}<Element>, rhs: ${Self}<Element>
+) -> Bool {
+  let lhsCount = lhs.count
+  if lhsCount != rhs.count {
+    return false
+  }
 
-    // Test referential equality.
-    if lhsCount == 0 || lhs._buffer.identity == rhs._buffer.identity {
-      return true
-    }
-
-  %if Self == 'ArraySlice':
-
-    var streamLHS = lhs.makeIterator()
-    var streamRHS = rhs.makeIterator()
-
-    var nextLHS = streamLHS.next()
-    while nextLHS != nil {
-      let nextRHS = streamRHS.next()
-      if nextLHS != nextRHS {
-        return false
-      }
-      nextLHS = streamLHS.next()
-    }
-
-  %else:
-
-    _sanityCheck(lhs.startIndex == 0 && rhs.startIndex == 0)
-    _sanityCheck(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
-
-    // We know that lhs.count == rhs.count, compare element wise.
-    for idx in 0..<lhsCount {
-      if lhs[idx] != rhs[idx] {
-        return false
-      }
-    }
-  %end
-
+  // Test referential equality.
+  if lhsCount == 0 || lhs._buffer.identity == rhs._buffer.identity {
     return true
   }
 
-  /// Returns `true` if the arrays do not contain the same elements.
-  @_inlineable
-  public static func !=(lhs: ${Self}<Element>, rhs: ${Self}<Element>) -> Bool {
-    return !(lhs == rhs)
+%if Self == 'ArraySlice':
+
+  var streamLHS = lhs.makeIterator()
+  var streamRHS = rhs.makeIterator()
+
+  var nextLHS = streamLHS.next()
+  while nextLHS != nil {
+    let nextRHS = streamRHS.next()
+    if nextLHS != nextRHS {
+      return false
+    }
+    nextLHS = streamLHS.next()
   }
+
+%else:
+
+  _sanityCheck(lhs.startIndex == 0 && rhs.startIndex == 0)
+  _sanityCheck(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
+
+  // We know that lhs.count == rhs.count, compare element wise.
+  for idx in 0..<lhsCount {
+    if lhs[idx] != rhs[idx] {
+      return false
+    }
+  }
+%end
+
+  return true
+}
+
+/// Returns `true` if the arrays do not contain the same elements.
+@_inlineable
+public func != <Element : Equatable>(
+  lhs: ${Self}<Element>, rhs: ${Self}<Element>
+) -> Bool {
+  return !(lhs == rhs)
 }
 
 extension ${Self} {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2708,7 +2708,7 @@ extension Dictionary {
   }
 }
 
-extension Dictionary : Equatable where Value : Equatable {
+extension Dictionary where Value : Equatable {
   @_inlineable // FIXME(sil-serialize-all)
   public static func == (lhs: [Key : Value], rhs: [Key : Value]) -> Bool {
     switch (lhs._variantBuffer, rhs._variantBuffer) {

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -313,100 +313,98 @@ func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
     line: UInt(_line))
 }
 
-extension Optional : Equatable where Wrapped : Equatable {
-  /// Returns a Boolean value indicating whether two optional instances are
-  /// equal.
-  ///
-  /// Use this equal-to operator (`==`) to compare any two optional instances of
-  /// a type that conforms to the `Equatable` protocol. The comparison returns
-  /// `true` if both arguments are `nil` or if the two arguments wrap values
-  /// that are equal. Conversely, the comparison returns `false` if only one of
-  /// the arguments is `nil` or if the two arguments wrap values that are not
-  /// equal.
-  ///
-  ///     let group1 = [1, 2, 3, 4, 5]
-  ///     let group2 = [1, 3, 5, 7, 9]
-  ///     if group1.first == group2.first {
-  ///         print("The two groups start the same.")
-  ///     }
-  ///     // Prints "The two groups start the same."
-  ///
-  /// You can also use this operator to compare a non-optional value to an
-  /// optional that wraps the same type. The non-optional value is wrapped as an
-  /// optional before the comparison is made. In the following example, the
-  /// `numberToMatch` constant is wrapped as an optional before comparing to the
-  /// optional `numberFromString`:
-  ///
-  ///     let numberToFind: Int = 23
-  ///     let numberFromString: Int? = Int("23")      // Optional(23)
-  ///     if numberToFind == numberFromString {
-  ///         print("It's a match!")
-  ///     }
-  ///     // Prints "It's a match!"
-  ///
-  /// An instance that is expressed as a literal can also be used with this
-  /// operator. In the next example, an integer literal is compared with the
-  /// optional integer `numberFromString`. The literal `23` is inferred as an
-  /// `Int` instance and then wrapped as an optional before the comparison is
-  /// performed.
-  ///
-  ///     if 23 == numberFromString {
-  ///         print("It's a match!")
-  ///     }
-  ///     // Prints "It's a match!"
-  ///
-  /// - Parameters:
-  ///   - lhs: An optional value to compare.
-  ///   - rhs: Another optional value to compare.
-  @_inlineable
-  public static func ==(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
-    switch (lhs, rhs) {
-    case let (l?, r?):
-      return l == r
-    case (nil, nil):
-      return true
-    default:
-      return false
-    }
+/// Returns a Boolean value indicating whether two optional instances are
+/// equal.
+///
+/// Use this equal-to operator (`==`) to compare any two optional instances of
+/// a type that conforms to the `Equatable` protocol. The comparison returns
+/// `true` if both arguments are `nil` or if the two arguments wrap values
+/// that are equal. Conversely, the comparison returns `false` if only one of
+/// the arguments is `nil` or if the two arguments wrap values that are not
+/// equal.
+///
+///     let group1 = [1, 2, 3, 4, 5]
+///     let group2 = [1, 3, 5, 7, 9]
+///     if group1.first == group2.first {
+///         print("The two groups start the same.")
+///     }
+///     // Prints "The two groups start the same."
+///
+/// You can also use this operator to compare a non-optional value to an
+/// optional that wraps the same type. The non-optional value is wrapped as an
+/// optional before the comparison is made. In the following example, the
+/// `numberToMatch` constant is wrapped as an optional before comparing to the
+/// optional `numberFromString`:
+///
+///     let numberToFind: Int = 23
+///     let numberFromString: Int? = Int("23")      // Optional(23)
+///     if numberToFind == numberFromString {
+///         print("It's a match!")
+///     }
+///     // Prints "It's a match!"
+///
+/// An instance that is expressed as a literal can also be used with this
+/// operator. In the next example, an integer literal is compared with the
+/// optional integer `numberFromString`. The literal `23` is inferred as an
+/// `Int` instance and then wrapped as an optional before the comparison is
+/// performed.
+///
+///     if 23 == numberFromString {
+///         print("It's a match!")
+///     }
+///     // Prints "It's a match!"
+///
+/// - Parameters:
+///   - lhs: An optional value to compare.
+///   - rhs: Another optional value to compare.
+@_inlineable
+public func == <T: Equatable>(lhs: T?, rhs: T?) -> Bool {
+  switch (lhs, rhs) {
+  case let (l?, r?):
+    return l == r
+  case (nil, nil):
+    return true
+  default:
+    return false
   }
-  
-  /// Returns a Boolean value indicating whether two optional instances are not
-  /// equal.
-  ///
-  /// Use this not-equal-to operator (`!=`) to compare any two optional instances
-  /// of a type that conforms to the `Equatable` protocol. The comparison
-  /// returns `true` if only one of the arguments is `nil` or if the two
-  /// arguments wrap values that are not equal. The comparison returns `false`
-  /// if both arguments are `nil` or if the two arguments wrap values that are
-  /// equal.
-  ///
-  ///     let group1 = [2, 4, 6, 8, 10]
-  ///     let group2 = [1, 3, 5, 7, 9]
-  ///     if group1.first != group2.first {
-  ///         print("The two groups start differently.")
-  ///     }
-  ///     // Prints "The two groups start differently."
-  ///
-  /// You can also use this operator to compare a non-optional value to an
-  /// optional that wraps the same type. The non-optional value is wrapped as an
-  /// optional before the comparison is made. In this example, the
-  /// `numberToMatch` constant is wrapped as an optional before comparing to the
-  /// optional `numberFromString`:
-  ///
-  ///     let numberToFind: Int = 23
-  ///     let numberFromString: Int? = Int("not-a-number")      // nil
-  ///     if numberToFind != numberFromString {
-  ///         print("No match.")
-  ///     }
-  ///     // Prints "No match."
-  ///
-  /// - Parameters:
-  ///   - lhs: An optional value to compare.
-  ///   - rhs: Another optional value to compare.
-  @_inlineable
-  public static func !=(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
-    return !(lhs == rhs)
-  }
+}
+
+/// Returns a Boolean value indicating whether two optional instances are not
+/// equal.
+///
+/// Use this not-equal-to operator (`!=`) to compare any two optional instances
+/// of a type that conforms to the `Equatable` protocol. The comparison
+/// returns `true` if only one of the arguments is `nil` or if the two
+/// arguments wrap values that are not equal. The comparison returns `false`
+/// if both arguments are `nil` or if the two arguments wrap values that are
+/// equal.
+///
+///     let group1 = [2, 4, 6, 8, 10]
+///     let group2 = [1, 3, 5, 7, 9]
+///     if group1.first != group2.first {
+///         print("The two groups start differently.")
+///     }
+///     // Prints "The two groups start differently."
+///
+/// You can also use this operator to compare a non-optional value to an
+/// optional that wraps the same type. The non-optional value is wrapped as an
+/// optional before the comparison is made. In this example, the
+/// `numberToMatch` constant is wrapped as an optional before comparing to the
+/// optional `numberFromString`:
+///
+///     let numberToFind: Int = 23
+///     let numberFromString: Int? = Int("not-a-number")      // nil
+///     if numberToFind != numberFromString {
+///         print("No match.")
+///     }
+///     // Prints "No match."
+///
+/// - Parameters:
+///   - lhs: An optional value to compare.
+///   - rhs: Another optional value to compare.
+@_inlineable
+public func != <T : Equatable>(lhs: T?, rhs: T?) -> Bool {
+  return !(lhs == rhs)
 }
 
 // Enable pattern matching against the nil literal, even if the element type
@@ -420,177 +418,175 @@ public struct _OptionalNilComparisonType : ExpressibleByNilLiteral {
   }
 }
 
-extension Optional {
-  /// Returns a Boolean value indicating whether an argument matches `nil`.
-  ///
-  /// You can use the pattern-matching operator (`~=`) to test whether an
-  /// optional instance is `nil` even when the wrapped value's type does not
-  /// conform to the `Equatable` protocol. The pattern-matching operator is used
-  /// internally in `case` statements for pattern matching.
-  ///
-  /// The following example declares the `stream` variable as an optional
-  /// instance of a hypothetical `DataStream` type, and then uses a `switch`
-  /// statement to determine whether the stream is `nil` or has a configured
-  /// value. When evaluating the `nil` case of the `switch` statement, this
-  /// operator is called behind the scenes.
-  ///
-  ///     var stream: DataStream? = nil
-  ///     switch stream {
-  ///     case nil:
-  ///         print("No data stream is configured.")
-  ///     case let x?:
-  ///         print("The data stream has \(x.availableBytes) bytes available.")
-  ///     }
-  ///     // Prints "No data stream is configured."
-  ///
-  /// - Note: To test whether an instance is `nil` in an `if` statement, use the
-  ///   equal-to operator (`==`) instead of the pattern-matching operator. The
-  ///   pattern-matching operator is primarily intended to enable `case`
-  ///   statement pattern matching.
-  ///
-  /// - Parameters:
-  ///   - lhs: A `nil` literal.
-  ///   - rhs: A value to match against `nil`.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  static public func ~=(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
-    switch rhs {
-    case .some(_):
-      return false
-    case .none:
-      return true
-    }
+/// Returns a Boolean value indicating whether an argument matches `nil`.
+///
+/// You can use the pattern-matching operator (`~=`) to test whether an
+/// optional instance is `nil` even when the wrapped value's type does not
+/// conform to the `Equatable` protocol. The pattern-matching operator is used
+/// internally in `case` statements for pattern matching.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type, and then uses a `switch`
+/// statement to determine whether the stream is `nil` or has a configured
+/// value. When evaluating the `nil` case of the `switch` statement, this
+/// operator is called behind the scenes.
+///
+///     var stream: DataStream? = nil
+///     switch stream {
+///     case nil:
+///         print("No data stream is configured.")
+///     case let x?:
+///         print("The data stream has \(x.availableBytes) bytes available.")
+///     }
+///     // Prints "No data stream is configured."
+///
+/// - Note: To test whether an instance is `nil` in an `if` statement, use the
+///   equal-to operator (`==`) instead of the pattern-matching operator. The
+///   pattern-matching operator is primarily intended to enable `case`
+///   statement pattern matching.
+///
+/// - Parameters:
+///   - lhs: A `nil` literal.
+///   - rhs: A value to match against `nil`.
+@_inlineable // FIXME(sil-serialize-all)
+@_transparent
+public func ~= <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
+  switch rhs {
+  case .some(_):
+    return false
+  case .none:
+    return true
   }
+}
 
-  // Enable equality comparisons against the nil literal, even if the
-  // element type isn't equatable
+// Enable equality comparisons against the nil literal, even if the
+// element type isn't equatable
 
-  /// Returns a Boolean value indicating whether the left-hand-side argument is
-  /// `nil`.
-  ///
-  /// You can use this equal-to operator (`==`) to test whether an optional
-  /// instance is `nil` even when the wrapped value's type does not conform to
-  /// the `Equatable` protocol.
-  ///
-  /// The following example declares the `stream` variable as an optional
-  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
-  /// an `Equatable` type, this operator allows checking whether `stream` is
-  /// `nil`.
-  ///
-  ///     var stream: DataStream? = nil
-  ///     if stream == nil {
-  ///         print("No data stream is configured.")
-  ///     }
-  ///     // Prints "No data stream is configured."
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare to `nil`.
-  ///   - rhs: A `nil` literal.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  static public func ==(lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool {
-    switch lhs {
-    case .some(_):
-      return false
-    case .none:
-      return true
-    }
+/// Returns a Boolean value indicating whether the left-hand-side argument is
+/// `nil`.
+///
+/// You can use this equal-to operator (`==`) to test whether an optional
+/// instance is `nil` even when the wrapped value's type does not conform to
+/// the `Equatable` protocol.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` is
+/// `nil`.
+///
+///     var stream: DataStream? = nil
+///     if stream == nil {
+///         print("No data stream is configured.")
+///     }
+///     // Prints "No data stream is configured."
+///
+/// - Parameters:
+///   - lhs: A value to compare to `nil`.
+///   - rhs: A `nil` literal.
+@_inlineable // FIXME(sil-serialize-all)
+@_transparent
+public func == <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
+  switch lhs {
+  case .some(_):
+    return false
+  case .none:
+    return true
   }
+}
 
-  /// Returns a Boolean value indicating whether the left-hand-side argument is
-  /// not `nil`.
-  ///
-  /// You can use this not-equal-to operator (`!=`) to test whether an optional
-  /// instance is not `nil` even when the wrapped value's type does not conform
-  /// to the `Equatable` protocol.
-  ///
-  /// The following example declares the `stream` variable as an optional
-  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
-  /// an `Equatable` type, this operator allows checking whether `stream` wraps
-  /// a value and is therefore not `nil`.
-  ///
-  ///     var stream: DataStream? = fetchDataStream()
-  ///     if stream != nil {
-  ///         print("The data stream has been configured.")
-  ///     }
-  ///     // Prints "The data stream has been configured."
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare to `nil`.
-  ///   - rhs: A `nil` literal.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  static public func !=(lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool {
-    switch lhs {
-    case .some(_):
-      return true
-    case .none:
-      return false
-    }
+/// Returns a Boolean value indicating whether the left-hand-side argument is
+/// not `nil`.
+///
+/// You can use this not-equal-to operator (`!=`) to test whether an optional
+/// instance is not `nil` even when the wrapped value's type does not conform
+/// to the `Equatable` protocol.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` wraps
+/// a value and is therefore not `nil`.
+///
+///     var stream: DataStream? = fetchDataStream()
+///     if stream != nil {
+///         print("The data stream has been configured.")
+///     }
+///     // Prints "The data stream has been configured."
+///
+/// - Parameters:
+///   - lhs: A value to compare to `nil`.
+///   - rhs: A `nil` literal.
+@_inlineable // FIXME(sil-serialize-all)
+@_transparent
+public func != <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
+  switch lhs {
+  case .some(_):
+    return true
+  case .none:
+    return false
   }
+}
 
-  /// Returns a Boolean value indicating whether the right-hand-side argument is
-  /// `nil`.
-  ///
-  /// You can use this equal-to operator (`==`) to test whether an optional
-  /// instance is `nil` even when the wrapped value's type does not conform to
-  /// the `Equatable` protocol.
-  ///
-  /// The following example declares the `stream` variable as an optional
-  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
-  /// an `Equatable` type, this operator allows checking whether `stream` is
-  /// `nil`.
-  ///
-  ///     var stream: DataStream? = nil
-  ///     if nil == stream {
-  ///         print("No data stream is configured.")
-  ///     }
-  ///     // Prints "No data stream is configured."
-  ///
-  /// - Parameters:
-  ///   - lhs: A `nil` literal.
-  ///   - rhs: A value to compare to `nil`.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  static public func ==(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
-    switch rhs {
-    case .some(_):
-      return false
-    case .none:
-      return true
-    }
+/// Returns a Boolean value indicating whether the right-hand-side argument is
+/// `nil`.
+///
+/// You can use this equal-to operator (`==`) to test whether an optional
+/// instance is `nil` even when the wrapped value's type does not conform to
+/// the `Equatable` protocol.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` is
+/// `nil`.
+///
+///     var stream: DataStream? = nil
+///     if nil == stream {
+///         print("No data stream is configured.")
+///     }
+///     // Prints "No data stream is configured."
+///
+/// - Parameters:
+///   - lhs: A `nil` literal.
+///   - rhs: A value to compare to `nil`.
+@_inlineable // FIXME(sil-serialize-all)
+@_transparent
+public func == <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
+  switch rhs {
+  case .some(_):
+    return false
+  case .none:
+    return true
   }
+}
 
-  /// Returns a Boolean value indicating whether the right-hand-side argument is
-  /// not `nil`.
-  ///
-  /// You can use this not-equal-to operator (`!=`) to test whether an optional
-  /// instance is not `nil` even when the wrapped value's type does not conform
-  /// to the `Equatable` protocol.
-  ///
-  /// The following example declares the `stream` variable as an optional
-  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
-  /// an `Equatable` type, this operator allows checking whether `stream` wraps
-  /// a value and is therefore not `nil`.
-  ///
-  ///     var stream: DataStream? = fetchDataStream()
-  ///     if nil != stream {
-  ///         print("The data stream has been configured.")
-  ///     }
-  ///     // Prints "The data stream has been configured."
-  ///
-  /// - Parameters:
-  ///   - lhs: A `nil` literal.
-  ///   - rhs: A value to compare to `nil`.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  static public func !=(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
-    switch rhs {
-    case .some(_):
-      return true
-    case .none:
-      return false
-    }
+/// Returns a Boolean value indicating whether the right-hand-side argument is
+/// not `nil`.
+///
+/// You can use this not-equal-to operator (`!=`) to test whether an optional
+/// instance is not `nil` even when the wrapped value's type does not conform
+/// to the `Equatable` protocol.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` wraps
+/// a value and is therefore not `nil`.
+///
+///     var stream: DataStream? = fetchDataStream()
+///     if nil != stream {
+///         print("The data stream has been configured.")
+///     }
+///     // Prints "The data stream has been configured."
+///
+/// - Parameters:
+///   - lhs: A `nil` literal.
+///   - rhs: A value to compare to `nil`.
+@_inlineable // FIXME(sil-serialize-all)
+@_transparent
+public func != <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
+  switch rhs {
+  case .some(_):
+    return true
+  case .none:
+    return false
   }
 }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -181,9 +181,8 @@ func dictionaryToNSDictionary() {
 struct NotEquatable {}
 func notEquatableError(_ d: Dictionary<Int, NotEquatable>) -> Bool {
   // FIXME: Another awful diagnostic.
-  return d == d // expected-error{{'<Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool' requires that 'NotEquatable' conform to 'Equatable'}}
-  // expected-note @-1 {{requirement specified as 'NotEquatable' : 'Equatable'}}
-  // expected-note @-2 {{requirement from conditional conformance of 'Dictionary<Int, NotEquatable>' to 'Equatable'}}
+  return d == d // expected-error{{binary operator '==' cannot be applied to two 'Dictionary<Int, NotEquatable>' operands}}
+  // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
 }
 
 // NSString -> String

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -163,8 +163,9 @@ case nil?: break // expected-warning {{case is already handled by previous patte
 default: break
 }
 
+// <rdar://problem/21995744> QoI: Binary operator '~=' cannot be applied to operands of type 'String' and 'String?'
 switch ("foo" as String?) {
-case "what": break
+case "what": break // expected-error{{expression pattern of type 'String' cannot match values of type 'String?'}} {{12-12=?}}
 default: break
 }
 

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -144,7 +144,7 @@ enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int { // expected-error {{raw ty
 }
 
 enum ExpressibleByRawTypeNotLiteral : Array<Int> { // expected-error {{raw type 'Array<Int>' is not expressible by any literal}}
-  // expected-error@-1{{'ExpressibleByRawTypeNotLiteral' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  // expected-error@-1{{'ExpressibleByRawTypeNotLiteral' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error@-1 {{RawRepresentable conformance cannot be synthesized because raw type 'Array<Int>' is not Equatable}}
   case Ladd, Elliott, Sixteenth, Harrison
 }
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -291,10 +291,8 @@ struct NotEquatable {}
 func arrayComparison(_ x: [NotEquatable], y: [NotEquatable], p: UnsafeMutablePointer<NotEquatable>) {
   var x = x
   // Don't allow implicit array-to-pointer conversions in operators.
-  // FIXME: The use of <Self: Equatable> in this diagnostic is awful.
-  let a: Bool = x == y // expected-error{{'<Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool' requires that 'NotEquatable' conform to 'Equatable'}}
-  // expected-note @-1 {{requirement specified as 'NotEquatable' : 'Equatable'}}
-  // expected-note @-2 {{requirement from conditional conformance of '[NotEquatable]' to 'Equatable'}}
+  let a: Bool = x == y // expected-error{{binary operator '==' cannot be applied to two '[NotEquatable]' operands}}
+  // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists:}}
 
   let _: Bool = p == &x  // Allowed!
 }

--- a/test/SILOptimizer/mandatory_nil_comparison_inlining.swift
+++ b/test/SILOptimizer/mandatory_nil_comparison_inlining.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -enable-sil-ownership -sil-verify-all -primary-file %s -module-name=test -emit-sil -o - -verify | %FileCheck %s
 
-struct X { }
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}generic_func
 // CHECK: switch_enum_addr
@@ -12,28 +11,28 @@ func generic_func<T>(x: [T]?) -> Bool {
 // CHECK-LABEL: sil {{.*}} @{{.*}}array_func_rhs_nil
 // CHECK: switch_enum_addr
 // CHECK: return
-func array_func_rhs_nil(x: [X]?) -> Bool {
+func array_func_rhs_nil(x: [Int]?) -> Bool {
   return x == nil
 }
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}array_func_lhs_nil
 // CHECK: switch_enum_addr
 // CHECK: return
-func array_func_lhs_nil(x: [X]?) -> Bool {
+func array_func_lhs_nil(x: [Int]?) -> Bool {
   return nil == x
 }
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}array_func_rhs_non_nil
 // CHECK: switch_enum_addr
 // CHECK: return
-func array_func_rhs_non_nil(x: [X]?) -> Bool {
+func array_func_rhs_non_nil(x: [Int]?) -> Bool {
   return x != nil
 }
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}array_func_lhs_non_nil
 // CHECK: switch_enum_addr
 // CHECK: return
-func array_func_lhs_non_nil(x: [X]?) -> Bool {
+func array_func_lhs_non_nil(x: [Int]?) -> Bool {
   return nil != x
 }
 

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -226,18 +226,6 @@ indirect enum TotallyIndirect: Hashable {
   case end(Int)
 }
 
-// Check the use of conditional conformances.
-enum ArrayOfEquatables : Equatable {
-case only([Int])
-}
-
-struct NotEquatable { }
-
-// FIXME: rdar://problem/35518088 this should fail.
-enum ArrayOfNotEquatables : Equatable {
-case only([NotEquatable])
-}
-
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -78,6 +78,8 @@ class Outer {
   let a: Int = E.a // expected-error {{cannot convert value of type 'Outer.E' to specified type 'Int'}}
 
   enum E : Array<Int> { // expected-error {{raw type 'Array<Int>' is not expressible by any literal}}
+  // expected-error@-1 {{'Outer.E' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'Array<Int>' is not Equatable}}
     case a
   }
 }
@@ -144,10 +146,3 @@ func rdar32432253(_ condition: Bool = false) {
   let _ = choice == "bar"
   // expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{11-11=}} {{17-17=.rawValue}}
 }
-
-
-struct NotEquatable { }
-
-enum ArrayOfNewEquatable : Array<NotEquatable> { }
-// expected-error@-1{{raw type 'Array<NotEquatable>' is not expressible by any literal}}
-// expected-error@-2{{'ArrayOfNewEquatable' declares raw type 'Array<NotEquatable>', but does not conform to RawRepresentable and conformance could not be synthesized}}

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -52,7 +52,6 @@ protocol Bindable: class { }
 extension Bindable {
   func test<Value>(to targetKeyPath: ReferenceWritableKeyPath<Self, Value>, change: Value?) {
     if self[keyPath:targetKeyPath] != change {  // expected-error{{}}
-      // expected-note@-1{{overloads for '!=' exist with these partially matching parameter lists: (Self, Self), (_OptionalNilComparisonType, Wrapped?)}}
       self[keyPath: targetKeyPath] = change!
     }
   }

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -134,7 +134,7 @@ default:
 }
 
 switch optionalSel {
-case #selector(SR1827.bar):
+case #selector(SR1827.bar): // expected-error{{expression pattern of type 'Selector' cannot match values of type 'Selector?'}} {{27-27=?}}
   break
 case #selector(SR1827.bar)!: // expected-error{{cannot force unwrap value of non-optional type 'Selector'}}
   break

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -5,8 +5,7 @@ class NotEquatable {}
 func test_ArrayOfNotEquatableIsNotEquatable() {
   var a = [ NotEquatable(), NotEquatable() ]
   // FIXME: This is an awful error.
-  if a == a {} // expected-error {{'<Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool' requires that 'NotEquatable' conform to 'Equatable'}}
-  // expected-note @-1 {{requirement specified as 'NotEquatable' : 'Equatable'}}
-  // expected-note @-2 {{requirement from conditional conformance of '[NotEquatable]' to 'Equatable'}}
+  if a == a {} // expected-error {{binary operator '==' cannot be applied to two '[NotEquatable]' operands}}
+  // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
 }
 

--- a/test/stdlib/TestNSNumberBridging.swift
+++ b/test/stdlib/TestNSNumberBridging.swift
@@ -522,7 +522,7 @@ func testNSNumberBridgeFromUInt32() {
             let float = (number!) as? Float
             let expectedFloat = Float(uint32!)
             // these are disabled because of https://bugs.swift.org/browse/SR-4634
-            if (uint32! != UInt32.max && uint32! != UInt32.max - UInt32(1)) {
+            if (uint32! != UInt32.max && uint32! != UInt32.max - 1) {
                 testFloat(expectedFloat, float)
             }
             

--- a/validation-test/stdlib/ValidationNSNumberBridging.swift
+++ b/validation-test/stdlib/ValidationNSNumberBridging.swift
@@ -516,7 +516,7 @@ func testNSNumberBridgeFromUInt32() {
             let float = (number!) as? Float
             let expectedFloat = Float(uint32!)
             // these are disabled because of https://bugs.swift.org/browse/SR-4634
-            if (uint32! != UInt32.max && uint32! != UInt32.max - UInt32(1)) {
+            if (uint32! != UInt32.max && uint32! != UInt32.max - 1) {
                 testFloat(expectedFloat, float)
             }
             


### PR DESCRIPTION
Reverts apple/swift#12910

This broke test SIL/parse_stdlib.sil.