### PR TITLE
[stdlib] Use a different access pattern to check uniqueness to work a…

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -120,7 +120,16 @@ extension _ArrayBuffer {
     if !_isClassOrObjCExistential(Element.self) {
       return _storage.isUniquelyReferenced_native_noSpareBits()
     }
-    return _storage.isUniquelyReferencedNative() && _isNative
+
+    // This is a performance optimization. This code used to be:
+    //
+    //   return _storage.isUniquelyReferencedNative() && _isNative.
+    //
+    // SR-6437
+    if !_storage.isUniquelyReferencedNative() {
+      return false
+    }
+    return _isNative
   }
 
   /// Returns `true` iff this buffer's storage is either
@@ -131,7 +140,16 @@ extension _ArrayBuffer {
     if !_isClassOrObjCExistential(Element.self) {
       return _storage.isUniquelyReferencedOrPinned_native_noSpareBits()
     }
-    return _storage.isUniquelyReferencedOrPinnedNative() && _isNative
+
+    // This is a performance optimization. This code used to be:
+    //
+    //   return _storage.isUniquelyReferencedOrPinnedNative() && _isNative.
+    //
+    // SR-6437
+    if !_storage.isUniquelyReferencedOrPinnedNative() {
+      return false
+    }
+    return _isNative
   }
 
   /// Convert to an NSArray.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1363,6 +1363,15 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   @_versioned
   @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
+    // This is a performance optimization. This code used to be in an ||
+    // statement in the _sanityCheck below.
+    //
+    //   _sanityCheck(_buffer.capacity == 0 ||
+    //                _buffer.isMutableAndUniquelyReferenced())
+    //
+    // SR-6437
+    let capacity = _buffer.capacity == 0
+
     // Due to make_mutable hoisting the situation can arise where we hoist
     // _makeMutableAndUnique out of loop and use it to replace
     // _makeUniqueAndReserveCapacityIfNotUnique that preceeds this call. If the
@@ -1372,7 +1381,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     // This specific case is okay because we will make the buffer unique in this
     // function because we request a capacity > 0 and therefore _copyToNewBuffer
     // will be called creating a new buffer.
-    _sanityCheck(_buffer.capacity == 0 ||
+    _sanityCheck(capacity ||
                  _buffer.isMutableAndUniquelyReferenced())
 
     if _slowPath(oldCount + 1 > _buffer.capacity) {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -4880,51 +4880,88 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   }
 #endif
 
+  /// Return true if self is native.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _isNative : Bool {
+#if _runtime(_ObjC)
+    switch self {
+    case .native:
+      return true
+    case .cocoa:
+      return false
+    }
+#else
+    return true
+#endif
+  }
+
+  @inline(__always)
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal mutating func ensureUniqueNativeBufferNative(_ minimumCapacity: Int)
+  -> (reallocated: Bool, capacityChanged: Bool) {
+    let oldCapacity = asNative.capacity
+    if oldCapacity >= minimumCapacity && isUniquelyReferenced() {
+      return (reallocated: false, capacityChanged: false)
+    }
+
+    let oldNativeBuffer = asNative
+    var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
+    let newCapacity = newNativeBuffer.capacity
+    for i in 0..<oldCapacity {
+      if oldNativeBuffer.isInitializedEntry(at: i) {
+        if oldCapacity == newCapacity {
+          let key = oldNativeBuffer.key(at: i)
+%if Self == 'Set':
+          newNativeBuffer.initializeKey(key, at: i)
+%elif Self == 'Dictionary':
+          let value = oldNativeBuffer.value(at: i)
+          newNativeBuffer.initializeKey(key, value: value , at: i)
+%end
+        } else {
+          let key = oldNativeBuffer.key(at: i)
+%if Self == 'Set':
+          newNativeBuffer.unsafeAddNew(key: key)
+%elif Self == 'Dictionary':
+          newNativeBuffer.unsafeAddNew(
+            key: key,
+            value: oldNativeBuffer.value(at: i))
+%end
+        }
+      }
+    }
+    newNativeBuffer.count = oldNativeBuffer.count
+
+    self = .native(newNativeBuffer)
+    return (reallocated: true,
+            capacityChanged: oldCapacity != newNativeBuffer.capacity)
+  }
+
   /// Ensure this we hold a unique reference to a native buffer
   /// having at least `minimumCapacity` elements.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal mutating func ensureUniqueNativeBuffer(_ minimumCapacity: Int)
