### PR TITLE
Sema: Coerce base to rvalue when calling a DeclViaBridging overload kind [4.1]

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2546,13 +2546,14 @@ namespace {
       auto selected = *selectedElt;
       switch (selected.choice.getKind()) {
       case OverloadChoiceKind::DeclViaBridge: {
+        base = cs.coerceToRValue(base);
+
         // Look through an implicitly unwrapped optional.
-        auto baseTy = cs.getType(base)->getRValueType();
+        auto baseTy = cs.getType(base);
         if (auto objTy = cs.lookThroughImplicitlyUnwrappedOptionalType(baseTy)){
           base = coerceImplicitlyUnwrappedOptionalToValue(base, objTy,
                                          cs.getConstraintLocator(base));
-
-          baseTy = cs.getType(base)->getRValueType();
+          baseTy = objTy;
         }
 
         auto &tc = cs.getTypeChecker();

--- a/test/SILGen/objc_bridging_nsstring.swift
+++ b/test/SILGen/objc_bridging_nsstring.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-silgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -sil-full-demangle -emit-silgen %s -enable-sil-ownership
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+extension NSString {
+  var x: Float { return 0.0 }
+}
+
+// note: this has to be a var
+var str: String = "hello world"
+
+// Crash when NSString member is accessed on a String with an lvalue base
+_ = str.x


### PR DESCRIPTION
I fixed this already while debugging another project, and now it came up in the swift-4.1-branch so cherry-pick the fix. Fixes https://bugs.swift.org/browse/SR-6349.