### PR TITLE
Code Size: mark enum's outlined retain/releases as no inline

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1485,6 +1485,9 @@ namespace {
         llvm::Function::Create(consumeTy, llvm::GlobalValue::InternalLinkage,
                                llvm::StringRef(name), IGM.getModule());
     func->setAttributes(IGM.constructInitialAttributes());
+    func->setDoesNotThrow();
+    func->setCallingConv(IGM.DefaultCC);
+    func->addFnAttr(llvm::Attribute::NoInline);
     return func;
   }
 

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -56,7 +56,7 @@ entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x
   return %r : $BitfieldOne
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testBigTempStruct(%T22big_types_corner_cases13BigTempStructV* noalias nocapture sret, %swift.bridge*, %swift.type* %Element) #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @testBigTempStruct(%T22big_types_corner_cases13BigTempStructV* noalias nocapture sret, %swift.bridge*, %swift.type* %Element)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases13BigTempStructV
 // CHECK: call swiftcc void @testBigTempStruct(%T22big_types_corner_cases13BigTempStructV* noalias nocapture sret [[ALLOC]], %swift.bridge* %1, %swift.type* %Element)
 // CHECK: ret void
@@ -68,7 +68,7 @@ bb0(%0 : $_ArrayBuffer<Element>):
   return %9 : $BigTempStruct<Element>
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testTryApply(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, i8*, %swift.refcounted*, %swift.refcounted* swiftself, %swift.error** swifterror) #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @testTryApply(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, i8*, %swift.refcounted*, %swift.refcounted* swiftself, %swift.error** swifterror)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK: call swiftcc void {{.*}}(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC]]
 // CHECK: ret void
