### PR TITLE
[Refactoring] Fix local rename missing occurrences in string interpolations

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -564,35 +564,21 @@ void NameMatcher::skipLocsBefore(SourceLoc Start) {
 }
 
 bool NameMatcher::shouldSkip(Expr *E) {
-  if (!isa<StringLiteralExpr>(E) || !Parent.getAsExpr() ||
-      !isa<InterpolatedStringLiteralExpr>(Parent.getAsExpr()))
-    return shouldSkip(E->getSourceRange());
+  if (isa<StringLiteralExpr>(E) && Parent.getAsExpr()) {
+    // Attempting to get the CharSourceRange from the SourceRange of a
+    // StringLiteralExpr that is a segment of an interpolated string gives
+    // incorrect ranges. Use the CharSourceRange of the corresponding token
+    // instead.
 
-  // The lexer treats interpolated strings as a single token when computing the
-  // CharSourceRange, so when we try to get the CharSourceRange of its first
-  // child StringLiteralExpr (at the same SourceLoc) it goes beyond any
-  // interpolated values. Use the StartLoc of the next sibling to bound it.
+    auto ExprStart = E->getStartLoc();
+    auto RemaingTokens = TokensToCheck.drop_while([&](const Token &tok) -> bool {
+      return getSourceMgr().isBeforeInBuffer(tok.getRange().getStart(), ExprStart);
+    });
 
-  StringLiteralExpr *SL = cast<StringLiteralExpr>(E);
-  InterpolatedStringLiteralExpr *ISL =
-    cast<InterpolatedStringLiteralExpr>(Parent.getAsExpr());
-
-  SourceLoc Start = SL->getStartLoc();
-  ArrayRef<Expr*> Segments = ISL->getSegments();
-  Segments = Segments.drop_until([&](Expr *Item){ return Item == SL; })
-    .drop_front();
-
-  CharSourceRange Range;
-  if (Segments.empty()) {
-    Range = Lexer::getCharSourceRangeFromSourceRange(getSourceMgr(),
-                                                     SourceRange(Start));
-  } else {
-    SourceLoc NextSiblingLoc = Segments.front()->getStartLoc();
-    unsigned Length = getSourceMgr().getByteDistance(Start, NextSiblingLoc);
-    Range = CharSourceRange(Start, Length);
+    if (!RemaingTokens.empty() && RemaingTokens.front().getLoc() == ExprStart)
+      return shouldSkip(RemaingTokens.front().getRange());
   }
-
-  return shouldSkip(Range);
+  return shouldSkip(E->getSourceRange());
 }
 
 bool NameMatcher::shouldSkip(SourceRange Range) {

--- a/test/SourceKit/Refactoring/find-rename-ranges/foo_arity1.expected
+++ b/test/SourceKit/Refactoring/find-rename-ranges/foo_arity1.expected
@@ -25,3 +25,5 @@ source.edit.kind.active:
   26:28-26:29 source.refactoring.range.kind.call-argument-colon arg-index=0
 source.edit.kind.string:
   26:33-26:36 source.refactoring.range.kind.basename
+source.edit.kind.string:
+  26:43-26:46 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename-ranges.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename-ranges.swift.expected
@@ -4,3 +4,5 @@ source.edit.kind.active:
   3:3-3:5 source.refactoring.range.kind.basename
 source.edit.kind.active:
   3:8-3:10 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  4:17-4:19 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
@@ -1,6 +1,7 @@
 func foo() {
   var aa = 3
   aa = aa + 1
+  _ = "before \(aa) after"
   return 1
 }
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift.expected
@@ -4,3 +4,5 @@ source.edit.kind.active:
   3:3-3:5 "new_name"
 source.edit.kind.active:
   3:8-3:10 "new_name"
+source.edit.kind.active:
+  4:17-4:19 "new_name"

--- a/test/SourceKit/Refactoring/syntactic-rename.swift
+++ b/test/SourceKit/Refactoring/syntactic-rename.swift
@@ -23,7 +23,7 @@ let s = "a foo is here"
 #selector(AStruct.foo(a:))
 #selector(AStruct.foo())
 #selector(AStruct.foo)
-let y = "before foo \(foo(a:1)) foo after"
+let y = "before foo \(foo(a:1)) foo after foo"
 
 func bar(a/* a comment */: Int, b c: Int, _: Int, _ d: Int) {}
 bar(a: 1, b: 2, 3, 4)

--- a/test/SourceKit/Refactoring/syntactic-rename/foo.in.json
+++ b/test/SourceKit/Refactoring/syntactic-rename/foo.in.json
@@ -54,6 +54,11 @@
         "key.line": 26,
         "key.column": 33,
         "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 26,
+        "key.column": 43,
+        "key.nametype": source.syntacticrename.unknown
       }
     ]
   }

--- a/test/SourceKit/Refactoring/syntactic-rename/foo_arity1.expected
+++ b/test/SourceKit/Refactoring/syntactic-rename/foo_arity1.expected
@@ -22,3 +22,5 @@ source.edit.kind.active:
   26:27-26:28 "first"
 source.edit.kind.string:
   26:33-26:36 "bar"
+source.edit.kind.string:
+  26:43-26:46 "bar"


### PR DESCRIPTION
<!-- What's in this pull request? -->
`NameMatcher` decided if a `StringLiteralExpr` was a string segment in an interpolated string by checking if the parent expression was an `InterpolatedStringLiteralExpr`. That's only true pre-type-checking though, and local rename uses the type-checked AST (unlike global rename).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/35231459

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->