### PR TITLE
IRGen: Add a pass to disable tail calling of objc_retainAutoreleasedR…

### DIFF
--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -32,7 +32,7 @@ func instanceMethods(_ b: B) {
 func extensionMethods(b b: B) {
   // CHECK:      load i8*, i8** @"\01L_selector(method:separateExtMethod:)", align 8
   // CHECK:      [[T0:%.*]] = call i8* bitcast (void ()* @objc_msgSend to i8*
-  // CHECK-NEXT: [[T1:%.*]] = call i8* @objc_retainAutoreleasedReturnValue(i8* [[T0]])
+  // CHECK-NEXT: [[T1:%.*]] = {{.*}}call i8* @objc_retainAutoreleasedReturnValue(i8* [[T0]])
   // CHECK-NOT:  [[T0]]
   // CHECK:      [[T1]]
   b.method(1, separateExtMethod:1.5)

--- a/test/IRGen/autorelease.sil
+++ b/test/IRGen/autorelease.sil
@@ -58,7 +58,7 @@ bb0(%0 : $C?):
 // x86_64:    define{{( protected)?}} swiftcc i64 @bar(i64)
 // x86_64:      [[T0:%.*]] = call swiftcc i64 @foo(i64 %0)
 // x86_64-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to i8*
-// x86_64-NEXT: [[T2:%.*]] = call i8* @objc_retainAutoreleasedReturnValue(i8* [[T1]])
+// x86_64-NEXT: [[T2:%.*]] = notail call i8* @objc_retainAutoreleasedReturnValue(i8* [[T1]])
 // x86_64-NEXT: [[T3:%.*]] = ptrtoint i8* [[T2]] to i64
 // x86_64-NEXT: ret i64 [[T3]]
 

--- a/test/IRGen/objc_retainAutoreleasedReturnValue.swift
+++ b/test/IRGen/objc_retainAutoreleasedReturnValue.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.12 -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -O -target x86_64-apple-macosx10.12 -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s --check-prefix=OPT
+
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64
+import Foundation
+
+@inline(never)
+public func useClosure(_ dict: NSDictionary, _ action : (NSDictionary) -> ()) {
+  action(dict)
+}
+
+@inline(never)
+public func test(_ dict: NSDictionary) {
+  useClosure(dict, { $0.objectEnumerator()} )
+}
+
+//  Don't tail call objc_retainAutoreleasedReturnValue as this would block the
+//  autorelease return value optimization.
+
+// callq  0x01ec08 ; symbol stub for: objc_msgSend
+// movq   %rax, %rdi
+// popq   %rbp  ;<== Blocks the handshake from objc_autoreleaseReturnValue
+// jmp    0x01ec20 ; symbol stub for: objc_retainAutoreleasedReturnValue
+
+// CHECK-LABEL: define {{.*}}swiftcc void @_T034objc_retainAutoreleasedReturnValue4testySo12NSDictionaryCFyADcfU_(%TSo12NSDictionaryC*)
+// CHECK: entry:
+// CHECK:   call {{.*}}@objc_msgSend
+// CHECK:   notail call i8* @objc_retainAutoreleasedReturnValue
+// CHECK:   ret void
+
+// OPT-LABEL: define {{.*}}swiftcc void @_T034objc_retainAutoreleasedReturnValue4testySo12NSDictionaryCFyADcfU_(%TSo12NSDictionaryC*)
+// OPT: entry:
+// OPT:   call {{.*}}@objc_msgSend
+// OPT:   notail call i8* @objc_retainAutoreleasedReturnValue
+// OPT:   ret void

--- a/test/IRGen/objc_retainAutoreleasedReturnValue.swift
+++ b/test/IRGen/objc_retainAutoreleasedReturnValue.swift
@@ -3,6 +3,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
 import Foundation
 
 @inline(never)


### PR DESCRIPTION
…eturnValue

We don't want this to happen:

  callq  0x01ec08 ; symbol stub for: objc_msgSend
  movq   %rax, %rdi
  popq   %rbp // <== Blocks the handshake from objc_autoreleaseReturnValue
  jmp    0x01ec20 ; symbol stub for: objc_retainAutoreleasedReturnValue

This was exposed by the change to callee_guaranteed closures.