@@ -84,7 +84,7 @@ bb2(%err : $Error):
   throw %err : $Error
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @testThinFuncPointer(%swift.type* %"BigTempStruct<Element>", %T22big_types_corner_cases13BigTempStructV* noalias nocapture swiftself dereferenceable({{.*}}) #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @testThinFuncPointer(%swift.type* %"BigTempStruct<Element>", %T22big_types_corner_cases13BigTempStructV* noalias nocapture swiftself dereferenceable({{.*}})
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret i8* bitcast (i8* (%swift.type*, %T22big_types_corner_cases13BigTempStructV*)* @testThinFuncPointer to i8*)
 sil @testThinFuncPointer : $@convention(method) <Element> (@guaranteed BigTempStruct<Element>) -> @owned Builtin.RawPointer {
@@ -95,7 +95,7 @@ bb0(%0 : $BigTempStruct<Element>):
   return %ret : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testFuncWithModBlockStorageApply({ %objc_block, %swift.function }* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @testFuncWithModBlockStorageApply({ %objc_block, %swift.function }* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}})
 // CHECK: call swiftcc void {{.*}}(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) %1
 // CHECK: ret void
 sil @testFuncWithModBlockStorageApply : $@convention(thin) (@inout_aliasable @block_storage @callee_owned (@owned BigStruct) -> (), BigStruct) -> () {
@@ -115,14 +115,14 @@ bb0(%0 : $*@block_storage @callee_owned (@owned BigStruct) -> (), %1 : $BigStruc
 
 sil public_external @c_return_func : $@convention(thin) () -> () -> @owned BigStruct
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @part_apply_caller() #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @part_apply_caller()
 // CHECK: [[CALLEXT:%.*]] = call swiftcc { i8*, %swift.refcounted* } @c_return_func()
 // CHECK: [[VALEXT:%.*]] = extractvalue { i8*, %swift.refcounted* } [[CALLEXT]], 1
 // CHECK: store %swift.refcounted* [[VALEXT]], %swift.refcounted**
 // CHECK: [[RET:%.*]] = insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%T22big_types_corner_cases9BigStructV*, i64, %swift.refcounted*)* @_T017part_apply_calleeTA to i8*), %swift.refcounted* undef }, %swift.refcounted*
 // CHECK: ret { i8*, %swift.refcounted* } [[RET]]
 
-// CHECK-LABEL: define internal swiftcc void @_T017part_apply_calleeTA(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, i64, %swift.refcounted* swiftself) #0 {
+// CHECK-LABEL: define internal swiftcc void @_T017part_apply_calleeTA(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, i64, %swift.refcounted* swiftself)
 // CHECK: bitcast %swift.refcounted* %2 to <{ %swift.refcounted, %swift.function }>*
 // CHECK: ret void
 
@@ -140,7 +140,7 @@ bb0(%0 : $Builtin.Int64, %1 : $() -> @owned BigStruct):
   return undef : $BigStruct
 }
 
-// CHECK-LABEL: define swiftcc void @poninter_to_mod_ret(i8*, %swift.refcounted*) #0 {
+// CHECK-LABEL: define swiftcc void @poninter_to_mod_ret(i8*, %swift.refcounted*)
 // CHECK: [[BITCAST:%.*]] = bitcast i8* %0 to { i8*, %swift.refcounted* } (%swift.refcounted*)*
 // CHECK: [[CALL:%.*]] = call swiftcc { i8*, %swift.refcounted* } [[BITCAST]](%swift.refcounted* swiftself %1)
 // CHECK: extractvalue { i8*, %swift.refcounted* } [[CALL]], 0
@@ -153,7 +153,7 @@ bb0(%funcpointer : $@callee_owned () -> @owned @callee_owned (@owned Builtin.Int
   return %ret : $()
 }
 
-// CHECK-LABEL: define swiftcc { i64, i64 } @ret_pointer_to_mod() #0 {
+// CHECK-LABEL: define swiftcc { i64, i64 } @ret_pointer_to_mod()
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret { i64, i64 } zeroinitializer
 sil @ret_pointer_to_mod : $@convention(thin) () -> @owned Optional<@callee_owned () -> @owned Optional<BigStruct>> {
@@ -189,7 +189,7 @@ sil @get_optional_none : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.T
 sil @short_circuit_operation : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
 sil @autoclosure_partialapply : $@convention(thin) (@owned @callee_owned () -> (BigStruct, @error Error)) -> (@out BigStruct, @error Error)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @closure(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*) #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @closure(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*)
 // CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
@@ -230,7 +230,7 @@ bb2(%24 : $Error):
 
 sil @returnBigStruct : $@convention(thin) () -> @owned BigStruct
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @closureToConvert() #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @closureToConvert()
 // CHECK: entry:
 // CHECK:   [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK:   call swiftcc void @returnBigStruct(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC]])
@@ -244,7 +244,7 @@ bb0:
   return %99 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testConvertFunc() #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @testConvertFunc()
 // CHECK: entry:
 // CHECK:   call swiftcc void bitcast (void ()* @closureToConvert to void (%swift.refcounted*)*)(%swift.refcounted* swiftself null)
 // CHECK:   ret void
@@ -261,7 +261,7 @@ bb0:
 
 sil @convertToThickHelper : $@convention(thin) (@owned BigStruct) -> ()
 
-// CHECK-LABAL: define {{.*}} swiftcc void @convertToThick(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}})) #0 {
+// CHECK-LABAL: define {{.*}} swiftcc void @convertToThick(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}))
 // CHECK: entry:
 // CHECK:   [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV, align 4
 // CHECK:   call void @llvm.memcpy.p0i8.p0i8.i64

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -34,7 +34,7 @@ class OptionalInoutFuncType {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} i32 @main(i32, i8**) #0 {
+// CHECK-LABEL: define{{( protected)?}} i32 @main(i32, i8**)
 // CHECK: call void @llvm.lifetime.start
 // CHECK: call void @llvm.memcpy
 // CHECK: call void @llvm.lifetime.end
@@ -93,7 +93,7 @@ public class BigClass {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @_T022big_types_corner_cases8BigClassC03useE6StructyAA0eH0V0aH0_tF(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself) #0 {
+// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @_T022big_types_corner_cases8BigClassC03useE6StructyAA0eH0V0aH0_tF(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself)
 // CHECK: getelementptr inbounds %T22big_types_corner_cases8BigClassC, %T22big_types_corner_cases8BigClassC*
 // CHECK: call void @_T0SqWy
 // CHECK: [[BITCAST:%.*]] = bitcast i8* {{.*}} to void (%T22big_types_corner_cases9BigStructV*, %swift.refcounted*)*
@@ -147,7 +147,7 @@ public func enumCallee(_ x: LargeEnum) {
 // CHECK-64: _T0s5printyypd_SS9separatorSS10terminatortF
 // CHECK-64: ret void
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @_T022big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*) #0 {
+// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @_T022big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*)
 // CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
@@ -171,7 +171,7 @@ class SuperSub : SuperBase {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret, %T22big_types_corner_cases10MUseStructV* noalias nocapture swiftself dereferenceable({{.*}})) #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret, %T22big_types_corner_cases10MUseStructV* noalias nocapture swiftself dereferenceable({{.*}}))
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK: [[LOAD:%.*]] = load %swift.refcounted*, %swift.refcounted** %.callInternalLet.data
 // CHECK: call swiftcc void %7(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret [[ALLOC]], %swift.refcounted* swiftself [[LOAD]])
@@ -200,7 +200,7 @@ func bigStructGet() -> BigStruct {
   return BigStruct()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases11testGetFuncyyF() #0 {
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases11testGetFuncyyF()
 // CHECK: ret void
 public func testGetFunc() {
   let testGetPtr: @convention(thin) () -> BigStruct = bigStructGet

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -472,7 +472,7 @@ sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> 
 // CHECK-LABEL: define{{.*}} @partial_apply_generic_indirect_return2
 // CHECK: insertvalue {{.*}}_T024generic_indirect_return2TA
 
-// CHECK-LABEL: define internal swiftcc void @_T024generic_indirect_return2TA(%T13partial_apply12GenericEnum2OySiG* noalias nocapture sret, %swift.refcounted* swiftself) #0 {
+// CHECK-LABEL: define internal swiftcc void @_T024generic_indirect_return2TA(%T13partial_apply12GenericEnum2OySiG* noalias nocapture sret, %swift.refcounted* swiftself)
 // CHECK:  [[CASTED_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* %0 to %T13partial_apply12GenericEnum2O*
 // CHECK: call swiftcc void @generic_indirect_return2(%T13partial_apply12GenericEnum2O* noalias nocapture sret [[CASTED_ADDR]]
 // CHECK:  ret void


### PR DESCRIPTION
radar rdar://problem/32987105

Mark enum's outlined functions as no inline to avoid them being inlined by LLVM.