### PR TITLE
[Syntax] Rewrite SyntaxParsingContext

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -83,7 +83,6 @@ namespace syntax {
   class SourceFileSyntax;
   class SyntaxParsingContext;
   class SyntaxParsingContextRoot;
-  struct RawSyntaxInfo;
 }
 
 /// Discriminator for file-units.
@@ -1083,21 +1082,15 @@ public:
   bool shouldKeepSyntaxInfo() const;
 
   syntax::SourceFileSyntax getSyntaxRoot() const;
+  void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
+  bool hasSyntaxRoot() const;
 
 private:
-  friend class syntax::SyntaxParsingContext;
-  friend class syntax::SyntaxParsingContextRoot;
 
   /// If not None, the underlying vector should contain tokens of this source file.
   Optional<std::vector<Token>> AllCorrectedTokens;
 
-  /// All of the raw token syntax nodes in the underlying source.
-  std::vector<syntax::RawSyntaxInfo> AllRawTokenSyntax;
-
   SourceFileSyntaxInfo &SyntaxInfo;
-
-  void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
-  bool hasSyntaxRoot() const;
 };
 
 

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -241,17 +241,21 @@ public:
 
   /// Lex a token. If \c TriviaRetentionMode is \c WithTrivia, passed pointers
   /// to trivias are populated.
