### PR TITLE
[4.1] [di] Once we have exclusively borrowed self, if we go down the non-fo…

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -833,9 +833,21 @@ RValue SILGenFunction::emitRValueForSelfInDelegationInit(SILLocation loc,
   }
 
   // If we hit this point, we must have DidExclusiveBorrowSelf. We should have
-  // gone through the formal evaluation variant.
-  llvm_unreachable("Accessed self via non-formal evaluation API after "
-                   "exclusively borrowing self?!");
+  // gone through the formal evaluation variant but did not. The only way that
+  // this can happen is if during argument evaluation, we are accessing self in
+  // a way that is illegal before we call super. Return a copy of self in this
+  // case so that DI will flag on this issue. We do not care where the destroy
+  // occurs, so we can use a normal scoped copy.
+  ManagedValue Result;
+  if (!SuperInitDelegationSelf) {
+    Result = InitDelegationSelf.copy(*this, loc);
+  } else {
+    Result =
+        B.createUncheckedRefCast(loc, SuperInitDelegationSelf.copy(*this, loc),
+                                 InitDelegationSelf.getType());
+  }
+
+  return RValue(*this, loc, refType, Result);
 }
 
 RValue SILGenFunction::emitFormalEvaluationRValueForSelfInDelegationInit(

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1230,3 +1230,81 @@ class SuperConvenienceSub : SuperConvenienceBase {
     self.init(i1, i1)
   }
 }
+
+// While testing some changes I found this regression that wasn't
+// covered by any existing tests
+class Base {}
+
+func makeAnAny() -> Any { return 3 }
+
+class Derived : Base {
+  var x: Int?
+  var y: Int?
+
+  override init() {
+    x = makeAnAny() as? Int
+    y = makeAnAny() as? Int
+    super.init()
+  }
+}
+
+// This test makes sure that we properly error (but don't crash) when calling a
+// subclass method as an argument to a super.init.
+class MethodTestParent {
+  init(i: Int) {}
+}
+
+class MethodTestChild : MethodTestParent {
+  init() {
+    super.init(i: getInt()) // expected-error {{'self' used in method call 'getInt' before 'super.init' call}}
+  }
+
+  init(val: ()) {
+    // Currently we squelch the inner error of using self in method call for 'getInt2'
+    super.init(i: getInt2(x: self)) // expected-error {{'self' used in method call 'getInt2' before 'super.init' call}}
+  }
+
+  func getInt() -> Int {
+    return 0
+  }
+
+  func getInt2(x: MethodTestChild) -> Int {
+    return 0
+  }
+}
+
+// This test makes sure that if we cast self to a protocol (implicitly or not), we properly error.
+protocol ProtocolCastTestProtocol : class {
+}
+
+class ProtocolCastTestParent {
+  init(foo f: ProtocolCastTestProtocol) {
+  }
+
+  init(foo2 f: Any) {
+  }
+}
+
+class ProtocolCastTestChild : ProtocolCastTestParent, ProtocolCastTestProtocol {
+  private let value: Int
+
+  init(value1 v: Int) {
+    value = v
+    super.init(foo: self) // expected-error {{'self' used before 'super.init' call}}
+  }
+
+  init(value2 v: Int) {
+    value = v
+    super.init(foo: self as ProtocolCastTestProtocol) // expected-error {{'self' used before 'super.init' call}}
+  }
+
+  init(value3 v: Int) {
+    value = v
+    super.init(foo2: self) // expected-error {{'self' used before 'super.init' call}}
+  }
+
+  init(value4 v: Int) {
+    value = v
+    super.init(foo2: self as Any) // expected-error {{'self' used before 'super.init' call}}
+  }
+}


### PR DESCRIPTION
…rmal evaluation path, copy instead of asserting.

We can only do this for two reasons:

1. There is a code path that should have gone through the non-exclusively
borrowed self entrypoints, but they were not implemented.
2. We are trying to access self for an argument.

By copying the value, we preserve invariants around ownership and also make it
easy for DI to catch 2 and not blow up in the case of 1. It is better to error
in DI incorrectly, than to hit an unreachable (especially since in non-assert
builds, we don't trap at unreachables and just continue to the next function in
the text segment).

SR-5682
rdar://35402738

(cherry picked from commit 2914c6b0f53eb9063234ab11bdc126a3ce3922e5)
