### PR TITLE
-embed-bitcode: Pass -O options to backend jobs too!

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -636,6 +636,9 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     llvm_unreachable("invalid mode for backend job");
   }
 
+  // Add flags implied by -embed-bitcode.
+  Arguments.push_back("-embed-bitcode");
+
   // -embed-bitcode only supports a restricted set of flags.
   Arguments.push_back("-target");
   Arguments.push_back(context.Args.MakeArgString(getTriple().str()));
@@ -650,6 +653,10 @@ ToolChain::constructInvocation(const BackendJobAction &job,
   if (auto arg = context.Args.getLastArg(options::OPT_target_cpu))
     arg->render(context.Args, Arguments);
 
+  // Enable optimizations, but disable all LLVM-IR-level transformations.
+  context.Args.AddLastArg(Arguments, options::OPT_O_Group);
+  Arguments.push_back("-disable-llvm-optzns");
+
   context.Args.AddLastArg(Arguments, options::OPT_parse_stdlib);
 
   Arguments.push_back("-module-name");
@@ -662,11 +669,6 @@ ToolChain::constructInvocation(const BackendJobAction &job,
       Arguments.push_back(FileName.c_str());
     }
   }
-
-  // Add flags implied by -embed-bitcode.
-  Arguments.push_back("-embed-bitcode");
-  // Disable all llvm IR level optimizations.
-  Arguments.push_back("-disable-llvm-optzns");
 
   return {SWIFT_EXECUTABLE_NAME, Arguments};
 }

--- a/test/Driver/embed-bitcode.swift
+++ b/test/Driver/embed-bitcode.swift
@@ -49,15 +49,35 @@
 // CHECK-SINGLE: -embed-bitcode
 // CHECK-SINGLE: -disable-llvm-optzns
 
+// RUN: %target-swiftc_driver -embed-bitcode -force-single-frontend-invocation -O %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-OPT
+// CHECK-SINGLE-OPT: -frontend
+// CHECK-SINGLE-OPT-SAME: -emit-bc
+// CHECK-SINGLE-OPT-SAME: -O{{[" ]}}
+// CHECK-SINGLE-OPT-NEXT: -frontend
+// CHECK-SINGLE-OPT-SAME: -c
+// CHECK-SINGLE-OPT-SAME: -embed-bitcode
+// CHECK-SINGLE-OPT-SAME: -O{{[" ]}}
+// CHECK-SINGLE-OPT-SAME: -disable-llvm-optzns
+
+// RUN: %target-swiftc_driver -embed-bitcode -force-single-frontend-invocation -Osize %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-OPT-SIZE
+// CHECK-SINGLE-OPT-SIZE: -frontend
+// CHECK-SINGLE-OPT-SIZE-SAME: -emit-bc
+// CHECK-SINGLE-OPT-SIZE-SAME: -Osize
+// CHECK-SINGLE-OPT-SIZE-NEXT: -frontend
+// CHECK-SINGLE-OPT-SIZE-SAME: -c
+// CHECK-SINGLE-OPT-SIZE-SAME: -embed-bitcode
+// CHECK-SINGLE-OPT-SIZE-SAME: -Osize
+// CHECK-SINGLE-OPT-SIZE-SAME: -disable-llvm-optzns
+
 // RUN: %target-swiftc_driver -embed-bitcode -c -parse-as-library -emit-module -force-single-frontend-invocation %s -parse-stdlib -module-name Swift 2>&1 -### | %FileCheck %s -check-prefix=CHECK-LIB-WMO
 // CHECK-LIB-WMO: -frontend
 // CHECK-LIB-WMO: -emit-bc
 // CHECK-LIB-WMO: -parse-stdlib
 // CHECK-LIB-WMO: -frontend
 // CHECK-LIB-WMO: -c
-// CHECK-LIB-WMO: -parse-stdlib
 // CHECK-LIB-WMO: -embed-bitcode
 // CHECK-LIB-WMO: -disable-llvm-optzns
+// CHECK-LIB-WMO: -parse-stdlib
 
 // RUN: %target-swiftc_driver -embed-bitcode -c -parse-as-library -emit-module %s %S/../Inputs/empty.swift -module-name ABC 2>&1 -### | %FileCheck %s -check-prefix=CHECK-LIB
 // CHECK-LIB: swift -frontend

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -1,11 +1,21 @@
 ; REQUIRES: CPU=x86_64
 ; RUN: llvm-as %s -o %t.bc
