### PR TITLE
master-next: fix build for mapped_iterator change in LLVM r317902

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -160,7 +160,7 @@ public:
   range getValues() const;
 
   using type_range = llvm::iterator_range<
-      llvm::mapped_iterator<iterator, std::function<SILType(SILValue)>>>;
+    llvm::mapped_iterator<iterator, std::function<SILType(SILValue)>, SILType>>;
   type_range getTypes() const;
 
   bool operator==(const SILInstructionResultArray &rhs);


### PR DESCRIPTION
The default template parameter assumes that the iterator type is a pointer,
which it is not for SILInstructionResultArray. Just specify the return
type directly instead of using the default.