-  void lex(Token &Result, syntax::Trivia *LeadingTriviaResult = nullptr,
-           syntax::Trivia *TrailingTriviaResult = nullptr) {
+  void lex(Token &Result, syntax::Trivia &LeadingTriviaResult,
+           syntax::Trivia &TrailingTriviaResult) {
     Result = NextToken;
-    if (LeadingTriviaResult && TrailingTriviaResult) {
-      *LeadingTriviaResult = syntax::Trivia {LeadingTrivia};
-      *TrailingTriviaResult = syntax::Trivia {TrailingTrivia};
+    LeadingTriviaResult = {LeadingTrivia};
+    TrailingTriviaResult = {TrailingTrivia};
+    if (Result.isNot(tok::eof)) {
       LeadingTrivia.clear();
       TrailingTrivia.clear();
-    }
-    if (Result.isNot(tok::eof))
       lexImpl();
+    }
+  }
+
+  void lex(Token &Result) {
+    syntax::Trivia LeadingTrivia, TrailingTrivia;
+    lex(Result, LeadingTrivia, TrailingTrivia);
   }
 
   bool isKeepingComments() const {

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -239,14 +239,20 @@ public:
     return CodeCompletionPtr != nullptr;
   }
 
-  void lex(Token &Result) {
+  /// Lex a token. If \c TriviaRetentionMode is \c WithTrivia, passed pointers
+  /// to trivias are populated.
+  void lex(Token &Result, syntax::Trivia *LeadingTriviaResult = nullptr,
+           syntax::Trivia *TrailingTriviaResult = nullptr) {
     Result = NextToken;
+    if (LeadingTriviaResult && TrailingTriviaResult) {
+      *LeadingTriviaResult = syntax::Trivia {LeadingTrivia};
+      *TrailingTriviaResult = syntax::Trivia {TrailingTrivia};
+      LeadingTrivia.clear();
+      TrailingTrivia.clear();
+    }
     if (Result.isNot(tok::eof))
       lexImpl();
   }
-
-  /// Lex a full token including leading and trailing trivia.
-  syntax::RawSyntaxInfo fullLex();
 
   bool isKeepingComments() const {
     return RetainComments == CommentRetentionMode::ReturnAsTokens;

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -28,11 +28,6 @@
 
 namespace swift {
 
-namespace syntax {
-  struct RawTokenSyntax;
-  struct RawSyntaxInfo;
-}
-
   /// Given a pointer to the starting byte of a UTF8 character, validate it and
   /// advance the lexer past it.  This returns the encoded character or ~0U if
   /// the encoding is invalid.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -198,6 +198,12 @@ public:
   /// \brief This is the current token being considered by the parser.
   Token Tok;
 
+  /// \brief leading trivias for \c Tok. Always empty if !SF.shouldKeepSyntaxInfo().
+  syntax::Trivia LeadingTrivia;
+
+  /// \brief This is the current token being considered by the parser.
+  syntax::Trivia TrailingTrivia;
+
   /// \brief The receiver to collect all consumed tokens.
   ConsumeTokenReceiver *TokReceiver;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -31,6 +31,7 @@
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Parse/Token.h"
 #include "swift/Parse/ParserResult.h"
+#include "swift/Syntax/SyntaxParsingContext.h"
 #include "swift/Config.h"
 #include "llvm/ADT/SetVector.h"
 
@@ -55,8 +56,6 @@ namespace swift {
   
   namespace syntax {
     class AbsolutePosition;
-    class SyntaxParsingContext;
-    struct RawSyntaxInfo;
     struct RawTokenSyntax;
     enum class SyntaxKind;
   }// end of syntax namespace
@@ -198,10 +197,12 @@ public:
   /// \brief This is the current token being considered by the parser.
   Token Tok;
 
-  /// \brief leading trivias for \c Tok. Always empty if !SF.shouldKeepSyntaxInfo().
+  /// \brief leading trivias for \c Tok.
+  /// Always empty if !SF.shouldKeepSyntaxInfo().
   syntax::Trivia LeadingTrivia;
 
-  /// \brief This is the current token being considered by the parser.
+  /// \brief trailing trivias for \c Tok.
+  /// Always empty if !SF.shouldKeepSyntaxInfo().
   syntax::Trivia TrailingTrivia;
 
   /// \brief The receiver to collect all consumed tokens.
@@ -417,16 +418,24 @@ public:
     Parser &P;
     ParserPosition PP;
     DiagnosticTransaction DT;
+    /// This context immediately deconstructed with transparent accumulation
+    /// on cancelBacktrack().
+    llvm::Optional<syntax::SyntaxParsingContext> SynContext;
     bool Backtrack = true;
 
   public:
     BacktrackingScope(Parser &P)
-      : P(P), PP(P.getParserPosition()), DT(P.Diags) {}
+        : P(P), PP(P.getParserPosition()), DT(P.Diags) {
+      SynContext.emplace(P.SyntaxContext);
+      SynContext->setDiscard();
+    }
 
     ~BacktrackingScope();
 
     void cancelBacktrack() {
       Backtrack = false;
+      SynContext->setTransparent();
+      SynContext.reset();
       DT.commit();
     }
   };
@@ -1432,12 +1441,6 @@ tokenizeWithTrivia(const LangOptions &LangOpts,
                    unsigned BufferID,
                    unsigned Offset = 0,
                    unsigned EndOffset = 0);
-
-
-void populateTokenSyntaxMap(const LangOptions &LangOpts,
-                            const SourceManager &SM,
-                            unsigned BufferID,
-                            std::vector<syntax::RawSyntaxInfo> &Result);
 } // end namespace swift
 
 #endif

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -52,7 +52,7 @@ struct RawSyntaxInfo {
     SyntaxRange(SyntaxRange), RawNode(RawNode) {}
 
   /// Construct from legacy Token and trivia lists.
-  RawSyntaxInfo(Token Tok, Trivia LeadingTrivia, Trivia TrailingTrivia);
+  RawSyntaxInfo(Token Tok, Trivia &LeadingTrivia, Trivia &TrailingTrivia);
 
   bool isImplicit() const { return SyntaxRange.isInvalid(); }
   SourceLoc getStartLoc() const { return SyntaxRange.Start; }

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -51,6 +51,9 @@ struct RawSyntaxInfo {
   RawSyntaxInfo(SourceRange SyntaxRange, RC<RawSyntax> RawNode):
     SyntaxRange(SyntaxRange), RawNode(RawNode) {}
 
+  /// Construct from legacy Token and trivia lists.
+  RawSyntaxInfo(Token Tok, Trivia LeadingTrivia, Trivia TrailingTrivia);
+
   bool isImplicit() const { return SyntaxRange.isInvalid(); }
   SourceLoc getStartLoc() const { return SyntaxRange.Start; }
   SourceLoc getEndLoc() const { return SyntaxRange.End; }

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -15,149 +15,175 @@
 
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Syntax/Syntax.h"
+#include "swift/Syntax/TokenSyntax.h"
 
 namespace swift {
-  class SourceLoc;
-  class SourceFile;
-  class Token;
+class SourceLoc;
+class SourceFile;
+class Token;
 
 namespace syntax {
-  struct RawTokenSyntax;
-  struct RawSyntax;
-  enum class SyntaxKind;
+struct RawTokenSyntax;
+struct RawSyntax;
+enum class SyntaxKind;
 
-enum class SyntaxContextKind: uint8_t{
-  Expr,
+enum class SyntaxContextKind {
   Decl,
   Stmt,
+  Expr,
+  Type,
+  Pattern,
 };
 
-/// The handler for parser to generate libSyntax entities.
-struct RawSyntaxInfo {
-  /// Start and end location of this syntax node.
-  SourceRange SyntaxRange;
+/// Indicates what action should be performed on the destruction of
+///  SyntaxParsingContext
+enum class AccumulationMode {
+  // Coerece the result to one of ContextKind.
+  // E.g. for ContextKind::Expr, passthroug if the result is CallExpr, whereas
+  // <UnknownExpr><SomeDecl /></UnknownDecl> for non Exprs.
+  CoerceKind,
 
-  /// This location must be valid if this node is an implicit node, e.g.
-  /// an empty statement list collection.
-  /// This location indicates the implicit node should appear before the token
-  /// on the location.
-  SourceLoc BeforeLoc;
+  // Construct a result Syntax with specified SyntaxKind.
+  CreateSyntax,
 
-  /// The raw node.
-  RC<RawSyntax> RawNode;
-  RawSyntaxInfo(RC<RawSyntax> RawNode): RawNode(RawNode) {}
-  RawSyntaxInfo(SourceLoc StartLoc, RC<RawSyntax> RawNode):
-    SyntaxRange(StartLoc), RawNode(RawNode) {}
-  RawSyntaxInfo(SourceRange SyntaxRange, RC<RawSyntax> RawNode):
-    SyntaxRange(SyntaxRange), RawNode(RawNode) {}
+  // Pass through all parts to the parent context.
+  Transparent,
 
-  /// Construct from legacy Token and trivia lists.
-  RawSyntaxInfo(Token Tok, Trivia &LeadingTrivia, Trivia &TrailingTrivia);
+  // Discard all parts in the context.
+  Discard,
 
-  bool isImplicit() const { return SyntaxRange.isInvalid(); }
-  SourceLoc getStartLoc() const { return SyntaxRange.Start; }
-  SourceLoc getEndLoc() const { return SyntaxRange.End; }
-
-  template <typename SyntaxNode>
-  SyntaxNode makeSyntax() const { return make<SyntaxNode>(RawNode); }
-
-  template <typename RawSyntaxNode>
-  RC<RawSyntaxNode> getRaw() const {
-    return RC<RawSyntaxNode>(cast<RawSyntaxNode>(RawNode));
-  }
-  void brigeWithContext(SyntaxContextKind Kind);
-  void setBeforeLoc(SourceLoc Loc) {
-    assert(isImplicit());
-    BeforeLoc = Loc;
-  }
-};
-
-enum class SyntaxParsingContextKind: uint8_t {
+  // Construct SourceFile syntax to the specified SF.
   Root,
-  Child,
+
+  // Invalid.
+  NotSet,
 };
 
-/// The base class of different kinds of Syntax context that Parser should use to
-/// create syntax nodes.
+/// RAII object which receive RawSyntax parts. On destruction, this constructs
+/// a specified syntax node from received parts and propagate it to the parent
+/// context.
+///
+/// e.g.
+///   parseExprParen() {
+///     SyntaxParsingContext LocalCtxt(SyntaxKind::ParenExpr, SyntaxContext);
+///     consumeToken(tok::l_paren) // In consumeToken(), a RawTokenSyntax is
+///                                // added to the context.
+///     parseExpr(); // On returning from parseExpr(), a Expr Syntax node is
+///                  // created and added to the context.
+///     consumeToken(tok::r_paren)
+///     // Now the context holds { '(' Expr ')' }.
+///     // From these parts, it creates ParenExpr node and add it to the parent.
+///   }
 class SyntaxParsingContext {
-protected:
-  SyntaxParsingContext(SourceFile &SF, unsigned BufferID, Token &Tok);
-  SyntaxParsingContext(SyntaxParsingContext &Another);
-public:
-  struct ContextInfo;
-  ContextInfo &ContextData;
-  const Token &Tok;
-
-  // Get the context kind.
-  virtual SyntaxParsingContextKind getKind() = 0;
-
-  // Create a syntax node of the given kind.
-  virtual void makeNode(SyntaxKind Kind, SourceLoc LastTokLoc) = 0;
-  virtual ~SyntaxParsingContext();
-  virtual void setSyntaxKind(SyntaxKind Kind) = 0;
-  virtual void setContextKind(SyntaxContextKind CKind) = 0;
-  virtual void finalize() = 0;
-
-  // Disable the building of syntax tree in the current context.
-  void disable();
-};
-
-// The start point of syntax tree parsing. This context is the root
-// of all other entity-specific contexts. This is the context Parser
-// has when the parser instance is firstly created.
-class SyntaxParsingContextRoot: public SyntaxParsingContext {
-  SourceFile &File;
-public:
-  SyntaxParsingContextRoot(SourceFile &File, unsigned BufferID, Token &Tok):
-    SyntaxParsingContext(File, BufferID, Tok), File(File) {}
-  ~SyntaxParsingContextRoot();
-  void makeNode(SyntaxKind Kind, SourceLoc LastTokLoc) override {};
-  void setSyntaxKind(SyntaxKind Kind) override {};
-  void setContextKind(SyntaxContextKind CKind) override {};
-  void finalize() override {};
-  SyntaxParsingContextKind getKind() override {
-    return SyntaxParsingContextKind::Root;
-  };
-};
-
-// The base class for contexts that are created from a parent context.
-// The stack instance will set the context holder when the context
-// is firstly created and reset the context holder to the parent when
-// it's destructed.
-class SyntaxParsingContextChild: public SyntaxParsingContext {
+  // Parent context. Only the root context has nullptr.
   SyntaxParsingContext *Parent;
-  SyntaxParsingContext *&ContextHolder;
-  Optional<SyntaxContextKind> ContextKind;
-  Optional<SyntaxKind> KnownSyntax;
-  void makeNodeWhole(SyntaxKind Kind);
-  SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-                            Optional<SyntaxContextKind> Kind,
-                            Optional<SyntaxKind> KnownSyntax);
-  bool isTopOfContextStack() const { return this == ContextHolder; }
-public:
-  SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-    SyntaxContextKind Kind): SyntaxParsingContextChild(ContextHolder,
-                                                       Kind, None) {}
 
-  SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-    SyntaxKind KnownSyntax): SyntaxParsingContextChild(ContextHolder,
-                             None, KnownSyntax) {};
+  // Reference to the
+  SyntaxParsingContext *&CtxtHolder;
 
-  SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-                            bool Disable = false);
+  // Collected parts.
+  std::vector<RC<RawSyntax>> Parts;
 
-  ~SyntaxParsingContextChild();
-  void makeNode(SyntaxKind Kind, SourceLoc LastTokLoc) override;
-  void finalize() override;
-  SyntaxParsingContext* getParent() { return Parent; }
-  void setSyntaxKind(SyntaxKind SKind) override;
-  void setContextKind(SyntaxContextKind CKind) override;
-  SyntaxParsingContextRoot &getRoot();
-  SyntaxParsingContextKind getKind() override {
-    return SyntaxParsingContextKind::Child;
+  // Operation on destruction.
+  AccumulationMode Mode = AccumulationMode::NotSet;
+
+  // Additional info depending on \c Mode.
+  union {
+    // For AccumulationMode::CreateSyntax; desired syntax node kind.
+    SyntaxKind SynKind;
+    // For AccumulationMode::CoerceKind; desired syntax node category.
+    SyntaxContextKind CtxtKind;
+    // For AccumulationMode::Root; the parsing source file.
+    SourceFile *SF;
   };
-};
-}
-}
-#endif // SWIFT_SYNTAX_PARSING_CONTEXT_H
 
+  // If false, context does nothing.
+  bool Enabled;
+
+public:
+  /// Construct root context.
+  SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SourceFile &SF);
+
+  /// Designated constructor for child context.
+  SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder)
+      : Parent(CtxtHolder), CtxtHolder(CtxtHolder), 
+        Enabled(Parent->isEnabled()) {
+    assert(CtxtHolder->isTopOfContextStack() &&
+           "SyntaxParsingContext cannot have multiple children");
+    CtxtHolder = this;
+  }
+
+  SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SyntaxContextKind Kind)
+      : SyntaxParsingContext(CtxtHolder) {
+    setCoerceKind(Kind);
+  }
+
+  SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SyntaxKind Kind)
+      : SyntaxParsingContext(CtxtHolder) {
+    setCreateSyntax(Kind);
+  }
+
+  ~SyntaxParsingContext();
+
+  void disable() { Enabled = false; }
+  bool isEnabled() const { return Enabled; }
+  bool isRoot() const { return !Parent; }
+  bool isTopOfContextStack() const { return this == CtxtHolder; }
+
+  SyntaxParsingContext *getRoot();
+
+  /// Add RawSyntax to the parts.
+  void addRawSyntax(RC<RawSyntax> Raw);
+
+  /// Add Token with Trivia to the parts.
+  void addToken(Token &Tok, Trivia &LeadingTrivia, Trivia &TrailingTrivia);
+
+  /// Add Syntax to the parts.
+  void addSyntax(Syntax Node);
+
+  RC<RawSyntax> popBack() {
+    auto Raw = std::move(Parts.back());
+    Parts.pop_back();
+    return Raw;
+  }
+
+  template<typename SyntaxNode>
+  llvm::Optional<SyntaxNode> popIf() {
+    if (auto Node = make<Syntax>(Parts.back()).getAs<SyntaxNode>()) {
+      Parts.pop_back();
+      return Node;
+    }
+    return None;
+  }
+
+  TokenSyntax popToken() {
+    assert(Parts.back()->Kind == SyntaxKind::Token);
+    return make<TokenSyntax>(popBack());
+  }
+
+  /// On destruction, construct a specified kind of RawSyntax node consuming the
+  /// collected parts, then append it to the parent context.
+  void setCreateSyntax(SyntaxKind Kind) {
+    Mode = AccumulationMode::CreateSyntax;
+    SynKind = Kind;
+  }
+
+  /// On destruction, if the parts size is 1 and it's kind of \c Kind, just
+  /// append it to the parent context. Otherwise, create Unknown{Kind} node from
+  /// the collected parts.
+  void setCoerceKind(SyntaxContextKind Kind) {
+    Mode = AccumulationMode::CoerceKind;
+    CtxtKind = Kind;
+  }
+
+  /// Move the collected parts to the tail of parent context.
+  void setTransparent() { Mode = AccumulationMode::Transparent; }
+
+  /// Discard collected parts on this context.
+  void setDiscard() { Mode = AccumulationMode::Discard; }
+
+};
+
+} // namespace syntax
+} // namespace swift
+#endif // SWIFT_SYNTAX_PARSING_CONTEXT_H

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -161,6 +161,15 @@ public:
     return make<TokenSyntax>(popBack());
   }
 
