### PR TITLE
driver: Make -remove-runtime-asserts a driver option, which is passed to the frontend

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -197,9 +197,6 @@ def enable_guaranteed_closure_contexts : Flag<["-"], "enable-guaranteed-closure-
 def disable_sil_partial_apply : Flag<["-"], "disable-sil-partial-apply">,
   HelpText<"Disable use of partial_apply in SIL generation">;
 
-def remove_runtime_asserts : Flag<["-"], "remove-runtime-asserts">,
-  HelpText<"Remove runtime asserts.">;
-
 def disable_access_control : Flag<["-"], "disable-access-control">,
   HelpText<"Don't respect access control restrictions">;
 def enable_access_control : Flag<["-"], "enable-access-control">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -403,6 +403,9 @@ def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
   Flags<[HelpHidden, FrontendOption]>,
   HelpText<"Compile with optimizations appropriate for a playground">;
 
+def RemoveRuntimeAsserts : Flag<["-"], "remove-runtime-asserts">,
+  Flags<[FrontendOption]>,
+  HelpText<"Remove runtime safety checks.">;
 def AssumeSingleThreaded : Flag<["-"], "assume-single-threaded">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Assume that code will be executed in a single-threaded "

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -168,6 +168,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
                        options::OPT_solver_shrink_unsolved_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_O_Group);
   inputArgs.AddLastArg(arguments, options::OPT_RemoveRuntimeAsserts);
+  inputArgs.AddLastArg(arguments, options::OPT_AssumeSingleThreaded);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -167,6 +167,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments,
                        options::OPT_solver_shrink_unsolved_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_O_Group);
+  inputArgs.AddLastArg(arguments, options::OPT_RemoveRuntimeAsserts);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1287,7 +1287,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   }
 
   // -Ounchecked might also set removal of runtime asserts (cond_fail).
-  Opts.RemoveRuntimeAsserts |= Args.hasArg(OPT_remove_runtime_asserts);
+  Opts.RemoveRuntimeAsserts |= Args.hasArg(OPT_RemoveRuntimeAsserts);
 
   Opts.EnableARCOptimizations |= !Args.hasArg(OPT_disable_arc_opts);
   Opts.DisableSILPerfOptimizations |= Args.hasArg(OPT_disable_sil_perf_optzns);

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -117,3 +117,8 @@
 // RUN: %swiftc_driver -driver-print-jobs -enforce-exclusivity=checked %s | %FileCheck -check-prefix=EXCLUSIVITY_CHECKED %s
 // EXCLUSIVITY_CHECKED: swift
 // EXCLUSIVITY_CHECKED: -enforce-exclusivity=checked
+
+// RUN: %swiftc_driver -driver-print-jobs -remove-runtime-asserts %s | %FileCheck -check-prefix=REMOVE_RUNTIME_ASSERTS %s
+// REMOVE_RUNTIME_ASSERTS: swift
+// REMOVE_RUNTIME_ASSERTS: -frontend {{.*}} -remove-runtime-asserts
+

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -122,3 +122,6 @@
 // REMOVE_RUNTIME_ASSERTS: swift
 // REMOVE_RUNTIME_ASSERTS: -frontend {{.*}} -remove-runtime-asserts
 
+// RUN: %swiftc_driver -driver-print-jobs -assume-single-threaded %s | %FileCheck -check-prefix=ASSUME_SINGLE_THREADED %s
+// ASSUME_SINGLE_THREADED: swift
+// ASSUME_SINGLE_THREADED: -frontend {{.*}} -assume-single-threaded


### PR DESCRIPTION
rdar://problem/35602951

And fix handling of hidden option -assume-single-threaded
It had no effect, because it was not passed to the frontend