### PR TITLE
[sourcekitd] Fix a race in EditableTextBuffer::getSnapshot()

### DIFF
--- a/tools/SourceKit/include/SourceKit/Support/ImmutableTextBuffer.h
+++ b/tools/SourceKit/include/SourceKit/Support/ImmutableTextBuffer.h
@@ -153,7 +153,7 @@ public:
 };
 
 class EditableTextBuffer : public ThreadSafeRefCountedBase<EditableTextBuffer> {
-  llvm::sys::Mutex EditMtx;
+  mutable llvm::sys::Mutex EditMtx;
   ImmutableTextBufferRef Root;
   ImmutableTextUpdateRef CurrUpd;
   std::string Filename;

--- a/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
+++ b/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
@@ -126,6 +126,7 @@ EditableTextBuffer::EditableTextBuffer(StringRef Filename, StringRef Text) {
 }
 
 ImmutableTextSnapshotRef EditableTextBuffer::getSnapshot() const {
+  llvm::sys::ScopedLock L(EditMtx);
   return new ImmutableTextSnapshot(const_cast<EditableTextBuffer*>(this), Root,
                                    CurrUpd);
 }


### PR DESCRIPTION
Found by TSan!

This was found while trying to reproduce a test failure on a linux bot
while running the test/Misc/stats.swift test.  Hopefully this was the
underlying issue.

rdar://35537968