### PR TITLE
[Serialization] Recover if an enum's generic requirements are broken

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2570,6 +2570,15 @@ static void collectDependenciesFromType(llvm::SmallSetVector<Type, 4> &seen,
   });
 }
 
+static void
+collectDependenciesFromRequirement(llvm::SmallSetVector<Type, 4> &seen,
+                                   const Requirement &req,
+                                   const ModuleDecl *excluding) {
+  collectDependenciesFromType(seen, req.getFirstType(), excluding);
+  if (req.getKind() != RequirementKind::Layout)
+    collectDependenciesFromType(seen, req.getSecondType(), excluding);
+}
+
 static SmallVector<Type, 4> collectDependenciesFromType(Type ty) {
   llvm::SmallSetVector<Type, 4> result;
   collectDependenciesFromType(result, ty, /*excluding*/nullptr);
@@ -2831,17 +2840,17 @@ void Serializer::writeDecl(const Decl *D) {
 
     auto underlying = typeAlias->getUnderlyingTypeLoc().getType();
 
-    SmallVector<TypeID, 2> dependencies;
-    for (Type dep : collectDependenciesFromType(underlying->getCanonicalType()))
-      dependencies.push_back(addTypeRef(dep));
-
+    llvm::SmallSetVector<Type, 4> dependencies;
+    collectDependenciesFromType(dependencies, underlying->getCanonicalType(),
+                                /*excluding*/nullptr);
     for (Requirement req : typeAlias->getGenericRequirements()) {
-      for (Type dep : collectDependenciesFromType(req.getFirstType()))
-        dependencies.push_back(addTypeRef(dep));
-      if (req.getKind() != RequirementKind::Layout)
-        for (Type dep : collectDependenciesFromType(req.getSecondType()))
-          dependencies.push_back(addTypeRef(dep));
+      collectDependenciesFromRequirement(dependencies, req,
+                                         /*excluding*/nullptr);
     }
+
+    SmallVector<TypeID, 4> dependencyIDs;
+    for (Type dep : dependencies)
+      dependencyIDs.push_back(addTypeRef(dep));
 
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(typeAlias->getFormalAccess());
@@ -2856,7 +2865,7 @@ void Serializer::writeDecl(const Decl *D) {
                                 addGenericEnvironmentRef(
                                              typeAlias->getGenericEnvironment()),
                                 rawAccessLevel,
-                                dependencies);
+                                dependencyIDs);
     writeGenericParams(typeAlias->getGenericParams());
     break;
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2964,6 +2964,10 @@ void Serializer::writeDecl(const Decl *D) {
                                   nextElt->getArgumentInterfaceType(),
                                   /*excluding*/theEnum->getParentModule());
     }
+    for (Requirement req : theEnum->getGenericRequirements()) {
+      collectDependenciesFromRequirement(dependencyTypes, req,
+                                         /*excluding*/nullptr);
+    }
     for (Type ty : dependencyTypes)
       inheritedAndDependencyTypes.push_back(addTypeRef(ty));
 