-    -> (reallocated: Bool, capacityChanged: Bool) {
+  -> (reallocated: Bool, capacityChanged: Bool) {
+#if _runtime(_ObjC)
+    // This is a performance optimization that was put in to ensure that we did
+    // not make a copy of self to call _isNative over the entire if region
+    // causing at -Onone the uniqueness check to fail. This code used to be:
+    //
+    //  if _isNative {
+    //    return ensureUniqueNativeBufferNative(minimumCapacity)
+    //  }
+    //
+    // SR-6437
+    let n = _isNative
+    if n {
+      return ensureUniqueNativeBufferNative(minimumCapacity)
+    }
+
     switch self {
     case .native:
-      let oldCapacity = asNative.capacity
-      if isUniquelyReferenced() && oldCapacity >= minimumCapacity {
-        return (reallocated: false, capacityChanged: false)
-      }
-
-      let oldNativeBuffer = asNative
-      var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
-      let newCapacity = newNativeBuffer.capacity
-      for i in 0..<oldCapacity {
-        if oldNativeBuffer.isInitializedEntry(at: i) {
-          if oldCapacity == newCapacity {
-            let key = oldNativeBuffer.key(at: i)
-%if Self == 'Set':
-            newNativeBuffer.initializeKey(key, at: i)
-%elif Self == 'Dictionary':
-            let value = oldNativeBuffer.value(at: i)
-            newNativeBuffer.initializeKey(key, value: value , at: i)
-%end
-          } else {
-            let key = oldNativeBuffer.key(at: i)
-%if Self == 'Set':
-            newNativeBuffer.unsafeAddNew(key: key)
-%elif Self == 'Dictionary':
-            newNativeBuffer.unsafeAddNew(
-              key: key,
-              value: oldNativeBuffer.value(at: i))
-%end
-          }
-        }
-      }
-      newNativeBuffer.count = oldNativeBuffer.count
-
-      self = .native(newNativeBuffer)
-      return (reallocated: true,
-              capacityChanged: oldCapacity != newNativeBuffer.capacity)
-
-#if _runtime(_ObjC)
+      fatalError("This should have been handled earlier")
     case .cocoa(let cocoaBuffer):
       let cocoa${Self} = cocoaBuffer.cocoa${Self}
       var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
@@ -4948,8 +4985,10 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
       self = .native(newNativeBuffer)
       return (reallocated: true, capacityChanged: true)
-#endif
     }
+#else
+    return ensureUniqueNativeBufferNative(minimumCapacity)
+#endif
   }
 
 #if _runtime(_ObjC)
@@ -5236,8 +5275,17 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal mutating func nativePointerToValue(at i: Index)
-    -> UnsafeMutablePointer<Value> {
-    _ = ensureUniqueNativeBuffer(asNative.capacity)
+  -> UnsafeMutablePointer<Value> {
+    // This is a performance optimization that was put in to ensure that we did
+    // not make a copy of self to call asNative.capacity over
+    // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
+    // fail. This code used to be:
+    //
+    // _ = ensureUniqueNativeBuffer(capacity)
+    //
+    // SR-6437
+    let capacity = asNative.capacity
+    _ = ensureUniqueNativeBuffer(capacity)
     return asNative.values + i._nativeIndex.offset
   }
 
@@ -5391,7 +5439,16 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
 
       if found {
-        _ = ensureUniqueNativeBuffer(asNative.capacity)
+        // This is a performance optimization that was put in to ensure that we
+        // did not make a copy of self to call asNative.capacity over
+        // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
+        // fail. This code used to be:
+        //
+        // _ = ensureUniqueNativeBuffer(asNative.capacity)
+        //
+        // SR-6437
+        let capacity = asNative.capacity
+        _ = ensureUniqueNativeBuffer(capacity)
         do {
           let newValue = try combine(asNative.value(at: i.offset), value)
           asNative.setKey(key, value: newValue, at: i.offset)
@@ -5545,8 +5602,17 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       return nil
     }
 
+    // This is a performance optimization that was put in to ensure that we
+    // did not make a copy of self to call asNative.capacity over
+    // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
+    // fail. This code used to be:
+    //
+    // _ = ensureUniqueNativeBuffer(asNative.capacity)
+    //
+    // SR-6437
+    let capacity = asNative.capacity
     let (_, capacityChanged) =
-      ensureUniqueNativeBuffer(asNative.capacity)
+      ensureUniqueNativeBuffer(capacity)
     let nativeBuffer = asNative
     if capacityChanged {
       idealBucket = nativeBuffer._bucket(key)
@@ -5568,10 +5634,18 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   internal mutating func nativeRemove(
     at nativeIndex: NativeIndex
   ) -> SequenceElement {
-
+    // This is a performance optimization that was put in to ensure that we did
+    // not make a copy of self to call asNative.capacity over
+    // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
+    // fail. This code used to be:
+    //
+    // _ = ensureUniqueNativeBuffer(asNative.capacity)
+    //
+    // SR-6437
+    let capacity = asNative.capacity
     // The provided index should be valid, so we will always mutating the
     // set buffer.  Request unique buffer.
-    _ = ensureUniqueNativeBuffer(asNative.capacity)
+    _ = ensureUniqueNativeBuffer(capacity)
     let nativeBuffer = asNative
 
     let result = nativeBuffer.assertingGet(nativeIndex)

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -102,8 +102,6 @@ ${Suite}.test("${ArrayType}/Sliceable/Enums") {
 }
 
 ${Suite}.test("${ArrayType}/appendNonUnique")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${ArrayType}" == "ArraySlice"},
-                 reason: "rdar://33358110"))
   .code {
   var x: ${ArrayType}<Int> = []
   x.reserveCapacity(10002)
@@ -269,8 +267,6 @@ let withUnsafeMutableBufferPointerIfSupportedTests = [
 ]
 
 ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${ArrayType}" == "ArraySlice"},
-                 reason: "rdar://33358110"))
   .code {
   for test in withUnsafeMutableBufferPointerIfSupportedTests {
     var a = getFresh${ArrayType}(test.sequence.map(OpaqueValue.init))
@@ -306,8 +302,6 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported")
 }
 
 ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported/ReplacingTheBufferTraps/1")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${ArrayType}" == "ArraySlice"},
-                 reason: "rdar://33358110"))
   .code {
   var a = getFresh${ArrayType}([ OpaqueValue(10) ])
   var result = a._withUnsafeMutableBufferPointerIfSupported {
@@ -320,8 +314,6 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported/Replacing
 }
 
 ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported/ReplacingTheBufferTraps/2")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${ArrayType}" == "ArraySlice"},
