### PR TITLE
SILGen: Remaining fixes for @callee_guaranteed closures and enable it

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -115,7 +115,7 @@ public:
   
   /// Emit captures and function contexts using +0 caller-guaranteed ARC
   /// conventions.
-  bool EnableGuaranteedClosureContexts = false;
+  bool EnableGuaranteedClosureContexts = true;
 
   /// Don't generate code using partial_apply in SIL generation.
   bool DisableSILPartialApply = false;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 385; // Last change: Optimization attribute
+const uint16_t VERSION_MINOR = 386; // Last change: @callee_guaranted closures
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1101,7 +1101,8 @@ public:
         }
         auto loweredResultTy = SGF.getLoweredLoadableType(resultTy);
         if (loweredResultTy != selfValue.getType()) {
-          selfValue = SGF.B.createUpcast(ice, selfValue, loweredResultTy);
+          selfValue = SGF.emitManagedRValueWithCleanup(
+              SGF.B.createUpcast(ice, selfValue.forward(SGF), loweredResultTy));
         }
 
         selfArg = ice->getSubExpr();
@@ -4100,8 +4101,8 @@ CallEmission::applyPartiallyAppliedSuperMethod(SGFContext C) {
   SILValue partialApply =
       SGF.B.createPartialApply(loc, superMethod.getValue(), partialApplyTy,
                                subs, {upcastedSelf.forward(SGF)}, closureTy);
-  firstLevelResult.value = RValue(SGF, loc, formalApplyType.getResult(),
-                                  ManagedValue::forUnmanaged(partialApply));
+  ManagedValue pa = SGF.emitManagedRValueWithCleanup(partialApply);
+  firstLevelResult.value = RValue(SGF, loc, formalApplyType.getResult(), pa);
   return firstLevelResult;
 }
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -811,7 +811,9 @@ static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
   // Add the block argument.
   SILValue blockV =
       entry->createFunctionArgument(SILType::getPrimitiveObjectType(blockTy));
-  ManagedValue block = SGF.emitManagedRValueWithCleanup(blockV);
+  ManagedValue block = SGF.SGM.M.getOptions().EnableGuaranteedClosureContexts
+                           ? ManagedValue::forUnmanaged(blockV)
+                           : SGF.emitManagedRValueWithCleanup(blockV);
 
   CanType formalResultType = formalFuncTy.getResult();
 

--- a/test/ClangImporter/serialization-sil.swift
+++ b/test/ClangImporter/serialization-sil.swift
@@ -12,32 +12,32 @@ public func testPartialApply(_ obj: Test) {
     // CHECK: dynamic_method_br [[CURRIED1_OBJ:%.+]] : $@opened([[CURRIED1_EXISTENTIAL:.+]]) Test, #Test.normalObject!1.foreign, [[CURRIED1_TRUE:[^,]+]], [[CURRIED1_FALSE:[^,]+]]
     // CHECK: [[CURRIED1_FALSE]]:
     // CHECK: [[CURRIED1_TRUE]]([[CURRIED1_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject):
-    // CHECK: [[CURRIED1_PARTIAL:%.+]] = partial_apply [[CURRIED1_METHOD]]([[CURRIED1_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
-    // CHECK: [[CURRIED1_THUNK:%.+]] = function_ref @_T0yXlIexo_ypIexr_TR : $@convention(thin) (@owned @callee_owned () -> @owned AnyObject) -> @out Any
-    // CHECK: = partial_apply [[CURRIED1_THUNK]]([[CURRIED1_PARTIAL]])
+    // CHECK: [[CURRIED1_PARTIAL:%.+]] = partial_apply [callee_guaranteed] [[CURRIED1_METHOD]]([[CURRIED1_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
+    // CHECK: [[CURRIED1_THUNK:%.+]] = function_ref @_T0yXlIego_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @owned AnyObject) -> @out Any
+    // CHECK: = partial_apply [callee_guaranteed] [[CURRIED1_THUNK]]([[CURRIED1_PARTIAL]])
     curried1()
   }
   if let curried2 = obj.innerPointer {
     // CHECK: dynamic_method_br [[CURRIED2_OBJ:%.+]] : $@opened([[CURRIED2_EXISTENTIAL:.+]]) Test, #Test.innerPointer!1.foreign, [[CURRIED2_TRUE:[^,]+]], [[CURRIED2_FALSE:[^,]+]]
     // CHECK: [[CURRIED2_FALSE]]:
     // CHECK: [[CURRIED2_TRUE]]([[CURRIED2_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer):
-    // CHECK: [[CURRIED2_PARTIAL:%.+]] = partial_apply [[CURRIED2_METHOD]]([[CURRIED2_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
+    // CHECK: [[CURRIED2_PARTIAL:%.+]] = partial_apply [callee_guaranteed] [[CURRIED2_METHOD]]([[CURRIED2_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
     curried2()
   }
   if let prop1 = obj.normalObjectProp {
     // CHECK: dynamic_method_br [[PROP1_OBJ:%.+]] : $@opened([[PROP1_EXISTENTIAL:.+]]) Test, #Test.normalObjectProp!getter.1.foreign, [[PROP1_TRUE:[^,]+]], [[PROP1_FALSE:[^,]+]]
     // CHECK: [[PROP1_FALSE]]:
     // CHECK: [[PROP1_TRUE]]([[PROP1_METHOD:%.+]] : $@convention(objc_method) (@opened([[PROP1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject):
-    // CHECK: [[PROP1_PARTIAL:%.+]] = partial_apply [[PROP1_METHOD]]([[PROP1_OBJ]]) : $@convention(objc_method) (@opened([[PROP1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
-    // CHECK: = apply [[PROP1_PARTIAL]]() : $@callee_owned () -> @owned AnyObject
+    // CHECK: [[PROP1_PARTIAL:%.+]] = partial_apply [callee_guaranteed] [[PROP1_METHOD]]([[PROP1_OBJ]]) : $@convention(objc_method) (@opened([[PROP1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
+    // CHECK: = apply [[PROP1_PARTIAL]]() : $@callee_guaranteed () -> @owned AnyObject
     _ = prop1
   }
   if let prop2 = obj.innerPointerProp {
     // CHECK: dynamic_method_br [[PROP2_OBJ:%.+]] : $@opened([[PROP2_EXISTENTIAL:.+]]) Test, #Test.innerPointerProp!getter.1.foreign, [[PROP2_TRUE:[^,]+]], [[PROP2_FALSE:[^,]+]]
     // CHECK: [[PROP2_FALSE]]:
     // CHECK: [[PROP2_TRUE]]([[PROP2_METHOD:%.+]] : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer):
-    // CHECK: [[PROP2_PARTIAL:%.+]] = partial_apply [[PROP2_METHOD]]([[PROP2_OBJ]]) : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
-    // CHECK: = apply [[PROP2_PARTIAL]]() : $@callee_owned () -> UnsafeMutableRawPointer
+    // CHECK: [[PROP2_PARTIAL:%.+]] = partial_apply [callee_guaranteed] [[PROP2_METHOD]]([[PROP2_OBJ]]) : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
+    // CHECK: = apply [[PROP2_PARTIAL]]() : $@callee_guaranteed () -> UnsafeMutableRawPointer
     _ = prop2
   }
 } // CHECK: // end sil function '_T04Test16testPartialApplyySoAA_pF'

--- a/test/Constraints/rdar35142121.swift
+++ b/test/Constraints/rdar35142121.swift
@@ -8,5 +8,5 @@ func foo(_ a: (Int) -> (Int)) -> Int {
   return 42
 }
 
-// CHECK: function_ref @_T012rdar351421213fooS3icF : $@convention(thin) (@owned @noescape @callee_owned (Int) -> Int) -> Int
+// CHECK: function_ref @_T012rdar351421213fooS3icF : $@convention(thin) (@owned @noescape @callee_guaranteed (Int) -> Int) -> Int
 let _ = foo({ (a: Int) -> Int in a + 1 })

--- a/test/DebugInfo/closure-multivalue.swift
+++ b/test/DebugInfo/closure-multivalue.swift
@@ -39,4 +39,4 @@ demo()
 // CHECK-O0-NOT: DW_OP_bit_piece
 // CHECK-O0: !DILocalVariable(name: "b", arg: 2{{.*}} line: 17,
 // CHECK-O0-NOT: DW_OP_bit_piece
-// CHECK-O0: !DISubprogram(linkageName: "_T0S2SSbs5Error_pIxxxdzo_S2SSbsAA_pIxiidzo_TR",
+// CHECK-O0: !DISubprogram(linkageName: "_T0S2SSbs5Error_pIgxxdzo_S2SSbsAA_pIgiidzo_TR",

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -12,7 +12,7 @@ func barz(_ i: Float, _ j: Float) -> Int64 { return 0; }
 func main() -> Int64 {
     // CHECK-DAG: !DILocalVariable(name: "bar_fnptr",{{.*}} line: [[@LINE+3]],{{.*}} type: ![[BARPT:[0-9]+]]
     // AST-DAG: !DILocalVariable(name: "bar_fnptr",{{.*}} line: [[@LINE+2]],{{.*}} type: ![[BAR_T:[0-9]+]]
-    // AST-DAG: ![[BAR_T]] = !DICompositeType({{.*}}, identifier: "_T0Iex_D")
+    // AST-DAG: ![[BAR_T]] = !DICompositeType({{.*}}, identifier: "_T0Ieg_D")
     var bar_fnptr = bar
     // CHECK-DAG: ![[BARPT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} elements: ![[BARMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARMEMBERS]] = !{![[BARMEMBER:.*]], {{.*}}}
@@ -25,7 +25,7 @@ func main() -> Int64 {
 
     // CHECK-DAG: !DILocalVariable(name: "baz_fnptr",{{.*}} type: ![[BAZPT:[0-9]+]]
     // AST-DAG: !DILocalVariable(name: "baz_fnptr",{{.*}} type: ![[BAZ_T:[0-9]+]]
-    // AST-DAG: ![[BAZ_T]] = !DICompositeType({{.*}}, identifier: "_T0Sfs5Int64VIexyd_D")
+    // AST-DAG: ![[BAZ_T]] = !DICompositeType({{.*}}, identifier: "_T0Sfs5Int64VIegyd_D")
     // CHECK-DAG: ![[BAZPT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} elements: ![[BAZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BAZMEMBERS]] = !{![[BAZMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BAZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BAZPTR:[0-9]+]]
@@ -39,7 +39,7 @@ func main() -> Int64 {
 
     // CHECK-DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZPT:[0-9]+]]
     // AST_DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZ_T:[0-9]+]]
-    // AST-DAG: ![[BARZ_T:[0-9]+]] = !DICompositeType({{.*}}, identifier: "_T0S2fs5Int64VIexyyd_D")
+    // AST-DAG: ![[BARZ_T:[0-9]+]] = !DICompositeType({{.*}}, identifier: "_T0S2fs5Int64VIegyyd_D")
     // CHECK-DAG: ![[BARZPT]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} elements: ![[BARZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARZMEMBERS]] = !{![[BARZMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BARZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BARZPTR:[0-9]+]]

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -45,7 +45,7 @@ struct Wrapper<T: AProtocol> {
   }
 }
 
-// CHECK-DAG: ![[FNTY:.*]] = !DICompositeType({{.*}}identifier: "_T012generic_args5applyq_x_q_xc1ftr0_lFQq_AaBq_x_q_xcACtr0_lFQq0_Ixir_D"
+// CHECK-DAG: ![[FNTY:.*]] = !DICompositeType({{.*}}identifier: "_T012generic_args5applyq_x_q_xc1ftr0_lFQq_AaBq_x_q_xcACtr0_lFQq0_Igir_D"
 // CHECK-DAG: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+1]], type: ![[FNTY]])
 func apply<T, U> (_ x: T, f: (T) -> (U)) -> U {
   return f(x)

--- a/test/DebugInfo/linetable.swift
+++ b/test/DebugInfo/linetable.swift
@@ -36,7 +36,7 @@ func main(_ x: Int64) -> Void
 // CHECK: call {{.*}} @swift_rt_swift_release {{.*}}
 // CHECK: bitcast
 // CHECK: llvm.lifetime.end
-// CHECK: call {{.*}} @swift_rt_swift_release {{.*}}, !dbg ![[CLOSURE_END:.*]]
+// CHECK: call {{.*}}llvm.lifetime.end{{.*}}, !dbg ![[CLOSURE_END:.*]]
 // CHECK-NEXT: ret void, !dbg ![[CLOSURE_END]]
 // CHECK: ![[CLOSURE_END]] = !DILocation(line: [[@LINE+1]],
         }

--- a/test/DebugInfo/thunks.swift
+++ b/test/DebugInfo/thunks.swift
@@ -13,14 +13,14 @@ let foo = Foo()
 let y = 3 as Int64
 let i = foo.foo(-, x: y)
 
-// CHECK: define {{.*}}@_T0s5Int64VABIyByd_A2BIxyd_TR
+// CHECK: define {{.*}}@_T0s5Int64VABIyByd_A2BIgyd_TR
 // CHECK-NOT: ret
 // CHECK: call {{.*}}, !dbg ![[LOC:.*]]
-// CHECK: ![[THUNK:.*]] = distinct !DISubprogram(linkageName: "_T0s5Int64VABIyByd_A2BIxyd_TR"
+// CHECK: ![[THUNK:.*]] = distinct !DISubprogram(linkageName: "_T0s5Int64VABIyByd_A2BIgyd_TR"
 // CHECK-NOT:                           line:
 // CHECK-SAME:                          ){{$}}
 // CHECK: ![[LOC]] = !DILocation(line: 0, scope: ![[THUNK]])
 
-// SIL-CHECK: sil shared {{.*}}@_T0s5Int64VABIyByd_A2BIxyd_TR
+// SIL-CHECK: sil shared {{.*}}@_T0s5Int64VABIyByd_A2BIgyd_TR
 // SIL-CHECK-NOT: return
 // SIL-CHECK: apply {{.*}}auto_gen

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -43,7 +43,7 @@ let bigStructGlobalArray : [BigStruct] = [
   BigStruct()
 ]
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @_T022big_types_corner_cases21OptionalInoutFuncTypeC7executeys5Error_pSgFyycfU_(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases21OptionalInoutFuncTypeC*, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIexcx_Sg* nocapture dereferenceable({{.*}})
+// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @_T022big_types_corner_cases21OptionalInoutFuncTypeC7executeys5Error_pSgFyycfU_(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases21OptionalInoutFuncTypeC*, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIegcx_Sg* nocapture dereferenceable({{.*}})
 // CHECK: call void @_T0SqWy
 // CHECK: call void @_T0SqWe
 // CHECK: ret void

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -40,8 +40,6 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // CHECK:   [[WITNESS:%.*]] = load i8**, i8*** [[WITNESSADDR]], align 8
 // CHECK:   [[BOXADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [16 x i8], %swift.refcounted* }>, <{ %swift.refcounted, [16 x i8], %swift.refcounted* }>* [[CONTEXT]], i32 0, i32 2
 // CHECK:   [[BOX:%.*]] = load %swift.refcounted*, %swift.refcounted** [[BOXADDR]], align 8
-// CHECK:   call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[BOX]])
-// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %1)
 // CHECK:   [[RES:%.*]] = tail call swiftcc i64 @_T07closure1bS2icx3seq_tAA9OrdinableRzlFS2icfU_(i64 %0, %swift.refcounted* [[BOX]], %swift.type* [[TYPE]], i8** [[WITNESS]])
 // CHECK:   ret i64 [[RES]]
 // CHECK: }

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -205,13 +205,13 @@ public func reabstraction<T>(_ f: (Medium) -> T) {}
 public func resilientEnumPartialApply(_ f: (Medium) -> Int) {
 
 // CHECK:     [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
-// CHECK:     call swiftcc void @_T015enum_resilience13reabstractionyx010resilient_A06MediumOclF(i8* bitcast (void (%TSi*, %swift.opaque*, %swift.refcounted*)* @_T014resilient_enum6MediumOSiIxid_ACSiIxir_TRTA to i8*), %swift.refcounted* [[CONTEXT:%.*]], %swift.type* @_T0SiN)
+// CHECK:     call swiftcc void @_T015enum_resilience13reabstractionyx010resilient_A06MediumOclF(i8* bitcast (void (%TSi*, %swift.opaque*, %swift.refcounted*)* @_T014resilient_enum6MediumOSiIgid_ACSiIgir_TRTA to i8*), %swift.refcounted* [[CONTEXT:%.*]], %swift.type* @_T0SiN)
   reabstraction(f)
 
 // CHECK:     ret void
 }
 
-// CHECK-LABEL: define internal swiftcc void @_T014resilient_enum6MediumOSiIxid_ACSiIxir_TRTA(%TSi* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.refcounted* swiftself)
+// CHECK-LABEL: define internal swiftcc void @_T014resilient_enum6MediumOSiIgid_ACSiIgir_TRTA(%TSi* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.refcounted* swiftself)
 
 
 // Enums with resilient payloads from a different resilience domain

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -240,7 +240,7 @@ entry:
 
   %k = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @k_id : $@convention(thin) () -> (), getter @k_get : $@convention(thin) (@in S) -> @out Int)
   %l = keypath $KeyPath<C, Int>, (root $C; settable_property $Int, id #C.w!getter.1, getter @l_get : $@convention(thin) (@in C) -> @out Int, setter @l_set : $@convention(thin) (@in Int, @in C) -> ())
-  %m = keypath $KeyPath<S, () -> ()>, (root $S; settable_property $() -> (), id ##S.reabstracted, getter @m_get : $@convention(thin) (@in S) -> @out @callee_owned (@in ()) -> @out (), setter @m_set : $@convention(thin) (@in @callee_owned (@in ()) -> @out (), @inout S) -> ())
+  %m = keypath $KeyPath<S, () -> ()>, (root $S; settable_property $() -> (), id ##S.reabstracted, getter @m_get : $@convention(thin) (@in S) -> @out @callee_guaranteed (@in ()) -> @out (), setter @m_set : $@convention(thin) (@in @callee_guaranteed (@in ()) -> @out (), @inout S) -> ())
 
   return undef : $()
 }
@@ -251,8 +251,8 @@ sil @k_get : $@convention(thin) (@in S) -> @out Int
 sil @l_get : $@convention(thin) (@in C) -> @out Int
 sil @l_set : $@convention(thin) (@in Int, @in C) -> ()
 
-sil @m_get : $@convention(thin) (@in S) -> @out @callee_owned (@in ()) -> @out ()
-sil @m_set : $@convention(thin) (@in @callee_owned (@in ()) -> @out (), @inout S) -> ()
+sil @m_get : $@convention(thin) (@in S) -> @out @callee_guaranteed (@in ()) -> @out ()
+sil @m_set : $@convention(thin) (@in @callee_guaranteed (@in ()) -> @out (), @inout S) -> ()
 
 struct Gen<T, U> {
   var x: T

--- a/test/IRGen/lowered_optional_self_metadata.sil
+++ b/test/IRGen/lowered_optional_self_metadata.sil
@@ -14,11 +14,11 @@ public protocol Protocol {
 
 sil @optional_method : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
 
-sil @call_optional_method_with_lowered_function : $@convention(thin) (@in_guaranteed Optional<@callee_owned (@in ()) -> @out ()>) -> () {
-entry(%x : $*Optional<@callee_owned (@in ()) -> @out ()>):
+sil @call_optional_method_with_lowered_function : $@convention(thin) (@in_guaranteed Optional<@callee_guaranteed (@in ()) -> @out ()>) -> () {
+entry(%x : $*Optional<@callee_guaranteed (@in ()) -> @out ()>):
   %f = function_ref @optional_method : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
   apply %f<() -> ()>(%x) : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
-  %p = partial_apply %f<() -> ()>() : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
+  %p = partial_apply [callee_guaranteed] %f<() -> ()>() : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
   return undef : $()
 }
 

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -23,13 +23,13 @@ bb0(%i: $Int, %b: $<τ_0_0> { var τ_0_0 } <Int>, %m: $@thin Int.Type, %p: $@thi
   return %12 : $()
 }
 
-sil @concrete_caller1 : $@convention(thin) (Int, @thick P.Type) -> @owned @callee_owned () -> () {
+sil @concrete_caller1 : $@convention(thin) (Int, @thick P.Type) -> @owned @callee_guaranteed () -> () {
 bb0(%i: $Int, %p: $@thick P.Type):
   %f = function_ref @concrete_callee1 : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>, @thin Int.Type, @thick P.Type) -> ()
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %m = metatype $@thin Int.Type
-  %c = partial_apply %f(%i, %b, %m, %p) : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>, @thin Int.Type, @thick P.Type) -> ()
-  return %c : $@callee_owned () -> ()
+  %c = partial_apply [callee_guaranteed] %f(%i, %b, %m, %p) : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>, @thin Int.Type, @thick P.Type) -> ()
+  return %c : $@callee_guaranteed () -> ()
 }
 
 // This is the descriptor for '<τ_0_0> { var τ_0_0 } <Int>' above
@@ -56,14 +56,14 @@ bb0(%i: $*T, %b: $<τ_0_0> { var τ_0_0 } <U>):
   return %12 : $()
 }
 
-sil @concrete_caller2 : $@convention(thin) () -> @owned @callee_owned () -> () {
+sil @concrete_caller2 : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 bb0:
   %f = function_ref @generic_callee2 : $@convention(thin) <T, U> (@in T, @owned <τ_0_0> { var τ_0_0 } <U>) -> ()
   %i = alloc_stack $Int
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <String>
-  %c = partial_apply %f<Int, String>(%i, %b) : $@convention(thin) <T, U> (@in T, @owned <τ_0_0> { var τ_0_0 } <U>) -> ()
+  %c = partial_apply [callee_guaranteed] %f<Int, String>(%i, %b) : $@convention(thin) <T, U> (@in T, @owned <τ_0_0> { var τ_0_0 } <U>) -> ()
   dealloc_stack %i : $*Int
-  return %c : $@callee_owned () -> ()
+  return %c : $@callee_guaranteed () -> ()
 }
 
 // This is the descriptor for '<τ_0_0> { var τ_0_0 } <String>' above
@@ -90,13 +90,13 @@ bb0(%t: $*T):
   return %12 : $()
 }
 
-sil @generic_caller3 : $@convention(thin) <A, B, C> () -> @owned @callee_owned () -> () {
+sil @generic_caller3 : $@convention(thin) <A, B, C> () -> @owned @callee_guaranteed () -> () {
 bb0:
   %f = function_ref @generic_callee3 : $@convention(thin) <T, U> (@in T) -> ()
-  %t = alloc_stack $Optional<@callee_owned (@in A) -> @out B>
-  %c = partial_apply %f<Optional<(A) -> B>, (B, (C) -> Int)>(%t) : $@convention(thin) <T, U> (@in T) -> ()
-  dealloc_stack %t : $*Optional<@callee_owned (@in A) -> @out B>
-  return %c : $@callee_owned () -> ()
+  %t = alloc_stack $Optional<@callee_guaranteed (@in A) -> @out B>
+  %c = partial_apply [callee_guaranteed] %f<Optional<(A) -> B>, (B, (C) -> Int)>(%t) : $@convention(thin) <T, U> (@in T) -> ()
+  dealloc_stack %t : $*Optional<@callee_guaranteed (@in A) -> @out B>
+  return %c : $@callee_guaranteed () -> ()
 }
 
 // CHECK:      - Capture types:
@@ -128,12 +128,12 @@ bb0(%t: $@thick Optional<T>.Type):
   return %12 : $()
 }
 
-sil @generic_caller4 : $@convention(thin) <A, B, C> () -> @owned @callee_owned () -> () {
+sil @generic_caller4 : $@convention(thin) <A, B, C> () -> @owned @callee_guaranteed () -> () {
 bb0:
   %f = function_ref @generic_callee4 : $@convention(thin) <T, U> (@thick Optional<T>.Type) -> ()
   %t = metatype $@thick Optional<(B) -> C>.Type
-  %c = partial_apply %f<(B) -> C, Int>(%t) : $@convention(thin) <T, U> (@thick Optional<T>.Type) -> ()
-  return %c : $@callee_owned () -> ()
+  %c = partial_apply [callee_guaranteed] %f<(B) -> C, Int>(%t) : $@convention(thin) <T, U> (@thick Optional<T>.Type) -> ()
+  return %c : $@callee_guaranteed () -> ()
 }
 
 // CHECK:      - Capture types:
@@ -165,11 +165,11 @@ bb0(%t: $GenericClass<T, U>):
   return %12 : $()
 }
 
-sil @generic_caller5 : $@convention(thin) <A, B, C> (@owned GenericClass<(A, B), (B, C)>) -> @owned @callee_owned () -> () {
+sil @generic_caller5 : $@convention(thin) <A, B, C> (@owned GenericClass<(A, B), (B, C)>) -> @owned @callee_guaranteed () -> () {
 bb0(%g: $GenericClass<(A, B), (B, C)>):
   %f = function_ref @generic_callee5 : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> ()
-  %c = partial_apply %f<(A, B), (B, C), (C, A)>(%g) : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> ()
-  return %c : $@callee_owned () -> ()
+  %c = partial_apply [callee_guaranteed] %f<(A, B), (B, C), (C, A)>(%g) : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> ()
+  return %c : $@callee_guaranteed () -> ()
 }
 
 sil_vtable GenericClass {}
@@ -208,11 +208,11 @@ bb0(%t: $T, %u: $U):
   return %12 : $()
 }
 
-sil @pseudogeneric_caller : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject, C : AnyObject> (@owned A, @owned B) -> @owned @pseudogeneric @callee_owned () -> () {
+sil @pseudogeneric_caller : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject, C : AnyObject> (@owned A, @owned B) -> @owned @pseudogeneric @callee_guaranteed () -> () {
 bb0(%a: $A, %b: $B):
   %f = function_ref @pseudogeneric_callee : $@convention(thin) @pseudogeneric <T : AnyObject, U : AnyObject> (@owned T, @owned U) -> ()
-  %c = partial_apply %f<A, B>(%a, %b) : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject> (@owned A, @owned B) -> ()
-  return %c : $@pseudogeneric @callee_owned () -> ()
+  %c = partial_apply [callee_guaranteed] %f<A, B>(%a, %b) : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject> (@owned A, @owned B) -> ()
+  return %c : $@pseudogeneric @callee_guaranteed () -> ()
 }
 
 // CHECK:      - Capture types:
@@ -229,11 +229,11 @@ bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: $@
   return %12 : $()
 }
 
-sil @function_caller : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> @owned @callee_owned () -> () {
+sil @function_caller : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> @owned @callee_guaranteed () -> () {
 bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: $@convention(block) () -> (), %thick: $@convention(thick) () -> (), %method: $@convention(method) () -> (), %witness_method: $@convention(witness_method: P) (Int) -> ()):
   %f = function_ref @function_callee : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
-  %result = partial_apply %f(%thin, %c, %block, %thick, %method, %witness_method) : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
-  return %result : $@callee_owned () -> ()
+  %result = partial_apply [callee_guaranteed] %f(%thin, %c, %block, %thick, %method, %witness_method) : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
+  return %result : $@callee_guaranteed () -> ()
 }
 
 // CHECK:      - Capture types:
@@ -280,8 +280,8 @@ sil @existential_caller : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   %payload = open_existential_addr immutable_access %0 : $*P to $*@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P
   %f = function_ref @existential_callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P
-  %result = partial_apply %f<@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P>() : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P
-  destroy_value %result : $@callee_owned () -> @out P
+  %result = partial_apply [callee_guaranteed] %f<@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P>() : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P
+  destroy_value %result : $@callee_guaranteed () -> @out P
   destroy_addr %0 : $*P
   %tuple = tuple ()
   return %tuple : $()

--- a/test/SIL/Parser/apply_with_substitution.sil
+++ b/test/SIL/Parser/apply_with_substitution.sil
@@ -6,46 +6,46 @@ sil_stage raw
 import Builtin
 import Swift
 
-// CHECK-LABEL: sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> @out ()>) -> ()
-sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> @out ()>) -> () {
-bb0(%0 : $Optional<@callee_owned (@in ()) -> @out ()>):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (@in ()) -> @out ()>>  // var f    // users: %2, %6, %32
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (@in ()) -> @out ()>>, 0
-  store %0 to [init] %1a : $*Optional<@callee_owned (@in ()) -> @out ()>         // id: %2
+// CHECK-LABEL: sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_guaranteed (@in ()) -> @out ()>) -> ()
+sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_guaranteed (@in ()) -> @out ()>) -> () {
+bb0(%0 : $Optional<@callee_guaranteed (@in ()) -> @out ()>):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in ()) -> @out ()>>  // var f    // users: %2, %6, %32
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in ()) -> @out ()>>, 0
+  store %0 to [init] %1a : $*Optional<@callee_guaranteed (@in ()) -> @out ()>         // id: %2
   %3 = alloc_stack $Optional<()>                  // users: %22, %28, %30, %31
   %4 = alloc_stack $()                            // users: %12, %22, %25
-  %5 = alloc_stack $Optional<@callee_owned (@in ()) -> @out ()>            // users: %6, %8, %10, %11, %16, %24
-  copy_addr %1a to [initialization] %5 : $*Optional<@callee_owned (@in ()) -> @out ()> // id: %6
+  %5 = alloc_stack $Optional<@callee_guaranteed (@in ()) -> @out ()>            // users: %6, %8, %10, %11, %16, %24
+  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed (@in ()) -> @out ()> // id: %6
   %7 = function_ref @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1 // user: %8
   %8 = apply %7<() -> ()>(%5) : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1 // user: %9
   br bb2                                          // id: %13
 
 bb2:                                              // Preds: bb0
   %14 = function_ref @_TFs17_getOptionalValueU__FT1vGSqQ___Q_ : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>) -> @out τ_0_0 // user: %16
-  %15 = alloc_stack $@callee_owned (@in ()) -> @out () // users: %16, %17, %23
+  %15 = alloc_stack $@callee_guaranteed (@in ()) -> @out () // users: %16, %17, %23
   // CHECK: apply %{{[0-9]+}}<() -> ()>(%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>) -> @out τ_0_0
   %16 = apply %14<() -> ()>(%15, %5) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>) -> @out τ_0_0
-  %17 = load [take] %15 : $*@callee_owned (@in ()) -> @out () // user: %19
-  %18 = function_ref @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> () // user: %19
-  %19 = partial_apply %18(%17) : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> () // user: %20
-  %20 = apply %19() : $@callee_owned () -> ()
+  %17 = load [take] %15 : $*@callee_guaranteed (@in ()) -> @out () // user: %19
+  %18 = function_ref @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@owned @callee_guaranteed (@in ()) -> @out ()) -> () // user: %19
+  %19 = partial_apply [callee_guaranteed] %18(%17) : $@convention(thin) (@owned @callee_guaranteed (@in ()) -> @out ()) -> () // user: %20
+  %20 = apply %19() : $@callee_guaranteed () -> ()
   %21 = function_ref @_TFs24_injectValueIntoOptionalU__FT1vQ__GSqQ__ : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out Optional<τ_0_0> // user: %22
   // CHECK: apply %{{[0-9]+}}<()>(%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out Optional<τ_0_0>
   %22 = apply %21<()>(%3, %4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out Optional<τ_0_0>
-  dealloc_stack %15 : $*@callee_owned (@in ()) -> @out () // id: %23
-  dealloc_stack %5 : $*Optional<@callee_owned (@in ()) -> @out ()> // id: %24
+  dealloc_stack %15 : $*@callee_guaranteed (@in ()) -> @out () // id: %23
+  dealloc_stack %5 : $*Optional<@callee_guaranteed (@in ()) -> @out ()> // id: %24
   dealloc_stack %4 : $*()        // id: %25
   br bb4                                          // id: %26
 
 bb4:                                              // Preds: bb2 bb3
   %30 = load [trivial] %3 : $*Optional<()>
   dealloc_stack %3 : $*Optional<()> // id: %31
-  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (@in ()) -> @out ()>>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in ()) -> @out ()>>
   %33 = tuple ()                                  // user: %34
   return %33 : $()                                // id: %34
 }
 
 sil [transparent] @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
 sil [transparent] @_TFs17_getOptionalValueU__FT1vGSqQ___Q_ : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>) -> @out τ_0_0
-sil [transparent] @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> ()
+sil [transparent] @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@owned @callee_guaranteed (@in ()) -> @out ()) -> ()
 sil [transparent] @_TFs24_injectValueIntoOptionalU__FT1vQ__GSqQ__ : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out Optional<τ_0_0>

--- a/test/SIL/Parser/bound_generic.sil
+++ b/test/SIL/Parser/bound_generic.sil
@@ -6,16 +6,16 @@ sil_stage raw
 import Builtin
 import Swift
 
-// CHECK-LABEL: sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> @out ()>) -> ()
-sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> (@out ())>) -> () {
-bb0(%0 : $Optional<@callee_owned (@in ()) -> (@out ())>):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (@in ()) -> (@out ())>>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (@in ()) -> (@out ())>>, 0
-  store %0 to [init] %1a : $*Optional<@callee_owned (@in ()) -> (@out ())>
+// CHECK-LABEL: sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_guaranteed (@in ()) -> @out ()>) -> ()
+sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_guaranteed (@in ()) -> (@out ())>) -> () {
+bb0(%0 : $Optional<@callee_guaranteed (@in ()) -> (@out ())>):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in ()) -> (@out ())>>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in ()) -> (@out ())>>, 0
+  store %0 to [init] %1a : $*Optional<@callee_guaranteed (@in ()) -> (@out ())>
   %3 = alloc_stack $Optional<()>
   %4 = alloc_stack $()
-  %5 = alloc_stack $Optional<@callee_owned (@in ()) -> (@out ())>
-  copy_addr %1a to [initialization] %5 : $*Optional<@callee_owned (@in ()) -> (@out ())>
+  %5 = alloc_stack $Optional<@callee_guaranteed (@in ()) -> (@out ())>
+  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed (@in ()) -> (@out ())>
   // function_ref Swift._doesOptionalHaveValue <A>(v : @inout Swift.Optional<A>) -> Builtin.Int1
   %7 = function_ref @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
   // CHECK: apply %{{[0-9]+}}<() -> ()>(%{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
@@ -23,8 +23,8 @@ bb0(%0 : $Optional<@callee_owned (@in ()) -> (@out ())>):
   br bb1
 
 bb1:
-  destroy_addr %5 : $*Optional<@callee_owned (@in ()) -> (@out ())>
-  dealloc_stack %5 : $*Optional<@callee_owned (@in ()) -> (@out ())>
+  destroy_addr %5 : $*Optional<@callee_guaranteed (@in ()) -> (@out ())>
+  dealloc_stack %5 : $*Optional<@callee_guaranteed (@in ()) -> (@out ())>
   dealloc_stack %4 : $*()
   br bb3
 
@@ -37,7 +37,7 @@ bb3:
 bb4:
   %30 = load [trivial] %3 : $*Optional<()>
   dealloc_stack %3 : $*Optional<()>
-  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (@in ()) -> (@out ())>>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in ()) -> (@out ())>>
   %33 = tuple ()
   return %33 : $()
 }

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -67,8 +67,8 @@ sil @get_s_int : $@convention(thin) (@in S) -> @out Int
 sil @set_s_int : $@convention(thin) (@in Int, @in S) -> ()
 sil @get_c_int : $@convention(thin) (@in C) -> @out Int
 sil @set_c_int : $@convention(thin) (@in Int, @in C) -> ()
-sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C
-sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ()
+sil @get_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in S) -> @out S) -> @out @callee_guaranteed (@in C) -> @out C
+sil @set_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in C) -> @out C, @in @callee_guaranteed (@in S) -> @out S) -> ()
 sil @get_s_int_subs : $@convention(thin) (@in S, UnsafeRawPointer) -> @out Int
 sil @set_s_int_subs : $@convention(thin) (@in Int, @in S, UnsafeRawPointer) -> ()
 sil @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool
@@ -86,8 +86,8 @@ entry:
   %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
   // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
   %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
-  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
-  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in S) -> @out S) -> @out @callee_guaranteed (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in C) -> @out C, @in @callee_guaranteed (@in S) -> @out S) -> ())
+  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in S) -> @out S) -> @out @callee_guaranteed (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in C) -> @out C, @in @callee_guaranteed (@in S) -> @out S) -> ())
   // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
   %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
 

--- a/test/SIL/Parser/projection_lowered_type_parse.sil
+++ b/test/SIL/Parser/projection_lowered_type_parse.sil
@@ -6,15 +6,15 @@ struct A {
   var f : () -> ()
 }
 
-sil @callee_check : $@convention(thin) (@callee_owned () -> ()) -> ()
+sil @callee_check : $@convention(thin) (@callee_guaranteed () -> ()) -> ()
 
 sil @test1 : $@convention(thin) (@inout A) -> () {
 bb0(%0 : $*A):
   %1 = struct_element_addr %0 : $*A, #A.f
   %2 = load %0 : $*A
   %3 = struct_extract %2 : $A, #A.f
-  %4 = function_ref @callee_check : $@convention(thin) (@callee_owned () -> ()) -> ()
-  apply %4(%3) : $@convention(thin) (@callee_owned () -> ()) -> ()
+  %4 = function_ref @callee_check : $@convention(thin) (@callee_guaranteed () -> ()) -> ()
+  apply %4(%3) : $@convention(thin) (@callee_guaranteed () -> ()) -> ()
   %5 = tuple()
   return %5 : $()
 }

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -72,8 +72,8 @@ sil @get_s_int : $@convention(thin) (@in S) -> @out Int
 sil @set_s_int : $@convention(thin) (@in Int, @in S) -> ()
 sil @get_c_int : $@convention(thin) (@in C) -> @out Int
 sil @set_c_int : $@convention(thin) (@in Int, @in C) -> ()
-sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C
-sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ()
+sil @get_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in S) -> @out S) -> @out @callee_guaranteed (@in C) -> @out C
+sil @set_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in C) -> @out C, @in @callee_guaranteed (@in S) -> @out S) -> ()
 sil @get_s_int_subs : $@convention(thin) (@in S, UnsafeRawPointer) -> @out Int
 sil @set_s_int_subs : $@convention(thin) (@in Int, @in S, UnsafeRawPointer) -> ()
 sil @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool
@@ -90,8 +90,8 @@ entry:
   %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
   // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
   %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
-  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
-  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in S) -> @out S) -> @out @callee_guaranteed (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in C) -> @out C, @in @callee_guaranteed (@in S) -> @out S) -> ())
+  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in S) -> @out S) -> @out @callee_guaranteed (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_guaranteed (@in C) -> @out C, @in @callee_guaranteed (@in S) -> @out S) -> ())
   // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
   %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
 

--- a/test/SIL/Serialization/projection_lowered_type_parse.sil
+++ b/test/SIL/Serialization/projection_lowered_type_parse.sil
@@ -4,15 +4,15 @@ struct A {
   var f : () -> ()
 }
 
-sil @callee_check : $@convention(thin) (@callee_owned () -> ()) -> ()
+sil @callee_check : $@convention(thin) (@callee_guaranteed () -> ()) -> ()
 
 sil @test1 : $@convention(thin) (@inout A) -> () {
 bb0(%0 : $*A):
   %1 = struct_element_addr %0 : $*A, #A.f
   %2 = load %0 : $*A
   %3 = struct_extract %2 : $A, #A.f
-  %4 = function_ref @callee_check : $@convention(thin) (@callee_owned () -> ()) -> ()
-  apply %4(%3) : $@convention(thin) (@callee_owned () -> ()) -> ()
+  %4 = function_ref @callee_check : $@convention(thin) (@callee_guaranteed () -> ()) -> ()
+  apply %4(%3) : $@convention(thin) (@callee_guaranteed () -> ()) -> ()
   %5 = tuple()
   return %5 : $()
 }

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -168,7 +168,7 @@ func test_carray(_ array: inout CArray<(Int32) -> Int32>) -> Int32 {
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors6CArrayVxSiciau :
 // CHECK:   [[T1:%.*]] = apply [[T0]]<(Int32) -> Int32>({{%.*}}, [[WRITE]])
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<(Int32) -> Int32>, #UnsafeMutablePointer._rawValue
-// CHECK:   [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*@callee_owned (@in Int32) -> @out Int32
+// CHECK:   [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*@callee_guaranteed (@in Int32) -> @out Int32
 // CHECK:   store {{%.*}} to [[T3]] :
   array[0] = id_int
 
@@ -177,7 +177,7 @@ func test_carray(_ array: inout CArray<(Int32) -> Int32>) -> Int32 {
 // CHECK:   [[T1:%.*]] = function_ref @_T010addressors6CArrayVxSicilu :
 // CHECK:   [[T2:%.*]] = apply [[T1]]<(Int32) -> Int32>({{%.*}}, [[T0]])
 // CHECK:   [[T3:%.*]] = struct_extract [[T2]] : $UnsafePointer<(Int32) -> Int32>, #UnsafePointer._rawValue
-// CHECK:   [[T4:%.*]] = pointer_to_address [[T3]] : $Builtin.RawPointer to [strict] $*@callee_owned (@in Int32) -> @out Int32
+// CHECK:   [[T4:%.*]] = pointer_to_address [[T3]] : $Builtin.RawPointer to [strict] $*@callee_guaranteed (@in Int32) -> @out Int32
 // CHECK:   [[T5:%.*]] = load [[T4]]
   return array[1](5)
 }

--- a/test/SILGen/apply_abstraction_nested.swift
+++ b/test/SILGen/apply_abstraction_nested.swift
@@ -19,7 +19,8 @@ struct X : P {}
 var a = X()
 (a~>bar)()
 
-// CHECK:  [[CHAINED_FUNC:%.*]] = apply {{%.*}}<X, (), ()>({{%.*}}, {{%.*}}) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P> (@inout τ_0_0, @owned @noescape @callee_owned (@inout τ_0_0) -> @owned @callee_owned (@in τ_0_1) -> @out τ_0_2) -> @owned @callee_owned (@in τ_0_1) -> @out τ_0_2
-// CHECK:  [[REABSTRACT:%.*]] = function_ref @_T0ytytIexir_Iex_TR
-// CHECK:  [[CHAINED_FUNC_REABSTRACTED:%.*]] = partial_apply [[REABSTRACT]]([[CHAINED_FUNC]])
-// CHECK:  apply [[CHAINED_FUNC_REABSTRACTED]]() : $@callee_owned () -> ()
+// CHECK:  [[CHAINED_FUNC:%.*]] = apply {{%.*}}<X, (), ()>({{%.*}}, {{%.*}}) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P> (@inout τ_0_0, @owned @noescape @callee_guaranteed (@inout τ_0_0) -> @owned @callee_guaranteed (@in τ_0_1) -> @out τ_0_2) -> @owned @callee_guaranteed (@in τ_0_1) -> @out τ_0_2
+// CHECK:  [[REABSTRACT:%.*]] = function_ref @_T0ytytIegir_Ieg_TR
+// CHECK:  [[CHAINED_FUNC_REABSTRACTED:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[CHAINED_FUNC]])
+// CHECK:  [[BORROW:%.*]] = begin_borrow [[CHAINED_FUNC_REABSTRACTED]]
+// CHECK:  apply [[BORROW]]() : $@callee_guaranteed () -> ()

--- a/test/SILGen/array_literal_abstraction.swift
+++ b/test/SILGen/array_literal_abstraction.swift
@@ -4,13 +4,13 @@
 // <rdar://problem/16039286>
 
 // CHECK-LABEL: sil hidden @_T025array_literal_abstraction0A9_of_funcsSayyycGyF
-// CHECK:         pointer_to_address {{.*}} $*@callee_owned (@in ()) -> @out ()
+// CHECK:         pointer_to_address {{.*}} $*@callee_guaranteed (@in ()) -> @out ()
 func array_of_funcs() -> [(() -> ())] {
   return [{}, {}]
 }
 
 // CHECK-LABEL: sil hidden @_T025array_literal_abstraction13dict_of_funcss10DictionaryVySiyycGyF
-// CHECK:         pointer_to_address {{.*}} $*(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:         pointer_to_address {{.*}} $*(Int, @callee_guaranteed (@in ()) -> @out ())
 func dict_of_funcs() -> Dictionary<Int, () -> ()> {
   return [0: {}, 1: {}]
 }
@@ -18,7 +18,7 @@ func dict_of_funcs() -> Dictionary<Int, () -> ()> {
 func vararg_funcs(_ fs: (() -> ())...) {}
 
 // CHECK-LABEL: sil hidden @_T025array_literal_abstraction17call_vararg_funcsyyF
-// CHECK:         pointer_to_address {{.*}} $*@callee_owned (@in ()) -> @out ()
+// CHECK:         pointer_to_address {{.*}} $*@callee_guaranteed (@in ()) -> @out ()
 func call_vararg_funcs() {
   vararg_funcs({}, {})
 }

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -3,12 +3,15 @@
 struct Bool {}
 var false_ = Bool()
 
-// CHECK-LABEL: sil hidden @_T013auto_closures05call_A8_closureAA4BoolVADyXKF : $@convention(thin) (@owned @noescape @callee_owned () -> Bool) -> Bool
+// CHECK-LABEL: sil hidden @_T013auto_closures05call_A8_closureAA4BoolVADyXKF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Bool) -> Bool
 func call_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
-  // CHECK: bb0([[CLOSURE:%.*]] : $@noescape @callee_owned () -> Bool):
+  // CHECK: bb0([[CLOSURE:%.*]] : $@noescape @callee_guaranteed () -> Bool):
   // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
-  // CHECK: [[RET:%.*]] = apply [[CLOSURE_COPY]]()
+  // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
+  // CHECK: [[RET:%.*]] = apply [[B]]()
+  // CHECK: end_borrow [[B]]
+  // CHECK: destroy_value [[CLOSURE_COPY]]
   // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   // CHECK: destroy_value [[CLOSURE]]
   // CHECK: return [[RET]]
@@ -18,7 +21,7 @@ func call_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
 // CHECK-LABEL: sil hidden @_T013auto_closures05test_A21_closure_with_capture{{[_0-9a-zA-Z]*}}F
 func test_auto_closure_with_capture(_ x: Bool) -> Bool {
   // CHECK: [[CLOSURE:%.*]] = function_ref @_T013auto_closures05test_A21_closure_with_capture
-  // CHECK: [[WITHCAPTURE:%.*]] = partial_apply [[CLOSURE]](
+  // CHECK: [[WITHCAPTURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE]](
   // CHECK: [[CVT:%.*]] = convert_function [[WITHCAPTURE]]
   // CHECK: [[RET:%.*]] = apply {{%.*}}([[CVT]])
   // CHECK: return [[RET]]
@@ -29,7 +32,7 @@ func test_auto_closure_with_capture(_ x: Bool) -> Bool {
 func test_auto_closure_without_capture() -> Bool {
   // CHECK: [[CLOSURE:%.*]] = function_ref @_T013auto_closures05test_A24_closure_without_capture
   // CHECK: [[CVT:%.*]] = convert_function [[CLOSURE]]
-  // CHECK: [[THICK:%.*]] = thin_to_thick_function [[CVT]] : $@convention(thin) @noescape () -> Bool to $@noescape @callee_owned () -> Bool
+  // CHECK: [[THICK:%.*]] = thin_to_thick_function [[CVT]] : $@convention(thin) @noescape () -> Bool to $@noescape @callee_guaranteed () -> Bool
   // CHECK: [[RET:%.*]] = apply {{%.*}}([[THICK]])
   // CHECK: return [[RET]]
   return call_auto_closure(false_)
@@ -42,16 +45,16 @@ public class Base {
 public class Sub : Base {
   // CHECK-LABEL: sil hidden @_T013auto_closures3SubC1xAA4BoolVvg : $@convention(method) (@guaranteed Sub) -> Bool {
   // CHECK: bb0([[SELF:%.*]] : $Sub):
-  // CHECK: [[AUTOCLOSURE_FUNC:%.*]] = function_ref @_T013auto_closures3SubC1xAA4BoolVvgAFyXKfu_ : $@convention(thin) (@owned Sub) -> Bool
+  // CHECK: [[AUTOCLOSURE_FUNC:%.*]] = function_ref @_T013auto_closures3SubC1xAA4BoolVvgAFyXKfu_ : $@convention(thin) (@guaranteed Sub) -> Bool
   // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK: [[AUTOCLOSURE:%.*]] = partial_apply [[AUTOCLOSURE_FUNC]]([[SELF_COPY]])
+  // CHECK: [[AUTOCLOSURE:%.*]] = partial_apply [callee_guaranteed] [[AUTOCLOSURE_FUNC]]([[SELF_COPY]])
   // CHECK: [[CVT:%.*]] = convert_function [[AUTOCLOSURE]]
   // CHECK: [[AUTOCLOSURE_CONSUMER:%.*]] = function_ref @_T013auto_closures05call_A8_closureAA4BoolVADyXKF : $@convention(thin)
   // CHECK: [[RET:%.*]] = apply [[AUTOCLOSURE_CONSUMER]]([[CVT]])
   // CHECK: return [[RET]] : $Bool
   // CHECK: }
 
-  // CHECK-LABEL: sil private [transparent] @_T013auto_closures3SubC1xAA4BoolVvgAFyXKfu_ : $@convention(thin) (@owned Sub) -> Bool {
+  // CHECK-LABEL: sil private [transparent] @_T013auto_closures3SubC1xAA4BoolVvgAFyXKfu_ : $@convention(thin) (@guaranteed Sub) -> Bool {
   // CHECK: [[SUPER:%[0-9]+]] = function_ref @_T013auto_closures4BaseC1xAA4BoolVvg : $@convention(method) (@guaranteed Base) -> Bool
   // CHECK: [[RET:%.*]] = apply [[SUPER]]({{%.*}})
   // CHECK: return [[RET]]

--- a/test/SILGen/call_chain_reabstraction.swift
+++ b/test/SILGen/call_chain_reabstraction.swift
@@ -7,9 +7,11 @@ struct A {
         // CHECK-LABEL: sil hidden @_T024call_chain_reabstraction1AV1f{{[_0-9a-zA-Z]*}}F
         // CHECK:         [[G:%.*]] = function_ref @_T024call_chain_reabstraction1AV1g{{[_0-9a-zA-Z]*}}F
         // CHECK:         [[G2:%.*]] = apply [[G]]<A>
-        // CHECK:         [[REABSTRACT_THUNK:%.*]] = function_ref @_T024call_chain_reabstraction1AVA2CIexyir_A3CIexyyd_TR
-        // CHECK:         [[REABSTRACT:%.*]] = partial_apply [[REABSTRACT_THUNK]]([[G2]])
-        // CHECK:         apply [[REABSTRACT]]([[SELF:%.*]], [[SELF]])
+        // CHECK:         [[REABSTRACT_THUNK:%.*]] = function_ref @_T024call_chain_reabstraction1AVA2CIegyir_A3CIegyyd_TR
+        // CHECK:         [[REABSTRACT:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[G2]])
+        // CHECK:         [[BORROW:%.*]] = begin_borrow [[REABSTRACT]]
+        // CHECK:         apply [[BORROW]]([[SELF:%.*]], [[SELF]])
+        // CHECK:         destroy_value [[REABSTRACT]]
         func f() {
                 let recur: (A, A) -> A = { c, x in x }
                 let b = g(recur)(self, self)

--- a/test/SILGen/capture_typed_boxes.swift
+++ b/test/SILGen/capture_typed_boxes.swift
@@ -4,8 +4,8 @@ func foo(_ x: Int) -> () -> Int {
   var x = x
   return { x }
 }
-// CHECK-LABEL: sil private @_T019capture_typed_boxes3fooSiycSiFSiycfU_ : $@convention(thin) (@owned { var Int }) -> Int {
-// CHECK:       bb0(%0 : @owned ${ var Int }):
+// CHECK-LABEL: sil private @_T019capture_typed_boxes3fooSiycSiFSiycfU_ : $@convention(thin) (@guaranteed { var Int }) -> Int {
+// CHECK:       bb0(%0 : @guaranteed ${ var Int }):
 
 func closure(_ f: @escaping (Int) -> Int) -> Int {
   var f = f
@@ -15,8 +15,8 @@ func closure(_ f: @escaping (Int) -> Int) -> Int {
 
   return bar(0)
 }
-// CHECK-LABEL: sil private @_T019capture_typed_boxes7closureS3icF3barL_S2iF : $@convention(thin) (Int, @owned { var @callee_owned (Int) -> Int }) -> Int {
-// CHECK:       bb0(%0 : @trivial $Int, %1 : @owned ${ var @callee_owned (Int) -> Int }):
+// CHECK-LABEL: sil private @_T019capture_typed_boxes7closureS3icF3barL_S2iF : $@convention(thin) (Int, @guaranteed { var @callee_guaranteed (Int) -> Int }) -> Int {
+// CHECK:       bb0(%0 : @trivial $Int, %1 : @guaranteed ${ var @callee_guaranteed (Int) -> Int }):
 
 func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
   var f = f
@@ -26,6 +26,6 @@ func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
 
   return bar(x)
 }
-// CHECK-LABEL: sil private @_T019capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>) -> @out T {
-// CHECK-LABEL: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @owned $<τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>):
+// CHECK-LABEL: sil private @_T019capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @guaranteed <τ_0_0> { var @callee_guaranteed (@in τ_0_0) -> @out τ_0_0 } <T>) -> @out T {
+// CHECK-LABEL: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @guaranteed $<τ_0_0> { var @callee_guaranteed (@in τ_0_0) -> @out τ_0_0 } <T>):
 

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -43,8 +43,10 @@ public func foo(_ x: Double) {
   // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
   // CHECK: [[A_COPY:%.*]] = copy_value [[BORROWED_A]]
+  // CHECK: [[BORROWED_A2:%.*]] = begin_borrow [[A_COPY]]
   let a: (Double) -> Struct1 = Struct1.init(value:)
-  // CHECK: apply [[A_COPY]]([[X]])
+  // CHECK: apply [[BORROWED_A2]]([[X]])
+  // CHECK: destroy_value [[A_COPY]]
   // CHECK: end_borrow [[BORROWED_A]] from [[A]]
   z = a(x)
 
@@ -70,8 +72,10 @@ public func foo(_ x: Double) {
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
+  // CHECK: [[BORROWED_C2:%.*]] = begin_borrow [[C_COPY]]
   let c: (Double) -> Struct1 = z.translate(radians:)
-  // CHECK: apply [[C_COPY]]([[X]])
+  // CHECK: apply [[BORROWED_C2]]([[X]])
+  // CHECK: destroy_value [[C_COPY]]
   // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   z = c(x)
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME]]
@@ -81,7 +85,9 @@ public func foo(_ x: Double) {
   let d: (Struct1) -> (Double) -> Struct1 = Struct1.translate(radians:)
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
-  // CHECK: apply [[COPY]]([[ZVAL]])
+  // CHECK: [[BORROW_COPY:%.*]] = begin_borrow [[COPY]]
+  // CHECK: apply [[BORROW_COPY]]([[ZVAL]])
+  // CHECK: destroy_value [[COPY]]
   z = d(z)(x)
 
   // TODO: If we implement SE-0042, this should thunk the value Struct1 param
@@ -103,8 +109,10 @@ public func foo(_ x: Double) {
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
   // CHECK: [[F_COPY:%.*]] = copy_value [[BORROWED_F]]
+  // CHECK: [[BORROWED_F2:%.*]] = begin_borrow [[F_COPY]]
   let f = z.scale
-  // CHECK: apply [[F_COPY]]([[X]])
+  // CHECK: apply [[BORROWED_F2]]([[X]])
+  // CHECK: destroy_value [[F_COPY]]
   // CHECK: end_borrow [[BORROWED_F]] from [[F]]
   z = f(x)
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
@@ -157,8 +165,10 @@ public func foo(_ x: Double) {
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
   // CHECK: [[BORROWED_I:%.*]] = begin_borrow [[I]]
   // CHECK: [[I_COPY:%.*]] = copy_value [[BORROWED_I]]
+  // CHECK: [[BORROWED_I2:%.*]] = begin_borrow [[I_COPY]]
   let i = Struct1.staticMethod
-  // CHECK: apply [[I_COPY]]()
+  // CHECK: apply [[BORROWED_I2]]()
+  // CHECK: destroy_value [[I_COPY]]
   // CHECK: end_borrow [[BORROWED_I]] from [[I]]
   y = i()
 

--- a/test/SILGen/class_resilience.swift
+++ b/test/SILGen/class_resilience.swift
@@ -83,11 +83,11 @@ public func callResilientMethod(_ s: MyResilientSubclass) {
 // CHECK:   return
 }
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T016class_resilience19MyResilientSubclassC17publicMethodFirstSiyFTc : $@convention(thin) (@owned MyResilientSubclass) -> @owned @callee_owned () -> Int
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T016class_resilience19MyResilientSubclassC17publicMethodFirstSiyFTc : $@convention(thin) (@owned MyResilientSubclass) -> @owned @callee_guaranteed () -> Int
 // CHECK:     function_ref @_T016class_resilience19MyResilientSubclassC17publicMethodFirstSiyFTj
 // CHECK:     return
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T016class_resilience19MyResilientSubclassC18publicMethodSecondyyXlSgFTc : $@convention(thin) (@owned MyResilientSubclass) -> @owned @callee_owned (@owned Optional<AnyObject>) -> ()
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T016class_resilience19MyResilientSubclassC18publicMethodSecondyyXlSgFTc : $@convention(thin) (@owned MyResilientSubclass) -> @owned @callee_guaranteed (@owned Optional<AnyObject>) -> ()
 // CHECK:     function_ref @_T016class_resilience16MyResilientClassC18publicMethodSecondyyXlFTj : $@convention(method) (@owned AnyObject, @guaranteed MyResilientClass) -> ()
 // CHECK:     return
 

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -6,14 +6,14 @@ import Swift
 var zero = 0
 
 // <rdar://problem/15921334>
-// CHECK-LABEL: sil hidden @_T08closures46return_local_generic_function_without_captures{{[_0-9a-zA-Z]*}}F : $@convention(thin) <A, R> () -> @owned @callee_owned (@in A) -> @out R {
+// CHECK-LABEL: sil hidden @_T08closures46return_local_generic_function_without_captures{{[_0-9a-zA-Z]*}}F : $@convention(thin) <A, R> () -> @owned @callee_guaranteed (@in A) -> @out R {
 func return_local_generic_function_without_captures<A, R>() -> (A) -> R {
   func f(_: A) -> R {
     Builtin.int_trap()
   }
   // CHECK:  [[FN:%.*]] = function_ref @_T08closures46return_local_generic_function_without_captures{{[_0-9a-zA-Z]*}} : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> @out τ_0_1
-  // CHECK:  [[FN_WITH_GENERIC_PARAMS:%.*]] = partial_apply [[FN]]<A, R>() : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> @out τ_0_1
-  // CHECK:  return [[FN_WITH_GENERIC_PARAMS]] : $@callee_owned (@in A) -> @out R
+  // CHECK:  [[FN_WITH_GENERIC_PARAMS:%.*]] = partial_apply [callee_guaranteed] [[FN]]<A, R>() : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> @out τ_0_1
+  // CHECK:  return [[FN_WITH_GENERIC_PARAMS]] : $@callee_guaranteed (@in A) -> @out R
   return f
 }
 
@@ -39,22 +39,22 @@ func read_only_capture(_ x: Int) -> Int {
   }
 
   return cap()
-  // CHECK:   [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // CHECK:   [[XBOX_BORROW:%.*]] = begin_borrow [[XBOX]]
   // SEMANTIC ARC TODO: See above. This needs to happen on the copy_valued box.
   // CHECK:   mark_function_escape [[PROJECT]]
-  // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_T08closures17read_only_capture.*]] : $@convention(thin) (@owned { var Int }) -> Int
-  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XBOX_COPY]])
+  // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_T08closures17read_only_capture.*]] : $@convention(thin) (@guaranteed { var Int }) -> Int
+  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XBOX_BORROW]])
+  // CHECK:   end_borrow [[XBOX_BORROW]]
   // CHECK:   destroy_value [[XBOX]]
   // CHECK:   return [[RET]]
 }
 // CHECK:   } // end sil function '_T08closures17read_only_captureS2iF'
 
 // CHECK: sil private @[[CAP_NAME]]
-// CHECK: bb0([[XBOX:%[0-9]+]] : @owned ${ var Int }):
+// CHECK: bb0([[XBOX:%[0-9]+]] : @guaranteed ${ var Int }):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
 // CHECK: [[X:%[0-9]+]] = load [trivial] [[ACCESS]]
-// CHECK: destroy_value [[XBOX]]
 // CHECK: return [[X]]
 // } // end sil function '[[CAP_NAME]]'
 
@@ -70,8 +70,8 @@ func write_to_capture(_ x: Int) -> Int {
   // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*Int
   // CHECK:   copy_addr [[ACCESS]] to [initialization] [[X2BOX_PB]]
-  // CHECK:   [[X2BOX_COPY:%.*]] = copy_value [[X2BOX]]
-  // SEMANTIC ARC TODO: This next mark_function_escape should be on a projection from X2BOX_COPY.
+  // CHECK:   [[X2BOX_BORROW:%.*]] = begin_borrow [[X2BOX]]
+  // SEMANTIC ARC TODO: This next mark_function_escape should be on a projection from X2BOX_BORROW.
   // CHECK:   mark_function_escape [[X2BOX_PB]]
   var x2 = x
 
@@ -80,9 +80,9 @@ func write_to_capture(_ x: Int) -> Int {
   }
 
   scribble()
-  // CHECK:   [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:_T08closures16write_to_capture.*]] : $@convention(thin) (@owned { var Int }) -> ()
-  // CHECK:   apply [[SCRIB]]([[X2BOX_COPY]])
-  // SEMANTIC ARC TODO: This should load from X2BOX_COPY project. There is an
+  // CHECK:   [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:_T08closures16write_to_capture.*]] : $@convention(thin) (@guaranteed { var Int }) -> ()
+  // CHECK:   apply [[SCRIB]]([[X2BOX_BORROW]])
+  // SEMANTIC ARC TODO: This should load from X2BOX_BORROW project. There is an
   // issue here where after a copy_value, we need to reassign a projection in
   // some way.
   // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[X2BOX_PB]] : $*Int
@@ -95,11 +95,10 @@ func write_to_capture(_ x: Int) -> Int {
 // CHECK:  } // end sil function '_T08closures16write_to_captureS2iF'
 
 // CHECK: sil private @[[SCRIB_NAME]]
-// CHECK: bb0([[XBOX:%[0-9]+]] : @owned ${ var Int }):
+// CHECK: bb0([[XBOX:%[0-9]+]] : @guaranteed ${ var Int }):
 // CHECK:   [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[XADDR]] : $*Int
 // CHECK:   assign {{%[0-9]+}} to [[ACCESS]]
-// CHECK:   destroy_value [[XBOX]]
 // CHECK:   return
 // CHECK: } // end sil function '[[SCRIB_NAME]]'
 
@@ -111,15 +110,15 @@ func multiple_closure_refs(_ x: Int) -> (() -> Int, () -> Int) {
   }
 
   return (cap, cap)
-  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_T08closures21multiple_closure_refs.*]] : $@convention(thin) (@owned { var Int }) -> Int
-  // CHECK: [[CAP_CLOSURE_1:%[0-9]+]] = partial_apply [[CAP]]
-  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_T08closures21multiple_closure_refs.*]] : $@convention(thin) (@owned { var Int }) -> Int
-  // CHECK: [[CAP_CLOSURE_2:%[0-9]+]] = partial_apply [[CAP]]
+  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_T08closures21multiple_closure_refs.*]] : $@convention(thin) (@guaranteed { var Int }) -> Int
+  // CHECK: [[CAP_CLOSURE_1:%[0-9]+]] = partial_apply [callee_guaranteed] [[CAP]]
+  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_T08closures21multiple_closure_refs.*]] : $@convention(thin) (@guaranteed { var Int }) -> Int
+  // CHECK: [[CAP_CLOSURE_2:%[0-9]+]] = partial_apply [callee_guaranteed] [[CAP]]
   // CHECK: [[RET:%[0-9]+]] = tuple ([[CAP_CLOSURE_1]] : {{.*}}, [[CAP_CLOSURE_2]] : {{.*}})
   // CHECK: return [[RET]]
 }
 
-// CHECK-LABEL: sil hidden @_T08closures18capture_local_funcSiycycSiF : $@convention(thin) (Int) -> @owned @callee_owned () -> @owned @callee_owned () -> Int {
+// CHECK-LABEL: sil hidden @_T08closures18capture_local_funcSiycycSiF : $@convention(thin) (Int) -> @owned @callee_guaranteed () -> @owned @callee_guaranteed () -> Int {
 func capture_local_func(_ x: Int) -> () -> () -> Int {
   // CHECK: bb0([[ARG:%.*]] : @trivial $Int):
   var x = x
@@ -130,11 +129,11 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
   func aleph() -> Int { return x }
 
   func beth() -> () -> Int { return aleph }
-  // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:_T08closures18capture_local_funcSiycycSiF4bethL_SiycyF]] : $@convention(thin) (@owned { var Int }) -> @owned @callee_owned () -> Int
+  // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:_T08closures18capture_local_funcSiycycSiF4bethL_SiycyF]] : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> Int
   // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
   // SEMANTIC ARC TODO: This is incorrect. This should be a project_box from XBOX_COPY.
   // CHECK: mark_function_escape [[XBOX_PB]]
-  // CHECK: [[BETH_CLOSURE:%[0-9]+]] = partial_apply [[BETH_REF]]([[XBOX_COPY]])
+  // CHECK: [[BETH_CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[BETH_REF]]([[XBOX_COPY]])
 
   return beth
   // CHECK: destroy_value [[XBOX]]
@@ -142,18 +141,17 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
 }
 // CHECK: } // end sil function '_T08closures18capture_local_funcSiycycSiF'
 
-// CHECK: sil private @[[ALEPH_NAME:_T08closures18capture_local_funcSiycycSiF5alephL_SiyF]] : $@convention(thin) (@owned { var Int }) -> Int {
-// CHECK: bb0([[XBOX:%[0-9]+]] : @owned ${ var Int }):
+// CHECK: sil private @[[ALEPH_NAME:_T08closures18capture_local_funcSiycycSiF5alephL_SiyF]] : $@convention(thin) (@guaranteed { var Int }) -> Int {
+// CHECK: bb0([[XBOX:%[0-9]+]] : @guaranteed ${ var Int }):
 
-// CHECK: sil private @[[BETH_NAME]] : $@convention(thin) (@owned { var Int }) -> @owned @callee_owned () -> Int {
-// CHECK: bb0([[XBOX:%[0-9]+]] : @owned ${ var Int }):
+// CHECK: sil private @[[BETH_NAME]] : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> Int {
+// CHECK: bb0([[XBOX:%[0-9]+]] : @guaranteed ${ var Int }):
 // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
-// CHECK:   [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@owned { var Int }) -> Int
+// CHECK:   [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@guaranteed { var Int }) -> Int
 // CHECK:   [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
 // SEMANTIC ARC TODO: This should be on a PB from XBOX_COPY.
 // CHECK:   mark_function_escape [[XBOX_PB]]
-// CHECK:   [[ALEPH_CLOSURE:%[0-9]+]] = partial_apply [[ALEPH_REF]]([[XBOX_COPY]])
-// CHECK:   destroy_value [[XBOX]]
+// CHECK:   [[ALEPH_CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[ALEPH_REF]]([[XBOX_COPY]])
 // CHECK:   return [[ALEPH_CLOSURE]]
 // CHECK: } // end sil function '[[BETH_NAME]]'
 
@@ -209,9 +207,9 @@ func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
 
   return { x + $0 }
   // -- func expression
-  // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:_T08closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @owned { var Int }) -> Int
+  // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:_T08closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @guaranteed { var Int }) -> Int
   // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
-  // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [[ANON]]([[XBOX_COPY]])
+  // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [callee_guaranteed] [[ANON]]([[XBOX_COPY]])
   // -- return
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[ANON_CLOSURE_APP]]
@@ -230,7 +228,7 @@ func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
 // CHECK-LABEL: sil hidden @_T08closures24small_closure_no_capture{{[_0-9a-zA-Z]*}}F
 func small_closure_no_capture() -> (_ y: Int) -> Int {
   // CHECK:   [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:_T08closures24small_closure_no_captureS2icyFS2icfU_]] : $@convention(thin) (Int) -> Int
-  // CHECK:   [[ANON_THICK:%[0-9]+]] = thin_to_thick_function [[ANON]] : ${{.*}} to $@callee_owned (Int) -> Int
+  // CHECK:   [[ANON_THICK:%[0-9]+]] = thin_to_thick_function [[ANON]] : ${{.*}} to $@callee_guaranteed (Int) -> Int
   // CHECK:   return [[ANON_THICK]]
   return { $0 }
 }
@@ -293,14 +291,11 @@ func generateWithConstant(_ x : SomeSpecificClass) {
   takesSomeClassGenerator({ x })
 }
 
-// CHECK-LABEL: sil private @_T08closures20generateWithConstantyAA17SomeSpecificClassCFAA0eG0CycfU_ : $@convention(thin) (@owned SomeSpecificClass) -> @owned SomeClass {
-// CHECK: bb0([[T0:%.*]] : @owned $SomeSpecificClass):
+// CHECK-LABEL: sil private @_T08closures20generateWithConstantyAA17SomeSpecificClassCFAA0eG0CycfU_ : $@convention(thin) (@guaranteed SomeSpecificClass) -> @owned SomeClass {
+// CHECK: bb0([[T0:%.*]] : @guaranteed $SomeSpecificClass):
 // CHECK:   debug_value [[T0]] : $SomeSpecificClass, let, name "x", argno 1
-// CHECK:   [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
-// CHECK:   [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
+// CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK:   [[T0_COPY_CASTED:%.*]] = upcast [[T0_COPY]] : $SomeSpecificClass to $SomeClass
-// CHECK:   end_borrow [[BORROWED_T0]] from [[T0]]
-// CHECK:   destroy_value [[T0]]
 // CHECK:   return [[T0_COPY_CASTED]]
 // CHECK: } // end sil function '_T08closures20generateWithConstantyAA17SomeSpecificClassCFAA0eG0CycfU_'
 
@@ -333,9 +328,9 @@ class SelfCapturedInInit : Base {
   // Finally put self in the closure.
   // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[PB_SELF_BOX]]
   // CHECK:   [[COPIED_SELF:%.*]] = load [copy] [[PB_SELF_BOX]]
-  // CHECK:   [[FOO_VALUE:%.*]] = partial_apply {{%.*}}([[COPIED_SELF]]) : $@convention(thin) (@owned SelfCapturedInInit) -> @owned SelfCapturedInInit
+  // CHECK:   [[FOO_VALUE:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[COPIED_SELF]]) : $@convention(thin) (@guaranteed SelfCapturedInInit) -> @owned SelfCapturedInInit
   // CHECK:   [[FOO_LOCATION:%.*]] = ref_element_addr [[BORROWED_SELF]]
-  // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[FOO_LOCATION]] : $*@callee_owned () -> @owned SelfCapturedInInit
+  // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[FOO_LOCATION]] : $*@callee_guaranteed () -> @owned SelfCapturedInInit
   // CHECK:   assign [[FOO_VALUE]] to [[ACCESS]]
   override init() {
     super.init()
@@ -379,10 +374,11 @@ func closeOverLetLValue() {
 
 // The let property needs to be captured into a temporary stack slot so that it
 // is loadable even though we capture the value.
-// CHECK-LABEL: sil private @_T08closures18closeOverLetLValueyyFSiycfU_ : $@convention(thin) (@owned ClassWithIntProperty) -> Int {
-// CHECK: bb0([[ARG:%.*]] : @owned $ClassWithIntProperty):
+// CHECK-LABEL: sil private @_T08closures18closeOverLetLValueyyFSiycfU_ : $@convention(thin) (@guaranteed ClassWithIntProperty) -> Int {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $ClassWithIntProperty):
 // CHECK:   [[TMP_CLASS_ADDR:%.*]] = alloc_stack $ClassWithIntProperty, let, name "a", argno 1
-// CHECK:   store [[ARG]] to [init] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   store [[COPY_ARG]] to [init] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
 // CHECK:   [[LOADED_CLASS:%.*]] = load [copy] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
 // CHECK:   [[BORROWED_LOADED_CLASS:%.*]] = begin_borrow [[LOADED_CLASS]]
 // CHECK:   [[INT_IN_CLASS_ADDR:%.*]] = ref_element_addr [[BORROWED_LOADED_CLASS]] : $ClassWithIntProperty, #ClassWithIntProperty.x
@@ -426,7 +422,7 @@ struct StructWithMutatingMethod {
 // CHECK-LABEL: sil hidden @_T08closures24StructWithMutatingMethodV08mutatingE0{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : @trivial $*StructWithMutatingMethod):
 // CHECK: [[CLOSURE:%[0-9]+]] = function_ref @_T08closures24StructWithMutatingMethodV08mutatingE0{{.*}} : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int
-// CHECK: partial_apply [[CLOSURE]](%0) : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int
+// CHECK: partial_apply [callee_guaranteed] [[CLOSURE]](%0) : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int
 
 // Check that the closure body only takes the pointer.
 // CHECK-LABEL: sil private @_T08closures24StructWithMutatingMethodV08mutatingE0{{.*}} : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int {
@@ -440,26 +436,20 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1ayyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1a[_0-9a-zA-Z]*]] : $@convention(thin) (@owned SuperSub) -> ()
-  // CHECK:   apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1a[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+  // CHECK:   apply [[INNER]]([[SELF]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1ayyF'
   func a() {
-    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
-    // CHECK:   = apply [[CLASS_METHOD]]([[BORROWED_ARG]])
-    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
+    // CHECK:   = apply [[CLASS_METHOD]]([[ARG]])
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
     // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-    // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func a1() {
       self.boom()
@@ -470,34 +460,26 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1byyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1b[_0-9a-zA-Z]*]] : $@convention(thin) (@owned SuperSub) -> ()
-  // CHECK:   = apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1b[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+  // CHECK:   = apply [[INNER]]([[SELF]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1byyF'
   func b() {
-    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1b.*]] : $@convention(thin) (@owned SuperSub) -> ()
-    // CHECK:   = apply [[INNER]]([[ARG_COPY]])
-    // CHECK:   destroy_value [[ARG]]
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1b.*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+    // CHECK:   = apply [[INNER]]([[ARG]])
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func b1() {
-      // CHECK: sil private @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
-      // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-      // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
-      // CHECK:   = apply [[CLASS_METHOD]]([[BORROWED_ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
-      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+      // CHECK: sil private @[[INNER_FUNC_2]] : $@convention(thin) (@guaranteed SuperSub) -> () {
+      // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+      // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
+      // CHECK:   = apply [[CLASS_METHOD]]([[ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase)
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-      // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       func b2() {
         self.boom()
@@ -510,31 +492,29 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1cyyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1c[_0-9a-zA-Z]*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1c[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[SELF_COPY]])
   // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [[PA]]
   // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
-  // CHECK:   apply [[PA_COPY]]()
+  // CHECK:   [[B:%.*]] = begin_borrow [[PA_COPY]]
+  // CHECK:   apply [[B]]()
+	// CHECK:   end_borrow [[B]]
+  // CHECK:   destroy_value [[PA_COPY]]
   // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_T08closures8SuperSubC1cyyF'
   func c() {
-    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
-    // CHECK:   = apply [[CLASS_METHOD]]([[BORROWED_ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
-    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
+    // CHECK:   = apply [[CLASS_METHOD]]([[ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
     // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-    // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let c1 = { () -> Void in
       self.boom()
@@ -545,35 +525,33 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1dyyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1d[_0-9a-zA-Z]*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1d[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[SELF_COPY]])
   // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [[PA]]
   // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
-  // CHECK:   apply [[PA_COPY]]()
+  // CHECK:   [[B:%.*]] = begin_borrow [[PA_COPY]]
+  // CHECK:   apply [[B]]()
+  // CHECK:   end_borrow [[B]]
+  // CHECK:   destroy_value [[PA_COPY]]
   // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_T08closures8SuperSubC1dyyF'
   func d() {
-    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1d.*]] : $@convention(thin) (@owned SuperSub) -> ()
-    // CHECK:   = apply [[INNER]]([[ARG_COPY]])
-    // CHECK:   destroy_value [[ARG]]
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1d.*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+    // CHECK:   = apply [[INNER]]([[ARG]])
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let d1 = { () -> Void in
-      // CHECK: sil private @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
-      // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+      // CHECK: sil private @[[INNER_FUNC_2]] : $@convention(thin) (@guaranteed SuperSub) -> () {
+      // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-      // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       func d2() {
         super.boom()
@@ -585,35 +563,33 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1eyyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK: [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME1:_T08closures8SuperSubC1e[_0-9a-zA-Z]*]] : $@convention(thin)
-  // CHECK: = apply [[INNER]]([[SELF_COPY]])
+  // CHECK: = apply [[INNER]]([[SELF]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1eyyF'
   func e() {
     // CHECK: sil private @[[INNER_FUNC_NAME1]] : $@convention(thin)
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME2:_T08closures8SuperSubC1e.*]] : $@convention(thin)
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-    // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[ARG_COPY]])
     // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [[PA]]
     // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
-    // CHECK:   apply [[PA_COPY]]() : $@callee_owned () -> ()
+    // CHECK:   [[B:%.*]] = begin_borrow [[PA_COPY]]
+    // CHECK:   apply [[B]]() : $@callee_guaranteed () -> ()
+    // CHECK:   end_borrow [[B]]
+    // CHECK:   destroy_value [[PA_COPY]]
     // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
     // CHECK:   destroy_value [[PA]]
-    // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_NAME1]]'
     func e1() {
       // CHECK: sil private @[[INNER_FUNC_NAME2]] : $@convention(thin)
-      // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+      // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
       // CHECK:   [[ARG_COPY_SUPERCAST:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[BORROWED_ARG_COPY_SUPERCAST:%.*]] = begin_borrow [[ARG_COPY_SUPERCAST]]
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPERCAST]])
       // CHECK:   destroy_value [[ARG_COPY_SUPERCAST]]
-      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-      // CHECK:   destroy_value [[ARG]]
       // CHECK:   return
       // CHECK: } // end sil function '[[INNER_FUNC_NAME2]]'
       let e2 = {
@@ -626,37 +602,33 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1fyyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1fyyFyycfU_]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1fyyFyycfU_]] : $@convention(thin) (@guaranteed SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[SELF_COPY]])
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_T08closures8SuperSubC1fyyF'
   func f() {
-    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1fyyFyycfU_yyKXKfu_]] : $@convention(thin) (@owned SuperSub) -> @error Error
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1fyyFyycfU_yyKXKfu_]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-    // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[ARG_COPY]])
     // CHECK:   [[CVT:%.*]] = convert_function [[PA]]
-    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply {{.*}}([[CVT]])
+    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply [callee_guaranteed] {{.*}}([[CVT]])
     // CHECK:   [[REABSTRACT_CVT:%.*]] = convert_function [[REABSTRACT_PA]]    
-    // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @_T0s2qqoixxSg_xyKXKtKlF : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
-    // CHECK:   try_apply [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
+    // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @_T0s2qqoixxSg_xyKXKtKlF : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_guaranteed () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
+    // CHECK:   try_apply [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_guaranteed () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
     // CHECK: [[NORMAL_BB]]{{.*}}
-    // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let f1 = {
       // CHECK: sil private [transparent] @[[INNER_FUNC_2]]
-      // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+      // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-      // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       nil ?? super.boom()
     }
@@ -664,36 +636,31 @@ class SuperSub : SuperBase {
 
   // CHECK-LABEL: sil hidden @_T08closures8SuperSubC1gyyF : $@convention(method) (@guaranteed SuperSub) -> () {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $SuperSub):
-  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1g[_0-9a-zA-Z]*]] : $@convention(thin) (@owned SuperSub) -> ()
-  // CHECK:   = apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_T08closures8SuperSubC1g[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+  // CHECK:   = apply [[INNER]]([[SELF]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1gyyF'
   func g() {
-    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
-    // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1g.*]] : $@convention(thin) (@owned SuperSub) -> @error Error
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> ()
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1g.*]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-    // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
-    // CHECK:   [[CVT:%.*]] = convert_function [[PA]] : $@callee_owned () -> @error Error to $@noescape @callee_owned () -> @error Error
-    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply {{%.*}}([[CVT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> @error Error) -> (@out (), @error Error)
+    // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[ARG_COPY]])
+    // CHECK:   [[CVT:%.*]] = convert_function [[PA]] : $@callee_guaranteed () -> @error Error to $@noescape @callee_guaranteed () -> @error Error
+    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[CVT]]) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @error Error) -> (@out (), @error Error)
     // CHECK:   [[REABSTRACT_CVT:%.*]] = convert_function [[REABSTRACT_PA]]
-    // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @_T0s2qqoixxSg_xyKXKtKlF : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
-    // CHECK:   try_apply [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
+    // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @_T0s2qqoixxSg_xyKXKtKlF : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_guaranteed () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
+    // CHECK:   try_apply [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @noescape @callee_guaranteed () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
     // CHECK: [[NORMAL_BB]]{{.*}}
-    // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func g1() {
-      // CHECK: sil private [transparent] @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> @error Error {
-      // CHECK: bb0([[ARG:%.*]] : @owned $SuperSub):
-      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+      // CHECK: sil private [transparent] @[[INNER_FUNC_2]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error {
+      // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_T08closures9SuperBaseC4boomyyF : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-      // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       nil ?? super.boom()
     }
@@ -725,13 +692,17 @@ class SuperSub : SuperBase {
 // -- strong +1, unowned +2
 // CHECK:         destroy_value [[SELF]]
 // -- closure takes unowned ownership
-// CHECK:         [[OUTER_CLOSURE:%.*]] = partial_apply {{%.*}}([[UNOWNED_SELF2_COPY]])
+// CHECK:         [[OUTER_CLOSURE:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[UNOWNED_SELF2_COPY]])
 // CHECK:         [[OUTER_CONVERT:%.*]] = convert_function [[OUTER_CLOSURE]]
 // -- call consumes closure
 // -- strong +1, unowned +1
-// CHECK:         [[INNER_CLOSURE:%.*]] = apply [[OUTER_CONVERT]]
-// CHECK:         [[CONSUMED_RESULT:%.*]] = apply [[INNER_CLOSURE]]()
+// CHECK:         [[B:%.*]] = begin_borrow [[OUTER_CONVERT]]
+// CHECK:         [[INNER_CLOSURE:%.*]] = apply [[B]]
+// CHECK:         [[B:%.*]] = begin_borrow [[INNER_CLOSURE]]
+// CHECK:         [[CONSUMED_RESULT:%.*]] = apply [[B]]()
 // CHECK:         destroy_value [[CONSUMED_RESULT]]
+// CHECK:         destroy_value [[INNER_CLOSURE]]
+// CHECK:         destroy_value [[OUTER_CONVERT]]
 // -- destroy_values unowned self in box
 // -- strong +1, unowned +0
 // CHECK:         destroy_value [[OUTER_SELF_CAPTURE]]
@@ -740,25 +711,23 @@ class SuperSub : SuperBase {
 
 // -- outer closure
 // -- strong +0, unowned +1
-// CHECK: sil private @[[OUTER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned @callee_owned () -> @owned UnownedSelfNestedCapture {
-// CHECK: bb0([[CAPTURED_SELF:%.*]] : @owned $@sil_unowned UnownedSelfNestedCapture):
+// CHECK: sil private @[[OUTER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_]] : $@convention(thin) (@guaranteed @sil_unowned UnownedSelfNestedCapture) -> @owned @callee_guaranteed () -> @owned UnownedSelfNestedCapture {
+// CHECK: bb0([[CAPTURED_SELF:%.*]] : @guaranteed $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +0, unowned +2
 // CHECK:         [[CAPTURED_SELF_COPY:%.*]] = copy_value [[CAPTURED_SELF]] :
 // -- closure takes ownership of unowned ref
-// CHECK:         [[INNER_CLOSURE:%.*]] = partial_apply {{%.*}}([[CAPTURED_SELF_COPY]])
+// CHECK:         [[INNER_CLOSURE:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[CAPTURED_SELF_COPY]])
 // -- strong +0, unowned +1 (claimed by closure)
-// CHECK:         destroy_value [[CAPTURED_SELF]]
 // CHECK:         return [[INNER_CLOSURE]]
 // CHECK: } // end sil function '[[OUTER_CLOSURE_FUN]]'
 
 // -- inner closure
 // -- strong +0, unowned +1
-// CHECK: sil private @[[INNER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_ACycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned UnownedSelfNestedCapture {
-// CHECK: bb0([[CAPTURED_SELF:%.*]] : @owned $@sil_unowned UnownedSelfNestedCapture):
+// CHECK: sil private @[[INNER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_ACycfU_]] : $@convention(thin) (@guaranteed @sil_unowned UnownedSelfNestedCapture) -> @owned UnownedSelfNestedCapture {
+// CHECK: bb0([[CAPTURED_SELF:%.*]] : @guaranteed $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +1, unowned +1
 // CHECK:         [[SELF:%.*]] = copy_unowned_value [[CAPTURED_SELF:%.*]] :
 // -- strong +1, unowned +0 (claimed by return)
-// CHECK:         destroy_value [[CAPTURED_SELF]]
 // CHECK:         return [[SELF]]
 // CHECK: } // end sil function '[[INNER_CLOSURE_FUN]]'
 class UnownedSelfNestedCapture {
@@ -774,17 +743,14 @@ class ConcreteBase {
   func swim() {}
 }
 
-// CHECK-LABEL: sil private @_T08closures14GenericDerivedC4swimyyFyycfU_ : $@convention(thin) <Ocean> (@owned GenericDerived<Ocean>) -> ()
-// CHECK: bb0([[ARG:%.*]] : @owned $GenericDerived<Ocean>):
-// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-// CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
+// CHECK-LABEL: sil private @_T08closures14GenericDerivedC4swimyyFyycfU_ : $@convention(thin) <Ocean> (@guaranteed GenericDerived<Ocean>) -> ()
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $GenericDerived<Ocean>):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $GenericDerived<Ocean> to $ConcreteBase
 // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
 // CHECK:   [[METHOD:%.*]] = function_ref @_T08closures12ConcreteBaseC4swimyyF
 // CHECK:   apply [[METHOD]]([[BORROWED_ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
 // CHECK:   destroy_value [[ARG_COPY_SUPER]]
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-// CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_T08closures14GenericDerivedC4swimyyFyycfU_'
 
 class GenericDerived<Ocean> : ConcreteBase {
@@ -824,4 +790,4 @@ struct r29810997 {
 }
 
 //   DI will turn this into a direct capture of the specific stored property.
-// CHECK-LABEL: sil hidden @_T08closures16r29810997_helperS3icF : $@convention(thin) (@owned @noescape @callee_owned (Int) -> Int) -> Int
+// CHECK-LABEL: sil hidden @_T08closures16r29810997_helperS3icF : $@convention(thin) (@owned @noescape @callee_guaranteed (Int) -> Int) -> Int

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -219,15 +219,15 @@ class ReabstractDefaultArgument<T> {
 
 // CHECK-LABEL: sil hidden @_T017default_arguments32testDefaultArgumentReabstractionyyF
 // function_ref default_arguments.ReabstractDefaultArgument.__allocating_init <A>(default_arguments.ReabstractDefaultArgument<A>.Type)(a : (A, A) -> Swift.Bool) -> default_arguments.ReabstractDefaultArgument<A>
-// CHECK: [[FN:%.*]] = function_ref @_T017default_arguments25ReabstractDefaultArgument{{.*}} : $@convention(thin) <τ_0_0> () -> @owned @noescape @callee_owned (@in τ_0_0, @in τ_0_0) -> Bool
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Int>() : $@convention(thin) <τ_0_0> () -> @owned @noescape @callee_owned (@in τ_0_0, @in τ_0_0) -> Bool
-// CHECK-NEXT: function_ref reabstraction thunk helper from @callee_owned (@in Swift.Int, @in Swift.Int) -> (@unowned Swift.Bool) to @callee_owned (@unowned Swift.Int, @unowned Swift.Int) -> (@unowned Swift.Bool)
-// CHECK-NEXT: [[THUNK:%.*]] = function_ref @_T0S2iSbIxiid_S2iSbIxyyd_TR : $@convention(thin) (Int, Int, @owned @noescape @callee_owned (@in Int, @in Int) -> Bool) -> Bool
-// CHECK-NEXT: [[FN:%.*]] = partial_apply [[THUNK]]([[RESULT]]) : $@convention(thin) (Int, Int, @owned @noescape @callee_owned (@in Int, @in Int) -> Bool) -> Bool
+// CHECK: [[FN:%.*]] = function_ref @_T017default_arguments25ReabstractDefaultArgument{{.*}} : $@convention(thin) <τ_0_0> () -> @owned @noescape @callee_guaranteed (@in τ_0_0, @in τ_0_0) -> Bool
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Int>() : $@convention(thin) <τ_0_0> () -> @owned @noescape @callee_guaranteed (@in τ_0_0, @in τ_0_0) -> Bool
+// CHECK-NEXT: function_ref reabstraction thunk helper from @callee_guaranteed (@in Swift.Int, @in Swift.Int) -> (@unowned Swift.Bool) to @callee_guaranteed (@unowned Swift.Int, @unowned Swift.Int) -> (@unowned Swift.Bool)
+// CHECK-NEXT: [[THUNK:%.*]] = function_ref @_T0S2iSbIgiid_S2iSbIgyyd_TR : $@convention(thin) (Int, Int, @guaranteed @noescape @callee_guaranteed (@in Int, @in Int) -> Bool) -> Bool
+// CHECK-NEXT: [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[RESULT]]) : $@convention(thin) (Int, Int, @guaranteed @noescape @callee_guaranteed (@in Int, @in Int) -> Bool) -> Bool
 // CHECK-NEXT: [[CONV_FN:%.*]] = convert_function [[FN]]
-// function_ref reabstraction thunk helper from @callee_owned (@unowned Swift.Int, @unowned Swift.Int) -> (@unowned Swift.Bool) to @callee_owned (@in Swift.Int, @in Swift.Int) -> (@unowned Swift.Bool)
-// CHECK: [[THUNK:%.*]] = function_ref @_T0S2iSbIxyyd_S2iSbIxiid_TR : $@convention(thin) (@in Int, @in Int, @owned @noescape @callee_owned (Int, Int) -> Bool) -> Bool
-// CHECK-NEXT: [[FN:%.*]] = partial_apply [[THUNK]]([[CONV_FN]]) : $@convention(thin) (@in Int, @in Int, @owned @noescape @callee_owned (Int, Int) -> Bool) -> Bool
+// function_ref reabstraction thunk helper from @callee_guaranteed (@unowned Swift.Int, @unowned Swift.Int) -> (@unowned Swift.Bool) to @callee_guaranteed (@in Swift.Int, @in Swift.Int) -> (@unowned Swift.Bool)
+// CHECK: [[THUNK:%.*]] = function_ref @_T0S2iSbIgyyd_S2iSbIgiid_TR : $@convention(thin) (@in Int, @in Int, @guaranteed @noescape @callee_guaranteed (Int, Int) -> Bool) -> Bool
+// CHECK-NEXT: [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[CONV_FN]]) : $@convention(thin) (@in Int, @in Int, @guaranteed @noescape @callee_guaranteed (Int, Int) -> Bool) -> Bool
 // CHECK-NEXT: [[CONV_FN:%.*]] = convert_function [[FN]]
 // CHECK: [[INITFN:%[0-9]+]] = function_ref @_T017default_arguments25ReabstractDefaultArgumentC{{[_0-9a-zA-Z]*}}fC
 // CHECK-NEXT: apply [[INITFN]]<Int>([[CONV_FN]], 

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -16,6 +16,6 @@ struct Bar<T>: P {
   typealias A = (Int) -> T
 
   func f(_ t: @escaping (Int) -> T) {}
-  // CHECK-LABEL: sil private [transparent] [thunk] @_T025dependent_member_lowering3BarVyxGAA1PA2aEP1fy1AQzFTW : $@convention(witness_method: P) <τ_0_0> (@in @callee_owned (@in Int) -> @out τ_0_0, @in_guaranteed Bar<τ_0_0>) -> ()
-  // CHECK:       bb0(%0 : @trivial $*@callee_owned (@in Int) -> @out τ_0_0, %1 : @trivial $*Bar<τ_0_0>):
+  // CHECK-LABEL: sil private [transparent] [thunk] @_T025dependent_member_lowering3BarVyxGAA1PA2aEP1fy1AQzFTW : $@convention(witness_method: P) <τ_0_0> (@in @callee_guaranteed (@in Int) -> @out τ_0_0, @in_guaranteed Bar<τ_0_0>) -> ()
+  // CHECK:       bb0(%0 : @trivial $*@callee_guaranteed (@in Int) -> @out τ_0_0, %1 : @trivial $*Bar<τ_0_0>):
 }

--- a/test/SILGen/downcast_reabstraction.swift
+++ b/test/SILGen/downcast_reabstraction.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @_T022downcast_reabstraction19condFunctionFromAnyyypF 
-// CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_owned (@in ()) -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed (@in ()) -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 // CHECK:       [[YES]]:
 // CHECK:         [[ORIG_VAL:%.*]] = load [take] [[OUT]]
-// CHECK:         [[REABSTRACT:%.*]] = function_ref @_T0ytytIexir_Iex_TR
-// CHECK:         [[SUBST_VAL:%.*]] = partial_apply [[REABSTRACT]]([[ORIG_VAL]])
+// CHECK:         [[REABSTRACT:%.*]] = function_ref @_T0ytytIegir_Ieg_TR
+// CHECK:         [[SUBST_VAL:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[ORIG_VAL]])
 
 func condFunctionFromAny(_ x: Any) {
   if let f = x as? () -> () {
@@ -14,11 +14,14 @@ func condFunctionFromAny(_ x: Any) {
 }
 
 // CHECK-LABEL: sil hidden @_T022downcast_reabstraction21uncondFunctionFromAnyyypF : $@convention(thin) (@in Any) -> () {
-// CHECK:         unconditional_checked_cast_addr Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_owned (@in ()) -> @out ()
+// CHECK:         unconditional_checked_cast_addr Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed (@in ()) -> @out ()
 // CHECK:         [[ORIG_VAL:%.*]] = load [take] [[OUT]]
-// CHECK:         [[REABSTRACT:%.*]] = function_ref @_T0ytytIexir_Iex_TR
-// CHECK:         [[SUBST_VAL:%.*]] = partial_apply [[REABSTRACT]]([[ORIG_VAL]])
-// CHECK:         apply [[SUBST_VAL]]()
+// CHECK:         [[REABSTRACT:%.*]] = function_ref @_T0ytytIegir_Ieg_TR
+// CHECK:         [[SUBST_VAL:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[ORIG_VAL]])
+// CHECK:         [[BORROW:%.*]] = begin_borrow [[SUBST_VAL]]
+// CHECK:         apply [[BORROW]]()
+// CHECK:         end_borrow [[BORROW]] from [[SUBST_VAL]]
+// CHECK:         destroy_value [[SUBST_VAL]]
 func uncondFunctionFromAny(_ x: Any) {
   (x as! () -> ())()
 }

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -445,16 +445,15 @@ public class Base {
 public class Sub : Base {
   // CHECK-LABEL: sil hidden @_T07dynamic3SubC1xSbvg : $@convention(method) (@guaranteed Sub) -> Bool {
   // CHECK: bb0([[SELF:%.*]] : $Sub):
-  // CHECK:     [[AUTOCLOSURE:%.*]] = function_ref @_T07dynamic3SubC1xSbvgSbyKXKfu_ : $@convention(thin) (@owned Sub) -> (Bool, @error Error)
+  // CHECK:     [[AUTOCLOSURE:%.*]] = function_ref @_T07dynamic3SubC1xSbvgSbyKXKfu_ : $@convention(thin) (@guaranteed Sub) -> (Bool, @error Error)
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:     = partial_apply [[AUTOCLOSURE]]([[SELF_COPY]])
+  // CHECK:     = partial_apply [callee_guaranteed] [[AUTOCLOSURE]]([[SELF_COPY]])
   // CHECK:     return {{%.*}} : $Bool
   // CHECK: } // end sil function '_T07dynamic3SubC1xSbvg'
 
-  // CHECK-LABEL: sil private [transparent] @_T07dynamic3SubC1xSbvgSbyKXKfu_ : $@convention(thin) (@owned Sub) -> (Bool, @error Error) {
+  // CHECK-LABEL: sil private [transparent] @_T07dynamic3SubC1xSbvgSbyKXKfu_ : $@convention(thin) (@guaranteed Sub) -> (Bool, @error Error) {
   // CHECK: bb0([[VALUE:%.*]] : $Sub):
-  // CHECK:     [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
-  // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[BORROWED_VALUE]]
+  // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
   // CHECK:     [[CASTED_VALUE_COPY:%.*]] = upcast [[VALUE_COPY]]
   // CHECK:     [[BORROWED_CASTED_VALUE_COPY:%.*]] = begin_borrow [[CASTED_VALUE_COPY]]
   // CHECK:     [[DOWNCAST_FOR_SUPERMETHOD:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_VALUE_COPY]]
@@ -462,8 +461,6 @@ public class Sub : Base {
   // CHECK:     end_borrow [[BORROWED_CASTED_VALUE_COPY]]
   // CHECK:     = apply [[SUPER]]([[CASTED_VALUE_COPY]])
   // CHECK:     destroy_value [[CASTED_VALUE_COPY]]
-  // CHECK:     end_borrow [[BORROWED_VALUE]] from [[VALUE]]
-  // CHECK:     destroy_value [[VALUE]]
   // CHECK: } // end sil function '_T07dynamic3SubC1xSbvgSbyKXKfu_'
   override var x: Bool { return false || super.x }
 }

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -112,7 +112,7 @@ func testAnyObjectDispatch(o: AnyObject) {
 
   // CHECK: bb1([[METHOD:%[0-9]+]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased AnyObject):
   // CHECK:   [[O_OBJ_COPY:%.*]] = copy_value [[O_OBJ]]
-  // CHECK:   [[VAR_9:%[0-9]+]] = partial_apply [[METHOD]]([[O_OBJ_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased AnyObject
+  // CHECK:   [[VAR_9:%[0-9]+]] = partial_apply [callee_guaranteed] [[METHOD]]([[O_OBJ_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased AnyObject
   var _ = o.method
 }
 // CHECK: } // end sil function '_T012dynamic_self21testAnyObjectDispatchyyXl1o_tF'
@@ -176,18 +176,18 @@ class Z {
 
     // Single capture of 'self' type
 
-    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU_ : $@convention(thin) (@owned Z) -> ()
+    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU_ : $@convention(thin) (@guaranteed Z) -> ()
     // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Z
-    // CHECK-NEXT: partial_apply [[FN]]([[SELF_COPY]])
+    // CHECK-NEXT: partial_apply [callee_guaranteed] [[FN]]([[SELF_COPY]])
     let fn1 = { _ = self }
     fn1()
 
     // Capturing 'self', but it's not the last capture. Make sure it ends
     // up at the end of the list anyway
 
-    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU0_ : $@convention(thin) (Int, @owned Z) -> ()
+    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU0_ : $@convention(thin) (Int, @guaranteed Z) -> ()
     // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Z
-    // CHECK-NEXT: partial_apply [[FN]]({{.*}}, [[SELF_COPY]])
+    // CHECK-NEXT: partial_apply [callee_guaranteed] [[FN]]({{.*}}, [[SELF_COPY]])
     let fn2 = {
       _ = self
       _ = x
@@ -198,10 +198,10 @@ class Z {
     // so that IRGen can recover metadata.
 
     // CHECK:      [[WEAK_SELF:%.*]] = alloc_box ${ var @sil_weak Optional<Z> }
-    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU1_ : $@convention(thin) (@owned { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
+    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU1_ : $@convention(thin) (@guaranteed { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
     // CHECK:      [[WEAK_SELF_COPY:%.*]] = copy_value [[WEAK_SELF]] : ${ var @sil_weak Optional<Z> }
     // CHECK-NEXT: [[DYNAMIC_SELF:%.*]] = metatype $@thick @dynamic_self Z.Type
-    // CHECK:      partial_apply [[FN]]([[WEAK_SELF_COPY]], [[DYNAMIC_SELF]]) : $@convention(thin) (@owned { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
+    // CHECK:      partial_apply [callee_guaranteed] [[FN]]([[WEAK_SELF_COPY]], [[DYNAMIC_SELF]]) : $@convention(thin) (@guaranteed { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
     let fn3 = {
       [weak self] in
       _ = self
@@ -210,7 +210,7 @@ class Z {
 
     // Capturing a value with a complex type involving self
 
-    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU2_ : $@convention(thin) (@owned (Z, Z), @thick @dynamic_self Z.Type) -> ()
+    // CHECK:      [[FN:%.*]] = function_ref @_T012dynamic_self1ZC23testDynamicSelfCapturesACXDSi1x_tFyycfU2_ : $@convention(thin) (@guaranteed (Z, Z), @thick @dynamic_self Z.Type) -> ()
     let xx = (self, self)
     let fn4 = {
       _ = xx
@@ -261,26 +261,26 @@ class Factory {
 
 // CHECK-LABEL: sil hidden @_T012dynamic_self22partialApplySelfReturnyAA7FactoryC1c_ADm1ttF : $@convention(thin) (@owned Factory, @thick Factory.Type) -> ()
 func partialApplySelfReturn(c: Factory, t: Factory.Type) {
-  // CHECK: function_ref @_T012dynamic_self7FactoryC11newInstanceACXDyFTc : $@convention(thin) (@owned Factory) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC11newInstanceACXDyFTc : $@convention(thin) (@owned Factory) -> @owned @callee_guaranteed () -> @owned Factory
   _ = c.newInstance
-  // CHECK: function_ref @_T012dynamic_self7FactoryC11newInstanceACXDyFTc : $@convention(thin) (@owned Factory) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC11newInstanceACXDyFTc : $@convention(thin) (@owned Factory) -> @owned @callee_guaranteed () -> @owned Factory
   _ = Factory.newInstance
-  // CHECK: function_ref @_T012dynamic_self7FactoryC11newInstanceACXDyFTc : $@convention(thin) (@owned Factory) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC11newInstanceACXDyFTc : $@convention(thin) (@owned Factory) -> @owned @callee_guaranteed () -> @owned Factory
   _ = t.newInstance
   _ = type(of: c).newInstance
 
-  // CHECK: function_ref @_T012dynamic_self7FactoryC16classNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC16classNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_guaranteed () -> @owned Factory
   _ = t.classNewInstance
-  // CHECK: function_ref @_T012dynamic_self7FactoryC16classNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC16classNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_guaranteed () -> @owned Factory
   _ = type(of: c).classNewInstance
-  // CHECK: function_ref @_T012dynamic_self7FactoryC16classNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC16classNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_guaranteed () -> @owned Factory
   _ = Factory.classNewInstance
 
-  // CHECK: function_ref @_T012dynamic_self7FactoryC17staticNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC17staticNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_guaranteed () -> @owned Factory
   _ = t.staticNewInstance
-  // CHECK: function_ref @_T012dynamic_self7FactoryC17staticNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC17staticNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_guaranteed () -> @owned Factory
   _ = type(of: c).staticNewInstance
-  // CHECK: function_ref @_T012dynamic_self7FactoryC17staticNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  // CHECK: function_ref @_T012dynamic_self7FactoryC17staticNewInstanceACXDyFZTc : $@convention(thin) (@thick Factory.Type) -> @owned @callee_guaranteed () -> @owned Factory
   _ = Factory.staticNewInstance
 }
 
@@ -358,20 +358,20 @@ class Derived : Base {
 class Generic<T> {
   // Examples where we have to add a special argument to capture Self's metadata
   func t1() -> Self {
-    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t1ACyxGXDyFAEXDSgycfU_ : $@convention(thin) <T> (@owned <τ_0_0> { var @sil_weak Optional<Generic<τ_0_0>> } <T>, @thick @dynamic_self Generic<T>.Type) -> @owned Optional<Generic<T>>
+    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t1ACyxGXDyFAEXDSgycfU_ : $@convention(thin) <T> (@guaranteed <τ_0_0> { var @sil_weak Optional<Generic<τ_0_0>> } <T>, @thick @dynamic_self Generic<T>.Type) -> @owned Optional<Generic<T>>
     _ = {[weak self] in self }
     return self
   }
 
   func t2() -> Self {
-    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t2ACyxGXDyFAEXD_AEXDtycfU_ : $@convention(thin) <T> (@owned (Generic<T>, Generic<T>), @thick @dynamic_self Generic<T>.Type) -> (@owned Generic<T>, @owned Generic<T>)
+    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t2ACyxGXDyFAEXD_AEXDtycfU_ : $@convention(thin) <T> (@guaranteed (Generic<T>, Generic<T>), @thick @dynamic_self Generic<T>.Type) -> (@owned Generic<T>, @owned Generic<T>)
     let selves = (self, self)
     _ = { selves }
     return self
   }
 
   func t3() -> Self {
-    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t3ACyxGXDyFAEXDycfU_ : $@convention(thin) <T> (@owned @sil_unowned Generic<T>, @thick @dynamic_self Generic<T>.Type) -> @owned Generic<T> 
+    // CHECK-LABEL: sil private @_T012dynamic_self7GenericC2t3ACyxGXDyFAEXDycfU_ : $@convention(thin) <T> (@guaranteed @sil_unowned Generic<T>, @thick @dynamic_self Generic<T>.Type) -> @owned Generic<T> 
     _ = {[unowned self] in self }
     return self
   }

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -46,7 +46,7 @@ func Optionable_cases(_ x: Int) {
 
 // CHECK-LABEL: sil shared [transparent] [thunk] @_T0s10OptionableO4mereABSicABmF
 // CHECK:        [[FN:%.*]] = function_ref @_T0s10OptionableO4mereABSicABmF
-// CHECK-NEXT:   [[METHOD:%.*]] = partial_apply [[FN]](%0)
+// CHECK-NEXT:   [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]](%0)
 // CHECK-NEXT:   return [[METHOD]]
 // CHECK-NEXT: }
 
@@ -106,8 +106,8 @@ func AddressOnly_cases(_ s: S) {
 
 // CHECK-LABEL: sil shared [transparent] [thunk] @_T0s11AddressOnlyO4mereABs1P_pcABmF
 // CHECK:       [[FN:%.*]] = function_ref @_T0s11AddressOnlyO4mereABs1P_pcABmF
-// CHECK-NEXT:  [[METHOD:%.*]] = partial_apply [[FN]](%0)
-// CHECK-NEXT:  return [[METHOD]] : $@callee_owned (@in P) -> @out AddressOnly
+// CHECK-NEXT:  [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]](%0)
+// CHECK-NEXT:  return [[METHOD]] : $@callee_guaranteed (@in P) -> @out AddressOnly
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil shared [transparent] @_T0s11AddressOnlyO4mereABs1P_pcABmF
@@ -173,7 +173,7 @@ enum Foo { case A(P, String) }
 
 // CHECK-LABEL: sil shared [transparent] [thunk] @_T0s3FooO1AABs1P_p_SStcABmF
 // CHECK:         [[FN:%.*]] = function_ref @_T0s3FooO1AABs1P_p_SStcABmF
-// CHECK-NEXT:    [[METHOD:%.*]] = partial_apply [[FN]](%0)
+// CHECK-NEXT:    [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]](%0)
 // CHECK-NEXT:    return [[METHOD]]
 // CHECK-NEXT:  }
 

--- a/test/SILGen/erasure_reabstraction.swift
+++ b/test/SILGen/erasure_reabstraction.swift
@@ -12,8 +12,8 @@ let x: Any = Foo.self
 // CHECK: [[CONCRETE:%.*]] = init_existential_addr [[EXISTENTIAL:%.*]] : $*Any, $() -> ()
 // CHECK: [[CLOSURE:%.*]] = function_ref
 // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE]]
-// CHECK: [[REABSTRACTION_THUNK:%.*]] = function_ref @_T0Iex_ytytIexir_TR
-// CHECK: [[CLOSURE_REABSTRACTED:%.*]] = partial_apply [[REABSTRACTION_THUNK]]([[CLOSURE_THICK]])
+// CHECK: [[REABSTRACTION_THUNK:%.*]] = function_ref @_T0Ieg_ytytIegir_TR
+// CHECK: [[CLOSURE_REABSTRACTED:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTION_THUNK]]([[CLOSURE_THICK]])
 // CHECK: store [[CLOSURE_REABSTRACTED]] to [init] [[CONCRETE]]
 let y: Any = {() -> () in ()}
 

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -146,9 +146,9 @@ extension NSObject {
 }
 
 let fn = ErrorProne.fail
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10ErrorProneC4failyyKFZTcTO : $@convention(thin) (@thick ErrorProne.Type) -> @owned @callee_owned () -> @error Error
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10ErrorProneC4failyyKFZTcTO : $@convention(thin) (@thick ErrorProne.Type) -> @owned @callee_guaranteed () -> @error Error
 // CHECK:      [[T0:%.*]] = function_ref @_T0So10ErrorProneC4failyyKFZTO : $@convention(method) (@thick ErrorProne.Type) -> @error Error
-// CHECK-NEXT: [[T1:%.*]] = partial_apply [[T0]](%0)
+// CHECK-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[T0]](%0)
 // CHECK-NEXT: return [[T1]]
 
 // CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10ErrorProneC4failyyKFZTO : $@convention(method) (@thick ErrorProne.Type) -> @error Error {

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -5,9 +5,9 @@
 
 // ==== Representation conversions
 
-// CHECK-LABEL: sil hidden @_T019function_conversion7cToFuncS2icS2iXCF : $@convention(thin) (@convention(c) (Int) -> Int) -> @owned @callee_owned (Int) -> Int
-// CHECK:         [[THUNK:%.*]] = function_ref @_T0S2iIetCyd_S2iIexyd_TR
-// CHECK:         [[FUNC:%.*]] = partial_apply [[THUNK]](%0)
+// CHECK-LABEL: sil hidden @_T019function_conversion7cToFuncS2icS2iXCF : $@convention(thin) (@convention(c) (Int) -> Int) -> @owned @callee_guaranteed (Int) -> Int
+// CHECK:         [[THUNK:%.*]] = function_ref @_T0S2iIetCyd_S2iIegyd_TR
+// CHECK:         [[FUNC:%.*]] = partial_apply [callee_guaranteed] [[THUNK]](%0)
 // CHECK:         return [[FUNC]]
 func cToFunc(_ arg: @escaping @convention(c) (Int) -> Int) -> (Int) -> Int {
   return arg
@@ -24,11 +24,11 @@ func cToBlock(_ arg: @escaping @convention(c) (Int) -> Int) -> @convention(block
 
 // ==== Throws variance
 
-// CHECK-LABEL: sil hidden @_T019function_conversion12funcToThrowsyyKcyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> @owned @callee_owned () -> @error Error
-// CHECK: bb0([[ARG:%.*]] : @owned $@callee_owned () -> ()):
+// CHECK-LABEL: sil hidden @_T019function_conversion12funcToThrowsyyKcyycF : $@convention(thin) (@owned @callee_guaranteed () -> ()) -> @owned @callee_guaranteed () -> @error Error
+// CHECK: bb0([[ARG:%.*]] : @owned $@callee_guaranteed () -> ()):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_owned () -> () to $@callee_owned () -> @error Error
+// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_guaranteed () -> () to $@callee_guaranteed () -> @error Error
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[FUNC]]
@@ -58,11 +58,11 @@ func thinToThrows() {
 class Feral {}
 class Domesticated : Feral {}
 
-// CHECK-LABEL: sil hidden @_T019function_conversion12funcToUpcastAA5FeralCycAA12DomesticatedCycF : $@convention(thin) (@owned @callee_owned () -> @owned Domesticated) -> @owned @callee_owned () -> @owned Feral {
-// CHECK: bb0([[ARG:%.*]] : @owned $@callee_owned () -> @owned Domesticated):
+// CHECK-LABEL: sil hidden @_T019function_conversion12funcToUpcastAA5FeralCycAA12DomesticatedCycF : $@convention(thin) (@owned @callee_guaranteed () -> @owned Domesticated) -> @owned @callee_guaranteed () -> @owned Feral {
+// CHECK: bb0([[ARG:%.*]] : @owned $@callee_guaranteed () -> @owned Domesticated):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_owned () -> @owned Domesticated to $@callee_owned () -> @owned Feral
+// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_guaranteed () -> @owned Domesticated to $@callee_guaranteed () -> @owned Feral
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[FUNC]]
@@ -71,11 +71,11 @@ func funcToUpcast(_ x: @escaping () -> Domesticated) -> () -> Feral {
   return x
 }
 
-// CHECK-LABEL: sil hidden @_T019function_conversion12funcToUpcastyAA12DomesticatedCcyAA5FeralCcF : $@convention(thin) (@owned @callee_owned (@owned Feral) -> ()) -> @owned @callee_owned (@owned Domesticated) -> ()
+// CHECK-LABEL: sil hidden @_T019function_conversion12funcToUpcastyAA12DomesticatedCcyAA5FeralCcF : $@convention(thin) (@owned @callee_guaranteed (@owned Feral) -> ()) -> @owned @callee_guaranteed (@owned Domesticated) -> ()
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_owned (@owned Feral) -> () to $@callee_owned (@owned Domesticated) -> (){{.*}}
+// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_guaranteed (@owned Feral) -> () to $@callee_guaranteed (@owned Domesticated) -> (){{.*}}
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[FUNC]]
@@ -123,61 +123,77 @@ struct AddrOnly {
 
 // CHECK-LABEL: sil hidden @_T019function_conversion19convOptionalTrivialyAA0E0VADSgcF
 func convOptionalTrivial(_ t1: @escaping (Trivial?) -> Trivial) {
-// CHECK:         function_ref @_T019function_conversion7TrivialVSgACIexyd_AcDIexyd_TR
+// CHECK:         function_ref @_T019function_conversion7TrivialVSgACIegyd_AcDIegyd_TR
 // CHECK:         partial_apply
   let _: (Trivial) -> Trivial? = t1
 
-// CHECK:         function_ref @_T019function_conversion7TrivialVSgACIexyd_A2DIexyd_TR
+// CHECK:         function_ref @_T019function_conversion7TrivialVSgACIegyd_A2DIegyd_TR
 // CHECK:         partial_apply
   let _: (Trivial!) -> Trivial? = t1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion7TrivialVSgACIexyd_AcDIexyd_TR : $@convention(thin) (Trivial, @owned @callee_owned (Optional<Trivial>) -> Trivial) -> Optional<Trivial>
-// CHECK:         enum $Optional<Trivial>
-// CHECK-NEXT:    apply %1(%2)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion7TrivialVSgACIegyd_AcDIegyd_TR : $@convention(thin) (Trivial, @guaranteed @callee_guaranteed (Optional<Trivial>) -> Trivial) -> Optional<Trivial>
+// CHECK:    [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:    [[ENUM:%.*]] = enum $Optional<Trivial>
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]([[ENUM]])
 // CHECK-NEXT:    enum $Optional<Trivial>
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion7TrivialVSgACIexyd_A2DIexyd_TR : $@convention(thin) (Optional<Trivial>, @owned @callee_owned (Optional<Trivial>) -> Trivial) -> Optional<Trivial>
-// CHECK:         apply %1(%0)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion7TrivialVSgACIegyd_A2DIegyd_TR : $@convention(thin) (Optional<Trivial>, @guaranteed @callee_guaranteed (Optional<Trivial>) -> Trivial) -> Optional<Trivial>
+// CHECK:    [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]](%0)
 // CHECK-NEXT:    enum $Optional<Trivial>
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_T019function_conversion20convOptionalLoadableyAA0E0VADSgcF
 func convOptionalLoadable(_ l1: @escaping (Loadable?) -> Loadable) {
-// CHECK:         function_ref @_T019function_conversion8LoadableVSgACIexxo_AcDIexxo_TR
+// CHECK:         function_ref @_T019function_conversion8LoadableVSgACIegxo_AcDIegxo_TR
 // CHECK:         partial_apply
   let _: (Loadable) -> Loadable? = l1
 
-// CHECK:         function_ref @_T019function_conversion8LoadableVSgACIexxo_A2DIexxo_TR
+// CHECK:         function_ref @_T019function_conversion8LoadableVSgACIegxo_A2DIegxo_TR
 // CHECK:         partial_apply
   let _: (Loadable!) -> Loadable? = l1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion8LoadableVSgACIexxo_A2DIexxo_TR : $@convention(thin) (@owned Optional<Loadable>, @owned @callee_owned (@owned Optional<Loadable>) -> @owned Loadable) -> @owned Optional<Loadable>
-// CHECK:         apply %1(%0)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion8LoadableVSgACIegxo_A2DIegxo_TR : $@convention(thin) (@owned Optional<Loadable>, @guaranteed @callee_guaranteed (@owned Optional<Loadable>) -> @owned Loadable) -> @owned Optional<Loadable>
+// CHECK:    [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]](%0)
 // CHECK-NEXT:    enum $Optional<Loadable>
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_T019function_conversion20convOptionalAddrOnlyyAA0eF0VADSgcF
 func convOptionalAddrOnly(_ a1: @escaping (AddrOnly?) -> AddrOnly) {
-// CHECK:         function_ref @_T019function_conversion8AddrOnlyVSgACIexir_A2DIexir_TR
+// CHECK:         function_ref @_T019function_conversion8AddrOnlyVSgACIegir_A2DIegir_TR
 // CHECK:         partial_apply
   let _: (AddrOnly?) -> AddrOnly? = a1
 
-// CHECK:         function_ref @_T019function_conversion8AddrOnlyVSgACIexir_A2DIexir_TR
+// CHECK:         function_ref @_T019function_conversion8AddrOnlyVSgACIegir_A2DIegir_TR
 // CHECK:         partial_apply
   let _: (AddrOnly!) -> AddrOnly? = a1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion8AddrOnlyVSgACIexir_A2DIexir_TR : $@convention(thin) (@in Optional<AddrOnly>, @owned @callee_owned (@in Optional<AddrOnly>) -> @out AddrOnly) -> @out Optional<AddrOnly>
-// CHECK:         alloc_stack $AddrOnly
-// CHECK-NEXT:    apply %2(%3, %1)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion8AddrOnlyVSgACIegir_A2DIegir_TR : $@convention(thin) (@in Optional<AddrOnly>, @guaranteed @callee_guaranteed (@in Optional<AddrOnly>) -> @out AddrOnly) -> @out Optional<AddrOnly>
+// CHECK:    [[COPY:%.*]] = copy_value %2
+// CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $AddrOnly
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]([[TEMP]], %1)
 // CHECK-NEXT:    init_enum_data_addr %0 : $*Optional<AddrOnly>
 // CHECK-NEXT:    copy_addr [take] {{.*}} to [initialization] {{.*}} : $*AddrOnly
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<AddrOnly>
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow
 // CHECK-NEXT:    dealloc_stack {{.*}} : $*AddrOnly
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // ==== Existentials
@@ -194,29 +210,31 @@ extension AddrOnly : P {}
 
 // CHECK-LABEL: sil hidden @_T019function_conversion22convExistentialTrivialyAA0E0VAA1Q_pc_AdaE_pSgc2t3tF
 func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -> Trivial) {
-// CHECK:         function_ref @_T019function_conversion1Q_pAA7TrivialVIexid_AdA1P_pIexyr_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pAA7TrivialVIegid_AdA1P_pIegyr_TR
 // CHECK:         partial_apply
   let _: (Trivial) -> P = t2
 
-// CHECK:         function_ref @_T019function_conversion1Q_pSgAA7TrivialVIexid_AESgAA1P_pIexyr_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pSgAA7TrivialVIegid_AESgAA1P_pIegyr_TR
 // CHECK:         partial_apply
   let _: (Trivial?) -> P = t3
 
-// CHECK:         function_ref @_T019function_conversion1Q_pAA7TrivialVIexid_AA1P_pAaE_pIexir_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pAA7TrivialVIegid_AA1P_pAaE_pIegir_TR
 // CHECK:         partial_apply
   let _: (P) -> P = t2
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pAA7TrivialVIexid_AdA1P_pIexyr_TR : $@convention(thin) (Trivial, @owned @callee_owned (@in Q) -> Trivial) -> @out P
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pAA7TrivialVIegid_AdA1P_pIegyr_TR : $@convention(thin) (Trivial, @guaranteed @callee_guaranteed (@in Q) -> Trivial) -> @out P
 // CHECK:         alloc_stack $Q
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
+// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
+// CHECK:         end_borrow
 // CHECK:         return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pSgAA7TrivialVIexid_AESgAA1P_pIexyr_TR
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pSgAA7TrivialVIegid_AESgAA1P_pIegyr_TR
 // CHECK:         switch_enum
 // CHECK: bb1([[TRIVIAL:%.*]] : @trivial $Trivial):
 // CHECK:         init_existential_addr
@@ -231,14 +249,16 @@ func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -
 // CHECK:         store
 // CHECK:         return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pAA7TrivialVIexid_AA1P_pAaE_pIexir_TR : $@convention(thin) (@in P, @owned @callee_owned (@in Q) -> Trivial) -> @out P
-// CHECK:         alloc_stack $Q
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pAA7TrivialVIegid_AA1P_pAaE_pIegir_TR : $@convention(thin) (@in P, @guaranteed @callee_guaranteed (@in Q) -> Trivial) -> @out P
+// CHECK:         [[TMP:%.*]] = alloc_stack $Q
 // CHECK-NEXT:    open_existential_addr immutable_access %1 : $*P
-// CHECK-NEXT:    init_existential_addr %3 : $*Q
+// CHECK-NEXT:    init_existential_addr [[TMP]] : $*Q
 // CHECK-NEXT:    copy_addr {{.*}} to [initialization] {{.*}}
+// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
+// CHECK:         end_borrow
 // CHECK:         destroy_addr
 // CHECK:         return
 
@@ -246,29 +266,33 @@ func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -
 
 // CHECK-LABEL: sil hidden @_T019function_conversion23convExistentialMetatypeyAA7TrivialVmAA1Q_pXpSgcF
 func convExistentialMetatype(_ em: @escaping (Q.Type?) -> Trivial.Type) {
-// CHECK:         function_ref @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIexyd_AEXMtAA1P_pXmTIexyd_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AEXMtAA1P_pXmTIegyd_TR
 // CHECK:         partial_apply
   let _: (Trivial.Type) -> P.Type = em
 
-// CHECK:         function_ref @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIexyd_AEXMtSgAA1P_pXmTIexyd_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AEXMtSgAA1P_pXmTIegyd_TR
 // CHECK:         partial_apply
   let _: (Trivial.Type?) -> P.Type = em
 
-// CHECK:         function_ref @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIexyd_AA1P_pXmTAaF_pXmTIexyd_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AA1P_pXmTAaF_pXmTIegyd_TR
 // CHECK:         partial_apply
   let _: (P.Type) -> P.Type = em
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIexyd_AEXMtAA1P_pXmTIexyd_TR : $@convention(thin) (@thin Trivial.Type, @owned @callee_owned (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
-// CHECK:         metatype $@thick Trivial.Type
-// CHECK-NEXT:    init_existential_metatype %2 : $@thick Trivial.Type, $@thick Q.Type
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AEXMtAA1P_pXmTIegyd_TR : $@convention(thin) (@thin Trivial.Type, @guaranteed @callee_guaranteed (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
+// CHECK:         [[ARGCOPY:%.*]] = copy_value
+// CHECK-NEXT:    [[META:%.*]] = metatype $@thick Trivial.Type
+// CHECK-NEXT:    init_existential_metatype [[META]] : $@thick Trivial.Type, $@thick Q.Type
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>
+// CHECK-NEXT:     begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick P.Type
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    destroy_value [[ARGCOPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIexyd_AEXMtSgAA1P_pXmTIexyd_TR : $@convention(thin) (Optional<@thin Trivial.Type>, @owned @callee_owned (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AEXMtSgAA1P_pXmTIegyd_TR : $@convention(thin) (Optional<@thin Trivial.Type>, @guaranteed @callee_guaranteed (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
 // CHECK:         switch_enum %0 : $Optional<@thin Trivial.Type>
 // CHECK: bb1([[META:%.*]] : @trivial $@thin Trivial.Type):
 // CHECK-NEXT:    metatype $@thick Trivial.Type
@@ -277,18 +301,25 @@ func convExistentialMetatype(_ em: @escaping (Q.Type?) -> Trivial.Type) {
 // CHECK: bb2:
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>
 // CHECK: bb3({{.*}}):
+// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick P.Type
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIexyd_AA1P_pXmTAaF_pXmTIexyd_TR : $@convention(thin) (@thick P.Type, @owned @callee_owned (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
-// CHECK:         open_existential_metatype %0 : $@thick P.Type to $@thick (@opened({{.*}}) P).Type
-// CHECK-NEXT:    init_existential_metatype %2 : $@thick (@opened({{.*}}) P).Type, $@thick Q.Type
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AA1P_pXmTAaF_pXmTIegyd_TR : $@convention(thin) (@thick P.Type, @guaranteed @callee_guaranteed (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
+// CHECK:         copy_value
+// CHECK-NEXT:    open_existential_metatype %0 : $@thick P.Type to $@thick (@opened({{.*}}) P).Type
+// CHECK-NEXT:    init_existential_metatype %3 : $@thick (@opened({{.*}}) P).Type, $@thick Q.Type
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>
+// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick P.Type
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    return
 
 // ==== Class metatype upcasts
@@ -302,33 +333,33 @@ class Child : Parent {}
 // CHECK-LABEL: sil hidden @_T019function_conversion18convUpcastMetatypeyAA5ChildCmAA6ParentCm_AA7TrivialVSgtc_ADmAFmSg_AItc2c5tF
 func convUpcastMetatype(_ c4: @escaping (Parent.Type, Trivial?) -> Child.Type,
                         c5: @escaping (Parent.Type?, Trivial?) -> Child.Type) {
-// CHECK:         function_ref @_T019function_conversion6ParentCXMTAA7TrivialVSgAA5ChildCXMTIexyyd_AHXMTAeCXMTIexyyd_TR
+// CHECK:         function_ref @_T019function_conversion6ParentCXMTAA7TrivialVSgAA5ChildCXMTIegyyd_AHXMTAeCXMTIegyyd_TR
 // CHECK:         partial_apply
   let _: (Child.Type, Trivial) -> Parent.Type = c4
 
-// CHECK:         function_ref @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIexyyd_AIXMTAfCXMTIexyyd_TR
+// CHECK:         function_ref @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIegyyd_AIXMTAfCXMTIegyyd_TR
 // CHECK:         partial_apply
   let _: (Child.Type, Trivial) -> Parent.Type = c5
 
-// CHECK:         function_ref @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIexyyd_AIXMTSgAfDIexyyd_TR
+// CHECK:         function_ref @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIegyyd_AIXMTSgAfDIegyyd_TR
 // CHECK:         partial_apply
   let _: (Child.Type?, Trivial) -> Parent.Type? = c5
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTAA7TrivialVSgAA5ChildCXMTIexyyd_AHXMTAeCXMTIexyyd_TR : $@convention(thin) (@thick Child.Type, Trivial, @owned @callee_owned (@thick Parent.Type, Optional<Trivial>) -> @thick Child.Type) -> @thick Parent.Type
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTAA7TrivialVSgAA5ChildCXMTIegyyd_AHXMTAeCXMTIegyyd_TR : $@convention(thin) (@thick Child.Type, Trivial, @guaranteed @callee_guaranteed (@thick Parent.Type, Optional<Trivial>) -> @thick Child.Type) -> @thick Parent.Type
 // CHECK:         upcast %0 : $@thick Child.Type to $@thick Parent.Type
 // CHECK:         apply
 // CHECK:         upcast {{.*}} : $@thick Child.Type to $@thick Parent.Type
 // CHECK:         return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIexyyd_AIXMTAfCXMTIexyyd_TR : $@convention(thin) (@thick Child.Type, Trivial, @owned @callee_owned (Optional<@thick Parent.Type>, Optional<Trivial>) -> @thick Child.Type) -> @thick Parent.Type
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIegyyd_AIXMTAfCXMTIegyyd_TR : $@convention(thin) (@thick Child.Type, Trivial, @guaranteed @callee_guaranteed (Optional<@thick Parent.Type>, Optional<Trivial>) -> @thick Child.Type) -> @thick Parent.Type
 // CHECK:         upcast %0 : $@thick Child.Type to $@thick Parent.Type
 // CHECK:         enum $Optional<@thick Parent.Type>
 // CHECK:         apply
 // CHECK:         upcast {{.*}} : $@thick Child.Type to $@thick Parent.Type
 // CHECK:         return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIexyyd_AIXMTSgAfDIexyyd_TR : $@convention(thin) (Optional<@thick Child.Type>, Trivial, @owned @callee_owned (Optional<@thick Parent.Type>, Optional<Trivial>) -> @thick Child.Type) -> Optional<@thick Parent.Type>
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTSgAA7TrivialVSgAA5ChildCXMTIegyyd_AIXMTSgAfDIegyyd_TR : $@convention(thin) (Optional<@thick Child.Type>, Trivial, @guaranteed @callee_guaranteed (Optional<@thick Parent.Type>, Optional<Trivial>) -> @thick Child.Type) -> Optional<@thick Parent.Type>
 // CHECK:         unchecked_trivial_bit_cast %0 : $Optional<@thick Child.Type> to $Optional<@thick Parent.Type>
 // CHECK:         apply
 // CHECK:         upcast {{.*}} : $@thick Child.Type to $@thick Parent.Type
@@ -337,12 +368,12 @@ func convUpcastMetatype(_ c4: @escaping (Parent.Type, Trivial?) -> Child.Type,
 
 // ==== Function to existential -- make sure we maximally abstract it
 
-// CHECK-LABEL: sil hidden @_T019function_conversion19convFuncExistentialyS2icypcF : $@convention(thin) (@owned @callee_owned (@in Any) -> @owned @callee_owned (Int) -> Int) -> ()
+// CHECK-LABEL: sil hidden @_T019function_conversion19convFuncExistentialyS2icypcF : $@convention(thin) (@owned @callee_guaranteed (@in Any) -> @owned @callee_guaranteed (Int) -> Int) -> ()
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[REABSTRACT_THUNK:%.*]] = function_ref @_T0ypS2iIexyd_Iexio_S2iIxyd_ypIexxr_TR
-// CHECK:   [[PA:%.*]] = partial_apply [[REABSTRACT_THUNK]]([[ARG_COPY]])
+// CHECK:   [[REABSTRACT_THUNK:%.*]] = function_ref @_T0ypS2iIegyd_Iegio_S2iIgyd_ypIegxr_TR
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[ARG_COPY]])
 // CHECK:   destroy_value [[PA]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
@@ -351,39 +382,48 @@ func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
   let _: ((Int) -> Int) -> Any = f1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypS2iIexyd_Iexio_S2iIxyd_ypIexxr_TR : $@convention(thin) (@owned @noescape @callee_owned (Int) -> Int, @owned @callee_owned (@in Any) -> @owned @callee_owned (Int) -> Int) -> @out Any
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypS2iIegyd_Iegio_S2iIgyd_ypIegxr_TR : $@convention(thin) (@owned @noescape @callee_guaranteed (Int) -> Int, @guaranteed @callee_guaranteed (@in Any) -> @owned @callee_guaranteed (Int) -> Int) -> @out Any
+// CHECK:         copy_value
 // CHECK:         alloc_stack $Any
-// CHECK:         function_ref @_T0S2iIxyd_S2iIxir_TR
+// CHECK:         function_ref @_T0S2iIgyd_S2iIgir_TR
 // CHECK-NEXT:    partial_apply
 // CHECK-NEXT:    convert_function
-// CHECK-NEXT:    init_existential_addr %3 : $*Any, $(Int) -> Int
+// CHECK-NEXT:    init_existential_addr %4 : $*Any, $(Int) -> Int
 // CHECK-NEXT:    store
+// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
-// CHECK:         function_ref @_T0S2iIexyd_S2iIexir_TR
+// CHECK:         function_ref @_T0S2iIegyd_S2iIegir_TR
 // CHECK-NEXT:    partial_apply
 // CHECK-NEXT:    init_existential_addr %0 : $*Any, $(Int) -> Int
-// CHECK-NEXT:    store {{.*}} to {{.*}} : $*@callee_owned (@in Int) -> @out Int
+// CHECK-NEXT:    store {{.*}} to {{.*}} : $*@callee_guaranteed (@in Int) -> @out Int
 // CHECK:         return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIexyd_S2iIexir_TR : $@convention(thin) (@in Int, @owned @callee_owned (Int) -> Int) -> @out Int
-// CHECK:         load [trivial] %1 : $*Int
-// CHECK-NEXT:    apply %2(%3)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegyd_S2iIegir_TR : $@convention(thin) (@in Int, @guaranteed @callee_guaranteed (Int) -> Int) -> @out Int
+// CHECK:         [[COPY:%.*]] = copy_value %2
+// CHECK-NEXT:    [[LOADED:%.*]] = load [trivial] %1 : $*Int
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]([[LOADED]])
 // CHECK-NEXT:    store {{.*}} to [trivial] %0
-// CHECK:         return
+// CHECK-NEXT:    [[VOID:%.*]] = tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
+// CHECK:         return [[VOID]]
 
 // ==== Class-bound archetype upcast
 
 // CHECK-LABEL: sil hidden @_T019function_conversion29convClassBoundArchetypeUpcast{{[_0-9a-zA-Z]*}}F
 func convClassBoundArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent) -> (T, Trivial)) {
-// CHECK:         function_ref @_T019function_conversion6ParentCxAA7TrivialVIexxod_xAcESgIexxod_ACRbzlTR
+// CHECK:         function_ref @_T019function_conversion6ParentCxAA7TrivialVIegxod_xAcESgIegxod_ACRbzlTR
 // CHECK:         partial_apply
   let _: (T) -> (Parent, Trivial?) = f1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCxAA7TrivialVIexxod_xAcESgIexxod_ACRbzlTR : $@convention(thin) <T where T : Parent> (@owned T, @owned @callee_owned (@owned Parent) -> (@owned T, Trivial)) -> (@owned Parent, Optional<Trivial>)
-// CHECK: bb0([[ARG:%.*]] : @owned $T, [[CLOSURE:%.*]] : @owned $@callee_owned (@owned Parent) -> (@owned T, Trivial)):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCxAA7TrivialVIegxod_xAcESgIegxod_ACRbzlTR : $@convention(thin) <T where T : Parent> (@owned T, @guaranteed @callee_guaranteed (@owned Parent) -> (@owned T, Trivial)) -> (@owned Parent, Optional<Trivial>)
+// CHECK: bb0([[ARG:%.*]] : @owned $T, [[CLOSURE:%.*]] : @guaranteed $@callee_guaranteed (@owned Parent) -> (@owned T, Trivial)):
+// CHECK:    [[COPY:%.*]] = copy_value [[CLOSURE]]
 // CHECK:    [[CASTED_ARG:%.*]] = upcast [[ARG]] : $T to $Parent
-// CHECK:    [[RESULT:%.*]] = apply [[CLOSURE]]([[CASTED_ARG]])
+// CHECK:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:    [[RESULT:%.*]] = apply [[BORROW]]([[CASTED_ARG]])
 // CHECK:    [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]] : $(T, Trivial)
 // CHECK:    [[FIRST_RESULT:%.*]] = tuple_extract [[BORROWED_RESULT]] : $(T, Trivial), 0
 // CHECK:    [[COPIED_FIRST_RESULT:%.*]] = copy_value [[FIRST_RESULT]]
@@ -397,31 +437,35 @@ func convClassBoundArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent) -> (T, T
 
 // CHECK-LABEL: sil hidden @_T019function_conversion37convClassBoundMetatypeArchetypeUpcast{{[_0-9a-zA-Z]*}}F
 func convClassBoundMetatypeArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent.Type) -> (T.Type, Trivial)) {
-// CHECK:         function_ref @_T019function_conversion6ParentCXMTxXMTAA7TrivialVIexydd_xXMTACXMTAESgIexydd_ACRbzlTR
+// CHECK:         function_ref @_T019function_conversion6ParentCXMTxXMTAA7TrivialVIegydd_xXMTACXMTAESgIegydd_ACRbzlTR
 // CHECK:         partial_apply
   let _: (T.Type) -> (Parent.Type, Trivial?) = f1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTxXMTAA7TrivialVIexydd_xXMTACXMTAESgIexydd_ACRbzlTR : $@convention(thin) <T where T : Parent> (@thick T.Type, @owned @callee_owned (@thick Parent.Type) -> (@thick T.Type, Trivial)) -> (@thick Parent.Type, Optional<Trivial>)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTxXMTAA7TrivialVIegydd_xXMTACXMTAESgIegydd_ACRbzlTR : $@convention(thin) <T where T : Parent> (@thick T.Type, @guaranteed @callee_guaranteed (@thick Parent.Type) -> (@thick T.Type, Trivial)) -> (@thick Parent.Type, Optional<Trivial>)
+// CHECK:         copy_value
 // CHECK:         upcast %0 : $@thick T.Type to $@thick Parent.Type
+// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    tuple_extract
 // CHECK-NEXT:    tuple_extract
 // CHECK-NEXT:    upcast {{.*}} : $@thick T.Type to $@thick Parent.Type
 // CHECK-NEXT:    enum $Optional<Trivial>
 // CHECK-NEXT:    tuple
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    return
 
 // ==== Make sure we destructure one-element tuples
 
 // CHECK-LABEL: sil hidden @_T019function_conversion15convTupleScalaryyAA1Q_pc_yAaC_pc2f2ySi_SitSgc2f3tF
-// CHECK:         function_ref @_T019function_conversion1Q_pIexi_AA1P_pIexi_TR
-// CHECK:         function_ref @_T019function_conversion1Q_pIexi_AA1P_pIexi_TR
-// CHECK:         function_ref @_T0Si_SitSgIexy_S2iIexyy_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pIegi_AA1P_pIegi_TR
+// CHECK:         function_ref @_T019function_conversion1Q_pIegi_AA1P_pIegi_TR
+// CHECK:         function_ref @_T0Si_SitSgIegy_S2iIegyy_TR
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pIexi_AA1P_pIexi_TR : $@convention(thin) (@in P, @owned @callee_owned (@in Q) -> ()) -> ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pIegi_AA1P_pIegi_TR : $@convention(thin) (@in P, @guaranteed @callee_guaranteed (@in Q) -> ()) -> ()
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si_SitSgIexy_S2iIexyy_TR : $@convention(thin) (Int, Int, @owned @callee_owned (Optional<(Int, Int)>) -> ()) -> ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si_SitSgIegy_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (Optional<(Int, Int)>) -> ()) -> ()
 
 func convTupleScalar(_ f1: @escaping (Q) -> (),
                      f2: @escaping (_ parent: Q) -> (),
@@ -435,47 +479,56 @@ func convTupleScalarOpaque<T>(_ f: @escaping (T...) -> ()) -> ((_ args: T...) ->
   return f
 }
 
-// CHECK-LABEL: sil hidden @_T019function_conversion25convTupleToOptionalDirectSi_SitSgSicSi_SitSicF : $@convention(thin) (@owned @callee_owned (Int) -> (Int, Int)) -> @owned @callee_owned (Int) -> Optional<(Int, Int)>
-// CHECK:         bb0([[ARG:%.*]] : @owned $@callee_owned (Int) -> (Int, Int)):
+// CHECK-LABEL: sil hidden @_T019function_conversion25convTupleToOptionalDirectSi_SitSgSicSi_SitSicF : $@convention(thin) (@owned @callee_guaranteed (Int) -> (Int, Int)) -> @owned @callee_guaranteed (Int) -> Optional<(Int, Int)>
+// CHECK:         bb0([[ARG:%.*]] : @owned $@callee_guaranteed (Int) -> (Int, Int)):
 // CHECK:           [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:           [[FN:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:           [[THUNK_FN:%.*]] = function_ref @_T0S3iIexydd_S2i_SitSgIexyd_TR
-// CHECK-NEXT:      [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[FN]])
+// CHECK:           [[THUNK_FN:%.*]] = function_ref @_T0S3iIegydd_S2i_SitSgIegyd_TR
+// CHECK-NEXT:      [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]([[FN]])
 // CHECK-NEXT:      end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT:      destroy_value [[ARG]]
 // CHECK-NEXT:      return [[THUNK]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S3iIexydd_S2i_SitSgIexyd_TR : $@convention(thin) (Int, @owned @callee_owned (Int) -> (Int, Int)) -> Optional<(Int, Int)>
-// CHECK:         bb0(%0 : @trivial $Int, %1 : @owned $@callee_owned (Int) -> (Int, Int)):
-// CHECK:           [[RESULT:%.*]] = apply %1(%0)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S3iIegydd_S2i_SitSgIegyd_TR : $@convention(thin) (Int, @guaranteed @callee_guaranteed (Int) -> (Int, Int)) -> Optional<(Int, Int)>
+// CHECK:         bb0(%0 : @trivial $Int, %1 : @guaranteed $@callee_guaranteed (Int) -> (Int, Int)):
+// CHECK:           [[COPY:%.*]] = copy_value %1
+// CHECK:           [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:           [[RESULT:%.*]] = apply [[BORROW]](%0)
 // CHECK-NEXT:      [[LEFT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:      [[RIGHT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:      [[RESULT:%.*]] = tuple ([[LEFT]] : $Int, [[RIGHT]] : $Int)
 // CHECK-NEXT:      [[OPTIONAL:%.*]] = enum $Optional<(Int, Int)>, #Optional.some!enumelt.1, [[RESULT]]
+// CHECK-NEXT:      end_borrow [[BORROW]]
+// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[OPTIONAL]]
 
 func convTupleToOptionalDirect(_ f: @escaping (Int) -> (Int, Int)) -> (Int) -> (Int, Int)? {
   return f
 }
 
-// CHECK-LABEL: sil hidden @_T019function_conversion27convTupleToOptionalIndirectx_xtSgxcx_xtxclF : $@convention(thin) <T> (@owned @callee_owned (@in T) -> (@out T, @out T)) -> @owned @callee_owned (@in T) -> @out Optional<(T, T)>
-// CHECK:       bb0([[ARG:%.*]] : @owned $@callee_owned (@in T) -> (@out T, @out T)):
+// CHECK-LABEL: sil hidden @_T019function_conversion27convTupleToOptionalIndirectx_xtSgxcx_xtxclF : $@convention(thin) <T> (@owned @callee_guaranteed (@in T) -> (@out T, @out T)) -> @owned @callee_guaranteed (@in T) -> @out Optional<(T, T)>
+// CHECK:       bb0([[ARG:%.*]] : @owned $@callee_guaranteed (@in T) -> (@out T, @out T)):
 // CHECK:          [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:          [[FN:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:          [[THUNK_FN:%.*]] = function_ref @_T0xxxIexirr_xx_xtSgIexir_lTR
-// CHECK-NEXT:     [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<T>([[FN]])
+// CHECK:          [[THUNK_FN:%.*]] = function_ref @_T0xxxIegirr_xx_xtSgIegir_lTR
+// CHECK-NEXT:     [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<T>([[FN]])
 // CHECK-NEXT:     end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT:     destroy_value [[ARG]]
 // CHECK-NEXT:     return [[THUNK]]
 
-// CHECK:       sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xxxIexirr_xx_xtSgIexir_lTR : $@convention(thin) <T> (@in T, @owned @callee_owned (@in T) -> (@out T, @out T)) -> @out Optional<(T, T)>
-// CHECK:       bb0(%0 : @trivial $*Optional<(T, T)>, %1 : @trivial $*T, %2 : @owned $@callee_owned (@in T) -> (@out T, @out T)):
+// CHECK:       sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xxxIegirr_xx_xtSgIegir_lTR : $@convention(thin) <T> (@in T, @guaranteed @callee_guaranteed (@in T) -> (@out T, @out T)) -> @out Optional<(T, T)>
+// CHECK:       bb0(%0 : @trivial $*Optional<(T, T)>, %1 : @trivial $*T, %2 : @guaranteed $@callee_guaranteed (@in T) -> (@out T, @out T)):
+// CHECK:         [[COPY:%.*]] = copy_value %2
 // CHECK:         [[OPTIONAL:%.*]] = init_enum_data_addr %0 : $*Optional<(T, T)>, #Optional.some!enumelt.1
-// CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr %3 : $*(T, T), 0
-// CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr %3 : $*(T, T), 1
-// CHECK-NEXT:    apply %2([[LEFT]], [[RIGHT]], %1)
+// CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[OPTIONAL]] : $*(T, T), 0
+// CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[OPTIONAL]] : $*(T, T), 1
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]([[LEFT]], [[RIGHT]], %1)
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<(T, T)>, #Optional.some!enumelt.1
-// CHECK:         return
+// CHECK-NEXT:    [[VOID:%.*]] = tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
+// CHECK:         return [[VOID]]
 
 func convTupleToOptionalIndirect<T>(_ f: @escaping (T) -> (T, T)) -> (T) -> (T, T)? {
   return f
@@ -485,9 +538,9 @@ func convTupleToOptionalIndirect<T>(_ f: @escaping (T) -> (T, T)) -> (T) -> (T, 
 
 // CHECK-LABEL: sil hidden @_T019function_conversion15convAnyHashableyx1t_ts0E0RzlF
 // CHECK:         function_ref @_T019function_conversion15convAnyHashableyx1t_ts0E0RzlFSbs0dE0V_AFtcfU_
-// CHECK:         function_ref @_T0s11AnyHashableVABSbIexiid_xxSbIexiid_s0B0RzlTR
+// CHECK:         function_ref @_T0s11AnyHashableVABSbIegiid_xxSbIegiid_s0B0RzlTR
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0s11AnyHashableVABSbIexiid_xxSbIexiid_s0B0RzlTR : $@convention(thin) <T where T : Hashable> (@in T, @in T, @owned @callee_owned (@in AnyHashable, @in AnyHashable) -> Bool) -> Bool
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0s11AnyHashableVABSbIegiid_xxSbIegiid_s0B0RzlTR : $@convention(thin) <T where T : Hashable> (@in T, @in T, @guaranteed @callee_guaranteed (@in AnyHashable, @in AnyHashable) -> Bool) -> Bool
 // CHECK:         alloc_stack $AnyHashable
 // CHECK:         function_ref @_swift_convertToAnyHashable
 // CHECK:         apply {{.*}}<T>
@@ -505,17 +558,17 @@ func convAnyHashable<T : Hashable>(t: T) {
 // ==== Convert exploded tuples to Any or Optional<Any>
 
 // CHECK-LABEL: sil hidden @_T019function_conversion12convTupleAnyyyyc_Si_SitycyypcyypSgctF
-// CHECK:         function_ref @_T0Iex_ypIexr_TR
+// CHECK:         function_ref @_T0Ieg_ypIegr_TR
 // CHECK:         partial_apply
-// CHECK:         function_ref @_T0Iex_ypSgIexr_TR
+// CHECK:         function_ref @_T0Ieg_ypSgIegr_TR
 // CHECK:         partial_apply
-// CHECK:         function_ref @_T0S2iIexdd_ypIexr_TR
+// CHECK:         function_ref @_T0S2iIegdd_ypIegr_TR
 // CHECK:         partial_apply
-// CHECK:         function_ref @_T0S2iIexdd_ypSgIexr_TR
+// CHECK:         function_ref @_T0S2iIegdd_ypSgIegr_TR
 // CHECK:         partial_apply
-// CHECK:         function_ref @_T0ypIexi_S2iIexyy_TR
+// CHECK:         function_ref @_T0ypIegi_S2iIegyy_TR
 // CHECK:         partial_apply
-// CHECK:         function_ref @_T0ypSgIexi_S2iIexyy_TR
+// CHECK:         function_ref @_T0ypSgIegi_S2iIegyy_TR
 // CHECK:         partial_apply
 
 func convTupleAny(_ f1: @escaping () -> (),
@@ -533,59 +586,80 @@ func convTupleAny(_ f1: @escaping () -> (),
   let _: ((Int, Int)) -> () = f4
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Iex_ypIexr_TR : $@convention(thin) (@owned @callee_owned () -> ()) -> @out Any
-// CHECK:         init_existential_addr %0 : $*Any, $()
-// CHECK-NEXT:    apply %1()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ieg_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any
+// CHECK:         [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:    init_existential_addr %0 : $*Any, $()
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]()
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Iex_ypSgIexr_TR : $@convention(thin) (@owned @callee_owned () -> ()) -> @out Optional<Any>
-// CHECK:         [[ENUM_PAYLOAD:%.*]] = init_enum_data_addr %0 : $*Optional<Any>, #Optional.some!enumelt.1
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ieg_ypSgIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Optional<Any>
+// CHECK:         [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:    [[ENUM_PAYLOAD:%.*]] = init_enum_data_addr %0 : $*Optional<Any>, #Optional.some!enumelt.1
 // CHECK-NEXT:    init_existential_addr [[ENUM_PAYLOAD]] : $*Any, $()
-// CHECK-NEXT:    apply %1()
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]()
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt.1
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIexdd_ypIexr_TR : $@convention(thin) (@owned @callee_owned () -> (Int, Int)) -> @out Any
-// CHECK:         [[ANY_PAYLOAD:%.*]] = init_existential_addr %0
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegdd_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Any
+// CHECK:         [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr %0
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
-// CHECK-NEXT:    [[RESULT:%.*]] = apply %1()
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[BORROW]]()
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    store [[LEFT:%.*]] to [trivial] [[LEFT_ADDR]]
 // CHECK-NEXT:    store [[RIGHT:%.*]] to [trivial] [[RIGHT_ADDR]]
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIexdd_ypSgIexr_TR : $@convention(thin) (@owned @callee_owned () -> (Int, Int)) -> @out Optional<Any> {
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegdd_ypSgIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Optional<Any> {
+// CHECK:         [[COPY:%.*]] = copy_value %1
 // CHECK:         [[OPTIONAL_PAYLOAD:%.*]] = init_enum_data_addr %0
 // CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[OPTIONAL_PAYLOAD]]
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
-// CHECK-NEXT:    [[RESULT:%.*]] = apply %1()
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[BORROW]]()
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    store [[LEFT:%.*]] to [trivial] [[LEFT_ADDR]]
 // CHECK-NEXT:    store [[RIGHT:%.*]] to [trivial] [[RIGHT_ADDR]]
 // CHECK-NEXT:    inject_enum_addr %0
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIexi_S2iIexyy_TR : $@convention(thin) (Int, Int, @owned @callee_owned (@in Any) -> ()) -> ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIegi_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Any) -> ()) -> ()
+// CHECK:         [[COPY:%.*]] = copy_value %2
 // CHECK:         [[ANY_VALUE:%.*]] = alloc_stack $Any
 // CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[ANY_VALUE]]
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    store %0 to [trivial] [[LEFT_ADDR]]
 // CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    store %1 to [trivial] [[RIGHT_ADDR]]
-// CHECK-NEXT:    apply %2([[ANY_VALUE]])
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]([[ANY_VALUE]])
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
 // CHECK-NEXT:    dealloc_stack [[ANY_VALUE]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIexi_S2iIexyy_TR : $@convention(thin) (Int, Int, @owned @callee_owned (@in Optional<Any>) -> ()) -> ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIegi_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Optional<Any>) -> ()) -> ()
+// CHECK:         [[COPY:%.*]] = copy_value %2
 // CHECK:         [[ANY_VALUE:%.*]] = alloc_stack $Any
 // CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[ANY_VALUE]]
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
@@ -596,8 +670,11 @@ func convTupleAny(_ f1: @escaping () -> (),
 // CHECK-NEXT:    [[OPTIONAL_PAYLOAD:%.*]] = init_enum_data_addr [[OPTIONAL_VALUE]]
 // CHECK-NEXT:    copy_addr [take] [[ANY_VALUE]] to [initialization] [[OPTIONAL_PAYLOAD]]
 // CHECK-NEXT:    inject_enum_addr [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    apply %2([[OPTIONAL_VALUE]])
+// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[BORROW]]([[OPTIONAL_VALUE]])
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROW]]
 // CHECK-NEXT:    dealloc_stack [[OPTIONAL_VALUE]]
 // CHECK-NEXT:    dealloc_stack [[ANY_VALUE]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -8,13 +8,15 @@ import Foundation
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc20convMetatypeToObjectySo8NSObjectCmADcF
 func convMetatypeToObject(_ f: @escaping (NSObject) -> NSObject.Type) {
-// CHECK:         function_ref @_T0So8NSObjectCABXMTIexxd_AByXlIexxo_TR
+// CHECK:         function_ref @_T0So8NSObjectCABXMTIegxd_AByXlIegxo_TR
 // CHECK:         partial_apply
   let _: (NSObject) -> AnyObject = f
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0So8NSObjectCABXMTIexxd_AByXlIexxo_TR : $@convention(thin) (@owned NSObject, @owned @callee_owned (@owned NSObject) -> @thick NSObject.Type) -> @owned AnyObject {
-// CHECK:         apply %1(%0)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0So8NSObjectCABXMTIegxd_AByXlIegxo_TR : $@convention(thin) (@owned NSObject, @guaranteed @callee_guaranteed (@owned NSObject) -> @thick NSObject.Type) -> @owned AnyObject {
+// CHECK:         [[COPY:%.*]] = copy_value %1
+// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:         apply [[BORROW]](%0)
 // CHECK:         thick_to_objc_metatype {{.*}} : $@thick NSObject.Type to $@objc_metatype NSObject.Type
 // CHECK:         objc_metatype_to_object {{.*}} : $@objc_metatype NSObject.Type to $AnyObject
 // CHECK:         return
@@ -23,33 +25,37 @@ func convMetatypeToObject(_ f: @escaping (NSObject) -> NSObject.Type) {
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc31convExistentialMetatypeToObjectyAA9NSBurrito_pXpAaC_pcF
 func convExistentialMetatypeToObject(_ f: @escaping (NSBurrito) -> NSBurrito.Type) {
-// CHECK:         function_ref @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIexxd_AaB_pyXlIexxo_TR
+// CHECK:         function_ref @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIegxd_AaB_pyXlIegxo_TR
 // CHECK:         partial_apply
   let _: (NSBurrito) -> AnyObject = f
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIexxd_AaB_pyXlIexxo_TR : $@convention(thin) (@owned NSBurrito, @owned @callee_owned (@owned NSBurrito) -> @thick NSBurrito.Type) -> @owned AnyObject
-// CHECK:         apply %1(%0)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIegxd_AaB_pyXlIegxo_TR : $@convention(thin) (@owned NSBurrito, @guaranteed @callee_guaranteed (@owned NSBurrito) -> @thick NSBurrito.Type) -> @owned AnyObject
+// CHECK:         [[COPY:%.*]] = copy_value %1
+// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:         apply [[BORROW]](%0)
 // CHECK:         thick_to_objc_metatype {{.*}} : $@thick NSBurrito.Type to $@objc_metatype NSBurrito.Type
 // CHECK:         objc_existential_metatype_to_object {{.*}} : $@objc_metatype NSBurrito.Type to $AnyObject
 // CHECK:         return
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc28convProtocolMetatypeToObjectyAA9NSBurrito_pmycF
 func convProtocolMetatypeToObject(_ f: @escaping () -> NSBurrito.Protocol) {
-// CHECK:         function_ref @_T024function_conversion_objc9NSBurrito_pXMtIexd_So8ProtocolCIexo_TR
+// CHECK:         function_ref @_T024function_conversion_objc9NSBurrito_pXMtIegd_So8ProtocolCIego_TR
 // CHECK:         partial_apply
   let _: () -> Protocol = f
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pXMtIexd_So8ProtocolCIexo_TR : $@convention(thin) (@owned @callee_owned () -> @thin NSBurrito.Protocol) -> @owned Protocol
-// CHECK:         apply %0() : $@callee_owned () -> @thin NSBurrito.Protocol
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pXMtIegd_So8ProtocolCIego_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @thin NSBurrito.Protocol) -> @owned Protocol
+// CHECK:         [[COPY:%.*]] = copy_value %0
+// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:         apply [[BORROW]]() : $@callee_guaranteed () -> @thin NSBurrito.Protocol
 // CHECK:         objc_protocol #NSBurrito : $Protocol
 // CHECK:         copy_value
 // CHECK:         return
 
 // ==== Representation conversions
 
-// CHECK-LABEL: sil hidden @_T024function_conversion_objc11funcToBlockyyXByycF : $@convention(thin) (@owned @callee_owned () -> ()) -> @owned @convention(block) () -> ()
+// CHECK-LABEL: sil hidden @_T024function_conversion_objc11funcToBlockyyXByycF : $@convention(thin) (@owned @callee_guaranteed () -> ()) -> @owned @convention(block) () -> ()
 // CHECK:         [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage
 // CHECK:         [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]]
 // CHECK:         [[COPY:%.*]] = copy_block [[BLOCK]] : $@convention(block) () -> ()
@@ -58,13 +64,13 @@ func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
   return x
 }
 
-// CHECK-LABEL: sil hidden @_T024function_conversion_objc11blockToFuncyycyyXBF : $@convention(thin) (@owned @convention(block) () -> ()) -> @owned @callee_owned () -> ()
+// CHECK-LABEL: sil hidden @_T024function_conversion_objc11blockToFuncyycyyXBF : $@convention(thin) (@owned @convention(block) () -> ()) -> @owned @callee_guaranteed () -> ()
 // CHECK: bb0([[ARG:%.*]] : $@convention(block) () -> ()):
 // CHECK:   [[COPIED:%.*]] = copy_block [[ARG]]
 // CHECK:   [[BORROWED_COPIED:%.*]] = begin_borrow [[COPIED]]
 // CHECK:   [[COPIED_2:%.*]] = copy_value [[BORROWED_COPIED]]
-// CHECK:   [[THUNK:%.*]] = function_ref @_T0IeyB_Iex_TR
-// CHECK:   [[FUNC:%.*]] = partial_apply [[THUNK]]([[COPIED_2]])
+// CHECK:   [[THUNK:%.*]] = function_ref @_T0IeyB_Ieg_TR
+// CHECK:   [[FUNC:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[COPIED_2]])
 // CHECK:   end_borrow [[BORROWED_COPIED]] from [[COPIED]]
 // CHECK:   destroy_value [[COPIED]]
 // CHECK:   destroy_value [[ARG]]
@@ -75,19 +81,19 @@ func blockToFunc(_ x: @escaping @convention(block) () -> ()) -> () -> () {
 
 // ==== Representation change + function type conversion
 
-// CHECK-LABEL: sil hidden @_T024function_conversion_objc22blockToFuncExistentialypycSiyXBF : $@convention(thin) (@owned @convention(block) () -> Int) -> @owned @callee_owned () -> @out Any
-// CHECK:         function_ref @_T0SiIeyBd_SiIexd_TR
+// CHECK-LABEL: sil hidden @_T024function_conversion_objc22blockToFuncExistentialypycSiyXBF : $@convention(thin) (@owned @convention(block) () -> Int) -> @owned @callee_guaranteed () -> @out Any
+// CHECK:         function_ref @_T0SiIeyBd_SiIegd_TR
 // CHECK:         partial_apply
-// CHECK:         function_ref @_T0SiIexd_ypIexr_TR
+// CHECK:         function_ref @_T0SiIegd_ypIegr_TR
 // CHECK:         partial_apply
 // CHECK:         return
 func blockToFuncExistential(_ x: @escaping @convention(block) () -> Int) -> () -> Any {
   return x
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiIeyBd_SiIexd_TR : $@convention(thin) (@owned @convention(block) () -> Int) -> Int
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiIeyBd_SiIegd_TR : $@convention(thin) (@guaranteed @convention(block) () -> Int) -> Int
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiIexd_ypIexr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Any
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiIegd_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Any
 
 // C function pointer conversions
 

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -327,7 +327,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // SIL-level "thin" function values need to be able to convert to
   // "thick" function values when stored, returned, or passed as arguments.
 
-  // CHECK: [[FBOX:%[0-9]+]] = alloc_box ${ var @callee_owned (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 }
+  // CHECK: [[FBOX:%[0-9]+]] = alloc_box ${ var @callee_guaranteed (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 }
   // CHECK: [[FADDR:%.*]] = project_box [[FBOX]]
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_T09functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
@@ -339,7 +339,10 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
-  // CHECK: apply [[F]]([[I]], [[J]])
+  // CHECK: [[BORROW:%.*]] =  begin_borrow [[F]]
+  // CHECK: apply [[BORROW]]([[I]], [[J]])
+  // CHECK: end_borrow [[BORROW]]
+  // CHECK: destroy_value [[F]]
   f(i, j)
 
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_T09functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
@@ -366,15 +369,15 @@ func calls(_ i:Int, j:Int, k:Int) {
 }
 
 // -- Curried entry points
-// CHECK-LABEL: sil shared [thunk] @_T09functions10SomeStructV6method{{[_0-9a-zA-Z]*}}FTc : $@convention(thin) (@inout SomeStruct) -> @owned @callee_owned (Builtin.Int64) -> () {
+// CHECK-LABEL: sil shared [thunk] @_T09functions10SomeStructV6method{{[_0-9a-zA-Z]*}}FTc : $@convention(thin) (@inout SomeStruct) -> @owned @callee_guaranteed (Builtin.Int64) -> () {
 // CHECK:   [[UNCURRIED:%.*]] = function_ref @_T09functions10SomeStructV6method{{[_0-9a-zA-Z]*}}F : $@convention(method) (Builtin.Int64, @inout SomeStruct) -> (){{.*}} // user: %2
-// CHECK:   [[CURRIED:%.*]] = partial_apply [[UNCURRIED]]
+// CHECK:   [[CURRIED:%.*]] = partial_apply [callee_guaranteed] [[UNCURRIED]]
 // CHECK:   return [[CURRIED]]
 
-// CHECK-LABEL: sil shared [thunk] @_T09functions9SomeClassC6method{{[_0-9a-zA-Z]*}}FTc : $@convention(thin) (@owned SomeClass) -> @owned @callee_owned (Builtin.Int64) -> ()
+// CHECK-LABEL: sil shared [thunk] @_T09functions9SomeClassC6method{{[_0-9a-zA-Z]*}}FTc : $@convention(thin) (@owned SomeClass) -> @owned @callee_guaranteed (Builtin.Int64) -> ()
 // CHECK: bb0(%0 : @owned $SomeClass):
 // CHECK:   class_method %0 : $SomeClass, #SomeClass.method!1 : (SomeClass) -> (Builtin.Int64) -> ()
-// CHECK:   %2 = partial_apply %1(%0)
+// CHECK:   %2 = partial_apply [callee_guaranteed] %1(%0)
 // CHECK:   return %2
 
 func return_func() -> (_ x: Builtin.Int64, _ y: Builtin.Int64) -> Builtin.Int64 {
@@ -389,9 +392,9 @@ func standalone_generic<T>(_ x: T, y: T) -> T { return x }
 // CHECK-LABEL: sil hidden @_T09functions14return_genericBi64_Bi64__Bi64_tcyF
 func return_generic() -> (_ x:Builtin.Int64, _ y:Builtin.Int64) -> Builtin.Int64 {
   // CHECK: [[GEN:%.*]] = function_ref @_T09functions18standalone_generic{{[_0-9a-zA-Z]*}}F : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> @out τ_0_0
-  // CHECK: [[SPEC:%.*]] = partial_apply [[GEN]]<Builtin.Int64>()
-  // CHECK: [[THUNK:%.*]] = function_ref  @{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64, @owned @callee_owned (@in Builtin.Int64, @in Builtin.Int64) -> @out Builtin.Int64) -> Builtin.Int64
-  // CHECK: [[T0:%.*]] = partial_apply [[THUNK]]([[SPEC]])
+  // CHECK: [[SPEC:%.*]] = partial_apply [callee_guaranteed] [[GEN]]<Builtin.Int64>()
+  // CHECK: [[THUNK:%.*]] = function_ref  @{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64, @guaranteed @callee_guaranteed (@in Builtin.Int64, @in Builtin.Int64) -> @out Builtin.Int64) -> Builtin.Int64
+  // CHECK: [[T0:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[SPEC]])
   // CHECK: return [[T0]]
   return standalone_generic
 }
@@ -400,9 +403,9 @@ func return_generic() -> (_ x:Builtin.Int64, _ y:Builtin.Int64) -> Builtin.Int64
 func return_generic_tuple()
 -> (_ x: (Builtin.Int64, Builtin.Int64), _ y: (Builtin.Int64, Builtin.Int64)) -> (Builtin.Int64, Builtin.Int64) {
   // CHECK: [[GEN:%.*]] = function_ref @_T09functions18standalone_generic{{[_0-9a-zA-Z]*}}F  : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> @out τ_0_0
-  // CHECK: [[SPEC:%.*]] = partial_apply [[GEN]]<(Builtin.Int64, Builtin.Int64)>()
-  // CHECK: [[THUNK:%.*]] = function_ref @{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64, Builtin.Int64, Builtin.Int64, @owned @callee_owned (@in (Builtin.Int64, Builtin.Int64), @in (Builtin.Int64, Builtin.Int64)) -> @out (Builtin.Int64, Builtin.Int64)) -> (Builtin.Int64, Builtin.Int64)
-  // CHECK: [[T0:%.*]] = partial_apply [[THUNK]]([[SPEC]])
+  // CHECK: [[SPEC:%.*]] = partial_apply [callee_guaranteed] [[GEN]]<(Builtin.Int64, Builtin.Int64)>()
+  // CHECK: [[THUNK:%.*]] = function_ref @{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed @callee_guaranteed (@in (Builtin.Int64, Builtin.Int64), @in (Builtin.Int64, Builtin.Int64)) -> @out (Builtin.Int64, Builtin.Int64)) -> (Builtin.Int64, Builtin.Int64)
+  // CHECK: [[T0:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[SPEC]])
   // CHECK: return [[T0]]
   return standalone_generic
 }
@@ -412,7 +415,7 @@ func testNoReturnAttr() -> Never {}
 // CHECK-LABEL: sil hidden @_T09functions20testNoReturnAttrPoly{{[_0-9a-zA-Z]*}}F : $@convention(thin) <T> (@in T) -> Never
 func testNoReturnAttrPoly<T>(_ x: T) -> Never {}
 
-// CHECK-LABEL: sil hidden @_T09functions21testNoReturnAttrParam{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned @noescape @callee_owned () -> Never) -> ()
+// CHECK-LABEL: sil hidden @_T09functions21testNoReturnAttrParam{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Never) -> ()
 func testNoReturnAttrParam(_ fptr: () -> Never) -> () {}
 
 // CHECK-LABEL: sil hidden [transparent] @_T09functions15testTransparent{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
@@ -501,7 +504,7 @@ final class r17828355Class {
 // CHECK: bb0(%0 : @owned $r17828355Class):
 // CHECK-NEXT: // function_ref functions.r17828355Class.method(Builtin.Int64) -> ()
 // CHECK-NEXT:  %1 = function_ref @_T09functions14r17828355ClassC6method{{[_0-9a-zA-Z]*}}F : $@convention(method) (Builtin.Int64, @guaranteed r17828355Class) -> ()
-// CHECK-NEXT:  partial_apply %1(%0) : $@convention(method) (Builtin.Int64, @guaranteed r17828355Class) -> ()
+// CHECK-NEXT:  partial_apply [callee_guaranteed] %1(%0) : $@convention(method) (Builtin.Int64, @guaranteed r17828355Class) -> ()
 // CHECK-NEXT:  return
 
 
@@ -523,12 +526,12 @@ func testNoescape() {
 // CHECK-LABEL: functions.testNoescape() -> ()
 // CHECK-NEXT: sil hidden @_T09functions12testNoescapeyyF : $@convention(thin) () -> ()
 // CHECK: function_ref closure #1 () -> () in functions.testNoescape() -> ()
-// CHECK-NEXT: function_ref @_T09functions12testNoescapeyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> ()
+// CHECK-NEXT: function_ref @_T09functions12testNoescapeyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> ()
 
 // Despite being a noescape closure, this needs to capture 'a' by-box so it can
 // be passed to the capturing closure.closure
 // CHECK: closure #1 () -> () in functions.testNoescape() -> ()
-// CHECK-NEXT: sil private @_T09functions12testNoescapeyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-NEXT: sil private @_T09functions12testNoescapeyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 
 
@@ -548,10 +551,10 @@ func testNoescape2() {
 // CHECK-LABEL: sil hidden @_T09functions13testNoescape2yyF : $@convention(thin) () -> () {
 
 // CHECK: // closure #1 () -> () in functions.testNoescape2() -> ()
-// CHECK-NEXT: sil private @_T09functions13testNoescape2yyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-NEXT: sil private @_T09functions13testNoescape2yyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 // CHECK: // closure #1 () -> () in closure #1 () -> () in functions.testNoescape2() -> ()
-// CHECK-NEXT: sil private @_T09functions13testNoescape2yyFyycfU_yycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-NEXT: sil private @_T09functions13testNoescape2yyFyycfU_yycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 enum PartialApplyEnumPayload<T, U> {
   case Left(T)
@@ -571,10 +574,10 @@ func partialApplyEnumCases(_ x: S, y: C) {
 
 // CHECK-LABEL: sil shared [transparent] [thunk] @_T09functions23PartialApplyEnumPayloadO4Left{{[_0-9a-zA-Z]*}}F
 // CHECK:         [[UNCURRIED:%.*]] = function_ref @_T09functions23PartialApplyEnumPayloadO4Left{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [[UNCURRIED]]<T, U>(%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[UNCURRIED]]<T, U>(%0)
 // CHECK:         return [[CLOSURE]]
 
 // CHECK-LABEL: sil shared [transparent] [thunk] @_T09functions23PartialApplyEnumPayloadO5Right{{[_0-9a-zA-Z]*}}F
 // CHECK:         [[UNCURRIED:%.*]] = function_ref @_T09functions23PartialApplyEnumPayloadO5Right{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [[UNCURRIED]]<T, U>(%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[UNCURRIED]]<T, U>(%0)
 // CHECK:         return [[CLOSURE]]

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -11,12 +11,12 @@ func generic_nondependent_context<T>(_ x: T, y: Int) -> Int {
   func bar() -> Int { return y }
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A21_nondependent_context{{.*}} : $@convention(thin) (Int) -> Int
-  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [[FOO]](%1)
+  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FOO]](%1)
   // CHECK: destroy_value [[FOO_CLOSURE]]
   let _ = foo
 
   // CHECK: [[BAR:%.*]] = function_ref @_T016generic_closures0A21_nondependent_context{{.*}} : $@convention(thin) (Int) -> Int
-  // CHECK: [[BAR_CLOSURE:%.*]] = partial_apply [[BAR]](%1)
+  // CHECK: [[BAR_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[BAR]](%1)
   // CHECK: destroy_value [[BAR_CLOSURE]]
   let _ = bar
 
@@ -36,7 +36,7 @@ func generic_capture<T>(_ x: T) -> Any.Type {
   func foo() -> Any.Type { return T.self }
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A8_capture{{.*}} : $@convention(thin) <τ_0_0> () -> @thick Any.Type
-  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [[FOO]]<T>()
+  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FOO]]<T>()
   // CHECK: destroy_value [[FOO_CLOSURE]]
   let _ = foo
 
@@ -52,7 +52,7 @@ func generic_capture_cast<T>(_ x: T, y: Any) -> Bool {
   func foo(_ a: Any) -> Bool { return a is T }
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A13_capture_cast{{.*}} : $@convention(thin) <τ_0_0> (@in Any) -> Bool
-  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [[FOO]]<T>()
+  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FOO]]<T>()
   // CHECK: destroy_value [[FOO_CLOSURE]]
   let _ = foo
 
@@ -87,12 +87,12 @@ func generic_nocapture_existential<T>(_ x: T, y: Concept) -> Bool {
 func generic_dependent_context<T>(_ x: T, y: Int) -> T {
   func foo() -> T { return x }
 
-  // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A18_dependent_context{{.*}} : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
-  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [[FOO]]<T>([[BOX:%.*]])
+  // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A18_dependent_context{{.*}} : $@convention(thin) <τ_0_0> (@guaranteed <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
+  // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FOO]]<T>([[BOX:%.*]])
   // CHECK: destroy_value [[FOO_CLOSURE]]
   let _ = foo
 
-  // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A18_dependent_context{{.*}} : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
+  // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A18_dependent_context{{.*}} : $@convention(thin) <τ_0_0> (@guaranteed <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   // CHECK: [[FOO_CLOSURE:%.*]] = apply [[FOO]]<T>
 
   // CHECK: return
@@ -130,8 +130,8 @@ class NestedGeneric<U> {
   }
 
   // CHECK-LABEL: sil hidden @_T016generic_closures13NestedGenericC20nested_reabstraction{{[_0-9a-zA-Z]*}}F
-  //   CHECK:       [[REABSTRACT:%.*]] = function_ref @_T0Iex_ytytIexir_TR
-  //   CHECK:       partial_apply [[REABSTRACT]]
+  //   CHECK:       [[REABSTRACT:%.*]] = function_ref @_T0Ieg_ytytIegir_TR
+  //   CHECK:       partial_apply [callee_guaranteed] [[REABSTRACT]]
   func nested_reabstraction<T>(_ x: T) -> Optionable<() -> ()> {
     return .some({})
   }
@@ -206,10 +206,10 @@ class Class {}
 protocol HasClassAssoc { associatedtype Assoc : Class }
 
 // CHECK-LABEL: sil hidden @_T016generic_closures027captures_class_constrained_A0yx_5AssocQzADc1ftAA08HasClassF0RzlF
-// CHECK: bb0([[ARG1:%.*]] : @trivial $*T, [[ARG2:%.*]] : @owned $@callee_owned (@owned T.Assoc) -> @owned T.Assoc):
+// CHECK: bb0([[ARG1:%.*]] : @trivial $*T, [[ARG2:%.*]] : @owned $@callee_guaranteed (@owned T.Assoc) -> @owned T.Assoc):
 // CHECK: [[GENERIC_FN:%.*]] = function_ref @_T016generic_closures027captures_class_constrained_A0yx_5AssocQzADc1ftAA08HasClassF0RzlFA2DcycfU_
 // CHECK: [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
-// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T>([[ARG2_COPY]])
+// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [callee_guaranteed] [[GENERIC_FN]]<T>([[ARG2_COPY]])
 
 func captures_class_constrained_generic<T : HasClassAssoc>(_ x: T, f: @escaping (T.Assoc) -> T.Assoc) {
   let _: () -> (T.Assoc) -> T.Assoc = { f }
@@ -233,9 +233,9 @@ func outer_generic<T>(t: T, i: Int) {
 
   let _: () -> () = inner_generic_nocapture
   // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF06inner_A10_nocaptureL_qd__qd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0) -> @out τ_1_0
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[FN]]<T, ()>() : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0) -> @out τ_1_0
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytytIexir_Iex_TR
-  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [[THUNK]]([[CLOSURE]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]<T, ()>() : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0) -> @out τ_1_0
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytytIegir_Ieg_TR
+  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[CLOSURE]])
   // CHECK: destroy_value [[THUNK_CLOSURE]]
 
   // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF06inner_A10_nocaptureL_qd__qd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0) -> @out τ_1_0
@@ -243,9 +243,9 @@ func outer_generic<T>(t: T, i: Int) {
   _ = inner_generic_nocapture(u: t)
 
   // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF14inner_generic1L_Siqd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, Int) -> Int
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[FN]]<T, ()>(%1) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, Int) -> Int
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytSiIexid_SiIexd_TR
-  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [[THUNK]]([[CLOSURE]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]<T, ()>(%1) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, Int) -> Int
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytSiIegid_SiIegd_TR
+  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[CLOSURE]])
   // CHECK: destroy_value [[THUNK_CLOSURE]]
   let _: () -> Int = inner_generic1
 
@@ -253,15 +253,15 @@ func outer_generic<T>(t: T, i: Int) {
   // CHECK: [[RESULT:%.*]] = apply [[FN]]<T, T>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, Int) -> Int
   _ = inner_generic1(u: t)
 
-  // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF14inner_generic2L_xqd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[FN]]<T, ()>([[ARG:%.*]]) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytxIexir_xIexr_lTR
-  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [[THUNK]]<T>([[CLOSURE]])
+  // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF14inner_generic2L_xqd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @guaranteed <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]<T, ()>([[ARG:%.*]]) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @guaranteed <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytxIegir_xIegr_lTR
+  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]<T>([[CLOSURE]])
   // CHECK: destroy_value [[THUNK_CLOSURE]]
   let _: () -> T = inner_generic2
 
-  // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF14inner_generic2L_xqd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
-  // CHECK: [[RESULT:%.*]] = apply [[FN]]<T, T>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
+  // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures06outer_A0yx1t_Si1itlF14inner_generic2L_xqd__1u_tr__lF : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @guaranteed <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]<T, T>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0> (@in τ_1_0, @guaranteed <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   _ = inner_generic2(u: t)
 }
 
@@ -276,9 +276,9 @@ func outer_concrete(i: Int) {
   }
 
   // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures14outer_concreteySi1i_tF06inner_A10_nocaptureL_xx1u_tlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[FN]]<()>() : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytytIexir_Iex_TR
-  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [[THUNK]]([[CLOSURE]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]<()>() : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytytIegir_Ieg_TR
+  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[CLOSURE]])
   // CHECK: destroy_value [[THUNK_CLOSURE]]
   let _: () -> () = inner_generic_nocapture
 
@@ -287,9 +287,9 @@ func outer_concrete(i: Int) {
   _ = inner_generic_nocapture(u: i)
 
   // CHECK: [[FN:%.*]] = function_ref @_T016generic_closures14outer_concreteySi1i_tF06inner_A0L_Six1u_tlF : $@convention(thin) <τ_0_0> (@in τ_0_0, Int) -> Int
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[FN]]<()>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0, Int) -> Int
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytSiIexid_SiIexd_TR
-  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [[THUNK]]([[CLOSURE]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]<()>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0, Int) -> Int
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0ytSiIegid_SiIegd_TR
+  // CHECK: [[THUNK_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[CLOSURE]])
   // CHECK: destroy_value [[THUNK_CLOSURE]]
   let _: () -> Int = inner_generic
 
@@ -314,7 +314,7 @@ func mixed_generic_nongeneric_nesting<T>(t: T) {
 
 // CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF : $@convention(thin) <T> () -> ()
 // CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF : $@convention(thin) <T><U> (@in U) -> ()
-// CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF5innerL_qd__yr__lF : $@convention(thin) <T><U> (@owned <τ_0_0><τ_1_0> { var τ_1_0 } <T, U>) -> @out U
+// CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF5innerL_qd__yr__lF : $@convention(thin) <T><U> (@guaranteed <τ_0_0><τ_1_0> { var τ_1_0 } <T, U>) -> @out U
 
 protocol Doge {
   associatedtype Nose : NoseProtocol

--- a/test/SILGen/generic_objc_block_bridge.swift
+++ b/test/SILGen/generic_objc_block_bridge.swift
@@ -14,4 +14,4 @@ class Tubb<GenericParamName>: Butt {
   }
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIyByd_S2iIxyd_TR : $@convention(thin) (Int, @owned @convention(block) @noescape (Int) -> Int) -> Int {
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIyByd_S2iIgyd_TR : $@convention(thin) (Int, @guaranteed @convention(block) @noescape (Int) -> Int) -> Int {

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -46,16 +46,16 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 // CHECK: // end sil function '_T013indirect_enum11TreeA_casesyx_AA0C1AOyxG1lAE1rtlF'
 
 
-// CHECK-LABEL: sil hidden @_T013indirect_enum16TreeA_reabstractyS2icF : $@convention(thin) (@owned @callee_owned (Int) -> Int) -> () {
+// CHECK-LABEL: sil hidden @_T013indirect_enum16TreeA_reabstractyS2icF : $@convention(thin) (@owned @callee_guaranteed (Int) -> Int) -> () {
 func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned (Int) -> Int):
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (Int) -> Int):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_owned (@in Int) -> @out Int>
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_guaranteed (@in Int) -> @out Int>
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:         [[THUNK:%.*]] = function_ref @_T0S2iIexyd_S2iIexir_TR
-// CHECK-NEXT:    [[FN:%.*]] = partial_apply [[THUNK]]([[ARG_COPY]])
+// CHECK:         [[THUNK:%.*]] = function_ref @_T0S2iIegyd_S2iIegir_TR
+// CHECK-NEXT:    [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[ARG_COPY]])
 // CHECK-NEXT:    store [[FN]] to [init] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<(Int) -> Int>, #TreeA.Leaf!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[LEAF]]

--- a/test/SILGen/inlineable_attribute.swift
+++ b/test/SILGen/inlineable_attribute.swift
@@ -43,7 +43,7 @@ public class MyCls {
   case c(MySt)
 }
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T020inlineable_attribute6MyEnumO1cAcA0C2StVcACmFTc : $@convention(thin) (@thin MyEnum.Type) -> @owned @callee_owned (MySt) -> MyEnum
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T020inlineable_attribute6MyEnumO1cAcA0C2StVcACmFTc : $@convention(thin) (@thin MyEnum.Type) -> @owned @callee_guaranteed (MySt) -> MyEnum
 
 @_inlineable public func referencesMyEnum() {
   _ = MyEnum.c
@@ -66,7 +66,7 @@ public class Horse {
 // CHECK: return
 // CHECK: }
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T020inlineable_attribute5HorseC6gallopyyFTc : $@convention(thin) (@owned Horse) -> @owned @callee_owned () -> () {
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T020inlineable_attribute5HorseC6gallopyyFTc : $@convention(thin) (@owned Horse) -> @owned @callee_guaranteed () -> () {
 // CHECK: class_method
 // CHECK: return
 // CHECK: }

--- a/test/SILGen/inlineable_attribute_objc.swift
+++ b/test/SILGen/inlineable_attribute_objc.swift
@@ -15,11 +15,11 @@ public class Horse : NSObject {
 // from inlineable scopes
 
 // CHECK-LABEL: sil [serialized] @_T025inlineable_attribute_objc15talkAboutAHorseyAA5HorseC1h_tF : $@convention(thin) (@owned Horse) -> () {
-// CHECK: function_ref @_T025inlineable_attribute_objc5HorseC6gallopyyFTc : $@convention(thin) (@owned Horse) -> @owned @callee_owned () -> ()
+// CHECK: function_ref @_T025inlineable_attribute_objc5HorseC6gallopyyFTc : $@convention(thin) (@owned Horse) -> @owned @callee_guaranteed () -> ()
 // CHECK: return
 // CHECK: }
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T025inlineable_attribute_objc5HorseC6gallopyyFTc : $@convention(thin) (@owned Horse) -> @owned @callee_owned () -> ()
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T025inlineable_attribute_objc5HorseC6gallopyyFTc : $@convention(thin) (@owned Horse) -> @owned @callee_guaranteed () -> ()
 // CHECK:   %1 = function_ref @_T025inlineable_attribute_objc5HorseC6gallopyyFTD
 // CHECK: return
 // CHECK: }

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -94,8 +94,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $() -> (), 
   // CHECK-SAME:   id ##C.reabstracted,
-  // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out @callee_owned (@in ()) -> @out (),
-  // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_owned (@in ()) -> @out (), @in C<τ_0_0>) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out @callee_guaranteed (@in ()) -> @out (),
+  // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_guaranteed (@in ()) -> @out (), @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.reabstracted
 
@@ -123,8 +123,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:  root $S<τ_0_0>;
   // CHECK-SAME:  settable_property $() -> (),
   // CHECK-SAME:    id ##S.reabstracted,
-  // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out @callee_owned (@in ()) -> @out (),
-  // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_owned (@in ()) -> @out (), @inout S<τ_0_0>) -> ()
+  // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out @callee_guaranteed (@in ()) -> @out (),
+  // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_guaranteed (@in ()) -> @out (), @inout S<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \S<T>.reabstracted
 

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -377,10 +377,12 @@ func member_ref_abstraction_change(_ x: GenericFunctionStruct<Int, Int>) -> (Int
 }
 
 // CHECK-LABEL: sil hidden @{{.*}}call_auto_closure
-// CHECK: bb0([[CLOSURE:%.*]] : @owned $@noescape @callee_owned () -> Bool):
+// CHECK: bb0([[CLOSURE:%.*]] : @owned $@noescape @callee_guaranteed () -> Bool):
 // CHECK:   [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
 // CHECK:   [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
-// CHECK:   apply [[CLOSURE_COPY]]() : $@noescape @callee_owned () -> Bool
+// CHECK:   [[BORROW:%.*]] =  begin_borrow [[CLOSURE_COPY]]
+// CHECK:   apply [[BORROW]]() : $@noescape @callee_guaranteed () -> Bool
+// CHECK:   destroy_value [[CLOSURE_COPY]]
 // CHECK:   end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
 // CHECK:   destroy_value [[CLOSURE]]
 // CHECK: } // end sil function '{{.*}}call_auto_closure{{.*}}'

--- a/test/SILGen/local_captures.swift
+++ b/test/SILGen/local_captures.swift
@@ -3,7 +3,7 @@
 // Check that we don't crash if a local function references another local
 // function without captures.
 
-// CHECK-LABEL: sil hidden @_T014local_captures10globalfuncyycyF : $@convention(thin) () -> @owned @callee_owned () -> ()
+// CHECK-LABEL: sil hidden @_T014local_captures10globalfuncyycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> ()
 func globalfunc() -> () -> () {
 
 	// CHECK-LABEL: sil private @_T014local_captures10globalfuncyycyF0A4FuncL_yyF : $@convention(thin) () -> ()
@@ -15,7 +15,7 @@ func globalfunc() -> () -> () {
 		localFunc()
 	}
 
-	// CHECK-LABEL: sil private @_T014local_captures10globalfuncyycyF5getitL_yycyF : $@convention(thin) () -> @owned @callee_owned () -> ()
+	// CHECK-LABEL: sil private @_T014local_captures10globalfuncyycyF5getitL_yycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> ()
 	func getit() -> () -> () {
 		return localFunc
 	}

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -14,11 +14,14 @@ func local_recursion(_ x: Int, y: Int) {
   self_recursive(x)
 
   // CHECK: [[SELF_RECURSIVE_REF:%.*]] = function_ref [[SELF_RECURSIVE]]
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[SELF_RECURSIVE_REF]]([[X]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[SELF_RECURSIVE_REF]]([[X]])
   // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   let sr = self_recursive
-  // CHECK: apply [[CLOSURE_COPY]]([[Y]])
+  // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
+  // CHECK: apply [[B]]([[Y]])
+  // CHECK: end_borrow [[B]]
+  // CHECK: destroy_value [[CLOSURE_COPY]]
   // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   sr(y)
 
@@ -48,11 +51,14 @@ func local_recursion(_ x: Int, y: Int) {
   transitive_capture_2(x)
 
   // CHECK: [[TRANS_CAPTURE_REF:%.*]] = function_ref [[TRANS_CAPTURE]]
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[TRANS_CAPTURE_REF]]([[X]], [[Y]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[TRANS_CAPTURE_REF]]([[X]], [[Y]])
   // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   let tc = transitive_capture_2
-  // CHECK: apply [[CLOSURE_COPY]]([[X]])
+  // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
+  // CHECK: apply [[B]]([[X]])
+  // CHECK: end_borrow [[B]]
+  // CHECK: destroy_value [[CLOSURE_COPY]]
   // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   tc(x)
 
@@ -64,10 +70,13 @@ func local_recursion(_ x: Int, y: Int) {
   }(x)
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @_T015local_recursionAAySi_Si1ytFySicfU0_
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [[CLOSURE_REF]]([[X]], [[Y]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_REF]]([[X]], [[Y]])
   // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
-  // CHECK: apply [[CLOSURE_COPY]]([[X]])
+  // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
+  // CHECK: apply [[B]]([[X]])
+  // CHECK: end_borrow [[B]]
+  // CHECK: destroy_value [[CLOSURE_COPY]]
   // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   let f: (Int) -> () = {
     self_recursive($0)

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -107,9 +107,9 @@ struct HasVarInit {
 // auto_closures should not collide with the equivalent non-auto_closure
 // function type.
 
-// CHECK-LABEL: sil hidden @_T08mangling19autoClosureOverloadySiyXK1f_tF : $@convention(thin) (@owned @noescape @callee_owned () -> Int) -> () {
+// CHECK-LABEL: sil hidden @_T08mangling19autoClosureOverloadySiyXK1f_tF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Int) -> () {
 func autoClosureOverload(f: @autoclosure () -> Int) {}
-// CHECK-LABEL: sil hidden @_T08mangling19autoClosureOverloadySiyc1f_tF : $@convention(thin) (@owned @noescape @callee_owned () -> Int) -> () {
+// CHECK-LABEL: sil hidden @_T08mangling19autoClosureOverloadySiyc1f_tF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Int) -> () {
 func autoClosureOverload(f: () -> Int) {}
 
 // CHECK-LABEL: sil hidden @_T08mangling24autoClosureOverloadCallsyyF : $@convention(thin) () -> () {
@@ -165,17 +165,17 @@ func curry1Throws() throws {
 
 }
 
-// CHECK-LABEL: sil hidden @_T08mangling12curry2ThrowsyycyKF : $@convention(thin) () -> (@owned @callee_owned () -> (), @error Error)
+// CHECK-LABEL: sil hidden @_T08mangling12curry2ThrowsyycyKF : $@convention(thin) () -> (@owned @callee_guaranteed () -> (), @error Error)
 func curry2Throws() throws -> () -> () {
   return curry1
 }
 
-// CHECK-LABEL: sil hidden @_T08mangling6curry3yyKcyF : $@convention(thin) () -> @owned @callee_owned () -> @error Error
+// CHECK-LABEL: sil hidden @_T08mangling6curry3yyKcyF : $@convention(thin) () -> @owned @callee_guaranteed () -> @error Error
 func curry3() -> () throws -> () {
   return curry1Throws
 }
 
-// CHECK-LABEL: sil hidden @_T08mangling12curry3ThrowsyyKcyKF : $@convention(thin) () -> (@owned @callee_owned () -> @error Error, @error Error)
+// CHECK-LABEL: sil hidden @_T08mangling12curry3ThrowsyyKcyKF : $@convention(thin) () -> (@owned @callee_guaranteed () -> @error Error, @error Error)
 func curry3Throws() throws -> () throws -> () {
   return curry1Throws
 }

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -80,11 +80,11 @@ extension Derived : Abstractable {}
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
-// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: function_ref
-// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexr_SiIexd_TR : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
-// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
+// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegr_SiIegd_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out Int) -> Int
+// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[VALUE]])
 // CHECK-NEXT: [[FN:%.*]] = class_method [[SELF]] : $Base, #Base.storedFunction!setter.1 : (Base) -> (@escaping () -> Int) -> ()
 // CHECK-NEXT: apply [[FN]]([[NEWVALUE]], [[SELF]])
 // CHECK-NEXT: end_borrow [[T0]] from %2
@@ -93,20 +93,20 @@ extension Derived : Abstractable {}
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T017materializeForSet7DerivedCAA12AbstractableA2aDP14storedFunction{{[_0-9a-zA-Z]*}}vmTW
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
-// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
-// CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $@callee_owned () -> Int
+// CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $@callee_guaranteed () -> Int
 // CHECK-NEXT: [[FN:%.*]] = class_method [[SELF]] : $Base, #Base.storedFunction!getter.1
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]([[SELF]])
 // CHECK-NEXT: store [[RESULT]] to [init] [[TEMP]]
 // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[TEMP]]
 // CHECK-NEXT: function_ref
-// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexd_SiIexr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
-// CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
+// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegd_SiIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+// CHECK-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[RESULT]])
 // CHECK-NEXT: destroy_addr [[TEMP]]
 // CHECK-NEXT: store [[T1]] to [init] [[RESULT_ADDR]]
-// CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
+// CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int to $Builtin.RawPointer
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[T2:%.*]] = function_ref @_T017materializeForSet7DerivedCAA12AbstractableA2aDP14storedFunction6ResultQzycvmytfU_TW
 // CHECK-NEXT: [[T3:%.*]] = thin_function_to_pointer [[T2]]
@@ -120,15 +120,15 @@ extension Derived : Abstractable {}
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
-// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: // function_ref
-// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexr_SiIexd_TR : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
-// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
+// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegr_SiIegd_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out Int) -> Int
+// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[VALUE]])
 // CHECK-NEXT: [[ADDR:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.finalStoredFunction
-// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*@callee_owned () -> Int
+// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*@callee_guaranteed () -> Int
 // CHECK-NEXT: assign [[NEWVALUE]] to [[WRITE]]
-// CHECK-NEXT: end_access [[WRITE]] : $*@callee_owned () -> Int
+// CHECK-NEXT: end_access [[WRITE]] : $*@callee_guaranteed () -> Int
 // CHECK-NEXT: end_borrow [[T0]] from %2
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
@@ -137,11 +137,11 @@ extension Derived : Abstractable {}
 // UNCHECKED: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
 // UNCHECKED-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // UNCHECKED-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
-// UNCHECKED-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// UNCHECKED-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
+// UNCHECKED-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
+// UNCHECKED-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int
 // UNCHECKED-NEXT: // function_ref
-// UNCHECKED-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexr_SiIexd_TR : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
-// UNCHECKED-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
+// UNCHECKED-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegr_SiIegd_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out Int) -> Int
+// UNCHECKED-NEXT: [[NEWVALUE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[VALUE]])
 // UNCHECKED-NEXT: [[ADDR:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.finalStoredFunction
 // UNCHECKED-NEXT: assign [[NEWVALUE]] to [[ADDR]]
 // UNCHECKED-NEXT: end_borrow [[T0]] from %2
@@ -150,18 +150,18 @@ extension Derived : Abstractable {}
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T017materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction{{[_0-9a-zA-Z]*}}vmTW
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
-// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[ADDR:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.finalStoredFunction
-// CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*@callee_owned () -> Int
+// CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*@callee_guaranteed () -> Int
 // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[READ]]
 // CHECK-NEXT: function_ref
-// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexd_SiIexr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
-// CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
-// CHECK-NEXT: end_access [[READ]] : $*@callee_owned () -> Int
+// CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegd_SiIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+// CHECK-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[RESULT]])
+// CHECK-NEXT: end_access [[READ]] : $*@callee_guaranteed () -> Int
 // CHECK-NEXT: store [[T1]] to [init] [[RESULT_ADDR]]
-// CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
+// CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int to $Builtin.RawPointer
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[T2:%.*]] = function_ref @_T017materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction6ResultQzycvmytfU_TW
 // CHECK-NEXT: [[T3:%.*]] = thin_function_to_pointer [[T2]]
@@ -172,16 +172,16 @@ extension Derived : Abstractable {}
 
 // UNCHECKED-LABEL: sil private [transparent] [thunk] @_T017materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction{{[_0-9a-zA-Z]*}}vmTW
 // UNCHECKED: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
-// UNCHECKED-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
+// UNCHECKED-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // UNCHECKED-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // UNCHECKED-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // UNCHECKED-NEXT: [[ADDR:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.finalStoredFunction
 // UNCHECKED-NEXT: [[RESULT:%.*]] = load [copy] [[ADDR]]
 // UNCHECKED-NEXT: function_ref
-// UNCHECKED-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexd_SiIexr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
-// UNCHECKED-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
+// UNCHECKED-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegd_SiIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+// UNCHECKED-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[RESULT]])
 // UNCHECKED-NEXT: store [[T1]] to [init] [[RESULT_ADDR]]
-// UNCHECKED-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
+// UNCHECKED-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int to $Builtin.RawPointer
 // UNCHECKED-NEXT: function_ref
 // UNCHECKED-NEXT: [[T2:%.*]] = function_ref @_T017materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction6ResultQzycvmytfU_TW
 // UNCHECKED-NEXT: [[T3:%.*]] = thin_function_to_pointer [[T2]]
@@ -194,34 +194,34 @@ extension Derived : Abstractable {}
 // CHECK: bb0([[ARG1:%.*]] : $Builtin.RawPointer, [[ARG2:%.*]] : $*Builtin.UnsafeValueBuffer, [[ARG3:%.*]] : $*@thick Derived.Type, [[ARG4:%.*]] : $@thick Derived.Type.Type):
 // CHECK-NEXT: [[SELF:%.*]] = load [trivial] [[ARG3]] : $*@thick Derived.Type
 // CHECK-NEXT: [[BASE_SELF:%.*]] = upcast [[SELF]] : $@thick Derived.Type to $@thick Base.Type
-// CHECK-NEXT: [[BUFFER:%.*]] = pointer_to_address [[ARG1]] : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[BUFFER]] : $*@callee_owned () -> @out Int
-// CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexr_SiIexd_TR : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
-// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]]) : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
-// CHECK:      [[SETTER_FN:%.*]] = function_ref @_T017materializeForSet4BaseC14staticFunctionSiycvsZ : $@convention(method) (@owned @callee_owned () -> Int, @thick Base.Type) -> ()
-// CHECK-NEXT: apply [[SETTER_FN]]([[NEWVALUE]], [[BASE_SELF]]) : $@convention(method) (@owned @callee_owned () -> Int, @thick Base.Type) -> ()
+// CHECK-NEXT: [[BUFFER:%.*]] = pointer_to_address [[ARG1]] : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[BUFFER]] : $*@callee_guaranteed () -> @out Int
+// CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegr_SiIegd_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out Int) -> Int
+// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[VALUE]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out Int) -> Int
+// CHECK:      [[SETTER_FN:%.*]] = function_ref @_T017materializeForSet4BaseC14staticFunctionSiycvsZ : $@convention(method) (@owned @callee_guaranteed () -> Int, @thick Base.Type) -> ()
+// CHECK-NEXT: apply [[SETTER_FN]]([[NEWVALUE]], [[BASE_SELF]]) : $@convention(method) (@owned @callee_guaranteed () -> Int, @thick Base.Type) -> ()
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]] : $()
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T017materializeForSet7DerivedCAA12AbstractableA2aDP14staticFunction6ResultQzycvmZTW
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $@thick Derived.Type):
-// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: [[SELF:%.*]] = upcast %2 : $@thick Derived.Type to $@thick Base.Type
-// CHECK-NEXT: [[OUT:%.*]] = alloc_stack $@callee_owned () -> Int
-// CHECK:      [[GETTER:%.*]] = function_ref @_T017materializeForSet4BaseC14staticFunctionSiycvgZ : $@convention(method) (@thick Base.Type) -> @owned @callee_owned () -> Int
-// CHECK-NEXT: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]]) : $@convention(method) (@thick Base.Type) -> @owned @callee_owned () -> Int
-// CHECK-NEXT: store [[VALUE]] to [init] [[OUT]] : $*@callee_owned () -> Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [copy] [[OUT]] : $*@callee_owned () -> Int
-// CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_T0SiIexd_SiIexr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
-// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
-// CHECK-NEXT: destroy_addr [[OUT]] : $*@callee_owned () -> Int
-// CHECK-NEXT: store [[NEWVALUE]] to [init] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[ADDR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
+// CHECK-NEXT: [[OUT:%.*]] = alloc_stack $@callee_guaranteed () -> Int
+// CHECK:      [[GETTER:%.*]] = function_ref @_T017materializeForSet4BaseC14staticFunctionSiycvgZ : $@convention(method) (@thick Base.Type) -> @owned @callee_guaranteed () -> Int
+// CHECK-NEXT: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]]) : $@convention(method) (@thick Base.Type) -> @owned @callee_guaranteed () -> Int
+// CHECK-NEXT: store [[VALUE]] to [init] [[OUT]] : $*@callee_guaranteed () -> Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [copy] [[OUT]] : $*@callee_guaranteed () -> Int
+// CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_T0SiIegd_SiIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+// CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[VALUE]])
+// CHECK-NEXT: destroy_addr [[OUT]] : $*@callee_guaranteed () -> Int
+// CHECK-NEXT: store [[NEWVALUE]] to [init] [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int
+// CHECK-NEXT: [[ADDR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_guaranteed () -> @out Int to $Builtin.RawPointer
 // CHECK:      [[CALLBACK_FN:%.*]] = function_ref @_T017materializeForSet7DerivedCAA12AbstractableA2aDP14staticFunction6ResultQzycvmZytfU_TW : $@convention(witness_method: Abstractable) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout @thick Derived.Type, @thick Derived.Type.Type) -> ()
 // CHECK-NEXT: [[CALLBACK_ADDR:%.*]] = thin_function_to_pointer [[CALLBACK_FN]] : $@convention(witness_method: Abstractable) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout @thick Derived.Type, @thick Derived.Type.Type) -> () to $Builtin.RawPointer
 // CHECK-NEXT: [[CALLBACK:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, [[CALLBACK_ADDR]] : $Builtin.RawPointer
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ([[ADDR]] : $Builtin.RawPointer, [[CALLBACK]] : $Optional<Builtin.RawPointer>)
-// CHECK-NEXT: dealloc_stack [[OUT]] : $*@callee_owned () -> Int
+// CHECK-NEXT: dealloc_stack [[OUT]] : $*@callee_guaranteed () -> Int
 // CHECK-NEXT: return [[RESULT]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
 
 protocol ClassAbstractable : class {
@@ -570,11 +570,11 @@ struct TuxedoPanda : Panda { }
 
   // FIXME: Useless re-abstractions
 
-  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIexir_A2CIexyd_TR : $@convention(thin) (TuxedoPanda, @owned @callee_owned (@in TuxedoPanda) -> @out TuxedoPanda) -> TuxedoPanda
+  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIegir_A2CIegyd_TR : $@convention(thin) (TuxedoPanda, @guaranteed @callee_guaranteed (@in TuxedoPanda) -> @out TuxedoPanda) -> TuxedoPanda
 
-  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIexyd_A2CIexir_TR : $@convention(thin) (@in TuxedoPanda, @owned @callee_owned (TuxedoPanda) -> TuxedoPanda) -> @out TuxedoPanda
+  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIegyd_A2CIegir_TR : $@convention(thin) (@in TuxedoPanda, @guaranteed @callee_guaranteed (TuxedoPanda) -> TuxedoPanda) -> @out TuxedoPanda
 
-  // CHECK: function_ref @_T017materializeForSet5PandaPAAE1xxxcvs : $@convention(method) <τ_0_0 where τ_0_0 : Panda> (@owned @callee_owned (@in τ_0_0) -> @out τ_0_0, @inout τ_0_0) -> ()
+  // CHECK: function_ref @_T017materializeForSet5PandaPAAE1xxxcvs : $@convention(method) <τ_0_0 where τ_0_0 : Panda> (@owned @callee_guaranteed (@in τ_0_0) -> @out τ_0_0, @inout τ_0_0) -> ()
 
 // CHECK: }
 
@@ -582,18 +582,18 @@ struct TuxedoPanda : Panda { }
 
 // Call the getter:
 
-  // CHECK: function_ref @_T017materializeForSet5PandaPAAE1xxxcvg : $@convention(method) <τ_0_0 where τ_0_0 : Panda> (@in_guaranteed τ_0_0) -> @owned @callee_owned (@in τ_0_0) -> @out τ_0_0
+  // CHECK: function_ref @_T017materializeForSet5PandaPAAE1xxxcvg : $@convention(method) <τ_0_0 where τ_0_0 : Panda> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed (@in τ_0_0) -> @out τ_0_0
 
 // Result of calling the getter is re-abstracted to the maximally substituted type
 // by SILGenFunction::emitApply():
 
-  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIexir_A2CIexyd_TR : $@convention(thin) (TuxedoPanda, @owned @callee_owned (@in TuxedoPanda) -> @out TuxedoPanda) -> TuxedoPanda
+  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIegir_A2CIegyd_TR : $@convention(thin) (TuxedoPanda, @guaranteed @callee_guaranteed (@in TuxedoPanda) -> @out TuxedoPanda) -> TuxedoPanda
 
 // ... then we re-abstract to the requirement signature:
 // FIXME: Peephole this away with the previous one since there's actually no
 // abstraction change in this case.
 
-  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIexyd_A2CIexir_TR : $@convention(thin) (@in TuxedoPanda, @owned @callee_owned (TuxedoPanda) -> TuxedoPanda) -> @out TuxedoPanda
+  // CHECK: function_ref @_T017materializeForSet11TuxedoPandaVACIegyd_A2CIegir_TR : $@convention(thin) (@in TuxedoPanda, @guaranteed @callee_guaranteed (TuxedoPanda) -> TuxedoPanda) -> @out TuxedoPanda
 
 // The callback:
 

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -47,7 +47,7 @@ struct Lunch<T : Pizza> where T.Topping : CuredMeat {
 // CHECK-LABEL: sil private @_T015nested_generics5LunchV6DinnerV15coolCombinationy7ToppingQz1t_AA4DeliC7MustardOyAA6PepperV_G1utF0A7GenericL_qd0___qd0_0_tqd0__1x_qd0_0_1ytAA5PizzaRzAA6HotDogRd__AA9CuredMeatAHRQAP9CondimentRtd__r__0_lF : $@convention(thin) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard><X, Y> (@in X, @in Y) -> (@out X, @out Y)
 
 // CHECK-LABEL: // nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: Swift.Optional<A1>, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
-// CHECK-LABEL: sil hidden @_T015nested_generics5LunchV6DinnerVAEyx_qd__Gx11firstCourse_qd__Sg06secondF0x9leftoversqd__xc14transformationtcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_owned (@owned T) -> @out U, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
+// CHECK-LABEL: sil hidden @_T015nested_generics5LunchV6DinnerVAEyx_qd__Gx11firstCourse_qd__Sg06secondF0x9leftoversqd__xc14transformationtcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_guaranteed (@owned T) -> @out U, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
 
 // Non-generic nested inside generic
 
@@ -153,8 +153,8 @@ func eatDinnerConcrete(d: inout Lunch<Pizzas<ChiliFlakes>.NewYork>.Dinner<HotDog
   _ = d.transformation(d.leftovers)
 }
 
-// CHECK-LABEL: // reabstraction thunk helper from @escaping @callee_owned (@owned nested_generics.Pizzas<nested_generics.ChiliFlakes>.NewYork) -> (@out nested_generics.HotDogs.American) to @escaping @callee_owned (@owned nested_generics.Pizzas<nested_generics.ChiliFlakes>.NewYork) -> (@unowned nested_generics.HotDogs.American)
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA11ChiliFlakesV_GAA7HotDogsC8AmericanVIexxr_AhLIexxd_TR : $@convention(thin) (@owned Pizzas<ChiliFlakes>.NewYork, @owned @callee_owned (@owned Pizzas<ChiliFlakes>.NewYork) -> @out HotDogs.American) -> HotDogs.American
+// CHECK-LABEL: // reabstraction thunk helper from @escaping @callee_guaranteed (@owned nested_generics.Pizzas<nested_generics.ChiliFlakes>.NewYork) -> (@out nested_generics.HotDogs.American) to @escaping @callee_guaranteed (@owned nested_generics.Pizzas<nested_generics.ChiliFlakes>.NewYork) -> (@unowned nested_generics.HotDogs.American)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA11ChiliFlakesV_GAA7HotDogsC8AmericanVIegxr_AhLIegxd_TR : $@convention(thin) (@owned Pizzas<ChiliFlakes>.NewYork, @guaranteed @callee_guaranteed (@owned Pizzas<ChiliFlakes>.NewYork) -> @out HotDogs.American) -> HotDogs.American
 
 // CHECK-LABEL: // nested_generics.eatDinnerConcrete(d: inout nested_generics.Lunch<nested_generics.Pizzas<nested_generics.Pepper>.NewYork>.Dinner<nested_generics.HotDogs.American>, t: nested_generics.Deli<nested_generics.Pepper>.Pepperoni, u: nested_generics.Deli<nested_generics.Pepper>.Mustard) -> ()
 // CHECK-LABEL: sil hidden @_T015nested_generics17eatDinnerConcreteyAA5LunchV0D0VyAA6PizzasV7NewYorkCyAA6PepperV_G_AA7HotDogsC8AmericanVGz1d_AA4DeliC9PepperoniCyAL_G1tAU7MustardOyAL_G1utF : $@convention(thin) (@inout Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDogs.American>, @owned Deli<Pepper>.Pepperoni, Deli<Pepper>.Mustard) -> ()
@@ -175,8 +175,8 @@ func eatDinnerConcrete(d: inout Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDogs.Ame
   _ = d.transformation(d.leftovers)
 }
 
-// CHECK-LABEL: // reabstraction thunk helper from @escaping @callee_owned (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@out nested_generics.HotDogs.American) to @escaping @callee_owned (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@unowned nested_generics.HotDogs.American)
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA6PepperV_GAA7HotDogsC8AmericanVIexxr_AhLIexxd_TR : $@convention(thin) (@owned Pizzas<Pepper>.NewYork, @owned @callee_owned (@owned Pizzas<Pepper>.NewYork) -> @out HotDogs.American) -> HotDogs.American
+// CHECK-LABEL: // reabstraction thunk helper from @escaping @callee_guaranteed (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@out nested_generics.HotDogs.American) to @escaping @callee_guaranteed (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@unowned nested_generics.HotDogs.American)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA6PepperV_GAA7HotDogsC8AmericanVIegxr_AhLIegxd_TR : $@convention(thin) (@owned Pizzas<Pepper>.NewYork, @guaranteed @callee_guaranteed (@owned Pizzas<Pepper>.NewYork) -> @out HotDogs.American) -> HotDogs.American
 
 // CHECK-LABEL: // closure #1 (nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> nested_generics.HotDogs.American in nested_generics.calls() -> ()
 // CHECK-LABEL: sil private @_T015nested_generics5callsyyFAA7HotDogsC8AmericanVAA6PizzasV7NewYorkCyAA6PepperV_GcfU_ : $@convention(thin) (@owned Pizzas<Pepper>.NewYork) -> HotDogs.American
@@ -222,8 +222,8 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
   }
 }
 
-// CHECK-LABEL: // reabstraction thunk helper from @escaping @callee_owned (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@unowned nested_generics.HotDogs.American) to @escaping @callee_owned (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@out nested_generics.HotDogs.American)
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA6PepperV_GAA7HotDogsC8AmericanVIexxd_AhLIexxr_TR : $@convention(thin) (@owned Pizzas<Pepper>.NewYork, @owned @callee_owned (@owned Pizzas<Pepper>.NewYork) -> HotDogs.American) -> @out HotDogs.American
+// CHECK-LABEL: // reabstraction thunk helper from @escaping @callee_guaranteed (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@unowned nested_generics.HotDogs.American) to @escaping @callee_guaranteed (@owned nested_generics.Pizzas<nested_generics.Pepper>.NewYork) -> (@out nested_generics.HotDogs.American)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA6PepperV_GAA7HotDogsC8AmericanVIegxd_AhLIegxr_TR : $@convention(thin) (@owned Pizzas<Pepper>.NewYork, @guaranteed @callee_guaranteed (@owned Pizzas<Pepper>.NewYork) -> HotDogs.American) -> @out HotDogs.American
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015nested_generics9OuterRingC05InnerD0Cyx_qd__GAA30ProtocolWithGenericRequirementA2aGP6method1TQz_1UQzqd__tAK1t_AM1uqd__1vtlFTW : $@convention(witness_method: ProtocolWithGenericRequirement) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @in_guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0) {
 // CHECK: bb0([[T:%[0-9]+]] : @trivial $*τ_0_0, [[U:%[0-9]+]] : @trivial $*τ_1_0, [[V:%[0-9]+]] : @trivial $*τ_2_0, [[TOut:%[0-9]+]] : @trivial $*τ_0_0, [[UOut:%[0-9]+]] : @trivial $*τ_1_0, [[VOut:%[0-9]+]] : @trivial $*τ_2_0, [[SELF:%[0-9]+]] : @trivial $*OuterRing<τ_0_0>.InnerRing<τ_1_0>):

--- a/test/SILGen/noescape_reabstraction.swift
+++ b/test/SILGen/noescape_reabstraction.swift
@@ -10,7 +10,7 @@ func noescape_generic<T>(_ x: (T) -> T) {
 }
 
 // CHECK-LABEL: sil hidden @_T022noescape_reabstraction0A9_concreteyAA1SVADcF
-// CHECK:         function_ref [[REABSTRACTION_THUNK:@_T022noescape_reabstraction1SVACIxyd_A2CIxir_TR]]
+// CHECK:         function_ref [[REABSTRACTION_THUNK:@_T022noescape_reabstraction1SVACIgyd_A2CIgir_TR]]
 
 func concrete(_ x: (S) -> S) {
   noescape_generic(x)

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module -enable-sil-ownership -enable-guaranteed-closure-contexts %s | %FileCheck %s --check-prefix=GUARANTEED
 
 // REQUIRES: objc_interop
 
@@ -11,11 +12,11 @@ import Foundation
   // CHECK: bb0([[ARG1:%.*]] : @unowned $@convention(block) @noescape (Int) -> Int, {{.*}}, [[SELF:%.*]] : @unowned $Foo):
   // CHECK:         [[ARG1_COPY:%.*]] = copy_block [[ARG1]]
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:         [[THUNK:%.*]] = function_ref @_T0S2iIyByd_S2iIxyd_TR
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[ARG1_COPY]])
+  // CHECK:         [[THUNK:%.*]] = function_ref @_T0S2iIyByd_S2iIgyd_TR
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[ARG1_COPY]])
   // CHECK:         [[CONVERT:%.*]] = convert_function [[BRIDGED]]
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
-  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC3foo{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned @noescape @callee_owned (Int) -> Int, Int, @guaranteed Foo) -> Int
+  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC3foo{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned @noescape @callee_guaranteed (Int) -> Int, Int, @guaranteed Foo) -> Int
   // CHECK:         apply [[NATIVE]]([[CONVERT]], {{.*}}, [[BORROWED_SELF_COPY]])
   // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK: } // end sil function '_T020objc_blocks_bridging3FooC3fooS3ic_Si1xtFTo'
@@ -28,11 +29,11 @@ import Foundation
   // CHECK:         [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
   // CHECK:         [[NSSTRING_COPY:%.*]] = copy_value [[NSSTRING]]
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:         [[THUNK:%.*]] = function_ref @_T0So8NSStringCABIyBya_S2SIxxo_TR
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[BLOCK_COPY]])
+  // CHECK:         [[THUNK:%.*]] = function_ref @_T0So8NSStringCABIyBya_S2SIgxo_TR
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[BLOCK_COPY]])
   // CHECK:         [[CONVERT:%.*]] = convert_function [[BRIDGED]]
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
-  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC3bar{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned @noescape @callee_owned (@owned String) -> @owned String, @owned String, @guaranteed Foo) -> @owned String
+  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC3bar{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned @noescape @callee_guaranteed (@owned String) -> @owned String, @owned String, @guaranteed Foo) -> @owned String
   // CHECK:         apply [[NATIVE]]([[CONVERT]], {{%.*}}, [[BORROWED_SELF_COPY]])
   // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK: } // end sil function '_T020objc_blocks_bridging3FooC3barS3Sc_SS1xtFTo'
@@ -40,16 +41,24 @@ import Foundation
     return f(x)
   }
 
+  // GUARANTEED-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0So8NSStringCABIyBya_S2SIgxo_TR : $@convention(thin) (@owned String, @guaranteed @convention(block) @noescape (NSString) -> @autoreleased NSString) -> @owned String {
+  // GUARANTEED: bb0(%0 : @owned $String, [[BLOCK:%.*]] : @guaranteed $@convention(block) @noescape (NSString) -> @autoreleased NSString):
+  // GUARANTEED:   [[BRIDGE:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
+  // GUARANTEED:   [[STR:%.*]] = begin_borrow %0 : $String
+  // GUARANTEED:   [[NSSTR:%.*]] = apply [[BRIDGE]]([[STR]])
+  // GUARANTEED:   apply [[BLOCK]]([[NSSTR]]) : $@convention(block) @noescape (NSString) -> @autoreleased NSString
+  // GUARANTEED: } // end sil function '_T0So8NSStringCABIyBya_S2SIgxo_TR'
+
   // CHECK-LABEL: sil hidden [thunk] @_T020objc_blocks_bridging3FooC3basSSSgA2Ec_AE1xtFTo : $@convention(objc_method) (@convention(block) @noescape (Optional<NSString>) -> @autoreleased Optional<NSString>, Optional<NSString>, Foo) -> @autoreleased Optional<NSString> {
   // CHECK:       bb0([[BLOCK:%.*]] : @unowned $@convention(block) @noescape (Optional<NSString>) -> @autoreleased Optional<NSString>, [[OPT_STRING:%.*]] : @unowned $Optional<NSString>, [[SELF:%.*]] : @unowned $Foo):
   // CHECK:         [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
   // CHECK:         [[OPT_STRING_COPY:%.*]] = copy_value [[OPT_STRING]]
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:         [[THUNK:%.*]] = function_ref @_T0So8NSStringCSgACIyBya_SSSgADIxxo_TR
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[BLOCK_COPY]])
+  // CHECK:         [[THUNK:%.*]] = function_ref @_T0So8NSStringCSgACIyBya_SSSgADIgxo_TR
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[BLOCK_COPY]])
   // CHECK:         [[CONVERT:%.*]] = convert_function [[BRIDGED]]
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
-  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC3bas{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned @noescape @callee_owned (@owned Optional<String>) -> @owned Optional<String>, @owned Optional<String>, @guaranteed Foo) -> @owned Optional<String>
+  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC3bas{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned @noescape @callee_guaranteed (@owned Optional<String>) -> @owned Optional<String>, @owned Optional<String>, @guaranteed Foo) -> @owned Optional<String>
   // CHECK:         apply [[NATIVE]]([[CONVERT]], {{%.*}}, [[BORROWED_SELF_COPY]])
   // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   dynamic func bas(_ f: (String?) -> String?, x: String?) -> String? {
@@ -75,10 +84,10 @@ import Foundation
   // CHECK:         switch_enum [[COPY]] : $Optional<@convention(block) (NSString) -> @autoreleased NSString>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
   // CHECK: [[SOME_BB]]([[BLOCK:%.*]] : @owned $@convention(block) (NSString) -> @autoreleased NSString):
   // TODO: redundant reabstractions here
-  // CHECK:         [[BLOCK_THUNK:%.*]] = function_ref @_T0So8NSStringCABIeyBya_S2SIexxo_TR
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[BLOCK_THUNK]]([[BLOCK]])
-  // CHECK:         enum $Optional<@callee_owned (@owned String) -> @owned String>, #Optional.some!enumelt.1, [[BRIDGED]]
-  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC7optFunc{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned Optional<@callee_owned (@owned String) -> @owned String>, @owned String, @guaranteed Foo) -> @owned Optional<String>
+  // CHECK:         [[BLOCK_THUNK:%.*]] = function_ref @_T0So8NSStringCABIeyBya_S2SIegxo_TR
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [callee_guaranteed] [[BLOCK_THUNK]]([[BLOCK]])
+  // CHECK:         enum $Optional<@callee_guaranteed (@owned String) -> @owned String>, #Optional.some!enumelt.1, [[BRIDGED]]
+  // CHECK:         [[NATIVE:%.*]] = function_ref @_T020objc_blocks_bridging3FooC7optFunc{{[_0-9a-zA-Z]*}}F : $@convention(method) (@owned Optional<@callee_guaranteed (@owned String) -> @owned String>, @owned String, @guaranteed Foo) -> @owned Optional<String>
   // CHECK:         apply [[NATIVE]]
   dynamic func optFunc(_ f: ((String) -> String)?, x: String) -> String? {
     return f?(x)
@@ -99,7 +108,7 @@ func callBlocks(_ x: Foo,
   g: @escaping (String) -> String,
   h: @escaping (String?) -> String?
 ) -> (Int, String, String?, String?) {
-  // CHECK: bb0([[ARG0:%.*]] : @owned $Foo, [[ARG1:%.*]] : @owned $@callee_owned (Int) -> Int, [[ARG2:%.*]] : @owned $@callee_owned (@owned String) -> @owned String, [[ARG3:%.*]] : @owned $@callee_owned (@owned Optional<String>) -> @owned Optional<String>):
+  // CHECK: bb0([[ARG0:%.*]] : @owned $Foo, [[ARG1:%.*]] : @owned $@callee_guaranteed (Int) -> Int, [[ARG2:%.*]] : @owned $@callee_guaranteed (@owned String) -> @owned String, [[ARG3:%.*]] : @owned $@callee_guaranteed (@owned Optional<String>) -> @owned Optional<String>):
   // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
   // CHECK: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
@@ -107,21 +116,21 @@ func callBlocks(_ x: Foo,
   // CHECK: [[F_BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage
   // CHECK: [[F_BLOCK_CAPTURE:%.*]] = project_block_storage [[F_BLOCK_STORAGE]]
   // CHECK: store [[CONVERT]] to [init] [[F_BLOCK_CAPTURE]]
-  // CHECK: [[F_BLOCK_INVOKE:%.*]] = function_ref @_T0S2iIxyd_S2iIyByd_TR
+  // CHECK: [[F_BLOCK_INVOKE:%.*]] = function_ref @_T0S2iIgyd_S2iIyByd_TR
   // CHECK: [[F_STACK_BLOCK:%.*]] = init_block_storage_header [[F_BLOCK_STORAGE]] : {{.*}}, invoke [[F_BLOCK_INVOKE]]
   // CHECK: [[F_BLOCK:%.*]] = copy_block [[F_STACK_BLOCK]]
   // CHECK: [[FOO:%.*]] =  objc_method [[BORROWED_ARG0]] : $Foo, #Foo.foo!1.foreign
   // CHECK: apply [[FOO]]([[F_BLOCK]]
 
   // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
-  // CHECK: [[G_BLOCK_INVOKE:%.*]] = function_ref @_T0S2SIxxo_So8NSStringCABIyBya_TR
+  // CHECK: [[G_BLOCK_INVOKE:%.*]] = function_ref @_T0S2SIgxo_So8NSStringCABIyBya_TR
   // CHECK: [[G_STACK_BLOCK:%.*]] = init_block_storage_header {{.*}}, invoke [[G_BLOCK_INVOKE]]
   // CHECK: [[G_BLOCK:%.*]] = copy_block [[G_STACK_BLOCK]]
   // CHECK: [[BAR:%.*]] = objc_method [[BORROWED_ARG0]] : $Foo, #Foo.bar!1.foreign
   // CHECK: apply [[BAR]]([[G_BLOCK]]
 
   // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
-  // CHECK: [[H_BLOCK_INVOKE:%.*]] = function_ref @_T0SSSgAAIxxo_So8NSStringCSgADIyBya_TR
+  // CHECK: [[H_BLOCK_INVOKE:%.*]] = function_ref @_T0SSSgAAIgxo_So8NSStringCSgADIyBya_TR
   // CHECK: [[H_STACK_BLOCK:%.*]] = init_block_storage_header {{.*}}, invoke [[H_BLOCK_INVOKE]]
   // CHECK: [[H_BLOCK:%.*]] = copy_block [[H_STACK_BLOCK]]
   // CHECK: [[BAS:%.*]] = objc_method [[BORROWED_ARG0]] : $Foo, #Foo.bas!1.foreign
@@ -137,9 +146,9 @@ class Test: NSObject {
   func blockTakesBlock() -> ((Int) -> Int) -> Int {}
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIxyd_SiIexxd_S2iIyByd_SiIeyByd_TR
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIgyd_SiIegxd_S2iIyByd_SiIeyByd_TR
 // CHECK:         [[BLOCK_COPY:%.*]] = copy_block [[ORIG_BLOCK:%.*]] :
-// CHECK:         [[CLOSURE:%.*]] = partial_apply {{%.*}}([[BLOCK_COPY]])
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BLOCK_COPY]])
 // CHECK: [[CONVERT:%.*]] = convert_function [[CLOSURE]]
 // CHECK:         [[RESULT:%.*]] = apply {{%.*}}([[CONVERT]])
 // CHECK:         return [[RESULT]]
@@ -147,14 +156,14 @@ class Test: NSObject {
 func clearDraggingItemImageComponentsProvider(_ x: NSDraggingItem) {
   x.imageComponentsProvider = {}
 }
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SayypGIexo_So7NSArrayCSgIeyBa_TR
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SayypGIego_So7NSArrayCSgIeyBa_TR
 // CHECK:         [[CONVERT:%.*]] = function_ref @_T0Sa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF
 // CHECK:         [[CONVERTED:%.*]] = apply [[CONVERT]]
 // CHECK:         [[OPTIONAL:%.*]] = enum $Optional<NSArray>, #Optional.some!enumelt.1, [[CONVERTED]]
 // CHECK:         return [[OPTIONAL]]
 
 // CHECK-LABEL: sil hidden @{{.*}}bridgeNonnullBlockResult{{.*}}
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SSIexo_So8NSStringCSgIeyBa_TR
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SSIego_So8NSStringCSgIeyBa_TR
 // CHECK:         [[CONVERT:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
 // CHECK:         [[BRIDGED:%.*]] = apply [[CONVERT]]
 // CHECK:         [[OPTIONAL_BRIDGED:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
@@ -165,9 +174,9 @@ func bridgeNonnullBlockResult() {
 
 // CHECK-LABEL: sil hidden @{{.*}}bridgeNoescapeBlock{{.*}}
 func bridgeNoescapeBlock() {
-  // CHECK: function_ref @_T0Ix_IyB_TR
+  // CHECK: function_ref @_T0Ig_IyB_TR
   noescapeBlockAlias { }
-  // CHECK: function_ref @_T0Ix_IyB_TR
+  // CHECK: function_ref @_T0Ig_IyB_TR
   noescapeNonnullBlockAlias { }
 }
 
@@ -185,8 +194,8 @@ struct GenericStruct<T> {
   }
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ix_Ixx_IyB_IyBy_TR : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_owned (@owned @noescape @callee_owned () -> ()) -> (), @convention(block) @noescape () -> ()) -> ()
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0IyB_Ix_TR : $@convention(thin) (@owned @convention(block) @noescape () -> ()) -> ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ig_Igx_IyB_IyBy_TR : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_guaranteed (@owned @noescape @callee_guaranteed () -> ()) -> (), @convention(block) @noescape () -> ()) -> ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0IyB_Ig_TR : $@convention(thin) (@guaranteed @convention(block) @noescape () -> ()) -> ()
 
 // rdar://35402696
 func takeOptStringFunction(fn: (String) -> String?) {}
@@ -195,4 +204,4 @@ func testGlobalBlock() {
 }
 // CHECK-LABEL: sil hidden @_T020objc_blocks_bridging15testGlobalBlockyyF
 // CHECK: global_addr @GlobalBlock : $*@convention(block) (NSString) -> @autoreleased Optional<NSString>
-// CHECK: function_ref @_T0So8NSStringCABSgIeyBya_S2SIexxo_TR : $@convention(thin) (@owned String, @owned @convention(block) (NSString) -> @autoreleased Optional<NSString>) -> @owned String
+// CHECK: function_ref @_T0So8NSStringCABSgIeyBya_S2SIegxo_TR : $@convention(thin) (@owned String, @guaranteed @convention(block) (NSString) -> @autoreleased Optional<NSString>) -> @owned String

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -643,13 +643,13 @@ func takeTwoAnys(_ lhs: Any, _ rhs: Any) -> Any { return lhs }
 // CHECK-LABEL: sil hidden @_T013objc_bridging22defineNonStandardBlockyyp1x_tF
 func defineNonStandardBlock(x: Any) {
   // CHECK: function_ref @_T013objc_bridging22defineNonStandardBlockyyp1x_tFypypcfU_
-  // CHECK: function_ref @_T0ypypIexir_yXlyXlIeyBya_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> @out Any, AnyObject) -> @autoreleased AnyObject
+  // CHECK: function_ref @_T0ypypIegir_yXlyXlIeyBya_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in Any) -> @out Any, AnyObject) -> @autoreleased AnyObject
 
   let fn : @convention(block) (Any) -> Any = { y in takeTwoAnys(x, y) }
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypypIexir_yXlyXlIeyBya_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> @out Any, AnyObject) -> @autoreleased AnyObject
-// CHECK: bb0(%0 : @trivial $*@block_storage @callee_owned (@in Any) -> @out Any, %1 : @unowned $AnyObject):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypypIegir_yXlyXlIeyBya_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in Any) -> @out Any, AnyObject) -> @autoreleased AnyObject
+// CHECK: bb0(%0 : @trivial $*@block_storage @callee_guaranteed (@in Any) -> @out Any, %1 : @unowned $AnyObject):
 // CHECK:   [[T0:%.*]] = copy_value %1 : $AnyObject
 // CHECK:   [[T1:%.*]] = open_existential_ref [[T0]] : $AnyObject
 // CHECK:   [[ARG:%.*]] = alloc_stack $Any

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -540,14 +540,14 @@ class SwiftIdLover : NSObject, Anyable {
 
   // CHECK-LABEL: sil hidden [thunk] @_T017objc_bridging_any12SwiftIdLoverC23methodTakingOptionalAnyyypSg1a_tFTo
 
-  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC017methodTakingBlockH3AnyyyypcF : $@convention(method) (@owned @noescape @callee_owned (@in Any) -> (), @guaranteed SwiftIdLover) -> ()
+  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC017methodTakingBlockH3AnyyyypcF : $@convention(method) (@owned @noescape @callee_guaranteed (@in Any) -> (), @guaranteed SwiftIdLover) -> ()
 
   // CHECK-LABEL: sil hidden [thunk] @_T017objc_bridging_any12SwiftIdLoverC017methodTakingBlockH3AnyyyypcFTo : $@convention(objc_method) (@convention(block) @noescape (AnyObject) -> (), SwiftIdLover) -> ()
   // CHECK:    bb0([[BLOCK:%.*]] : @unowned $@convention(block) @noescape (AnyObject) -> (), [[SELF:%.*]] : @unowned $SwiftIdLover):
   // CHECK-NEXT:  [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
   // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0yXlIyBy_ypIxi_TR
-  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK_COPY]])
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0yXlIyBy_ypIgi_TR
+  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]([[BLOCK_COPY]])
   // CHECK-NEXT:  [[THUNK_CVT:%.*]] = convert_function [[THUNK]]
   // CHECK:       [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK-NEXT:  // function_ref
@@ -557,8 +557,8 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0yXlIyBy_ypIxi_TR
-  // CHECK:     bb0([[ANY:%.*]] : @trivial $*Any, [[BLOCK:%.*]] : @owned $@convention(block) @noescape (AnyObject) -> ()):
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0yXlIyBy_ypIgi_TR
+  // CHECK:     bb0([[ANY:%.*]] : @trivial $*Any, [[BLOCK:%.*]] : @guaranteed $@convention(block) @noescape (AnyObject) -> ()):
   // CHECK-NEXT:  [[OPENED_ANY:%.*]] = open_existential_addr immutable_access [[ANY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
 	// CHECK:   [[TMP:%.*]] = alloc_stack
   // CHECK:   copy_addr [[OPENED_ANY]] to [initialization] [[TMP]]
@@ -567,7 +567,6 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])
   // CHECK-NEXT:  apply [[BLOCK]]([[BRIDGED]])
   // CHECK-NEXT:  [[VOID:%.*]] = tuple ()
-  // CHECK-NEXT:  destroy_value [[BLOCK]]
   // CHECK-NEXT:  destroy_value [[BRIDGED]]
 	// CHECK-NEXT: dealloc_stack [[TMP]]
   // CHECK-NEXT:  destroy_addr [[ANY]]
@@ -575,7 +574,7 @@ class SwiftIdLover : NSObject, Anyable {
 
   @objc func methodTakingBlockTakingAny(_: (Any) -> ()) {}
 
-  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC29methodReturningBlockTakingAnyyypcyF : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_owned (@in Any) -> ()
+  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC29methodReturningBlockTakingAnyyypcyF : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_guaranteed (@in Any) -> ()
 
   // CHECK-LABEL: sil hidden [thunk] @_T017objc_bridging_any12SwiftIdLoverC29methodReturningBlockTakingAnyyypcyFTo : $@convention(objc_method) (SwiftIdLover) -> @autoreleased @convention(block) (AnyObject) -> ()
   // CHECK:     bb0([[SELF:%.*]] : @unowned $SwiftIdLover):
@@ -586,18 +585,18 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD:%.*]]([[BORROWED_SELF_COPY]])
   // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
-  // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned (@in Any) -> ()
+  // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_guaranteed (@in Any) -> ()
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  store [[RESULT:%.*]] to [init] [[BLOCK_STORAGE_ADDR]]
-  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0ypIexi_yXlIeyBy_TR
-  // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned (@in Any) -> (), invoke [[THUNK_FN]]
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0ypIegi_yXlIeyBy_TR
+  // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_guaranteed (@in Any) -> (), invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
   // CHECK-NEXT:  destroy_addr [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
   // CHECK-NEXT:  return [[BLOCK]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIexi_yXlIeyBy_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> (), AnyObject) -> ()
-  // CHECK:     bb0([[BLOCK_STORAGE:%.*]] : @trivial $*@block_storage @callee_owned (@in Any) -> (), [[ANY:%.*]] : @unowned $AnyObject):
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIegi_yXlIeyBy_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in Any) -> (), AnyObject) -> ()
+  // CHECK:     bb0([[BLOCK_STORAGE:%.*]] : @trivial $*@block_storage @callee_guaranteed (@in Any) -> (), [[ANY:%.*]] : @unowned $AnyObject):
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  [[FUNCTION:%.*]] = load [copy] [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  [[ANY_COPY:%.*]] = copy_value [[ANY]]
@@ -605,24 +604,27 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
   // CHECK-NEXT:  [[INIT:%.*]] = init_existential_addr [[RESULT]] : $*Any
   // CHECK-NEXT:  store [[OPENED_ANY]] to [init] [[INIT]]
-  // CHECK-NEXT:  apply [[FUNCTION]]([[RESULT]])
+  // CHECK-NEXT:  [[BORROW_FUN:%.*]] =  begin_borrow [[FUNCTION]]
+  // CHECK-NEXT:  apply [[BORROW_FUN]]([[RESULT]])
+  // CHECK-NEXT:  end_borrow [[BORROW_FUN]] from [[FUNCTION]]
   // CHECK-NEXT:  [[VOID:%.*]] = tuple ()
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:   destroy_value [[FUNCTION]]
   // CHECK-NEXT:  return [[VOID]] : $()
 
   @objc func methodTakingBlockTakingOptionalAny(_: (Any?) -> ()) {}
 
   @objc func methodReturningBlockTakingAny() -> ((Any) -> ()) {}
 
-  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC29methodTakingBlockReturningAnyyypycF : $@convention(method) (@owned @noescape @callee_owned () -> @out Any, @guaranteed SwiftIdLover) -> () {
+  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC29methodTakingBlockReturningAnyyypycF : $@convention(method) (@owned @noescape @callee_guaranteed () -> @out Any, @guaranteed SwiftIdLover) -> () {
 
   // CHECK-LABEL: sil hidden [thunk] @_T017objc_bridging_any12SwiftIdLoverC29methodTakingBlockReturningAnyyypycFTo : $@convention(objc_method) (@convention(block) @noescape () -> @autoreleased AnyObject, SwiftIdLover) -> ()
   // CHECK:     bb0([[BLOCK:%.*]] : @unowned $@convention(block) @noescape () -> @autoreleased AnyObject, [[ANY:%.*]] : @unowned $SwiftIdLover):
   // CHECK-NEXT:  [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
   // CHECK-NEXT:  [[ANY_COPY:%.*]] = copy_value [[ANY]]
   // CHECK-NEXT:  // function_ref
-  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0yXlIyBa_ypIxr_TR
-  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK_COPY]])
+  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0yXlIyBa_ypIgr_TR
+  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]([[BLOCK_COPY]])
   // CHECK-NEXT:  [[THUNK_CVT:%.*]] = convert_function [[THUNK]]
   // CHECK-NEXT:  [[BORROWED_ANY_COPY:%.*]] = begin_borrow [[ANY_COPY]]
   // CHECK-NEXT:  // function_ref
@@ -632,22 +634,21 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[ANY_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0yXlIyBa_ypIxr_TR : $@convention(thin) (@owned @convention(block) @noescape () -> @autoreleased AnyObject) -> @out Any
-  // CHECK:     bb0([[ANY_ADDR:%.*]] : @trivial $*Any, [[BLOCK:%.*]] : @owned $@convention(block) @noescape () -> @autoreleased AnyObject):
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0yXlIyBa_ypIgr_TR : $@convention(thin) (@guaranteed @convention(block) @noescape () -> @autoreleased AnyObject) -> @out Any
+  // CHECK:     bb0([[ANY_ADDR:%.*]] : @trivial $*Any, [[BLOCK:%.*]] : @guaranteed $@convention(block) @noescape () -> @autoreleased AnyObject):
   // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BLOCK]]()
   // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast [[BRIDGED]]
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[BRIDGE_TO_ANY:%.*]] = function_ref [[BRIDGE_TO_ANY_FUNC:@.*]] :
   // CHECK-NEXT:  [[RESULT_VAL:%.*]] = apply [[BRIDGE_TO_ANY]]([[ANY_ADDR]], [[OPTIONAL]])
   // CHECK-NEXT:  [[EMPTY:%.*]] = tuple ()
-  // CHECK-NEXT:  destroy_value [[BLOCK]]
   // CHECK-NEXT:  return [[EMPTY]]
 
   @objc func methodReturningBlockTakingOptionalAny() -> ((Any?) -> ()) {}
 
   @objc func methodTakingBlockReturningAny(_: () -> Any) {}
 
-  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC020methodReturningBlockH3AnyypycyF : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_owned () -> @out Any
+  // CHECK-LABEL: sil hidden @_T017objc_bridging_any12SwiftIdLoverC020methodReturningBlockH3AnyypycyF : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_guaranteed () -> @out Any
 
   // CHECK-LABEL: sil hidden [thunk] @_T017objc_bridging_any12SwiftIdLoverC020methodReturningBlockH3AnyypycyFTo : $@convention(objc_method) (SwiftIdLover) -> @autoreleased @convention(block) () -> @autoreleased AnyObject
   // CHECK:     bb0([[SELF:%.*]] : @unowned $SwiftIdLover):
@@ -658,23 +659,25 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[FUNCTION:%.*]] = apply [[METHOD]]([[BORROWED_SELF_COPY]])
   // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
-  // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned () -> @out Any
+  // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_guaranteed () -> @out Any
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  store [[FUNCTION]] to [init] [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  // function_ref
-  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0ypIexr_yXlIeyBa_TR
-  // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned () -> @out Any, invoke [[THUNK_FN]]
+  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0ypIegr_yXlIeyBa_TR
+  // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_guaranteed () -> @out Any, invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
   // CHECK-NEXT:  destroy_addr [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
   // CHECK-NEXT:  return [[BLOCK]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIexr_yXlIeyBa_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned () -> @out Any) -> @autoreleased AnyObject
-  // CHECK:     bb0(%0 : @trivial $*@block_storage @callee_owned () -> @out Any):
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIegr_yXlIeyBa_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> @out Any) -> @autoreleased AnyObject
+  // CHECK:     bb0(%0 : @trivial $*@block_storage @callee_guaranteed () -> @out Any):
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage %0
   // CHECK-NEXT:  [[FUNCTION:%.*]] = load [copy] [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
-  // CHECK-NEXT:  apply [[FUNCTION]]([[RESULT]])
+  // CHECK-NEXT:  [[BORROW_FUN:%.*]] = begin_borrow [[FUNCTION]]
+  // CHECK-NEXT:  apply [[BORROW_FUN]]([[RESULT]])
+  // CHECK-NEXT:  end_borrow [[BORROW_FUN]] from [[FUNCTION]]
   // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr immutable_access [[RESULT]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
   // CHECK:       [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
   // CHECK:       copy_addr [[OPENED]] to [initialization] [[TMP]]
@@ -684,6 +687,7 @@ class SwiftIdLover : NSObject, Anyable {
 	// CHECK-NEXT:  dealloc_stack [[TMP]]
   // CHECK-NEXT:  destroy_addr [[RESULT]]
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:  destroy_value [[FUNCTION]]
   // CHECK-NEXT:  return [[BRIDGED]]
 
   @objc func methodTakingBlockReturningOptionalAny(_: () -> Any?) {}
@@ -691,7 +695,7 @@ class SwiftIdLover : NSObject, Anyable {
   @objc func methodReturningBlockReturningAny() -> (() -> Any) {}
 
   @objc func methodReturningBlockReturningOptionalAny() -> (() -> Any?) {}
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIexr_yXlSgIeyBa_TR
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIegr_yXlSgIeyBa_TR
   // CHECK: function_ref @_T0s27_bridgeAnythingToObjectiveC{{.*}}F
 
   override init() { super.init() }
@@ -738,11 +742,11 @@ class AnyHashableClass : NSObject {
   }
 }
 
-// CHECK-LABEL: sil hidden @_T017objc_bridging_any33bridgeOptionalFunctionToAnyObjectyXlyycSg2fn_tF : $@convention(thin) (@owned Optional<@callee_owned () -> ()>) -> @owned AnyObject
+// CHECK-LABEL: sil hidden @_T017objc_bridging_any33bridgeOptionalFunctionToAnyObjectyXlyycSg2fn_tF : $@convention(thin) (@owned Optional<@callee_guaranteed () -> ()>) -> @owned AnyObject
 // CHECK: [[BRIDGE:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCyXlyF
-// CHECK: [[FN:%.*]] = function_ref @_T0Iex_ytytIexir_TR
-// CHECK: partial_apply [[FN]]
-// CHECK: [[SELF:%.*]] = alloc_stack $Optional<@callee_owned (@in ()) -> @out ()>
+// CHECK: [[FN:%.*]] = function_ref @_T0Ieg_ytytIegir_TR
+// CHECK: partial_apply [callee_guaranteed] [[FN]]
+// CHECK: [[SELF:%.*]] = alloc_stack $Optional<@callee_guaranteed (@in ()) -> @out ()>
 // CHECK: apply [[BRIDGE]]<() -> ()>([[SELF]])
 func bridgeOptionalFunctionToAnyObject(fn: (() -> ())?) -> AnyObject {
   return fn as AnyObject

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -10,20 +10,20 @@ import gizmo
 func curry_pod(_ x: CurryTest) -> (Int) -> Int {
   return x.pod
 }
-// CHECK-LABEL: sil hidden @_T013objc_currying9curry_podS2icSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
+// CHECK-LABEL: sil hidden @_T013objc_currying9curry_podS2icSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed (Int) -> Int
 // CHECK:      bb0([[ARG1:%.*]] : @owned $CurryTest):
 // CHECK:         [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:         [[COPIED_ARG1:%.*]] = copy_value [[BORROWED_ARG1]]
-// CHECK:         [[THUNK:%.*]] = function_ref @[[THUNK_FOO_1:_T0So9CurryTestC3podS2iFTcTO]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
+// CHECK:         [[THUNK:%.*]] = function_ref @[[THUNK_FOO_1:_T0So9CurryTestC3podS2iFTcTO]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed (Int) -> Int
 // CHECK:         [[FN:%.*]] = apply [[THUNK]]([[COPIED_ARG1]])
 // CHECK:         end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:         destroy_value [[ARG1]]
 // CHECK:         return [[FN]]
 // CHECK: } // end sil function '_T013objc_currying9curry_podS2icSo9CurryTestCF'
 
-// CHECK: sil shared [serializable] [thunk] @[[THUNK_FOO_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
+// CHECK: sil shared [serializable] [thunk] @[[THUNK_FOO_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed (Int) -> Int
 // CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_FOO_2:_T0So9CurryTestC3podS2iFTO]]
-// CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
+// CHECK:   [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]](%0)
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '[[THUNK_FOO_1]]'
 
@@ -39,7 +39,7 @@ func curry_pod(_ x: CurryTest) -> (Int) -> Int {
 func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
   return x.bridged
 }
-// CHECK-LABEL: sil hidden @_T013objc_currying13curry_bridgedSQySSGACcSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
+// CHECK-LABEL: sil hidden @_T013objc_currying13curry_bridgedSQySSGACcSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed (@owned Optional<String>) -> @owned Optional<String>
 // CHECK: bb0([[ARG1:%.*]] : @owned $CurryTest):
 // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
@@ -50,10 +50,10 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '_T013objc_currying13curry_bridgedSQySSGACcSo9CurryTestCF'
 
-// CHECK: sil shared [serializable] [thunk] @[[THUNK_BAR_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
+// CHECK: sil shared [serializable] [thunk] @[[THUNK_BAR_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed (@owned Optional<String>) -> @owned Optional<String>
 // CHECK: bb0([[ARG1:%.*]] : @owned $CurryTest):
 // CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_BAR_2:_T0So9CurryTestC7bridgedSQySSGADFTO]]
-// CHECK:   [[FN:%.*]] = partial_apply [[THUNK]]([[ARG1]])
+// CHECK:   [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[ARG1]])
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '[[THUNK_BAR_1]]'
 
@@ -100,7 +100,7 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer
 }
-// CHECK-LABEL: sil hidden @_T013objc_currying25curry_returnsInnerPointerSQySvGycSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
+// CHECK-LABEL: sil hidden @_T013objc_currying25curry_returnsInnerPointerSQySvGycSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed () -> Optional<UnsafeMutableRawPointer> {
 // CHECK: bb0([[SELF:%.*]] : @owned $CurryTest):
 // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK:   [[SELF_COPY:%.*]] = copy_value [[BORROWED_SELF]]
@@ -111,9 +111,9 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '_T013objc_currying25curry_returnsInnerPointerSQySvGycSo9CurryTestCF'
 
-// CHECK: sil shared [serializable] [thunk] @[[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer>
+// CHECK: sil shared [serializable] [thunk] @[[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_guaranteed () -> Optional<UnsafeMutableRawPointer>
 // CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_RETURNSINNERPOINTER_2:_T0So9CurryTestC19returnsInnerPointerSQySvGyFTO]]
-// CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
+// CHECK:   [[FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]](%0)
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '[[THUNK_RETURNSINNERPOINTER]]'
 
@@ -126,7 +126,7 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 // CHECK:   return [[RES]]
 // CHECK: } // end sil function '[[THUNK_RETURNSINNERPOINTER_2]]'
 
-// CHECK-LABEL: sil hidden @_T013objc_currying19curry_pod_AnyObjectS2icyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (Int) -> Int
+// CHECK-LABEL: sil hidden @_T013objc_currying19curry_pod_AnyObjectS2icyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed (Int) -> Int
 // CHECK: bb0([[ANY:%.*]] : @owned $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -134,14 +134,14 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.pod!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:   [[HAS_METHOD]]([[METHOD:%.*]] : @trivial $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
-// CHECK:   partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   partial_apply [callee_guaranteed] [[METHOD]]([[OPENED_ANY_COPY_2]])
 // CHECK: } // end sil function '_T013objc_currying19curry_pod_AnyObjectS2icyXlF'
 func curry_pod_AnyObject(_ x: AnyObject) -> (Int) -> Int {
   return x.pod!
 }
 
 // normalOwnership requires a thunk to bring the method to Swift conventions
-// CHECK-LABEL: sil hidden @_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> {
+// CHECK-LABEL: sil hidden @_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> {
 // CHECK: bb0([[ANY:%.*]] : @owned $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -149,9 +149,9 @@ func curry_pod_AnyObject(_ x: AnyObject) -> (Int) -> Int {
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.normalOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : @trivial $@convention(objc_method) (Optional<CurryTest>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<CurryTest>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
-// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
-// CHECK:   [[THUNK:%.*]] = function_ref @_T0So9CurryTestCSgACIexyo_A2CIexxo_TR
-// CHECK:   partial_apply [[THUNK]]([[PA]])
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   [[THUNK:%.*]] = function_ref @_T0So9CurryTestCSgACIegyo_A2CIegxo_TR
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[PA]])
 // CHECK: } // end sil function '_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF'
 func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest! {
   return x.normalOwnership!
@@ -159,7 +159,7 @@ func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTes
 
 // weirdOwnership is NS_RETURNS_RETAINED and NS_CONSUMES_SELF so already
 // follows Swift conventions
-// CHECK-LABEL: sil hidden @_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest>
+// CHECK-LABEL: sil hidden @_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed (@owned Optional<CurryTest>) -> @owned Optional<CurryTest>
 // CHECK: bb0([[ANY:%.*]] : @owned $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -167,14 +167,14 @@ func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTes
 // CHECK:   dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.weirdOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: bb1([[METHOD:%.*]] : @trivial $@convention(objc_method) (@owned Optional<CurryTest>, @owned @opened({{.*}}) AnyObject) -> @owned Optional<CurryTest>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
-// CHECK:   partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   partial_apply [callee_guaranteed] [[METHOD]]([[OPENED_ANY_COPY_2]])
 // CHECK: } // end sil function '_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF'
 func curry_weirdOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest! {
   return x.weirdOwnership!
 }
 
 // bridged requires a thunk to handle bridging conversions
-// CHECK-LABEL: sil hidden @_T013objc_currying23curry_bridged_AnyObjectSQySSGACcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
+// CHECK-LABEL: sil hidden @_T013objc_currying23curry_bridged_AnyObjectSQySSGACcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed (@owned Optional<String>) -> @owned Optional<String>
 // CHECK: bb0([[ANY:%.*]] : @owned $AnyObject):
 // CHECK:    [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -182,9 +182,9 @@ func curry_weirdOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.bridged!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : @trivial $@convention(objc_method) (Optional<NSString>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<NSString>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
-// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
-// CHECK:   [[THUNK:%.*]] = function_ref @_T0So8NSStringCSgACIexyo_SSSgADIexxo_TR
-// CHECK:   partial_apply [[THUNK]]([[PA]])
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   [[THUNK:%.*]] = function_ref @_T0So8NSStringCSgACIegyo_SSSgADIegxo_TR
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[PA]])
 // CHECK: } // end sil function '_T013objc_currying23curry_bridged_AnyObjectSQySSGACcyXlF'
 func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
   return x.bridged!
@@ -192,7 +192,7 @@ func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
 
 // check that we substitute Self = AnyObject correctly for Self-returning
 // methods
-// CHECK-LABEL: sil hidden @_T013objc_currying27curry_returnsSelf_AnyObjectSQyyXlGycyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> @owned Optional<AnyObject> {
+// CHECK-LABEL: sil hidden @_T013objc_currying27curry_returnsSelf_AnyObjectSQyyXlGycyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed () -> @owned Optional<AnyObject> {
 // CHECK: bb0([[ANY:%.*]] : @owned $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -200,13 +200,13 @@ func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsSelf!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : @trivial $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased Optional<AnyObject>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
-// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[METHOD]]([[OPENED_ANY_COPY_2]])
 // CHECK: } // end sil function '_T013objc_currying27curry_returnsSelf_AnyObjectSQyyXlGycyXlF'
 func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!
 }
 
-// CHECK-LABEL: sil hidden @_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
+// CHECK-LABEL: sil hidden @_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed () -> Optional<UnsafeMutableRawPointer> {
 // CHECK: bb0([[ANY:%.*]] : @owned $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -214,7 +214,7 @@ func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsInnerPointer!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : @trivial $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
-// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[METHOD]]([[OPENED_ANY_COPY_2]])
 // CHECK: } // end sil function '_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycyXlF'
 
 func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutableRawPointer! {

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -89,9 +89,9 @@ public func genericBlockBridging<T: Ansible>(x: GenericClass<T>) {
 }
 
 // CHECK-LABEL: sil @_T021objc_imported_generic0C13BlockBridging{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_T0xxIeyBya_xxIexxo_21objc_imported_generic7AnsibleRzlTR
-// CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T>
-// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_T0xxIexxo_xxIeyBya_21objc_imported_generic7AnsibleRzlTR
+// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_T0xxIeyBya_xxIegxo_21objc_imported_generic7AnsibleRzlTR
+// CHECK:         partial_apply [callee_guaranteed] [[BLOCK_TO_FUNC]]<T>
+// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_T0xxIegxo_xxIeyBya_21objc_imported_generic7AnsibleRzlTR
 // CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T>
 
 // CHECK-LABEL: sil @_T021objc_imported_generic20arraysOfGenericParam{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -56,7 +56,7 @@ func objc_generic_partial_apply<T : NSRuncing>(_ x: T) {
   _ = x.runce
 
   // CHECK:   [[FN:%.*]] = function_ref @[[THUNK1]] :
-  // CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]<T>()
+  // CHECK:   [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]]<T>()
   // CHECK:   destroy_value [[METHOD]]
   _ = T.runce
 
@@ -72,7 +72,7 @@ func objc_generic_partial_apply<T : NSRuncing>(_ x: T) {
 // CHECK: sil shared [serializable] [thunk] @[[THUNK1]] :
 // CHECK: bb0([[SELF:%.*]] : @owned $Self):
 // CHECK:   [[FN:%.*]] = function_ref @[[THUNK1_THUNK:_T014objc_protocols9NSRuncingP5runceSo8NSObjectCyFTO]] :
-// CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]<Self>([[SELF]])
+// CHECK:   [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]]<Self>([[SELF]])
 // CHECK:   return [[METHOD]]
 // CHECK: } // end sil function '[[THUNK1]]'
 
@@ -87,7 +87,7 @@ func objc_generic_partial_apply<T : NSRuncing>(_ x: T) {
 
 // CHECK: sil shared [serializable] [thunk] @[[THUNK2]] :
 // CHECK:   [[FN:%.*]] = function_ref @[[THUNK2_THUNK:_T014objc_protocols9NSRuncingP5minceSo8NSObjectCyFZTO]]
-// CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]<Self>(%0)
+// CHECK:   [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]]<Self>(%0)
 // CHECK:   return [[METHOD]]
 // CHECK: } // end sil function '[[THUNK2]]'
 

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -75,10 +75,10 @@ func s010_hasVarArg(_ args: Any...) {}
 // CHECK:   [[RETVAL:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.mere!enumelt.1, [[ARG0]] : $EmptyP
 // CHECK:   return [[RETVAL]] : $AddressOnlyEnum
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen15AddressOnlyEnumO4mereAcA6EmptyP_pcACmF'
-// CHECK-LABEL: sil shared [transparent] [thunk] @_T020opaque_values_silgen15AddressOnlyEnumO4mereAcA6EmptyP_pcACmFTc : $@convention(thin) (@thin AddressOnlyEnum.Type) -> @owned @callee_owned (@in EmptyP) -> @out AddressOnlyEnum {
+// CHECK-LABEL: sil shared [transparent] [thunk] @_T020opaque_values_silgen15AddressOnlyEnumO4mereAcA6EmptyP_pcACmFTc : $@convention(thin) (@thin AddressOnlyEnum.Type) -> @owned @callee_guaranteed (@in EmptyP) -> @out AddressOnlyEnum {
 // CHECK: bb0([[ARG:%.*]] : $@thin AddressOnlyEnum.Type):
 // CHECK:   [[RETVAL:%.*]] = partial_apply {{.*}}([[ARG]]) : $@convention(method) (@in EmptyP, @thin AddressOnlyEnum.Type) -> @out AddressOnlyEnum
-// CHECK:   return [[RETVAL]] : $@callee_owned (@in EmptyP) -> @out AddressOnlyEnum
+// CHECK:   return [[RETVAL]] : $@callee_guaranteed (@in EmptyP) -> @out AddressOnlyEnum
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen15AddressOnlyEnumO4mereAcA6EmptyP_pcACmFTc'
 enum AddressOnlyEnum {
   case nought
@@ -109,45 +109,49 @@ enum AddressOnlyEnum {
 
 // Test vtables - StillOpaqueClass
 // ---
-// CHECK-LABEL: sil private @_T020opaque_values_silgen16StillOpaqueClassC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tFAA0eF0CAdEx_xm_xxcttAF_tFTV : $@convention(method) <T> (@in T, @thick T.Type, @owned @callee_owned (@in T) -> @out T, @guaranteed StillOpaqueClass<T>) -> @out Optional<(T, (@thick T.Type, @callee_owned (@in T) -> @out T))> {
-// CHECK: bb0([[ARG0:%.*]] : $T, [[ARG1:%.*]] : $@thick T.Type, [[ARG2:%.*]] : $@callee_owned (@in T) -> @out T, [[ARG3:%.*]] : $StillOpaqueClass<T>):
-// CHECK:   [[TELEM0:%.*]] = tuple ([[ARG1]] : $@thick T.Type, [[ARG2]] : $@callee_owned (@in T) -> @out T)
-// CHECK:   [[TELEM1:%.*]] = tuple ([[ARG0]] : $T, [[TELEM0]] : $(@thick T.Type, @callee_owned (@in T) -> @out T))
-// CHECK:   [[ENUMOPT0:%.*]] = enum $Optional<(T, (@thick T.Type, @callee_owned (@in T) -> @out T))>, #Optional.some!enumelt.1, [[TELEM1]] : $(T, (@thick T.Type, @callee_owned (@in T) -> @out T))
-// CHECK:   [[APPLY:%.*]] = apply {{.*}}<T>([[ENUMOPT0]], [[ARG3]]) : $@convention(method) <τ_0_0> (@in Optional<(τ_0_0, (@thick τ_0_0.Type, @callee_owned (@in τ_0_0) -> @out τ_0_0))>, @guaranteed StillOpaqueClass<τ_0_0>) -> (@out τ_0_0, @thick τ_0_0.Type, @owned @callee_owned (@in τ_0_0) -> @out τ_0_0)
+// CHECK-LABEL: sil private @_T020opaque_values_silgen16StillOpaqueClassC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tFAA0eF0CAdEx_xm_xxcttAF_tFTV : $@convention(method) <T> (@in T, @thick T.Type, @owned @callee_guaranteed (@in T) -> @out T, @guaranteed StillOpaqueClass<T>) -> @out Optional<(T, (@thick T.Type, @callee_guaranteed (@in T) -> @out T))> {
+// CHECK: bb0([[ARG0:%.*]] : $T, [[ARG1:%.*]] : $@thick T.Type, [[ARG2:%.*]] : $@callee_guaranteed (@in T) -> @out T, [[ARG3:%.*]] : $StillOpaqueClass<T>):
+// CHECK:   [[TELEM0:%.*]] = tuple ([[ARG1]] : $@thick T.Type, [[ARG2]] : $@callee_guaranteed (@in T) -> @out T)
+// CHECK:   [[TELEM1:%.*]] = tuple ([[ARG0]] : $T, [[TELEM0]] : $(@thick T.Type, @callee_guaranteed (@in T) -> @out T))
+// CHECK:   [[ENUMOPT0:%.*]] = enum $Optional<(T, (@thick T.Type, @callee_guaranteed (@in T) -> @out T))>, #Optional.some!enumelt.1, [[TELEM1]] : $(T, (@thick T.Type, @callee_guaranteed (@in T) -> @out T))
+// CHECK:   [[APPLY:%.*]] = apply {{.*}}<T>([[ENUMOPT0]], [[ARG3]]) : $@convention(method) <τ_0_0> (@in Optional<(τ_0_0, (@thick τ_0_0.Type, @callee_guaranteed (@in τ_0_0) -> @out τ_0_0))>, @guaranteed StillOpaqueClass<τ_0_0>) -> (@out τ_0_0, @thick τ_0_0.Type, @owned @callee_guaranteed (@in τ_0_0) -> @out τ_0_0)
 // CHECK:   [[BORROWED_T:%.*]] = begin_borrow [[APPLY]]
-// CHECK:   [[BORROWED_T_EXT0:%.*]] = tuple_extract [[BORROWED_T]] : $(T, @thick T.Type, @callee_owned (@in T) -> @out T), 0
+// CHECK:   [[BORROWED_T_EXT0:%.*]] = tuple_extract [[BORROWED_T]] : $(T, @thick T.Type, @callee_guaranteed (@in T) -> @out T), 0
 // CHECK:   [[RETVAL0:%.*]] = copy_value [[BORROWED_T_EXT0]]
-// CHECK:   [[BORROWED_T_EXT1:%.*]] = tuple_extract [[BORROWED_T]] : $(T, @thick T.Type, @callee_owned (@in T) -> @out T), 1
-// CHECK:   [[BORROWED_T_EXT2:%.*]] = tuple_extract [[BORROWED_T]] : $(T, @thick T.Type, @callee_owned (@in T) -> @out T), 2
+// CHECK:   [[BORROWED_T_EXT1:%.*]] = tuple_extract [[BORROWED_T]] : $(T, @thick T.Type, @callee_guaranteed (@in T) -> @out T), 1
+// CHECK:   [[BORROWED_T_EXT2:%.*]] = tuple_extract [[BORROWED_T]] : $(T, @thick T.Type, @callee_guaranteed (@in T) -> @out T), 2
 // CHECK:   [[RETVAL1:%.*]] = copy_value [[BORROWED_T_EXT2]]
 // CHECK:   end_borrow [[BORROWED_T]]
-// CHECK:   [[RETTUPLE0:%.*]] = tuple ([[BORROWED_T_EXT1]] : $@thick T.Type, [[RETVAL1]] : $@callee_owned (@in T) -> @out T)
-// CHECK:   [[RETTUPLE1:%.*]] = tuple ([[RETVAL0]] : $T, [[RETTUPLE0]] : $(@thick T.Type, @callee_owned (@in T) -> @out T))
-// CHECK:   [[RETVAL:%.*]] = enum $Optional<(T, (@thick T.Type, @callee_owned (@in T) -> @out T))>, #Optional.some!enumelt.1, [[RETTUPLE1]] : $(T, (@thick T.Type, @callee_owned (@in T) -> @out T))
+// CHECK:   [[RETTUPLE0:%.*]] = tuple ([[BORROWED_T_EXT1]] : $@thick T.Type, [[RETVAL1]] : $@callee_guaranteed (@in T) -> @out T)
+// CHECK:   [[RETTUPLE1:%.*]] = tuple ([[RETVAL0]] : $T, [[RETTUPLE0]] : $(@thick T.Type, @callee_guaranteed (@in T) -> @out T))
+// CHECK:   [[RETVAL:%.*]] = enum $Optional<(T, (@thick T.Type, @callee_guaranteed (@in T) -> @out T))>, #Optional.some!enumelt.1, [[RETTUPLE1]] : $(T, (@thick T.Type, @callee_guaranteed (@in T) -> @out T))
 // CHECK:   return [[RETVAL]]
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen16StillOpaqueClassC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tFAA0eF0CAdEx_xm_xxcttAF_tFTV'
 
 
 // part of s280_convExistTrivial: conversion between existential types - reabstraction thunk
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen1P_pAA13TrivialStructVIexid_AA2P2_pAaE_pIexir_TR : $@convention(thin) (@in P2, @owned @callee_owned (@in P) -> TrivialStruct) -> @out P2 {
-// CHECK: bb0([[ARG0:%.*]] : $P2, [[ARG1:%.*]] : $@callee_owned (@in P) -> TrivialStruct):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen1P_pAA13TrivialStructVIegid_AA2P2_pAaE_pIegir_TR : $@convention(thin) (@in P2, @guaranteed @callee_guaranteed (@in P) -> TrivialStruct) -> @out P2 {
+// CHECK: bb0([[ARG0:%.*]] : $P2, [[ARG1:%.*]] : $@callee_guaranteed (@in P) -> TrivialStruct):
+// CHECK:   [[FUN_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG0]] : $P2
 // CHECK:   [[OPENED_ARG:%.*]] = open_existential_value [[BORROWED_ARG]] : $P2 to $@opened({{.*}}) P2
 // CHECK:   [[COPIED_VAL:%.*]] = copy_value [[OPENED_ARG]]
 // CHECK:   [[INIT_P:%.*]] = init_existential_value [[COPIED_VAL]] : $@opened({{.*}}) P2, $@opened({{.*}}) P2, $P
-// CHECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[INIT_P]]) : $@callee_owned (@in P) -> TrivialStruct
+// CHECK:   [[BORROW:%.*]] = begin_borrow [[FUN_COPY]]
+// CHECK:   [[APPLY_P:%.*]] = apply [[BORROW]]([[INIT_P]]) : $@callee_guaranteed (@in P) -> TrivialStruct
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $P2
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG0]] : $P2, $P2
+// CHECK:   destroy_value [[FUN_COPY]]
 // CHECK:   destroy_value [[ARG0]]
 // CHECK:   return [[RETVAL]] : $P2
-// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen1P_pAA13TrivialStructVIexid_AA2P2_pAaE_pIexir_TR'
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen1P_pAA13TrivialStructVIegid_AA2P2_pAaE_pIegir_TR'
 
 // part of s290_convOptExistTriv: conversion between existential types - reabstraction thunk - optionals case
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen1P_pSgAA13TrivialStructVIexid_AESgAA2P2_pIexyr_TR : $@convention(thin) (Optional<TrivialStruct>, @owned @callee_owned (@in Optional<P>) -> TrivialStruct) -> @out P2 {
-// CHECK: bb0([[ARG0:%.*]] : $Optional<TrivialStruct>, [[ARG1:%.*]] : $@callee_owned (@in Optional<P>) -> TrivialStruct):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen1P_pSgAA13TrivialStructVIegid_AESgAA2P2_pIegyr_TR : $@convention(thin) (Optional<TrivialStruct>, @guaranteed @callee_guaranteed (@in Optional<P>) -> TrivialStruct) -> @out P2 {
+// CHECK: bb0([[ARG0:%.*]] : $Optional<TrivialStruct>, [[ARG1:%.*]] : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct):
+// CHECK:   [[FUN_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK:   switch_enum [[ARG0]] : $Optional<TrivialStruct>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
 // CHECK:   [[ONONE:%.*]] = enum $Optional<P>, #Optional.none!enumelt
@@ -157,10 +161,12 @@ enum AddressOnlyEnum {
 // CHECK:   [[ENUM_S:%.*]] = enum $Optional<P>, #Optional.some!enumelt.1, [[INIT_S]] : $P
 // CHECK:   br bb3([[ENUM_S]] : $Optional<P>)
 // CHECK: bb3([[OPT_S:%.*]] : $Optional<P>):
-// CHECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[OPT_S]]) : $@callee_owned (@in Optional<P>) -> TrivialStruct
+// CHECK:   [[BORROW:%.*]] = begin_borrow [[FUN_COPY]]
+// CHECK:   [[APPLY_P:%.*]] = apply [[BORROW]]([[OPT_S]]) : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $P2
+// CHECK:   destroy_value [[FUN_COPY]]
 // CHECK:   return [[RETVAL]] : $P2
-// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen1P_pSgAA13TrivialStructVIexid_AESgAA2P2_pIexyr_TR'
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen1P_pSgAA13TrivialStructVIegid_AESgAA2P2_pIegyr_TR'
 
 // Test array initialization - we are still (somewhat) using addresses
 // ---
@@ -509,10 +515,10 @@ func s220_____openExistBox(_ x: Error) -> String {
 // CHECK: bb0([[ARG:%.*]] : $Any):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY__ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   checked_cast_value_br [[COPY__ARG]] : $Any to $@callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int), bb2, bb1
-// CHECK: bb2([[THUNK_PARAM:%.*]] : $@callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
-// CHECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @owned @callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
-// CHECK:   partial_apply [[THUNK_REF]]([[THUNK_PARAM]])
+// CHECK:   checked_cast_value_br [[COPY__ARG]] : $Any to $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int), bb2, bb1
+// CHECK: bb2([[THUNK_PARAM:%.*]] : $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
+// CHECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @guaranteed @callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]([[THUNK_PARAM]])
 // CHECK: bb6:
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s230______condFromAnyyypF'
@@ -566,7 +572,7 @@ func s250_________testBoxT() {
 // CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s260_______AOnly_enumyAA17AddressOnlyStructVF : $@convention(thin) (AddressOnlyStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : $AddressOnlyStruct):
 // CHECK:   [[MTYPE1:%.*]] = metatype $@thin AddressOnlyEnum.Type
-// CHECK:   [[APPLY1:%.*]] =  apply {{.*}}([[MTYPE1]]) : $@convention(thin) (@thin AddressOnlyEnum.Type) -> @owned @callee_owned (@in EmptyP) -> @out AddressOnlyEnum
+// CHECK:   [[APPLY1:%.*]] =  apply {{.*}}([[MTYPE1]]) : $@convention(thin) (@thin AddressOnlyEnum.Type) -> @owned @callee_guaranteed (@in EmptyP) -> @out AddressOnlyEnum
 // CHECK:   destroy_value [[APPLY1]]
 // CHECK:   [[MTYPE2:%.*]] = metatype $@thin AddressOnlyEnum.Type
 // CHECK:   [[ENUM1:%.*]] = enum $AddressOnlyEnum, #AddressOnlyEnum.nought!enumelt
@@ -590,19 +596,19 @@ func s260_______AOnly_enum(_ s: AddressOnlyStruct) {
 
 // Tests InjectOptional for opaque value types + conversion of opaque structs
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s270_convOptAnyStructyAA0gH0VADSgcF : $@convention(thin) (@owned @callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s270_convOptAnyStructyAA0gH0VADSgcF : $@convention(thin) (@owned @callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in Optional<AnyStruct>, @owned @callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct>
-// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned (@in Optional<AnyStruct>) -> @out Optional<AnyStruct>
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct, $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct>
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out Optional<AnyStruct>
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct, $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct
 // CHECK:   [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG2:%.*]] = copy_value [[BORROWED_ARG2]]
-// CHECK:   [[PAPPLY2:%.*]] = partial_apply %{{.*}}([[COPY_ARG2]]) : $@convention(thin) (@in Optional<AnyStruct>, @owned @callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct>
-// CHECK:   destroy_value [[PAPPLY2]] : $@callee_owned (@in Optional<AnyStruct>) -> @out Optional<AnyStruct>
-// CHECK:   end_borrow [[BORROWED_ARG2]] from [[ARG]] : $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct, $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct
-// CHECK:   destroy_value [[ARG]] : $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct
+// CHECK:   [[PAPPLY2:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG2]]) : $@convention(thin) (@in Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct>
+// CHECK:   destroy_value [[PAPPLY2]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out Optional<AnyStruct>
+// CHECK:   end_borrow [[BORROWED_ARG2]] from [[ARG]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct, $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct
+// CHECK:   destroy_value [[ARG]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s270_convOptAnyStructyAA0gH0VADSgcF'
 func s270_convOptAnyStruct(_ a1: @escaping (AnyStruct?) -> AnyStruct) {
@@ -612,13 +618,13 @@ func s270_convOptAnyStruct(_ a1: @escaping (AnyStruct?) -> AnyStruct) {
 
 // Tests conversion between existential types
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s280_convExistTrivialyAA0G6StructVAA1P_pcF : $@convention(thin) (@owned @callee_owned (@in P) -> TrivialStruct) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned (@in P) -> TrivialStruct):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s280_convExistTrivialyAA0G6StructVAA1P_pcF : $@convention(thin) (@owned @callee_guaranteed (@in P) -> TrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (@in P) -> TrivialStruct):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in P2, @owned @callee_owned (@in P) -> TrivialStruct) -> @out P2
-// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned (@in P2) -> @out P2
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned (@in P) -> TrivialStruct
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@in P2, @guaranteed @callee_guaranteed (@in P) -> TrivialStruct) -> @out P2
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (@in P2) -> @out P2
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_guaranteed (@in P) -> TrivialStruct
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s280_convExistTrivialyAA0G6StructVAA1P_pcF'
@@ -628,13 +634,13 @@ func s280_convExistTrivial(_ s: @escaping (P) -> TrivialStruct) {
 
 // Tests conversion between existential types - optionals case
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s290_convOptExistTrivyAA13TrivialStructVAA1P_pSgcF : $@convention(thin) (@owned @callee_owned (@in Optional<P>) -> TrivialStruct) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned (@in Optional<P>) -> TrivialStruct):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s290_convOptExistTrivyAA13TrivialStructVAA1P_pSgcF : $@convention(thin) (@owned @callee_guaranteed (@in Optional<P>) -> TrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Optional<TrivialStruct>, @owned @callee_owned (@in Optional<P>) -> TrivialStruct) -> @out P2
-// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned (Optional<TrivialStruct>) -> @out P2
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned (@in Optional<P>) -> TrivialStruct, $@callee_owned (@in Optional<P>) -> TrivialStruct
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Optional<TrivialStruct>, @guaranteed @callee_guaranteed (@in Optional<P>) -> TrivialStruct) -> @out P2
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (Optional<TrivialStruct>) -> @out P2
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct, $@callee_guaranteed (@in Optional<P>) -> TrivialStruct
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s290_convOptExistTrivyAA13TrivialStructVAA1P_pSgcF'
@@ -644,13 +650,13 @@ func s290_convOptExistTriv(_ s: @escaping (P?) -> TrivialStruct) {
 
 // Tests corner-case: reabstraction of an empty tuple to any
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s300__convETupleToAnyyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> ()):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s300__convETupleToAnyyyycF : $@convention(thin) (@owned @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> ()):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> @out Any
-// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned () -> @out Any
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned () -> (), $@callee_owned () -> ()
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed () -> @out Any
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_guaranteed () -> (), $@callee_guaranteed () -> ()
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s300__convETupleToAnyyyycF'
@@ -660,13 +666,13 @@ func s300__convETupleToAny(_ t: @escaping () -> ()) {
 
 // Tests corner-case: reabstraction of a non-empty tuple to any
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s310__convIntTupleAnyySi_SitycF : $@convention(thin) (@owned @callee_owned () -> (Int, Int)) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> (Int, Int)):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s310__convIntTupleAnyySi_SitycF : $@convention(thin) (@owned @callee_guaranteed () -> (Int, Int)) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> (Int, Int)):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@owned @callee_owned () -> (Int, Int)) -> @out Any
-// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned () -> @out Any
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned () -> (Int, Int), $@callee_owned () -> (Int, Int)
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Any
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed () -> @out Any
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_guaranteed () -> (Int, Int), $@callee_guaranteed () -> (Int, Int)
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s310__convIntTupleAnyySi_SitycF'
@@ -676,13 +682,13 @@ func s310__convIntTupleAny(_ t: @escaping () -> (Int, Int)) {
 
 // Tests translating and imploding into Any under opaque value mode
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s320__transImplodeAnyyyypcF : $@convention(thin) (@owned @callee_owned (@in Any) -> ()) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned (@in Any) -> ()):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s320__transImplodeAnyyyypcF : $@convention(thin) (@owned @callee_guaranteed (@in Any) -> ()) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (@in Any) -> ()):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Int, Int, @owned @callee_owned (@in Any) -> ()) -> ()
-// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned (Int, Int) -> ()
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned (@in Any) -> (), $@callee_owned (@in Any) -> ()
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[COPY_ARG]]) : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Any) -> ()) -> ()
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_guaranteed (Int, Int) -> ()
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_guaranteed (@in Any) -> (), $@callee_guaranteed (@in Any) -> ()
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s320__transImplodeAnyyyypcF'
@@ -692,12 +698,9 @@ func s320__transImplodeAny(_ t: @escaping (Any) -> ()) {
 
 // Tests support for address only let closures under opaque value mode - they are not by-address anymore
 // ---
-// CHECK-LABEL: sil private @_T020opaque_values_silgen21s330___addrLetClosurexxlFxycfU_xycfU_ : $@convention(thin) <T> (@in T) -> @out T {
+// CHECK-LABEL: sil private @_T020opaque_values_silgen21s330___addrLetClosurexxlFxycfU_xycfU_ : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0([[ARG:%.*]] : $T):
-// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]] : $T
-// CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]] : $T
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $T
-// CHECK:   destroy_value [[ARG]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]] : $T
 // CHECK:   return [[COPY_ARG]] : $T
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s330___addrLetClosurexxlFxycfU_xycfU_'
 func s330___addrLetClosure<T>(_ x:T) -> T {
@@ -713,9 +716,9 @@ func s330___addrLetClosure<T>(_ x:T) -> T {
 // CHECK:   [[APPLY_FOR_BOX:%.*]] = apply %{{.*}}(%{{.*}}) : $@convention(method) (@thin AddressOnlyStruct.Type) -> AddressOnlyStruct
 // CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[APPLY_FOR_BOX]] : $AddressOnlyStruct, $AddressOnlyStruct, $EmptyP
 // CHECK:   store [[INIT_OPAQUE]] to [init] [[PROJ_BOX]] : $*EmptyP
-// CHECK:   [[COPY_BOX:%.*]] = copy_value [[ALLOC_OF_BOX]] : ${ var EmptyP }
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [[ALLOC_OF_BOX]] : ${ var EmptyP }
 // CHECK:   mark_function_escape [[PROJ_BOX]] : $*EmptyP
-// CHECK:   apply %{{.*}}([[COPY_BOX]]) : $@convention(thin) (@owned { var EmptyP }) -> ()
+// CHECK:   apply %{{.*}}([[BORROW_BOX]]) : $@convention(thin) (@guaranteed { var EmptyP }) -> ()
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s340_______captureBoxyyF'
 func s340_______captureBox() {
@@ -826,8 +829,8 @@ func s380___contextualInit(_ a : Int?) {
 
 // Tests opaque call result types
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s390___addrCallResultyxycSglF : $@convention(thin) <T> (@owned Optional<@callee_owned () -> @out T>) -> () {
-// CHECK: bb0([[ARG:%.*]] : $Optional<@callee_owned () -> @out T>):
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s390___addrCallResultyxycSglF : $@convention(thin) <T> (@owned Optional<@callee_guaranteed () -> @out T>) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Optional<@callee_guaranteed () -> @out T>):
 // CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -855,8 +858,8 @@ func s390___addrCallResult<T>(_ f: (() -> T)?) {
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[OPEN_ARG:%.*]] = open_existential_value [[BORROWED_ARG]] : $Clonable
 // CHECK:   [[COPY_OPAQUE:%.*]] = copy_value [[OPEN_ARG]]
-// CHECK:   [[APPLY_OPAQUE:%.*]] = apply %{{.*}}<@opened({{.*}}) Clonable>([[COPY_OPAQUE]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@in τ_0_0) -> @owned @callee_owned () -> @out Optional<τ_0_0>
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}<@opened({{.*}}) Clonable>([[APPLY_OPAQUE]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
+// CHECK:   [[APPLY_OPAQUE:%.*]] = apply %{{.*}}<@opened({{.*}}) Clonable>([[COPY_OPAQUE]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@in τ_0_0) -> @owned @callee_guaranteed () -> @out Optional<τ_0_0>
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<@opened({{.*}}) Clonable>([[APPLY_OPAQUE]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
 // CHECK:   end_borrow [[BORROWED_ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
@@ -902,25 +905,25 @@ func s420__globalLvalueGet(_ i : Int) -> Int {
 // CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s430_callUnreachableFyx1t_tlF : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0([[ARG:%.*]] : $T):
 // CHECK:   [[APPLY_T:%.*]] = apply %{{.*}}<((T) -> (), T)>() : $@convention(thin) <τ_0_0> () -> @out Optional<(Int, τ_0_0)>
-// CHECK:   switch_enum [[APPLY_T]] : $Optional<(Int, (@callee_owned (@in T) -> @out (), T))>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
-// CHECK: bb2([[ENUMARG:%.*]] : $(Int, (@callee_owned (@in T) -> @out (), T))):
-// CHECK:   [[BORROWED_ENUMARG:%.*]] = begin_borrow [[ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T))
-// CHECK:   [[TELEM0:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T)), 0
-// CHECK:   [[TELEM1:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_owned (@in T) -> @out (), T)), 1
-// CHECK:   [[COPY1:%.*]] = copy_value [[TELEM1]] : $(@callee_owned (@in T) -> @out (), T)
+// CHECK:   switch_enum [[APPLY_T]] : $Optional<(Int, (@callee_guaranteed (@in T) -> @out (), T))>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
+// CHECK: bb2([[ENUMARG:%.*]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T))):
+// CHECK:   [[BORROWED_ENUMARG:%.*]] = begin_borrow [[ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T))
+// CHECK:   [[TELEM0:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T)), 0
+// CHECK:   [[TELEM1:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T)), 1
+// CHECK:   [[COPY1:%.*]] = copy_value [[TELEM1]] : $(@callee_guaranteed (@in T) -> @out (), T)
 // CHECK:   end_borrow [[BORROWED_ENUMARG]]
-// CHECK:   [[BORROWED_COPY1:%.*]] = begin_borrow [[COPY1]] : $(@callee_owned (@in T) -> @out (), T)
-// CHECK:   [[TELEM1P0:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_owned (@in T) -> @out (), T), 0
-// CHECK:   [[COPY1P0:%.*]] = copy_value [[TELEM1P0]] : $@callee_owned (@in T) -> @out ()
-// CHECK:   [[TELEM1P1:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_owned (@in T) -> @out (), T), 1
+// CHECK:   [[BORROWED_COPY1:%.*]] = begin_borrow [[COPY1]] : $(@callee_guaranteed (@in T) -> @out (), T)
+// CHECK:   [[TELEM1P0:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_guaranteed (@in T) -> @out (), T), 0
+// CHECK:   [[COPY1P0:%.*]] = copy_value [[TELEM1P0]] : $@callee_guaranteed (@in T) -> @out ()
+// CHECK:   [[TELEM1P1:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_guaranteed (@in T) -> @out (), T), 1
 // CHECK:   [[COPY1P1:%.*]] = copy_value [[TELEM1P1]] : $T
 // CHECK:   end_borrow [[BORROWED_COPY1]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}<T>([[COPY1P0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @out ()) -> ()
-// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_owned (@in T) -> (), [[COPY1P1]] : $T)
-// CHECK:   [[NEWT1:%.*]] = tuple ([[TELEM0]] : $Int, [[NEWT0]] : $(@callee_owned (@in T) -> (), T))
-// CHECK:   [[NEWENUM:%.*]] = enum $Optional<(Int, (@callee_owned (@in T) -> (), T))>, #Optional.some!enumelt.1, [[NEWT1]] : $(Int, (@callee_owned (@in T) -> (), T))
-// CHECK:   br bb3([[NEWENUM]] : $Optional<(Int, (@callee_owned (@in T) -> (), T))>)
-// CHECK: bb3([[ENUMIN:%.*]] : $Optional<(Int, (@callee_owned (@in T) -> (), T))>):
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<T>([[COPY1P0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out ()) -> ()
+// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_guaranteed (@in T) -> (), [[COPY1P1]] : $T)
+// CHECK:   [[NEWT1:%.*]] = tuple ([[TELEM0]] : $Int, [[NEWT0]] : $(@callee_guaranteed (@in T) -> (), T))
+// CHECK:   [[NEWENUM:%.*]] = enum $Optional<(Int, (@callee_guaranteed (@in T) -> (), T))>, #Optional.some!enumelt.1, [[NEWT1]] : $(Int, (@callee_guaranteed (@in T) -> (), T))
+// CHECK:   br bb3([[NEWENUM]] : $Optional<(Int, (@callee_guaranteed (@in T) -> (), T))>)
+// CHECK: bb3([[ENUMIN:%.*]] : $Optional<(Int, (@callee_guaranteed (@in T) -> (), T))>):
 // CHECK:   destroy_value [[ENUMIN]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s430_callUnreachableFyx1t_tlF'
@@ -1114,10 +1117,10 @@ struct s510_______OpaqueSelf<Base> : FooP {
 // CHECK: bb0([[ARG0:%.*]] : $Any, [[ARG1:%.*]] : $T):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG0]]
 // CHECK:   [[COPY__ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   checked_cast_value_br [[COPY__ARG]] : $Any to $@callee_owned (@in (Int, T)) -> @out (Int, T), bb2, bb1
-// CHECK: bb2([[THUNK_PARAM:%.*]] : $@callee_owned (@in (Int, T)) -> @out (Int, T)):
-// CHECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0, @owned @callee_owned (@in (Int, τ_0_0)) -> @out (Int, τ_0_0)) -> (Int, @out τ_0_0)
-// CHECK:   partial_apply [[THUNK_REF]]<T>([[THUNK_PARAM]])
+// CHECK:   checked_cast_value_br [[COPY__ARG]] : $Any to $@callee_guaranteed (@in (Int, T)) -> @out (Int, T), bb2, bb1
+// CHECK: bb2([[THUNK_PARAM:%.*]] : $@callee_guaranteed (@in (Int, T)) -> @out (Int, T)):
+// CHECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0, @guaranteed @callee_guaranteed (@in (Int, τ_0_0)) -> @out (Int, τ_0_0)) -> (Int, @out τ_0_0)
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]<T>([[THUNK_PARAM]])
 // CHECK: bb6:
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s999_____condTFromAnyyyp_xtlF'
@@ -1161,51 +1164,65 @@ public func s020_______assignToVar() {
 
 // s270_convOptAnyStruct continued Test: reabstraction thunk helper
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen9AnyStructVSgACIexir_A2DIexir_TR : $@convention(thin) (@in Optional<AnyStruct>, @owned @callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct> {
-// CHECK: bb0([[ARG0:%.*]] : $Optional<AnyStruct>, [[ARG1:%.*]] : $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct):
-// CHECK:   [[APPLYARG:%.*]] = apply [[ARG1]]([[ARG0]]) : $@callee_owned (@in Optional<AnyStruct>) -> @out AnyStruct
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen9AnyStructVSgACIegir_A2DIegir_TR : $@convention(thin) (@in Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct> {
+// CHECK: bb0([[ARG0:%.*]] : $Optional<AnyStruct>, [[ARG1:%.*]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct):
+// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
+// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW_FUNC]]([[ARG0]]) : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct
 // CHECK:   [[RETVAL:%.*]] = enum $Optional<AnyStruct>, #Optional.some!enumelt.1, [[APPLYARG]] : $AnyStruct
+// CHECK:   end_borrow [[BORROW_FUNC]]
+// CHECK:   destroy_value [[COPY_FUNC]]
 // CHECK:   return [[RETVAL]] : $Optional<AnyStruct>
-// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen9AnyStructVSgACIexir_A2DIexir_TR'
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen9AnyStructVSgACIegir_A2DIegir_TR'
 
 // s300__convETupleToAny continued Test: reabstraction of () to Any
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Iex_ypIexr_TR : $@convention(thin) (@owned @callee_owned () -> ()) -> @out Any {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> ()):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ieg_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> ()):
+// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG]]
 // CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
 // CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $()
-// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_owned () -> ()
+// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
+// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW_FUNC]]() : $@callee_guaranteed () -> ()
 // CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*()
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(), $(), $Any
+// CHECK:   end_borrow [[BORROW_FUNC]]
+// CHECK:   destroy_value [[COPY_FUNC]]
 // CHECK:   return [[RETVAL]] : $Any
-// CHECK-LABEL: } // end sil function '_T0Iex_ypIexr_TR'
+// CHECK-LABEL: } // end sil function '_T0Ieg_ypIegr_TR'
 
 // s310_convIntTupleAny continued Test: reabstraction of non-empty tuple to Any
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIexdd_ypIexr_TR : $@convention(thin) (@owned @callee_owned () -> (Int, Int)) -> @out Any {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> (Int, Int)):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegdd_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Any {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> (Int, Int)):
+// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG]]
 // CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
 // CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Int, Int)
 // CHECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Int, Int), 0
 // CHECK:   [[TADDR1:%.*]] = tuple_element_addr [[IADDR]] : $*(Int, Int), 1
-// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_owned () -> (Int, Int)
+// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
+// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW_FUNC]]() : $@callee_guaranteed () -> (Int, Int)
 // CHECK:   [[TEXTRACT0:%.*]] = tuple_extract [[APPLYARG]] : $(Int, Int), 0
 // CHECK:   [[TEXTRACT1:%.*]] = tuple_extract [[APPLYARG]] : $(Int, Int), 1
 // CHECK:   store [[TEXTRACT0]] to [trivial] [[TADDR0]] : $*Int
 // CHECK:   store [[TEXTRACT1]] to [trivial] [[TADDR1]] : $*Int
 // CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Int, Int)
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Int, Int), $(Int, Int), $Any
+// CHECK:   end_borrow [[BORROW_FUNC]]
 // CHECK:   dealloc_stack [[ASTACK]] : $*Any
+// CHECK:   destroy_value [[COPY_FUNC]]
 // CHECK:   return [[RETVAL]] : $Any
-// CHECK-LABEL: } // end sil function '_T0S2iIexdd_ypIexr_TR'
+// CHECK-LABEL: } // end sil function '_T0S2iIegdd_ypIegr_TR'
 
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @owned @callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
-// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $Int, [[ARG3:%.*]] : $Int, [[ARG4:%.*]] : $Int, [[ARG5:%.*]] : $@callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @guaranteed @callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
+// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $Int, [[ARG3:%.*]] : $Int, [[ARG4:%.*]] : $Int, [[ARG5:%.*]] : $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
+// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG5]]
 // CHECK:   [[TUPLE_TO_APPLY0:%.*]] = tuple ([[ARG2]] : $Int, [[ARG3]] : $Int)
 // CHECK:   [[TUPLE_TO_APPLY1:%.*]] = tuple ([[ARG1]] : $Int, [[TUPLE_TO_APPLY0]] : $(Int, Int))
 // CHECK:   [[TUPLE_TO_APPLY2:%.*]] = tuple ([[ARG0]] : $Int, [[TUPLE_TO_APPLY1]] : $(Int, (Int, Int)), [[ARG4]] : $Int)
-// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[ARG5]]([[TUPLE_TO_APPLY2]]) : $@callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)
+// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
+// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[BORROW_FUNC]]([[TUPLE_TO_APPLY2]]) : $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)
 // CHECK:   [[RET_VAL0:%.*]] = tuple_extract [[TUPLE_APPLY]] : $(Int, (Int, (Int, Int)), Int), 0
 // CHECK:   [[TUPLE_EXTRACT1:%.*]] = tuple_extract [[TUPLE_APPLY]] : $(Int, (Int, (Int, Int)), Int), 1
 // CHECK:   [[RET_VAL1:%.*]] = tuple_extract [[TUPLE_EXTRACT1]] : $(Int, (Int, Int)), 0
@@ -1217,10 +1234,12 @@ public func s020_______assignToVar() {
 // CHECK:   return [[RET_VAL_TUPLE]] : $(Int, Int, Int, Int, Int)
 // CHECK-LABEL: } // end sil function '{{.*}}'
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @{{.*}} : $@convention(thin) <T> (Int, @in T, @owned @callee_owned (@in (Int, T)) -> @out (Int, T)) -> (Int, @out T) {
-// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $T, [[ARG2:%.*]] : $@callee_owned (@in (Int, T)) -> @out (Int, T)):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @{{.*}} : $@convention(thin) <T> (Int, @in T, @guaranteed @callee_guaranteed (@in (Int, T)) -> @out (Int, T)) -> (Int, @out T) {
+// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $T, [[ARG2:%.*]] : $@callee_guaranteed (@in (Int, T)) -> @out (Int, T)):
+// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG2]]
 // CHECK:   [[TUPLE_TO_APPLY:%.*]] = tuple ([[ARG0]] : $Int, [[ARG1]] : $T)
-// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[ARG2]]([[TUPLE_TO_APPLY]]) : $@callee_owned (@in (Int, T)) -> @out (Int, T)
+// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
+// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[BORROW_FUNC]]([[TUPLE_TO_APPLY]]) : $@callee_guaranteed (@in (Int, T)) -> @out (Int, T)
 // CHECK:   [[TUPLE_BORROW:%.*]] = begin_borrow [[TUPLE_APPLY]] : $(Int, T)
 // CHECK:   [[RET_VAL0:%.*]] = tuple_extract [[TUPLE_BORROW]] : $(Int, T), 0
 // CHECK:   [[TUPLE_EXTRACT:%.*]] = tuple_extract [[TUPLE_BORROW]] : $(Int, T), 1
@@ -1275,9 +1294,11 @@ extension Dictionary {
 
 // s400______maybeCloneP continued Test: reabstraction thunk
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xSgIexr_20opaque_values_silgen8Clonable_pSgIexr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable> {
-// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> @out Optional<τ_0_0>):
-// CHECK:   [[APPLY_ARG:%.*]] = apply [[ARG]]() : $@callee_owned () -> @out Optional<τ_0_0>
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xSgIegr_20opaque_values_silgen8Clonable_pSgIegr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable> {
+// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> @out Optional<τ_0_0>):
+// CHECK:   [[COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:   [[APPLY_ARG:%.*]] = apply [[BORROW]]() : $@callee_guaranteed () -> @out Optional<τ_0_0>
 // CHECK:   switch_enum [[APPLY_ARG]] : $Optional<τ_0_0>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
 // CHECK:   [[ONONE:%.*]] = enum $Optional<Clonable>, #Optional.none!enumelt
@@ -1287,13 +1308,15 @@ extension Dictionary {
 // CHECK:   [[OSOME:%.*]] = enum $Optional<Clonable>, #Optional.some!enumelt.1, [[INIT_OPAQUE]] : $Clonable
 // CHECK:   br bb3([[OSOME]] : $Optional<Clonable>)
 // CHECK: bb3([[RETVAL:%.*]] : $Optional<Clonable>):
+// CHECK:   destroy_value [[COPY]]
 // CHECK:   return [[RETVAL]] : $Optional<Clonable>
-// CHECK-LABEL: } // end sil function '_T0xSgIexr_20opaque_values_silgen8Clonable_pSgIexr_AbCRzlTR'
+// CHECK-LABEL: } // end sil function '_T0xSgIegr_20opaque_values_silgen8Clonable_pSgIegr_AbCRzlTR'
 
 // s320__transImplodeAny continued Test: reabstraction thunk
 // ---
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIexi_S2iIexyy_TR : $@convention(thin) (Int, Int, @owned @callee_owned (@in Any) -> ()) -> () {
-// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $@callee_owned (@in Any) -> ()):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIegi_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Any) -> ()) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $@callee_guaranteed (@in Any) -> ()):
+// CHECK:   [[COPY:%.*]] = copy_value [[ARG2]]
 // CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
 // CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Int, Int)
 // CHECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Int, Int), 0
@@ -1302,7 +1325,9 @@ extension Dictionary {
 // CHECK:   store [[ARG1]] to [trivial] [[TADDR1]] : $*Int
 // CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Int, Int)
 // CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Int, Int), $(Int, Int), $Any
-// CHECK:   [[APPLYARG:%.*]] = apply [[ARG2]]([[INIT_OPAQUE]]) : $@callee_owned (@in Any) -> ()
+// CHECK:   [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW]]([[INIT_OPAQUE]]) : $@callee_guaranteed (@in Any) -> ()
 // CHECK:   dealloc_stack [[ASTACK]] : $*Any
+// CHECK:   destroy_value [[COPY]]
 // CHECK:   return %{{.*}} : $()
-// CHECK-LABEL: } // end sil function '_T0ypIexi_S2iIexyy_TR'
+// CHECK-LABEL: } // end sil function '_T0ypIegi_S2iIegyy_TR'

--- a/test/SILGen/opaque_values_silgen_lib.swift
+++ b/test/SILGen/opaque_values_silgen_lib.swift
@@ -17,7 +17,7 @@ struct String { var ptr: Builtin.NativeObject }
 // CHECK-LABEL: sil hidden @_T0s21s010______PAndS_casesyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK:   [[MTYPE:%.*]] = metatype $@thin PAndSEnum.Type
-// CHECK:   [[EAPPLY:%.*]] = apply {{.*}}([[MTYPE]]) : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_owned (@in EmptyP, @owned String) -> @out PAndSEnum
+// CHECK:   [[EAPPLY:%.*]] = apply {{.*}}([[MTYPE]]) : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_guaranteed (@in EmptyP, @owned String) -> @out PAndSEnum
 // CHECK:   destroy_value [[EAPPLY]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T0s21s010______PAndS_casesyyF'
@@ -67,10 +67,10 @@ func s030__________refCast<T, U>(_ x: T, to: U.Type) -> U {
 // CHECK:   [[RETVAL:%.*]] = enum $PAndSEnum, #PAndSEnum.A!enumelt.1, [[RTUPLE]] : $(EmptyP, String)
 // CHECK:   return [[RETVAL]] : $PAndSEnum
 // CHECK-LABEL: } // end sil function '_T0s9PAndSEnumO1AABs6EmptyP_p_SStcABmF'
-// CHECK-LABEL: sil shared [transparent] [thunk] @_T0s9PAndSEnumO1AABs6EmptyP_p_SStcABmFTc : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_owned (@in EmptyP, @owned String) -> @out PAndSEnum {
+// CHECK-LABEL: sil shared [transparent] [thunk] @_T0s9PAndSEnumO1AABs6EmptyP_p_SStcABmFTc : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_guaranteed (@in EmptyP, @owned String) -> @out PAndSEnum {
 // CHECK: bb0([[ARG:%.*]] : @trivial $@thin PAndSEnum.Type):
-// CHECK:   [[RETVAL:%.*]] = partial_apply {{.*}}([[ARG]]) : $@convention(method) (@in EmptyP, @owned String, @thin PAndSEnum.Type) -> @out PAndSEnum
-// CHECK:   return [[RETVAL]] : $@callee_owned (@in EmptyP, @owned String) -> @out PAndSEnum
+// CHECK:   [[RETVAL:%.*]] = partial_apply [callee_guaranteed] {{.*}}([[ARG]]) : $@convention(method) (@in EmptyP, @owned String, @thin PAndSEnum.Type) -> @out PAndSEnum
+// CHECK:   return [[RETVAL]] : $@callee_guaranteed (@in EmptyP, @owned String) -> @out PAndSEnum
 // CHECK-LABEL: } // end sil function '_T0s9PAndSEnumO1AABs6EmptyP_p_SStcABmFTc'
 enum PAndSEnum { case A(EmptyP, String) }
 

--- a/test/SILGen/optional_lvalue.swift
+++ b/test/SILGen/optional_lvalue.swift
@@ -42,9 +42,9 @@ struct Struct<T> {
 }
 
 // CHECK-LABEL: sil hidden @_T015optional_lvalue07assign_a1_B13_reabstractedyAA6StructVyS2icGz_S2ictF
-// CHECK:         [[REABSTRACT:%.*]] = function_ref @_T0S2iIexyd_S2iIexir_TR
-// CHECK:         [[REABSTRACTED:%.*]] = partial_apply [[REABSTRACT]]
-// CHECK:         assign [[REABSTRACTED]] to {{%.*}} : $*@callee_owned (@in Int) -> @out Int
+// CHECK:         [[REABSTRACT:%.*]] = function_ref @_T0S2iIegyd_S2iIegir_TR
+// CHECK:         [[REABSTRACTED:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]
+// CHECK:         assign [[REABSTRACTED]] to {{%.*}} : $*@callee_guaranteed (@in Int) -> @out Int
 func assign_optional_lvalue_reabstracted(_ x: inout Struct<(Int) -> Int>,
                                          _ y: @escaping (Int) -> Int) {
   x.value! = y

--- a/test/SILGen/partial_apply_generic.swift
+++ b/test/SILGen/partial_apply_generic.swift
@@ -21,7 +21,7 @@ func getStaticFunc1<T: Foo>(t: T.Type) -> () -> () {
 
 // CHECK-LABEL: sil shared [thunk] @_T021partial_apply_generic3FooP10staticFunc{{[_0-9a-zA-Z]*}}FZ
 // CHECK: [[REF:%.*]] = witness_method $Self, #Foo.staticFunc!1
-// CHECK-NEXT: partial_apply [[REF]]<Self>(%0)
+// CHECK-NEXT: partial_apply [callee_guaranteed] [[REF]]<Self>(%0)
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil hidden @_T021partial_apply_generic14getStaticFunc2{{[_0-9a-zA-Z]*}}F
@@ -47,13 +47,13 @@ func getInstanceFunc1<T: Foo>(t: T) -> () -> () {
 
 // CHECK-LABEL: sil shared [thunk] @_T021partial_apply_generic3FooP12instanceFunc{{[_0-9a-zA-Z]*}}F
 // CHECK: [[REF:%.*]] = witness_method $Self, #Foo.instanceFunc!1
-// CHECK-NEXT: partial_apply [[REF]]<Self>(%0)
+// CHECK-NEXT: partial_apply [callee_guaranteed] [[REF]]<Self>(%0)
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil hidden @_T021partial_apply_generic16getInstanceFunc2{{[_0-9a-zA-Z]*}}F
 func getInstanceFunc2<T: Foo>(t: T) -> (T) -> () -> () {
 // CHECK: [[REF:%.*]] = function_ref @_T021partial_apply_generic3FooP12instanceFunc{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT: partial_apply [[REF]]<T>(
+// CHECK-NEXT: partial_apply [callee_guaranteed] [[REF]]<T>(
   return T.instanceFunc
 // CHECK-NEXT: destroy_addr %0 : $*
 // CHECK-NEXT: return
@@ -62,21 +62,21 @@ func getInstanceFunc2<T: Foo>(t: T) -> (T) -> () -> () {
 // CHECK-LABEL: sil hidden @_T021partial_apply_generic16getInstanceFunc3{{[_0-9a-zA-Z]*}}F
 func getInstanceFunc3<T: Foo>(t: T.Type) -> (T) -> () -> () {
 // CHECK: [[REF:%.*]] = function_ref @_T021partial_apply_generic3FooP12instanceFunc{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT: partial_apply [[REF]]<T>(
+// CHECK-NEXT: partial_apply [callee_guaranteed] [[REF]]<T>(
   return t.instanceFunc
 // CHECK-NEXT: return
 }
 
-// CHECK-LABEL: sil hidden @_T021partial_apply_generic23getNonCanonicalSelfFuncyq_cxcxm1t_t7CuddlesQy_RszAA5PandaR_r0_lF : $@convention(thin) <T, U where T == U.Cuddles, U : Panda> (@thick T.Type) -> @owned @callee_owned (@in T) -> @owned @callee_owned (@in U) -> () {
+// CHECK-LABEL: sil hidden @_T021partial_apply_generic23getNonCanonicalSelfFuncyq_cxcxm1t_t7CuddlesQy_RszAA5PandaR_r0_lF : $@convention(thin) <T, U where T == U.Cuddles, U : Panda> (@thick T.Type) -> @owned @callee_guaranteed (@in T) -> @owned @callee_guaranteed (@in U) -> () {
 func getNonCanonicalSelfFunc<T : Foo, U : Panda>(t: T.Type) -> (T) -> (U) -> () where U.Cuddles == T {
-// CHECK: [[REF:%.*]] = function_ref @_T021partial_apply_generic3FooP21makesSelfNonCanonicalyqd__7CuddlesQyd__RszAA5PandaRd__lFTc : $@convention(thin) <τ_0_0><τ_1_0 where τ_0_0 == τ_1_0.Cuddles, τ_1_0 : Panda> (@in τ_0_0) -> @owned @callee_owned (@in τ_1_0) -> ()
-// CHECK-NEXT: [[CLOSURE:%.*]] = partial_apply [[REF]]<T, U>()
+// CHECK: [[REF:%.*]] = function_ref @_T021partial_apply_generic3FooP21makesSelfNonCanonicalyqd__7CuddlesQyd__RszAA5PandaRd__lFTc : $@convention(thin) <τ_0_0><τ_1_0 where τ_0_0 == τ_1_0.Cuddles, τ_1_0 : Panda> (@in τ_0_0) -> @owned @callee_guaranteed (@in τ_1_0) -> ()
+// CHECK-NEXT: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REF]]<T, U>()
   return t.makesSelfNonCanonical
 // CHECK-NEXT: return [[CLOSURE]]
 }
 
 // curry thunk of Foo.makesSelfNonCanonical<A where ...> (A1) -> ()
-// CHECK-LABEL: sil shared [thunk] @_T021partial_apply_generic3FooP21makesSelfNonCanonicalyqd__7CuddlesQyd__RszAA5PandaRd__lFTc : $@convention(thin) <Self><T where Self == T.Cuddles, T : Panda> (@in Self) -> @owned @callee_owned (@in T) -> () {
+// CHECK-LABEL: sil shared [thunk] @_T021partial_apply_generic3FooP21makesSelfNonCanonicalyqd__7CuddlesQyd__RszAA5PandaRd__lFTc : $@convention(thin) <Self><T where Self == T.Cuddles, T : Panda> (@in Self) -> @owned @callee_guaranteed (@in T) -> () {
 // CHECK: [[REF:%.*]] = witness_method $Self, #Foo.makesSelfNonCanonical!1 : <Self><T where Self == T.Cuddles, T : Panda> (Self) -> (T) -> () : $@convention(witness_method: Foo) <τ_0_0><τ_1_0 where τ_0_0 == τ_1_0.Cuddles, τ_1_0 : Panda> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-// CHECK-NEXT: [[CLOSURE:%.*]] = partial_apply [[REF]]<Self, T>(%0)
+// CHECK-NEXT: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REF]]<Self, T>(%0)
 // CHECK-NEXT: return [[CLOSURE]]

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -17,45 +17,51 @@ protocol Clonable {
 
 // CHECK-LABEL: sil hidden @_T022partial_apply_protocol12testClonableyAA0E0_p1c_tF : $@convention(thin) (@in Clonable) -> ()
 func testClonable(c: Clonable) {
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIexr_22partial_apply_protocol8Clonable_pIexr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}})
   let _: () -> Clonable = c.clone
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xSgIexr_22partial_apply_protocol8Clonable_pSgIexr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xSgIegr_22partial_apply_protocol8Clonable_pSgIegr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}})
   let _: () -> Clonable? = c.maybeClone
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xXMTIexd_22partial_apply_protocol8Clonable_pXmTIexd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xXMTIegd_22partial_apply_protocol8Clonable_pXmTIegd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @thick τ_0_0.Type) -> @thick Clonable.Type
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @thick τ_0_0.Type) -> @thick Clonable.Type
   let _: () -> Clonable.Type = c.cloneMetatype
 
-  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1 : {{.*}}, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
-  // CHECK: [[RESULT:%.*]] = apply [[METHOD_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIexr_22partial_apply_protocol8Clonable_pIexr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>([[RESULT]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1 : {{.*}}, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed () -> @out τ_0_0
+  // CHECK: [[RESULT:%.*]] = apply [[METHOD_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed () -> @out τ_0_0
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>([[RESULT]])
   let _: () -> Clonable = c.getCloneFn()
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIexr_Iexo_22partial_apply_protocol8Clonable_pIexr_Iexo_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @owned @callee_owned () -> @out τ_0_0) -> @owned @callee_owned () -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @owned @callee_owned () -> @out τ_0_0) -> @owned @callee_owned () -> @out Clonable
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIegr_Iego_22partial_apply_protocol8Clonable_pIegr_Iego_AaBRzlTR
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}})
   let _: () -> () -> Clonable = c.getCloneFn
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xIexr_22partial_apply_protocol8Clonable_pIexr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
-// CHECK:       bb0(%0 : @trivial $*Clonable, %1 : @owned $@callee_owned () -> @out τ_0_0):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
+// CHECK:       bb0(%0 : @trivial $*Clonable, %1 : @guaranteed $@callee_guaranteed () -> @out τ_0_0):
+// CHECK-NEXT:    [[COPY:%.*]] = copy_value %1
 // CHECK-NEXT:    [[INNER_RESULT:%.*]] = alloc_stack $τ_0_0
-// CHECK-NEXT:    apply %1([[INNER_RESULT]])
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[B]]([[INNER_RESULT]])
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = init_existential_addr %0
 // CHECK-NEXT:    copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
 // CHECK-NEXT:    [[EMPTY:%.*]] = tuple ()
+// CHECK-NEXT:    end_borrow [[B]]
 // CHECK-NEXT:    dealloc_stack [[INNER_RESULT]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return [[EMPTY]]
 
 // FIXME: This is horribly inefficient, too much alloc_stack / copy_addr!
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xSgIexr_22partial_apply_protocol8Clonable_pSgIexr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
-// CHECK:       bb0(%0 : @trivial $*Optional<Clonable>, %1 : @owned $@callee_owned () -> @out Optional<τ_0_0>):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xSgIegr_22partial_apply_protocol8Clonable_pSgIegr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
+// CHECK:       bb0(%0 : @trivial $*Optional<Clonable>, %1 : @guaranteed $@callee_guaranteed () -> @out Optional<τ_0_0>):
+// CHECK-NEXT:    [[COPY:%.*]] = copy_value %1
 // CHECK-NEXT:    [[INNER_RESULT:%.*]] = alloc_stack $Optional<τ_0_0>
-// CHECK-NEXT:    apply %1([[INNER_RESULT]])
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:    apply [[B]]([[INNER_RESULT]])
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = alloc_stack $Optional<Clonable>
 // CHECK-NEXT:    switch_enum_addr [[INNER_RESULT]] : $*Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]],
 // CHECK:       [[SOME_BB]]:
@@ -75,20 +81,30 @@ func testClonable(c: Clonable) {
 // CHECK-NEXT:    copy_addr [take] [[OUTER_RESULT]] to [initialization] %0
 // CHECK-NEXT:    [[EMPTY:%.*]] = tuple ()
 // CHECK-NEXT:    dealloc_stack [[OUTER_RESULT]]
+// CHECK-NEXT:    end_borrow [[B]]
 // CHECK-NEXT:    dealloc_stack [[INNER_RESULT]]
+// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return [[EMPTY]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xXMTIexd_22partial_apply_protocol8Clonable_pXmTIexd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
-// CHECK:       bb0(%0 : @owned $@callee_owned () -> @thick τ_0_0.Type):
-// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply %0()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xXMTIegd_22partial_apply_protocol8Clonable_pXmTIegd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @thick τ_0_0.Type) -> @thick Clonable.Type
+// CHECK:       bb0(%0 : @guaranteed $@callee_guaranteed () -> @thick τ_0_0.Type):
+// CHECK-NEXT:    [[C:%.*]] = copy_value %0
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[C]]
+// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply [[B]]()
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = init_existential_metatype [[INNER_RESULT]]
+// CHECK-NEXT:    end_borrow [[B]]
+// CHECK-NEXT:    destroy_value [[C]]
 // CHECK-NEXT:    return [[OUTER_RESULT]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xIexr_Iexo_22partial_apply_protocol8Clonable_pIexr_Iexo_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @owned @callee_owned () -> @out τ_0_0) -> @owned @callee_owned () -> @out Clonable
-// CHECK:       bb0(%0 : @owned $@callee_owned () -> @owned @callee_owned () -> @out τ_0_0):
-// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply %0()
-// CHECK:         [[THUNK_FN:%.*]] = function_ref @_T0xIexr_22partial_apply_protocol8Clonable_pIexr_AaBRzlTR
-// CHECK-NEXT:    [[OUTER_RESULT:%.*]] = partial_apply [[THUNK_FN]]<τ_0_0>([[INNER_RESULT]])
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xIegr_Iego_22partial_apply_protocol8Clonable_pIegr_Iego_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @owned @callee_guaranteed () -> @out τ_0_0) -> @owned @callee_guaranteed () -> @out Clonable
+// CHECK:       bb0(%0 : @guaranteed $@callee_guaranteed () -> @owned @callee_guaranteed () -> @out τ_0_0):
+// CHECK-NEXT:    [[C:%.*]] = copy_value %0
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[C]]
+// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply [[B]]()
+// CHECK:         [[THUNK_FN:%.*]] = function_ref @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR
+// CHECK-NEXT:    [[OUTER_RESULT:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0>([[INNER_RESULT]])
+// CHECK-NEXT:    end_borrow [[B]]
+// CHECK-NEXT:    destroy_value [[C]]
 // CHECK-NEXT:    return [[OUTER_RESULT]]
 
 //===----------------------------------------------------------------------===//
@@ -99,60 +115,72 @@ func testClonable(c: Clonable) {
 
 // CHECK-LABEL: sil hidden @_T022partial_apply_protocol28testClonableInGenericContextyAA0E0_p1c_x1ttlF : $@convention(thin) <T> (@in Clonable, @in T) -> ()
 func testClonableInGenericContext<T>(c: Clonable, t: T) {
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIexr_22partial_apply_protocol8Clonable_pIexr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}})
   let _: () -> Clonable = c.clone
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xSgIexr_22partial_apply_protocol8Clonable_pSgIexr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xSgIegr_22partial_apply_protocol8Clonable_pSgIegr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
   let _: () -> Clonable? = c.maybeClone
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xXMTIexd_22partial_apply_protocol8Clonable_pXmTIexd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xXMTIegd_22partial_apply_protocol8Clonable_pXmTIegd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @thick τ_0_0.Type) -> @thick Clonable.Type
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @thick τ_0_0.Type) -> @thick Clonable.Type
   let _: () -> Clonable.Type = c.cloneMetatype
 
-  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1 : {{.*}}, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
-  // CHECK: [[RESULT:%.*]] = apply [[METHOD_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIexr_22partial_apply_protocol8Clonable_pIexr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>([[RESULT]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1 : {{.*}}, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed () -> @out τ_0_0
+  // CHECK: [[RESULT:%.*]] = apply [[METHOD_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(witness_method: Clonable) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed () -> @out τ_0_0
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>([[RESULT]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
   let _: () -> Clonable = c.getCloneFn()
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIexr_Iexo_22partial_apply_protocol8Clonable_pIexr_Iexo_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @owned @callee_owned () -> @out τ_0_0) -> @owned @callee_owned () -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @owned @callee_owned () -> @out τ_0_0) -> @owned @callee_owned () -> @out Clonable
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIegr_Iego_22partial_apply_protocol8Clonable_pIegr_Iego_AaBRzlTR
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @owned @callee_guaranteed () -> @out τ_0_0) -> @owned @callee_guaranteed () -> @out Clonable
   let _: () -> () -> Clonable = c.getCloneFn
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xqd__Iexir_x22partial_apply_protocol8Clonable_pIexir_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<T, @opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xqd__Iegir_x22partial_apply_protocol8Clonable_pIegir_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<T, @opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
   let _: (T) -> Clonable = c.genericClone
 
-  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xqd__Iexr_Iexio_x22partial_apply_protocol8Clonable_pIexr_Iexio_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @owned @callee_owned () -> @out τ_1_0) -> @owned @callee_owned () -> @out Clonable
-  // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<T, @opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @owned @callee_owned () -> @out τ_1_0) -> @owned @callee_owned () -> @out Clonable
+  // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xqd__Iegr_Iegio_x22partial_apply_protocol8Clonable_pIegr_Iegio_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @owned @callee_guaranteed () -> @out τ_1_0) -> @owned @callee_guaranteed () -> @out Clonable
+  // CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<T, @opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @owned @callee_guaranteed () -> @out τ_1_0) -> @owned @callee_guaranteed () -> @out Clonable
   let _: (T) -> () -> Clonable = c.genericGetCloneFn
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xqd__Iexir_x22partial_apply_protocol8Clonable_pIexir_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
-// CHECK:         bb0(%0 : @trivial $*Clonable, %1 : @trivial $*τ_0_0, %2 : @owned $@callee_owned (@in τ_0_0) -> @out τ_1_0):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xqd__Iegir_x22partial_apply_protocol8Clonable_pIegir_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
+// CHECK:         bb0(%0 : @trivial $*Clonable, %1 : @trivial $*τ_0_0, %2 : @guaranteed $@callee_guaranteed (@in τ_0_0) -> @out τ_1_0):
+// CHECK-NEXT:      [[COPY:%.*]] = copy_value %2
 // CHECK-NEXT:      [[INNER_RESULT:%.*]] = alloc_stack $τ_1_0
-// CHECK-NEXT:      apply %2([[INNER_RESULT]], %1)
+// CHECK-NEXT:      [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:      apply [[BORROW]]([[INNER_RESULT]], %1)
 // CHECK-NEXT:      [[OUTER_RESULT:%.*]] = init_existential_addr %0
 // CHECK-NEXT:      copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
 // CHECK-NEXT:      [[EMPTY:%.*]] = tuple ()
+// CHECK-NEXT:      end_borrow [[BORROW]]
 // CHECK-NEXT:      dealloc_stack [[INNER_RESULT]]
+// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[EMPTY]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xqd__Iexr_Iexio_x22partial_apply_protocol8Clonable_pIexr_Iexio_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @owned @callee_owned (@in τ_0_0) -> @owned @callee_owned () -> @out τ_1_0) -> @owned @callee_owned () -> @out Clonable
-// CHECK:         bb0(%0 : @trivial $*τ_0_0, %1 : @owned $@callee_owned (@in τ_0_0) -> @owned @callee_owned () -> @out τ_1_0):
-// CHECK-NEXT:      apply %1(%0)
-// CHECK:           [[THUNK_FN:%.*]] = function_ref @_T0qd__Iexr_22partial_apply_protocol8Clonable_pIexr_AaBRd__r__lTR
-// CHECK-NEXT:      [[RESULT:%.*]] = partial_apply [[THUNK_FN]]<τ_0_0, τ_1_0>(%2)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xqd__Iegr_Iegio_x22partial_apply_protocol8Clonable_pIegr_Iegio_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @owned @callee_guaranteed () -> @out τ_1_0) -> @owned @callee_guaranteed () -> @out Clonable
+// CHECK:         bb0(%0 : @trivial $*τ_0_0, %1 : @guaranteed $@callee_guaranteed (@in τ_0_0) -> @owned @callee_guaranteed () -> @out τ_1_0):
+// CHECK-NEXT:      [[COPY:%.*]] = copy_value %1
+// CHECK-NEXT:      [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:      [[RES:%.*]] = apply [[BORROW]](%0)
+// CHECK:           [[THUNK_FN:%.*]] = function_ref @_T0qd__Iegr_22partial_apply_protocol8Clonable_pIegr_AaBRd__r__lTR
+// CHECK-NEXT:      [[RESULT:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0, τ_1_0>([[RES]])
+// CHECK-NEXT:      end_borrow [[BORROW]]
+// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[RESULT]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0qd__Iexr_22partial_apply_protocol8Clonable_pIexr_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@owned @callee_owned () -> @out τ_1_0) -> @out Clonable {
-// CHECK:         bb0(%0 : @trivial $*Clonable, %1 : @owned $@callee_owned () -> @out τ_1_0):
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0qd__Iegr_22partial_apply_protocol8Clonable_pIegr_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_1_0) -> @out Clonable {
+// CHECK:         bb0(%0 : @trivial $*Clonable, %1 : @guaranteed $@callee_guaranteed () -> @out τ_1_0):
+// CHECK-NEXT:      [[COPY:%.*]] = copy_value %1
 // CHECK-NEXT:      [[INNER_RESULT:%.*]] = alloc_stack $τ_1_0
-// CHECK-NEXT:      apply %1([[INNER_RESULT]])
+// CHECK-NEXT:      [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT:      apply [[BORROW]]([[INNER_RESULT]])
 // CHECK-NEXT:      [[OUTER_RESULT:%.*]] = init_existential_addr %0
 // CHECK-NEXT:      copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
 // CHECK-NEXT:      [[EMPTY:%.*]] = tuple ()
+// CHECK-NEXT:      end_borrow [[BORROW]]
 // CHECK-NEXT:      dealloc_stack [[INNER_RESULT:%.*]]
+// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[EMPTY]]

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -33,11 +33,11 @@ class Child : Parent {
   // CHECK: bb0([[SELF:%.*]] : $Child):
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
-  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC6methodyyFTcTd : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
-  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC6methodyyFTcTd : $@convention(thin) (@owned Parent) -> @owned @callee_guaranteed () -> ()
+  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(thin) (@owned Parent) -> @owned @callee_guaranteed () -> ()
   // CHECK:   [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:   apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super5ChildC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -45,11 +45,11 @@ class Child : Parent {
 
   // CHECK-LABEL: sil hidden @_T019partial_apply_super5ChildC11classMethodyyFZ : $@convention(method) (@thick Child.Type) -> () {
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick Child.Type to $@thick Parent.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC11classMethodyyFZTcTd : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC11classMethodyyFZTcTd : $@convention(thin) (@thick Parent.Type) -> @owned @callee_guaranteed () -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick Parent.Type) -> @owned @callee_guaranteed () -> ()
   // CHECK:   [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -58,11 +58,11 @@ class Child : Parent {
   // CHECK: bb0([[SELF:%.*]] : $Child):
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
-  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC11finalMethodyyFTc : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
-  // CHECK:     [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC11finalMethodyyFTc : $@convention(thin) (@owned Parent) -> @owned @callee_guaranteed () -> ()
+  // CHECK:     [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(thin) (@owned Parent) -> @owned @callee_guaranteed () -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_function [[APPLIED_SELF]]
-  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super5ChildC20callFinalSuperMethodyyF'
   func callFinalSuperMethod() {
     doFoo(super.finalMethod)
@@ -70,11 +70,11 @@ class Child : Parent {
 
   // CHECK-LABEL: sil hidden @_T019partial_apply_super5ChildC25callFinalSuperClassMethodyyFZ : $@convention(method) (@thick Child.Type) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick Child.Type to $@thick Parent.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC16finalClassMethodyyFZTc : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
-  // CHECK: [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super6ParentC16finalClassMethodyyFZTc : $@convention(thin) (@thick Parent.Type) -> @owned @callee_guaranteed () -> ()
+  // CHECK: [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick Parent.Type) -> @owned @callee_guaranteed () -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[APPLIED_SELF]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   class func callFinalSuperClassMethod() {
     doFoo(super.finalClassMethod)
   }
@@ -88,11 +88,11 @@ class GenericChild<A> : GenericParent<A> {
   // CHECK: bb0([[SELF:%.*]] : $GenericChild<A>):
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GenericChild<A> to $GenericParent<A>
-  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super13GenericParentC6methodyyFTcTd : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
-  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super13GenericParentC6methodyyFTcTd : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_guaranteed () -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_guaranteed () -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super12GenericChildC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -100,11 +100,11 @@ class GenericChild<A> : GenericParent<A> {
 
   // CHECK-LABEL: sil hidden @_T019partial_apply_super12GenericChildC11classMethodyyFZ : $@convention(method) <A> (@thick GenericChild<A>.Type) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChild<A>.Type to $@thick GenericParent<A>.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super13GenericParentC11classMethodyyFZTcTd : $@convention(thin) <τ_0_0> (@thick GenericParent<τ_0_0>.Type) -> @owned @callee_owned () -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@thick GenericParent<τ_0_0>.Type) -> @owned @callee_owned () -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_T019partial_apply_super13GenericParentC11classMethodyyFZTcTd : $@convention(thin) <τ_0_0> (@thick GenericParent<τ_0_0>.Type) -> @owned @callee_guaranteed () -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@thick GenericParent<τ_0_0>.Type) -> @owned @callee_guaranteed () -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -119,10 +119,10 @@ class ChildToFixedOutsideParent : OutsideParent {
   // CHECK:   [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $ChildToFixedOutsideParent, #OutsideParent.method!1 : (OutsideParent) -> () -> (), $@convention(method) (@guaranteed OutsideParent) -> ()
   // CHECK: end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
-  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideParent) -> ()
+  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideParent) -> ()
   // CHECK:   [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:   apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super25ChildToFixedOutsideParentC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -131,10 +131,10 @@ class ChildToFixedOutsideParent : OutsideParent {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super25ChildToFixedOutsideParentC11classMethodyyFZ
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick ChildToFixedOutsideParent.Type to $@thick OutsideParent.Type
   // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToFixedOutsideParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> (), $@convention(method) (@thick OutsideParent.Type) -> (){{.*}}
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick OutsideParent.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick OutsideParent.Type) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -149,10 +149,10 @@ class ChildToResilientOutsideParent : ResilientOutsideParent {
   // CHECK:   [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $ChildToResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   // CHECK:   end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
-  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   // CHECK:   [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:   apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super29ChildToResilientOutsideParentC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -161,10 +161,10 @@ class ChildToResilientOutsideParent : ResilientOutsideParent {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super29ChildToResilientOutsideParentC11classMethodyyFZ
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick ChildToResilientOutsideParent.Type to $@thick ResilientOutsideParent.Type
   // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToResilientOutsideParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -179,10 +179,10 @@ class GrandchildToFixedOutsideChild : OutsideChild {
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $GrandchildToFixedOutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> (), $@convention(method) (@guaranteed OutsideChild) -> ()
   // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
-  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideChild) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideChild) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super29GrandchildToFixedOutsideChildC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -191,10 +191,10 @@ class GrandchildToFixedOutsideChild : OutsideChild {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super29GrandchildToFixedOutsideChildC11classMethodyyFZ
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GrandchildToFixedOutsideChild.Type to $@thick OutsideChild.Type
   // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToFixedOutsideChild.Type, #OutsideChild.classMethod!1 : (OutsideChild.Type) -> () -> (), $@convention(method) (@thick OutsideChild.Type) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick OutsideChild.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick OutsideChild.Type) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -209,10 +209,10 @@ class GrandchildToResilientOutsideChild : ResilientOutsideChild {
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $GrandchildToResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
   // CHEC:      end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
-  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super33GrandchildToResilientOutsideChildC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -221,10 +221,10 @@ class GrandchildToResilientOutsideChild : ResilientOutsideChild {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super33GrandchildToResilientOutsideChildC11classMethodyyFZ
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GrandchildToResilientOutsideChild.Type to $@thick ResilientOutsideChild.Type
   // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToResilientOutsideChild.Type, #ResilientOutsideChild.classMethod!1 : (ResilientOutsideChild.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideChild.Type) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick ResilientOutsideChild.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick ResilientOutsideChild.Type) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -239,10 +239,10 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> (), $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
-  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super019GenericChildToFixedD13OutsideParentC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -251,10 +251,10 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super019GenericChildToFixedD13OutsideParentC11classMethodyyFZ
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type to $@thick GenericOutsideParent<A>.Type
   // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type, #GenericOutsideParent.classMethod!1 : <A> (GenericOutsideParent<A>.Type) -> () -> (), $@convention(method) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }
@@ -269,10 +269,10 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> (), $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
-  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK:     apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super023GenericChildToResilientD13OutsideParentC6methodyyF'
   override func method() {
     doFoo(super.method)
@@ -281,10 +281,10 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK-LABEL: sil hidden @_T019partial_apply_super023GenericChildToResilientD13OutsideParentC11classMethodyyFZ
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type to $@thick ResilientGenericOutsideParent<A>.Type
   // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type, #ResilientGenericOutsideParent.classMethod!1 : <A> (ResilientGenericOutsideParent<A>.Type) -> () -> (), $@convention(method) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[PARTIAL_APPLY]]
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
-  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
+  // CHECK: apply [[DOFOO]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> ()) -> ()
   override class func classMethod() {
     doFoo(super.classMethod)
   }

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -264,10 +264,10 @@ func classInoutToPointer() {
 // rdar://problem/21505805
 // CHECK-LABEL: sil hidden @_T018pointer_conversion22functionInoutToPointeryyF
 func functionInoutToPointer() {
-  // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_owned () -> () }
+  // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_guaranteed () -> () }
   var f: () -> () = {}
 
-  // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_owned (@in ()) -> @out ()
+  // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_guaranteed (@in ()) -> @out ()
   // CHECK: address_to_pointer [[REABSTRACT_BUF]]
   takesMutableVoidPointer(&f)
 }

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -763,13 +763,11 @@ func propertyWithDidSetTakingOldValue() {
 // CHECK-NEXT:  [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG2_PB]]
 // CHECK-NEXT:  assign [[ARG1]] to [[WRITE]] : $*Int
 // CHECK-NEXT:  end_access [[WRITE]]
-// CHECK-NEXT:  [[ARG2_COPY:%.*]] = copy_value [[ARG2]] : ${ var Int }
 // SEMANTIC ARC TODO: Another case where we need to put the mark_function_escape on a new projection after a copy.
 // CHECK-NEXT:  mark_function_escape [[ARG2_PB]]
 // CHECK-NEXT:  // function_ref
-// CHECK-NEXT:  [[FUNC:%.*]] = function_ref @_T010properties32propertyWithDidSetTakingOldValueyyF1pL_SivW : $@convention(thin) (Int, @owned { var Int }) -> ()
-// CHECK-NEXT:  %{{.*}} = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2_COPY]]) : $@convention(thin) (Int, @owned { var Int }) -> ()
-// CHECK-NEXT:  destroy_value [[ARG2]] : ${ var Int }
+// CHECK-NEXT:  [[FUNC:%.*]] = function_ref @_T010properties32propertyWithDidSetTakingOldValueyyF1pL_SivW : $@convention(thin) (Int, @guaranteed { var Int }) -> ()
+// CHECK-NEXT:  %{{.*}} = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2]]) : $@convention(thin) (Int, @guaranteed { var Int }) -> ()
 // CHECK-NEXT:  %{{.*}} = tuple ()
 // CHECK-NEXT:  return %{{.*}} : $()
 // CHECK-NEXT:} // end sil function '_T010properties32propertyWithDidSetTakingOldValue{{[_0-9a-zA-Z]*}}'

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -10,13 +10,13 @@ struct Foo<T, U> {
   var g: T
 }
 
-// CHECK-LABEL: sil hidden @_T020property_abstraction4getF{{[_0-9a-zA-Z]*}}Foo{{.*}}F : $@convention(thin) (@owned Foo<Int, Int>) -> @owned @callee_owned (Int) -> Int {
+// CHECK-LABEL: sil hidden @_T020property_abstraction4getF{{[_0-9a-zA-Z]*}}Foo{{.*}}F : $@convention(thin) (@owned Foo<Int, Int>) -> @owned @callee_guaranteed (Int) -> Int {
 // CHECK:       bb0([[X_ORIG:%.*]] : @owned $Foo<Int, Int>):
 // CHECK:         [[BORROWED_X_ORIG:%.*]] = begin_borrow [[X_ORIG]] : $Foo<Int, Int>
 // CHECK:         [[F_ORIG:%.*]] = struct_extract [[BORROWED_X_ORIG]] : $Foo<Int, Int>, #Foo.f
 // CHECK:         [[F_ORIG_COPY:%.*]] = copy_value [[F_ORIG]]
 // CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:         [[F_SUBST:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG_COPY]])
+// CHECK:         [[F_SUBST:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_FN]]([[F_ORIG_COPY]])
 // CHECK:         end_borrow [[BORROWED_X_ORIG]] from [[X_ORIG]]
 // CHECK:         destroy_value [[X_ORIG]]
 // CHECK:         return [[F_SUBST]]
@@ -27,7 +27,7 @@ func getF(_ x: Foo<Int, Int>) -> (Int) -> Int {
 
 // CHECK-LABEL: sil hidden @_T020property_abstraction4setF{{[_0-9a-zA-Z]*}}F
 // CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:         [[F_ORIG:%.*]] = partial_apply [[REABSTRACT_FN]]({{%.*}})
+// CHECK:         [[F_ORIG:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_FN]]({{%.*}})
 // CHECK:         [[F_ADDR:%.*]] = struct_element_addr {{%.*}} : $*Foo<Int, Int>, #Foo.f
 // CHECK:         assign [[F_ORIG]] to [[F_ADDR]]
 func setF(_ x: inout Foo<Int, Int>, f: @escaping (Int) -> Int) {
@@ -49,13 +49,13 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK:   [[F_SUBST_MAT:%.*]] = alloc_stack
 // CHECK:   [[F_ORIG:%.*]] = load [copy] [[F_ADDR]]
 // CHECK:   [[REABSTRACT_FN:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:   [[F_SUBST_IN:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG]])
+// CHECK:   [[F_SUBST_IN:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_FN]]([[F_ORIG]])
 // CHECK:   store [[F_SUBST_IN]] to [init] [[F_SUBST_MAT]]
 // CHECK:   [[INOUTFUNC:%.*]] = function_ref @_T020property_abstraction9inOutFunc{{[_0-9a-zA-Z]*}}F
 // CHECK:   apply [[INOUTFUNC]]([[F_SUBST_MAT]])
 // CHECK:   [[F_SUBST_OUT:%.*]] = load [take] [[F_SUBST_MAT]]
 // CHECK:   [[REABSTRACT_FN:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:   [[F_ORIG:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_SUBST_OUT]])
+// CHECK:   [[F_ORIG:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_FN]]([[F_SUBST_OUT]])
 // CHECK:   assign [[F_ORIG]] to [[F_ADDR]]
 // CHECK:   destroy_value [[XBOX]]
 // CHECK:   destroy_value [[ARG]]
@@ -82,12 +82,12 @@ struct AddressOnlyLet<T> {
   let makeAddressOnly: P
 }
 
-// CHECK-LABEL: sil hidden @_T020property_abstraction34getAddressOnlyReabstractedProperty{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@in AddressOnlyLet<Int>) -> @owned @callee_owned (Int) -> Int
+// CHECK-LABEL: sil hidden @_T020property_abstraction34getAddressOnlyReabstractedProperty{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@in AddressOnlyLet<Int>) -> @owned @callee_guaranteed (Int) -> Int
 // CHECK: bb0([[ARG:%.*]] : @trivial $*AddressOnlyLet<Int>):
 // CHECK:   [[CLOSURE_ADDR:%.*]] = struct_element_addr {{%.*}} : $*AddressOnlyLet<Int>, #AddressOnlyLet.f
 // CHECK:   [[CLOSURE_ORIG:%.*]] = load [copy] [[CLOSURE_ADDR]]
 // CHECK:   [[REABSTRACT:%.*]] = function_ref
-// CHECK:   [[CLOSURE_SUBST:%.*]] = partial_apply [[REABSTRACT]]([[CLOSURE_ORIG]])
+// CHECK:   [[CLOSURE_SUBST:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[CLOSURE_ORIG]])
 // CHECK:   destroy_addr [[ARG]]
 // CHECK:   return [[CLOSURE_SUBST]]
 // CHECK: } // end sil function '_T020property_abstraction34getAddressOnlyReabstractedProperty{{[_0-9a-zA-Z]*}}F'
@@ -120,7 +120,7 @@ struct T20341012 {
     private var options: ArrayLike<Test20341012> { get {} set {} }
 
     // CHECK-LABEL: sil hidden @_T020property_abstraction9T20341012V1t{{[_0-9a-zA-Z]*}}F
-    // CHECK:         [[TMP1:%.*]] = alloc_stack $(title: (), action: @callee_owned (@in ()) -> @out ())
+    // CHECK:         [[TMP1:%.*]] = alloc_stack $(title: (), action: @callee_guaranteed (@in ()) -> @out ())
     // CHECK:         apply {{.*}}<(title: (), action: () -> ())>([[TMP1]],
     mutating func t() {
         _ = self.options[].title
@@ -143,7 +143,7 @@ func setBuilder<F: Factory where F.Product == MyClass>(_ factory: inout F) {
 // CHECK:   [[F0:%.*]] = function_ref @_T020property_abstraction10setBuilder{{[_0-9a-zA-Z]*}} : $@convention(thin) () -> @owned MyClass
 // CHECK:   [[F1:%.*]] = thin_to_thick_function [[F0]]
 // CHECK:   [[REABSTRACTOR:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:   [[F2:%.*]] = partial_apply [[REABSTRACTOR]]([[F1]])
+// CHECK:   [[F2:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[F1]])
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*F
 // CHECK:   [[SETTER:%.*]] = witness_method $F, #Factory.builder!setter.1
 // CHECK:   apply [[SETTER]]<F>([[F2]], [[WRITE]])

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -18,11 +18,11 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T_BORROW]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   end_borrow [[T_BORROW]] from [[T]]
-  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned (Int) -> ()> }
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed (Int) -> ()> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
-  // CHECK:   alloc_stack $Optional<@callee_owned (Int) -> ()>
+  // CHECK:   alloc_stack $Optional<@callee_guaranteed (Int) -> ()>
   // CHECK:   dynamic_method_br [[T]] : $T, #P1.method!1.foreign
   var methodRef = t.method
 }

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -14,40 +14,40 @@ class Box<T> {
 // CHECK: bb0:
 // CHECK:   // function_ref closure #1 in testBox()
 // CHECK:   [[CLOSURE:%.*]] = function_ref @_T04main7testBoxyyFyycfU_ : $@convention(thin) () -> ()
-// CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) () -> () to $@callee_owned () -> ()
-// CHECK:   [[TUPLEA:%.*]] = tuple (%{{.*}} : $Int, [[THICK]] : $@callee_owned () -> ())
-// CHECK:   [[BORROWA:%.*]] = begin_borrow [[TUPLEA]] : $(Int, @callee_owned () -> ())
-// CHECK:   [[ELTA_0:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_owned () -> ()), 0
-// CHECK:   [[ELTA_1:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_owned () -> ()), 1
-// CHECK:   [[COPYA_1:%.*]] = copy_value [[ELTA_1]] : $@callee_owned () -> () 
-// CHECK:   end_borrow [[BORROWA]] from %{{.*}} : $(Int, @callee_owned () -> ()), $(Int, @callee_owned () -> ())
-// CHECK:   [[THUNK1:%.*]] = function_ref @_T0Iex_ytytIexir_TR : $@convention(thin) (@in (), @owned @callee_owned () -> ()) -> @out ()
-// CHECK:   [[PA:%.*]] = partial_apply [[THUNK1]]([[COPYA_1]]) : $@convention(thin) (@in (), @owned @callee_owned () -> ()) -> @out ()
-// CHECK:   [[TUPLEB:%.*]] = tuple ([[ELTA_0]] : $Int, [[PA]] : $@callee_owned (@in ()) -> @out ())
-// CHECK:   [[BORROWB:%.*]] = begin_borrow [[TUPLEB]] : $(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   [[TUPLEB_0:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_owned (@in ()) -> @out ()), 0
-// CHECK:   [[TUPLEB_1:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_owned (@in ()) -> @out ()), 1
-// CHECK:   [[COPYB_1:%.*]] = copy_value [[TUPLEB_1]] : $@callee_owned (@in ()) -> @out ()
+// CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+// CHECK:   [[TUPLEA:%.*]] = tuple (%{{.*}} : $Int, [[THICK]] : $@callee_guaranteed () -> ())
+// CHECK:   [[BORROWA:%.*]] = begin_borrow [[TUPLEA]] : $(Int, @callee_guaranteed () -> ())
+// CHECK:   [[ELTA_0:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_guaranteed () -> ()), 0
+// CHECK:   [[ELTA_1:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_guaranteed () -> ()), 1
+// CHECK:   [[COPYA_1:%.*]] = copy_value [[ELTA_1]] : $@callee_guaranteed () -> () 
+// CHECK:   end_borrow [[BORROWA]] from %{{.*}} : $(Int, @callee_guaranteed () -> ()), $(Int, @callee_guaranteed () -> ())
+// CHECK:   [[THUNK1:%.*]] = function_ref @_T0Ieg_ytytIegir_TR : $@convention(thin) (@in (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK1]]([[COPYA_1]]) : $@convention(thin) (@in (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
+// CHECK:   [[TUPLEB:%.*]] = tuple ([[ELTA_0]] : $Int, [[PA]] : $@callee_guaranteed (@in ()) -> @out ())
+// CHECK:   [[BORROWB:%.*]] = begin_borrow [[TUPLEB]] : $(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   [[TUPLEB_0:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_guaranteed (@in ()) -> @out ()), 0
+// CHECK:   [[TUPLEB_1:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_guaranteed (@in ()) -> @out ()), 1
+// CHECK:   [[COPYB_1:%.*]] = copy_value [[TUPLEB_1]] : $@callee_guaranteed (@in ()) -> @out ()
 // CHECK:   // function_ref Box.__allocating_init(_:)
 // CHECK:   [[INIT_F:%.*]] = function_ref @_T04main3BoxCACyxGxcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
 // CHECK:   [[CALL:%.*]] = apply [[INIT_F]]<(Int, () -> ())>(%{{.*}}, %{{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
-// CHECK:   end_borrow [[BORROWB]] from %{{.*}} : $(Int, @callee_owned (@in ()) -> @out ()), $(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   destroy_value [[TUPLEB]] : $(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   destroy_value [[TUPLEA]] : $(Int, @callee_owned () -> ())
+// CHECK:   end_borrow [[BORROWB]] from %{{.*}} : $(Int, @callee_guaranteed (@in ()) -> @out ()), $(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   destroy_value [[TUPLEB]] : $(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   destroy_value [[TUPLEA]] : $(Int, @callee_guaranteed () -> ())
 // CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [[CALL]] : $Box<(Int, () -> ())> 
 // CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_CALL]] : $Box<(Int, () -> ())>, #Box.value
-// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[REF]] : $*(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   [[TUPLEC:%.*]] = load [copy] [[READ]] : $*(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   [[BORROW_TUPLEC:%.*]] = begin_borrow [[TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   [[TUPLEC_0:%.*]] = tuple_extract [[BORROW_TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ()), 0
-// CHECK:   [[TUPLEC_1:%.*]] = tuple_extract [[BORROW_TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ()), 1
-// CHECK:   [[COPYC_1:%.*]] = copy_value [[TUPLEC_1]] : $@callee_owned (@in ()) -> @out ()
-// CHECK:   [[THUNK2:%.*]] = function_ref @_T0ytytIexir_Iex_TR : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> ()
-// CHECK:   [[PA2:%.*]] = partial_apply [[THUNK2]]([[COPYC_1]]) : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> ()
-// CHECK:   end_access [[READ]] : $*(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   destroy_value [[PA2]] : $@callee_owned () -> ()    
-// CHECK:   end_borrow [[BORROW_TUPLEC]] from %{{.*}} : $(Int, @callee_owned (@in ()) -> @out ()), $(Int, @callee_owned (@in ()) -> @out ())
-// CHECK:   destroy_value [[TUPLEC]] : $(Int, @callee_owned (@in ()) -> @out ())
+// CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[REF]] : $*(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   [[TUPLEC:%.*]] = load [copy] [[READ]] : $*(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   [[BORROW_TUPLEC:%.*]] = begin_borrow [[TUPLEC]] : $(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   [[TUPLEC_0:%.*]] = tuple_extract [[BORROW_TUPLEC]] : $(Int, @callee_guaranteed (@in ()) -> @out ()), 0
+// CHECK:   [[TUPLEC_1:%.*]] = tuple_extract [[BORROW_TUPLEC]] : $(Int, @callee_guaranteed (@in ()) -> @out ()), 1
+// CHECK:   [[COPYC_1:%.*]] = copy_value [[TUPLEC_1]] : $@callee_guaranteed (@in ()) -> @out ()
+// CHECK:   [[THUNK2:%.*]] = function_ref @_T0ytytIegir_Ieg_TR : $@convention(thin) (@guaranteed @callee_guaranteed (@in ()) -> @out ()) -> ()
+// CHECK:   [[PA2:%.*]] = partial_apply [callee_guaranteed] [[THUNK2]]([[COPYC_1]]) : $@convention(thin) (@guaranteed @callee_guaranteed (@in ()) -> @out ()) -> ()
+// CHECK:   end_access [[READ]] : $*(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   destroy_value [[PA2]] : $@callee_guaranteed () -> ()    
+// CHECK:   end_borrow [[BORROW_TUPLEC]] from %{{.*}} : $(Int, @callee_guaranteed (@in ()) -> @out ()), $(Int, @callee_guaranteed (@in ()) -> @out ())
+// CHECK:   destroy_value [[TUPLEC]] : $(Int, @callee_guaranteed (@in ()) -> @out ())
 // CHECK:   end_borrow [[BORROW_CALL]] from %{{.*}} : $Box<(Int, () -> ())>, $Box<(Int, () -> ())>
 // CHECK-LABEL: } // end sil function '_T04main7testBoxyyF'
 public func testBox() {

--- a/test/SILGen/reabstract.swift
+++ b/test/SILGen/reabstract.swift
@@ -15,23 +15,27 @@ func test0() {
 // CHECK-NEXT: [[CVT:%.*]] = convert_function [[T2]]
 // CHECK-NEXT: reabstraction thunk
 // CHECK-NEXT: [[T3:%.*]] = function_ref [[THUNK:@.*]] :
-// CHECK-NEXT: [[T4:%.*]] = partial_apply [[T3]]([[CVT]])
+// CHECK-NEXT: [[T4:%.*]] = partial_apply [callee_guaranteed] [[T3]]([[CVT]])
 // CHECK-NEXT: [[CVT:%.*]] = convert_function [[T4]]
 // CHECK:      [[T0:%.*]] = function_ref @_T010reabstract6takeFn{{[_0-9a-zA-Z]*}}F
 // CHECK-NEXT: apply [[T0]]<Int>([[CVT]])
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 
-// CHECK:    sil shared [transparent] [serializable] [reabstraction_thunk] [[THUNK]] : $@convention(thin) (@in Int, @owned @noescape @callee_owned (Int) -> Optional<Int>) -> @out Optional<Int> {
+// CHECK:    sil shared [transparent] [serializable] [reabstraction_thunk] [[THUNK]] : $@convention(thin) (@in Int, @guaranteed @noescape @callee_guaranteed (Int) -> Optional<Int>) -> @out Optional<Int> {
+// CHECK:      [[COPY:%.*]] = copy_value %2
 // CHECK:      [[T0:%.*]] = load [trivial] %1 : $*Int
-// CHECK-NEXT: [[T1:%.*]] = apply %2([[T0]])
+// CHECK:      [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK-NEXT: [[T1:%.*]] = apply [[BORROW]]([[T0]])
 // CHECK-NEXT: store [[T1]] to [trivial] %0
 // CHECK-NEXT: tuple ()
+// CHECK-NEXT: end_borrow [[BORROW]]
+// CHECK-NEXT: destroy_value [[COPY]]
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil hidden @_T010reabstract10testThrowsyypF
-// CHECK:         function_ref @_T0ytytIexir_Iex_TR
-// CHECK:         function_ref @_T0ytyts5Error_pIexirzo_sAA_pIexzo_TR
+// CHECK:         function_ref @_T0ytytIegir_Ieg_TR
+// CHECK:         function_ref @_T0ytyts5Error_pIegirzo_sAA_pIegzo_TR
 func testThrows(_ x: Any) {
   _ = x as? () -> ()
   _ = x as? () throws -> ()
@@ -56,13 +60,13 @@ func testInoutOpaque(_ c: C, i: Int) {
 // CHECK-LABEL: sil hidden @_T010reabstract15testInoutOpaqueyAA1CC_Si1itF
 // CHECK:         function_ref @_T010reabstract6notFunyAA1CCz_Si1itF
 // CHECK:         thin_to_thick_function {{%[0-9]+}}
-// CHECK:         function_ref @_T010reabstract1CCSiIexly_ACSiytIexlir_TR
+// CHECK:         function_ref @_T010reabstract1CCSiIegly_ACSiytIeglir_TR
 // CHECK:         partial_apply
 // CHECK:         store
 // CHECK:         load
-// CHECK:         function_ref @_T010reabstract1CCSiytIexlir_ACSiIexly_TR
+// CHECK:         function_ref @_T010reabstract1CCSiytIeglir_ACSiIegly_TR
 // CHECK:         partial_apply
 // CHECK:         apply
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T010reabstract1CCSiIexly_ACSiytIexlir_TR : $@convention(thin) (@inout C, @in Int, @owned @callee_owned (@inout C, Int) -> ()) -> @out () {
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T010reabstract1CCSiytIexlir_ACSiIexly_TR : $@convention(thin) (@inout C, Int, @owned @callee_owned (@inout C, @in Int) -> @out ()) -> () {
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T010reabstract1CCSiIegly_ACSiytIeglir_TR : $@convention(thin) (@inout C, @in Int, @guaranteed @callee_guaranteed (@inout C, Int) -> ()) -> @out () {
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T010reabstract1CCSiytIeglir_ACSiIegly_TR : $@convention(thin) (@inout C, Int, @guaranteed @callee_guaranteed (@inout C, @in Int) -> @out ()) -> () {

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -12,28 +12,28 @@ func transform(_ i: Int) -> Double {
 
 // CHECK-LABEL: sil hidden @_T017reabstract_lvalue0A13FunctionInOutyyF : $@convention(thin) () -> ()
 func reabstractFunctionInOut() {
-  // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_owned (Int) -> Double }
+  // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_guaranteed (Int) -> Double }
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   // CHECK: [[ARG:%.*]] = function_ref @_T017reabstract_lvalue9transformSdSiF
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]
   // CHECK: store [[THICK_ARG:%.*]] to [init] [[PB]]
-  // CHECK:  [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*@callee_owned (Int) -> Double
-  // CHECK: [[ABSTRACTED_BOX:%.*]] = alloc_stack $@callee_owned (@in Int) -> @out Double
+  // CHECK:  [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*@callee_guaranteed (Int) -> Double
+  // CHECK: [[ABSTRACTED_BOX:%.*]] = alloc_stack $@callee_guaranteed (@in Int) -> @out Double
   // CHECK: [[THICK_ARG:%.*]] = load [copy] [[WRITE]]
-  // CHECK: [[THUNK1:%.*]] = function_ref @_T0SiSdIexyd_SiSdIexir_TR
-  // CHECK: [[ABSTRACTED_ARG:%.*]] = partial_apply [[THUNK1]]([[THICK_ARG]])
+  // CHECK: [[THUNK1:%.*]] = function_ref @_T0SiSdIegyd_SiSdIegir_TR
+  // CHECK: [[ABSTRACTED_ARG:%.*]] = partial_apply [callee_guaranteed] [[THUNK1]]([[THICK_ARG]])
   // CHECK: store [[ABSTRACTED_ARG]] to [init] [[ABSTRACTED_BOX]]
   // CHECK: [[FUNC:%.*]] = function_ref @_T017reabstract_lvalue19consumeGenericInOut{{[_0-9a-zA-Z]*}}F
   // CHECK: apply [[FUNC]]<(Int) -> Double>([[ABSTRACTED_BOX]])
   // CHECK: [[NEW_ABSTRACTED_ARG:%.*]] = load [take] [[ABSTRACTED_BOX]]
-  // CHECK: [[THUNK2:%.*]] = function_ref @_T0SiSdIexir_SiSdIexyd_TR
-  // CHECK: [[NEW_ARG:%.*]] = partial_apply [[THUNK2]]([[NEW_ABSTRACTED_ARG]])
+  // CHECK: [[THUNK2:%.*]] = function_ref @_T0SiSdIegir_SiSdIegyd_TR
+  // CHECK: [[NEW_ARG:%.*]] = partial_apply [callee_guaranteed] [[THUNK2]]([[NEW_ABSTRACTED_ARG]])
   var minimallyAbstracted = transform
   consumeGenericInOut(&minimallyAbstracted)
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiSdIexyd_SiSdIexir_TR : $@convention(thin) (@in Int, @owned @callee_owned (Int) -> Double) -> @out Double
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiSdIexir_SiSdIexyd_TR : $@convention(thin) (Int, @owned @callee_owned (@in Int) -> @out Double) -> Double
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiSdIegyd_SiSdIegir_TR : $@convention(thin) (@in Int, @guaranteed @callee_guaranteed (Int) -> Double) -> @out Double
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0SiSdIegir_SiSdIegyd_TR : $@convention(thin) (Int, @guaranteed @callee_guaranteed (@in Int) -> @out Double) -> Double
 
 // CHECK-LABEL: sil hidden @_T017reabstract_lvalue0A13MetatypeInOutyyF : $@convention(thin) () -> ()
 func reabstractMetatypeInOut() {

--- a/test/SILGen/result_abstraction.swift
+++ b/test/SILGen/result_abstraction.swift
@@ -25,8 +25,8 @@ protocol ReturnsFunction {
 }
 
 struct ConformsToReturnsFunction : ReturnsFunction {
-  // CHECK-LABEL: sil private [transparent] [thunk] @_T018result_abstraction25ConformsToReturnsFunctionVAA0eF0A2aDP7getFunc{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: ReturnsFunction) (@in_guaranteed ConformsToReturnsFunction) -> @owned @callee_owned (@in S) -> @out R
-  // CHECK:         function_ref @_T018result_abstraction1SVAA1RVIexyd_AcEIexir_TR : $@convention(thin) (@in S, @owned @callee_owned (S) -> R) -> @out R
+  // CHECK-LABEL: sil private [transparent] [thunk] @_T018result_abstraction25ConformsToReturnsFunctionVAA0eF0A2aDP7getFunc{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: ReturnsFunction) (@in_guaranteed ConformsToReturnsFunction) -> @owned @callee_guaranteed (@in S) -> @out R
+  // CHECK:         function_ref @_T018result_abstraction1SVAA1RVIegyd_AcEIegir_TR : $@convention(thin) (@in S, @guaranteed @callee_guaranteed (S) -> R) -> @out R
   func getFunc() -> (S) -> R {
     return {s in R()}
   }
@@ -50,8 +50,8 @@ struct ConformsToReturnsAssocWithMetatype : ReturnsAssoc {
 
 struct ConformsToReturnsAssocWithFunction : ReturnsAssoc {
   typealias Assoc = (S) -> R
-  // CHECK-LABEL: sil private [transparent] [thunk] @_T018result_abstraction34ConformsToReturnsAssocWithFunctionVAA0eF0A2aDP03getF0{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: ReturnsAssoc) (@inout ConformsToReturnsAssocWithFunction) -> @out @callee_owned (@in S) -> @out R
-  // CHECK:         function_ref @_T018result_abstraction34ConformsToReturnsAssocWithFunctionV03getF0{{[_0-9a-zA-Z]*}}F : $@convention(method) (@inout ConformsToReturnsAssocWithFunction) -> @owned @callee_owned (S) -> R
+  // CHECK-LABEL: sil private [transparent] [thunk] @_T018result_abstraction34ConformsToReturnsAssocWithFunctionVAA0eF0A2aDP03getF0{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: ReturnsAssoc) (@inout ConformsToReturnsAssocWithFunction) -> @out @callee_guaranteed (@in S) -> @out R
+  // CHECK:         function_ref @_T018result_abstraction34ConformsToReturnsAssocWithFunctionV03getF0{{[_0-9a-zA-Z]*}}F : $@convention(method) (@inout ConformsToReturnsAssocWithFunction) -> @owned @callee_guaranteed (S) -> R
   mutating
   func getAssoc() -> (S) -> R {
     return {s in R()}

--- a/test/SILGen/rethrows.swift
+++ b/test/SILGen/rethrows.swift
@@ -11,8 +11,8 @@ func nonthrower() -> Int { return 0 }
 // CHECK:       [[THROWER:%.*]] = function_ref @_T08rethrows7throwerSiyKF : $@convention(thin) () -> (Int, @error Error)
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[THROWER]]
 // CHECK:       [[CVT:%.*]] = convert_function [[T0]]
-// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[CVT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
+// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
+// CHECK:       try_apply [[RETHROWER]]([[CVT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
 // CHECK:     [[NORMAL]]([[T0:%.*]] : $Int):
 // CHECK-NEXT:  [[T1:%.*]] = tuple ()
 // CHECK-NEXT:  return [[T1]]
@@ -26,8 +26,8 @@ func test0() throws {
 // CHECK:       [[CLOSURE:%.*]] = function_ref @_T08rethrows5test1yyKFSiyKcfU_ : $@convention(thin) () -> (Int, @error Error)
 // CHECK:       [[CVT:%.*]] = convert_function [[CLOSURE]]
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[CVT]]
-// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[T0]]) : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
+// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
+// CHECK:       try_apply [[RETHROWER]]([[T0]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
 // CHECK:     [[NORMAL]]([[T0:%.*]] : $Int):
 // CHECK-NEXT:  [[T1:%.*]] = tuple ()
 // CHECK-NEXT:  return [[T1]]
@@ -38,8 +38,8 @@ func test0() throws {
 // CHECK:       [[THROWER:%.*]] = function_ref @_T08rethrows7throwerSiyKF : $@convention(thin) () -> (Int, @error Error)
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[THROWER]]
 // CHECK:       [[CVT:%.*]] = convert_function [[T0]]
-// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[CVT]]) : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
+// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
+// CHECK:       try_apply [[RETHROWER]]([[CVT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
 // CHECK:     [[NORMAL]]([[T0:%.*]] : $Int):
 // CHECK-NEXT:  return [[T0]]
 // CHECK:     [[ERROR]]([[T0:%.*]] : $Error):
@@ -51,9 +51,9 @@ func test1() throws {
 // CHECK-LABEL: sil hidden @_T08rethrows5test2yyF : $@convention(thin) () -> () {
 // CHECK:       [[NONTHROWER:%.*]] = function_ref @_T08rethrows10nonthrowerSiyF : $@convention(thin) () -> Int
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[NONTHROWER]]
-// CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@callee_owned () -> Int to $@noescape @callee_owned () -> (Int, @error Error)
-// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[T1]]) : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
+// CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> (Int, @error Error)
+// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
+// CHECK:       try_apply [[RETHROWER]]([[T1]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
 // CHECK:     [[NORMAL]]([[T0:%.*]] : $Int):
 // CHECK-NEXT:  [[T1:%.*]] = tuple ()
 // CHECK-NEXT:  return [[T1]]
@@ -67,9 +67,9 @@ func test2() {
 // CHECK:       [[CLOSURE:%.*]] = function_ref @_T08rethrows5test3yyFSiycfU_ : $@convention(thin) () -> Int
 // CHECK:       [[CVT:%.*]] = convert_function [[CLOSURE]] : $@convention(thin) () -> Int to $@convention(thin) @noescape () -> Int
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[CVT]]
-// CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@noescape @callee_owned () -> Int to $@noescape @callee_owned () -> (Int, @error Error)
-// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[T1]]) : $@convention(thin) (@owned @noescape @callee_owned () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
+// CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@noescape @callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> (Int, @error Error)
+// CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
+// CHECK:       try_apply [[RETHROWER]]([[T1]]) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
 // CHECK:     [[NORMAL]]([[T0:%.*]] : $Int):
 // CHECK-NEXT:  [[T1:%.*]] = tuple ()
 // CHECK-NEXT:  return [[T1]]

--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -33,18 +33,14 @@ func owned_arguments(trivial : Int, value : ValueAggregate, ref : RefAggregate) 
 // CHECK-LABEL: sil hidden @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftF : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
 func shared_argument_capture(trivial : __shared Int, value : __shared ValueAggregate, ref : __shared RefAggregate) {
   // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @guaranteed $ValueAggregate, [[REF_VAL:%[0-9]+]] : @guaranteed $RefAggregate):
-  // CHECK: [[COPY_VALUE_VAL:%[0-9]+]] = copy_value [[VALUE_VAL]] : $ValueAggregate
-  // CHECK: [[COPY_REF_VAL:%[0-9]+]] = copy_value [[REF_VAL]] : $RefAggregate
   // CHECK: [[CLO_1:%[0-9]+]] = function_ref @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU_
-  // CHECK: {{%.*}} = apply [[CLO_1]]([[TRIVIAL_VAL]], [[COPY_VALUE_VAL]], [[COPY_REF_VAL]]) : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
+  // CHECK: {{%.*}} = apply [[CLO_1]]([[TRIVIAL_VAL]], [[VALUE_VAL]], [[REF_VAL]]) : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
   _ = {
     return shared_arguments(trivial: trivial, value: value, ref: ref)
   }()
   
-  // CHECK: [[COPY_VALUE_VAL_AGAIN:%[0-9]+]] = copy_value [[VALUE_VAL]] : $ValueAggregate
-  // CHECK: [[COPY_REF_VAL_AGAIN:%[0-9]+]] = copy_value [[REF_VAL]] : $RefAggregate
-  // CHECK: [[CLO_2:%[0-9]+]] = function_ref @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU0_ : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
-  // CHECK: {{%.*}} = apply [[CLO_2]]([[TRIVIAL_VAL]], [[COPY_VALUE_VAL_AGAIN]], [[COPY_REF_VAL_AGAIN]]) : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
+  // CHECK: [[CLO_2:%[0-9]+]] = function_ref @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU0_ : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
+  // CHECK: {{%.*}} = apply [[CLO_2]]([[TRIVIAL_VAL]], [[VALUE_VAL]], [[REF_VAL]]) : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
   _ = {
     return owned_arguments(trivial: trivial, value: value, ref: ref)
   }()
@@ -53,90 +49,85 @@ func shared_argument_capture(trivial : __shared Int, value : __shared ValueAggre
   
   // ======== FIRST CLOSURE ==========
 
-  // CHECK-LABEL: sil private @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU_ : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
-  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @owned $ValueAggregate, [[REF_VAL:%[0-9]+]] : @owned $RefAggregate):
-  // CHECK: [[BORROW_VALUE_VAL:%[0-9]+]] = begin_borrow [[VALUE_VAL]] : $ValueAggregate
-  // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
+  // CHECK-LABEL: sil private @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU_ : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
+  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @guaranteed $ValueAggregate, [[REF_VAL:%[0-9]+]] : @guaranteed $RefAggregate):
   // CHECK: [[SHARED_CALL:%[0-9]+]] = function_ref @_T06shared0A10_argumentsySih7trivial_AA14ValueAggregateVh5valueAA03RefE0Ch3reftF : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
-  // CHECK: {{%.*}} = apply [[SHARED_CALL]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]]) : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
-  // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
-  // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
-  // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
-  // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
+  // CHECK: {{%.*}} = apply [[SHARED_CALL]]([[TRIVIAL_VAL]], [[VALUE_VAL]], [[REF_VAL]]) : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
   // CHECK: } // end sil function '_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU_'
   
   // ======== SECOND CLOSURE ==========
   
-  // CHECK-LABEL:  sil private @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU0_ : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> () {
-  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @owned $ValueAggregate, [[REF_VAL:%[0-9]+]] : @owned $RefAggregate):
-  // CHECK: [[BORROW_VALUE_VAL:%[0-9]+]] = begin_borrow [[VALUE_VAL]] : $ValueAggregate
-  // CHECK: [[COPY_BORROW_VALUE_VAL:%[0-9]+]] = copy_value [[BORROW_VALUE_VAL]] : $ValueAggregate
-  // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
-  // CHECK: [[COPY_BORROW_REF_VAL:%[0-9]+]] = copy_value [[BORROW_REF_VAL]] : $RefAggregate
+  // CHECK-LABEL:  sil private @_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU0_ : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> () {
+  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @guaranteed $ValueAggregate, [[REF_VAL:%[0-9]+]] : @guaranteed $RefAggregate):
+  // CHECK: [[COPY_BORROW_VALUE_VAL:%[0-9]+]] = copy_value [[VALUE_VAL]] : $ValueAggregate
+  // CHECK: [[COPY_BORROW_REF_VAL:%[0-9]+]] = copy_value [[REF_VAL]] : $RefAggregate
   // CHECK: [[OWNED_CALL:%[0-9]+]] = function_ref @_T06shared15owned_argumentsySi7trivial_AA14ValueAggregateV5valueAA03RefF0C3reftF : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
   // CHECK: {{%.*}} = apply [[OWNED_CALL]]([[TRIVIAL_VAL]], [[COPY_BORROW_VALUE_VAL]], [[COPY_BORROW_REF_VAL]]) : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
-  // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
-  // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
-  // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
-  // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
   // CHECK: } // end sil function '_T06shared0A17_argument_captureySih7trivial_AA14ValueAggregateVh5valueAA03RefF0Ch3reftFyycfU0_'
 }
 
-// CHECK-LABEL: sil hidden @_T06shared0A20_to_owned_conversionyySih_AA14ValueAggregateVhAA03RefF0ChtcF : $@convention(thin) (@owned @noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
+// CHECK-LABEL: sil hidden @_T06shared0A20_to_owned_conversionyySih_AA14ValueAggregateVhAA03RefF0ChtcF : $@convention(thin) (@owned @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
 func shared_to_owned_conversion(_ f : (__shared Int, __shared ValueAggregate, __shared RefAggregate) -> Void) {
-  // CHECK: bb0([[UNUSED_FUNC:%[0-9]+]] : @owned $@noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()):
+  // CHECK: bb0([[UNUSED_FUNC:%[0-9]+]] : @owned $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()):
   // CHECK: [[OWNED_THUNK:%[0-9]+]] = function_ref @_T06shared0A20_to_owned_conversionyySih_AA14ValueAggregateVhAA03RefF0ChtcFySi_AdFtcfU_ : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[OWNED_THUNK]]
-  // CHECK: [[THICK_OWNED_THUNK:%[0-9]+]] = thin_to_thick_function [[CONVERT]] : $@convention(thin) @noescape (Int, @owned ValueAggregate, @owned RefAggregate) -> () to $@noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
-  // CHECK: [[GUARANTEED_TO_OWNED_THUNK:%[0-9]+]] =  function_ref @_T0Si6shared14ValueAggregateVAA03RefC0CIxyxx_SiAcEIxygg_TR : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate, @owned @noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
-  // CHECK: [[APPLIED_THUNK:%[0-9]+]] = partial_apply [[GUARANTEED_TO_OWNED_THUNK]]([[THICK_OWNED_THUNK]]) : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate, @owned @noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+  // CHECK: [[THICK_OWNED_THUNK:%[0-9]+]] = thin_to_thick_function [[CONVERT]] : $@convention(thin) @noescape (Int, @owned ValueAggregate, @owned RefAggregate) -> () to $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
+  // CHECK: [[GUARANTEED_TO_OWNED_THUNK:%[0-9]+]] =  function_ref @_T0Si6shared14ValueAggregateVAA03RefC0CIgyxx_SiAcEIgygg_TR : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+  // CHECK: [[APPLIED_THUNK:%[0-9]+]] = partial_apply [callee_guaranteed] [[GUARANTEED_TO_OWNED_THUNK]]([[THICK_OWNED_THUNK]]) : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[APPLIED_THUNK]]
-  // CHECK: [[RECUR_FN:%[0-9]+]] = function_ref @_T06shared0A20_to_owned_conversionyySih_AA14ValueAggregateVhAA03RefF0ChtcF : $@convention(thin) (@owned @noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
-  // CHECK: {{%.*}} = apply [[RECUR_FN]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
-  // CHECK: destroy_value [[UNUSED_FUNC]] : $@noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
+  // CHECK: [[RECUR_FN:%[0-9]+]] = function_ref @_T06shared0A20_to_owned_conversionyySih_AA14ValueAggregateVhAA03RefF0ChtcF : $@convention(thin) (@owned @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
+  // CHECK: {{%.*}} = apply [[RECUR_FN]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
+  // CHECK: destroy_value [[UNUSED_FUNC]] : $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
   // CHECK: } // end sil function '_T06shared0A20_to_owned_conversionyySih_AA14ValueAggregateVhAA03RefF0ChtcF'
   
   // ======== REABSTRACTION THUNK =========
   
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si6shared14ValueAggregateVAA03RefC0CIxyxx_SiAcEIxygg_TR : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate, @owned @noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
-  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @guaranteed $ValueAggregate, [[REF_VAL:%[0-9]+]] : @guaranteed $RefAggregate, [[OWNED_FUNC:%[0-9]+]] : @owned $@noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()):
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si6shared14ValueAggregateVAA03RefC0CIgyxx_SiAcEIgygg_TR : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @guaranteed $ValueAggregate, [[REF_VAL:%[0-9]+]] : @guaranteed $RefAggregate, [[FUNC:%[0-9]+]] : @guaranteed $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()):
   // CHECK: [[COPY_VALUE_VAL:%[0-9]+]] = copy_value [[VALUE_VAL]] : $ValueAggregate
   // CHECK: [[COPY_REF_VAL:%[0-9]+]] = copy_value [[REF_VAL]] : $RefAggregate
-  // CHECK: {{%.*}} = apply %3([[TRIVIAL_VAL]], [[COPY_VALUE_VAL]], [[COPY_REF_VAL]]) : $@noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
-  // CHECK: } // end sil function '_T0Si6shared14ValueAggregateVAA03RefC0CIxyxx_SiAcEIxygg_TR'
+  // CHECK: [[COPY_FUNC:%.*]] = copy_value [[FUNC]]
+	// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY_FUNC]]
+  // CHECK: {{%.*}} = apply [[BORROW]]([[TRIVIAL_VAL]], [[COPY_VALUE_VAL]], [[COPY_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
+  // CHECK: destroy_value [[COPY_FUNC]]
+  // CHECK: } // end sil function '_T0Si6shared14ValueAggregateVAA03RefC0CIgyxx_SiAcEIgygg_TR'
   
   return shared_to_owned_conversion { (trivial : Int, val : ValueAggregate, ref : RefAggregate) in }
 }
 
-// CHECK-LABEL: sil hidden @_T06shared09owned_to_A11_conversionyySi_AA14ValueAggregateVAA03RefF0CtcF : $@convention(thin) (@owned @noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+// CHECK-LABEL: sil hidden @_T06shared09owned_to_A11_conversionyySi_AA14ValueAggregateVAA03RefF0CtcF : $@convention(thin) (@owned @noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
 func owned_to_shared_conversion(_ f : (Int, ValueAggregate, RefAggregate) -> Void) {
-  // CHECK: bb0([[UNUSED_FUNC:%[0-9]+]] : @owned $@noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()):
+  // CHECK: bb0([[UNUSED_FUNC:%[0-9]+]] : @owned $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()):
   // CHECK: [[SHARED_THUNK:%[0-9]+]] = function_ref @_T06shared09owned_to_A11_conversionyySi_AA14ValueAggregateVAA03RefF0CtcFySih_ADhAFhtcfU_ : $@convention(thin) (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[SHARED_THUNK]]
-  // CHECK: [[THICK_SHARED_THUNK:%[0-9]+]] = thin_to_thick_function [[CONVERT]] : $@convention(thin) @noescape (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> () to $@noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
-  // CHECK: [[OWNED_TO_GUARANTEED_THUNK:%[0-9]+]] = function_ref @_T0Si6shared14ValueAggregateVAA03RefC0CIxygg_SiAcEIxyxx_TR : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @owned @noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
-  // CHECK: [[APPLIED_THUNK:%[0-9]+]] = partial_apply [[OWNED_TO_GUARANTEED_THUNK]]([[THICK_SHARED_THUNK]]) : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @owned @noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
+  // CHECK: [[THICK_SHARED_THUNK:%[0-9]+]] = thin_to_thick_function [[CONVERT]] : $@convention(thin) @noescape (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> () to $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
+  // CHECK: [[OWNED_TO_GUARANTEED_THUNK:%[0-9]+]] = function_ref @_T0Si6shared14ValueAggregateVAA03RefC0CIgygg_SiAcEIgyxx_TR : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
+  // CHECK: [[APPLIED_THUNK:%[0-9]+]] = partial_apply [callee_guaranteed] [[OWNED_TO_GUARANTEED_THUNK]]([[THICK_SHARED_THUNK]]) : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
   // CHECK: [[CONVERT:%.*]] = convert_function [[APPLIED_THUNK]]
-  // CHECK: [[RECUR_FN:%[0-9]+]] = function_ref @_T06shared09owned_to_A11_conversionyySi_AA14ValueAggregateVAA03RefF0CtcF : $@convention(thin) (@owned @noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
-  // CHECK: {{%.*}} = apply [[RECUR_FN]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
-  // CHECK: destroy_value [[UNUSED_FUNC]] : $@noescape @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
+  // CHECK: [[RECUR_FN:%[0-9]+]] = function_ref @_T06shared09owned_to_A11_conversionyySi_AA14ValueAggregateVAA03RefF0CtcF : $@convention(thin) (@owned @noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+  // CHECK: {{%.*}} = apply [[RECUR_FN]]([[CONVERT]]) : $@convention(thin) (@owned @noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+  // CHECK: destroy_value [[UNUSED_FUNC]] : $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
   // CHECK: } // end sil function '_T06shared09owned_to_A11_conversionyySi_AA14ValueAggregateVAA03RefF0CtcF'
 
   // ======== REABSTRACTION THUNK =========
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si6shared14ValueAggregateVAA03RefC0CIxygg_SiAcEIxyxx_TR : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @owned @noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
-  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @owned $ValueAggregate, [[REF_VAL:%[0-9]+]] : @owned $RefAggregate, [[OWNED_FUNC:%[0-9]+]] : @owned $@noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()):
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si6shared14ValueAggregateVAA03RefC0CIgygg_SiAcEIgyxx_TR : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
+  // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @owned $ValueAggregate, [[REF_VAL:%[0-9]+]] : @owned $RefAggregate, [[FUNC:%[0-9]+]] : @guaranteed $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()):
+  // CHECK: [[COPY:%.*]] = copy_value [[FUNC]]
   // CHECK: [[BORROW_VALUE_VAL:%[0-9]+]] = begin_borrow [[VALUE_VAL]] : $ValueAggregate
   // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
-  // CHECK: {{%.*}} = apply %3([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]]) : $@noescape @callee_owned (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
+  // CHECK: [[BORROWED_FUNC:%.*]] = begin_borrow [[COPY]]
+  // CHECK: {{%.*}} = apply [[BORROWED_FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
+  // CHECK: end_borrow [[BORROWED_FUNC]]
   // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
   // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
+  // CHECK: destroy_value [[COPY]]
   // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
   // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
-  // CHECK: } // end sil function '_T0Si6shared14ValueAggregateVAA03RefC0CIxygg_SiAcEIxyxx_TR'
+  // CHECK: } // end sil function '_T0Si6shared14ValueAggregateVAA03RefC0CIgygg_SiAcEIgyxx_TR'
   
   return owned_to_shared_conversion { (trivial : __shared Int, val : __shared ValueAggregate, ref : __shared RefAggregate) in }
 }
 
-// CHECK-LABEL: sil hidden @_T06shared0A17_closure_loweringyySi_AA14ValueAggregateVAA03RefE0CtchF : $@convention(thin) (@guaranteed @callee_owned (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
+// CHECK-LABEL: sil hidden @_T06shared0A17_closure_loweringyySi_AA14ValueAggregateVAA03RefE0CtchF : $@convention(thin) (@guaranteed @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()) -> ()
 func shared_closure_lowering(_ f : __shared (Int, ValueAggregate, RefAggregate) -> Void) {}

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -222,7 +222,7 @@ func propertyAccesses(_ x: PropertyP & PropertyC) {
   xx[(1, 2)] += 1
 }
 
-// CHECK-LABEL: sil hidden @_T021subclass_existentials19functionConversionsyAA1P_AA4BaseCySiGXcyc07returnsE4AndP_AaC_AFXcXpyc0feG5PTypeAA7DerivedCyc0fI0AJmyc0fI4TypeAA1R_AJXcyc0fiG1RAaM_AJXcXpyc0fiG5RTypetF : $@convention(thin) (@owned @callee_owned () -> @owned Base<Int> & P, @owned @callee_owned () -> @thick (Base<Int> & P).Type, @owned @callee_owned () -> @owned Derived, @owned @callee_owned () -> @thick Derived.Type, @owned @callee_owned () -> @owned Derived & R, @owned @callee_owned () -> @thick (Derived & R).Type) -> () {
+// CHECK-LABEL: sil hidden @_T021subclass_existentials19functionConversionsyAA1P_AA4BaseCySiGXcyc07returnsE4AndP_AaC_AFXcXpyc0feG5PTypeAA7DerivedCyc0fI0AJmyc0fI4TypeAA1R_AJXcyc0fiG1RAaM_AJXcXpyc0fiG5RTypetF : $@convention(thin) (@owned @callee_guaranteed () -> @owned Base<Int> & P, @owned @callee_guaranteed () -> @thick (Base<Int> & P).Type, @owned @callee_guaranteed () -> @owned Derived, @owned @callee_guaranteed () -> @thick Derived.Type, @owned @callee_guaranteed () -> @owned Derived & R, @owned @callee_guaranteed () -> @thick (Derived & R).Type) -> () {
 func functionConversions(
   returnsBaseAndP: @escaping () -> (Base<Int> & P),
   returnsBaseAndPType: @escaping () -> (Base<Int> & P).Type,

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -172,7 +172,7 @@ public class GenericBase<T> {
 
 public class GenericDerived<T> : GenericBase<T> {
   public override func method() {
-    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyFyycfU_ : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
+    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyFyycfU_ : $@convention(thin) <T> (@guaranteed GenericDerived<T>) -> ()
     // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
     // CHECK: return
     {
@@ -180,7 +180,7 @@ public class GenericDerived<T> : GenericBase<T> {
     }()
     // CHECK: } // end sil function '_T05super14GenericDerivedC6methodyyFyycfU_'
 
-    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyF13localFunctionL_yylF : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
+    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyF13localFunctionL_yylF : $@convention(thin) <T> (@guaranteed GenericDerived<T>) -> ()
     // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
     // CHECK: return
     // CHECK: } // end sil function '_T05super14GenericDerivedC6methodyyF13localFunctionL_yylF'
@@ -189,7 +189,7 @@ public class GenericDerived<T> : GenericBase<T> {
     }
     localFunction()
 
-    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyF15genericFunctionL_yqd__r__lF : $@convention(thin) <T><U> (@in U, @owned GenericDerived<T>) -> ()
+    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyF15genericFunctionL_yqd__r__lF : $@convention(thin) <T><U> (@in U, @guaranteed GenericDerived<T>) -> ()
     // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
     // CHECK: return
     func genericFunction<U>(_: U) {

--- a/test/SILGen/switch_abstraction.swift
+++ b/test/SILGen/switch_abstraction.swift
@@ -9,9 +9,9 @@ enum Optionable<T> {
 
 // CHECK-LABEL: sil hidden @_T018switch_abstraction18enum_reabstractionyAA10OptionableOyAA1AVAFcG1x_AF1atF : $@convention(thin) (@owned Optionable<(A) -> A>, A) -> ()
 // CHECK: switch_enum {{%.*}} : $Optionable<(A) -> A>, case #Optionable.Summn!enumelt.1: [[DEST:bb[0-9]+]]
-// CHECK: [[DEST]]([[ORIG:%.*]] : @owned $@callee_owned (@in A) -> @out A):
+// CHECK: [[DEST]]([[ORIG:%.*]] : @owned $@callee_guaranteed (@in A) -> @out A):
 // CHECK:   [[REABSTRACT:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:   [[SUBST:%.*]] = partial_apply [[REABSTRACT]]([[ORIG]])
+// CHECK:   [[SUBST:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[ORIG]])
 func enum_reabstraction(x x: Optionable<(A) -> A>, a: A) {
   switch x {
   case .Summn(var f):
@@ -32,7 +32,7 @@ enum Wacky<A, B> {
 // CHECK:   [[ORIG_ADDR:%.*]] = unchecked_take_enum_data_addr [[ENUM]] : $*Wacky<T, A>, #Wacky.Bar
 // CHECK:   [[ORIG:%.*]] = load [take] [[ORIG_ADDR]]
 // CHECK:   [[REABSTRACT:%.*]] = function_ref @_T0{{.*}}TR :
-// CHECK:   [[SUBST:%.*]] = partial_apply [[REABSTRACT]]<T>([[ORIG]])
+// CHECK:   [[SUBST:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]<T>([[ORIG]])
 func enum_addr_only_to_loadable_with_reabstraction<T>(x x: Wacky<T, A>, a: A)
   -> T
 {

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -123,13 +123,15 @@ func testTupleUnsplat() {
   // CHECK: enum $GenericEnum<(Int, Int)>, #GenericEnum.one!enumelt.1, [[TUPLE]]
   _ = GenericEnum<(Int, Int)>.one(x, y)
 
-  // CHECK: [[THUNK:%.+]] = function_ref @_T0Si_SitIexi_S2iIexyy_TR
-  // CHECK: [[REABSTRACTED:%.+]] = partial_apply [[THUNK]]({{%.+}})
-  // CHECK: apply [[REABSTRACTED]]([[X]], [[Y]])
+  // CHECK: [[THUNK:%.+]] = function_ref @_T0Si_SitIegi_S2iIegyy_TR
+  // CHECK: [[REABSTRACTED:%.+]] = partial_apply [callee_guaranteed] [[THUNK]]({{%.+}})
+  // CHECK: [[BORROW:%.*]] = begin_borrow [[REABSTRACTED]]
+  // CHECK: apply [[BORROW]]([[X]], [[Y]])
   _ = GenericEnum<(Int, Int)>.callback((x, y))
-  // CHECK: [[THUNK:%.+]] = function_ref @_T0Si_SitIexi_S2iIexyy_TR
-  // CHECK: [[REABSTRACTED:%.+]] = partial_apply [[THUNK]]({{%.+}})
-  // CHECK: apply [[REABSTRACTED]]([[X]], [[Y]])
+  // CHECK: [[THUNK:%.+]] = function_ref @_T0Si_SitIegi_S2iIegyy_TR
+  // CHECK: [[REABSTRACTED:%.+]] = partial_apply [callee_guaranteed] [[THUNK]]({{%.+}})
+  // CHECK: [[BORROW:%.*]] = begin_borrow [[REABSTRACTED]]
+  // CHECK: apply [[BORROW]]([[X]], [[Y]])
   _ = GenericEnum<(Int, Int)>.callback(x, y)
 } // CHECK: end sil function '_T06tuples16testTupleUnsplatyyF'
 

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -69,14 +69,14 @@ enum ReferencedFromFunctionEnum {
   case g((ReferencedFromFunctionStruct) -> ())
 }
 
-// CHECK-LABEL: sil hidden @_T05types34referencedFromFunctionStructFieldsyAA010ReferencedcdE0Vc_yAA0gcD4EnumOctADF{{.*}} : $@convention(thin) (@owned ReferencedFromFunctionStruct) -> (@owned @callee_owned (@owned ReferencedFromFunctionStruct) -> (), @owned @callee_owned (@owned ReferencedFromFunctionEnum) -> ()) {
+// CHECK-LABEL: sil hidden @_T05types34referencedFromFunctionStructFieldsyAA010ReferencedcdE0Vc_yAA0gcD4EnumOctADF{{.*}} : $@convention(thin) (@owned ReferencedFromFunctionStruct) -> (@owned @callee_guaranteed (@owned ReferencedFromFunctionStruct) -> (), @owned @callee_guaranteed (@owned ReferencedFromFunctionEnum) -> ()) {
 // CHECK: bb0([[X:%.*]] : @owned $ReferencedFromFunctionStruct):
 // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
 // CHECK:   [[F:%.*]] = struct_extract [[BORROWED_X]] : $ReferencedFromFunctionStruct, #ReferencedFromFunctionStruct.f
-// CHECK:   [[COPIED_F:%.*]] = copy_value [[F]] : $@callee_owned (@owned ReferencedFromFunctionStruct) -> ()
+// CHECK:   [[COPIED_F:%.*]] = copy_value [[F]] : $@callee_guaranteed (@owned ReferencedFromFunctionStruct) -> ()
 // CHECK:   [[BORROWED_X_2:%.*]] = begin_borrow [[X]]
 // CHECK:   [[G:%.*]] = struct_extract [[BORROWED_X_2]] : $ReferencedFromFunctionStruct, #ReferencedFromFunctionStruct.g
-// CHECK:   [[COPIED_G:%.*]] = copy_value [[G]] : $@callee_owned (@owned ReferencedFromFunctionEnum) -> ()
+// CHECK:   [[COPIED_G:%.*]] = copy_value [[G]] : $@callee_guaranteed (@owned ReferencedFromFunctionEnum) -> ()
 // CHECK:   end_borrow [[BORROWED_X_2]] from [[X]]
 // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
 // CHECK:   destroy_value [[X]]
@@ -89,8 +89,8 @@ func referencedFromFunctionStructFields(_ x: ReferencedFromFunctionStruct)
 }
 
 // CHECK-LABEL: sil hidden @_T05types32referencedFromFunctionEnumFieldsyAA010ReferencedcdE0OcSg_yAA0gcD6StructVcSgtADF
-// CHECK:       bb{{[0-9]+}}([[F:%.*]] : @owned $@callee_owned (@owned ReferencedFromFunctionEnum) -> ()):
-// CHECK:       bb{{[0-9]+}}([[G:%.*]] : @owned $@callee_owned (@owned ReferencedFromFunctionStruct) -> ()):
+// CHECK:       bb{{[0-9]+}}([[F:%.*]] : @owned $@callee_guaranteed (@owned ReferencedFromFunctionEnum) -> ()):
+// CHECK:       bb{{[0-9]+}}([[G:%.*]] : @owned $@callee_guaranteed (@owned ReferencedFromFunctionStruct) -> ()):
 func referencedFromFunctionEnumFields(_ x: ReferencedFromFunctionEnum)
     -> (
       ((ReferencedFromFunctionEnum) -> ())?,

--- a/test/SILGen/unmanaged.swift
+++ b/test/SILGen/unmanaged.swift
@@ -46,12 +46,13 @@ func get(holder holder: inout Holder) -> C {
 func project(fn fn: () -> Holder) -> C {
   return fn().value
 }
-// CHECK-LABEL:sil hidden @_T09unmanaged7projectAA1CCAA6HolderVyc2fn_tF : $@convention(thin) (@owned @noescape @callee_owned () -> Holder) -> @owned C
-// CHECK: bb0([[FN:%.*]] : $@noescape @callee_owned () -> Holder):
+// CHECK-LABEL:sil hidden @_T09unmanaged7projectAA1CCAA6HolderVyc2fn_tF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Holder) -> @owned C
+// CHECK: bb0([[FN:%.*]] : $@noescape @callee_guaranteed () -> Holder):
 // CHECK:        strong_retain [[FN]]
 // CHECK-NEXT: [[T0:%.*]] = apply [[FN]]()
 // CHECK-NEXT: [[T1:%.*]] = struct_extract [[T0]] : $Holder, #Holder.value
 // CHECK-NEXT: [[T2:%.*]] = unmanaged_to_ref [[T1]]
 // CHECK-NEXT: strong_retain [[T2]]
+// CHECK-NEXT: strong_release [[FN]]
 // CHECK-NEXT: strong_release [[FN]]
 // CHECK-NEXT: return [[T2]]

--- a/test/SILGen/unmanaged_ownership.swift
+++ b/test/SILGen/unmanaged_ownership.swift
@@ -57,14 +57,17 @@ func get(holder holder: inout Holder) -> C {
 func project(fn fn: () -> Holder) -> C {
   return fn().value
 }
-// CHECK-LABEL: sil hidden @_T0s7projects1CCs6HolderVyc2fn_tF : $@convention(thin) (@owned @noescape @callee_owned () -> Holder) -> @owned C {
-// CHECK: bb0([[FN:%.*]] : @owned $@noescape @callee_owned () -> Holder):
+// CHECK-LABEL: sil hidden @_T0s7projects1CCs6HolderVyc2fn_tF : $@convention(thin) (@owned @noescape @callee_guaranteed () -> Holder) -> @owned C {
+// CHECK: bb0([[FN:%.*]] : @owned $@noescape @callee_guaranteed () -> Holder):
 // CHECK:      [[BORROWED_FN:%.*]] = begin_borrow [[FN]]
 // CHECK-NEXT: [[BORROWED_FN_COPY:%.*]] = copy_value [[BORROWED_FN]]
-// CHECK-NEXT: [[T0:%.*]] = apply [[BORROWED_FN_COPY]]()
+// CHECK-NEXT: [[BORROW:%.*]] = begin_borrow [[BORROWED_FN_COPY]]
+// CHECK-NEXT: [[T0:%.*]] = apply [[BORROW]]()
+// CHECK-NEXT: end_borrow [[BORROW]]
 // CHECK-NEXT: [[T1:%.*]] = struct_extract [[T0]] : $Holder, #Holder.value
 // CHECK-NEXT: [[T2:%.*]] = unmanaged_to_ref [[T1]]
 // CHECK-NEXT: [[COPIED_T2:%.*]] = copy_value [[T2]]
+// CHECK-NEXT: destroy_value [[BORROWED_FN_COPY]]
 // CHECK-NEXT: end_borrow [[BORROWED_FN]] from [[FN]]
 // CHECK-NEXT: destroy_value [[FN]]
 // CHECK-NEXT: return [[COPIED_T2]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -116,8 +116,8 @@ func test_unowned_let_capture(_ aC : C) {
   takeClosure { bC.f() }
 }
 
-// CHECK-LABEL: sil private @_T07unowned05test_A12_let_captureyAA1CCFSiycfU_ : $@convention(thin) (@owned @sil_unowned C) -> Int {
-// CHECK: bb0([[ARG:%.*]] : @owned $@sil_unowned C):
+// CHECK-LABEL: sil private @_T07unowned05test_A12_let_captureyAA1CCFSiycfU_ : $@convention(thin) (@guaranteed @sil_unowned C) -> Int {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $@sil_unowned C):
 // CHECK-NEXT:   debug_value %0 : $@sil_unowned C, let, name "bC", argno 1
 // CHECK-NEXT:   [[UNOWNED_ARG:%.*]] = copy_unowned_value [[ARG]] : $@sil_unowned C
 // CHECK-NEXT:   [[BORROWED_UNOWNED_ARG:%.*]] = begin_borrow [[UNOWNED_ARG]]
@@ -125,7 +125,6 @@ func test_unowned_let_capture(_ aC : C) {
 // CHECK-NEXT:   [[RESULT:%.*]] = apply [[FUN]]([[BORROWED_UNOWNED_ARG]]) : $@convention(method) (@guaranteed C) -> Int
 // CHECK-NEXT:   end_borrow [[BORROWED_UNOWNED_ARG]]
 // CHECK-NEXT:   destroy_value [[UNOWNED_ARG]]
-// CHECK-NEXT:   destroy_value [[ARG]] : $@sil_unowned C
 // CHECK-NEXT:   return [[RESULT]] : $Int
 
 

--- a/test/SILGen/versioned_attribute.swift
+++ b/test/SILGen/versioned_attribute.swift
@@ -4,7 +4,7 @@
 // CHECK-LABEL: sil @_T019versioned_attribute25referencedFromTransparentyyF : $@convention(thin) () -> () {
 @_versioned func referencedFromTransparent() {}
 
-// CHECK-LABEL: sil [serialized] @_T019versioned_attribute23referencesVersionedFuncyycyF : $@convention(thin) () -> @owned @callee_owned () -> () {
+// CHECK-LABEL: sil [serialized] @_T019versioned_attribute23referencesVersionedFuncyycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 @_inlineable public func referencesVersionedFunc() -> () -> () {
   return referencedFromTransparent
 }

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -216,33 +216,37 @@ class Noot : Aap {
   override func map() -> (S?) -> () -> Noot {}
 }
 
-// CHECK-LABEL: sil private @_T013vtable_thunks3BarC3foo{{[_0-9a-zA-Z]*}}FTV : $@convention(method) (@owned @callee_owned (Int) -> Int, @guaranteed Bar) -> @owned Optional<@callee_owned (Int) -> Int>
+// CHECK-LABEL: sil private @_T013vtable_thunks3BarC3foo{{[_0-9a-zA-Z]*}}FTV : $@convention(method) (@owned @callee_guaranteed (Int) -> Int, @guaranteed Bar) -> @owned Optional<@callee_guaranteed (Int) -> Int>
 // CHECK:         [[IMPL:%.*]] = function_ref @_T013vtable_thunks3BarC3foo{{[_0-9a-zA-Z]*}}F
 // CHECK:         apply [[IMPL]]
 
 // CHECK-LABEL: sil private @_T013vtable_thunks4NootC4flip{{[_0-9a-zA-Z]*}}FTV
 // CHECK:         [[IMPL:%.*]] = function_ref @_T013vtable_thunks4NootC4flip{{[_0-9a-zA-Z]*}}F
 // CHECK:         [[INNER:%.*]] = apply %1(%0)
-// CHECK:         [[THUNK:%.*]] = function_ref @_T013vtable_thunks1SVIexd_ACSgIexd_TR
-// CHECK:         [[OUTER:%.*]] = partial_apply [[THUNK]]([[INNER]])
+// CHECK:         [[THUNK:%.*]] = function_ref @_T013vtable_thunks1SVIegd_ACSgIegd_TR
+// CHECK:         [[OUTER:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[INNER]])
 // CHECK:         return [[OUTER]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T013vtable_thunks1SVIexd_ACSgIexd_TR
-// CHECK:         [[INNER:%.*]] = apply %0()
-// CHECK:         [[OUTER:%.*]] = enum $Optional<S>, #Optional.some!enumelt.1, %1 : $S
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T013vtable_thunks1SVIegd_ACSgIegd_TR
+// CHECK:         [[COPY:%.*]] = copy_value %0
+// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:         [[INNER:%.*]] = apply [[BORROW]]()
+// CHECK:         [[OUTER:%.*]] = enum $Optional<S>, #Optional.some!enumelt.1, [[INNER]] : $S
 // CHECK:         return [[OUTER]] : $Optional<S>
 
 // CHECK-LABEL: sil private @_T013vtable_thunks4NootC3map{{[_0-9a-zA-Z]*}}FTV
 // CHECK:         [[IMPL:%.*]] = function_ref @_T013vtable_thunks4NootC3map{{[_0-9a-zA-Z]*}}F
 // CHECK:         [[INNER:%.*]] = apply %1(%0)
-// CHECK:         [[THUNK:%.*]] = function_ref @_T013vtable_thunks1SVSgAA4NootCIexo_Iexyo_AcA3AapCSgIexo_Iexyo_TR
-// CHECK:         [[OUTER:%.*]] = partial_apply [[THUNK]]([[INNER]])
+// CHECK:         [[THUNK:%.*]] = function_ref @_T013vtable_thunks1SVSgAA4NootCIego_Iegyo_AcA3AapCSgIego_Iegyo_TR
+// CHECK:         [[OUTER:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[INNER]])
 // CHECK:         return [[OUTER]]
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T013vtable_thunks1SVSgAA4NootCIexo_Iexyo_AcA3AapCSgIexo_Iexyo_TR
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T013vtable_thunks1SVSgAA4NootCIego_Iegyo_AcA3AapCSgIego_Iegyo_TR
+// CHECK:         [[COPY:%.*]] = copy_value %1
 // CHECK:         [[ARG:%.*]] = enum $Optional<S>, #Optional.some!enumelt.1, %0
-// CHECK:         [[INNER:%.*]] = apply %1(%2)
-// CHECK:         [[OUTER:%.*]] = convert_function [[INNER]] : $@callee_owned () -> @owned Noot to $@callee_owned () -> @owned Optional<Aap>
+// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK:         [[INNER:%.*]] = apply [[BORROW]]([[ARG]])
+// CHECK:         [[OUTER:%.*]] = convert_function [[INNER]] : $@callee_guaranteed () -> @owned Noot to $@callee_guaranteed () -> @owned Optional<Aap>
 // CHECK:         return [[OUTER]]
 // CHECK-LABEL: sil_vtable D {
 // CHECK:         #B.iuo!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -51,8 +51,8 @@ func test0(c c: C) {
 
 // <rdar://problem/16871284> silgen crashes on weak capture
 // CHECK: closure #1 () -> Swift.Int in weak.testClosureOverWeak() -> ()
-// CHECK-LABEL: sil private @_T04weak19testClosureOverWeakyyFSiycfU_ : $@convention(thin) (@owned { var @sil_weak Optional<C> }) -> Int {
-// CHECK: bb0(%0 : @owned ${ var @sil_weak Optional<C> }):
+// CHECK-LABEL: sil private @_T04weak19testClosureOverWeakyyFSiycfU_ : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> Int {
+// CHECK: bb0(%0 : @guaranteed ${ var @sil_weak Optional<C> }):
 // CHECK-NEXT:  %1 = project_box %0
 // CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1
 // CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] %1

--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -4,7 +4,7 @@ var escapeHatch: Any = 0
 
 // CHECK-LABEL: sil hidden @_T025without_actually_escaping9letEscapeyycyyc1f_tF
 func letEscape(f: () -> ()) -> () -> () {
-  // CHECK: bb0([[ARG:%.*]] : @owned $@noescape @callee_owned () -> ()):
+  // CHECK: bb0([[ARG:%.*]] : @owned $@noescape @callee_guaranteed () -> ()):
   // TODO: Use a canary wrapper instead of just copying the nonescaping value
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[ESCAPABLE_COPY:%.*]] = copy_value [[BORROWED_ARG]]

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -438,8 +438,8 @@ struct GenericParameterNameCollision<T: HasAssoc> :
   // CHECK:         apply {{%.*}}<τ_0_0, τ_1_0>
   func foo<U>(_ x: U) {}
 
-  // CHECK-LABEL: sil private [transparent] [thunk] @_T09witnesses29GenericParameterNameCollisionVyxGAA0bcdE8ProtocolA2aEP3bary6Assoc2Qzqd__clFTW : $@convention(witness_method: GenericParameterNameCollisionProtocol) <τ_0_0 where τ_0_0 : HasAssoc><τ_1_0> (@owned @noescape @callee_owned (@in τ_1_0) -> @out τ_0_0.Assoc, @in_guaranteed GenericParameterNameCollision<τ_0_0>) -> () {
-  // CHECK:       bb0(%0 : @owned $@noescape @callee_owned (@in τ_1_0) -> @out τ_0_0.Assoc, %1 : @trivial $*GenericParameterNameCollision<τ_0_0>):
+  // CHECK-LABEL: sil private [transparent] [thunk] @_T09witnesses29GenericParameterNameCollisionVyxGAA0bcdE8ProtocolA2aEP3bary6Assoc2Qzqd__clFTW : $@convention(witness_method: GenericParameterNameCollisionProtocol) <τ_0_0 where τ_0_0 : HasAssoc><τ_1_0> (@owned @noescape @callee_guaranteed (@in τ_1_0) -> @out τ_0_0.Assoc, @in_guaranteed GenericParameterNameCollision<τ_0_0>) -> () {
+  // CHECK:       bb0(%0 : @owned $@noescape @callee_guaranteed (@in τ_1_0) -> @out τ_0_0.Assoc, %1 : @trivial $*GenericParameterNameCollision<τ_0_0>):
   // CHECK:         apply {{%.*}}<τ_0_0, τ_1_0>
   func bar<V>(_ x: (V) -> T.Assoc) {}
 }

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -82,10 +82,10 @@ func inoutReadRead(x: inout Int) {
   doTwo({ _ = x }, { _ = x })
 }
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape09inoutReadE0ySiz1x_tF : $@convention(thin) (@inout Int) -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape09inoutReadE0ySiz1x_tF'
@@ -114,16 +114,16 @@ func readBoxRead() {
   x = 42
 }
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape11readBoxReadyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape11readBoxReadyyF'
 
 // closure #1 in readBoxRead()
-// CHECK-LABEL: sil private @_T027access_enforcement_noescape11readBoxReadyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape11readBoxReadyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int
 // CHECK: end_access [[ACCESS]] 
@@ -150,10 +150,10 @@ func readWrite() {
   doTwo({ _ = x }, { x = 42 })
 }
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape9readWriteyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape9readWriteyyF'
@@ -180,10 +180,10 @@ func inoutReadWrite(x: inout Int) {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape14inoutReadWriteySiz1x_tF : $@convention(thin) (@inout Int) -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14inoutReadWriteySiz1x_tF'
 
@@ -208,16 +208,16 @@ func readBoxWrite() {
   doTwo(c, { x = 42 })
 }
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape12readBoxWriteyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readBoxWriteyyF'
 
 // closure #1 in readBoxWrite()
-// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readBoxWriteyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readBoxWriteyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int
 // CHECK: end_access [[ACCESS]] 
@@ -244,16 +244,16 @@ func readWriteBox() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape12readWriteBoxyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT2]], [[CVT1]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readWriteBoxyyF'
 
 // closure #1 in readWriteBox()
-// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readWriteBoxyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readWriteBoxyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
 // CHECK: end_access [[ACCESS]] 
@@ -282,8 +282,8 @@ func readWriteInout() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape14readWriteInoutyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply %{{.*}}([[CVT]], [[ACCESS2]])
 // CHECK: end_access [[ACCESS2]]
@@ -305,8 +305,8 @@ func inoutReadWriteInout(x: inout Int) {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tF : $@convention(thin) (@inout Int) -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply %{{.*}}([[CVT]], [[ACCESS2]])
 // CHECK: end_access [[ACCESS2]]
@@ -329,15 +329,15 @@ func readBoxWriteInout() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape17readBoxWriteInoutyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %1 : $*Int
 // CHECK: apply %{{.*}}([[CVT]], [[ACCESS]])
 // CHECK: end_access [[ACCESS]]
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape17readBoxWriteInoutyyF'
 
 // closure #1 in readBoxWriteInout()
-// CHECK-LABEL: sil private @_T027access_enforcement_noescape17readBoxWriteInoutyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape17readBoxWriteInoutyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int
 // CHECK: end_access [[ACCESS]] 
@@ -360,10 +360,10 @@ func writeWrite() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape10writeWriteyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape10writeWriteyyF'
@@ -389,10 +389,10 @@ func inoutWriteWrite(x: inout Int) {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tF : $@convention(thin) (@inout Int) -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT1]], [[CVT2]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tF'
@@ -421,16 +421,16 @@ func writeWriteBox() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape13writeWriteBoxyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[PA2:%.*]] = partial_apply
-// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT2:%.*]] = convert_function [[PA2]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[CVT1:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK-NOT: begin_access
 // CHECK: apply %{{.*}}([[CVT2]], [[CVT1]])
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13writeWriteBoxyyF'
 
 // closure #1 in writeWriteBox()
-// CHECK-LABEL: sil private @_T027access_enforcement_noescape13writeWriteBoxyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape13writeWriteBoxyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
 // CHECK: end_access [[ACCESS]] 
@@ -459,8 +459,8 @@ func writeWriteInout() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape15writeWriteInoutyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply %{{.*}}([[CVT]], [[ACCESS2]])
 // CHECK: end_access [[ACCESS2]]
@@ -483,8 +483,8 @@ func inoutWriteWriteInout(x: inout Int) {
 
 // inoutWriteWriteInout(x:)
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tF : $@convention(thin) (@inout Int) -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply %{{.*}}([[CVT]], [[ACCESS2]])
 // CHECK: end_access [[ACCESS2]]
@@ -507,15 +507,15 @@ func writeBoxWriteInout() {
 }
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape18writeBoxWriteInoutyyF : $@convention(thin) () -> () {
-// CHECK: [[PA1:%.*]] = partial_apply
-// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK: [[PA1:%.*]] = partial_apply [callee_guaranteed]
+// CHECK: [[CVT:%.*]] = convert_function [[PA1]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %1 : $*Int
 // CHECK: apply %{{.*}}([[CVT]], [[ACCESS]])
 // CHECK: end_access [[ACCESS]]
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape18writeBoxWriteInoutyyF'
 
 // closure #1 in writeBoxWriteInout()
-// CHECK-LABEL: sil private @_T027access_enforcement_noescape18writeBoxWriteInoutyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape18writeBoxWriteInoutyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
 // CHECK: end_access [[ACCESS]]
@@ -540,7 +540,7 @@ func readBlockWriteInout() {
 
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape19readBlockWriteInoutyyF : $@convention(thin) () -> () {
 // CHECK: [[F1:%.*]] = function_ref @_T027access_enforcement_noescape19readBlockWriteInoutyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> ()
-// CHECK: [[PA:%.*]] = partial_apply [[F1]](%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+// CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] [[F1]](%0) : $@convention(thin) (@inout_aliasable Int) -> ()
 // CHECK-NOT: begin_access
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply
@@ -562,26 +562,26 @@ func noEscapeBlock() {
   }
 }
 // CHECK-LABEL: sil hidden @_T027access_enforcement_noescape13noEscapeBlockyyF : $@convention(thin) () -> () {
-// CHECK: partial_apply
+// CHECK: partial_apply [callee_guaranteed]
 // CHECK-NOT: begin_access
 // CHECK: apply
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13noEscapeBlockyyF'
 
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape13noEscapeBlockyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
 // CHECK: [[F1:%.*]] = function_ref @_T027access_enforcement_noescape13noEscapeBlockyyFyycfU_yycfU_ : $@convention(thin) (@inout_aliasable Int) -> ()
-// CHECK: [[PA:%.*]] = partial_apply [[F1]](%0) : $@convention(thin) (@inout_aliasable Int) -> ()
-// CHECK: [[CVT:%.*]] = convert_function [[PA]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// CHECK: [[STORAGE:%.*]] = alloc_stack $@block_storage @noescape @callee_owned () -> ()
-// CHECK: [[ADDR:%.*]] = project_block_storage [[STORAGE]] : $*@block_storage @noescape @callee_owned () -> ()
-// CHECK: store [[CVT]] to [[ADDR]] : $*@noescape @callee_owned () -> ()
-// CHECK: [[F2:%.*]] = function_ref @_T0Ix_IyB_TR : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_owned () -> ()) -> ()
-// CHECK: [[BLOCK:%.*]] = init_block_storage_header [[STORAGE]] : $*@block_storage @noescape @callee_owned () -> (), invoke [[F2]] : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_owned () -> ()) -> (), type $@convention(block) @noescape () -> ()
+// CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] [[F1]](%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+// CHECK: [[CVT:%.*]] = convert_function [[PA]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: [[STORAGE:%.*]] = alloc_stack $@block_storage @noescape @callee_guaranteed () -> ()
+// CHECK: [[ADDR:%.*]] = project_block_storage [[STORAGE]] : $*@block_storage @noescape @callee_guaranteed () -> ()
+// CHECK: store [[CVT]] to [[ADDR]] : $*@noescape @callee_guaranteed () -> ()
+// CHECK: [[F2:%.*]] = function_ref @_T0Ig_IyB_TR : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_guaranteed () -> ()) -> ()
+// CHECK: [[BLOCK:%.*]] = init_block_storage_header [[STORAGE]] : $*@block_storage @noescape @callee_guaranteed () -> (), invoke [[F2]] : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_guaranteed () -> ()) -> (), type $@convention(block) @noescape () -> ()
 // CHECK: [[ARG:%.*]] = copy_block [[BLOCK]] : $@convention(block) @noescape () -> ()
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply %{{.*}}([[ARG]], [[WRITE]]) : $@convention(thin) (@owned @convention(block) @noescape () -> (), @inout Int) -> ()
 // CHECK: end_access [[WRITE]] : $*Int
-// CHECK: destroy_addr [[ADDR]] : $*@noescape @callee_owned () -> ()
-// CHECK: dealloc_stack [[STORAGE]] : $*@block_storage @noescape @callee_owned () -> ()
+// CHECK: destroy_addr [[ADDR]] : $*@noescape @callee_guaranteed () -> ()
+// CHECK: dealloc_stack [[STORAGE]] : $*@block_storage @noescape @callee_guaranteed () -> ()
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13noEscapeBlockyyFyycfU_'
 
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape13noEscapeBlockyyFyycfU_yycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -66,16 +66,16 @@ public func modifyAndReadS(o: AnyObject) {
 // Otherwise, we may try to convert the access to [deinit] which
 // doesn't make sense dynamically.
 //
-// CHECK-LABEL: sil hidden @_T023access_marker_mandatory19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_owned () -> Int {
+// CHECK-LABEL: sil hidden @_T023access_marker_mandatory19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> Int {
 // CHECK-LABEL: bb0:
 // CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] [[STK]] : $*Int
 // CHECK: store %{{.*}} to [[WRITE]] : $*Int
 // CHECK: end_access [[WRITE]] : $*Int
 // CHECK: [[F:%.*]] = function_ref @_T023access_marker_mandatory19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int
-// CHECK: [[C:%.*]] = partial_apply [[F]](%{{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK: [[C:%.*]] = partial_apply [callee_guaranteed] [[F]](%{{.*}}) : $@convention(thin) (Int) -> Int
 // CHECK: dealloc_stack [[STK]] : $*Int
-// CHECK: return [[C]] : $@callee_owned () -> Int
+// CHECK: return [[C]] : $@callee_guaranteed () -> Int
 // CHECK-LABEL: } // end sil function '_T023access_marker_mandatory19captureStackPromoteSiycyF'
 func captureStackPromote() -> () -> Int {
   var x = 1

--- a/test/SILOptimizer/capture_promotion.swift
+++ b/test/SILOptimizer/capture_promotion.swift
@@ -23,10 +23,10 @@ func test_capture_promotion() -> () -> Int {
 // CHECK-NOT: alloc_box
 
 // CHECK: [[CLOSURE0_PROMOTE0:%.*]] = function_ref @_T017capture_promotion05test_a1_B0SiycyFSiycfU_Tf2iii_n
-// CHECK: partial_apply [[CLOSURE0_PROMOTE0]]({{%[0-9]*}}, {{%[0-9]*}}, {{%[0-9]*}})
+// CHECK: partial_apply [callee_guaranteed] [[CLOSURE0_PROMOTE0]]({{%[0-9]*}}, {{%[0-9]*}}, {{%[0-9]*}})
 
   return { x + y.foo() + z.x }
 }
 
-// CHECK: sil private @_T017capture_promotion05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @owned Foo, @owned Baz) -> Int
+// CHECK: sil private @_T017capture_promotion05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @guaranteed Foo, @guaranteed Baz) -> Int
 

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -22,17 +22,17 @@ entry(%b : $<τ_0_0> { var τ_0_0 } <Int>):
 
 // CHECK-LABEL: sil {{.*}}@call_promotable_box_from_generic
 // CHECK:         [[F:%.*]] = function_ref @_T014promotable_boxTf2i_n
-// CHECK:         partial_apply [[F]](
+// CHECK:         partial_apply [callee_guaranteed] [[F]](
 
-sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @owned @callee_owned () -> Int {
+sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @owned @callee_guaranteed () -> Int {
 entry(%0 : $*T, %1 : $Int):
   destroy_addr %0 : $*T
   %f = function_ref @promotable_box : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Int>) -> Int
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
   store %1 to %a : $*Int
-  %k = partial_apply %f(%b) : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Int>) -> Int
-  return %k : $@callee_owned () -> Int
+  %k = partial_apply [callee_guaranteed] %f(%b) : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Int>) -> Int
+  return %k : $@callee_guaranteed () -> Int
 }
 
 protocol P {}
@@ -53,10 +53,10 @@ entry(%0 : $*T, %b : $<τ_0_0> { var τ_0_0 } <Int>):
 // CHECK-NEXT:    destroy_addr %0 : $*T
 // CHECK-NEXT:    destroy_addr %1 : $*U
 // CHECK:         [[F:%.*]] = function_ref @_T022generic_promotable_boxTf2ni_n : $@convention(thin) <τ_0_0> (@in τ_0_0, Builtin.Int32) -> Builtin.Int32
-// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [[F]]<U>(%2)
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[F]]<U>(%2)
 // CHECK-NEXT:    return [[CLOSURE]]
 
-sil @call_generic_promotable_box_from_different_generic : $@convention(thin) <T, U: P> (@in T, @in U, Int) -> @owned @callee_owned (@in U) -> Int {
+sil @call_generic_promotable_box_from_different_generic : $@convention(thin) <T, U: P> (@in T, @in U, Int) -> @owned @callee_guaranteed (@in U) -> Int {
 entry(%0 : $*T, %1 : $*U, %2 : $Int):
   destroy_addr %0 : $*T
   destroy_addr %1 : $*U
@@ -64,8 +64,8 @@ entry(%0 : $*T, %1 : $*U, %2 : $Int):
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
   store %2 to %a : $*Int
-  %k = partial_apply %f<U>(%b) : $@convention(thin) <V> (@in V, <τ_0_0> { var τ_0_0 } <Int>) -> Int
-  return %k : $@callee_owned (@in U) -> Int
+  %k = partial_apply [callee_guaranteed] %f<U>(%b) : $@convention(thin) <V> (@in V, <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  return %k : $@callee_guaranteed (@in U) -> Int
 }
 
 enum E<X> {
@@ -90,9 +90,9 @@ entry(%0: $*R<T>, %1 : $*Int, %b : $<τ_0_0> { var E< (R<τ_0_0>)->Int > } <T>):
   %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <T>, 0
   %e = load %a : $*E<(R<T>)->Int>
   switch_enum %e : $E<(R<T>)->Int>, case #E.Some!enumelt.1 : bb1, default bb2
-bb1(%f : $@callee_owned (@in R<T>) -> @out Int):
+bb1(%f : $@callee_guaranteed (@in R<T>) -> @out Int):
   %t = tuple ()
-  apply %f(%1, %0) : $@callee_owned (@in R<T>) -> @out Int
+  apply %f(%1, %0) : $@callee_guaranteed (@in R<T>) -> @out Int
   br exit
 bb2:
   br exit
@@ -107,16 +107,16 @@ exit:
 // CHECK:       bb0(%0 : $*R<T>, %1 : $*E<(R<U>) -> Builtin.Int32>, %2 : $*Builtin.Int32):
 // CHECK:         %3 = load %1 : $*E<(R<U>) -> Builtin.Int32>
 // CHECK:         [[F:%.*]] = function_ref @_T023generic_promotable_box2Tf2nni_n : $@convention(thin) <τ_0_0> (@in R<τ_0_0>, @in Builtin.Int32, @owned E<(R<τ_0_0>) -> Builtin.Int32>) -> ()
-// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [[F]]<U>(%2, %3)
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[F]]<U>(%2, %3)
 // CHECK-NEXT:    return [[CLOSURE]]
 
-sil @call_generic_promotable_box_from_different_generic2 : $@convention(thin) <T, U: P> (@in R<T>, @in E<(R<U>)->Int>, @in Int) -> @owned @callee_owned (@in R<U>) -> () {
+sil @call_generic_promotable_box_from_different_generic2 : $@convention(thin) <T, U: P> (@in R<T>, @in E<(R<U>)->Int>, @in Int) -> @owned @callee_guaranteed (@in R<U>) -> () {
 entry(%0 : $*R<T>, %1 : $*E<(R<U>)->Int>, %2 : $*Int):
   destroy_addr %0 : $*R<T>
   %f = function_ref @generic_promotable_box2 : $@convention(thin) <V> (@in R<V>, @in Int, <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
   %b = alloc_box $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>
   %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>, 0
   copy_addr [take] %1 to [initialization] %a : $*E<(R<U>)->Int>
-  %k = partial_apply %f<U>(%2, %b) : $@convention(thin) <V> (@in R<V>, @in Int, <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
-  return %k : $@callee_owned (@in R<U>) -> ()
+  %k = partial_apply [callee_guaranteed] %f<U>(%2, %b) : $@convention(thin) <V> (@in R<V>, @in Int, <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
+  return %k : $@callee_guaranteed (@in R<U>) -> ()
 }

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -22,17 +22,17 @@ entry(%b : @owned $<τ_0_0> { var τ_0_0 } <Int>):
 
 // CHECK-LABEL: sil {{.*}}@call_promotable_box_from_generic
 // CHECK:         [[F:%.*]] = function_ref @_T014promotable_boxTf2i_n
-// CHECK:         partial_apply [[F]](
+// CHECK:         partial_apply [callee_guaranteed] [[F]](
 
-sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @owned @callee_owned () -> Int {
+sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @owned @callee_guaranteed () -> Int {
 entry(%0 : @trivial $*T, %1 : @trivial $Int):
   destroy_addr %0 : $*T
   %f = function_ref @promotable_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
   store %1 to [trivial] %a : $*Int
-  %k = partial_apply %f(%b) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
-  return %k : $@callee_owned () -> Int
+  %k = partial_apply [callee_guaranteed] %f(%b) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  return %k : $@callee_guaranteed () -> Int
 }
 
 protocol P {}
@@ -54,10 +54,10 @@ entry(%0 : @trivial $*T, %b : @owned $<τ_0_0> { var τ_0_0 } <Int>):
 // CHECK-NEXT:    destroy_addr [[ARG0]] : $*T
 // CHECK-NEXT:    destroy_addr [[ARG1]] : $*U
 // CHECK:         [[F:%.*]] = function_ref @_T022generic_promotable_boxTf2ni_n : $@convention(thin) <τ_0_0> (@in τ_0_0, Builtin.Int32) -> Builtin.Int32
-// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [[F]]<U>([[ARG2]])
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[F]]<U>([[ARG2]])
 // CHECK-NEXT:    return [[CLOSURE]]
 
-sil @call_generic_promotable_box_from_different_generic : $@convention(thin) <T, U: P> (@in T, @in U, Int) -> @owned @callee_owned (@in U) -> Int {
+sil @call_generic_promotable_box_from_different_generic : $@convention(thin) <T, U: P> (@in T, @in U, Int) -> @owned @callee_guaranteed (@in U) -> Int {
 entry(%0 : @trivial $*T, %1 : @trivial $*U, %2 : @trivial $Int):
   destroy_addr %0 : $*T
   destroy_addr %1 : $*U
@@ -65,8 +65,8 @@ entry(%0 : @trivial $*T, %1 : @trivial $*U, %2 : @trivial $Int):
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
   store %2 to [trivial] %a : $*Int
-  %k = partial_apply %f<U>(%b) : $@convention(thin) <V> (@in V, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
-  return %k : $@callee_owned (@in U) -> Int
+  %k = partial_apply [callee_guaranteed] %f<U>(%b) : $@convention(thin) <V> (@in V, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  return %k : $@callee_guaranteed (@in U) -> Int
 }
 
 enum E<X> {
@@ -92,8 +92,11 @@ entry(%0 : @trivial $*R<T>, %1 : @trivial $*Int, %b : @owned $<τ_0_0> { var E<(
   %e = load [copy] %a : $*E<(R<T>)->Int>
   switch_enum %e : $E<(R<T>)->Int>, case #E.Some!enumelt.1 : bb1, default bb2
 
-bb1(%f : @owned $@callee_owned (@in R<T>) -> @out Int):
-  apply %f(%1, %0) : $@callee_owned (@in R<T>) -> @out Int
+bb1(%f : @owned $@callee_guaranteed (@in R<T>) -> @out Int):
+  %bf = begin_borrow %f : $@callee_guaranteed (@in R<T>) -> @out Int
+  apply %bf(%1, %0) : $@callee_guaranteed (@in R<T>) -> @out Int
+  end_borrow %bf from %f : $@callee_guaranteed (@in R<T>) -> @out Int , $@callee_guaranteed (@in R<T>) -> @out Int
+  destroy_value %f : $@callee_guaranteed (@in R<T>) -> @out Int
   br exit
 
 bb2(%original : @owned $E<(R<T>)->Int>):
@@ -112,16 +115,16 @@ exit:
 // CHECK:       bb0([[ARG0:%.*]] : $*R<T>, [[ARG1:%.*]] : $*E<(R<U>) -> Builtin.Int32>, [[ARG2:%.*]] : $*Builtin.Int32):
 // CHECK:         %3 = load [[ARG1]] : $*E<(R<U>) -> Builtin.Int32>
 // CHECK:         [[F:%.*]] = function_ref @_T023generic_promotable_box2Tf2nni_n : $@convention(thin) <τ_0_0> (@in R<τ_0_0>, @in Builtin.Int32, @owned E<(R<τ_0_0>) -> Builtin.Int32>) -> ()
-// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [[F]]<U>(%2, %3)
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[F]]<U>(%2, %3)
 // CHECK-NEXT:    return [[CLOSURE]]
 
-sil @call_generic_promotable_box_from_different_generic2 : $@convention(thin) <T, U: P> (@in R<T>, @in E<(R<U>)->Int>, @in Int) -> @owned @callee_owned (@in R<U>) -> () {
+sil @call_generic_promotable_box_from_different_generic2 : $@convention(thin) <T, U: P> (@in R<T>, @in E<(R<U>)->Int>, @in Int) -> @owned @callee_guaranteed (@in R<U>) -> () {
 entry(%0 : @trivial $*R<T>, %1 : @trivial $*E<(R<U>)->Int>, %2 : @trivial $*Int):
   destroy_addr %0 : $*R<T>
   %f = function_ref @generic_promotable_box2 : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
   %b = alloc_box $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>
   %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>, 0
   copy_addr [take] %1 to [initialization] %a : $*E<(R<U>)->Int>
-  %k = partial_apply %f<U>(%2, %b) : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
-  return %k : $@callee_owned (@in R<U>) -> ()
+  %k = partial_apply [callee_guaranteed] %f<U>(%2, %b) : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
+  return %k : $@callee_guaranteed (@in R<U>) -> ()
 }

--- a/test/SILOptimizer/capture_promotion_ownership.swift
+++ b/test/SILOptimizer/capture_promotion_ownership.swift
@@ -28,10 +28,10 @@ func test_capture_promotion() -> () -> Int {
 // CHECK-NOT: alloc_box
 
 // CHECK: [[CLOSURE0_PROMOTE0:%.*]] = function_ref @_T027capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n
-// CHECK: partial_apply [[CLOSURE0_PROMOTE0]]({{%[0-9]*}}, {{%[0-9]*}}, {{%[0-9]*}})
+// CHECK: partial_apply [callee_guaranteed] [[CLOSURE0_PROMOTE0]]({{%[0-9]*}}, {{%[0-9]*}}, {{%[0-9]*}})
 
   return { x + y.foo() + z.x }
 }
 
-// CHECK: sil private @_T027capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @owned Foo, @owned Baz) -> Int
+// CHECK: sil private @_T027capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @guaranteed Foo, @guaranteed Baz) -> Int
 

--- a/test/SILOptimizer/dead_partial_apply_arg.swift
+++ b/test/SILOptimizer/dead_partial_apply_arg.swift
@@ -14,7 +14,7 @@ extension Int32 {
   }
 }
 
-// CHECK-LABEL: sil hidden @_T04test6callitSbs5Int32V_ADtcyF : $@convention(thin) () -> @owned @callee_owned (Int32, Int32) -> Bool
+// CHECK-LABEL: sil hidden @_T04test6callitSbs5Int32V_ADtcyF : $@convention(thin) () -> @owned @callee_guaranteed (Int32, Int32) -> Bool
 // CHECK: [[F:%[0-9]+]] = function_ref @_T0s5Int32V4testE8lessthanSbAB3lhs_AB3rhstFZTf4nnd_n
 // CHECK: [[R:%[0-9]+]] = thin_to_thick_function [[F]]
 // CHECK: return [[R]]

--- a/test/SILOptimizer/inline_heuristics.sil
+++ b/test/SILOptimizer/inline_heuristics.sil
@@ -39,22 +39,22 @@ enum E {
 
 sil @testDirectClosure : $@convention(thin) () -> Int32 {
 bb0:
-  %0 = function_ref @takeDirectClosure : $@convention(thin) (@owned @callee_owned (Int32) -> Int32) -> Int32
+  %0 = function_ref @takeDirectClosure : $@convention(thin) (@owned @callee_guaranteed (Int32) -> Int32) -> Int32
   %1 = function_ref @closure : $@convention(thin) (Int32) -> Int32
-  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_owned (Int32) -> Int32
-  %3 = apply %0(%2) : $@convention(thin) (@owned @callee_owned (Int32) -> Int32) -> Int32
+  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_guaranteed (Int32) -> Int32
+  %3 = apply %0(%2) : $@convention(thin) (@owned @callee_guaranteed (Int32) -> Int32) -> Int32
   return %3 : $Int32
 }
 
-sil @takeDirectClosure : $@convention(thin) (@owned @callee_owned (Int32) -> Int32) -> Int32 {
-bb0(%0 : $@callee_owned (Int32) -> Int32):
+sil @takeDirectClosure : $@convention(thin) (@owned @callee_guaranteed (Int32) -> Int32) -> Int32 {
+bb0(%0 : $@callee_guaranteed (Int32) -> Int32):
   // increase the scope length
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
 
   %1 = integer_literal $Builtin.Int32, 27
   %2 = struct $Int32 (%1 : $Builtin.Int32)
-  %3 = apply %0(%2) : $@callee_owned (Int32) -> Int32
+  %3 = apply %0(%2) : $@callee_guaranteed (Int32) -> Int32
   return %3 : $Int32
 }
 
@@ -71,8 +71,8 @@ sil @testStructClosure : $@convention(thin) () -> Int32 {
 bb0:
   %0 = function_ref @takeStructClosure : $@convention(thin) (@owned Cont) -> Int32
   %1 = function_ref @closure : $@convention(thin) (Int32) -> Int32
-  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_owned (Int32) -> Int32
-  %3 = struct $Cont (%2 : $@callee_owned (Int32) -> Int32)
+  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_guaranteed (Int32) -> Int32
+  %3 = struct $Cont (%2 : $@callee_guaranteed (Int32) -> Int32)
   %4 = apply %0(%3) : $@convention(thin) (@owned Cont) -> Int32
   return %4 : $Int32
 }
@@ -86,7 +86,7 @@ bb0(%0 : $Cont):
   %1 = struct_extract %0 : $Cont, #Cont.cl
   %2 = integer_literal $Builtin.Int32, 27
   %3 = struct $Int32 (%2 : $Builtin.Int32)
-  %4 = apply %1(%3) : $@callee_owned (Int32) -> Int32
+  %4 = apply %1(%3) : $@callee_guaranteed (Int32) -> Int32
   return %4 : $Int32
 }
 
@@ -103,14 +103,14 @@ sil @testStructAddrClosure : $@convention(thin) () -> Int32 {
 bb0:
   %0 = alloc_stack $Cont
   %1 = function_ref @closure : $@convention(thin) (Int32) -> Int32
-  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_owned (Int32) -> Int32
-  %3 = struct $Cont (%2 : $@callee_owned (Int32) -> Int32)
+  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_guaranteed (Int32) -> Int32
+  %3 = struct $Cont (%2 : $@callee_guaranteed (Int32) -> Int32)
   store %3 to %0 : $*Cont
   %5 = function_ref @takeStructAddrClosure : $@convention(thin) (@inout Cont) -> Int32
   %6 = apply %5(%0) : $@convention(thin) (@inout Cont) -> Int32
   %7 = struct_element_addr %0 : $*Cont, #Cont.cl
-  %8 = load %7 : $*@callee_owned (Int32) -> Int32
-  strong_release %8 : $@callee_owned (Int32) -> Int32
+  %8 = load %7 : $*@callee_guaranteed (Int32) -> Int32
+  strong_release %8 : $@callee_guaranteed (Int32) -> Int32
   dealloc_stack %0 : $*Cont
   return %6 : $Int32
 }
@@ -122,11 +122,11 @@ bb0(%0 : $*Cont):
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
 
   %1 = struct_element_addr %0 : $*Cont, #Cont.cl
-  %2 = load %1 : $*@callee_owned (Int32) -> Int32
+  %2 = load %1 : $*@callee_guaranteed (Int32) -> Int32
   %3 = integer_literal $Builtin.Int32, 27
   %4 = struct $Int32 (%3 : $Builtin.Int32)
-  strong_retain %2 : $@callee_owned (Int32) -> Int32
-  %6 = apply %2(%4) : $@callee_owned (Int32) -> Int32
+  strong_retain %2 : $@callee_guaranteed (Int32) -> Int32
+  %6 = apply %2(%4) : $@callee_guaranteed (Int32) -> Int32
   return %6 : $Int32
 }
 
@@ -145,9 +145,9 @@ bb0:
   %1 = integer_literal $Builtin.Int32, 27
   %2 = struct $Int32 (%1 : $Builtin.Int32)
   %3 = function_ref @closure : $@convention(thin) (Int32) -> Int32
-  %4 = thin_to_thick_function %3 : $@convention(thin) (Int32) -> Int32 to $@callee_owned (Int32) -> Int32
-  %5 = tuple (%2 : $Int32, %4 : $@callee_owned (Int32) -> Int32)
-  %6 = struct $Cont2 (%5 : $(Int32, @callee_owned (Int32) -> Int32))
+  %4 = thin_to_thick_function %3 : $@convention(thin) (Int32) -> Int32 to $@callee_guaranteed (Int32) -> Int32
+  %5 = tuple (%2 : $Int32, %4 : $@callee_guaranteed (Int32) -> Int32)
+  %6 = struct $Cont2 (%5 : $(Int32, @callee_guaranteed (Int32) -> Int32))
   %7 = apply %0(%6) : $@convention(thin) (@owned Cont2) -> Int32
   return %7 : $Int32
 }
@@ -160,10 +160,10 @@ bb0(%0 : $Cont2):
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
 
   %1 = struct_extract %0 : $Cont2, #Cont2.tp
-  %2 = tuple_extract %1 : $(Int32, @callee_owned (Int32) -> Int32), 1
+  %2 = tuple_extract %1 : $(Int32, @callee_guaranteed (Int32) -> Int32), 1
   %3 = integer_literal $Builtin.Int32, 27
   %4 = struct $Int32 (%3 : $Builtin.Int32)
-  %5 = apply %2(%4) : $@callee_owned (Int32) -> Int32
+  %5 = apply %2(%4) : $@callee_guaranteed (Int32) -> Int32
   return %5 : $Int32
 }
 
@@ -179,8 +179,8 @@ sil @testEnumClosure : $@convention(thin) () -> Int32 {
 bb0:
   %0 = function_ref @takeEnumClosure : $@convention(thin) (@owned E) -> Int32
   %1 = function_ref @closure : $@convention(thin) (Int32) -> Int32
-  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_owned (Int32) -> Int32
-  %3 = enum $E, #E.B!enumelt.1, %2 : $@callee_owned (Int32) -> Int32
+  %2 = thin_to_thick_function %1 : $@convention(thin) (Int32) -> Int32 to $@callee_guaranteed (Int32) -> Int32
+  %3 = enum $E, #E.B!enumelt.1, %2 : $@callee_guaranteed (Int32) -> Int32
   %4 = apply %0(%3) : $@convention(thin) (@owned E) -> Int32
   return %4 : $Int32
 }
@@ -195,7 +195,7 @@ bb0(%0 : $E):
   %1 = unchecked_enum_data %0 : $E, #E.B!enumelt.1
   %2 = integer_literal $Builtin.Int32, 27
   %3 = struct $Int32 (%2 : $Builtin.Int32)
-  %4 = apply %1(%3) : $@callee_owned (Int32) -> Int32
+  %4 = apply %1(%3) : $@callee_guaranteed (Int32) -> Int32
   return %4 : $Int32
 }
 

--- a/test/SILOptimizer/specialize_partial_apply.swift
+++ b/test/SILOptimizer/specialize_partial_apply.swift
@@ -17,10 +17,10 @@ struct MyError : Error {
 // We need a reabstraction thunk to convert from direct args/result to indirect
 // args/result, which is expected in the returned closure.
 
-// CHECK-LABEL: sil shared [noinline] @_T04test16generic_get_funcxxcx_SbtlFSi_Tg5 : $@convention(thin) (Int, Bool) -> @owned @callee_owned (@in Int) -> @out Int {
-// CHECK: [[F:%[0-9]+]] = function_ref @_T04test16generic_get_funcxxcx_SbtlF0B0L_xxlFSi_TG5 : $@convention(thin) (@in Int, Bool, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int
-// CHECK: [[PA:%[0-9]+]] = partial_apply [[F]](%1, %{{[0-9]+}}) : $@convention(thin) (@in Int, Bool, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int
-// CHECK: return [[PA]] : $@callee_owned (@in Int) -> @out Int
+// CHECK-LABEL: sil shared [noinline] @_T04test16generic_get_funcxxcx_SbtlFSi_Tg5 : $@convention(thin) (Int, Bool) -> @owned @callee_guaranteed (@in Int) -> @out Int {
+// CHECK: [[F:%[0-9]+]] = function_ref @_T04test16generic_get_funcxxcx_SbtlF0B0L_xxlFSi_TG5 : $@convention(thin) (@in Int, Bool, @guaranteed <τ_0_0> { var τ_0_0 } <Int>) -> @out Int
+// CHECK: [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [[F]](%1, %{{[0-9]+}}) : $@convention(thin) (@in Int, Bool, @guaranteed <τ_0_0> { var τ_0_0 } <Int>) -> @out Int
+// CHECK: return [[PA]] : $@callee_guaranteed (@in Int) -> @out Int
 @inline(never)
 func generic_get_func<T>(_ t1: T, _ b: Bool) -> (T) -> T {
 
@@ -32,12 +32,12 @@ func generic_get_func<T>(_ t1: T, _ b: Bool) -> (T) -> T {
 	return generic
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T04test7testit1S2icSbF : $@convention(thin) (Bool) -> @owned @callee_owned (Int) -> Int {
-// CHECK: [[F:%[0-9]+]] = function_ref @_T04test16generic_get_funcxxcx_SbtlFSi_Tg5 : $@convention(thin) (Int, Bool) -> @owned @callee_owned (@in Int) -> @out Int
-// CHECK: [[CL:%[0-9]+]] = apply [[F]](%{{[0-9]+}}, %0) : $@convention(thin) (Int, Bool) -> @owned @callee_owned (@in Int) -> @out Int
-// CHECK: [[TH:%[0-9]+]] = function_ref @_T0S2iIexir_S2iIexyd_TR : $@convention(thin) (Int, @owned @callee_owned (@in Int) -> @out Int) -> Int
-// CHECK: [[RET:%[0-9]+]] = partial_apply [[TH]]([[CL]]) : $@convention(thin) (Int, @owned @callee_owned (@in Int) -> @out Int) -> Int
-// CHECK: return [[RET]] : $@callee_owned (Int) -> Int
+// CHECK-LABEL: sil hidden [noinline] @_T04test7testit1S2icSbF : $@convention(thin) (Bool) -> @owned @callee_guaranteed (Int) -> Int {
+// CHECK: [[F:%[0-9]+]] = function_ref @_T04test16generic_get_funcxxcx_SbtlFSi_Tg5 : $@convention(thin) (Int, Bool) -> @owned @callee_guaranteed (@in Int) -> @out Int
+// CHECK: [[CL:%[0-9]+]] = apply [[F]](%{{[0-9]+}}, %0) : $@convention(thin) (Int, Bool) -> @owned @callee_guaranteed (@in Int) -> @out Int
+// CHECK: [[TH:%[0-9]+]] = function_ref @_T0S2iIegir_S2iIegyd_TR : $@convention(thin) (Int, @guaranteed @callee_guaranteed (@in Int) -> @out Int) -> Int
+// CHECK: [[RET:%[0-9]+]] = partial_apply [callee_guaranteed] [[TH]]([[CL]])
+// CHECK: return [[RET]] : $@callee_guaranteed (Int) -> Int
 @inline(never)
 func testit1(_ b: Bool) -> (Int) -> Int {
 	return generic_get_func(27, b)
@@ -52,10 +52,10 @@ func generic2<T>(_ t1: T, t2: T, b: Bool) -> T {
 // No reabstraction thunk is needed because the returned closure expects direct
 // args/result anyway.
 
-// CHECK-LABEL: sil hidden [noinline] @_T04test17concrete_get_funcS2i_SiSbtcyF : $@convention(thin) () -> @owned @callee_owned (Int, Int, Bool) -> Int {
+// CHECK-LABEL: sil hidden [noinline] @_T04test17concrete_get_funcS2i_SiSbtcyF : $@convention(thin) () -> @owned @callee_guaranteed (Int, Int, Bool) -> Int {
 // CHECK: [[F:%[0-9]+]] = function_ref @_T04test8generic2xx_x2t2Sb1btlFSi_Tg5 : $@convention(thin) (Int, Int, Bool) -> Int
-// CHECK: [[RET:%[0-9]+]] = thin_to_thick_function [[F]] : $@convention(thin) (Int, Int, Bool) -> Int to $@callee_owned (Int, Int, Bool) -> Int
-// CHECK: return [[RET]] : $@callee_owned (Int, Int, Bool) -> Int
+// CHECK: [[RET:%[0-9]+]] = thin_to_thick_function [[F]] : $@convention(thin) (Int, Int, Bool) -> Int to $@callee_guaranteed (Int, Int, Bool) -> Int
+// CHECK: return [[RET]] : $@callee_guaranteed (Int, Int, Bool) -> Int
 @inline(never)
 func concrete_get_func() -> (Int, Int, Bool) -> Int {
 	return generic2
@@ -88,10 +88,10 @@ func testit3(_ b: Bool) -> Int {
 // We need a reabstraction thunk to convert from direct args/result to indirect
 // args/result, which is expected in the returned closure.
 
-// CHECK-LABEL: sil shared [noinline] @_T04test25generic_get_func_throwingxxKcSblFSi_Tg5 : $@convention(thin) (Bool) -> @owned @callee_owned (@in Int) -> (@out Int, @error Error) {
+// CHECK-LABEL: sil shared [noinline] @_T04test25generic_get_func_throwingxxKcSblFSi_Tg5 : $@convention(thin) (Bool) -> @owned @callee_guaranteed (@in Int) -> (@out Int, @error Error) {
 // CHECK: [[F:%[0-9]+]] = function_ref @_T04test25generic_get_func_throwingxxKcSblF0B0L_xxKlFSi_TG5 : $@convention(thin) (@in Int, Bool) -> (@out Int, @error Error)
-// CHECK: [[PA:%[0-9]+]] = partial_apply [[F]](%0) : $@convention(thin) (@in Int, Bool) -> (@out Int, @error Error)
-// CHECK: return [[PA]] : $@callee_owned (@in Int) -> (@out Int, @error Error)
+// CHECK: [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [[F]](%0) : $@convention(thin) (@in Int, Bool) -> (@out Int, @error Error)
+// CHECK: return [[PA]] : $@callee_guaranteed (@in Int) -> (@out Int, @error Error)
 @inline(never)
 func generic_get_func_throwing<T>(_ b: Bool) -> (T) throws -> T {
 
@@ -106,12 +106,12 @@ func generic_get_func_throwing<T>(_ b: Bool) -> (T) throws -> T {
 	return generic
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T04test16testit1_throwingS2iKcSbF : $@convention(thin) (Bool) -> @owned @callee_owned (Int) -> (Int, @error Error) {
-// CHECK: [[F:%[0-9]+]] = function_ref @_T04test25generic_get_func_throwingxxKcSblFSi_Tg5 : $@convention(thin) (Bool) -> @owned @callee_owned (@in Int) -> (@out Int, @error Error)
-// CHECK: [[CL:%[0-9]+]] = apply [[F]](%0) : $@convention(thin) (Bool) -> @owned @callee_owned (@in Int) -> (@out Int, @error Error)
-// CHECK: [[TH:%[0-9]+]] = function_ref @_T0S2is5Error_pIexirzo_S2isAA_pIexydzo_TR : $@convention(thin) (Int, @owned @callee_owned (@in Int) -> (@out Int, @error Error)) -> (Int, @error Error)
-// CHECK: [[RET:%[0-9]+]] = partial_apply [[TH]]([[CL]]) : $@convention(thin) (Int, @owned @callee_owned (@in Int) -> (@out Int, @error Error)) -> (Int, @error Error)
-// CHECK: return [[RET]] : $@callee_owned (Int) -> (Int, @error Error)
+// CHECK-LABEL: sil hidden [noinline] @_T04test16testit1_throwingS2iKcSbF : $@convention(thin) (Bool) -> @owned @callee_guaranteed (Int) -> (Int, @error Error) {
+// CHECK: [[F:%[0-9]+]] = function_ref @_T04test25generic_get_func_throwingxxKcSblFSi_Tg5 : $@convention(thin) (Bool) -> @owned @callee_guaranteed (@in Int) -> (@out Int, @error Error)
+// CHECK: [[CL:%[0-9]+]] = apply [[F]](%0) : $@convention(thin) (Bool) -> @owned @callee_guaranteed (@in Int) -> (@out Int, @error Error)
+// CHECK: [[TH:%[0-9]+]] = function_ref @_T0S2is5Error_pIegirzo_S2isAA_pIegydzo_TR : $@convention(thin) (Int, @guaranteed @callee_guaranteed (@in Int) -> (@out Int, @error Error)) -> (Int, @error Error)
+// CHECK: [[RET:%[0-9]+]] = partial_apply [callee_guaranteed] [[TH]]([[CL]])
+// CHECK: return [[RET]] : $@callee_guaranteed (Int) -> (Int, @error Error)
 @inline(never)
 func testit1_throwing(_ b: Bool) -> (Int) throws -> Int {
 	return generic_get_func_throwing(b)
@@ -129,10 +129,10 @@ func generic2_throwing<T>(_ t1: T, b: Bool) throws -> T {
 // No reabstraction thunk is needed because the returned closure expects direct
 // args/result anyway.
 
-// CHECK-LABEL: sil hidden [noinline] @_T04test26concrete_get_func_throwingS2i_SbtKcyF : $@convention(thin) () -> @owned @callee_owned (Int, Bool) -> (Int, @error Error) {
+// CHECK-LABEL: sil hidden [noinline] @_T04test26concrete_get_func_throwingS2i_SbtKcyF : $@convention(thin) () -> @owned @callee_guaranteed (Int, Bool) -> (Int, @error Error) {
 // CHECK: [[F:%[0-9]+]] = function_ref @_T04test17generic2_throwingxx_Sb1btKlFSi_Tg5 : $@convention(thin) (Int, Bool) -> (Int, @error Error)
-// CHECK: [[RET:%[0-9]+]] = thin_to_thick_function [[F]] : $@convention(thin) (Int, Bool) -> (Int, @error Error) to $@callee_owned (Int, Bool) -> (Int, @error Error)
-// CHECK: return [[RET]] : $@callee_owned (Int, Bool) -> (Int, @error Error)
+// CHECK: [[RET:%[0-9]+]] = thin_to_thick_function [[F]] : $@convention(thin) (Int, Bool) -> (Int, @error Error) to $@callee_guaranteed (Int, Bool) -> (Int, @error Error)
+// CHECK: return [[RET]] : $@callee_guaranteed (Int, Bool) -> (Int, @error Error)
 @inline(never)
 func concrete_get_func_throwing() -> (Int, Bool) throws -> Int {
 	return generic2_throwing
@@ -168,11 +168,11 @@ func testit3_throwing(_ b: Bool) -> Int {
 	}
 }
 
-// CHECK-LABEL: sil shared [transparent] [thunk] @_T04test16generic_get_funcxxcx_SbtlF0B0L_xxlFSi_TG5 : $@convention(thin) (@in Int, Bool, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int {
+// CHECK-LABEL: sil shared [transparent] [thunk] @_T04test16generic_get_funcxxcx_SbtlF0B0L_xxlFSi_TG5 : $@convention(thin) (@in Int, Bool, @guaranteed <τ_0_0> { var τ_0_0 } <Int>) -> @out Int {
 // CHECK: bb0(%0 : $*Int, %1 : $*Int, %2 : $Bool, %3 : $<τ_0_0> { var τ_0_0 } <Int>):
 // CHECK: [[LD:%[0-9]+]] = load %1 : $*Int
-// CHECK: [[F:%[0-9]+]] = function_ref @_T04test16generic_get_funcxxcx_SbtlF0B0L_xxlFSi_Tg5 : $@convention(thin) (Int, Bool, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
-// CHECK: [[RET:%[0-9]+]] = apply [[F]]([[LD]], %2, %3) : $@convention(thin) (Int, Bool, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+// CHECK: [[F:%[0-9]+]] = function_ref @_T04test16generic_get_funcxxcx_SbtlF0B0L_xxlFSi_Tg5 : $@convention(thin) (Int, Bool, @guaranteed <τ_0_0> { var τ_0_0 } <Int>) -> Int
+// CHECK: [[RET:%[0-9]+]] = apply [[F]]([[LD]], %2, %3)
 // CHECK: store [[RET]] to %0 : $*Int
 // CHECK: return %{{[0-9]*}} : $()
 

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -300,11 +300,11 @@ bb1:
   %6 = alloc_stack $UnfoldSequence<Element, State>
   copy_addr %1 to [initialization] %6 : $*UnfoldSequence<Element, State>
   %8 = struct_element_addr %6 : $*UnfoldSequence<Element, State>, #UnfoldSequence._next
-  %9 = load %8 : $*@callee_owned (@inout State) -> @out Optional<Element>
+  %9 = load %8 : $*@callee_guaranteed (@inout State) -> @out Optional<Element>
   %10 = alloc_stack $Optional<Element>
   %11 = struct_element_addr %1 : $*UnfoldSequence<Element, State>, #UnfoldSequence._state
-  strong_retain %9 : $@callee_owned (@inout State) -> @out Optional<Element>
-  %13 = apply %9(%10, %11) : $@callee_owned (@inout State) -> @out Optional<Element>
+  strong_retain %9 : $@callee_guaranteed (@inout State) -> @out Optional<Element>
+  %13 = apply %9(%10, %11) : $@callee_guaranteed (@inout State) -> @out Optional<Element>
   switch_enum_addr %10 : $*Optional<Element>, case #Optional.some!enumelt.1: bb3, case #Optional.none!enumelt: bb2
 
 bb2:

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3212,7 +3212,9 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration.U
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 3))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 3)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration.UseFromObjC") {
@@ -3224,7 +3226,9 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration.U
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 3))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 3)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration_Empty") {
@@ -3309,7 +3313,9 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.KeyEnumerator.FastEnumeration.Use
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 3))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 3)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Custom.KeyEnumerator.FastEnumeration.UseFromSwift.Partial") {
@@ -3335,7 +3341,9 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.KeyEnumerator.FastEnumeration.Use
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 3))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 3)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Custom.FastEnumeration.UseFromSwift") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2226,7 +2226,9 @@ SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFr
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 0))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 0)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFromObjC") {
@@ -2237,7 +2239,9 @@ SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFr
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 0))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 0)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration_Empty") {
@@ -2260,7 +2264,9 @@ SetTestSuite.test("BridgedToObjC.Custom.ObjectEnumerator.FastEnumeration.UseFrom
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 0))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 0)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Custom.ObjectEnumerator.FastEnumeration.UseFromSwift") {
@@ -2271,7 +2277,9 @@ SetTestSuite.test("BridgedToObjC.Custom.ObjectEnumerator.FastEnumeration.UseFrom
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  expectAutoreleasedKeysAndValues(unopt: (3, 0))
+  let autoreleased  = _isDebugAssertConfiguration() ?
+    (0, 0) : (3, 0)
+  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.FastEnumeration.UseFromSwift") {


### PR DESCRIPTION
- Fix block to func reabstraction thunks block argument handling
- Forward cast ownership
- Fix applyPartiallyAppliedSuperMethod ownership for @callee_guaranteed closures
- Update tests for callee_guaranteed closures

SR-5441
rdar://33255593
