### PR TITLE
Remove invalid preset option

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1643,7 +1643,6 @@ build-runtime-with-host-compiler=0
 skip-build-benchmarks
 llvm-include-tests=0
 llvm-enable-modules=0
-build-swift-ios-test=0
 build-swift-examples=0
 swift-include-tests=0
 darwin-deployment-version-ios=10.0


### PR DESCRIPTION
Removed invalid preset option `build-swift-ios-test` which has never existed AFAIK.

rdar://35602853