-                 reason: "rdar://33358110"))
   .code {
   var a = getFresh${ArrayType}([ OpaqueValue(10) ])
   var result = a._withUnsafeMutableBufferPointerIfSupported {
@@ -339,8 +331,6 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported/Replacing
 
 // Test the uniqueness of the raw buffer.
 ${Suite}.test("${ArrayType}/withUnsafeMutableBytes")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${ArrayType}" == "ArraySlice"},
-                 reason: "rdar://33358110"))
   .code {
   var a = getFresh${ArrayType}([UInt8](repeating: 10, count: 1))
   let b = a
@@ -365,8 +355,6 @@ ${Suite}.test(
 
 ${Suite}.test(
   "${ArrayType}/mutationDoesNotAffectIterator/subscript/append")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${ArrayType}" == "ArraySlice"},
-                 reason: "rdar://33358110"))
   .code {
   var arr: ${ArrayType}<Int> = [ 1010, 1020, 1030 ]
   var iter = arr.makeIterator()

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -49,8 +49,6 @@ func withInoutT<T>(_ x: inout T, body: (_ x: inout T) -> Void) {
 %     end
 
 ArrayTestSuite.test("${array_type}<${element_type}>/subscript(_: Int)/COW")
-  .xfail(.custom({ _isStdlibDebugConfiguration() && "${array_type}" == "ArraySlice" },
-                 reason: "rdar://33358110"))
   .code {
   var a: ${array_type}<${array_type}<${element_type}>> = [[
     ${element_type}(10), ${element_type}(20), ${element_type}(30),

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -216,8 +216,6 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
 
 
 DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   var d = getCOWFastDictionary()
   var identity1 = d._rawIdentifier()
@@ -273,8 +271,6 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate")
 }
 
 DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
 
   var d = getCOWSlowDictionary()
@@ -485,8 +481,6 @@ DictionaryTestSuite.test("COW.Slow.AddDoesNotReallocate") {
 }
 
 DictionaryTestSuite.test("COW.Fast.MergeSequenceDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
 
   do {
@@ -610,8 +604,6 @@ DictionaryTestSuite.test("COW.Fast.MergeSequenceDoesNotReallocate")
 }
 
 DictionaryTestSuite.test("COW.Fast.MergeDictionaryDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
 
   do {
@@ -881,8 +873,6 @@ DictionaryTestSuite.test("COW.Slow.IndexForKeyDoesNotReallocate") {
 
 
 DictionaryTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var d = getCOWFastDictionary()
@@ -927,8 +917,6 @@ DictionaryTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
 }
 
 DictionaryTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var d = getCOWSlowDictionary()
@@ -972,8 +960,6 @@ DictionaryTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
 
 
 DictionaryTestSuite.test("COW.Fast.RemoveValueForKeyDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var d1 = getCOWFastDictionary()
@@ -1013,8 +999,6 @@ DictionaryTestSuite.test("COW.Fast.RemoveValueForKeyDoesNotReallocate")
 }
 
 DictionaryTestSuite.test("COW.Slow.RemoveValueForKeyDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var d1 = getCOWSlowDictionary()
@@ -2431,8 +2415,6 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   var d = getBridgedNonverbatimDictionary()
   var identity1 = d._rawIdentifier()
@@ -2513,8 +2495,6 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveValueForKey") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveValueForKey")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var d = getBridgedNonverbatimDictionary()

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -450,8 +450,6 @@ SetTestSuite.test("COW.Fast.ContainsDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   var s = getCOWSlowSet()
   var identity1 = s._rawIdentifier()
@@ -665,8 +663,6 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var s = getCOWFastSet()
@@ -707,8 +703,6 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
 }
 
 SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var s = getCOWSlowSet()
@@ -749,8 +743,6 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
 }
 
 SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var s1 = getCOWFastSet()
@@ -790,8 +782,6 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate")
 }
 
 SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   do {
     var s1 = getCOWSlowSet()
@@ -1663,8 +1653,6 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   var s = getBridgedNonverbatimSet()
   let identity1 = s._rawIdentifier()
@@ -1743,8 +1731,6 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
 
   do {
@@ -2969,8 +2955,6 @@ SetTestSuite.test("formUnion") {
 }
 
 SetTestSuite.test("subtract")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   let s1 = Set([1010, 2020, 3030])
   let s2 = Set([4040, 5050, 6060])
@@ -2998,8 +2982,6 @@ SetTestSuite.test("subtract")
 }
 
 SetTestSuite.test("subtract")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   var s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
   let s2 = Set([1010, 2020, 3030])
@@ -3090,8 +3072,6 @@ SetTestSuite.test("symmetricDifference") {
 }
 
 SetTestSuite.test("formSymmetricDifference")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
   // Overlap with 4040, 5050, 6060
   var s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
@@ -3130,8 +3110,6 @@ SetTestSuite.test("removeFirst") {
 }
 
 SetTestSuite.test("remove(member)")
-  .xfail(.custom({ _isStdlibDebugConfiguration() },
-                 reason: "rdar://33358110"))
   .code {
 
   let s1 : Set<TestKeyTy> = [1010, 2020, 3030]


### PR DESCRIPTION
…round more conservative SILGen codegen.

Using && here causes us to go down a SILGen path that guarantees that self will
be evaluated over the entire && expression instead of just the LHS. This cause
the uniqueness check to always return false at -Onone. At -O, the optimizer is
smart enough to remove this issue.

rdar://33358110