--- a/test/Serialization/Recovery/typedefs-in-enums.swift
+++ b/test/Serialization/Recovery/typedefs-in-enums.swift
@@ -41,6 +41,17 @@ public enum BadEnum {
 // CHECK-LABEL: enum BadEnum {
 // CHECK-RECOVERY-NOT: enum BadEnum
 
+public enum GenericBadEnum<T: HasAssoc> where T.Assoc == WrappedInt {
+  case noPayload
+  case perfectlyOkayPayload(Int)
+
+  static public func ==(a: GenericBadEnum<T>, b: GenericBadEnum<T>) -> Bool {
+    return false
+  }
+}
+// CHECK-LABEL: enum GenericBadEnum<T> where T : HasAssoc, T.Assoc == WrappedInt {
+// CHECK-RECOVERY-NOT: enum GenericBadEnum
+
 public enum OkayEnum {
   case noPayload
   case plainOldAlias(Any, UnwrappedInt)
@@ -83,9 +94,17 @@ public enum OkayEnumWithSelfRefs {
 // CHECK-RECOVERY-NEXT:   case nested(OkayEnumWithSelfRefs.Nested)
 // CHECK-RECOVERY-NEXT: }
 
+public protocol HasAssoc {
+  associatedtype Assoc
+}
+
 public func producesBadEnum() -> BadEnum { return .noPayload }
 // CHECK-LABEL: func producesBadEnum() -> BadEnum
 // CHECK-RECOVERY-NOT: func producesBadEnum() -> BadEnum
+
+public func producesGenericBadEnum<T>() -> GenericBadEnum<T> { return .noPayload }
+// CHECK-LABEL: func producesGenericBadEnum<T>() -> GenericBadEnum<T>
+// CHECK-RECOVERY-NOT: func producesGenericBadEnum
 
 public func producesOkayEnum() -> OkayEnum { return .noPayload }
 // CHECK-LABEL: func producesOkayEnum() -> OkayEnum

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -29,11 +29,11 @@ func testSymbols() {
 
 // CHECK-IR-LABEL: define{{.*}} void @_T08typedefs18testVTableBuildingy3Lib4UserC4user_tF
 public func testVTableBuilding(user: User) {
-  // The important thing in this CHECK line is the "i64 24", which is the offset
+  // The important thing in this CHECK line is the "i64 28", which is the offset
   // for the vtable slot for 'lastMethod()'. If the layout here
-  // changes, please check that offset 24 is still correct.
+  // changes, please check that offset 28 is still correct.
   // CHECK-IR-NOT: ret
-  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, {{i64 24|i32 27}}
+  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, {{i64 28|i32 31}}
   _ = user.lastMethod()
 } // CHECK-IR: ret void
 
@@ -133,9 +133,20 @@ open class User {
   // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() */
   public func returnsWrappedMethod() -> WrappedInt { fatalError() }
 
+  // CHECK: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == UnwrappedInt
+  // CHECK-RECOVERY: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == Int32
+  public func constrainedUnwrapped<T: HasAssoc>(_: T) where T.Assoc == UnwrappedInt { fatalError() }
+  // CHECK: func constrainedWrapped<T>(_: T) where T : HasAssoc, T.Assoc == WrappedInt
+  // CHECK-RECOVERY: /* placeholder for constrainedWrapped(_:) */
+  public func constrainedWrapped<T: HasAssoc>(_: T) where T.Assoc == WrappedInt { fatalError() }
+
   // CHECK: subscript(_: WrappedInt) -> () { get }
   // CHECK-RECOVERY: /* placeholder for _ */
   public subscript(_: WrappedInt) -> () { return () }
+
+  // CHECK: subscript<T>(_: T) -> () where T : HasAssoc, T.Assoc == WrappedInt { get }
+  // CHECK-RECOVERY: /* placeholder for _ */
+  public subscript<T: HasAssoc>(_: T) -> () where T.Assoc == WrappedInt { return () }
 
   // CHECK: init()
   // CHECK-RECOVERY: init()
@@ -148,6 +159,10 @@ open class User {
   // CHECK: convenience init(conveniently: Int)
   // CHECK-RECOVERY: convenience init(conveniently: Int)
   public convenience init(conveniently: Int) { self.init() }
+
+  // CHECK: convenience init<T>(generic: T) where T : HasAssoc, T.Assoc == WrappedInt
+  // CHECK-RECOVERY: /* placeholder for init(generic:) */
+  public convenience init<T: HasAssoc>(generic: T) where T.Assoc == WrappedInt { self.init() }
 
   // CHECK: required init(wrappedRequired: WrappedInt)
   // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
@@ -170,13 +185,17 @@ open class User {
 // 15 CHECK-VTABLE-NEXT: #User.wrappedProp!materializeForSet.1:
 // 16 CHECK-VTABLE-NEXT: #User.returnsUnwrappedMethod!1:
 // 17 CHECK-VTABLE-NEXT: #User.returnsWrappedMethod!1:
-// 18 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
-// 19 CHECK-VTABLE-NEXT: #User.init!initializer.1:
-// 20 CHECK-VTABLE-NEXT: #User.init!initializer.1:
-// 21 CHECK-VTABLE-NEXT: #User.init!initializer.1:
-// 22 CHECK-VTABLE-NEXT: #User.init!allocator.1:
+// 18 CHECK-VTABLE-NEXT: #User.constrainedUnwrapped!1:
+// 19 CHECK-VTABLE-NEXT: #User.constrainedWrapped!1:
+// 20 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
+// 21 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
+// 22 CHECK-VTABLE-NEXT: #User.init!initializer.1:
 // 23 CHECK-VTABLE-NEXT: #User.init!initializer.1:
-// 24 CHECK-VTABLE-NEXT: #User.lastMethod!1:
+// 24 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 25 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 26 CHECK-VTABLE-NEXT: #User.init!allocator.1:
+// 27 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 28 CHECK-VTABLE-NEXT: #User.lastMethod!1:
 // CHECK-VTABLE: }
 
 


### PR DESCRIPTION
Follow-up to #12979 that adds a similar feature for enums. This probably doesn't come up much, but the infrastructure's already there. Also, add some additional tests to cover at least the simple cases for functions, subscripts, and initializers.