### PR TITLE
Fixed faulty boolean logic

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1397,7 +1397,7 @@ std::string Demangler::demangleBridgedMethodParams() {
 
   while (!nextIf('_')) {
     auto c = nextChar();
-    if (!c && c != 'n' && c != 'b')
+    if (c != 'n' && c != 'b')
       return std::string();
     Str.push_back(c);
   }


### PR DESCRIPTION
This is a trivial logic error. The "abort" condition would be followed only if `c == 0` with other clauses having no effect. The error was found by code inspection not testing; it is not associated with any known bugs or problems. You'd need to be demangling a non-conforming string to trigger it and the effort might not be worth it.

With the `!c &&` clause dropped, the logic is in accordance with:
https://github.com/apple/swift/blob/master/docs/ABI/Mangling.rst
which states the the only valid chars at this point are `n` or `b`.