### PR TITLE
[4.0] Disable ModelIO test on ios and tvos

### DIFF
--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -3,6 +3,11 @@
 // UNSUPPORTED: OS=watchos
 // REQUIRES: objc_interop
 
+// Currently crashes on iphonesimulator.
+// rdar://35490456
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+
 import StdlibUnittest
 
 import Foundation


### PR DESCRIPTION
(cherry picked from commit be114b156dc2f512f8a9fe906aba87a8d1a5aab2)

* Explanation: This test crashes in the ModelIO library and blocks testing and creating a package.
* Scope: Disables a test that fails because of a library external to Swift
* Testing: CI Testing
* Risk: Low, this disables a test.

rdar://35490456 