### PR TITLE
[Driver] Use simpler idiom for forwarding -target-cpu

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -121,8 +121,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   }
 
   // Handle the CPU and its preferences.
-  if (auto arg = inputArgs.getLastArg(options::OPT_target_cpu))
-    arg->render(inputArgs, arguments);
+  inputArgs.AddLastArg(arguments, options::OPT_target_cpu);
 
   if (!OI.SDKPath.empty()) {
     arguments.push_back("-sdk");
@@ -650,8 +649,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
   }
 
   // Handle the CPU and its preferences.
-  if (auto arg = context.Args.getLastArg(options::OPT_target_cpu))
-    arg->render(context.Args, Arguments);
+  context.Args.AddLastArg(Arguments, options::OPT_target_cpu);
 
   // Enable optimizations, but disable all LLVM-IR-level transformations.
   context.Args.AddLastArg(Arguments, options::OPT_O_Group);

--- a/test/Driver/embed-bitcode.swift
+++ b/test/Driver/embed-bitcode.swift
@@ -69,6 +69,16 @@
 // CHECK-SINGLE-OPT-SIZE-SAME: -Osize
 // CHECK-SINGLE-OPT-SIZE-SAME: -disable-llvm-optzns
 
+// RUN: %target-swiftc_driver -embed-bitcode -target-cpu abc -force-single-frontend-invocation %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-MISC
+// CHECK-SINGLE-MISC: -frontend
+// CHECK-SINGLE-MISC-SAME: -emit-bc
+// CHECK-SINGLE-MISC-SAME: -target-cpu abc
+// CHECK-SINGLE-MISC: -frontend
+// CHECK-SINGLE-MISC-SAME: -c
+// CHECK-SINGLE-MISC-SAME: -embed-bitcode
+// CHECK-SINGLE-MISC-SAME: -target-cpu abc
+// CHECK-SINGLE-MISC-SAME: -disable-llvm-optzns
+
 // RUN: %target-swiftc_driver -embed-bitcode -c -parse-as-library -emit-module -force-single-frontend-invocation %s -parse-stdlib -module-name Swift 2>&1 -### | %FileCheck %s -check-prefix=CHECK-LIB-WMO
 // CHECK-LIB-WMO: -frontend
 // CHECK-LIB-WMO: -emit-bc


### PR DESCRIPTION
No functionality change, but now at least we're testing this more explicitly than just in test/Misc/tbi.sil.