### PR TITLE
[AST] Store only interface types in NormalProtocolConformances.

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -96,7 +96,7 @@ class alignas(1 << DeclAlignInBits) ProtocolConformance {
 
 protected:
   ProtocolConformance(ProtocolConformanceKind kind, Type conformingType)
-    : Kind(kind), ConformingType(conformingType) { }
+    : Kind(kind), ConformingType(conformingType) {}
 
 public:
   /// Determine the kind of protocol conformance.
@@ -371,7 +371,6 @@ class NormalProtocolConformance : public ProtocolConformance,
   /// by the ASTContext's LazyResolver, which is really a Sema instance.
   LazyConformanceLoader *Loader = nullptr;
   uint64_t LoaderContextData;
-
   friend class ASTContext;
 
   NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
@@ -380,6 +379,8 @@ class NormalProtocolConformance : public ProtocolConformance,
     : ProtocolConformance(ProtocolConformanceKind::Normal, conformingType),
       ProtocolAndState(protocol, state), Loc(loc), ContextAndInvalid(dc, false)
   {
+    assert(!conformingType->hasArchetype() &&
+           "ProtocolConformances should store interface types");
     differenceAndStoreConditionalRequirements();
   }
 
@@ -391,6 +392,8 @@ class NormalProtocolConformance : public ProtocolConformance,
       ProtocolAndState(protocol, state), Loc(loc),
       ContextAndInvalid(behaviorStorage, false)
   {
+    assert(!conformingType->hasArchetype() &&
+           "ProtocolConformances should store interface types");
     differenceAndStoreConditionalRequirements();
   }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1978,7 +1978,10 @@ void ASTMangler::appendProtocolConformance(const ProtocolConformance *conformanc
     appendProtocolName(conformance->getProtocol());
     appendIdentifier(behaviorStorage->getBaseName().getIdentifier().str());
   } else {
-    auto conformingType = conformance->getType()->mapTypeOutOfContext();
+    auto conformingType = conformance->getType();
+    if (!isa<NormalProtocolConformance>(conformance)) {
+      conformingType = conformingType->mapTypeOutOfContext();
+    }
     appendType(conformingType->getCanonicalType());
     appendProtocolName(conformance->getProtocol());
     appendModule(conformance->getDeclContext()->getParentModule());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1979,9 +1979,6 @@ void ASTMangler::appendProtocolConformance(const ProtocolConformance *conformanc
     appendIdentifier(behaviorStorage->getBaseName().getIdentifier().str());
   } else {
     auto conformingType = conformance->getType();
-    if (!isa<NormalProtocolConformance>(conformance)) {
-      conformingType = conformingType->mapTypeOutOfContext();
-    }
     appendType(conformingType->getCanonicalType());
     appendProtocolName(conformance->getProtocol());
     appendModule(conformance->getDeclContext()->getParentModule());

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -804,7 +804,7 @@ ProtocolConformance *ConformanceLookupTable::getConformance(
     conformingDC->getAsNominalTypeOrNominalTypeExtensionContext();
 
   // Form the conformance.
-  Type type = entry->getDeclContext()->getDeclaredTypeInContext();
+  Type type = entry->getDeclContext()->getDeclaredInterfaceType();
   ProtocolConformance *conformance;
     ASTContext &ctx = nominal->getASTContext();
   if (entry->getKind() == ConformanceEntryKind::Inherited) {
@@ -828,7 +828,7 @@ ProtocolConformance *ConformanceLookupTable::getConformance(
                     inheritedConformance->getConcrete());
   } else {
     // Create or find the normal conformance.
-    Type conformingType = conformingDC->getDeclaredTypeInContext();
+    Type conformingType = conformingDC->getDeclaredInterfaceType();
     SourceLoc conformanceLoc
       = conformingNominal == conformingDC
           ? conformingNominal->getLoc()

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6527,7 +6527,7 @@ void SwiftDeclConverter::addObjCProtocolConformances(
   for (unsigned i = 0, n = protocols.size(); i != n; ++i) {
     // FIXME: Build a superclass conformance if the superclass
     // conforms.
-    auto conformance = ctx.getConformance(dc->getDeclaredTypeInContext(),
+    auto conformance = ctx.getConformance(dc->getDeclaredInterfaceType(),
                                           protocols[i], SourceLoc(), dc,
                                           ProtocolConformanceState::Incomplete);
     conformance->setLazyLoader(&Impl, /*context*/0);

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -136,13 +136,16 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       Type First;
       Type Second;
       RequirementKind Kind;
+      CanType CanFirst;
+      CanType CanSecond;
+
       bool operator< (const Requirement& Rhs) const {
         if (Kind != Rhs.Kind)
           return Kind < Rhs.Kind;
-        else if (First.getPointer() != Rhs.First.getPointer())
-          return First.getPointer() < Rhs.First.getPointer();
+        else if (CanFirst != Rhs.CanFirst)
+          return CanFirst < Rhs.CanFirst;
         else
-          return Second.getPointer() < Rhs.Second.getPointer();
+          return CanSecond < Rhs.CanSecond;
       }
       bool operator== (const Requirement& Rhs) const {
         return (!(*this < Rhs)) && (!(Rhs < *this));
@@ -152,8 +155,13 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     bool HasDocComment;
     unsigned InheritsCount;
     std::set<Requirement> Requirements;
-    void addRequirement(Type First, Type Second, RequirementKind Kind) {
-      Requirements.insert({First, Second, Kind});
+    void addRequirement(GenericSignature *GenericSig,
+                        Type First, Type Second, RequirementKind Kind) {
+      CanType CanFirst = GenericSig->getCanonicalTypeInContext(First);
+      CanType CanSecond;
+      if (Second) CanSecond = GenericSig->getCanonicalTypeInContext(Second);
+
+      Requirements.insert({First, Second, Kind, CanFirst, CanSecond});
     }
     bool operator== (const ExtensionMergeInfo& Another) const {
       // Trivially unmergeable.
@@ -260,7 +268,8 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       subMap = BaseType->getContextSubstitutionMap(M, Ext);
 
     assert(Ext->getGenericSignature() && "No generic signature.");
-    for (auto Req : Ext->getGenericSignature()->getRequirements()) {
+    auto GenericSig = Ext->getGenericSignature();
+    for (auto Req : GenericSig->getRequirements()) {
       auto Kind = Req.getKind();
 
       // FIXME: Could do something here
@@ -289,14 +298,14 @@ struct SynthesizedExtensionAnalyzer::Implementation {
           if (!canPossiblyConvertTo(First, Second, *DC))
             return {Result, MergeInfo};
           else if (!isConvertibleTo(First, Second, *DC))
-            MergeInfo.addRequirement(First, Second, Kind);
+            MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           break;
 
         case RequirementKind::SameType:
           if (!canPossiblyEqual(First, Second, *DC)) {
             return {Result, MergeInfo};
           } else if (!First->isEqual(Second)) {
-            MergeInfo.addRequirement(First, Second, Kind);
+            MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           }
           break;
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -991,7 +991,7 @@ static bool isDependentConformance(IRGenModule &IGM,
         [&](AssociatedTypeDecl *requirement, Type type,
             TypeDecl *explicitDecl) -> bool {
           // RESILIENCE: this could be an opaque conformance
-          return DC->mapTypeIntoContext(type)->hasArchetype();
+          return type->hasTypeParameter();
        })) {
     return true;
   }
@@ -1209,7 +1209,10 @@ public:
     WitnessTableBuilder(IRGenModule &IGM, ConstantArrayBuilder &table,
                         SILWitnessTable *SILWT)
         : IGM(IGM), Table(table),
-          ConcreteType(SILWT->getConformance()->getDeclContext()->mapTypeIntoContext(SILWT->getConformance()->getType()->getCanonicalType())),
+          ConcreteType(SILWT->getConformance()->getDeclContext()
+                         ->mapTypeIntoContext(
+                           SILWT->getConformance()->getType()
+                             ->getCanonicalType())),
           Conformance(*SILWT->getConformance()),
           SILEntries(SILWT->getEntries()),
           SILConditionalConformances(SILWT->getConditionalConformances()),
@@ -2357,8 +2360,9 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
     if (sourceConformance.isConcrete() &&
         isa<NormalProtocolConformance>(sourceConformance.getConcrete())) {
       associatedType =
-        sourceConformance.getConcrete()->getDeclContext()->mapTypeIntoContext(associatedType)
-        ->getCanonicalType();
+        sourceConformance.getConcrete()->getDeclContext()
+          ->mapTypeIntoContext(associatedType)
+          ->getCanonicalType();
     }
     sourceKey.Type = associatedType;
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -981,8 +981,9 @@ static bool isDependentConformance(IRGenModule &IGM,
       return true;
   }
 
+  auto DC = conformance->getDeclContext();
   // If the conforming type isn't dependent, the below check is never true.
-  if (!conformance->getDeclContext()->isGenericContext())
+  if (!DC->isGenericContext())
     return false;
 
   // Check whether any of the associated types are dependent.
@@ -990,7 +991,7 @@ static bool isDependentConformance(IRGenModule &IGM,
         [&](AssociatedTypeDecl *requirement, Type type,
             TypeDecl *explicitDecl) -> bool {
           // RESILIENCE: this could be an opaque conformance
-          return type->hasArchetype();
+          return DC->mapTypeIntoContext(type)->hasArchetype();
        })) {
     return true;
   }
@@ -1208,7 +1209,7 @@ public:
     WitnessTableBuilder(IRGenModule &IGM, ConstantArrayBuilder &table,
                         SILWitnessTable *SILWT)
         : IGM(IGM), Table(table),
-          ConcreteType(SILWT->getConformance()->getType()->getCanonicalType()),
+          ConcreteType(SILWT->getConformance()->getDeclContext()->mapTypeIntoContext(SILWT->getConformance()->getType()->getCanonicalType())),
           Conformance(*SILWT->getConformance()),
           SILEntries(SILWT->getEntries()),
           SILConditionalConformances(SILWT->getConditionalConformances()),
@@ -1316,13 +1317,15 @@ public:
 
       SILEntries = SILEntries.slice(1);
 
-      CanType associate =
-        Conformance.getTypeWitness(requirement.getAssociation(), nullptr)
-          ->getCanonicalType();
+      auto interfaceAssociate =
+        Conformance.getTypeWitness(requirement.getAssociation(), nullptr);
 
       // This type will be expressed in terms of the archetypes
       // of the conforming context.
-      assert(!associate->hasTypeParameter());
+      assert(!interfaceAssociate->hasArchetype());
+      auto associate = Conformance.getDeclContext()->mapTypeIntoContext(interfaceAssociate)
+        ->getCanonicalType();
+
 
       llvm::Constant *metadataAccessFunction =
         getAssociatedTypeMetadataAccessFunction(requirement, associate);
@@ -1332,10 +1335,13 @@ public:
     void addAssociatedConformance(AssociatedConformance requirement) {
       // FIXME: Add static witness tables for type conformances.
 
-      CanType associate =
-        Conformance.getAssociatedType(requirement.getAssociation())
+      auto interfaceAssociate =
+        Conformance.getAssociatedType(requirement.getAssociation());
+      assert(!interfaceAssociate->hasArchetype());
+
+      auto associate =
+        Conformance.getDeclContext()->mapTypeIntoContext(interfaceAssociate)
           ->getCanonicalType();
-      assert(!associate->hasTypeParameter());
 
       ProtocolConformanceRef associatedConformance =
         Conformance.getAssociatedConformance(requirement.getAssociation(),
@@ -2347,7 +2353,13 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
 
     CanType associatedType =
       sourceConformance.getAssociatedType(sourceType, association)
+      ->getCanonicalType();
+    if (sourceConformance.isConcrete() &&
+        isa<NormalProtocolConformance>(sourceConformance.getConcrete())) {
+      associatedType =
+        sourceConformance.getConcrete()->getDeclContext()->mapTypeIntoContext(associatedType)
         ->getCanonicalType();
+    }
     sourceKey.Type = associatedType;
 
     auto associatedConformance =

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -879,12 +879,9 @@ emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance) {
   auto collectTypeWitness = [&](const AssociatedTypeDecl *AssocTy,
                                 Type Replacement,
                                 const TypeDecl *TD) -> bool {
-
-    auto Subst = Replacement->mapTypeOutOfContext();
-
     AssociatedTypes.push_back({
       AssocTy->getNameStr(),
-      Subst->getCanonicalType()
+      Replacement->getCanonicalType()
     });
     return false;
   };

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2687,6 +2687,8 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
     OS << "[serialized] ";
 
   getConformance()->printName(OS, Options);
+  Options.GenericEnv =
+    getConformance()->getDeclContext()->getGenericEnvironmentOfContext();
 
   if (isDeclaration()) {
     OS << "\n\n";
@@ -2727,7 +2729,7 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
       auto &assocWitness = witness.getAssociatedTypeWitness();
       OS << "associated_type ";
       OS << assocWitness.Requirement->getName() << ": ";
-      assocWitness.Witness->print(OS, PrintOptions::printSIL());
+      assocWitness.Witness->print(OS, Options);
       break;
     }
     case AssociatedTypeProtocol: {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1798,7 +1798,7 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
       // property is in a non-type context.
       Type behaviorSelf;
       if (dc->isTypeContext()) {
-        behaviorSelf = dc->getSelfTypeInContext();
+        behaviorSelf = dc->getSelfInterfaceType();
         assert(behaviorSelf && "type context doesn't have self type?!");
         if (var->isStatic())
           behaviorSelf = MetatypeType::get(behaviorSelf);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2015,7 +2015,8 @@ namespace {
     ConformanceChecker(TypeChecker &tc, NormalProtocolConformance *conformance,
                        llvm::SetVector<ValueDecl*> &GlobalMissingWitnesses,
                        bool suppressDiagnostics = true)
-        : WitnessChecker(tc, conformance->getProtocol(), conformance->getType(),
+        : WitnessChecker(tc, conformance->getProtocol(),
+                         conformance->getType(),
                          conformance->getDeclContext()),
           Conformance(conformance), Loc(conformance->getLoc()),
           GlobalMissingWitnesses(GlobalMissingWitnesses),
@@ -2714,6 +2715,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
              ->isEqual(type) && "Conflicting type witness deductions");
     return;
   }
+
+  assert(!type->hasArchetype() && "Got a contextual type here?");
 
   if (typeDecl) {
     // Check access.
@@ -3546,22 +3549,24 @@ static CheckTypeWitnessResult checkTypeWitness(TypeChecker &tc, DeclContext *dc,
   auto *depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                          assocType);
 
+  Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
+                                              : type;
   if (auto superclass = genericSig->getSuperclassBound(depTy)) {
-    if (!superclass->isExactSuperclassOf(type))
+    if (!superclass->isExactSuperclassOf(contextType))
       return superclass;
   }
 
   // Check protocol conformances.
   for (auto reqProto : genericSig->getConformsTo(depTy)) {
-    if (!tc.conformsToProtocol(type, reqProto, dc, None))
+    if (!tc.conformsToProtocol(contextType, reqProto, dc, None))
       return CheckTypeWitnessResult(reqProto->getDeclaredType());
 
     // FIXME: Why is conformsToProtocol() not enough? The stdlib doesn't
     // build unless we fail here while inferring an associated type
     // somewhere.
-    if (type->isSpecialized()) {
-      auto *decl = type->getAnyNominal();
-      auto subMap = type->getContextSubstitutionMap(
+    if (contextType->isSpecialized()) {
+      auto *decl = contextType->getAnyNominal();
+      auto subMap = contextType->getContextSubstitutionMap(
           dc->getParentModule(),
           decl,
           decl->getGenericEnvironmentOfContext());
@@ -3575,8 +3580,8 @@ static CheckTypeWitnessResult checkTypeWitness(TypeChecker &tc, DeclContext *dc,
   }
 
   if (genericSig->requiresClass(depTy)) {
-    if (!type->isObjCExistentialType() &&
-        !type->mayHaveSuperclass())
+    if (!contextType->isObjCExistentialType() &&
+        !contextType->mayHaveSuperclass())
       return CheckTypeWitnessResult(tc.Context.getAnyObjectType());
   }
 
@@ -3635,7 +3640,10 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
 
   // If there is a single viable candidate, form a substitution for it.
   if (viable.size() == 1) {
-    recordTypeWitness(assocType, viable.front().second, viable.front().first, true);
+    auto interfaceType = viable.front().second;
+    if (interfaceType->hasArchetype())
+      interfaceType = interfaceType->mapTypeOutOfContext();
+    recordTypeWitness(assocType, interfaceType, viable.front().first, true);
     return ResolveWitnessResult::Success;
   }
 
@@ -3808,7 +3816,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(
           if (!associatedTypesAreSameEquivalenceClass(dmt->getAssocType(),
                                                       result.first))
             return false;
-          if (!dmt->getBase()->isEqual(Conformance->getType()))
+          if (!dmt->getBase()->isEqual(DC->mapTypeIntoContext(Conformance->getType())))
             return false;
           
           // If this associated type is same-typed to another associated type
@@ -3875,6 +3883,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(
       if (!allUnresolved.count(result.first)) {
         auto existingWitness =
           Conformance->getTypeWitness(result.first, nullptr);
+        existingWitness = Conformance->getDeclContext()->mapTypeIntoContext(existingWitness);
 
         // If the deduced type contains an irreducible
         // DependentMemberType, that indicates a dependency
@@ -4007,7 +4016,7 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
   }
 
   // Retrieve the set of substitutions to be applied to the witness.
-  Type model = conformance->getType();
+  Type model = conformance->getDeclContext()->mapTypeIntoContext(conformance->getType());
   TypeSubstitutionMap substitutions = model->getMemberSubstitutions(witness);
   Type type = witness->getInterfaceType()->getReferenceStorageReferent();
   
@@ -4531,7 +4540,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
     // FIXME: Base this on dependent types rather than archetypes?
     TypeSubstitutionMap substitutions;
     substitutions[Proto->mapTypeIntoContext(selfType)
-        ->castTo<ArchetypeType>()] = Adoptee;
+        ->castTo<ArchetypeType>()] = DC->mapTypeIntoContext(Adoptee);
     for (auto assocType : Proto->getAssociatedTypeMembers()) {
       auto archetype = Proto->mapTypeIntoContext(
         assocType->getDeclaredInterfaceType())
@@ -4540,7 +4549,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
         continue;
       if (Conformance->hasTypeWitness(assocType)) {
         substitutions[archetype] =
-          Conformance->getTypeWitness(assocType, nullptr);
+          DC->mapTypeIntoContext(Conformance->getTypeWitness(assocType, nullptr));
       } else {
         auto known = typeWitnesses.begin(assocType);
         if (known != typeWitnesses.end())
@@ -4701,12 +4710,14 @@ void ConformanceChecker::resolveTypeWitnesses() {
             AssociatedTypeDecl *assocType) -> TypeBase * {
           if (conformance != Conformance) return nullptr;
 
-          return typeWitnesses.begin(assocType)->first.getPointer();
+          auto type = typeWitnesses.begin(assocType)->first;
+          return type->mapTypeOutOfContext().getPointer();
         };
 
+      auto typeInContext = Conformance->getDeclContext()->mapTypeIntoContext(Conformance->getType());
       auto substitutions =
-        SubstitutionMap::getProtocolSubstitutions(
-                                          Proto, Conformance->getType(),
+      SubstitutionMap::getProtocolSubstitutions(
+        Proto, typeInContext,
                                           ProtocolConformanceRef(Conformance));
 
       SmallVector<Requirement, 4> sanitizedRequirements;
@@ -4717,7 +4728,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
                                sanitizedRequirements);
       auto result =
         TC.checkGenericArguments(DC, SourceLoc(), SourceLoc(),
-                                 Conformance->getType(), requirementSig,
+                                 typeInContext, requirementSig,
                                  QuerySubstitutionMap{substitutions},
                                  TypeChecker::LookUpConformance(
                                    TC, Conformance->getDeclContext()),
@@ -5047,6 +5058,8 @@ void ConformanceChecker::resolveTypeWitnesses() {
       // away for some reason.
       if (replacement->hasDependentMember())
         replacement = ErrorType::get(TC.Context);
+      else if (replacement->hasArchetype())
+        replacement = replacement->mapTypeOutOfContext();
       recordTypeWitness(assocType, replacement, nullptr, true);
     }
 
@@ -5403,32 +5416,50 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
   auto reqSig = GenericSignature::get({proto->getProtocolSelfType()},
                                       proto->getRequirementSignature());
 
+  auto DC = Conformance->getDeclContext();
+  auto substitutingType = DC->mapTypeIntoContext(Conformance->getType());
   auto substitutions = SubstitutionMap::getProtocolSubstitutions(
-      proto, Conformance->getType(), ProtocolConformanceRef(Conformance));
+      proto, substitutingType, ProtocolConformanceRef(Conformance));
 
   // Create a writer to populate the signature conformances.
   std::function<void(ProtocolConformanceRef)> writer
     = Conformance->populateSignatureConformances();
 
   class GatherConformancesListener : public GenericRequirementsCheckListener {
+    TypeChecker &tc;
+    DeclContext *dc;
     std::function<void(ProtocolConformanceRef)> &writer;
   public:
     GatherConformancesListener(
+                         TypeChecker &tc, DeclContext *dc,
                          std::function<void(ProtocolConformanceRef)> &writer)
-      : writer(writer) { }
+      : tc(tc), dc(dc), writer(writer) { }
 
     void satisfiedConformance(Type depTy, Type replacementTy,
                               ProtocolConformanceRef conformance) override {
+      // The conformance will use contextual types, but we want the
+      // interface type equivalent.
+      if (conformance.isConcrete() &&
+          conformance.getConcrete()->getType()->hasArchetype()) {
+        auto interfaceType =
+          conformance.getConcrete()->getType()->mapTypeOutOfContext();
+        conformance = *tc.conformsToProtocol(
+                            interfaceType,
+                            conformance.getRequirement(),
+                            dc,
+                            ConformanceCheckFlags::SuppressDependencyTracking);
+      }
+
       writer(conformance);
     }
-  } listener(writer);
+  } listener(TC, DC, writer);
 
   auto result = TC.checkGenericArguments(
-      Conformance->getDeclContext(), Loc, Loc,
+      DC, Loc, Loc,
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(), reqSig,
       QuerySubstitutionMap{substitutions},
-      TypeChecker::LookUpConformance(TC, Conformance->getDeclContext()),
+      TypeChecker::LookUpConformance(TC, DC),
       nullptr,
       ConformanceCheckFlags::Used, &listener);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -625,7 +625,7 @@ NormalProtocolConformance *ModuleFile::readNormalConformance(
 
   ASTContext &ctx = getContext();
   DeclContext *dc = getDeclContext(contextID);
-  Type conformingType = dc->getDeclaredTypeInContext();
+  Type conformingType = dc->getDeclaredInterfaceType();
   PrettyStackTraceType trace(ctx, "reading conformance for", conformingType);
 
   auto proto = cast<ProtocolDecl>(getDecl(protoID));

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -88,7 +88,7 @@ func overlapping_sub_bad<U: P1>(_: U) {
 
 struct SameType<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType<Int>
-// CHECK-NEXT: (normal_conformance type=SameType<Int> protocol=P2
+// CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 Int)
 extension SameType: P2 where T == Int {}
 func same_type_good() {
@@ -102,7 +102,7 @@ func same_type_bad<U>(_: U) {
 
 struct SameTypeGeneric<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric<T, T>
-// CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, T> protocol=P2
+// CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
 extension SameTypeGeneric: P2 where T == U {}
 func same_type_generic_good<U, V>(_: U, _: V)
@@ -124,7 +124,7 @@ func same_type_bad<U, V>(_: U, _: V) {
 
 struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer<Constrained<U>, U>
-// CHECK-NEXT: (normal_conformance type=Infer<Constrained<U>, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type=Infer<T, U> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>
 // CHECK-NEXT:   conforms_to:  τ_0_1 P1)
 extension Infer: P2 where T == Constrained<U> {}
@@ -142,7 +142,7 @@ func infer_bad<U: P1, V>(_: U, _: V) {
 
 struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant<Constrained<U>, U>
-// CHECK-NEXT: (normal_conformance type=InferRedundant<Constrained<U>, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type=InferRedundant<T, U> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>)
 extension InferRedundant: P2 where T == Constrained<U> {}
 func infer_redundant_good<U: P1>(_: U) {
@@ -310,12 +310,12 @@ extension TwoDisjointConformances: P2 where T == String {}
 // true in the original type's generic signature.
 struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood<T, T>
-// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, T> protocol=P2
+// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, U> protocol=P2
 // CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad<T, T>
-// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, T> protocol=P2
+// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
 // CHECK-NEXT:   conforms_to: τ_0_0 P1
 // CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}

--- a/test/SILGen/conditional_conformance.swift
+++ b/test/SILGen/conditional_conformance.swift
@@ -19,7 +19,7 @@ extension Conformance: P1 where A: P2 {
 // CHECK-LABEL: sil_witness_table hidden <A where A : P2> Conformance<A>: P1 module conditional_conformance {
 // CHECK-NEXT:    method #P1.normal!1: <Self where Self : P1> (Self) -> () -> () : @_T023conditional_conformance11ConformanceVyxGAA2P1A2A2P2RzlAaEP6normalyyFTW	// protocol witness for P1.normal() in conformance <A> Conformance<A>
 // CHECK-NEXT:    method #P1.generic!1: <Self where Self : P1><T where T : P3> (Self) -> (T) -> () : @_T023conditional_conformance11ConformanceVyxGAA2P1A2A2P2RzlAaEP7genericyqd__AA2P3Rd__lFTW	// protocol witness for P1.generic<A>(_:) in conformance <A> Conformance<A>
-// CHECK-NEXT:    conditional_conformance (τ_0_0: P2): dependent
+// CHECK-NEXT:    conditional_conformance (A: P2): dependent
 // CHECK-NEXT:  }
 
 struct ConformanceAssoc<A> {}
@@ -30,8 +30,8 @@ extension ConformanceAssoc: P1 where A: P4, A.AT: P2 {
 // CHECK-LABEL: sil_witness_table hidden <A where A : P4, A.AT : P2> ConformanceAssoc<A>: P1 module conditional_conformance {
 // CHECK-NEXT:    method #P1.normal!1: <Self where Self : P1> (Self) -> () -> () : @_T023conditional_conformance16ConformanceAssocVyxGAA2P1A2A2P4RzAA2P22ATRpzlAaEP6normalyyFTW // protocol witness for P1.normal() in conformance <A> ConformanceAssoc<A>
 // CHECK-NEXT:    method #P1.generic!1: <Self where Self : P1><T where T : P3> (Self) -> (T) -> () : @_T023conditional_conformance16ConformanceAssocVyxGAA2P1A2A2P4RzAA2P22ATRpzlAaEP7genericyqd__AA2P3Rd__lFTW // protocol witness for P1.generic<A>(_:) in conformance <A> ConformanceAssoc<A>
-// CHECK-NEXT:    conditional_conformance (τ_0_0: P4): dependent
-// CHECK-NEXT:    conditional_conformance (τ_0_0.AT: P2): dependent
+// CHECK-NEXT:    conditional_conformance (A: P4): dependent
+// CHECK-NEXT:    conditional_conformance (A.AT: P2): dependent
 // CHECK-NEXT:  }
 
 /*
@@ -72,7 +72,7 @@ extension Base: P1 where A: P2 {
 // CHECK-LABEL: sil_witness_table hidden <A where A : P2> Base<A>: P1 module conditional_conformance {
 // CHECK-NEXT:  method #P1.normal!1: <Self where Self : P1> (Self) -> () -> () : @_T023conditional_conformance4BaseCyxGAA2P1A2A2P2RzlAaEP6normalyyFTW	// protocol witness for P1.normal() in conformance <A> Base<A>
 // CHECK-NEXT:    method #P1.generic!1: <Self where Self : P1><T where T : P3> (Self) -> (T) -> () : @_T023conditional_conformance4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyqd__AA2P3Rd__lFTW	// protocol witness for P1.generic<A>(_:) in conformance <A> Base<A>
-// CHECK-NEXT:    conditional_conformance (τ_0_0: P2): dependent
+// CHECK-NEXT:    conditional_conformance (A: P2): dependent
 // CHECK-NEXT:  }
 
 // These don't get separate witness tables, but shouldn't crash anything.

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -249,11 +249,11 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 // CHECK: }
 
 // CHECK: sil_witness_table hidden <Spices> Pizzas<Spices>.NewYork: Pizza module nested_generics {
-// CHECK:   associated_type Topping: Deli<Spices>.Pepperoni
+// CHECK:   associated_type Topping: Deli<τ_0_0>.Pepperoni
 // CHECK: }
 
 // CHECK: sil_witness_table hidden <Spices> Pizzas<Spices>.DeepDish: Pizza module nested_generics {
-// CHECK:   associated_type Topping: Deli<Spices>.Sausage
+// CHECK:   associated_type Topping: Deli<τ_0_0>.Sausage
 // CHECK: }
 
 // CHECK: sil_witness_table hidden HotDogs.Bratwurst: HotDog module nested_generics {

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -249,11 +249,11 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 // CHECK: }
 
 // CHECK: sil_witness_table hidden <Spices> Pizzas<Spices>.NewYork: Pizza module nested_generics {
-// CHECK:   associated_type Topping: Deli<τ_0_0>.Pepperoni
+// CHECK:   associated_type Topping: Deli<Spices>.Pepperoni
 // CHECK: }
 
 // CHECK: sil_witness_table hidden <Spices> Pizzas<Spices>.DeepDish: Pizza module nested_generics {
-// CHECK:   associated_type Topping: Deli<τ_0_0>.Sausage
+// CHECK:   associated_type Topping: Deli<Spices>.Sausage
 // CHECK: }
 
 // CHECK: sil_witness_table hidden HotDogs.Bratwurst: HotDog module nested_generics {

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -296,7 +296,7 @@ struct ConformingGeneric<R: AssocReqt> : AnyProtocol {
 func <~> <R: AssocReqt>(x: ConformingGeneric<R>, y: ConformingGeneric<R>) {}
 // TABLE-LABEL: sil_witness_table hidden <R where R : AssocReqt> ConformingGeneric<R>: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
-// TABLE-NEXT:    associated_type AssocWithReqt: τ_0_0
+// TABLE-NEXT:    associated_type AssocWithReqt: R
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): dependent
 // TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolA2aEP6method{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolA2aEP7generic{{[_0-9a-zA-Z]*}}FTW
@@ -323,7 +323,7 @@ struct ConformingGenericWithMoreGenericWitnesses<S: AssocReqt>
 func <~> <AA: AnotherProtocol, BB: AnotherProtocol>(x: AA, y: BB) {}
 // TABLE-LABEL: sil_witness_table hidden <S where S : AssocReqt> ConformingGenericWithMoreGenericWitnesses<S>: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
-// TABLE-NEXT:    associated_type AssocWithReqt: τ_0_0
+// TABLE-NEXT:    associated_type AssocWithReqt: S
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): dependent
 // TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolA2aEP6method{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolA2aEP7{{[_0-9a-zA-Z]*}}FTW
@@ -482,7 +482,7 @@ struct ConformsWithDependentAssocType1<CC: AssocReqt> : AssocTypeWithReqt {
   typealias AssocType = CC
 }
 // TABLE-LABEL: sil_witness_table hidden <CC where CC : AssocReqt> ConformsWithDependentAssocType1<CC>: AssocTypeWithReqt module witness_tables {
-// TABLE-NEXT:    associated_type AssocType: τ_0_0
+// TABLE-NEXT:    associated_type AssocType: CC
 // TABLE-NEXT:    associated_type_protocol (AssocType: AssocReqt): dependent
 // TABLE-NEXT:  }
 
@@ -490,7 +490,7 @@ struct ConformsWithDependentAssocType2<DD> : AssocTypeWithReqt {
   typealias AssocType = GenericAssocType<DD>
 }
 // TABLE-LABEL: sil_witness_table hidden <DD> ConformsWithDependentAssocType2<DD>: AssocTypeWithReqt module witness_tables {
-// TABLE-NEXT:    associated_type AssocType: GenericAssocType<τ_0_0>
+// TABLE-NEXT:    associated_type AssocType: GenericAssocType<DD>
 // TABLE-NEXT:    associated_type_protocol (AssocType: AssocReqt): <T> GenericAssocType<T>: AssocReqt module witness_tables
 // TABLE-NEXT:  }
 

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -12,7 +12,7 @@ struct Arg {}
 
 @objc class ObjCClass {}
 
-infix operator <~> {}
+infix operator <~>
 
 protocol AssocReqt {
   func requiredMethod()
@@ -26,33 +26,33 @@ protocol AnyProtocol {
   associatedtype AssocType
   associatedtype AssocWithReqt: AssocReqt
 
-  func method(x x: Arg, y: Self)
-  func generic<A: ArchetypeReqt>(x x: A, y: Self)
+  func method(x: Arg, y: Self)
+  func generic<A: ArchetypeReqt>(x: A, y: Self)
 
-  func assocTypesMethod(x x: AssocType, y: AssocWithReqt)
+  func assocTypesMethod(x: AssocType, y: AssocWithReqt)
 
-  static func staticMethod(x x: Self)
+  static func staticMethod(x: Self)
 
-  func <~>(x: Self, y: Self)
+  static func <~>(x: Self, y: Self)
 }
 
 protocol ClassProtocol : class {
   associatedtype AssocType
   associatedtype AssocWithReqt: AssocReqt
 
-  func method(x x: Arg, y: Self)
-  func generic<B: ArchetypeReqt>(x x: B, y: Self)
+  func method(x: Arg, y: Self)
+  func generic<B: ArchetypeReqt>(x: B, y: Self)
 
-  func assocTypesMethod(x x: AssocType, y: AssocWithReqt)
+  func assocTypesMethod(x: AssocType, y: AssocWithReqt)
 
-  static func staticMethod(x x: Self)
+  static func staticMethod(x: Self)
 
-  func <~>(x: Self, y: Self)
+  static func <~>(x: Self, y: Self)
 }
 
 @objc protocol ObjCProtocol {
-  func method(x x: ObjCClass)
-  static func staticMethod(y y: ObjCClass)
+  func method(x: ObjCClass)
+  static func staticMethod(y: ObjCClass)
 }
 
 class SomeAssoc {}
@@ -71,12 +71,12 @@ struct ConformingStruct : AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method(x x: Arg, y: ConformingStruct) {}
-  func generic<D: ArchetypeReqt>(x x: D, y: ConformingStruct) {}
+  func method(x: Arg, y: ConformingStruct) {}
+  func generic<D: ArchetypeReqt>(x: D, y: ConformingStruct) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: ConformingStruct) {}
+  static func staticMethod(x: ConformingStruct) {}
 }
 func <~>(x: ConformingStruct, y: ConformingStruct) {}
 // TABLE-LABEL: sil_witness_table hidden ConformingStruct: AnyProtocol module witness_tables {
@@ -108,12 +108,12 @@ struct ConformingAddressOnlyStruct : AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method(x x: Arg, y: ConformingAddressOnlyStruct) {}
-  func generic<E: ArchetypeReqt>(x x: E, y: ConformingAddressOnlyStruct) {}
+  func method(x: Arg, y: ConformingAddressOnlyStruct) {}
+  func generic<E: ArchetypeReqt>(x: E, y: ConformingAddressOnlyStruct) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: ConformingAddressOnlyStruct) {}
+  static func staticMethod(x: ConformingAddressOnlyStruct) {}
 }
 func <~>(x: ConformingAddressOnlyStruct, y: ConformingAddressOnlyStruct) {}
 // TABLE-LABEL: sil_witness_table hidden ConformingAddressOnlyStruct: AnyProtocol module witness_tables {
@@ -136,12 +136,12 @@ class ConformingClass : AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method(x x: Arg, y: ConformingClass) {}
-  func generic<F: ArchetypeReqt>(x x: F, y: ConformingClass) {}
+  func method(x: Arg, y: ConformingClass) {}
+  func generic<F: ArchetypeReqt>(x: F, y: ConformingClass) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  class func staticMethod(x x: ConformingClass) {}
+  class func staticMethod(x: ConformingClass) {}
 }
 func <~>(x: ConformingClass, y: ConformingClass) {}
 // TABLE-LABEL: sil_witness_table hidden ConformingClass: AnyProtocol module witness_tables {
@@ -165,12 +165,12 @@ extension ConformsByExtension : AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method(x x: Arg, y: ConformsByExtension) {}
-  func generic<G: ArchetypeReqt>(x x: G, y: ConformsByExtension) {}
+  func method(x: Arg, y: ConformsByExtension) {}
+  func generic<G: ArchetypeReqt>(x: G, y: ConformsByExtension) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: ConformsByExtension) {}
+  static func staticMethod(x: ConformsByExtension) {}
 }
 func <~>(x: ConformsByExtension, y: ConformsByExtension) {}
 // TABLE-LABEL: sil_witness_table hidden ConformsByExtension: AnyProtocol module witness_tables {
@@ -193,12 +193,12 @@ extension OtherModuleStruct : AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method(x x: Arg, y: OtherModuleStruct) {}
-  func generic<H: ArchetypeReqt>(x x: H, y: OtherModuleStruct) {}
+  func method(x: Arg, y: OtherModuleStruct) {}
+  func generic<H: ArchetypeReqt>(x: H, y: OtherModuleStruct) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: OtherModuleStruct) {}
+  static func staticMethod(x: OtherModuleStruct) {}
 }
 func <~>(x: OtherModuleStruct, y: OtherModuleStruct) {}
 // TABLE-LABEL: sil_witness_table hidden OtherModuleStruct: AnyProtocol module witness_tables {
@@ -223,12 +223,12 @@ struct ConformsWithMoreGenericWitnesses : AnyProtocol, OtherProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method<I, J>(x x: I, y: J) {}
-  func generic<K, L>(x x: K, y: L) {}
+  func method<I, J>(x: I, y: J) {}
+  func generic<K, L>(x: K, y: L) {}
 
-  func assocTypesMethod<M, N>(x x: M, y: N) {}
+  func assocTypesMethod<M, N>(x: M, y: N) {}
 
-  static func staticMethod<O>(x x: O) {}
+  static func staticMethod<O>(x: O) {}
 }
 func <~> <P: OtherProtocol>(x: P, y: P) {}
 // TABLE-LABEL: sil_witness_table hidden ConformsWithMoreGenericWitnesses: AnyProtocol module witness_tables {
@@ -251,12 +251,12 @@ class ConformingClassToClassProtocol : ClassProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
   
-  func method(x x: Arg, y: ConformingClassToClassProtocol) {}
-  func generic<Q: ArchetypeReqt>(x x: Q, y: ConformingClassToClassProtocol) {}
+  func method(x: Arg, y: ConformingClassToClassProtocol) {}
+  func generic<Q: ArchetypeReqt>(x: Q, y: ConformingClassToClassProtocol) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  class func staticMethod(x x: ConformingClassToClassProtocol) {}
+  class func staticMethod(x: ConformingClassToClassProtocol) {}
 }
 func <~>(x: ConformingClassToClassProtocol,
          y: ConformingClassToClassProtocol) {}
@@ -277,8 +277,8 @@ func <~>(x: ConformingClassToClassProtocol,
 // SYMBOL:  sil private [transparent] [thunk] @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0A2aDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW : $@convention(witness_method: ClassProtocol) (@owned ConformingClassToClassProtocol, @owned ConformingClassToClassProtocol, @thick ConformingClassToClassProtocol.Type) -> ()
 
 class ConformingClassToObjCProtocol : ObjCProtocol {
-  @objc func method(x x: ObjCClass) {}
-  @objc class func staticMethod(y y: ObjCClass) {}
+  @objc func method(x: ObjCClass) {}
+  @objc class func staticMethod(y: ObjCClass) {}
 }
 // TABLE-NOT:  sil_witness_table hidden ConformingClassToObjCProtocol
 
@@ -286,17 +286,17 @@ struct ConformingGeneric<R: AssocReqt> : AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = R
 
-  func method(x x: Arg, y: ConformingGeneric) {}
-  func generic<Q: ArchetypeReqt>(x x: Q, y: ConformingGeneric) {}
+  func method(x: Arg, y: ConformingGeneric) {}
+  func generic<Q: ArchetypeReqt>(x: Q, y: ConformingGeneric) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: R) {}
+  func assocTypesMethod(x: SomeAssoc, y: R) {}
 
-  static func staticMethod(x x: ConformingGeneric) {}
+  static func staticMethod(x: ConformingGeneric) {}
 }
 func <~> <R: AssocReqt>(x: ConformingGeneric<R>, y: ConformingGeneric<R>) {}
 // TABLE-LABEL: sil_witness_table hidden <R where R : AssocReqt> ConformingGeneric<R>: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
-// TABLE-NEXT:    associated_type AssocWithReqt: R
+// TABLE-NEXT:    associated_type AssocWithReqt: τ_0_0
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): dependent
 // TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolA2aEP6method{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolA2aEP7generic{{[_0-9a-zA-Z]*}}FTW
@@ -313,17 +313,17 @@ struct ConformingGenericWithMoreGenericWitnesses<S: AssocReqt>
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = S
 
-  func method<T, U>(x x: T, y: U) {}
-  func generic<V, W>(x x: V, y: W) {}
+  func method<T, U>(x: T, y: U) {}
+  func generic<V, W>(x: V, y: W) {}
 
-  func assocTypesMethod<X, Y>(x x: X, y: Y) {}
+  func assocTypesMethod<X, Y>(x: X, y: Y) {}
 
-  static func staticMethod<Z>(x x: Z) {}
+  static func staticMethod<Z>(x: Z) {}
 }
 func <~> <AA: AnotherProtocol, BB: AnotherProtocol>(x: AA, y: BB) {}
 // TABLE-LABEL: sil_witness_table hidden <S where S : AssocReqt> ConformingGenericWithMoreGenericWitnesses<S>: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
-// TABLE-NEXT:    associated_type AssocWithReqt: S
+// TABLE-NEXT:    associated_type AssocWithReqt: τ_0_0
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): dependent
 // TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolA2aEP6method{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolA2aEP7{{[_0-9a-zA-Z]*}}FTW
@@ -348,12 +348,12 @@ struct InheritedConformance : InheritedProtocol1 {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
 
-  func method(x x: Arg, y: InheritedConformance) {}
-  func generic<H: ArchetypeReqt>(x x: H, y: InheritedConformance) {}
+  func method(x: Arg, y: InheritedConformance) {}
+  func generic<H: ArchetypeReqt>(x: H, y: InheritedConformance) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: InheritedConformance) {}
+  static func staticMethod(x: InheritedConformance) {}
 
   func inheritedMethod() {}
 }
@@ -377,12 +377,12 @@ struct RedundantInheritedConformance : InheritedProtocol1, AnyProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
 
-  func method(x x: Arg, y: RedundantInheritedConformance) {}
-  func generic<H: ArchetypeReqt>(x x: H, y: RedundantInheritedConformance) {}
+  func method(x: Arg, y: RedundantInheritedConformance) {}
+  func generic<H: ArchetypeReqt>(x: H, y: RedundantInheritedConformance) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: RedundantInheritedConformance) {}
+  static func staticMethod(x: RedundantInheritedConformance) {}
 
   func inheritedMethod() {}
 }
@@ -406,12 +406,12 @@ struct DiamondInheritedConformance : InheritedProtocol1, InheritedProtocol2 {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
 
-  func method(x x: Arg, y: DiamondInheritedConformance) {}
-  func generic<H: ArchetypeReqt>(x x: H, y: DiamondInheritedConformance) {}
+  func method(x: Arg, y: DiamondInheritedConformance) {}
+  func generic<H: ArchetypeReqt>(x: H, y: DiamondInheritedConformance) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  static func staticMethod(x x: DiamondInheritedConformance) {}
+  static func staticMethod(x: DiamondInheritedConformance) {}
 
   func inheritedMethod() {}
 }
@@ -439,12 +439,12 @@ class ClassInheritedConformance : InheritedClassProtocol {
   typealias AssocType = SomeAssoc
   typealias AssocWithReqt = ConformingAssoc
 
-  func method(x x: Arg, y: ClassInheritedConformance) {}
-  func generic<H: ArchetypeReqt>(x x: H, y: ClassInheritedConformance) {}
+  func method(x: Arg, y: ClassInheritedConformance) {}
+  func generic<H: ArchetypeReqt>(x: H, y: ClassInheritedConformance) {}
 
-  func assocTypesMethod(x x: SomeAssoc, y: ConformingAssoc) {}
+  func assocTypesMethod(x: SomeAssoc, y: ConformingAssoc) {}
 
-  class func staticMethod(x x: ClassInheritedConformance) {}
+  class func staticMethod(x: ClassInheritedConformance) {}
 
   func inheritedMethod() {}
 }
@@ -482,7 +482,7 @@ struct ConformsWithDependentAssocType1<CC: AssocReqt> : AssocTypeWithReqt {
   typealias AssocType = CC
 }
 // TABLE-LABEL: sil_witness_table hidden <CC where CC : AssocReqt> ConformsWithDependentAssocType1<CC>: AssocTypeWithReqt module witness_tables {
-// TABLE-NEXT:    associated_type AssocType: CC
+// TABLE-NEXT:    associated_type AssocType: τ_0_0
 // TABLE-NEXT:    associated_type_protocol (AssocType: AssocReqt): dependent
 // TABLE-NEXT:  }
 
@@ -490,8 +490,8 @@ struct ConformsWithDependentAssocType2<DD> : AssocTypeWithReqt {
   typealias AssocType = GenericAssocType<DD>
 }
 // TABLE-LABEL: sil_witness_table hidden <DD> ConformsWithDependentAssocType2<DD>: AssocTypeWithReqt module witness_tables {
-// TABLE-NEXT:    associated_type AssocType: GenericAssocType<DD>
-// TABLE-NEXT:    associated_type_protocol (AssocType: AssocReqt): GenericAssocType<DD>: specialize <DD> (<T> GenericAssocType<T>: AssocReqt module witness_tables)
+// TABLE-NEXT:    associated_type AssocType: GenericAssocType<τ_0_0>
+// TABLE-NEXT:    associated_type_protocol (AssocType: AssocReqt): <T> GenericAssocType<T>: AssocReqt module witness_tables
 // TABLE-NEXT:  }
 
 protocol InheritedFromObjC : ObjCProtocol {
@@ -499,8 +499,8 @@ protocol InheritedFromObjC : ObjCProtocol {
 }
 
 class ConformsInheritedFromObjC : InheritedFromObjC {
-  @objc func method(x x: ObjCClass) {}
-  @objc class func staticMethod(y y: ObjCClass) {}
+  @objc func method(x: ObjCClass) {}
+  @objc class func staticMethod(y: ObjCClass) {}
   func inheritedMethod() {}
 }
 // TABLE-LABEL: sil_witness_table hidden ConformsInheritedFromObjC: InheritedFromObjC module witness_tables {

--- a/validation-test/compiler_crashers_2_fixed/rdar35441779.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar35441779.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-typecheck-verify-swift
+
+class Q {
+  var z: Q.z
+  
+  init () {
+    // FIXME: Per rdar://problem/35469647, this should be well-formed, but
+    // it's no longer crashing the compiler.
+    z = Q.z.M
+  }
+  
+  enum z: Int {
+    case M = 1
+  }
+}


### PR DESCRIPTION
Rather than storing contextual types in the type witnesses and associated
conformances of NormalProtocolConformance, store only interface types.

@huonw did most of the work here, and @DougGregor patched things up to
complete the change.

Part of rdar://problem/34944286.