### PR TITLE
[runtime] Remove _swift_getSuperclass().

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -259,7 +259,7 @@ _dynamicCastClassMetatype(const ClassMetadata *sourceType,
     if (sourceType == targetType) {
       return sourceType;
     }
-    sourceType = _swift_getSuperclass(sourceType);
+    sourceType = sourceType->SuperClass;
   } while (sourceType);
   
   return nullptr;
@@ -3213,7 +3213,7 @@ bool _swift_isClassOrObjCExistentialType(const Metadata *value,
   return swift_isClassOrObjCExistentialTypeImpl(T);
 }
 
-SWIFT_CC(swift)
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
   if (const ClassMetadata *classType = theClass->getClassObject())
     if (classHasSuperclass(classType))

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -3213,7 +3213,7 @@ bool _swift_isClassOrObjCExistentialType(const Metadata *value,
   return swift_isClassOrObjCExistentialTypeImpl(T);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SWIFT_CC(swift)
 const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
   if (const ClassMetadata *classType = theClass->getClassObject())
     if (classHasSuperclass(classType))

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -116,11 +116,6 @@ namespace swift {
   LLVM_LIBRARY_VISIBILITY
   const ClassMetadata *_swift_getClass(const void *object);
 
-  static inline
-  const ClassMetadata *_swift_getSuperclass(const ClassMetadata *theClass) {
-    return theClass->SuperClass;
-  }
-
   LLVM_LIBRARY_VISIBILITY
   bool usesNativeSwiftReferenceCounting(const ClassMetadata *theClass);
 

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -761,14 +761,14 @@ SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
 intptr_t swift_ObjCMirror_count(HeapObject *owner,
                                 const OpaqueValue *value,
                                 const Metadata *type) {
-  auto isa = (Class)type;
+  auto isa = (const ClassMetadata *)type;
 
   unsigned count = 0;
   // ObjC makes no guarantees about the state of ivars, so we can't safely
   // introspect them in the general case.
 
   // The superobject counts as a child.
-  if (_swift_getSuperclass((const ClassMetadata*) isa))
+  if (isa->SuperClass)
     count += 1;
 
   swift_release(owner);
@@ -790,7 +790,7 @@ void swift_ObjCMirror_subscript(String *outString,
   auto isa = (Class)type;
 
   // If there's a superclass, it becomes the first child.
-  if (auto sup = (Class) _swift_getSuperclass((const ClassMetadata*) isa)) {
+  if (auto sup = class_getSuperclass(isa)) {
     if (i == 0) {
       const char *supName = class_getName(sup);
       new (outString) String(supName, strlen(supName));

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -453,9 +453,10 @@ bool swift::usesNativeSwiftReferenceCounting(const ClassMetadata *theClass) {
 /// reference-counting.  The metadata is known to correspond to a class
 /// type, but note that does not imply being known to be a ClassMetadata
 /// due to the existence of ObjCClassWrapper.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SWIFT_CC(swift)
+SWIFT_RUNTIME_EXPORT
 bool
-_objcClassUsesNativeSwiftReferenceCounting(const Metadata *theClass) {
+swift_objc_class_usesNativeSwiftReferenceCounting(const Metadata *theClass) {
 #if SWIFT_OBJC_INTEROP
   // If this is ObjC wrapper metadata, the class is definitely not using
   // Swift ref-counting.
@@ -1425,9 +1426,9 @@ bool swift::swift_isUniquelyReferencedOrPinned_nonNull_native(
 
 using ClassExtents = TwoWordPair<size_t, size_t>;
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
 ClassExtents::Return
-_getSwiftClassInstanceExtents(const Metadata *c) {
+swift_class_getInstanceExtents(const Metadata *c) {
   assert(c && c->isClassObject());
   auto metaData = c->getClassObject();
   return ClassExtents{
@@ -1438,14 +1439,15 @@ _getSwiftClassInstanceExtents(const Metadata *c) {
 
 #if SWIFT_OBJC_INTEROP
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SWIFT_CC(swift)
+SWIFT_RUNTIME_EXPORT
 ClassExtents::Return
-_getObjCClassInstanceExtents(const ClassMetadata* c) {
+swift_objc_class_unknownGetInstanceExtents(const ClassMetadata* c) {
   // Pure ObjC classes never have negative extents.
   if (c->isPureObjC())
     return ClassExtents{0, class_getInstanceSize(class_const_cast(c))};
 
-  return _getSwiftClassInstanceExtents(c);
+  return swift_class_getInstanceExtents(c);
 }
 
 SWIFT_CC(swift)


### PR DESCRIPTION
There are too many superclass-lookup functions.
This one does not pull its own weight.