### PR TITLE
Improve Plist and JSON Encoder/Decoder resilience to errors thrown during coding

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2011,9 +2011,9 @@ extension _JSONDecoder {
         switch self.options.dateDecodingStrategy {
         case .deferredToDate:
             self.storage.push(container: value)
-            let date = try Date(from: self)
-            self.storage.popContainer()
-            return date
+            defer { self.storage.popContainer() }
+
+            return try Date(from: self)
 
         case .secondsSince1970:
             let double = try self.unbox(value, as: Double.self)!
@@ -2045,9 +2045,9 @@ extension _JSONDecoder {
 
         case .custom(let closure):
             self.storage.push(container: value)
-            let date = try closure(self)
-            self.storage.popContainer()
-            return date
+            defer { self.storage.popContainer() }
+
+            return try closure(self)
         }
     }
 
@@ -2057,9 +2057,9 @@ extension _JSONDecoder {
         switch self.options.dataDecodingStrategy {
         case .deferredToData:
             self.storage.push(container: value)
-            let data = try Data(from: self)
-            self.storage.popContainer()
-            return data
+            defer { self.storage.popContainer() }
+
+            return try Data(from: self)
 
         case .base64:
             guard let string = value as? String else {
@@ -2074,9 +2074,9 @@ extension _JSONDecoder {
 
         case .custom(let closure):
             self.storage.push(container: value)
-            let data = try closure(self)
-            self.storage.popContainer()
-            return data
+            defer { self.storage.popContainer() }
+
+            return try closure(self)
         }
     }
 
@@ -2116,8 +2116,9 @@ extension _JSONDecoder {
             decoded = decimal as! T
         } else {
             self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+
             decoded = try type.init(from: self)
-            self.storage.popContainer()
         }
 
         return decoded


### PR DESCRIPTION
<!-- What's in this pull request? -->
`_JSONDecoder` internal state could be corrupted by trying to decode failing nested object. Fix this by ensuring storage stack pop after error throw.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6408](https://bugs.swift.org/projects/SR/issues/SR-6408).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->