### PR TITLE
[CSSolver] Add test-cases for ambiguity issues resolved by weighted ranking

### DIFF
--- a/test/Sema/fixed_ambiguities/rdar27033993.swift
+++ b/test/Sema/fixed_ambiguities/rdar27033993.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+class S {}
+let arr: [(S, Int)] = []
+let _: [S] = arr.sorted {
+    $0.1 < $1.1
+// CHECK: function_ref @_T0s10CollectionPsE6prefix11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+}.prefix(1).map {
+    return $0.0
+}

--- a/test/Sema/fixed_ambiguities/rdar27198177.swift
+++ b/test/Sema/fixed_ambiguities/rdar27198177.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s -swift-version 4 | %FileCheck %s
+
+let arr = ["A", "B", "C"]
+let lazy: LazyMapCollection = arr.lazy.map { $0 }
+// CHECK: function_ref @_T0s22LazyCollectionProtocolPsE6filters0a6FilterB0Vy8ElementsQzGSb7ElementQzcF : $@convention(method) <τ_0_0 where τ_0_0 : LazyCollectionProtocol> (@owned @callee_guaranteed (@in τ_0_0.Element) -> Bool, @in_guaranteed τ_0_0) -> @out LazyFilterCollection<τ_0_0.Elements>
+_ = lazy.filter { $0 > "A" }.count

--- a/test/Sema/fixed_ambiguities/rdar33142386.swift
+++ b/test/Sema/fixed_ambiguities/rdar33142386.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s -swift-version 4 | %FileCheck %s
+
+let x: String = "ultimate question"
+// CHECK: function_ref @_T0s26RangeReplaceableCollectionPsE6filterxSb7ElementQzKcKF : $@convention(method) <τ_0_0 where τ_0_0 : RangeReplaceableCollection> (@owned @noescape @callee_guaranteed (@in τ_0_0.Element) -> (Bool, @error Error), @in_guaranteed τ_0_0) -> (@out τ_0_0, @error Error)
+_ = x.filter({ $0 == " " }).count < 3

--- a/test/Sema/fixed_ambiguities/rdar35623181.swift
+++ b/test/Sema/fixed_ambiguities/rdar35623181.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+extension Sequence where Element == String {
+  func record() -> String {
+    // CHECK: function_ref @_T0s20LazySequenceProtocolPsE3maps0a3MapB0Vy8ElementsQzqd__Gqd__7ElementQzclF : $@convention(method) <τ_0_0 where τ_0_0 : LazySequenceProtocol><τ_1_0> (@owned @callee_guaranteed (@in τ_0_0.Element) -> @out τ_1_0, @in_guaranteed τ_0_0) -> @out LazyMapSequence<τ_0_0.Elements, τ_1_0
+    return lazy.map({ $0 }).joined(separator: ",")
+  }
+}

--- a/test/Sema/fixed_ambiguities/rdar35624855.swift
+++ b/test/Sema/fixed_ambiguities/rdar35624855.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+extension Collection {
+  func foo() {
+    // CHECK: witness_method $Self.Indices, #Sequence.dropFirst!1 : <Self where Self : Sequence> (Self) -> (Int) -> Self.SubSequence : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+    _ = zip(indices, indices.dropFirst(3))
+  }
+}

--- a/test/Sema/fixed_ambiguities/rdar35625339.swift
+++ b/test/Sema/fixed_ambiguities/rdar35625339.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+let arr = Array(10...20)
+// CHECK: function_ref @_T0s10CollectionPsE6prefix11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+arr.prefix(3).forEach { (v: Int) in }

--- a/test/Sema/fixed_ambiguities/rdar35625473.swift
+++ b/test/Sema/fixed_ambiguities/rdar35625473.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+// CHECK: function_ref @_T0s10CollectionPsE9dropFirst11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+_ = [1, 2, 3].dropFirst(1).dropFirst(1)


### PR DESCRIPTION
Collects all (I could find) of the test-cases fixed by weighted ranking of solutions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
