### PR TITLE
[Serialization] Recover if a typealias's underlying type is broken

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 386; // Last change: @callee_guaranted closures
+const uint16_t VERSION_MINOR = 387; // Last change: dependencies for typealiases
 
 using DeclIDField = BCFixed<31>;
 
@@ -819,7 +819,8 @@ namespace decls_block {
     TypeIDField, // interface type (no longer used)
     BCFixed<1>,  // implicit flag
     GenericEnvironmentIDField, // generic environment
-    AccessLevelField // access level
+    AccessLevelField, // access level
+    BCArray<TypeIDField> // dependency types
     // Trailed by generic parameters (if any).
   >;
 

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -52,6 +52,12 @@ let _ = unwrapped // okay
 _ = usesWrapped(nil) // expected-error {{use of unresolved identifier 'usesWrapped'}}
 _ = usesUnwrapped(nil) // expected-error {{nil is not compatible with expected argument type 'Int32'}}
 
+let _: WrappedAlias = nil // expected-error {{use of undeclared type 'WrappedAlias'}}
+let _: UnwrappedAlias = nil // expected-error {{nil cannot initialize specified type 'UnwrappedAlias' (aka 'Int32')}} expected-note {{add '?'}}
+
+let _: ConstrainedWrapped<Int> = nil // expected-error {{use of undeclared type 'ConstrainedWrapped'}}
+let _: ConstrainedUnwrapped<Int> = nil // expected-error {{type 'Int' does not conform to protocol 'HasAssoc'}}
+
 func testExtensions(wrapped: WrappedInt, unwrapped: UnwrappedInt) {
   wrapped.wrappedMethod() // expected-error {{value of type 'WrappedInt' (aka 'Int32') has no member 'wrappedMethod'}}
   unwrapped.unwrappedMethod() // expected-error {{value of type 'UnwrappedInt' has no member 'unwrappedMethod'}}
@@ -343,5 +349,11 @@ public func returnsWrappedGeneric<T>(_: T.Type) -> WrappedInt { fatalError() }
 
 public protocol WrappedProto {}
 public protocol UnwrappedProto {}
+
+public typealias WrappedAlias = WrappedInt
+public typealias UnwrappedAlias = UnwrappedInt
+
+public typealias ConstrainedWrapped<T: HasAssoc> = T where T.Assoc == WrappedInt
+public typealias ConstrainedUnwrapped<T: HasAssoc> = T where T.Assoc == UnwrappedInt
 
 #endif // TEST


### PR DESCRIPTION
We could handle a typealias itself disappearing, but not if the typealias was okay but the underlying type wasn't. This came up in real Swift 3/4 mix-and-match code.

rdar://problem/34940079