-; RUN: %swift -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
+
+; This test uses '%swiftc_driver_plain -frontend' instead of '%swift' or
+; '%target-swift-frontend' because it checks the contents of the command line as
+; serialized in the object file.
+
+; RUN: %swiftc_driver_plain -frontend -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -Xllvm -time-passes -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
 ; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t2.o | %FileCheck %s
 ; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t2.o | %FileCheck -check-prefix=CHECK-CMD %s
-; RUN: %FileCheck -check-prefix CHECK-IMPORTER %s < %t.diags.txt
+; RUN: %FileCheck -check-prefix CHECK-COMPILER %s < %t.diags.txt
 
-; RUN: %swift -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode-marker  -o %t3.o %t.bc
+; RUN: %swiftc_driver_plain -frontend -O -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -Xllvm -time-passes -o %t2-opt.o %t.bc -dump-clang-diagnostics 2> %t.diags-opt.txt
+; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t2-opt.o | %FileCheck %s
+; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t2-opt.o | %FileCheck -check-prefix=CHECK-CMD-OPT %s
+; RUN: %FileCheck -check-prefix CHECK-COMPILER-OPT %s < %t.diags-opt.txt
+
+; RUN: %swiftc_driver_plain -frontend -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode-marker  -o %t3.o %t.bc
 ; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t3.o | %FileCheck -check-prefix=MARKER %s
 ; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t3.o | %FileCheck -check-prefix=MARKER-CMD %s
 
@@ -14,16 +24,33 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 ; CHECK: Contents of (__LLVM,__bitcode) section
 ; CHECK-CMD: Contents of (__LLVM,__swift_cmdline) section
+; -target
+; CHECK-CMD: {{^[0-9a-f]+}} 2d 74 61 72 67 65 74 00
+; CHECK-CMD-OPT: Contents of (__LLVM,__swift_cmdline) section
+; -O -target
+; CHECK-CMD-OPT: {{^[0-9a-f]+}} 2d 4f 00 2d 74 61 72 67 65 74 00
 
 ; MARKER: Contents of (__LLVM,__bitcode) section
 ; MARKER-NEXT: 00
 ; MARKER-CMD: Contents of (__LLVM,__swift_cmdline) section
 ; MARKER-CMD-NEXT: 00
 
-; CHECK-IMPORTER: clang
-; CHECK-IMPORTER: -fembed-bitcode
-; CHECK-IMPORTER: -target
-; CHECK-IMPORTER-NOT: argument unused
+; CHECK-COMPILER-NOT: argument unused
+; CHECK-COMPILER: clang
+; CHECK-COMPILER-SAME: -fembed-bitcode
+; CHECK-COMPILER-SAME: -target
+; CHECK-COMPILER-NOT: argument unused
+; CHECK-COMPILER: Fast Register Allocator
+
+; CHECK-COMPILER-OPT-NOT: argument unused
+; CHECK-COMPILER-OPT: clang
+; CHECK-COMPILER-OPT-SAME: -fembed-bitcode
+; CHECK-COMPILER-OPT-SAME: -target
+; CHECK-COMPILER-OPT-SAME: -Os
+; CHECK-COMPILER-OPT-NOT: argument unused
+; CHECK-COMPILER-OPT-DAG: Control Flow Optimizer
+; CHECK-COMPILER-OPT-DAG: Machine Common Subexpression Elimination
+; CHECK-COMPILER-OPT-DAG: ObjC ARC contraction
 
 define i32 @f0() nounwind ssp {
        ret i32 0


### PR DESCRIPTION
Otherwise, we leave optimization opportunities on the table, and in some cases even fail to remove marker intrinsics inserted by earlier optimization.

Background: under -embed-bitcode, compilation happens in two stages: a "frontend" job that compiles Swift code, generates LLVM IR, optimizes it, and then emits a .bc file; and a "backend" job that takes that .bc, converts it to assembly, and emits an object file with the original bitcode embedded. However, there are actually optimization passes that run before and during that "convert to assembly" step that were getting completely skipped.

rdar://problem/34864094