### PR TITLE
[SE-0143] Various fixes for conditional conformances

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3015,8 +3015,6 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
 
     if (!conformance) return failed();
     if (!conformance->isConcrete()) return failed();
-    assert(conformance->getConditionalRequirements().empty() &&
-           "unhandled conditional requirements");
 
     // Retrieve the type witness.
     auto witness =

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -474,9 +474,6 @@ namespace {
               tc.conformsToProtocol(baseTy, proto, cs.DC,
                                     (ConformanceCheckFlags::InExpression|
                                          ConformanceCheckFlags::Used));
-            assert((!conformance ||
-                    conformance->getConditionalRequirements().empty()) &&
-                   "unhandled conditional conformance");
             if (conformance && conformance->isConcrete()) {
               if (auto witness =
                         conformance->getConcrete()->getWitnessDecl(decl, &tc)) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4844,7 +4844,7 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
     AFD = dyn_cast<AbstractFunctionDecl>(candidate);
   }
 
-  if (!AFD || !AFD->isGeneric() || !AFD->hasInterfaceType())
+  if (!AFD || !AFD->getGenericSignature() || !AFD->hasInterfaceType())
     return false;
 
   auto env = AFD->getGenericEnvironment();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1418,7 +1418,15 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     ///       x == nil    // also !=
     ///
     void checkOptionalPromotions(ApplyExpr *call) {
-      auto DRE = dyn_cast<DeclRefExpr>(call->getSemanticFn());
+      // We only care about binary expressions.
+      if (!isa<BinaryExpr>(call)) return;
+
+      // Dig out the function we're calling.
+      auto fnExpr = call->getSemanticFn();
+      if (auto dotSyntax = dyn_cast<DotSyntaxCallExpr>(fnExpr))
+        fnExpr = dotSyntax->getSemanticFn();
+
+      auto DRE = dyn_cast<DeclRefExpr>(fnExpr);
       auto args = dyn_cast<TupleExpr>(call->getArg());
       if (!DRE || !DRE->getDecl()->isOperator() ||
           !args || args->getNumElements() != 2)

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -96,3 +96,22 @@ sil_witness_table DeadMethodClass: Proto module witness_tables {
   method #Proto.abc!1: nil
 }
 
+protocol P {
+}
+
+struct ConditionalStruct<T> {
+  init()
+}
+
+extension ConditionalStruct : P where T : P {
+}
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : P> ConditionalStruct<T>: P module witness_tables {
+// CHECK-NEXT:    conditional_conformance (T: P): dependent
+// CHECL-NEXT:   }
+sil_witness_table hidden <T where T : P> ConditionalStruct<T>: P module t4 {
+  conditional_conformance (T: P): dependent
+}
+
+sil_default_witness_table hidden P {
+}


### PR DESCRIPTION
A small collection of compiler fixes for conditional conformances, addressing problems found while adopting them in the standard library, including:

* Teach the SIL parser how to properly parse conditional conformances
* Teach the type checker how to deal with ==/!= on `Optional` being a member
* Remove some assertions that were added defensively but are not correct