### PR TITLE
[ASTWalker|Refactoring] Walk generic params and requirements in source order for subscript decls

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1295,8 +1295,7 @@ public:
     return Requirements.slice(0, FirstTrailingWhereArg);
   }
 
-  /// Retrieve only those requirements that are written within the brackets,
-  /// which does not include any requirements written in a trailing where
+  /// Retrieve only those requirements written in a trailing where
   /// clause.
   ArrayRef<RequirementRepr> getTrailingRequirements() const {
     return Requirements.slice(FirstTrailingWhereArg);

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -354,10 +354,6 @@ parseFreestandingGenericWhereClause(GenericParamList *&genericParams,
       addToScope(pd);
   
   SmallVector<RequirementRepr, 4> Requirements;
-  if (genericParams)
-    Requirements.append(genericParams->getRequirements().begin(),
-                        genericParams->getRequirements().end());
-  
   SourceLoc WhereLoc;
   bool FirstTypeInComplete;
   auto result = parseGenericWhereClause(WhereLoc, Requirements,
@@ -368,11 +364,7 @@ parseFreestandingGenericWhereClause(GenericParamList *&genericParams,
   if (!genericParams)
     diagnose(WhereLoc, diag::where_without_generic_params, unsigned(kind));
   else
-    genericParams = GenericParamList::create(Context,
-                                             genericParams->getLAngleLoc(),
-                                             genericParams->getParams(),
-                                             WhereLoc, Requirements,
-                                             genericParams->getRAngleLoc());
+    genericParams->addTrailingWhereClause(Context, WhereLoc, Requirements);
   return ParserStatus();
 }
 

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -1310,9 +1310,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 1405,
     key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1407,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
@@ -1320,7 +1325,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1417,
     key.length: 1
   },
@@ -1364,16 +1369,6 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1471,
     key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1405,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1407,
-    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -1748,8 +1748,13 @@
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 1919,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1921,
     key.length: 1
   },
   {
@@ -1758,7 +1763,9 @@
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "T",
+    key.usr: "s:8__main__6genfooyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp",
     key.offset: 1924,
     key.length: 1
   },
@@ -1782,28 +1789,11 @@
     key.length: 7
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1919,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1921,
-    key.length: 1
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
     key.offset: 1946,
     key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "T",
-    key.usr: "s:8__main__6genfooyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp",
-    key.offset: 1924,
-    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -1294,6 +1294,16 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.length: 2
   },
   {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1532,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1534,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1532,
     key.length: 1
@@ -1304,8 +1314,18 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.length: 2
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1538,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1542,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1544,
     key.length: 2
   },
   {
@@ -1319,7 +1339,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.length: 2
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1548,
     key.length: 2
   },
@@ -1377,26 +1397,6 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.name: "C1",
     key.usr: "s:4cake2C1C",
     key.offset: 1602,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1532,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1534,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1542,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1544,
     key.length: 2
   },
   {

--- a/test/SourceKit/Refactoring/find-rename-ranges/rename-P.expected
+++ b/test/SourceKit/Refactoring/find-rename-ranges/rename-P.expected
@@ -1,0 +1,14 @@
+source.edit.kind.active:
+  84:10-84:11 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  86:18-86:19 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  91:16-91:17 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  91:33-91:34 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  91:57-91:58 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  91:63-91:64 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  91:74-91:75 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/syntactic-rename.swift
+++ b/test/SourceKit/Refactoring/syntactic-rename.swift
@@ -81,6 +81,17 @@ struct MultiPaneLayout<A: Layer, B: Layer>: Layer where A.Content == B.Content{
   typealias Content = Int
 }
 
+protocol P {}
+struct S {
+    subscript<K: P>(key: K) -> Int {
+        return 0
+    }
+}
+protocol Q {}
+func genfoo<T: P, U, V where U: P>(x: T, y: U, z: V, a: P) -> P where V: P {
+  fatalError()
+}
+
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/x.in.json %s >> %t.result/x.expected
 // RUN: diff -u %S/syntactic-rename/x.expected %t.result/x.expected
@@ -103,6 +114,8 @@ struct MultiPaneLayout<A: Layer, B: Layer>: Layer where A.Content == B.Content{
 // RUN: diff -u %S/syntactic-rename/rename-memberwise.expected %t.result/rename-memberwise.expected
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/rename-layer.in.json %s >> %t.result/rename-layer.expected
 // RUN: diff -u %S/syntactic-rename/rename-layer.expected %t.result/rename-layer.expected
+// RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/rename-P.in.json %s -- -swift-version 3 >> %t.result/rename-P.expected
+// RUN: diff -u %S/syntactic-rename/rename-P.expected %t.result/rename-P.expected
 
 // RUN: rm -rf %t.ranges && mkdir -p %t.ranges
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/x.in.json %s >> %t.ranges/x.expected
@@ -123,3 +136,5 @@ struct MultiPaneLayout<A: Layer, B: Layer>: Layer where A.Content == B.Content{
 // RUN: diff -u %S/find-rename-ranges/rename-memberwise.expected %t.ranges/rename-memberwise.expected
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/rename-layer.in.json %s >> %t.ranges/rename-layer.expected
 // RUN: diff -u %S/find-rename-ranges/rename-layer.expected %t.ranges/rename-layer.expected
+// RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/rename-P.in.json %s -- -swift-version 3 >> %t.ranges/rename-P.expected
+// RUN: diff -u %S/find-rename-ranges/rename-P.expected %t.ranges/rename-P.expected

--- a/test/SourceKit/Refactoring/syntactic-rename/rename-P.expected
+++ b/test/SourceKit/Refactoring/syntactic-rename/rename-P.expected
@@ -1,0 +1,14 @@
+source.edit.kind.active:
+  84:10-84:11 "NewP"
+source.edit.kind.active:
+  86:18-86:19 "NewP"
+source.edit.kind.active:
+  91:16-91:17 "NewP"
+source.edit.kind.active:
+  91:33-91:34 "NewP"
+source.edit.kind.active:
+  91:57-91:58 "NewP"
+source.edit.kind.active:
+  91:63-91:64 "NewP"
+source.edit.kind.active:
+  91:74-91:75 "NewP"

--- a/test/SourceKit/Refactoring/syntactic-rename/rename-P.in.json
+++ b/test/SourceKit/Refactoring/syntactic-rename/rename-P.in.json
@@ -1,0 +1,45 @@
+[
+  {
+    "key.name": "P",
+    "key.newname": "NewP",
+    "key.is_function_like": 0,
+    "key.is_non_protocol_type": 0,
+    "key.locations": [
+      {
+        "key.line": 84,
+        "key.column": 10,
+        "key.nametype": source.syntacticrename.definition
+      },
+      {
+        "key.line": 86,
+        "key.column": 18,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 91,
+        "key.column": 16,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 91,
+        "key.column": 33,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 91,
+        "key.column": 57,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 91,
+        "key.column": 63,
+        "key.nametype": source.syntacticrename.reference
+      },
+      {
+        "key.line": 91,
+        "key.column": 74,
+        "key.nametype": source.syntacticrename.reference
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- What's in this pull request? -->
Also walk generic requirements in non-trailing `where` clauses (that appear in the `<>` with `-swift-version 3`) in the correct order, rather than assuming all requirements come from a trailing `where` clause.

This fixes a few rename failures due to out-of-source-order walking.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/34859742

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->