### PR TITLE
Code size: copy_addr outline - Support Archetypes

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -83,10 +83,10 @@ Globals
   global ::= type 'We' // Outlined Consume Function Type
   global ::= type 'Wr' // Outlined Retain Function Type
   global ::= type 'Ws' // Outlined Release Function Type
-  global ::= type 'Wb' // Outlined InitializeWithTake Function Type
-  global ::= type 'Wc' // Outlined InitializeWithCopy Function Type
-  global ::= type 'Wd' // Outlined AssignWithTake Function Type
-  global ::= type 'Wf' // Outlined AssignWithCopy Function Type
+  global ::= type 'Wb' INDEX // Outlined InitializeWithTake Function Type
+  global ::= type 'Wc' INDEX // Outlined InitializeWithCopy Function Type
+  global ::= type 'Wd' INDEX // Outlined AssignWithTake Function Type
+  global ::= type 'Wf' INDEX // Outlined AssignWithCopy Function Type
 
   assoc_type_path ::= identifier '_' identifier*
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1692,20 +1692,24 @@ NodePointer Demangler::demangleWitness() {
                              popNode(Node::Kind::Type));
     }
     case 'b': {
-      return createWithChild(Node::Kind::OutlinedInitializeWithTake,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedInitializeWithTake,
+                                popNode(Node::Kind::Type), IndexChild);
     }
     case 'c': {
-      return createWithChild(Node::Kind::OutlinedInitializeWithCopy,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedInitializeWithCopy,
+                                popNode(Node::Kind::Type), IndexChild);
     }
     case 'd': {
-      return createWithChild(Node::Kind::OutlinedAssignWithTake,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedAssignWithTake,
+                                popNode(Node::Kind::Type), IndexChild);
     }
     case 'f': {
-      return createWithChild(Node::Kind::OutlinedAssignWithCopy,
-                             popNode(Node::Kind::Type));
+      NodePointer IndexChild = demangleIndexAsNode();
+      return createWithChildren(Node::Kind::OutlinedAssignWithCopy,
+                                popNode(Node::Kind::Type), IndexChild);
     }
 
     default:

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1755,23 +1755,27 @@ void Remangler::mangleOutlinedRelease(Node *node) {
 }
 
 void Remangler::mangleOutlinedInitializeWithTake(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wb";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedInitializeWithCopy(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wc";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedAssignWithTake(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wd";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedAssignWithCopy(Node *node) {
-  mangleSingleChildNode(node);
+  mangleChildNode(node, 0);
   Buffer << "Wf";
+  mangleChildNode(node, 1);
 }
 
 void Remangler::mangleOutlinedVariable(Node *node) {

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -73,12 +73,14 @@ public:
   }
 
   /// Set the arguments to the function from an explosion.
-  void setArgs(Explosion &arg, WitnessMetadata *witnessMetadata = nullptr);
-  
+  void setArgs(Explosion &arg, bool isOutlined,
+               WitnessMetadata *witnessMetadata = nullptr);
+
   void addAttribute(unsigned Index, llvm::Attribute::AttrKind Attr);
 
-  void emitToMemory(Address addr, const LoadableTypeInfo &substResultTI);
-  void emitToExplosion(Explosion &out);
+  void emitToMemory(Address addr, const LoadableTypeInfo &substResultTI,
+                    bool isOutlined);
+  void emitToExplosion(Explosion &out, bool isOutlined);
 };
 
 

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -83,8 +83,8 @@ public:
 
   // We can give these reasonable default implementations.
 
-  void initializeWithTake(IRGenFunction &IGF, Address destAddr,
-                          Address srcAddr, SILType T) const override;
+  void initializeWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                          SILType T, bool isOutlined) const override;
 
   llvm::Value *getSize(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getAlignmentMask(IRGenFunction &IGF, SILType T) const override;

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -228,6 +228,13 @@ public:
                           llvm::Value *vwtable,
                           SILType T) const override {}
 
+  void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
+      SILType T) const override {
+    return;
+  }
+
   llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,
                                        llvm::Value *numEmptyCases,
                                        Address enumAddr,

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -91,6 +91,19 @@ public:
   static const OpaqueArchetypeTypeInfo *create(llvm::Type *type) {
     return new OpaqueArchetypeTypeInfo(type);
   }