+  /// Create a syntax node using the tail \c N elements of collected parts and
+  /// replace those parts with the single result.
+  void createNodeInPlace(SyntaxKind Kind, size_t N);
+
+  /// Create a node using the tail of the collected parts. The number of parts
+  /// is automatically determined from \c Kind. Node: limited number of \c Kind
+  /// are supported. See the implementation.
+  void createNodeInPlace(SyntaxKind Kind);
+
   /// On destruction, construct a specified kind of RawSyntax node consuming the
   /// collected parts, then append it to the parent context.
   void setCreateSyntax(SyntaxKind Kind) {

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -231,6 +231,11 @@ struct Trivia {
     Pieces.insert(Pieces.begin(), Piece);
   }
 
+  /// Clear pieces.
+  void clear() {
+    Pieces.clear();
+  }
+
   /// Return a reference to the first piece.
   ///
   /// Precondition: !empty()

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -738,25 +738,6 @@ static bool rangeContainsPlaceholderEnd(const char *CurPtr,
   return false;
 }
 
-syntax::RawSyntaxInfo Lexer::fullLex() {
-  if (NextToken.isEscapedIdentifier()) {
-    LeadingTrivia.push_back(syntax::TriviaPiece::backtick());
-    TrailingTrivia.insert(TrailingTrivia.begin(),
-                          syntax::TriviaPiece::backtick());
-  }
-  auto Loc = NextToken.getLoc();
-  auto Result = syntax::RawTokenSyntax::make(NextToken.getKind(),
-                                        OwnedString(NextToken.getText()),
-                                        syntax::SourcePresence::Present,
-                                        {LeadingTrivia}, {TrailingTrivia});
-  LeadingTrivia.clear();
-  TrailingTrivia.clear();
-  if (NextToken.isNot(tok::eof)) {
-    lexImpl();
-  }
-  return {Loc, Result};
-}
-
 /// lexOperatorIdentifier - Match identifiers formed out of punctuation.
 void Lexer::lexOperatorIdentifier() {
   const char *TokStart = CurPtr-1;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2191,8 +2191,9 @@ void Parser::delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
 ParserResult<Decl>
 Parser::parseDecl(ParseDeclOptions Flags,
                   llvm::function_ref<void(Decl*)> Handler) {
-  SyntaxParsingContextChild DeclParsingContext(SyntaxContext,
-                                               SyntaxContextKind::Decl);
+  SyntaxParsingContext DeclParsingContext(SyntaxContext,
+                                          SyntaxContextKind::Decl);
+
   if (Tok.is(tok::pound_if)) {
     auto IfConfigResult = parseIfConfig(
       [&](SmallVectorImpl<ASTNode> &Decls, bool IsActive) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -193,7 +193,7 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
 
     // We know we can make a syntax node for ternary expression.
     if (PendingTernary) {
-      //SyntaxContext->makeNode(SyntaxKind::TernaryExpr, Tok.getLoc());
+      SyntaxContext->createNodeInPlace(SyntaxKind::TernaryExpr);
       PendingTernary = false;
     }
 
@@ -510,15 +510,6 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
     return makeParserCodeCompletionResult<Expr>();
   if (SubExpr.isNull())
     return nullptr;
-
-  if (SyntaxContext->isEnabled() && Operator->hasName() &&
-      (Operator->getName().getBaseName() == "-" ||
-       Operator->getName().getBaseName() == "+")) {
-    if (auto Node = SyntaxContext->popIf<IntegerLiteralExprSyntax>())
-      SyntaxContext->addSyntax(Node->withSign(SyntaxContext->popToken()));
-    else if (auto Node = SyntaxContext->popIf<FloatLiteralExprSyntax>())
-      SyntaxContext->addSyntax(Node->withSign(SyntaxContext->popToken()));
-  }
 
   // Check if we have a unary '-' with number literal sub-expression, for
   // example, "-42" or "-1.25".
@@ -1411,19 +1402,17 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
   ParserResult<Expr> Result;
   switch (Tok.getKind()) {
   case tok::integer_literal: {
-    SyntaxParsingContext IntegerContext(SyntaxContext,
-                                        SyntaxKind::IntegerLiteralExpr);
     StringRef Text = copyAndStripUnderscores(Context, Tok.getText());
     SourceLoc Loc = consumeToken(tok::integer_literal);
+    SyntaxContext->createNodeInPlace(SyntaxKind::IntegerLiteralExpr);
     Result = makeParserResult(new (Context) IntegerLiteralExpr(Text, Loc,
                                                            /*Implicit=*/false));
     break;
   }
   case tok::floating_literal: {
-    SyntaxParsingContext IntegerContext(SyntaxContext,
-                                        SyntaxKind::FloatLiteralExpr);
     StringRef Text = copyAndStripUnderscores(Context, Tok.getText());
     SourceLoc Loc = consumeToken(tok::floating_literal);
+    SyntaxContext->createNodeInPlace(SyntaxKind::FloatLiteralExpr);
     Result = makeParserResult(new (Context) FloatLiteralExpr(Text, Loc,
                                                            /*Implicit=*/false));
     break;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -40,8 +40,7 @@ using namespace swift::syntax;
 /// \param isExprBasic Whether we're only parsing an expr-basic.
 ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
   // Start a context for creating expression syntax.
-  SyntaxParsingContextChild ExprParsingContext(SyntaxContext,
-                                               SyntaxContextKind::Expr);
+  SyntaxParsingContext ExprParsingContext(SyntaxContext, SyntaxContextKind::Expr);
 
   // If we are parsing a refutable pattern, check to see if this is the start
   // of a let/var/is pattern.  If so, parse it to an UnresolvedPatternExpr and
@@ -165,8 +164,8 @@ ParserResult<Expr> Parser::parseExprArrow() {
 ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
                                              bool isExprBasic,
                                              bool isForConditionalDirective) {
-  SyntaxParsingContextChild ExprSequnceContext(SyntaxContext,
-                                               SyntaxContextKind::Expr);
+  SyntaxParsingContext ExprSequnceContext(SyntaxContext, SyntaxContextKind::Expr);
+
   SmallVector<Expr*, 8> SequencedExprs;
   SourceLoc startLoc = Tok.getLoc();
   bool HasCodeCompletion = false;
@@ -194,7 +193,7 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
 
     // We know we can make a syntax node for ternary expression.
     if (PendingTernary) {
-      SyntaxContext->makeNode(SyntaxKind::TernaryExpr, Tok.getLoc());
+      //SyntaxContext->makeNode(SyntaxKind::TernaryExpr, Tok.getLoc());
       PendingTernary = false;
     }
 
@@ -381,8 +380,8 @@ done:
 /// sequence, but this isn't enforced until sequence-folding.
 ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
                                                     bool isExprBasic) {
-  SyntaxParsingContextChild ElementContext(SyntaxContext,
-                                           SyntaxContextKind::Expr);
+  SyntaxParsingContext ElementContext(SyntaxContext,
+                                      SyntaxContextKind::Expr);
   SourceLoc tryLoc;
   bool hadTry = consumeIf(tok::kw_try, tryLoc);
   Optional<Token> trySuffix;
@@ -511,6 +510,15 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
     return makeParserCodeCompletionResult<Expr>();
   if (SubExpr.isNull())
     return nullptr;
+
+  if (SyntaxContext->isEnabled() && Operator->hasName() &&
+      (Operator->getName().getBaseName() == "-" ||
+       Operator->getName().getBaseName() == "+")) {
+    if (auto Node = SyntaxContext->popIf<IntegerLiteralExprSyntax>())
+      SyntaxContext->addSyntax(Node->withSign(SyntaxContext->popToken()));
+    else if (auto Node = SyntaxContext->popIf<FloatLiteralExprSyntax>())
+      SyntaxContext->addSyntax(Node->withSign(SyntaxContext->popToken()));
+  }
 
   // Check if we have a unary '-' with number literal sub-expression, for
   // example, "-42" or "-1.25".
@@ -1403,17 +1411,19 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
   ParserResult<Expr> Result;
   switch (Tok.getKind()) {
   case tok::integer_literal: {
+    SyntaxParsingContext IntegerContext(SyntaxContext,
+                                        SyntaxKind::IntegerLiteralExpr);
     StringRef Text = copyAndStripUnderscores(Context, Tok.getText());
     SourceLoc Loc = consumeToken(tok::integer_literal);
-    SyntaxContext->makeNode(SyntaxKind::IntegerLiteralExpr, Tok.getLoc());
     Result = makeParserResult(new (Context) IntegerLiteralExpr(Text, Loc,
                                                            /*Implicit=*/false));
     break;
   }
   case tok::floating_literal: {
+    SyntaxParsingContext IntegerContext(SyntaxContext,
+                                        SyntaxKind::FloatLiteralExpr);
     StringRef Text = copyAndStripUnderscores(Context, Tok.getText());
     SourceLoc Loc = consumeToken(tok::floating_literal);
-    SyntaxContext->makeNode(SyntaxKind::FloatLiteralExpr, Tok.getLoc());
     Result = makeParserResult(new (Context) FloatLiteralExpr(Text, Loc,
                                                            /*Implicit=*/false));
     break;
@@ -1435,7 +1445,7 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
     break;
   
   case tok::kw_nil: {
-    SyntaxParsingContextChild NilContext(SyntaxContext, SyntaxKind::NilLiteralExpr);
+    SyntaxParsingContext NilContext(SyntaxContext, SyntaxKind::NilLiteralExpr);
     Result = makeParserResult(
                       new (Context) NilLiteralExpr(consumeToken(tok::kw_nil)));
     break;
@@ -1443,8 +1453,8 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 
   case tok::kw_true:
   case tok::kw_false: {
-    SyntaxParsingContextChild BoolContext(SyntaxContext,
-                                          SyntaxKind::BooleanLiteralExpr);
+    SyntaxParsingContext BoolContext(SyntaxContext,
+                                     SyntaxKind::BooleanLiteralExpr);
     bool isTrue = Tok.is(tok::kw_true);
     Result = makeParserResult(
                new (Context) BooleanLiteralExpr(isTrue, consumeToken()));
@@ -1538,8 +1548,8 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 
     // If the next token is '_', parse a discard expression.
   case tok::kw__: {
-    SyntaxParsingContextChild DAContext(SyntaxContext,
-                                        SyntaxKind::DiscardAssignmentExpr);
+    SyntaxParsingContext DAContext(SyntaxContext,
+                                   SyntaxKind::DiscardAssignmentExpr);
     Result = makeParserResult(
       new (Context) DiscardAssignmentExpr(consumeToken(), /*Implicit=*/false));
     break;
@@ -1821,17 +1831,14 @@ createStringLiteralExprFromSegment(ASTContext &Ctx,
 ///   expr-literal:
 ///     string_literal
 ParserResult<Expr> Parser::parseExprStringLiteral() {
+  SyntaxParsingContext LocalContext(SyntaxContext,
+                                    SyntaxKind::StringLiteralExpr);
 
   SmallVector<Lexer::StringSegment, 1> Segments;
   L->getStringLiteralSegments(Tok, Segments);
 
   Token EntireTok = Tok;
 
-  // Create a syntax node for string literal.
-  SyntaxContext->makeNode(SyntaxKind::StringLiteralExpr, peekToken().getLoc());
-
-  // FIXME: Avoid creating syntax nodes for string interpolation.
-  SyntaxParsingContextChild LocalContext(SyntaxContext, /*disabled*/true);
 
   // The start location of the entire string literal.
   SourceLoc Loc = Tok.getLoc();
@@ -1844,9 +1851,24 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
         createStringLiteralExprFromSegment(Context, L, Segments.front(), Loc));
   }
 
+  // FIXME: Properly handle string interpolation.
+  // e.g. /*c*/"foo\(12)bar" should be something like (braces are trivia):
+  //   <InterpolatedStringExpr>
+  //     <InterpolatedStringLiteral>{/*c*/}{"}foo{\}</InterpolatedStringLiteral>
+  //     <ParenExpr>(<IntergerLiteralExpr>12</IntegerLiteralExpr>)</ParentExpr>
+  //     <InterpolatedStringLiteral>bar{"}</InterpolatedStringLiteral>
+  //   </InterpolatedStringExpr>
+  SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
+
   // We don't expose the entire interpolated string as one token. Instead, we
   // should expose the tokens in each segment.
   consumeTokenWithoutFeedingReceiver();
+  // We are going to mess with Tok to do reparsing for interpolated literals,
+  // don't lose our 'next' token.
+  llvm::SaveAndRestore<Token> SavedTok(Tok);
+  llvm::SaveAndRestore<Trivia> SavedLeadingTrivia(LeadingTrivia);
+  llvm::SaveAndRestore<Trivia> SavedTrailingTrivia(TrailingTrivia);
+
   ParserStatus Status;
   SmallVector<Expr*, 4> Exprs;
   bool First = true;
@@ -1878,9 +1900,10 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     }
         
     case Lexer::StringSegment::Expr: {
-      // We are going to mess with Tok to do reparsing for interpolated literals,
-      // don't lose our 'next' token.
-      llvm::SaveAndRestore<Token> SavedTok(Tok);
+      // FIXME: Properly handle string interpolation.
+      // For now, discard all nodes inside the literal.
+      SyntaxParsingContext TmpContext(SyntaxContext);
+      TmpContext.setDiscard();
 
       // Create a temporary lexer that lexes from the body of the string.
       Lexer::State BeginState =
@@ -2018,7 +2041,8 @@ DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
   while (true) {
     // The following code may backtrack; so we disable the syntax tree creation
     // in this scope.
-    SyntaxParsingContextChild DisabledContext(SyntaxContext, /*disabled*/true);
+    SyntaxParsingContext DisabledContext(SyntaxContext);
+    SyntaxContext->disable();
 
     // Terminate at ')'.
     if (Tok.is(tok::r_paren)) {
@@ -2079,8 +2103,8 @@ static bool shouldAddSelfFixit(DeclContext* Current, DeclName Name,
 ///     unqualified-decl-name generic-args?
 Expr *Parser::parseExprIdentifier() {
   assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));
-  SyntaxParsingContextChild IDSyntaxContext(SyntaxContext,
-                                            SyntaxKind::IdentifierExpr);
+  SyntaxParsingContext IDSyntaxContext(SyntaxContext,
+                                       SyntaxKind::IdentifierExpr);
   Token IdentTok = Tok;
 
   // Parse the unqualified-decl-name.
@@ -2170,7 +2194,7 @@ Expr *Parser::parseExprIdentifier() {
 
 Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
                                          Identifier PlaceholderId) {
-  SyntaxParsingContextChild DisableContext(SyntaxContext, /*disabled*/true);
+  SyntaxParsingContext TmpContext(SyntaxContext, SyntaxKind::UnknownExpr);
   assert(PlaceholderTok.is(tok::identifier));
   assert(PlaceholderId.isEditorPlaceholder());
 
@@ -2855,8 +2879,8 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     ParserStatus Status;
     Expr *SubExpr = nullptr;
     if (Tok.isBinaryOperator() && peekToken().isAny(rightTok, tok::comma)) {
-      SyntaxParsingContextChild operatorContext(SyntaxContext,
-                                                SyntaxContextKind::Expr);
+      SyntaxParsingContext operatorContext(SyntaxContext,
+                                           SyntaxContextKind::Expr);
       SourceLoc Loc;
       Identifier OperName;
       if (parseAnyIdentifier(OperName, Loc, diag::expected_operator_ref)) {
@@ -3117,7 +3141,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
 ///     expr-dictionary
 //      lsquare-starting ']'
 ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
-  SyntaxParsingContextChild ArrayOrDictContext(SyntaxContext);
+  SyntaxParsingContext ArrayOrDictContext(SyntaxContext);
 
   // If the caller didn't already consume the '[', do so now.
   if (LSquareLoc.isInvalid())
@@ -3130,8 +3154,8 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
   // [] is always an array.
   if (Tok.is(tok::r_square)) {
     // FIXME: Handle empty array syntax node.
-    ArrayOrDictContext.setSyntaxKind(SyntaxKind::ArrayExpr);
     SourceLoc RSquareLoc = consumeToken(tok::r_square);
+    ArrayOrDictContext.setCreateSyntax(SyntaxKind::ArrayExpr);
     return makeParserResult(
                     ArrayExpr::create(Context, LSquareLoc, {}, {}, RSquareLoc));
   }
@@ -3139,9 +3163,9 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
   // [:] is always an empty dictionary.
   if (Tok.is(tok::colon) && peekToken().is(tok::r_square)) {
     // FIXME: Handle empty dictionary syntax node.
-    ArrayOrDictContext.setSyntaxKind(SyntaxKind::DictionaryExpr);
     consumeToken(tok::colon);
     SourceLoc RSquareLoc = consumeToken(tok::r_square);
+    ArrayOrDictContext.setCreateSyntax(SyntaxKind::DictionaryExpr);
     return makeParserResult(
                   DictionaryExpr::create(Context, LSquareLoc, {}, RSquareLoc));
   }
@@ -3149,8 +3173,6 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
   bool ParseDict;
   {
     BacktrackingScope Scope(*this);
-    // Disable the syntax tree creation in the context.
-    SyntaxParsingContextChild DisabledContext(SyntaxContext, /*disabled*/true);
     auto HasDelayedDecl = State->hasDelayedDecl();
     // Parse the first expression.
     ParserResult<Expr> FirstExpr
@@ -3160,7 +3182,7 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
       if (Tok.is(tok::r_square))
         consumeToken();
       Scope.cancelBacktrack();
-      ArrayOrDictContext.setContextKind(SyntaxContextKind::Expr);
+      ArrayOrDictContext.setCoerceKind(SyntaxContextKind::Expr);
       return FirstExpr;
     }
     if (!HasDelayedDecl)
@@ -3168,11 +3190,12 @@ ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
     // If we have a ':', this is a dictionary literal.
     ParseDict = Tok.is(tok::colon);
   }
+
   if (ParseDict) {
-    ArrayOrDictContext.setSyntaxKind(SyntaxKind::DictionaryExpr);
+    ArrayOrDictContext.setCreateSyntax(SyntaxKind::DictionaryExpr);
     return parseExprDictionary(LSquareLoc);
   } else {
-    ArrayOrDictContext.setSyntaxKind(SyntaxKind::ArrayExpr);
+    ArrayOrDictContext.setCreateSyntax(SyntaxKind::ArrayExpr);
     return parseExprArray(LSquareLoc);
   }
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -226,7 +226,8 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
 ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                                      BraceItemListKind Kind,
                                      BraceItemListKind ConditionalBlockKind) {
-  SyntaxParsingContextChild StmtListContext(SyntaxContext, SyntaxKind::StmtList);
+  SyntaxParsingContext StmtListContext(SyntaxContext, SyntaxKind::StmtList);
+
   bool IsTopLevel = (Kind == BraceItemListKind::TopLevelCode) ||
                     (Kind == BraceItemListKind::TopLevelLibrary);
   bool isActiveConditionalBlock =
@@ -262,7 +263,9 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
          Tok.isNot(tok::kw_sil_default_witness_table) &&
          (isConditionalBlock ||
           !isTerminatorForBraceItemListKind(Kind, Entries))) {
-    SyntaxParsingContextChild StmtContext(SyntaxContext, SyntaxContextKind::Stmt);
+
+    SyntaxParsingContext StmtContext(SyntaxContext, SyntaxContextKind::Stmt);
+
     if (Kind == BraceItemListKind::TopLevelLibrary &&
         skipExtraTopLevelRBraces())
       continue;
@@ -493,7 +496,8 @@ static ParserResult<Stmt> recoverFromInvalidCase(Parser &P) {
 }
 
 ParserResult<Stmt> Parser::parseStmt() {
-  SyntaxParsingContextChild LocalContext(SyntaxContext, SyntaxContextKind::Stmt);
+  SyntaxParsingContext LocalContext(SyntaxContext, SyntaxContextKind::Stmt);
+
   // Note that we're parsing a statement.
   StructureMarkerRAII ParsingStmt(*this, Tok.getLoc(),
                                   StructureMarkerKind::Statement);
@@ -590,7 +594,7 @@ ParserResult<BraceStmt> Parser::parseBraceItemList(Diag<> ID) {
     if (Tok.isNot(tok::l_brace))
       return nullptr;
   }
-  SyntaxParsingContextChild LocalContext(SyntaxContext, SyntaxKind::CodeBlock);
+  SyntaxParsingContext LocalContext(SyntaxContext, SyntaxKind::CodeBlock);
   SourceLoc LBLoc = consumeToken(tok::l_brace);
 
   SmallVector<ASTNode, 16> Entries;
@@ -656,7 +660,7 @@ ParserResult<Stmt> Parser::parseStmtContinue() {
 ///     'return' expr?
 ///   
 ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
-  SyntaxParsingContextChild LocalContext(SyntaxContext, SyntaxKind::ReturnStmt);
+  SyntaxParsingContext LocalContext(SyntaxContext, SyntaxKind::ReturnStmt);
   SourceLoc ReturnLoc = consumeToken(tok::kw_return);
 
   if (Tok.is(tok::code_complete)) {

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -74,8 +74,8 @@ static RawSyntaxInfo createSyntaxAs(ArrayRef<RawSyntaxInfo> Parts,
 }
 } // End of anonymous namespace
 
-RawSyntaxInfo::RawSyntaxInfo(Token Tok, Trivia LeadingTrivia,
-                             Trivia TrailingTrivia) {
+RawSyntaxInfo::RawSyntaxInfo(Token Tok, Trivia &LeadingTrivia,
+                             Trivia &TrailingTrivia) {
   if (Tok.isEscapedIdentifier()) {
     LeadingTrivia.push_back(TriviaPiece::backtick());
     TrailingTrivia.push_front(TriviaPiece::backtick());

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -74,6 +74,18 @@ static RawSyntaxInfo createSyntaxAs(ArrayRef<RawSyntaxInfo> Parts,
 }
 } // End of anonymous namespace
 
+RawSyntaxInfo::RawSyntaxInfo(Token Tok, Trivia LeadingTrivia,
+                             Trivia TrailingTrivia) {
+  if (Tok.isEscapedIdentifier()) {
+    LeadingTrivia.push_back(TriviaPiece::backtick());
+    TrailingTrivia.push_front(TriviaPiece::backtick());
+  }
+  SyntaxRange = Tok.getLoc();
+  RawNode = RawTokenSyntax::make(Tok.getKind(), Tok.getText(),
+                                 SourcePresence::Present, LeadingTrivia,
+                                 TrailingTrivia);
+}
+
 struct SyntaxParsingContext::ContextInfo {
   bool Enabled;
 private:

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -10,488 +10,219 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Syntax/SyntaxParsingContext.h"
 #include "swift/AST/Module.h"
 #include "swift/Basic/Defer.h"
-#include "swift/Parse/Token.h"
 #include "swift/Parse/Parser.h"
-#include "swift/Syntax/RawTokenSyntax.h"
-#include "swift/Syntax/TokenSyntax.h"
-#include "swift/Syntax/References.h"
+#include "swift/Parse/Token.h"
 #include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/RawTokenSyntax.h"
+#include "swift/Syntax/References.h"
 #include "swift/Syntax/Syntax.h"
-#include "swift/Syntax/TokenKinds.h"
-#include "swift/Syntax/Trivia.h"
-#include "swift/Syntax/SyntaxParsingContext.h"
 #include "swift/Syntax/SyntaxFactory.h"
+#include "swift/Syntax/TokenKinds.h"
+#include "swift/Syntax/TokenSyntax.h"
+#include "swift/Syntax/Trivia.h"
 
 using namespace swift;
 using namespace swift::syntax;
 
 namespace {
-static Syntax makeUnknownSyntax(SyntaxKind Kind, ArrayRef<Syntax> SubExpr) {
+static RC<RawSyntax> makeUnknownSyntax(SyntaxKind Kind,
+                                       ArrayRef<RC<RawSyntax>> Parts) {
   assert(isUnknownKind(Kind));
-  RawSyntax::LayoutList Layout;
-  std::transform(SubExpr.begin(), SubExpr.end(), std::back_inserter(Layout),
-                 [](const Syntax &S) { return S.getRaw(); });
-  return make<Syntax>(RawSyntax::make(Kind, Layout, SourcePresence::Present));
+  RawSyntax::LayoutList Layout(Parts);
+  return RawSyntax::make(Kind, Layout, SourcePresence::Present);
 }
 
-static ArrayRef<Syntax> getSyntaxNodes(ArrayRef<RawSyntaxInfo> RawNodes,
-                                       llvm::SmallVectorImpl<Syntax> &Scratch) {
-  std::transform(RawNodes.begin(), RawNodes.end(), std::back_inserter(Scratch),
-    [](const RawSyntaxInfo &Info) { return Info.makeSyntax<Syntax>(); });
-  return Scratch;
-}
-
-static SourceRange getNodesRange(ArrayRef<RawSyntaxInfo> RawNodes) {
-  SourceLoc StartLoc, EndLoc;
-  for (auto Info: RawNodes) {
-    if (Info.isImplicit())
-      continue;
-    if (StartLoc.isInvalid()) {
-      StartLoc = Info.getStartLoc();
-    }
-    EndLoc = Info.getEndLoc();
-  }
-  assert(StartLoc.isValid() == EndLoc.isValid());
-  return SourceRange(StartLoc, EndLoc);
-}
-
-static RawSyntaxInfo createSyntaxAs(ArrayRef<RawSyntaxInfo> Parts,
-                                    SyntaxKind Kind) {
+static RC<RawSyntax> createSyntaxAs(SyntaxKind Kind,
+                                    ArrayRef<RC<RawSyntax>> Parts) {
+  // Convert RawSyntax to Syntax for SyntaxFactory.
   llvm::SmallVector<Syntax, 8> Scratch;
-  auto SyntaxParts = getSyntaxNodes(Parts, Scratch);
+  std::transform(Parts.begin(), Parts.end(), std::back_inserter(Scratch),
+                 [](const RC<RawSyntax> &Raw) { return make<Syntax>(Raw); });
 
   // Try to create the node of the given syntax.
-  Optional<Syntax> Result = SyntaxFactory::createSyntax(Kind, SyntaxParts);
-  if (!Result) {
+  if (auto Node = SyntaxFactory::createSyntax(Kind, Scratch))
+    return Node->getRaw();
 
-    // If unable to create, we should create an unknown node.
-    Result.emplace(makeUnknownSyntax(SyntaxFactory::getUnknownKind(Kind),
-                                     SyntaxParts));
-  }
-  return { getNodesRange(Parts), Result->getRaw() };
+  // Fallback to unknown syntax for the category.
+  return makeUnknownSyntax(SyntaxFactory::getUnknownKind(Kind), Parts);
 }
 } // End of anonymous namespace
 
-RawSyntaxInfo::RawSyntaxInfo(Token Tok, Trivia &LeadingTrivia,
-                             Trivia &TrailingTrivia) {
+SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder,
+                                           SourceFile &SF)
+    : Parent(nullptr), CtxtHolder(CtxtHolder), Mode(AccumulationMode::Root),
+      SF(&SF), Enabled(SF.shouldKeepSyntaxInfo()) {
+  CtxtHolder = this;
+}
+
+/// Add RawSyntax to the parts.
+void SyntaxParsingContext::addRawSyntax(RC<RawSyntax> Raw) {
+  Parts.emplace_back(Raw);
+}
+
+SyntaxParsingContext *SyntaxParsingContext::getRoot() {
+  auto Curr = this;
+  while (!Curr->isRoot())
+    Curr = Curr->Parent;
+  return Curr;
+}
+
+/// Add Token with Trivia to the parts.
+void SyntaxParsingContext::addToken(Token &Tok, Trivia &LeadingTrivia,
+                                    Trivia &TrailingTrivia) {
+  if (!Enabled)
+    return;
+
   if (Tok.isEscapedIdentifier()) {
     LeadingTrivia.push_back(TriviaPiece::backtick());
     TrailingTrivia.push_front(TriviaPiece::backtick());
   }
-  SyntaxRange = Tok.getLoc();
-  RawNode = RawTokenSyntax::make(Tok.getKind(), Tok.getText(),
-                                 SourcePresence::Present, LeadingTrivia,
-                                 TrailingTrivia);
+  addRawSyntax(RawTokenSyntax::make(Tok.getKind(), Tok.getText(),
+                                    SourcePresence::Present, LeadingTrivia,
+                                    TrailingTrivia));
 }
 
-struct SyntaxParsingContext::ContextInfo {
-  bool Enabled;
-private:
-  SourceLoc ContextStartLoc;
-  std::vector<RawSyntaxInfo> PendingSyntax;
-
-  // All tokens after the start of this context.
-  ArrayRef<RawSyntaxInfo> Tokens;
-
-  ArrayRef<RawSyntaxInfo>::const_iterator findTokenAt(SourceLoc Loc) const {
-    for (auto It = Tokens.begin(); It != Tokens.end(); It ++) {
-      assert(It->getStartLoc() == It->getEndLoc());
-      if (It->getStartLoc() == Loc)
-        return It;
-    }
-    llvm_unreachable("cannot find the token on the given location");
-  }
-
-public:
-  ContextInfo(SourceFile &File, unsigned BufferID):
-      Enabled(File.shouldKeepSyntaxInfo()) {
-    if (Enabled) {
-      populateTokenSyntaxMap(File.getASTContext().LangOpts,
-                             File.getASTContext().SourceMgr,
-                             BufferID, File.AllRawTokenSyntax);
-      Tokens = File.AllRawTokenSyntax;
-      assert(Tokens.back().makeSyntax<TokenSyntax>().getTokenKind() == tok::eof);
-    }
-  }
-
-  ContextInfo(ArrayRef<RawSyntaxInfo> Tokens, bool Enabled): Enabled(Enabled) {
-    if (Enabled) {
-      this->Tokens = Tokens;
-    }
-  }
-
-  // Squash N syntax nodex from the back of the pending list into one.
-  void createPartiallyFromBack(SyntaxKind Kind, ArrayRef<RawSyntaxInfo> UsedTokens,
-                               unsigned N);
-  void createWhole(SyntaxKind Kind, ArrayRef<RawSyntaxInfo> NodesToUse);
-  std::vector<RawSyntaxInfo> collectAllSyntax(SourceLoc EndLoc);
-  ArrayRef<RawSyntaxInfo> allTokens() const { return Tokens; }
-  ArrayRef<RawSyntaxInfo> getPendingSyntax() const { return PendingSyntax; }
-  SourceLoc getContextStartLoc() const { return ContextStartLoc; }
-
-  void addPendingSyntax(RawSyntaxInfo Info) {
-    assert(Info.isImplicit() || PendingSyntax.empty() ||
-           PendingSyntax.back().getStartLoc().getOpaquePointerValue() <
-             Info.getStartLoc().getOpaquePointerValue());
-    assert(!Info.RawNode->isToken() && "Pending syntax should not have tokens");
-    PendingSyntax.push_back(Info);
-  }
-
-  void setContextStart(SourceLoc Loc) {
-    assert(ContextStartLoc.isInvalid());
-    ContextStartLoc = Loc;
-    Tokens = Tokens.slice(findTokenAt(Loc) - Tokens.begin());
-  }
-
-  ArrayRef<RawSyntaxInfo> dropTokenAt(SourceLoc Loc) const {
-    return Tokens.take_front(findTokenAt(Loc) - Tokens.begin());
-  }
-
-  // Check if the pending syntax is a token syntax in the given kind.
-  bool checkTokenFromBack(tok Kind, ArrayRef<RawSyntaxInfo> UsedTokens,
-                          unsigned OffsetFromBack = 0) {
-    if (UsedTokens.size() - 1 < OffsetFromBack)
-      return false;
-    auto Back = UsedTokens[UsedTokens.size() - 1 - OffsetFromBack].
-      makeSyntax<Syntax>().getAs<TokenSyntax>();
-    return Back.hasValue() && Back->getTokenKind() == Kind;
-  }
-};
-
-static void addNodeToResults(std::vector<RawSyntaxInfo> &Results,
-                             std::vector<RawSyntaxInfo> &ImplicitNodes,
-                             RawSyntaxInfo Info) {
-  // Add implicit nodes before adding the explicit nodes they attach to.
-  assert(!Info.isImplicit());
-  auto StartSize = Results.size();
-
-  // Find all implicit nodes where the attach-to location is the start position
-  // of this non-implicit nodes.
-  Results.insert(Results.end(),
-                 std::find_if(ImplicitNodes.begin(), ImplicitNodes.end(),
-                   [&](const RawSyntaxInfo &Imp) {
-                     return Imp.BeforeLoc == Info.getStartLoc();
-                   }),
-                 ImplicitNodes.end());
-
-  // If any implicit nodes are inserted to results, we should clear the buffer
-  // to avoid re-inserting them.
-  if (StartSize != Results.size()) {
-    ImplicitNodes.clear();
-  }
-
-  // Add the non-implicit node.
-  Results.emplace_back(Info);
-}
-
-std::vector<RawSyntaxInfo>
-SyntaxParsingContext::ContextInfo::collectAllSyntax(SourceLoc EndLoc) {
-  std::vector<RawSyntaxInfo> Results;
-  std::vector<RawSyntaxInfo> ImplicitNodes;
-  auto CurSyntax = PendingSyntax.begin();
-  for (auto It = Tokens.begin(); It->getStartLoc() != EndLoc;) {
-    auto Tok = *It;
-    if (CurSyntax == PendingSyntax.end()) {
-      // If no remaining syntax nodes, add the token.
-      addNodeToResults(Results, ImplicitNodes, Tok);
-      It ++;
-    } else if (CurSyntax->isImplicit()) {
-      ImplicitNodes.emplace_back(*CurSyntax);
-      // Skip implicit syntax node.
-      CurSyntax ++;
-    } else if (CurSyntax->getStartLoc() == Tok.getStartLoc()) {
-      // Prefer syntax nodes to tokens.
-      addNodeToResults(Results, ImplicitNodes, *CurSyntax);
-      while(It->getEndLoc() != CurSyntax->getEndLoc()) It++;
-      assert(It < Tokens.end() && It->getEndLoc() == CurSyntax->getEndLoc());
-      It ++;
-      CurSyntax ++;
-    } else {
-      // We have to add token in this case since the next syntax node has not
-      // started.
-      assert(Tok.getStartLoc().getOpaquePointerValue() <
-             CurSyntax->getStartLoc().getOpaquePointerValue());
-      addNodeToResults(Results, ImplicitNodes, Tok);
-      It ++;
-    }
-  }
-  // Add the remaining syntax nodes.
-  for (;CurSyntax != PendingSyntax.end(); CurSyntax ++) {
-    Results.emplace_back(*CurSyntax);
-  }
-  return Results;
-}
-
-void SyntaxParsingContext::ContextInfo::
-createPartiallyFromBack(SyntaxKind Kind, ArrayRef<RawSyntaxInfo> NodesToUse,
-                        unsigned N) {
-  auto Size = NodesToUse.size();
-  assert(N && Size >= N);
-  auto Parts = llvm::makeArrayRef(NodesToUse).slice(Size - N);
-
-  // Count the parts from the pending syntax list.
-  unsigned UsedPending = std::accumulate(Parts.begin(), Parts.end(), 0,
-    [](unsigned Count, RawSyntaxInfo Info) {
-      return Count += Info.RawNode->isToken() ? 0 : 1;
-    });
-
-  // Remove all pending syntax ndoes that we used to create the new node.
-  for (unsigned I = 0; I < UsedPending; I ++)
-    PendingSyntax.pop_back();
-
-  // Add result to the pending syntax list.
-  addPendingSyntax(createSyntaxAs(Parts, Kind));
-}
-
-void SyntaxParsingContext::ContextInfo::
-createWhole(SyntaxKind Kind, ArrayRef<RawSyntaxInfo> NodesToUse) {
-  auto Result = createSyntaxAs(NodesToUse, Kind);
-  PendingSyntax.clear();
-  addPendingSyntax(Result);
-}
-
-SyntaxParsingContext::
-SyntaxParsingContext(SourceFile &SF, unsigned BufferID, Token &Tok):
-  ContextData(*new ContextInfo(SF, BufferID)),
-    Tok(Tok) {}
-
-SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext &Another):
-  ContextData(*new ContextInfo(Another.ContextData.allTokens(),
-    Another.ContextData.Enabled)), Tok(Another.Tok) {}
-
-SyntaxParsingContext::~SyntaxParsingContext() { delete &ContextData; }
-
-void SyntaxParsingContext::disable() { ContextData.Enabled = false; }
-
-SyntaxParsingContextRoot::~SyntaxParsingContextRoot() {
-  if (!ContextData.Enabled)
+/// Add Syntax to the parts.
+void SyntaxParsingContext::addSyntax(Syntax Node) {
+  if (!Enabled)
     return;
-  std::vector<DeclSyntax> AllTopLevel;
-  if (File.hasSyntaxRoot()) {
-    for (auto It: File.getSyntaxRoot().getTopLevelDecls()) {
-      AllTopLevel.push_back(It);
+  addRawSyntax(Node.getRaw());
+}
+
+namespace {
+RC<RawSyntax> bridgeAs(SyntaxContextKind Kind, ArrayRef<RC<RawSyntax>> Parts) {
+  if (Parts.size() == 1) {
+    auto RawNode = Parts.front();
+    switch (Kind) {
+    case SyntaxContextKind::Stmt: {
+      if (RawNode->isStmt())
+        return RawNode;
+      else if (RawNode->isDecl())
+        return createSyntaxAs(SyntaxKind::DeclarationStmt, Parts);
+      else if (RawNode->isExpr())
+        return createSyntaxAs(SyntaxKind::ExpressionStmt, Parts);
+      else
+        return makeUnknownSyntax(SyntaxKind::UnknownStmt, Parts);
+      break;
     }
-  }
-  for (auto Info: ContextData.getPendingSyntax()) {
-    assert(Info.RawNode->Kind == SyntaxKind::StmtList);
-    AllTopLevel.push_back(SyntaxFactory::makeTopLevelCodeDecl(
-      Info.makeSyntax<StmtListSyntax>()));
-  }
-
-  File.setSyntaxRoot(
-    SyntaxFactory::makeSourceFile(SyntaxFactory::makeDeclList(AllTopLevel),
-    // The last node must be eof.
-    ContextData.allTokens().back().makeSyntax<TokenSyntax>()));
-}
-
-SyntaxParsingContextRoot &SyntaxParsingContextChild::getRoot() {
-  for (SyntaxParsingContext *Root = getParent(); ;
-       Root = static_cast<SyntaxParsingContextChild*>(Root)->getParent()){
-    if (Root->getKind() == SyntaxParsingContextKind::Root)
-      return *static_cast<SyntaxParsingContextRoot*>(Root);
-  }
-  llvm_unreachable("can not find root");
-}
-
-SyntaxParsingContextChild::
-SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder,
-      Optional<SyntaxContextKind> ContextKind, Optional<SyntaxKind> KnownSyntax):
-    SyntaxParsingContext(*ContextHolder), Parent(ContextHolder),
-    ContextHolder(ContextHolder), ContextKind(ContextKind),
-    KnownSyntax(KnownSyntax) {
-  ContextHolder = this;
-  if (ContextData.Enabled)
-    ContextData.setContextStart(Tok.getLoc());
-}
-
-void SyntaxParsingContextChild::setSyntaxKind(SyntaxKind SKind) {
-  assert(!KnownSyntax.hasValue() && "reset");
-  KnownSyntax = SKind;
-  ContextKind = None;
-}
-
-void SyntaxParsingContextChild::setContextKind(SyntaxContextKind CKind) {
-  assert(!ContextKind.hasValue() && "reset");
-  ContextKind = CKind;
-  KnownSyntax = None;
-}
-
-SyntaxParsingContextChild::
-SyntaxParsingContextChild(SyntaxParsingContext *&ContextHolder, bool Disable):
-    SyntaxParsingContextChild(ContextHolder, None, None) {
-  if (Disable)
-    disable();
-}
-
-void SyntaxParsingContextChild::makeNode(SyntaxKind Kind, SourceLoc EndLoc) {
-  assert(isTopOfContextStack());
-  if (!ContextData.Enabled)
-    return;
-
-  auto AllNodes = ContextData.collectAllSyntax(EndLoc);
-
-  // Create syntax nodes according to the given kind.
-  switch (Kind) {
-  case SyntaxKind::FloatLiteralExpr:
-  case SyntaxKind::IntegerLiteralExpr: {
-    // Integer may include the signs before the digits, so check if the sign
-    // exists and create.
-    ContextData.createPartiallyFromBack(Kind, AllNodes, ContextData.
-      checkTokenFromBack(tok::oper_prefix, AllNodes, 1) ? 2 : 1);
-    break;
-  }
-  case SyntaxKind::TernaryExpr:
-  case SyntaxKind::StringLiteralExpr: {
-    auto Pair = SyntaxFactory::countChildren(Kind);
-    assert(Pair.first == Pair.second);
-    ContextData.createPartiallyFromBack(Kind, AllNodes, Pair.first);
-    break;
-  }
-  default:
-    llvm_unreachable("Unrecognized node kind.");
-  }
-}
-
-void SyntaxParsingContextChild::makeNodeWhole(SyntaxKind Kind) {
-  assert(ContextData.Enabled);
-  assert(isTopOfContextStack());
-
-  auto EndLoc = Tok.getLoc();
-  auto AllNodes = ContextData.collectAllSyntax(EndLoc);
-  switch (Kind) {
-  case SyntaxKind::BooleanLiteralExpr:
-  case SyntaxKind::NilLiteralExpr:
-  case SyntaxKind::DiscardAssignmentExpr:
-  case SyntaxKind::IdentifierExpr:
-  case SyntaxKind::DictionaryExpr:
-  case SyntaxKind::ArrayExpr:
-  case SyntaxKind::DictionaryElement:
-  case SyntaxKind::ArrayElement:
-  case SyntaxKind::FunctionCallArgument:
-  case SyntaxKind::ReturnStmt:
-  case SyntaxKind::CodeBlock: {
-    ContextData.createWhole(Kind, AllNodes);
-    break;
-  }
-  case SyntaxKind::DictionaryElementList:
-  case SyntaxKind::ArrayElementList:
-  case SyntaxKind::StmtList:
-  case SyntaxKind::FunctionCallArgumentList: {
-    if (AllNodes.empty()) {
-      // Create an empty argument list if no arguments are in the context.
-      RawSyntaxInfo Empty(SyntaxFactory::
-                          makeBlankCollectionSyntax(Kind).getRaw());
-      Empty.setBeforeLoc(EndLoc);
-      ContextData.addPendingSyntax(Empty);
-    } else {
-      ContextData.createWhole(Kind, AllNodes);
-    }
-    break;
-  }
-  default:
-    llvm_unreachable("Unrecognized node kind.");
-  }
-}
-
-void RawSyntaxInfo::brigeWithContext(SyntaxContextKind Kind) {
-  switch (Kind) {
-  case SyntaxContextKind::Stmt: {
-    if (RawNode->isDecl()) {
-      // Wrap a declaration with a declaration statement
-      RawNode = SyntaxFactory::createSyntax(SyntaxKind::DeclarationStmt,
-        { makeSyntax<Syntax>() })->getRaw();
-    } else if (RawNode->isExpr()) {
-      // Wrap an expression with an expression statement
-      RawNode = SyntaxFactory::createSyntax(SyntaxKind::ExpressionStmt,
-        { makeSyntax<Syntax>() })->getRaw();
-    } else if (RawNode->isToken()) {
-      // Wrap a standalone token withn an expression statement
-      RawNode = SyntaxFactory::createSyntax(SyntaxKind::ExpressionStmt,
-        makeUnknownSyntax(SyntaxKind::UnknownExpr,
-                          {make<Syntax>(RawNode)}))->getRaw();
-    }
-    assert(RawNode->isStmt());
-    break;
-  }
-  case SyntaxContextKind::Decl: {
-    if (!RawNode->isDecl()) {
-      RawNode = makeUnknownSyntax(SyntaxKind::UnknownDecl,
-                                  {make<Syntax>(RawNode)}).getRaw();
-    }
-    assert(RawNode->isDecl());
-    break;
-  }
-
-  case SyntaxContextKind::Expr:
-    if (!RawNode->isExpr()) {
-      RawNode = makeUnknownSyntax(SyntaxKind::UnknownExpr,
-                                  {make<Syntax>(RawNode)}).getRaw();
-    }
-    assert(RawNode->isExpr());
-    break;
-  }
-}
-
-void SyntaxParsingContextChild::finalize() {
-  assert(isTopOfContextStack());
-  SWIFT_DEFER {
-    // Reset the context holder to be Parent.
-    ContextHolder = Parent;
-  };
-  if (!ContextData.Enabled)
-    return;
-
-  assert(ContextKind.hasValue() != KnownSyntax.hasValue());
-  SourceLoc EndLoc = Tok.getLoc();
-  if (KnownSyntax) {
-    // If the entire context should be created to a known syntax kind, create
-    // all pending syntax nodes into that node.
-    makeNodeWhole(*KnownSyntax);
-    assert(ContextData.getPendingSyntax().size() == 1);
-    Parent->ContextData.addPendingSyntax(ContextData.getPendingSyntax().front());
-    return;
-  }
-  auto AllNodes = ContextData.collectAllSyntax(EndLoc);
-  RC<RawSyntax> FinalResult;
-  if (AllNodes.empty())
-    return;
-
-  // Make sure we used all tokens.
-  assert(AllNodes.front().getStartLoc() == ContextData.getContextStartLoc());
-
-  if (AllNodes.size() == 1) {
-    // If we have only one syntax node remaining, we are done.
-    auto Result = AllNodes.front();
-    // Bridge the syntax node to the expected context kind.
-    Result.brigeWithContext(*ContextKind);
-    Parent->ContextData.addPendingSyntax(Result);
-    return;
-  }
-
-  llvm::SmallVector<Syntax, 8> Scratch;
-  auto SyntaxNodes = getSyntaxNodes(AllNodes, Scratch);
-  SourceLoc Start = AllNodes.front().getStartLoc();
-  SourceLoc End = AllNodes.back().getEndLoc();
-  SyntaxKind UnknownKind;
-  switch (*ContextKind) {
+    case SyntaxContextKind::Decl:
+      if (!RawNode->isDecl())
+        return makeUnknownSyntax(SyntaxKind::UnknownDecl, Parts);
+      break;
     case SyntaxContextKind::Expr:
-      UnknownKind = SyntaxKind::UnknownExpr;
+      if (!RawNode->isExpr())
+        return makeUnknownSyntax(SyntaxKind::UnknownExpr, Parts);
+      break;
+    case SyntaxContextKind::Type:
+      if (!RawNode->isType())
+        return makeUnknownSyntax(SyntaxKind::UnknownType, Parts);
+      break;
+    case SyntaxContextKind::Pattern:
+      if (!RawNode->isPattern())
+        return makeUnknownSyntax(SyntaxKind::UnknownPattern, Parts);
+      break;
+    }
+    return RawNode;
+  } else {
+    SyntaxKind UnknownKind;
+    switch (Kind) {
+    case SyntaxContextKind::Stmt:
+      UnknownKind = SyntaxKind::UnknownStmt;
       break;
     case SyntaxContextKind::Decl:
       UnknownKind = SyntaxKind::UnknownDecl;
       break;
-    case SyntaxContextKind::Stmt:
-      UnknownKind = SyntaxKind::UnknownStmt;
+    case SyntaxContextKind::Expr:
+      UnknownKind = SyntaxKind::UnknownExpr;
       break;
+    case SyntaxContextKind::Type:
+      UnknownKind = SyntaxKind::UnknownType;
+      break;
+    case SyntaxContextKind::Pattern:
+      UnknownKind = SyntaxKind::UnknownPattern;
+      break;
+    }
+    return makeUnknownSyntax(UnknownKind, Parts);
   }
-  // Create an unknown node and give it to the parent context.
-  Parent->ContextData.addPendingSyntax({SourceRange(Start, End),
-    makeUnknownSyntax(UnknownKind, SyntaxNodes).getRaw()});
 }
 
-SyntaxParsingContextChild::~SyntaxParsingContextChild() {
-  if (isTopOfContextStack())
-    finalize();
+void finalizeSourceFile(SourceFile *SF, ArrayRef<RC<RawSyntax>> Parts) {
+  std::vector<DeclSyntax> AllTopLevel;
+  if (SF->hasSyntaxRoot()) {
+    for (auto It : SF->getSyntaxRoot().getTopLevelDecls()) {
+      AllTopLevel.push_back(It);
+    }
+  }
+
+  TokenSyntax EOFToken = Parts.back()->isToken()
+                             // TODO: Ensure tok::eof.
+                             ? make<TokenSyntax>(Parts.back())
+                             : TokenSyntax::missingToken(tok::eof, "");
+  if (Parts.back()->isToken())
+    Parts = Parts.drop_back();
+
+  for (auto RawNode : Parts) {
+    if (RawNode->Kind != SyntaxKind::StmtList)
+      // FIXME: Skip for now.
+      continue;
+    AllTopLevel.push_back(
+        SyntaxFactory::makeTopLevelCodeDecl(make<StmtListSyntax>(RawNode)));
+  }
+  SF->setSyntaxRoot(SyntaxFactory::makeSourceFile(
+      SyntaxFactory::makeDeclList(AllTopLevel), EOFToken));
+}
+
+} // End of anonymous namespace
+
+SyntaxParsingContext::~SyntaxParsingContext() {
+  assert(isTopOfContextStack() && "destructed in wrong order");
+
+  SWIFT_DEFER {
+    // Pop this context from the stack.
+    if (!isRoot())
+      CtxtHolder = Parent;
+  };
+
+  if (!Enabled)
+    return;
+
+  switch (Mode) {
+  // Create specified Syntax node from the parts and add it to the parent.
+  case AccumulationMode::CreateSyntax:
+    assert(!isRoot());
+    Parent->addRawSyntax(createSyntaxAs(SynKind, Parts));
+    break;
+
+  // Ensure the result is specified Syntax category and add it to the parent.
+  case AccumulationMode::CoerceKind:
+    assert(!isRoot());
+    Parent->addRawSyntax(bridgeAs(CtxtKind, Parts));
+    break;
+
+  // Just move the parts to the tail of the parent.
+  case AccumulationMode::Transparent:
+    assert(!isRoot());
+    std::move(Parts.begin(), Parts.end(), std::back_inserter(Parent->Parts));
+    break;
+
+  // Do nothing. Just let it discarded.
+  case AccumulationMode::Discard:
+    assert(!isRoot());
+    break;
+
+  // Accumulate parsed toplevel syntax onto the SourceFile.
+  case AccumulationMode::Root:
+    assert(isRoot() && "AccumulationMode::Root is only for root context");
+    finalizeSourceFile(SF, Parts);
+    break;
+
+  // Never.
+  case AccumulationMode::NotSet:
+    assert(!Enabled && "Cleanup mode must be spefcified before destruction");
+    break;
+  }
+
 }

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -10,14 +10,14 @@ class C {
   func bar3(a: Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
   func bar4(_ a: Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
   func foo() <CodeBlock>{
-    var a = /*comment*/<StringLiteralExpr>"abc"/*comment*/</StringLiteralExpr>
-    var b = /*comment*/<IntegerLiteralExpr>+2/*comment*/</IntegerLiteralExpr><IdentifierExpr>
+    var a = <StringLiteralExpr>/*comment*/"abc"</StringLiteralExpr>/*comment*/
+    var b = <IntegerLiteralExpr>/*comment*/+2</IntegerLiteralExpr><IdentifierExpr>/*comment*/
     bar</IdentifierExpr>(<FunctionCallArgument><IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
     bar</IdentifierExpr>(<FunctionCallArgument><IntegerLiteralExpr>+10</IntegerLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
     bar</IdentifierExpr>(<FunctionCallArgument><IntegerLiteralExpr>-10</IntegerLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
     bar1</IdentifierExpr>(<FunctionCallArgument><FloatLiteralExpr>-1.1</FloatLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
     bar1</IdentifierExpr>(<FunctionCallArgument><FloatLiteralExpr>1.1</FloatLiteralExpr></FunctionCallArgument>)
-    var f = /*comments*/<FloatLiteralExpr>+0.1/*comments*/</FloatLiteralExpr><IdentifierExpr>
+    var f = <FloatLiteralExpr>/*comments*/+0.1</FloatLiteralExpr><IdentifierExpr>/*comments*/
     foo</IdentifierExpr>()
   }</CodeBlock>
 

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -37,7 +37,7 @@ class C {
   func boolOr() -> Bool <CodeBlock>{ <ReturnStmt>return <BooleanLiteralExpr>true </BooleanLiteralExpr>|| <BooleanLiteralExpr>false </BooleanLiteralExpr></ReturnStmt>}</CodeBlock>
 
   func foo2() <CodeBlock>{<DiscardAssignmentExpr>
-    _ </DiscardAssignmentExpr>= <BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr><DiscardAssignmentExpr>
-    _ </DiscardAssignmentExpr>= (<FunctionCallArgument><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></FunctionCallArgument>) ? (<FunctionCallArgument><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></FunctionCallArgument>) : (<FunctionCallArgument><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></FunctionCallArgument>)
+    _ </DiscardAssignmentExpr>= <TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr><DiscardAssignmentExpr>
+    _ </DiscardAssignmentExpr>= <TernaryExpr>(<FunctionCallArgument><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></FunctionCallArgument>) ? (<FunctionCallArgument><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></FunctionCallArgument>) : (<FunctionCallArgument><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></FunctionCallArgument>)</TernaryExpr>
   }</CodeBlock>
 }

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -10,7 +10,7 @@ class C {
   func bar3(a: Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
   func bar4(_ a: Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
   func foo() <CodeBlock>{
-    var a = <StringLiteralExpr>/*comment*/"abc"</StringLiteralExpr>/*comment*/
+    var a = <StringLiteralExpr>/*comment*/"ab\(x)c"</StringLiteralExpr>/*comment*/
     var b = <IntegerLiteralExpr>/*comment*/+2</IntegerLiteralExpr><IdentifierExpr>/*comment*/
     bar</IdentifierExpr>(<FunctionCallArgument><IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
     bar</IdentifierExpr>(<FunctionCallArgument><IntegerLiteralExpr>+10</IntegerLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
@@ -37,7 +37,7 @@ class C {
   func boolOr() -> Bool <CodeBlock>{ <ReturnStmt>return <BooleanLiteralExpr>true </BooleanLiteralExpr>|| <BooleanLiteralExpr>false </BooleanLiteralExpr></ReturnStmt>}</CodeBlock>
 
   func foo2() <CodeBlock>{<DiscardAssignmentExpr>
-    _ </DiscardAssignmentExpr>= <TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr><DiscardAssignmentExpr>
-    _ </DiscardAssignmentExpr>= <TernaryExpr>(<FunctionCallArgument><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></FunctionCallArgument>) ? (<FunctionCallArgument><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></FunctionCallArgument>) : (<FunctionCallArgument><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></FunctionCallArgument>)</TernaryExpr>
+    _ </DiscardAssignmentExpr>= <BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr><DiscardAssignmentExpr>
+    _ </DiscardAssignmentExpr>= (<FunctionCallArgument><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></FunctionCallArgument>) ? (<FunctionCallArgument><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></FunctionCallArgument>) : (<FunctionCallArgument><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></FunctionCallArgument>)
   }</CodeBlock>
 }

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -10,7 +10,7 @@ class C {
   func bar3(a: Int) -> Int { return 1 }
   func bar4(_ a: Int) -> Int { return 1 }
   func foo() {
-    var a = /*comment*/"abc"/*comment*/
+    var a = /*comment*/"ab\(x)c"/*comment*/
     var b = /*comment*/+2/*comment*/
     bar(1)
     bar(+10)


### PR DESCRIPTION
CC: @nkcsgexi 

Read `RawSyntaxToken` along with `Parser::consumeToken()`.

* Avoids multiple `Lexer` pass
* Makes easy to handle split-token and backtracking
* Simplify implementation of `SyntaxParsingContext `