+
+  void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
+      SILType T) const override {
+    auto canType = T.getSwiftRValueType();
+    if (typeToMetadataVec.find(canType) != typeToMetadataVec.end()) {
+      return;
+    }
+    auto *metadata = IGF.emitTypeMetadataRef(canType);
+    assert(metadata && "Expected Type Metadata Ref");
+    typeToMetadataVec.insert(std::make_pair(canType, metadata));
+  }
 };
 
 /// A type implementation for a class archetype, that is, an archetype

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1331,15 +1331,16 @@ llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
 
 /// Emit the result of this call to memory.
 void CallEmission::emitToMemory(Address addr,
-                                const LoadableTypeInfo &indirectedResultTI) {
+                                const LoadableTypeInfo &indirectedResultTI,
+                                bool isOutlined) {
   assert(LastArgWritten <= 1);
 
   // If the call is naturally to an explosion, emit it that way and
   // then initialize the temporary.
   if (LastArgWritten == 0) {
     Explosion result;
-    emitToExplosion(result);
-    indirectedResultTI.initialize(IGF, result, addr);
+    emitToExplosion(result, isOutlined);
+    indirectedResultTI.initialize(IGF, result, addr, isOutlined);
     return;
   }
 
@@ -1373,7 +1374,7 @@ void CallEmission::emitToMemory(Address addr,
 }
 
 /// Emit the result of this call to an explosion.
-void CallEmission::emitToExplosion(Explosion &out) {
+void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
   assert(LastArgWritten <= 1);
 
   SILFunctionConventions fnConv(getCallee().getSubstFunctionType(),
@@ -1389,8 +1390,8 @@ void CallEmission::emitToExplosion(Explosion &out) {
     StackAddress ctemp = substResultTI.allocateStack(IGF, substResultType,
                                                      false, "call.aggresult");
     Address temp = ctemp.getAddress();
-    emitToMemory(temp, substResultTI);
- 
+    emitToMemory(temp, substResultTI, isOutlined);
+
     // We can use a take.
     substResultTI.loadAsTake(IGF, temp, out);
 
@@ -1600,13 +1601,13 @@ static llvm::Type *getOutputType(TranslationDirection direction, unsigned index,
             : nativeSchema[index].getScalarType());
 }
 
-
-static void emitCoerceAndExpand(IRGenFunction &IGF,
-                                Explosion &in, Explosion &out, SILType paramTy,
+static void emitCoerceAndExpand(IRGenFunction &IGF, Explosion &in,
+                                Explosion &out, SILType paramTy,
                                 const LoadableTypeInfo &paramTI,
                                 llvm::StructType *coercionTy,
-                                ArrayRef<llvm::Type*> expandedTys,
-                                TranslationDirection direction) {
+                                ArrayRef<llvm::Type *> expandedTys,
+                                TranslationDirection direction,
+                                bool isOutlined) {
   // If we can directly coerce the scalar values, avoid going through memory.
   auto schema = paramTI.getSchema();
   if (canCoerceToSchema(IGF.IGM, expandedTys, schema)) {
@@ -1641,7 +1642,7 @@ static void emitCoerceAndExpand(IRGenFunction &IGF,
   // If we're translating *to* the foreign expansion, do an ordinary
   // initialization from the input explosion.
   if (direction == TranslationDirection::ToForeign) {
-    paramTI.initialize(IGF, in, temporary);
+    paramTI.initialize(IGF, in, temporary, isOutlined);
   }
 
   Address coercedTemporary =
@@ -1689,7 +1690,8 @@ static void emitCoerceAndExpand(IRGenFunction &IGF,
 
 static void emitDirectExternalArgument(IRGenFunction &IGF, SILType argType,
                                        const clang::CodeGen::ABIArgInfo &AI,
-                                       Explosion &in, Explosion &out) {
+                                       Explosion &in, Explosion &out,
+                                       bool isOutlined) {
   bool IsDirectFlattened = AI.isDirect() && AI.getCanBeFlattened();
   bool IsIndirect = !AI.isDirect();
 
@@ -1725,7 +1727,7 @@ static void emitDirectExternalArgument(IRGenFunction &IGF, SILType argType,
   // Store to a temporary.
   Address tempOfArgTy = IGF.Builder.CreateBitCast(
       temporary, argTI.getStorageType()->getPointerTo());
-  argTI.initializeFromParams(IGF, in, tempOfArgTy, argType);
+  argTI.initializeFromParams(IGF, in, tempOfArgTy, argType, isOutlined);
 
   // Bitcast the temporary to the expected type.
   Address coercedAddr =
@@ -1783,11 +1785,10 @@ namespace {
 
 /// Given a Swift value explosion in 'in', produce a Clang expansion
 /// (according to ABIArgInfo::Expand) in 'out'.
-static void emitClangExpandedArgument(IRGenFunction &IGF,
-                                      Explosion &in, Explosion &out,
-                                      clang::CanQualType clangType,
-                                      SILType swiftType,
-                                      const LoadableTypeInfo &swiftTI) {
+static void
+emitClangExpandedArgument(IRGenFunction &IGF, Explosion &in, Explosion &out,
+                          clang::CanQualType clangType, SILType swiftType,
+                          const LoadableTypeInfo &swiftTI, bool isOutlined) {
   // If Clang's expansion schema matches Swift's, great.
   auto swiftSchema = swiftTI.getSchema();
   if (doesClangExpansionMatchSchema(IGF.IGM, clangType, swiftSchema)) {
@@ -1797,7 +1798,7 @@ static void emitClangExpandedArgument(IRGenFunction &IGF,
   // Otherwise, materialize to a temporary.
   Address temp = swiftTI.allocateStack(IGF, swiftType, false,
                                        "clang-expand-arg.temp").getAddress();
-  swiftTI.initialize(IGF, in, temp);
+  swiftTI.initialize(IGF, in, temp, isOutlined);
 
   Address castTemp = IGF.Builder.CreateBitCast(temp, IGF.IGM.Int8PtrTy);
   ClangExpandLoadEmitter(IGF, out).visit(clangType, castTemp);
@@ -1827,7 +1828,8 @@ void irgen::emitClangExpandedParameter(IRGenFunction &IGF,
 }
 
 static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
-                                 Explosion &in, Explosion &out) {
+                                 Explosion &in, Explosion &out,
+                                 bool isOutlined) {
   auto silConv = IGF.IGM.silConv;
   auto fnType = callee.getOrigFunctionType();
   auto params = fnType->getParameters();
@@ -1889,7 +1891,7 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
         break;
       }
 
-      emitDirectExternalArgument(IGF, paramType, AI, in, out);
+      emitDirectExternalArgument(IGF, paramType, AI, in, out, isOutlined);
       break;
     }
     case clang::CodeGen::ABIArgInfo::Indirect: {
@@ -1906,7 +1908,7 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
         }
       }
 
-      ti.initialize(IGF, in, addr);
+      ti.initialize(IGF, in, addr, isOutlined);
 
       out.add(addr.getAddress());
       break;
@@ -1916,12 +1918,13 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
       emitCoerceAndExpand(IGF, in, out, paramType, paramTI,
                           AI.getCoerceAndExpandType(),
                           AI.getCoerceAndExpandTypeSequence(),
-                          TranslationDirection::ToForeign);
+                          TranslationDirection::ToForeign, isOutlined);
       break;
     }
     case clang::CodeGen::ABIArgInfo::Expand:
-      emitClangExpandedArgument(IGF, in, out, clangParamTy, paramType,
-                         cast<LoadableTypeInfo>(IGF.getTypeInfo(paramType)));
+      emitClangExpandedArgument(
+          IGF, in, out, clangParamTy, paramType,
+          cast<LoadableTypeInfo>(IGF.getTypeInfo(paramType)), isOutlined);
       break;
     case clang::CodeGen::ABIArgInfo::Ignore:
       break;
@@ -1934,7 +1937,8 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
 
 /// Returns whether allocas are needed.
 bool irgen::addNativeArgument(IRGenFunction &IGF, Explosion &in,
-                              SILParameterInfo origParamInfo, Explosion &out) {
+                              SILParameterInfo origParamInfo, Explosion &out,
+                              bool isOutlined) {
   // Addresses consist of a single pointer argument.
   if (IGF.IGM.silConv.isSILIndirect(origParamInfo)) {
     out.add(in.claimNext());
@@ -1948,7 +1952,7 @@ bool irgen::addNativeArgument(IRGenFunction &IGF, Explosion &in,
     // Pass the argument indirectly.
     auto buf = IGF.createAlloca(ti.getStorageType(),
                                 ti.getFixedAlignment(), "");
-    ti.initialize(IGF, in, buf);
+    ti.initialize(IGF, in, buf, isOutlined);
     out.add(buf.getAddress());
     return true;
   } else {
@@ -1962,7 +1966,8 @@ bool irgen::addNativeArgument(IRGenFunction &IGF, Explosion &in,
     // calling convention.
     Explosion nonNativeParam;
     ti.reexplode(IGF, in, nonNativeParam);
-    Explosion nativeParam = nativeSchema.mapIntoNative(IGF.IGM, IGF, nonNativeParam, paramType);
+    Explosion nativeParam = nativeSchema.mapIntoNative(
+        IGF.IGM, IGF, nonNativeParam, paramType, isOutlined);
     nativeParam.transferInto(out, nativeParam.size());
     return false;
   }
@@ -2047,10 +2052,9 @@ static void emitDirectForeignParameter(IRGenFunction &IGF, Explosion &in,
 
 void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
                                  ForeignFunctionInfo foreignInfo,
-                                 unsigned foreignParamIndex,
-                                 SILType paramTy,
+                                 unsigned foreignParamIndex, SILType paramTy,
                                  const LoadableTypeInfo &paramTI,
-                                 Explosion &paramExplosion) {
+                                 Explosion &paramExplosion, bool isOutlined) {
   assert(foreignInfo.ClangInfo);
   auto &FI = *foreignInfo.ClangInfo;
 
@@ -2088,7 +2092,7 @@ void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
     emitCoerceAndExpand(IGF, params, paramExplosion, paramTy, paramTI,
                         AI.getCoerceAndExpandType(),
                         AI.getCoerceAndExpandTypeSequence(),
-                        TranslationDirection::ToNative);
+                        TranslationDirection::ToNative, isOutlined);
     break;
   }
 
@@ -2102,7 +2106,7 @@ void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
 
 
 /// Add a new set of arguments to the function.
-void CallEmission::setArgs(Explosion &original,
+void CallEmission::setArgs(Explosion &original, bool isOutlined,
                            WitnessMetadata *witnessMetadata) {
   // Convert arguments to a representation appropriate to the calling
   // convention.
@@ -2119,7 +2123,7 @@ void CallEmission::setArgs(Explosion &original,
   case SILFunctionTypeRepresentation::ObjCMethod:
     adjusted.add(getCallee().getObjCMethodReceiver());
     adjusted.add(getCallee().getObjCMethodSelector());
-    externalizeArguments(IGF, getCallee(), original, adjusted);
+    externalizeArguments(IGF, getCallee(), original, adjusted, isOutlined);
     break;
 
   case SILFunctionTypeRepresentation::Block:
@@ -2127,7 +2131,7 @@ void CallEmission::setArgs(Explosion &original,
     LLVM_FALLTHROUGH;
 
   case SILFunctionTypeRepresentation::CFunctionPointer:
-    externalizeArguments(IGF, getCallee(), original, adjusted);
+    externalizeArguments(IGF, getCallee(), original, adjusted, isOutlined);
     break;
 
   case SILFunctionTypeRepresentation::WitnessMethod:
@@ -2152,7 +2156,7 @@ void CallEmission::setArgs(Explosion &original,
       params = params.drop_back();
     }
     for (auto param : params) {
-      addNativeArgument(IGF, original, param, adjusted);
+      addNativeArgument(IGF, original, param, adjusted, isOutlined);
     }
 
     // Anything else, just pass along.  This will include things like
@@ -2577,7 +2581,8 @@ Explosion NativeConventionSchema::mapFromNative(IRGenModule &IGM,
 Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
                                                 IRGenFunction &IGF,
                                                 Explosion &fromNonNative,
-                                                SILType type) const {
+                                                SILType type,
+                                                bool isOutlined) const {
   if (fromNonNative.size() == 0) {
     assert(empty() && "Empty explosion must match the native convention");
     return Explosion();
@@ -2668,7 +2673,7 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
   // Initialize the memory of the temporary.
   Address storageAddr = Builder.CreateBitCast(
       temporary, loadableTI.getStorageType()->getPointerTo());
-  loadableTI.initialize(IGF, fromNonNative, storageAddr);
+  loadableTI.initialize(IGF, fromNonNative, storageAddr, isOutlined);
 
   // Load the expanded type elements from memory.
   auto coercionAddr = Builder.CreateElementBitCast(temporary, coercionTy);
@@ -2710,7 +2715,7 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
 }
 
 void IRGenFunction::emitScalarReturn(SILType resultType, Explosion &result,
-                                     bool isSwiftCCReturn) {
+                                     bool isSwiftCCReturn, bool isOutlined) {
   if (result.size() == 0) {
     assert(IGM.getTypeInfo(resultType).nativeReturnValueSchema(IGM).empty() &&
            "Empty explosion must match the native calling convention");
@@ -2726,7 +2731,7 @@ void IRGenFunction::emitScalarReturn(SILType resultType, Explosion &result,
     assert(!nativeSchema.requiresIndirect());
 
     Explosion native =
-        nativeSchema.mapIntoNative(IGM, *this, result, resultType);
+        nativeSchema.mapIntoNative(IGM, *this, result, resultType, isOutlined);
     if (native.size() == 1) {
       Builder.CreateRet(native.claimNext());
       return;

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -85,10 +85,9 @@ namespace irgen {
 
   void emitForeignParameter(IRGenFunction &IGF, Explosion &params,
                             ForeignFunctionInfo foreignInfo,
-                            unsigned foreignParamIndex,
-                            SILType paramTy, const LoadableTypeInfo &paramTI,
-                            Explosion &paramExplosion);
-
+                            unsigned foreignParamIndex, SILType paramTy,
+                            const LoadableTypeInfo &paramTI,
+                            Explosion &paramExplosion, bool isOutlined);
 
   void emitClangExpandedParameter(IRGenFunction &IGF,
                                   Explosion &in, Explosion &out,
@@ -97,8 +96,9 @@ namespace irgen {
                                   const LoadableTypeInfo &swiftTI);
 
   bool addNativeArgument(IRGenFunction &IGF, Explosion &in,
-                         SILParameterInfo origParamInfo, Explosion &args);
-  
+                         SILParameterInfo origParamInfo, Explosion &args,
+                         bool isOutlined);
+
   /// Allocate a stack buffer of the appropriate size to bitwise-coerce a value
   /// between two LLVM types.
   std::pair<Address, Size>

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3506,7 +3506,6 @@ llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &objectTI,
   return getOrCreateHelperFunction(
       funcName, llvmType, argTys,
       [&](IRGenFunction &IGF) {
-        IGF.setInOutlinedFunction();
         auto it = IGF.CurFn->arg_begin();
         Address addr(&*it++, loadableTI->getFixedAlignment());
         Explosion loaded;
@@ -3530,7 +3529,6 @@ IRGenModule::getOrCreateReleaseFunction(const TypeInfo &objectTI, Type t,
   return getOrCreateHelperFunction(
       funcName, llvmType, argTys,
       [&](IRGenFunction &IGF) {
-        IGF.setInOutlinedFunction();
         auto it = IGF.CurFn->arg_begin();
         Address addr(&*it++, loadableTI->getFixedAlignment());
         Explosion loaded;
@@ -3584,7 +3582,6 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedCopyAddrHelperFunction(
   return getOrCreateHelperFunction(
       funcName, llvmType, argsTysVec,
       [&](IRGenFunction &IGF) {
-        IGF.setInOutlinedFunction();
         auto it = IGF.CurFn->arg_begin();
         Address src(&*it++, objectTI.getBestKnownAlignment());
         Address dest(&*it++, objectTI.getBestKnownAlignment());
@@ -3611,7 +3608,7 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedInitializeWithTakeFunction(
       mangler.mangleOutlinedInitializeWithTakeFunction(canType, this);
   auto GenFunc = [](const TypeInfo &objectTI, IRGenFunction &IGF, Address dest,
                     Address src, SILType T) {
-    objectTI.initializeWithTake(IGF, dest, src, T);
+    objectTI.initializeWithTake(IGF, dest, src, T, true);
   };
   return getOrCreateOutlinedCopyAddrHelperFunction(
       objectTI, llvmType, addrTy, funcName, GenFunc, typeToMetadataVec);
@@ -3627,7 +3624,7 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedInitializeWithCopyFunction(
       mangler.mangleOutlinedInitializeWithCopyFunction(canType, this);
   auto GenFunc = [](const TypeInfo &objectTI, IRGenFunction &IGF, Address dest,
                     Address src, SILType T) {
-    objectTI.initializeWithCopy(IGF, dest, src, T);
+    objectTI.initializeWithCopy(IGF, dest, src, T, true);
   };
   return getOrCreateOutlinedCopyAddrHelperFunction(
       objectTI, llvmType, addrTy, funcName, GenFunc, typeToMetadataVec);
@@ -3642,8 +3639,9 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedAssignWithTakeFunction(
   std::string funcName =
       mangler.mangleOutlinedAssignWithTakeFunction(canType, this);
   auto GenFunc = [](const TypeInfo &objectTI, IRGenFunction &IGF, Address dest,
-                    Address src,
-                    SILType T) { objectTI.assignWithTake(IGF, dest, src, T); };
+                    Address src, SILType T) {
+    objectTI.assignWithTake(IGF, dest, src, T, true);
+  };
   return getOrCreateOutlinedCopyAddrHelperFunction(
       objectTI, llvmType, addrTy, funcName, GenFunc, typeToMetadataVec);
 }
@@ -3657,8 +3655,9 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedAssignWithCopyFunction(
   std::string funcName =
       mangler.mangleOutlinedAssignWithCopyFunction(canType, this);
   auto GenFunc = [](const TypeInfo &objectTI, IRGenFunction &IGF, Address dest,
-                    Address src,
-                    SILType T) { objectTI.assignWithCopy(IGF, dest, src, T); };
+                    Address src, SILType T) {
+    objectTI.assignWithCopy(IGF, dest, src, T, true);
+  };
   return getOrCreateOutlinedCopyAddrHelperFunction(
       objectTI, llvmType, addrTy, funcName, GenFunc, typeToMetadataVec);
 }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -142,12 +142,12 @@ SpareBitVector getBitVectorFromAPInt(const APInt &bits, unsigned startBit = 0) {
 
 void irgen::EnumImplStrategy::initializeFromParams(IRGenFunction &IGF,
                                                    Explosion &params,
-                                                   Address dest,
-                                                   SILType T) const {
+                                                   Address dest, SILType T,
+                                                   bool isOutlined) const {
   if (TIK >= Loadable)
-    return initialize(IGF, params, dest);
+    return initialize(IGF, params, dest, isOutlined);
   Address src = TI->getAddressForPointer(params.claimNext());
-  TI->initializeWithTake(IGF, dest, src, T);
+  TI->initializeWithTake(IGF, dest, src, T, isOutlined);
 }
 
 llvm::Constant *EnumImplStrategy::emitCaseNames() const {
@@ -427,19 +427,21 @@ namespace {
       getLoadableSingleton()->loadAsTake(IGF, getSingletonAddress(IGF, addr),e);
     }
 
-    void assign(IRGenFunction &IGF, Explosion &e, Address addr) const override {
+    void assign(IRGenFunction &IGF, Explosion &e, Address addr,
+                bool isOutlined) const override {
       if (!getLoadableSingleton()) return;
-      getLoadableSingleton()->assign(IGF, e, getSingletonAddress(IGF, addr));
+      getLoadableSingleton()->assign(IGF, e, getSingletonAddress(IGF, addr),
+                                     isOutlined);
     }
 
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T) const override {
+                        SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
+      if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
-        getSingleton()->assignWithCopy(IGF, dest, src,
-                                       getSingletonType(IGF.IGM, T));
+        getSingleton()->assignWithCopy(
+            IGF, dest, src, getSingletonType(IGF.IGM, T), isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -454,13 +456,13 @@ namespace {
     }
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T) const override {
+                        SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
+      if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
-        getSingleton()->assignWithTake(IGF, dest, src,
-                                       getSingletonType(IGF.IGM, T));
+        getSingleton()->assignWithTake(
+            IGF, dest, src, getSingletonType(IGF.IGM, T), isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -474,21 +476,21 @@ namespace {
       }
     }
 
-    void initialize(IRGenFunction &IGF, Explosion &e,
-                    Address addr) const override {
+    void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
+                    bool isOutlined) const override {
       if (!getLoadableSingleton()) return;
-      getLoadableSingleton()->initialize(IGF, e, getSingletonAddress(IGF, addr));
+      getLoadableSingleton()->initialize(IGF, e, getSingletonAddress(IGF, addr),
+                                         isOutlined);
     }
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
+                            SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
+      if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
-        getSingleton()->initializeWithCopy(IGF, dest, src,
-                                           getSingletonType(IGF.IGM, T));
+        getSingleton()->initializeWithCopy(
+            IGF, dest, src, getSingletonType(IGF.IGM, T), isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -503,14 +505,13 @@ namespace {
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
+                            SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
+      if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
-        getSingleton()->initializeWithTake(IGF, dest, src,
-                                           getSingletonType(IGF.IGM, T));
+        getSingleton()->initializeWithTake(
+            IGF, dest, src, getSingletonType(IGF.IGM, T), isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -926,8 +927,7 @@ namespace {
     void emitScalarFixLifetime(IRGenFunction &IGF, llvm::Value *value) const {}
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
+                            SILType T, bool isOutlined) const override {
       // No-payload enums are always POD, so we can always initialize by
       // primitive copy.
       llvm::Value *val = IGF.Builder.CreateLoad(src);
@@ -1352,18 +1352,19 @@ namespace {
       copy(IGF, tmp, e, IGF.getDefaultAtomicity());
     }
 
-    void assign(IRGenFunction &IGF, Explosion &e, Address addr) const override {
+    void assign(IRGenFunction &IGF, Explosion &e, Address addr,
+                bool isOutlined) const override {
       assert(TIK >= Loadable);
       Explosion old;
       if (!isPOD(ResilienceExpansion::Maximal))
         loadAsTake(IGF, addr, old);
-      initialize(IGF, e, addr);
+      initialize(IGF, e, addr, isOutlined);
       if (!isPOD(ResilienceExpansion::Maximal))
         consume(IGF, old, IGF.getDefaultAtomicity());
     }
 
-    void initialize(IRGenFunction &IGF, Explosion &e, Address addr)
-    const override {
+    void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
+                    bool isOutlined) const override {
       assert(TIK >= Loadable);
       auto payload = EnumPayload::fromExplosion(IGF.IGM, e, PayloadSchema);
       payload.store(IGF, projectPayload(IGF, addr));
@@ -2499,10 +2500,8 @@ namespace {
     }
 
     /// Emit a reassignment sequence from an enum at one address to another.
-    void emitIndirectAssign(IRGenFunction &IGF,
-       Address dest, Address src, SILType T,
-       IsTake_t isTake)
-    const {
+    void emitIndirectAssign(IRGenFunction &IGF, Address dest, Address src,
+                            SILType T, IsTake_t isTake, bool isOutlined) const {
       auto &C = IGF.IGM.getLLVMContext();
       auto PayloadT = getPayloadType(IGF.IGM, T);
 
@@ -2533,8 +2532,8 @@ namespace {
 
             // Here, both source and destination have payloads. Do the
             // reassignment of the payload in-place.
-            getPayloadTypeInfo().assign(IGF, destData, srcData,
-                                        isTake, PayloadT);
+            getPayloadTypeInfo().assign(IGF, destData, srcData, isTake,
+                                        PayloadT, isOutlined);
             IGF.Builder.CreateBr(endBB);
           }
 
@@ -2564,7 +2563,7 @@ namespace {
             // primitive-store the zero extra tag (if any).
 
             getPayloadTypeInfo().initialize(IGF, destData, srcData, isTake,
-                                            PayloadT);
+                                            PayloadT, isOutlined);
             emitInitializeExtraTagBitsForPayload(IGF, dest, T);
             IGF.Builder.CreateBr(endBB);
           }
@@ -2607,10 +2606,9 @@ namespace {
 
     /// Emit an initialization sequence, initializing an enum at one address
     /// with another at a different address.
-    void emitIndirectInitialize(IRGenFunction &IGF,
-                                Address dest, Address src, SILType T,
-                                IsTake_t isTake)
-    const {
+    void emitIndirectInitialize(IRGenFunction &IGF, Address dest, Address src,
+                                SILType T, IsTake_t isTake,
+                                bool isOutlined) const {
       auto &C = IGF.IGM.getLLVMContext();
 
       switch (CopyDestroyKind) {
@@ -2633,7 +2631,8 @@ namespace {
           // Here, the source value has a payload. Initialize the destination
           // with it, and set the extra tag if any to zero.
           getPayloadTypeInfo().initialize(IGF, destData, srcData, isTake,
-                                          getPayloadType(IGF.IGM, T));
+                                          getPayloadType(IGF.IGM, T),
+                                          isOutlined);
           emitInitializeExtraTagBitsForPayload(IGF, dest, T);
           IGF.Builder.CreateBr(endBB);
         }
@@ -2671,10 +2670,9 @@ namespace {
 
   public:
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectAssign(IGF, dest, src, T, IsNotTake);
+                        SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectAssign(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -2689,10 +2687,9 @@ namespace {
     }
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectAssign(IGF, dest, src, T, IsTake);
+                        SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectAssign(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -2707,10 +2704,9 @@ namespace {
     }
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
+                            SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectInitialize(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -2725,10 +2721,9 @@ namespace {
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectInitialize(IGF, dest, src, T, IsTake);
+                            SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -4166,9 +4161,8 @@ namespace {
 
   private:
     /// Emit a reassignment sequence from an enum at one address to another.
-    void emitIndirectAssign(IRGenFunction &IGF,
-                            Address dest, Address src, SILType T,
-                            IsTake_t isTake) const {
+    void emitIndirectAssign(IRGenFunction &IGF, Address dest, Address src,
+                            SILType T, IsTake_t isTake, bool isOutlined) const {
       auto &C = IGF.IGM.getLLVMContext();
 
       switch (CopyDestroyKind) {
@@ -4188,7 +4182,7 @@ namespace {
             loadAsCopy(IGF, src, tmpSrc);
 
           loadAsTake(IGF, dest, tmpOld);
-          initialize(IGF, tmpSrc, dest);
+          initialize(IGF, tmpSrc, dest, isOutlined);
           consume(IGF, tmpOld, IGF.getDefaultAtomicity());
           return;
         }
@@ -4207,7 +4201,7 @@ namespace {
         destroy(IGF, dest, T);
 
         // Reinitialize with the new value.
-        emitIndirectInitialize(IGF, dest, src, T, isTake);
+        emitIndirectInitialize(IGF, dest, src, T, isTake, isOutlined);
 
         IGF.Builder.CreateBr(endBB);
         IGF.Builder.emitBlock(endBB);
@@ -4216,10 +4210,9 @@ namespace {
       }
     }
 
-    void emitIndirectInitialize(IRGenFunction &IGF,
-                                Address dest, Address src,
-                                SILType T,
-                                IsTake_t isTake) const{
+    void emitIndirectInitialize(IRGenFunction &IGF, Address dest, Address src,
+                                SILType T, IsTake_t isTake,
+                                bool isOutlined) const {
       auto &C = IGF.IGM.getLLVMContext();
 
       switch (CopyDestroyKind) {
@@ -4242,7 +4235,7 @@ namespace {
             loadAsTake(IGF, src, tmpSrc);
           else
             loadAsCopy(IGF, src, tmpSrc);
-          initialize(IGF, tmpSrc, dest);
+          initialize(IGF, tmpSrc, dest, isOutlined);
           return;
         }
 
@@ -4307,9 +4300,11 @@ namespace {
                                     payloadTI.getStorageType()->getPointerTo());
 
           if (isTake)
-            payloadTI.initializeWithTake(IGF, destData, srcData, PayloadT);
+            payloadTI.initializeWithTake(IGF, destData, srcData, PayloadT,
+                                         isOutlined);
           else
-            payloadTI.initializeWithCopy(IGF, destData, srcData, PayloadT);
+            payloadTI.initializeWithCopy(IGF, destData, srcData, PayloadT,
+                                         isOutlined);
 
           // Plant spare bit tag bits, if any, into the new value.
           llvm::Value *tag = llvm::ConstantInt::get(IGF.IGM.Int32Ty, tagIndex);
@@ -4347,10 +4342,9 @@ namespace {
 
   public:
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectAssign(IGF, dest, src, T, IsNotTake);
+                        SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectAssign(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -4365,10 +4359,9 @@ namespace {
     }
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectAssign(IGF, dest, src, T, IsTake);
+                        SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectAssign(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -4383,10 +4376,9 @@ namespace {
     }
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
+                            SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectInitialize(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -4401,10 +4393,9 @@ namespace {
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
-      if (IGF.isInOutlinedFunction() || T.hasOpenedExistential()) {
-        emitIndirectInitialize(IGF, dest, src, T, IsTake);
+                            SILType T, bool isOutlined) const override {
+      if (isOutlined || T.hasOpenedExistential()) {
+        emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
             typeToMetadataVec;
@@ -4936,29 +4927,25 @@ namespace {
     }
 
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T)
-    const override {
+                        SILType T, bool isOutlined) const override {
       emitAssignWithCopyCall(IGF, T,
                              dest, src);
     }
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                        SILType T)
-    const override {
+                        SILType T, bool isOutlined) const override {
       emitAssignWithTakeCall(IGF, T,
                              dest, src);
     }
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
+                            SILType T, bool isOutlined) const override {
       emitInitializeWithCopyCall(IGF, T,
                                  dest, src);
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T)
-    const override {
+                            SILType T, bool isOutlined) const override {
       emitInitializeWithTakeCall(IGF, T,
                                  dest, src);
     }
@@ -5010,7 +4997,8 @@ namespace {
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                              Address dest, SILType T) const override {
+                              Address dest, SILType T,
+                              bool isOutlined) const override {
       llvm_unreachable("resilient enums are always indirect");
     }
   
@@ -5056,13 +5044,13 @@ namespace {
       llvm_unreachable("resilient enums are always indirect");
     }
 
-    void assign(IRGenFunction &IGF, Explosion &e,
-                        Address addr) const override {
+    void assign(IRGenFunction &IGF, Explosion &e, Address addr,
+                bool isOutlined) const override {
       llvm_unreachable("resilient enums are always indirect");
     }
 
-    void initialize(IRGenFunction &IGF, Explosion &e,
-                            Address addr) const override {
+    void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
+                    bool isOutlined) const override {
       llvm_unreachable("resilient enums are always indirect");
     }
 
@@ -5344,16 +5332,17 @@ namespace {
       return Strategy.destroy(IGF, addr, T);
     }
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                              Address dest, SILType T) const override {
-      return Strategy.initializeFromParams(IGF, params, dest, T);
+                              Address dest, SILType T,
+                              bool isOutlined) const override {
+      return Strategy.initializeFromParams(IGF, params, dest, T, isOutlined);
     }
-    void initializeWithCopy(IRGenFunction &IGF, Address dest,
-                            Address src, SILType T) const override {
-      return Strategy.initializeWithCopy(IGF, dest, src, T);
+    void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                            SILType T, bool isOutlined) const override {
+      return Strategy.initializeWithCopy(IGF, dest, src, T, isOutlined);
     }
-    void initializeWithTake(IRGenFunction &IGF, Address dest,
-                            Address src, SILType T) const override {
-      return Strategy.initializeWithTake(IGF, dest, src, T);
+    void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
+                            SILType T, bool isOutlined) const override {
+      return Strategy.initializeWithTake(IGF, dest, src, T, isOutlined);
     }
     void collectArchetypeMetadata(
         IRGenFunction &IGF,
@@ -5362,13 +5351,13 @@ namespace {
         SILType T) const override {
       return Strategy.collectArchetypeMetadata(IGF, typeToMetadataVec, T);
     }
-    void assignWithCopy(IRGenFunction &IGF, Address dest,
-                        Address src, SILType T) const override {
-      return Strategy.assignWithCopy(IGF, dest, src, T);
+    void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                        SILType T, bool isOutlined) const override {
+      return Strategy.assignWithCopy(IGF, dest, src, T, isOutlined);
     }
-    void assignWithTake(IRGenFunction &IGF, Address dest,
-                        Address src, SILType T) const override {
-      return Strategy.assignWithTake(IGF, dest, src, T);
+    void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
+                        SILType T, bool isOutlined) const override {
+      return Strategy.assignWithTake(IGF, dest, src, T, isOutlined);
     }
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
@@ -5447,13 +5436,13 @@ namespace {
                     Explosion &e) const override {
       return Strategy.loadAsTake(IGF, addr, e);
     }
-    void assign(IRGenFunction &IGF, Explosion &e,
-                Address addr) const override {
-      return Strategy.assign(IGF, e, addr);
+    void assign(IRGenFunction &IGF, Explosion &e, Address addr,
+                bool isOutlined) const override {
+      return Strategy.assign(IGF, e, addr, isOutlined);
     }
-    void initialize(IRGenFunction &IGF, Explosion &e,
-                    Address addr) const override {
-      return Strategy.initialize(IGF, e, addr);
+    void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
+                    bool isOutlined) const override {
+      return Strategy.initialize(IGF, e, addr, isOutlined);
     }
     void reexplode(IRGenFunction &IGF, Explosion &src,
                    Explosion &dest) const override {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2743,8 +2743,8 @@ namespace {
             &typeToMetadataVec,
         SILType T) const override {
       auto canType = T.getSwiftRValueType();
-      if (irgen::mightContainMetadata(IGF.IGM, canType)) {
-        auto *metadata = IGF.emitTypeMetadataRef(canType);
+      if (shouldEmitMetadataRefForLayout(IGF.IGM, canType)) {
+        auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
         assert(metadata && "Expected Type Metadata Ref");
         typeToMetadataVec.push_back(std::make_pair(canType, metadata));
       }
@@ -4415,8 +4415,8 @@ namespace {
             &typeToMetadataVec,
         SILType T) const override {
       auto canType = T.getSwiftRValueType();
-      if (irgen::mightContainMetadata(IGF.IGM, canType)) {
-        auto *metadata = IGF.emitTypeMetadataRef(canType);
+      if (shouldEmitMetadataRefForLayout(IGF.IGM, canType)) {
+        auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
         assert(metadata && "Expected Type Metadata Ref");
         typeToMetadataVec.push_back(std::make_pair(canType, metadata));
       }
@@ -4956,10 +4956,10 @@ namespace {
             &typeToMetadataVec,
         SILType T) const override {
       auto canType = T.getSwiftRValueType();
-      if (!irgen::mightContainMetadata(IGF.IGM, canType)) {
+      if (!shouldEmitMetadataRefForLayout(IGF.IGM, canType)) {
         return;
       }
-      auto *metadata = IGF.emitTypeMetadataRef(canType);
+      auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
       assert(metadata && "Expected Type Metadata Ref");
       typeToMetadataVec.push_back(std::make_pair(canType, metadata));
     }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2596,8 +2596,7 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -2610,8 +2609,7 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -2624,8 +2622,7 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -2638,8 +2635,7 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4238,8 +4234,7 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4252,8 +4247,7 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4266,8 +4260,7 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake);
       } else {
         // Create an outlined function to avoid explosion
@@ -4280,8 +4273,7 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T)
     const override {
-      if (IGF.isInOutlinedFunction() || (TIK < Loadable) ||
-          (T.hasArchetype())) {
+      if (IGF.isInOutlinedFunction() || T.hasArchetype()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake);
       } else {
         // Create an outlined function to avoid explosion

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -357,17 +357,18 @@ public:
   virtual void destroy(IRGenFunction &IGF, Address addr, SILType T) const = 0;
 
   virtual void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                                    Address dest, SILType T) const;
-  
-  virtual void assignWithCopy(IRGenFunction &IGF, Address dest,
-                              Address src, SILType T) const = 0;
-  virtual void assignWithTake(IRGenFunction &IGF, Address dest,
-                              Address src, SILType T) const = 0;
-  virtual void initializeWithCopy(IRGenFunction &IGF, Address dest,
-                                  Address src, SILType T) const = 0;
-  virtual void initializeWithTake(IRGenFunction &IGF, Address dest,
-                                  Address src, SILType T) const = 0;
-  
+                                    Address dest, SILType T,
+                                    bool isOutlined) const;
+
+  virtual void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                              SILType T, bool isOutlined) const = 0;
+  virtual void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
+                              SILType T, bool isOutlined) const = 0;
+  virtual void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                                  SILType T, bool isOutlined) const = 0;
+  virtual void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
+                                  SILType T, bool isOutlined) const = 0;
+
   virtual void initializeMetadata(IRGenFunction &IGF,
                                   llvm::Value *metadata,
                                   llvm::Value *vwtable,
@@ -402,10 +403,10 @@ public:
                           Explosion &e) const = 0;
   virtual void loadAsTake(IRGenFunction &IGF, Address addr,
                           Explosion &e) const = 0;
-  virtual void assign(IRGenFunction &IGF, Explosion &e,
-                      Address addr) const = 0;
-  virtual void initialize(IRGenFunction &IGF, Explosion &e,
-                          Address addr) const = 0;
+  virtual void assign(IRGenFunction &IGF, Explosion &e, Address addr,
+                      bool isOutlined) const = 0;
+  virtual void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
+                          bool isOutlined) const = 0;
   virtual void reexplode(IRGenFunction &IGF, Explosion &src,
                          Explosion &dest) const = 0;
   virtual void copy(IRGenFunction &IGF, Explosion &src,

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -436,6 +436,24 @@ public:
           &typeToMetadataVec,
       SILType T) const = 0;
 
+  bool shouldEmitMetadataRefForLayout(IRGenModule &IGM,
+                                      const CanType canType) const {
+    if (!irgen::isTypeDependent(IGM, canType)) {
+      return false;
+    }
+    if (canType->is<EnumType>()) {
+      return true;
+    }
+    auto genEnum = cast<BoundGenericEnumType>(canType);
+    assert(genEnum && "Expected a BoundGenericEnumType");
+    for (auto arg : genEnum->getGenericArgs()) {
+      if (isTypeDependent(IGM, arg->getCanonicalType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
 private:
   EnumImplStrategy(const EnumImplStrategy &) = delete;
   EnumImplStrategy &operator=(const EnumImplStrategy &) = delete;

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -429,6 +429,12 @@ public:
   virtual llvm::Value *loadRefcountedPtr(IRGenFunction &IGF, SourceLoc loc,
                                          Address addr) const;
 
+  virtual void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType T) const = 0;
+
 private:
   EnumImplStrategy(const EnumImplStrategy &) = delete;
   EnumImplStrategy &operator=(const EnumImplStrategy &) = delete;

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -432,27 +432,8 @@ public:
 
   virtual void collectArchetypeMetadata(
       IRGenFunction &IGF,
-      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          &typeToMetadataVec,
+      llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
       SILType T) const = 0;
-
-  bool shouldEmitMetadataRefForLayout(IRGenModule &IGM,
-                                      const CanType canType) const {
-    if (!irgen::isTypeDependent(IGM, canType)) {
-      return false;
-    }
-    if (canType->is<EnumType>()) {
-      return true;
-    }
-    auto genEnum = cast<BoundGenericEnumType>(canType);
-    assert(genEnum && "Expected a BoundGenericEnumType");
-    for (auto arg : genEnum->getGenericArgs()) {
-      if (isTypeDependent(IGM, arg->getCanonicalType())) {
-        return true;
-      }
-    }
-    return false;
-  }
 
 private:
   EnumImplStrategy(const EnumImplStrategy &) = delete;

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -290,8 +290,8 @@ public:
     return getLayout().projectWitnessTable(IGF, obj, index);
   }
 
-  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
+  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
 
     auto objPtrTy = dest.getAddress()->getType();
 
@@ -317,10 +317,9 @@ public:
     return metadata;
   }
 
-  void initializeWithCopy(IRGenFunction &IGF,
-                          Address dest, Address src,
-                          SILType T) const override {
-    if (IGF.isInOutlinedFunction()) {
+  void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                          SILType T, bool isOutlined) const override {
+    if (isOutlined) {
       llvm::Value *metadata = copyType(IGF, dest, src);
 
       auto layout = getLayout();
@@ -339,10 +338,9 @@ public:
     }
   }
 
-  void initializeWithTake(IRGenFunction &IGF,
-                          Address dest, Address src,
-                          SILType T) const override {
-    if (IGF.isInOutlinedFunction()) {
+  void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
+                          SILType T, bool isOutlined) const override {
+    if (isOutlined) {
       llvm::Value *metadata = copyType(IGF, dest, src);
 
       auto layout = getLayout();
@@ -408,9 +406,9 @@ public:
                           existential.getAddress()->getName() + ".weakref");
   }
 
-  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
-    if (IGF.isInOutlinedFunction()) {
+  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
+    if (isOutlined) {
       Address destValue = projectValue(IGF, dest);
       Address srcValue = projectValue(IGF, src);
       asDerived().emitValueAssignWithCopy(IGF, destValue, srcValue);
@@ -422,10 +420,9 @@ public:
     }
   }
 
-  void initializeWithCopy(IRGenFunction &IGF,
-                          Address dest, Address src,
-                          SILType T) const override {
-    if (IGF.isInOutlinedFunction()) {
+  void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                          SILType T, bool isOutlined) const override {
+    if (isOutlined) {
       Address destValue = projectValue(IGF, dest);
       Address srcValue = projectValue(IGF, src);
       asDerived().emitValueInitializeWithCopy(IGF, destValue, srcValue);
@@ -437,10 +434,9 @@ public:
     }
   }
 
-  void assignWithTake(IRGenFunction &IGF,
-                      Address dest, Address src,
-                      SILType T) const override {
-    if (IGF.isInOutlinedFunction()) {
+  void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
+    if (isOutlined) {
       Address destValue = projectValue(IGF, dest);
       Address srcValue = projectValue(IGF, src);
       asDerived().emitValueAssignWithTake(IGF, destValue, srcValue);
@@ -452,10 +448,9 @@ public:
     }
   }
 
-  void initializeWithTake(IRGenFunction &IGF,
-                          Address dest, Address src,
-                          SILType T) const override {
-    if (IGF.isInOutlinedFunction()) {
+  void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
+                          SILType T, bool isOutlined) const override {
+    if (isOutlined) {
       Address destValue = projectValue(IGF, dest);
       Address srcValue = projectValue(IGF, src);
       asDerived().emitValueInitializeWithTake(IGF, destValue, srcValue);
@@ -811,8 +806,8 @@ public:
     asDerived().emitLoadOfTables(IGF, address, e);
   }
 
-  void assign(IRGenFunction &IGF, Explosion &e,
-              Address address) const override {
+  void assign(IRGenFunction &IGF, Explosion &e, Address address,
+              bool isOutlined) const override {
     // Assign the value.
     Address instanceAddr = asDerived().projectValue(IGF, address);
     llvm::Value *old = IGF.Builder.CreateLoad(instanceAddr);
@@ -823,8 +818,8 @@ public:
     asDerived().emitStoreOfTables(IGF, e, address);
   }
 
-  void initialize(IRGenFunction &IGF, Explosion &e,
-                  Address address) const override {
+  void initialize(IRGenFunction &IGF, Explosion &e, Address address,
+                  bool isOutlined) const override {
     // Store the instance pointer.
     IGF.Builder.CreateStore(e.claimNext(),
                             asDerived().projectValue(IGF, address));
@@ -2038,7 +2033,8 @@ static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
 
 Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
     IRGenFunction &IGF, SILType existentialType, SILType valueType,
-    Address existentialContainer, GenericEnvironment *genericEnv) {
+    Address existentialContainer, GenericEnvironment *genericEnv,
+    bool isOutlined) {
 
   // Project to the existential buffer in the existential container.
   auto &existentialTI =
@@ -2060,7 +2056,8 @@ Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
     }
     // Otherwise, allocate a box with enough storage.
     Address addr = emitAllocateExistentialBoxInBuffer(
-        IGF, valueType, existentialBuffer, genericEnv, "exist.box.addr");
+        IGF, valueType, existentialBuffer, genericEnv, "exist.box.addr",
+        isOutlined);
     return addr;
   }
   /// Call a function to handle the non-fixed case.

--- a/lib/IRGen/GenExistential.h
+++ b/lib/IRGen/GenExistential.h
@@ -86,7 +86,8 @@ namespace irgen {
                                                    SILType destType,
                                                    SILType valueType,
                                                    Address existentialContainer,
-                                                   GenericEnvironment *genEnv);
+                                                   GenericEnvironment *genEnv,
+                                                   bool isOutlined);
   /// Deallocate the storage for an opaque existential in the existential
   /// container.
   /// If the value is not stored inline, this will deallocate the box for the

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -268,8 +268,8 @@ namespace {
       e.add(IGF.Builder.CreateLoad(dataAddr));
     }
 
-    void assign(IRGenFunction &IGF, Explosion &e,
-                Address address) const override {
+    void assign(IRGenFunction &IGF, Explosion &e, Address address,
+                bool isOutlined) const override {
       // Store the function pointer.
       Address fnAddr = projectFunction(IGF, address);
       IGF.Builder.CreateStore(e.claimNext(), fnAddr);
@@ -282,8 +282,8 @@ namespace {
         IGF.emitNativeStrongAssign(context, dataAddr);
     }
 
-    void initialize(IRGenFunction &IGF, Explosion &e,
-                    Address address) const override {
+    void initialize(IRGenFunction &IGF, Explosion &e, Address address,
+                    bool isOutlined) const override {
       // Store the function pointer.
       Address fnAddr = projectFunction(IGF, address);
       IGF.Builder.CreateStore(e.claimNext(), fnAddr);
@@ -486,13 +486,13 @@ namespace {
     // TODO
     // The frontend will currently never emit copy_addr or destroy_addr for
     // block storage.
-    
-    void assignWithCopy(IRGenFunction &IGF, Address dest,
-                        Address src, SILType T) const override {
+
+    void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                        SILType T, bool isOutlined) const override {
       IGF.unimplemented(SourceLoc(), "copying @block_storage");
     }
-    void initializeWithCopy(IRGenFunction &IGF, Address dest,
-                            Address src, SILType T) const override {
+    void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                            SILType T, bool isOutlined) const override {
       IGF.unimplemented(SourceLoc(), "copying @block_storage");
     }
     void destroy(IRGenFunction &IGF, Address addr, SILType T) const override {
@@ -875,7 +875,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       // Map back from the explosion scheme to the native calling convention for
       // the call.
       Explosion nativeApplyArg = nativeSchemaOrigParam.mapIntoNative(
-          subIGF.IGM, subIGF, nonNativeApplyArg, origParamSILType);
+          subIGF.IGM, subIGF, nonNativeApplyArg, origParamSILType, false);
       assert(nonNativeApplyArg.empty());
       nativeApplyArg.transferInto(args, nativeApplyArg.size());
     }
@@ -1089,7 +1089,8 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
         needsAllocas = true;
         auto stackAddr = fieldTI.allocateStack(subIGF, fieldTy, false, "arg.temp");
         auto addressPointer = stackAddr.getAddress().getAddress();
-        fieldTI.initializeWithCopy(subIGF, stackAddr.getAddress(), fieldAddr, fieldTy);
+        fieldTI.initializeWithCopy(subIGF, stackAddr.getAddress(), fieldAddr,
+                                   fieldTy, false);
         param.add(addressPointer);
         
         // Remember to deallocate later.
@@ -1149,7 +1150,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
             origParamI + 1 == origType->getParameters().size());
         needsAllocas |= addNativeArgument(
             subIGF, origParam, origParamInfo,
-            isWitnessMethodCalleeSelf ? witnessMethodSelfValue : args);
+            isWitnessMethodCalleeSelf ? witnessMethodSelfValue : args, false);
         ++origParamI;
       } else {
         args.add(param.claimAll());
@@ -1279,7 +1280,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       cast<LoadableTypeInfo>(outResultTI)
           .loadAsTake(subIGF, resultValueAddr, loadedResult);
       Explosion nativeResult = nativeResultSchema.mapIntoNative(
-          IGM, subIGF, loadedResult, outConv.getSILResultType());
+          IGM, subIGF, loadedResult, outConv.getSILResultType(), false);
       outResultTI.deallocateStack(subIGF, resultValueAddr,
                                   outConv.getSILResultType());
       if (nativeResult.size() == 1)
@@ -1310,17 +1311,12 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
 /// Emit a partial application thunk for a function pointer applied to a partial
 /// set of argument values.
-void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
-                                           SILFunction &SILFn,
-                                           const FunctionPointer &fn,
-                                           llvm::Value *fnContext,
-                                           Explosion &args,
-                                           ArrayRef<SILParameterInfo> params,
-                                           SubstitutionList subs,
-                                           CanSILFunctionType origType,
-                                           CanSILFunctionType substType,
-                                           CanSILFunctionType outType,
-                                           Explosion &out) {
+void irgen::emitFunctionPartialApplication(
+    IRGenFunction &IGF, SILFunction &SILFn, const FunctionPointer &fn,
+    llvm::Value *fnContext, Explosion &args, ArrayRef<SILParameterInfo> params,
+    SubstitutionList subs, CanSILFunctionType origType,
+    CanSILFunctionType substType, CanSILFunctionType outType, Explosion &out,
+    bool isOutlined) {
   // If we have a single Swift-refcounted context value, we can adopt it
   // directly as our closure context without creating a box and thunk.
   enum HasSingleSwiftRefcountedContext { Maybe, Yes, No, Thunkable }
@@ -1558,7 +1554,8 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
       case ParameterConvention::Indirect_In_Constant:
       case ParameterConvention::Indirect_In_Guaranteed: {
         auto addr = fieldLayout.getType().getAddressForPointer(args.claimNext());
-        fieldLayout.getType().initializeWithTake(IGF, fieldAddr, addr, fieldTy);
+        fieldLayout.getType().initializeWithTake(IGF, fieldAddr, addr, fieldTy,
+                                                 isOutlined);
         break;
       }
       // Take direct value arguments and inout pointers by value.
@@ -1568,7 +1565,7 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
       case ParameterConvention::Indirect_Inout:
       case ParameterConvention::Indirect_InoutAliasable:
         cast<LoadableTypeInfo>(fieldLayout.getType())
-          .initialize(IGF, args, fieldAddr);
+            .initialize(IGF, args, fieldAddr, isOutlined);
         break;
       }
     }
@@ -1624,8 +1621,8 @@ static llvm::Function *emitBlockCopyHelper(IRGenModule &IGM,
   auto srcCapture = blockTL.projectCapture(IGF, src);
   auto &captureTL = IGM.getTypeInfoForLowered(blockTy->getCaptureType());
   captureTL.initializeWithCopy(IGF, destCapture, srcCapture,
-                               blockTy->getCaptureAddressType());
-  
+                               blockTy->getCaptureAddressType(), false);
+
   IGF.Builder.CreateRetVoid();
   
   return func;

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -47,18 +47,13 @@ namespace irgen {
 
   /// Emit a partial application thunk for a function pointer applied to a
   /// partial set of argument values.
-  void emitFunctionPartialApplication(IRGenFunction &IGF,
-                                      SILFunction &SILFn,
-                                      const FunctionPointer &fnPtr,
-                                      llvm::Value *fnContext,
-                                      Explosion &args,
-                                      ArrayRef<SILParameterInfo> argTypes,
-                                      SubstitutionList subs,
-                                      CanSILFunctionType origType,
-                                      CanSILFunctionType substType,
-                                      CanSILFunctionType outType,
-                                      Explosion &out);
-  
+  void emitFunctionPartialApplication(
+      IRGenFunction &IGF, SILFunction &SILFn, const FunctionPointer &fnPtr,
+      llvm::Value *fnContext, Explosion &args,
+      ArrayRef<SILParameterInfo> argTypes, SubstitutionList subs,
+      CanSILFunctionType origType, CanSILFunctionType substType,
+      CanSILFunctionType outType, Explosion &out, bool isOutlined);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -494,22 +494,24 @@ namespace {
         ValueType(valueType) {}
 
     void initializeWithCopy(IRGenFunction &IGF, Address destAddr,
-                            Address srcAddr, SILType T) const override {
+                            Address srcAddr, SILType T,
+                            bool isOutlined) const override {
       IGF.emitNativeWeakCopyInit(destAddr, srcAddr);
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address destAddr,
-                            Address srcAddr, SILType T) const override {
+                            Address srcAddr, SILType T,
+                            bool isOutlined) const override {
       IGF.emitNativeWeakTakeInit(destAddr, srcAddr);
     }
 
-    void assignWithCopy(IRGenFunction &IGF, Address destAddr,
-                        Address srcAddr, SILType T) const override {
+    void assignWithCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                        SILType T, bool isOutlined) const override {
       IGF.emitNativeWeakCopyAssign(destAddr, srcAddr);
     }
 
-    void assignWithTake(IRGenFunction &IGF, Address destAddr,
-                        Address srcAddr, SILType T) const override {
+    void assignWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                        SILType T, bool isOutlined) const override {
       IGF.emitNativeWeakTakeAssign(destAddr, srcAddr);
     }
 
@@ -649,23 +651,23 @@ namespace {
                          IsNotPOD, IsNotBitwiseTakable, IsFixedSize) {
     }
 
-    void assignWithCopy(IRGenFunction &IGF, Address dest,
-                        Address src, SILType type) const override {
+    void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                        SILType type, bool isOutlined) const override {
       IGF.emitUnknownUnownedCopyAssign(dest, src);
     }
 
-    void initializeWithCopy(IRGenFunction &IGF, Address dest,
-                            Address src, SILType type) const override {
+    void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                            SILType type, bool isOutlined) const override {
       IGF.emitUnknownUnownedCopyInit(dest, src);
     }
 
-    void assignWithTake(IRGenFunction &IGF, Address dest,
-                        Address src, SILType type) const override {
+    void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
+                        SILType type, bool isOutlined) const override {
       IGF.emitUnknownUnownedTakeAssign(dest, src);
     }
 
-    void initializeWithTake(IRGenFunction &IGF, Address dest,
-                            Address src, SILType type) const override {
+    void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
+                            SILType type, bool isOutlined) const override {
       IGF.emitUnknownUnownedTakeInit(dest, src);
     }
 
@@ -722,22 +724,24 @@ namespace {
         ValueType(valueType) {}
 
     void initializeWithCopy(IRGenFunction &IGF, Address destAddr,
-                            Address srcAddr, SILType T) const override {
+                            Address srcAddr, SILType T,
+                            bool isOutlined) const override {
       IGF.emitUnknownWeakCopyInit(destAddr, srcAddr);
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address destAddr,
-                            Address srcAddr, SILType T) const override {
+                            Address srcAddr, SILType T,
+                            bool isOutlined) const override {
       IGF.emitUnknownWeakTakeInit(destAddr, srcAddr);
     }
 
-    void assignWithCopy(IRGenFunction &IGF, Address destAddr,
-                        Address srcAddr, SILType T) const override {
+    void assignWithCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                        SILType T, bool isOutlined) const override {
       IGF.emitUnknownWeakCopyAssign(destAddr, srcAddr);
     }
 
-    void assignWithTake(IRGenFunction &IGF, Address destAddr,
-                        Address srcAddr, SILType T) const override {
+    void assignWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                        SILType T, bool isOutlined) const override {
       IGF.emitUnknownWeakTakeAssign(destAddr, srcAddr);
     }
 
@@ -1687,11 +1691,9 @@ Address irgen::emitProjectBox(IRGenFunction &IGF,
                        boxType->getFieldType(IGF.IGM.getSILModule(), 0));
 }
 
-Address irgen::emitAllocateExistentialBoxInBuffer(IRGenFunction &IGF,
-                                                  SILType boxedType,
-                                                  Address destBuffer,
-                                                  GenericEnvironment *env,
-                                                  const llvm::Twine &name) {
+Address irgen::emitAllocateExistentialBoxInBuffer(
+    IRGenFunction &IGF, SILType boxedType, Address destBuffer,
+    GenericEnvironment *env, const llvm::Twine &name, bool isOutlined) {
   // Get a box for the boxed value.
   auto boxType = SILBoxType::get(boxedType.getSwiftRValueType());
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
@@ -1702,7 +1704,8 @@ Address irgen::emitAllocateExistentialBoxInBuffer(IRGenFunction &IGF,
                    Address(IGF.Builder.CreateBitCast(
                                destBuffer.getAddress(),
                                owned.getOwner()->getType()->getPointerTo()),
-                           destBuffer.getAlignment()));
+                           destBuffer.getAlignment()),
+                   isOutlined);
   return owned.getAddress();
 }
 

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -134,11 +134,10 @@ Address emitProjectBox(IRGenFunction &IGF, llvm::Value *box,
 
 /// Allocate a boxed value based on the boxed type. Returns the address of the
 /// storage for the value.
-Address emitAllocateExistentialBoxInBuffer(IRGenFunction &IGF,
-                                           SILType boxedType,
-                                           Address destBuffer,
-                                           GenericEnvironment *env,
-                                           const llvm::Twine &name);
+Address
+emitAllocateExistentialBoxInBuffer(IRGenFunction &IGF, SILType boxedType,
+                                   Address destBuffer, GenericEnvironment *env,
+                                   const llvm::Twine &name, bool isOutlined);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -447,8 +447,8 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         auto destEltAddr = ti.getAddressForPointer(
           IGF.Builder.CreateBitCast(destElt,
                                     ti.getStorageType()->getPointerTo()));
-        
-        ti.initializeWithCopy(IGF, destEltAddr, sourceEltAddr, ty);
+
+        ti.initializeWithCopy(IGF, destEltAddr, sourceEltAddr, ty, false);
         auto size = ti.getSize(IGF, ty);
         offset = IGF.Builder.CreateAdd(offset, size);
       }
@@ -590,9 +590,11 @@ getInitializerForComputedComponent(IRGenModule &IGM,
       // The last component using an operand can move the value out of the
       // buffer.
       if (&component == operands[index.Operand].LastUser) {
-        ti.initializeWithTake(IGF, destAddr, srcAddresses[index.Operand], ty);
+        ti.initializeWithTake(IGF, destAddr, srcAddresses[index.Operand], ty,
+                              false);
       } else {
-        ti.initializeWithCopy(IGF, destAddr, srcAddresses[index.Operand], ty);
+        ti.initializeWithCopy(IGF, destAddr, srcAddresses[index.Operand], ty,
+                              false);
       }
       auto size = ti.getSize(IGF, ty);
       offset = IGF.Builder.CreateAdd(offset, size);

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -307,6 +307,10 @@ namespace irgen {
   /// Get the runtime identifier for a special protocol, if any.
   SpecialProtocol getSpecialProtocolID(ProtocolDecl *P);
 
+  /// Use the argument as the 'self' type metadata.
+  void getArgAsLocalSelfTypeMetadata(IRGenFunction &IGF, llvm::Value *arg,
+                                     CanType abstractType);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -347,8 +347,9 @@ namespace {
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                              Address addr, SILType T) const override {
-      ClangRecordTypeInfo::initialize(IGF, params, addr);
+                              Address addr, SILType T,
+                              bool isOutlined) const override {
+      ClangRecordTypeInfo::initialize(IGF, params, addr, isOutlined);
     }
 
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
@@ -396,8 +397,9 @@ namespace {
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                              Address addr, SILType T) const override {
-      LoadableStructTypeInfo::initialize(IGF, params, addr);
+                              Address addr, SILType T,
+                              bool isOutlined) const override {
+      LoadableStructTypeInfo::initialize(IGF, params, addr, isOutlined);
     }
     llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const {
       return None;

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -158,7 +158,8 @@ namespace {
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                              Address src, SILType T) const override {
+                              Address src, SILType T,
+                              bool isOutlined) const override {
       llvm_unreachable("unexploded tuple as argument?");
     }
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1800,87 +1800,10 @@ static bool isIRTypeDependent(IRGenModule &IGM, NominalTypeDecl *decl) {
   }
 }
 
-bool irgen::mightContainMetadata(const IRGenModule &IGM, const CanType type) {
+bool irgen::isTypeDependent(const IRGenModule &IGM, const CanType type) {
   IRGenModule &IGMCast = const_cast<IRGenModule &>(IGM);
   auto runType = irgen::getRuntimeReifiedType(IGMCast, type);
-  if (!IsIRTypeDependent(IGMCast).visit(runType)) {
-    return false;
-  }
-  switch (runType->getKind()) {
-#define SUGARED_TYPE(ID, SUPER) case TypeKind::ID:
-#define UNCHECKED_TYPE(ID, SUPER) case TypeKind::ID:
-#define TYPE(ID, SUPER)
-#include "swift/AST/TypeNodes.def"
-  case TypeKind::Error:
-    llvm_unreachable("kind is invalid for a canonical type");
-
-#define ARTIFICIAL_TYPE(ID, SUPER) case TypeKind::ID:
-#define TYPE(ID, SUPER)
-#include "swift/AST/TypeNodes.def"
-  case TypeKind::LValue:
-  case TypeKind::InOut:
-  case TypeKind::DynamicSelf:
-    return false;
-
-// Builtin types might contain metadata
-#define BUILTIN_TYPE(ID, SUPER) case TypeKind::ID:
-#define TYPE(ID, SUPER)
-#include "swift/AST/TypeNodes.def"
-  case TypeKind::Module:
-    return true;
-
-  // Type parameters
-  case TypeKind::Archetype:
-  case TypeKind::GenericTypeParam:
-  case TypeKind::DependentMember:
-    return true;
-
-  case TypeKind::Tuple: {
-    auto genTuple = cast<TupleType>(runType);
-    for (auto elt : genTuple->getElements()) {
-      if (mightContainMetadata(IGM, elt.getType()->getCanonicalType())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // Nominal types
-  case TypeKind::Class:
-  case TypeKind::Enum:
-  case TypeKind::Protocol:
-  case TypeKind::Struct:
-    return true;
-
-  case TypeKind::BoundGenericEnum: {
-    auto genEnum = cast<BoundGenericEnumType>(runType);
-    for (auto arg : genEnum->getGenericArgs()) {
-      if (mightContainMetadata(IGM, arg->getCanonicalType())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // Bound generic types
-  case TypeKind::BoundGenericClass:
-  case TypeKind::BoundGenericStruct:
-    return true;
-
-  // Function types do not have metadata
-  case TypeKind::Function:
-  case TypeKind::GenericFunction:
-    return false;
-
-  case TypeKind::ProtocolComposition:
-    return true;
-
-  // Metatypes
-  case TypeKind::Metatype:
-  case TypeKind::ExistentialMetatype:
-    return true;
-  }
-  llvm_unreachable("bad type kind");
+  return IsIRTypeDependent(IGMCast).visit(runType);
 }
 
 TypeCacheEntry TypeConverter::convertAnyNominalType(CanType type,

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1778,7 +1778,6 @@ namespace {
     bool visitAnyFunctionType(CanAnyFunctionType type) {
       return false;
     }
-    bool visitSILFunctionType(CanSILFunctionType type) { return false; }
 
     // The safe default for a dependent type is to assume that it
     // needs its own implementation.
@@ -1798,12 +1797,6 @@ static bool isIRTypeDependent(IRGenModule &IGM, NominalTypeDecl *decl) {
     auto enumDecl = cast<EnumDecl>(decl);
     return IsIRTypeDependent(IGM).visitEnumDecl(enumDecl);
   }
-}
-
-bool irgen::isTypeDependent(const IRGenModule &IGM, const CanType type) {
-  IRGenModule &IGMCast = const_cast<IRGenModule &>(IGM);
-  auto runType = irgen::getRuntimeReifiedType(IGMCast, type);
-  return IsIRTypeDependent(IGMCast).visit(runType);
 }
 
 TypeCacheEntry TypeConverter::convertAnyNominalType(CanType type,

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1392,22 +1392,11 @@ void TypeInfo::assignArrayWithTake(IRGenFunction &IGF, Address dest,
   emitAssignArrayWithTakeCall(IGF, T, dest, src, count);
 }
 
-static bool shouldEmitTypeMetadata(const CanType canType) {
-  // Determine whether this type is an Archetype itself.
-  if (!canType->getWithoutSpecifierType()->is<ArchetypeType>()) {
-    return false;
-  }
-  return true;
-}
-
 void TypeInfo::collectArchetypeMetadata(
     IRGenFunction &IGF,
-    llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4> &typeToMetadataVec,
+    llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
     SILType T) const {
   auto canType = T.getSwiftRValueType();
-  if (shouldEmitTypeMetadata(canType)) {
-    auto *metadata = IGF.emitTypeMetadataRef(canType);
-    assert(metadata && "Expected Type Metadata Ref");
-    typeToMetadataVec.push_back(std::make_pair(canType, metadata));
-  }
+  assert(!canType->getWithoutSpecifierType()->is<ArchetypeType>() &&
+         "Did not expect an ArchetypeType");
 }

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -313,7 +313,7 @@ static Address emitDefaultInitializeBufferWithCopyOfBuffer(
         emitDefaultAllocateBuffer(IGF, destBuffer, T, type, packing);
     Address srcObject =
         emitDefaultProjectBuffer(IGF, srcBuffer, T, type, packing);
-    type.initializeWithCopy(IGF, destObject, srcObject, T);
+    type.initializeWithCopy(IGF, destObject, srcObject, T, true);
     return destObject;
   } else {
     assert(packing == FixedPacking::Allocate);
@@ -353,7 +353,7 @@ emitDefaultInitializeBufferWithTakeOfBuffer(IRGenFunction &IGF,
       emitDefaultAllocateBuffer(IGF, destBuffer, T, type, packing);
     Address srcObject =
       emitDefaultProjectBuffer(IGF, srcBuffer, T, type, packing);
-    type.initializeWithTake(IGF, destObject, srcObject, T);
+    type.initializeWithTake(IGF, destObject, srcObject, T, true);
     return destObject;
   }
 
@@ -484,7 +484,6 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
   assert(isValueWitnessFunction(index));
 
   IRGenFunction IGF(IGM, fn);
-  IGF.setInOutlinedFunction();
   if (IGM.DebugInfo)
     IGM.DebugInfo->emitArtificialFunction(IGF, fn);
 
@@ -494,7 +493,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     Address dest = getArgAs(IGF, argv, type, "dest");
     Address src = getArgAs(IGF, argv, type, "src");
     getArgAsLocalSelfTypeMetadata(IGF, argv, abstractType);
-    type.assignWithCopy(IGF, dest, src, concreteType);
+    type.assignWithCopy(IGF, dest, src, concreteType, true);
     dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
@@ -504,7 +503,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     Address dest = getArgAs(IGF, argv, type, "dest");
     Address src = getArgAs(IGF, argv, type, "src");
     getArgAsLocalSelfTypeMetadata(IGF, argv, abstractType);
-    type.assignWithTake(IGF, dest, src, concreteType);
+    type.assignWithTake(IGF, dest, src, concreteType, true);
     dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
@@ -549,7 +548,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     Address src = getArgAs(IGF, argv, type, "src");
     getArgAsLocalSelfTypeMetadata(IGF, argv, abstractType);
 
-    type.initializeWithCopy(IGF, dest, src, concreteType);
+    type.initializeWithCopy(IGF, dest, src, concreteType, true);
     dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
@@ -560,7 +559,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     Address src = getArgAs(IGF, argv, type, "src");
     getArgAsLocalSelfTypeMetadata(IGF, argv, abstractType);
 
-    type.initializeWithTake(IGF, dest, src, concreteType);
+    type.initializeWithTake(IGF, dest, src, concreteType, true);
     dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1392,12 +1392,20 @@ void TypeInfo::assignArrayWithTake(IRGenFunction &IGF, Address dest,
   emitAssignArrayWithTakeCall(IGF, T, dest, src, count);
 }
 
+static bool shouldEmitTypeMetadata(const CanType canType) {
+  // Determine whether this type is an Archetype itself.
+  if (!canType->getWithoutSpecifierType()->is<ArchetypeType>()) {
+    return false;
+  }
+  return true;
+}
+
 void TypeInfo::collectArchetypeMetadata(
     IRGenFunction &IGF,
     llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4> &typeToMetadataVec,
     SILType T) const {
   auto canType = T.getSwiftRValueType();
-  if (irgen::mightContainMetadata(IGF.IGM, canType)) {
+  if (shouldEmitTypeMetadata(canType)) {
     auto *metadata = IGF.emitTypeMetadataRef(canType);
     assert(metadata && "Expected Type Metadata Ref");
     typeToMetadataVec.push_back(std::make_pair(canType, metadata));

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -438,3 +438,8 @@ void IRGenFunction::setInOutlinedFunction() {
   assert(!isInOutlinedFunction() && "Expected inOutlinedFunction to be false");
   inOutlinedFunction = true;
 }
+
+void IRGenFunction::setNotInOutlinedFunction() {
+  assert(isInOutlinedFunction() && "Expected inOutlinedFunction to be true");
+  inOutlinedFunction = false;
+}

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -37,8 +37,7 @@ IRGenFunction::IRGenFunction(IRGenModule &IGM, llvm::Function *Fn,
                              Optional<SILLocation> DbgLoc)
     : IGM(IGM), Builder(IGM.getLLVMContext(),
                         IGM.DebugInfo && !IGM.Context.LangOpts.DebuggerSupport),
-      OptMode(OptMode),
-      CurFn(Fn), DbgScope(DbgScope), inOutlinedFunction(false) {
+      OptMode(OptMode), CurFn(Fn), DbgScope(DbgScope) {
 
   // Make sure the instructions in this function are attached its debug scope.
   if (IGM.DebugInfo) {
@@ -430,16 +429,4 @@ Address IRGenFunction::emitAddressAtOffset(llvm::Value *base, Offset offset,
   auto offsetValue = offset.getAsValue(*this);
   auto slotPtr = emitByteOffsetGEP(base, offsetValue, objectTy);
   return Address(slotPtr, objectAlignment);
-}
-
-bool IRGenFunction::isInOutlinedFunction() { return inOutlinedFunction; }
-
-void IRGenFunction::setInOutlinedFunction() {
-  assert(!isInOutlinedFunction() && "Expected inOutlinedFunction to be false");
-  inOutlinedFunction = true;
-}
-
-void IRGenFunction::setNotInOutlinedFunction() {
-  assert(isInOutlinedFunction() && "Expected inOutlinedFunction to be true");
-  inOutlinedFunction = false;
 }

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -575,6 +575,7 @@ public:
 public:
   bool isInOutlinedFunction();
   void setInOutlinedFunction();
+  void setNotInOutlinedFunction();
 
 private:
   LocalTypeDataCache &getOrCreateLocalTypeData();

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -90,7 +90,7 @@ public:
 public:
   Explosion collectParameters();
   void emitScalarReturn(SILType resultTy, Explosion &scalars,
-                        bool isSwiftCCReturn);
+                        bool isSwiftCCReturn, bool isOutlined);
   void emitScalarReturn(llvm::Type *resultTy, Explosion &scalars);
   
   void emitBBForReturn();
@@ -570,13 +570,6 @@ public:
   llvm::Value *getLocalSelfMetadata();
   void setLocalSelfMetadata(llvm::Value *value, LocalSelfKind kind);
 
-public:
-  //--- Outlined Function Support -------------------------------------------
-public:
-  bool isInOutlinedFunction();
-  void setInOutlinedFunction();
-  void setNotInOutlinedFunction();
-
 private:
   LocalTypeDataCache &getOrCreateLocalTypeData();
   void destroyLocalTypeData();
@@ -593,10 +586,6 @@ private:
   llvm::Value *LocalSelf = nullptr;
   
   LocalSelfKind SelfKind;
-
-  /// Flag indiacting wherever we are in the middle of creating
-  /// an outlined address type function
-  bool inOutlinedFunction;
 };
 
 using ConditionalDominanceScope = IRGenFunction::ConditionalDominanceScope;

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -180,8 +180,9 @@ public:
     beginMangling();
     if (!t->hasArchetype()) {
       appendType(t);
-      appendOperator("Wb", Index(0));
+      appendOperator("Wb", Index(1));
     } else {
+      appendModule(mod->getSwiftModule());
       appendOperator("y");
       appendOperator("t");
       appendOperator("Wb", Index(mod->getCanTypeID(t)));
@@ -193,8 +194,9 @@ public:
     beginMangling();
     if (!t->hasArchetype()) {
       appendType(t);
-      appendOperator("Wc", Index(0));
+      appendOperator("Wc", Index(1));
     } else {
+      appendModule(mod->getSwiftModule());
       appendOperator("y");
       appendOperator("t");
       appendOperator("Wc", Index(mod->getCanTypeID(t)));
@@ -206,8 +208,9 @@ public:
     beginMangling();
     if (!t->hasArchetype()) {
       appendType(t);
-      appendOperator("Wd", Index(0));
+      appendOperator("Wd", Index(1));
     } else {
+      appendModule(mod->getSwiftModule());
       appendOperator("y");
       appendOperator("t");
       appendOperator("Wd", Index(mod->getCanTypeID(t)));
@@ -219,8 +222,9 @@ public:
     beginMangling();
     if (!t->hasArchetype()) {
       appendType(t);
-      appendOperator("Wf", Index(0));
+      appendOperator("Wf", Index(1));
     } else {
+      appendModule(mod->getSwiftModule());
       appendOperator("y");
       appendOperator("t");
       appendOperator("Wf", Index(mod->getCanTypeID(t)));

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -13,7 +13,9 @@
 #ifndef SWIFT_IRGEN_IRGENMANGLER_H
 #define SWIFT_IRGEN_IRGENMANGLER_H
 
+#include "IRGenModule.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/IRGen/ValueWitness.h"
 
 namespace swift {
@@ -173,28 +175,56 @@ public:
     return finalize();
   }
 
-  std::string mangleOutlinedInitializeWithTakeFunction(const Type t) {
+  std::string mangleOutlinedInitializeWithTakeFunction(const CanType t,
+                                                       IRGenModule *mod) {
     beginMangling();
-    appendType(t);
-    appendOperator("Wb");
+    if (!t->hasArchetype()) {
+      appendType(t);
+      appendOperator("Wb", Index(0));
+    } else {
+      appendOperator("y");
+      appendOperator("t");
+      appendOperator("Wb", Index(mod->getCanTypeID(t)));
+    }
     return finalize();
   }
-  std::string mangleOutlinedInitializeWithCopyFunction(const Type t) {
+  std::string mangleOutlinedInitializeWithCopyFunction(const CanType t,
+                                                       IRGenModule *mod) {
     beginMangling();
-    appendType(t);
-    appendOperator("Wc");
+    if (!t->hasArchetype()) {
+      appendType(t);
+      appendOperator("Wc", Index(0));
+    } else {
+      appendOperator("y");
+      appendOperator("t");
+      appendOperator("Wc", Index(mod->getCanTypeID(t)));
+    }
     return finalize();
   }
-  std::string mangleOutlinedAssignWithTakeFunction(const Type t) {
+  std::string mangleOutlinedAssignWithTakeFunction(const CanType t,
+                                                   IRGenModule *mod) {
     beginMangling();
-    appendType(t);
-    appendOperator("Wd");
+    if (!t->hasArchetype()) {
+      appendType(t);
+      appendOperator("Wd", Index(0));
+    } else {
+      appendOperator("y");
+      appendOperator("t");
+      appendOperator("Wd", Index(mod->getCanTypeID(t)));
+    }
     return finalize();
   }
-  std::string mangleOutlinedAssignWithCopyFunction(const Type t) {
+  std::string mangleOutlinedAssignWithCopyFunction(const CanType t,
+                                                   IRGenModule *mod) {
     beginMangling();
-    appendType(t);
-    appendOperator("Wf");
+    if (!t->hasArchetype()) {
+      appendType(t);
+      appendOperator("Wf", Index(0));
+    } else {
+      appendOperator("y");
+      appendOperator("t");
+      appendOperator("Wf", Index(mod->getCanTypeID(t)));
+    }
     return finalize();
   }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -18,28 +18,29 @@
 #ifndef SWIFT_IRGEN_IRGENMODULE_H
 #define SWIFT_IRGEN_IRGENMODULE_H
 
+#include "IRGen.h"
+#include "SwiftTargetInfo.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
-#include "swift/SIL/SILFunction.h"
-#include "swift/Basic/LLVM.h"
 #include "swift/Basic/ClusteredBitVector.h"
-#include "swift/Basic/SuccessorMap.h"
+#include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptimizationMode.h"
+#include "swift/Basic/SuccessorMap.h"
+#include "swift/IRGen/ValueWitness.h"
+#include "swift/SIL/SILFunction.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/ValueHandle.h"
-#include "llvm/IR/Attributes.h"
 #include "llvm/Target/TargetMachine.h"
-#include "IRGen.h"
-#include "SwiftTargetInfo.h"
-#include "swift/IRGen/ValueWitness.h"
 
 #include <atomic>
 
@@ -718,34 +719,33 @@ public:
 
   typedef llvm::Constant *(IRGenModule::*OutlinedCopyAddrFunction)(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec);
 
   void generateCallToOutlinedCopyAddr(
       IRGenFunction &IGF, const TypeInfo &objectTI, Address dest, Address src,
       SILType T, const OutlinedCopyAddrFunction MethodToCall,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec = nullptr);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec =
+          nullptr);
 
   llvm::Constant *getOrCreateOutlinedInitializeWithTakeFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec = nullptr);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec =
+          nullptr);
 
   llvm::Constant *getOrCreateOutlinedInitializeWithCopyFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec = nullptr);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec =
+          nullptr);
 
   llvm::Constant *getOrCreateOutlinedAssignWithTakeFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec = nullptr);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec =
+          nullptr);
 
   llvm::Constant *getOrCreateOutlinedAssignWithCopyFunction(
       const TypeInfo &objectTI, llvm::Type *llvmType, SILType addrTy,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec = nullptr);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec =
+          nullptr);
 
   unsigned getCanTypeID(const CanType type);
 
@@ -759,8 +759,8 @@ private:
       llvm::function_ref<void(const TypeInfo &objectTI, IRGenFunction &IGF,
                               Address dest, Address src, SILType T)>
           Generate,
-      const llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          *typeToMetadataVec = nullptr);
+      const llvm::MapVector<CanType, llvm::Value *> *typeToMetadataVec =
+          nullptr);
 
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalVars;
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalGOTEquivalents;
@@ -847,7 +847,7 @@ private:
 
   /// Mapping from archetype-containing CanType to UniqueID (for outline)
   llvm::DenseMap<const swift::TypeBase *, unsigned> typeToUniqueID;
-  unsigned currUniqueID = 0;
+  unsigned currUniqueID = 2;
 
   ObjCProtocolPair getObjCProtocolGlobalVars(ProtocolDecl *proto);
   void emitLazyObjCProtocolDefinitions();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2321,8 +2321,8 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   
   Explosion llArgs;
 
+  // Lower the parameters in the callee's generic context.
   {
-    // Lower the parameters in the callee's generic context.
     GenericContextScope scope(IGM, i->getOrigCalleeType()->getGenericSignature());
     for (auto index : indices(args)) {
       assert(args[index]->getType() == IGM.silConv.getSILType(params[index]));

--- a/lib/IRGen/IndirectTypeInfo.h
+++ b/lib/IRGen/IndirectTypeInfo.h
@@ -50,16 +50,16 @@ public:
                                               this->getBestKnownAlignment()));
   }
 
-  void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                            Address dest, SILType T) const override {
+  void initializeFromParams(IRGenFunction &IGF, Explosion &params, Address dest,
+                            SILType T, bool isOutlined) const override {
     Address src = this->getAddressForPointer(params.claimNext());
-    asDerived().Derived::initializeWithTake(IGF, dest, src, T);
+    asDerived().Derived::initializeWithTake(IGF, dest, src, T, isOutlined);
   }
 
-  void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
+  void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
     asDerived().Derived::destroy(IGF, dest, T);
-    asDerived().Derived::initializeWithTake(IGF, dest, src, T);
+    asDerived().Derived::initializeWithTake(IGF, dest, src, T, isOutlined);
   }
 };
 

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -94,17 +94,16 @@ public:
 
   /// Assign a set of exploded values into an address.  The values are
   /// consumed out of the explosion.
-  virtual void assign(IRGenFunction &IGF, Explosion &explosion,
-                      Address addr) const = 0;
+  virtual void assign(IRGenFunction &IGF, Explosion &explosion, Address addr,
+                      bool isOutlined) const = 0;
 
   /// Initialize an address by consuming values out of an explosion.
   virtual void initialize(IRGenFunction &IGF, Explosion &explosion,
-                          Address addr) const = 0;
-
+                          Address addr, bool isOutlined) const = 0;
 
   // We can give this a reasonable default implementation.
-  void initializeWithCopy(IRGenFunction &IGF, Address destAddr,
-                          Address srcAddr, SILType T) const override;
+  void initializeWithCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                          SILType T, bool isOutlined) const override;
 
   /// Consume a bunch of values which have exploded at one explosion
   /// level and produce them at another.

--- a/lib/IRGen/NativeConventionSchema.h
+++ b/lib/IRGen/NativeConventionSchema.h
@@ -55,7 +55,8 @@ public:
   /// Map from a non-native explosion to an explosion that follows the native
   /// calling convention's schema.
   Explosion mapIntoNative(IRGenModule &IGM, IRGenFunction &IGF,
-                          Explosion &fromNonNative, SILType type) const;
+                          Explosion &fromNonNative, SILType type,
+                          bool isOutlined) const;
 
   /// Map form a native explosion that follows the native calling convention's
   /// schema to a non-native explosion whose schema is described by

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -47,8 +47,8 @@ protected:
                                  IsNotPOD, IsNotBitwiseTakable) {}
 
 public:
-  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
+  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
     emitAssignWithCopyCall(IGF, T, dest, src);
   }
 
@@ -70,8 +70,8 @@ public:
     emitAssignArrayWithCopyBackToFrontCall(IGF, T, dest, src, count);
   }
 
-  void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
+  void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
     emitAssignWithTakeCall(IGF, T, dest, src);
   }
 
@@ -94,8 +94,8 @@ public:
     return this->getAddressForPointer(addr);
   }
 
-  void initializeWithCopy(IRGenFunction &IGF,
-                        Address dest, Address src, SILType T) const override {
+  void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                          SILType T, bool isOutlined) const override {
     emitInitializeWithCopyCall(IGF, T, dest, src);
   }
 
@@ -105,8 +105,8 @@ public:
     emitInitializeArrayWithCopyCall(IGF, T, dest, src, count);
   }
 
-  void initializeWithTake(IRGenFunction &IGF,
-                        Address dest, Address src, SILType T) const override {
+  void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
+                          SILType T, bool isOutlined) const override {
     emitInitializeWithTakeCall(IGF, T, dest, src);
   }
 

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -42,30 +42,30 @@ protected:
   }
 
 public:
-  void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                            Address dest, SILType T) const override {
-    asDerived().Derived::initialize(IGF, params, dest);
+  void initializeFromParams(IRGenFunction &IGF, Explosion &params, Address dest,
+                            SILType T, bool isOutlined) const override {
+    asDerived().Derived::initialize(IGF, params, dest, isOutlined);
   }
 
   void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                          SILType T) const override {
+                          SILType T, bool isOutlined) const override {
     Explosion temp;
     asDerived().Derived::loadAsCopy(IGF, src, temp);
-    asDerived().Derived::initialize(IGF, temp, dest);
+    asDerived().Derived::initialize(IGF, temp, dest, isOutlined);
   }
 
-  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
+  void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
     Explosion temp;
     asDerived().Derived::loadAsCopy(IGF, src, temp);
-    asDerived().Derived::assign(IGF, temp, dest);
+    asDerived().Derived::assign(IGF, temp, dest, isOutlined);
   }
 
-  void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const override {
+  void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
+                      bool isOutlined) const override {
     Explosion temp;
     asDerived().Derived::loadAsTake(IGF, src, temp);
-    asDerived().Derived::assign(IGF, temp, dest);
+    asDerived().Derived::assign(IGF, temp, dest, isOutlined);
   }
 
   void reexplode(IRGenFunction &IGF, Explosion &in,
@@ -117,8 +117,8 @@ public:
     schema.add(ExplosionSchema::Element::forScalar(ty));
   }
 
-  void initialize(IRGenFunction &IGF, Explosion &src,
-                  Address addr) const override {
+  void initialize(IRGenFunction &IGF, Explosion &src, Address addr,
+                  bool isOutlined) const override {
     addr = asDerived().projectScalar(IGF, addr);
     IGF.Builder.CreateStore(src.claimNext(), addr);
   }
@@ -137,7 +137,8 @@ public:
     out.add(IGF.Builder.CreateLoad(addr));
   }
 
-  void assign(IRGenFunction &IGF, Explosion &src, Address dest) const override {
+  void assign(IRGenFunction &IGF, Explosion &src, Address dest,
+              bool isOutlined) const override {
     // Project down.
     dest = asDerived().projectScalar(IGF, dest);
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -500,7 +500,7 @@ public:
                       llvm::Value *typeMetadata,
                       SILType T) const;
 };
-bool mightContainMetadata(const IRGenModule &IGM, const CanType type);
+bool isTypeDependent(const IRGenModule &IGM, const CanType type);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -276,34 +276,36 @@ public:
   /// old value in the destination.  Equivalent to either assignWithCopy
   /// or assignWithTake depending on the value of isTake.
   void assign(IRGenFunction &IGF, Address dest, Address src, IsTake_t isTake,
-              SILType T) const;
+              SILType T, bool isOutlined) const;
 
   /// Copy a value out of an object and into another, destroying the
   /// old value in the destination.
-  virtual void assignWithCopy(IRGenFunction &IGF, Address dest,
-                              Address src, SILType T) const = 0;
+  virtual void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                              SILType T, bool isOutlined) const = 0;
 
   /// Move a value out of an object and into another, destroying the
   /// old value there and leaving the source object in an invalid state.
-  virtual void assignWithTake(IRGenFunction &IGF, Address dest,
-                              Address src, SILType T) const = 0;
+  virtual void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
+                              SILType T, bool isOutlined) const = 0;
 
   /// Copy-initialize or take-initialize an uninitialized object
   /// with the value from a different object.  Equivalent to either
   /// initializeWithCopy or initializeWithTake depending on the value
   /// of isTake.
   void initialize(IRGenFunction &IGF, Address dest, Address src,
-                  IsTake_t isTake, SILType T) const;
+                  IsTake_t isTake, SILType T, bool isOutlined) const;
 
   /// Perform a "take-initialization" from the given object.  A
   /// take-initialization is like a C++ move-initialization, except that
   /// the old object is actually no longer permitted to be destroyed.
   virtual void initializeWithTake(IRGenFunction &IGF, Address destAddr,
-                                  Address srcAddr, SILType T) const = 0;
+                                  Address srcAddr, SILType T,
+                                  bool isOutlined) const = 0;
 
   /// Perform a copy-initialization from the given object.
   virtual void initializeWithCopy(IRGenFunction &IGF, Address destAddr,
-                                  Address srcAddr, SILType T) const = 0;
+                                  Address srcAddr, SILType T,
+                                  bool isOutlined) const = 0;
 
   /// Perform a copy-initialization from the given fixed-size buffer
   /// into an uninitialized fixed-size buffer, allocating the buffer if
@@ -338,7 +340,8 @@ public:
 
   /// Take-initialize an address from a parameter explosion.
   virtual void initializeFromParams(IRGenFunction &IGF, Explosion &params,
-                                    Address src, SILType T) const = 0;
+                                    Address src, SILType T,
+                                    bool isOutlined) const = 0;
 
   /// Destroy an object of this type in memory.
   virtual void destroy(IRGenFunction &IGF, Address address, SILType T) const = 0;

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -477,6 +477,14 @@ public:
                                    Address src, llvm::Value *count,
                                    SILType T) const;
 
+  /// Outlining helper function: recursively traverse the SILType:
+  /// When encountering an Archetype - add it to a type-metadata vec.
+  virtual void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
+          &typeToMetadataVec,
+      SILType T) const;
+
   /// Get the native (abi) convention for a return value of this type.
   const NativeConventionSchema &nativeReturnValueSchema(IRGenModule &IGM) const;
 
@@ -489,6 +497,7 @@ public:
                       llvm::Value *typeMetadata,
                       SILType T) const;
 };
+bool mightContainMetadata(const IRGenModule &IGM, const CanType type);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -26,6 +26,7 @@
 #define SWIFT_IRGEN_TYPEINFO_H
 
 #include "IRGen.h"
+#include "llvm/ADT/MapVector.h"
 
 namespace llvm {
   class Constant;
@@ -484,8 +485,7 @@ public:
   /// When encountering an Archetype - add it to a type-metadata vec.
   virtual void collectArchetypeMetadata(
       IRGenFunction &IGF,
-      llvm::SmallVector<std::pair<CanType, llvm::Value *>, 4>
-          &typeToMetadataVec,
+      llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
       SILType T) const;
 
   /// Get the native (abi) convention for a return value of this type.
@@ -500,7 +500,6 @@ public:
                       llvm::Value *typeMetadata,
                       SILType T) const;
 };
-bool isTypeDependent(const IRGenModule &IGM, const CanType type);
 
 } // end namespace irgen
 } // end namespace swift

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -231,7 +231,7 @@ sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
 entry(%u : $Singleton):
-// CHECK-32:  [[CAST:%.*]] = bitcast %T4enum9SingletonO* %0 to <{ i64, i64 }>*
+// CHECK-32:  call %T4enum9SingletonO* @_T04enum9SingletonOWb0_
 // CHECK-64:   br label %[[PREDEST:[0-9]+]]
 // CHECK-32:   br label %[[PREDEST:[0-9]+]]
   switch_enum %u : $Singleton, case #Singleton.value!enumelt.1: dest

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -24,27 +24,42 @@ enum NullableRefcounted {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases18NullableRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases18NullableRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases18NullableRefcountedO* @_T034enum_value_semantics_special_cases18NullableRefcountedOWc(%T34enum_value_semantics_special_cases18NullableRefcountedO* %1, %T34enum_value_semantics_special_cases18NullableRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
+// CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %3, align 8
+// CHECK:   %5 = call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %4) #2
+// CHECK:   store %swift.refcounted* %4, %swift.refcounted** %2, align 8
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases18NullableRefcountedOwca(%swift.opaque* %dest, %swift.opaque* %src, %swift.type* %NullableRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases18NullableRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases18NullableRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases18NullableRefcountedO* @_T034enum_value_semantics_special_cases18NullableRefcountedOWf(%T34enum_value_semantics_special_cases18NullableRefcountedO* %1, %T34enum_value_semantics_special_cases18NullableRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
+// CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
+// CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
+// CHECK:   %6 = call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5) #2
+// CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) #2
+// CHECK:   %7 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %7
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases18NullableRefcountedOwta(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %NullableRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases18NullableRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases18NullableRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases18NullableRefcountedO* @_T034enum_value_semantics_special_cases18NullableRefcountedOWd(%T34enum_value_semantics_special_cases18NullableRefcountedO* %1, %T34enum_value_semantics_special_cases18NullableRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.refcounted**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %1 to %swift.refcounted**
+// CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
+// CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
+// CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) #2
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases18NullableRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // Enums consisting of a retainable block pointer and a single empty case use
@@ -67,27 +82,42 @@ enum NullableBlockRefcounted {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
-// CHECK:   %2 =  call %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOWc(%T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1, %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %objc_block**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1 to %objc_block**
+// CHECK:   %4 = load %objc_block*, %objc_block** %3, align 8
+// CHECK:   %5 = call %objc_block* @_Block_copy(%objc_block* %4)
+// CHECK:   store %objc_block* %4, %objc_block** %2, align 8
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOwca(%swift.opaque* %dest, %swift.opaque* %src, %swift.type* %NullableBlockRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOWf(%T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1, %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %objc_block**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1 to %objc_block**
+// CHECK:   %4 = load %objc_block*, %objc_block** %2, align 8
+// CHECK:   %5 = load %objc_block*, %objc_block** %3, align 8
+// CHECK:   %6 = call %objc_block* @_Block_copy(%objc_block* %5)
+// CHECK:   store %objc_block* %5, %objc_block** %2, align 8
+// CHECK:   call void @_Block_release(%objc_block* %4) #2
+// CHECK:   %7 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %7
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOwta(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %NullableBlockRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %dest to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
 // CHECK:   %1 = bitcast %swift.opaque* %src to %T34enum_value_semantics_special_cases23NullableBlockRefcountedO*
-// CHECK:   %2 = call %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* @_T034enum_value_semantics_special_cases23NullableBlockRefcountedOWd(%T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1, %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0)
-// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
-// CHECK:   ret %swift.opaque* %3
+// CHECK:   %2 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %objc_block**
+// CHECK:   %3 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %1 to %objc_block**
+// CHECK:   %4 = load %objc_block*, %objc_block** %2, align 8
+// CHECK:   %5 = load %objc_block*, %objc_block** %3, align 8
+// CHECK:   store %objc_block* %5, %objc_block** %2, align 8
+// CHECK:   call void @_Block_release(%objc_block* %4) #2
+// CHECK:   %6 = bitcast %T34enum_value_semantics_special_cases23NullableBlockRefcountedO* %0 to %swift.opaque*
+// CHECK:   ret %swift.opaque* %6
 // CHECK: }
 
 // With multiple empty cases, the nullable pointer semantics aren't used.
@@ -134,16 +164,6 @@ enum AllRefcounted {
   case None
 }
 
-// CHECK-LABEL: define linkonce_odr hidden %T34enum_value_semantics_special_cases13AllRefcountedO* @_T034enum_value_semantics_special_cases13AllRefcountedOWc(%T34enum_value_semantics_special_cases13AllRefcountedO*, %T34enum_value_semantics_special_cases13AllRefcountedO*)
-// --                              0x3fffffffffffffff
-// CHECK:         %4 = and i64 %3, 4611686018427387903
-// CHECK:         %5 = inttoptr i64 %4 to %swift.refcounted*
-// CHECK:         call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5)
-// CHECK:         %7 = bitcast %T34enum_value_semantics_special_cases13AllRefcountedO* %1 to i64*
-// -- NB: The original loaded value is stored, not the masked one.
-// CHECK:         store i64 %3, i64* %7, align 8
-// CHECK: }
-
 // CHECK-LABEL: define linkonce_odr hidden void @_T034enum_value_semantics_special_cases13AllRefcountedOwxx(%swift.opaque* noalias %object, %swift.type* %AllRefcounted) {{.*}} {
 // CHECK: entry:
 // CHECK:   %0 = bitcast %swift.opaque* %object to %T34enum_value_semantics_special_cases13AllRefcountedO*
@@ -154,6 +174,16 @@ enum AllRefcounted {
 // CHECK:   %4 = inttoptr i64 %3 to %swift.refcounted*
 // CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK:   ret void
+// CHECK: }
+
+// CHECK-LABEL: define linkonce_odr hidden %swift.opaque* @_T034enum_value_semantics_special_cases13AllRefcountedOwcp(%swift.opaque* noalias %dest, %swift.opaque* noalias %src, %swift.type* %AllRefcounted)
+// --                              0x3fffffffffffffff
+// CHECK:         %4 = and i64 %3, 4611686018427387903
+// CHECK:         %5 = inttoptr i64 %4 to %swift.refcounted*
+// CHECK:         call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned %5)
+// CHECK:         %6 = bitcast %T34enum_value_semantics_special_cases13AllRefcountedO* %0 to i64*
+// -- NB: The original loaded value is stored, not the masked one.
+// CHECK:         store i64 %3, i64* %6, align 8
 // CHECK: }
 
 enum AllRefcountedTwoSimple {

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -67,16 +67,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWb_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWb0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWd_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWd0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWc_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWc0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWf_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWf0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
 
   // CHECK: [[REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -67,16 +67,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWb({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWb_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWd({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWd_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWc({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWc_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWf({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T012existentials2CP_pSgXwWf_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
 
   // CHECK: [[REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -39,10 +39,10 @@ bb0(%0 : $*Any, %1 : $*Any):
 }
 
 // CHECK-DAG:   define{{( protected)?}} swiftcc void @take_opaque_existential([[ANY:%Any]]* noalias nocapture sret, %Any* noalias nocapture dereferenceable({{.*}})) {{.*}} {
-// CHECK: call %Any* @_T0ypWb_(%Any* %1, %Any* %0)
+// CHECK: call %Any* @_T0ypWb0_(%Any* %1, %Any* %0)
 // CHECK-NEXT:    ret void
 
-// CHECK-DAG:   define{{( protected)?}} linkonce_odr hidden %Any* @_T0ypWb_([[ANY:%Any]]*, %Any*)
+// CHECK-DAG:   define{{( protected)?}} internal %Any* @_T0ypWb0_([[ANY:%Any]]*, %Any*)
 // CHECK:         [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[SRC:%0]], i32 0, i32 1
 // CHECK-NEXT:    [[TYPE:%.*]] = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[DEST:%1]], i32 0, i32 1
@@ -138,16 +138,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWb_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWb0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWd_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWd0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWc_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWc0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWf_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWf0_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
 
   // CHECK: [[REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -39,10 +39,10 @@ bb0(%0 : $*Any, %1 : $*Any):
 }
 
 // CHECK-DAG:   define{{( protected)?}} swiftcc void @take_opaque_existential([[ANY:%Any]]* noalias nocapture sret, %Any* noalias nocapture dereferenceable({{.*}})) {{.*}} {
-// CHECK: call %Any* @_T0ypWb(%Any* %1, %Any* %0)
+// CHECK: call %Any* @_T0ypWb_(%Any* %1, %Any* %0)
 // CHECK-NEXT:    ret void
 
-// CHECK-DAG:   define{{( protected)?}} linkonce_odr hidden %Any* @_T0ypWb([[ANY:%Any]]*, %Any*)
+// CHECK-DAG:   define{{( protected)?}} linkonce_odr hidden %Any* @_T0ypWb_([[ANY:%Any]]*, %Any*)
 // CHECK:         [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[SRC:%0]], i32 0, i32 1
 // CHECK-NEXT:    [[TYPE:%.*]] = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[DEST:%1]], i32 0, i32 1
@@ -138,16 +138,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWb({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWb_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWd({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWd_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWc({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWc_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to [initialization] %v : $*@sil_weak CP?
 
-  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWf({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
+  // CHECK: call { %swift.weak, i8** }* @_T017existentials_objc2CP_pSgXwWf_({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
 
   // CHECK: [[REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* [[V]], i32 0, i32 0

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -432,7 +432,7 @@ bb0(%0 : $*Existential):
 // CHECK: define{{( protected)?}} swiftcc void @test_assignWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
-// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
+// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
 // CHECK:   ret void
 sil @test_assignWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -443,7 +443,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 // CHECK:   [[LOCAL_METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1
@@ -465,7 +465,7 @@ bb0(%0 : $*Existential):
 
 // CHECK: define{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
+// CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
 sil @test_initWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -478,9 +478,9 @@ bb0(%0 : $*Existential):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @test_initWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
+// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[TYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[ARG_TYPE:%.*]] = load %swift.type*, %swift.type** [[TYPE_ADDR]]
 // CHECK:   [[LOCAL_TYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -432,7 +432,7 @@ bb0(%0 : $*Existential):
 // CHECK: define{{( protected)?}} swiftcc void @test_assignWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
-// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
+// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb0_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
 // CHECK:   ret void
 sil @test_assignWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -443,7 +443,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK: define{{( protected)?}} internal %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb0_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 // CHECK:   [[LOCAL_METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1
@@ -465,7 +465,7 @@ bb0(%0 : $*Existential):
 
 // CHECK: define{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
+// CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWb0_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
 sil @test_initWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -478,9 +478,9 @@ bb0(%0 : $*Existential):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @test_initWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
+// CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc0_(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( protected)?}} internal %T25existentials_opaque_boxed11ExistentialP* @_T025existentials_opaque_boxed11Existential_pWc0_(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[TYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[ARG_TYPE:%.*]] = load %swift.type*, %swift.type** [[TYPE_ADDR]]
 // CHECK:   [[LOCAL_TYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -214,9 +214,7 @@ sil public_external @indirect_consumed_captured_class_pair_param : $@convention(
 
 // CHECK:       define internal swiftcc i64 [[PARTIAL_APPLY_FORWARDER]]
 // CHECK:         [[X_TMP:%.*]] = alloca
-// CHECK:         retain
-// CHECK:         retain
-// CHECK-NOT:     retain
+// CHECK:         call %T13partial_apply14SwiftClassPairV* @_T013partial_apply14SwiftClassPairVWc_
 // CHECK:         release{{.*}}%1)
 // CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_pair_param(i64 %0, %T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}) [[X_TMP]])
 // CHECK:         ret i64 [[RESULT]]

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -214,7 +214,7 @@ sil public_external @indirect_consumed_captured_class_pair_param : $@convention(
 
 // CHECK:       define internal swiftcc i64 [[PARTIAL_APPLY_FORWARDER]]
 // CHECK:         [[X_TMP:%.*]] = alloca
-// CHECK:         call %T13partial_apply14SwiftClassPairV* @_T013partial_apply14SwiftClassPairVWc_
+// CHECK:         call %T13partial_apply14SwiftClassPairV* @_T013partial_apply14SwiftClassPairVWc0_
 // CHECK:         release{{.*}}%1)
 // CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_pair_param(i64 %0, %T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}) [[X_TMP]])
 // CHECK:         ret i64 [[RESULT]]

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -61,7 +61,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[PV:%0]])
   store_unowned %p to [initialization] %x : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWc_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWc0_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr %x to [initialization] %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
@@ -73,7 +73,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call void @swift_unknownRelease([[UNKNOWN]]* [[TV]])
   strong_release %t0 : $P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWf_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWf0_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr %x to %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
@@ -82,10 +82,10 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedAssign(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[QV:%2]])
   store_unowned %q to %y : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWd_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWd0_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr [take] %x to %y : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWb_({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWb0_({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
   copy_addr [take] %y to [initialization] %x : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -61,7 +61,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[PV:%0]])
   store_unowned %p to [initialization] %x : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWc({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWc_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr %x to [initialization] %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
@@ -73,7 +73,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call void @swift_unknownRelease([[UNKNOWN]]* [[TV]])
   strong_release %t0 : $P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWf({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWf_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr %x to %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 1
@@ -82,10 +82,10 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: call %swift.unowned* @swift_unknownUnownedAssign(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[QV:%2]])
   store_unowned %q to %y : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWd({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWd_({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
   copy_addr [take] %x to %y : $*@sil_unowned P
 
-  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWb({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
+  // CHECK-NEXT: call { %swift.unowned, i8** }* @_T012unowned_objc1P_pXoWb_({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
   copy_addr [take] %y to [initialization] %x : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0


### PR DESCRIPTION
radar rdar://problem/33942466

Part two of `copy_addr`outlining: supports passing the Metatype information to the outlined function / outlining `CanType` that contain Archetypes

This is a modified version of PR https://github.com/apple/swift/pull/12840 that incorporates changes from some online/offline comments