### PR TITLE
Delayed parsing

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -478,7 +478,8 @@ public: // for static functions in Frontend.cpp
 
 private:
   void createREPLFile(const ImplicitImports &implicitImports) const;
-  std::unique_ptr<DelayedParsingCallbacks> computeDelayedParsingCallback();
+  std::unique_ptr<DelayedParsingCallbacks>
+  computeDelayedParsingCallback(bool isPrimary);
 
   void addMainFileToModule(const ImplicitImports &implicitImports);
 
@@ -487,13 +488,15 @@ private:
   void parseLibraryFile(unsigned BufferID,
                         const ImplicitImports &implicitImports,
                         PersistentParserState &PersistentState,
-                        DelayedParsingCallbacks *DelayedParseCB);
+                        DelayedParsingCallbacks *PrimaryDelayedCB,
+                        DelayedParsingCallbacks *SecondaryDelayedCB);
 
   /// Return true if had load error
   bool
   parsePartialModulesAndLibraryFiles(const ImplicitImports &implicitImports,
                                      PersistentParserState &PersistentState,
-                                     DelayedParsingCallbacks *DelayedParseCB);
+                                     DelayedParsingCallbacks *PrimaryDelayedCB,
+                                     DelayedParsingCallbacks *SecondaryDelayedCB);
 
   OptionSet<TypeCheckingFlags> computeTypeCheckingOptions();
 
@@ -502,7 +505,6 @@ private:
   void parseAndTypeCheckMainFile(PersistentParserState &PersistentState,
                                  DelayedParsingCallbacks *DelayedParseCB,
                                  OptionSet<TypeCheckingFlags> TypeCheckOptions);
-  void performTypeCheckingAndDelayedParsing();
 
   void finishTypeChecking(OptionSet<TypeCheckingFlags> TypeCheckOptions);
 };

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -287,14 +287,6 @@ public:
     return CodeCompletionFactory;
   }
 
-  void setDelayedFunctionBodyParsing(bool Val) {
-    FrontendOpts.DelayedFunctionBodyParsing = Val;
-  }
-
-  bool isDelayedFunctionBodyParsing() const {
-    return FrontendOpts.DelayedFunctionBodyParsing;
-  }
-
   /// Retrieve a module hash string that is suitable for uniquely
   /// identifying the conditions under which the module was built, for use
   /// in generating a cached PCH file for the bridging header.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -366,10 +366,6 @@ public:
   /// Trace changes to stats to files in StatsOutputDir.
   bool TraceStats = false;
 
-  /// Indicates whether function body parsing should be delayed
-  /// until the end of all files.
-  bool DelayedFunctionBodyParsing = false;
-
   /// If true, serialization encodes an extra lookup table for use in module-
   /// merging when emitting partial modules (the per-file modules in a non-WMO
   /// build).

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -21,10 +21,6 @@ def triple : Separate<["-"], "triple">, Alias<target>;
 def color_diagnostics : Flag<["-"], "color-diagnostics">,
   HelpText<"Print diagnostics in color">;
 
-def delayed_function_body_parsing :
-  Flag<["-"], "delayed-function-body-parsing">,
-  HelpText<"Delay function body parsing until the end of all files">;
-
 def primary_file : Separate<["-"], "primary-file">,
   HelpText<"Produce output for this file, not the whole module">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -135,7 +135,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
 
-  Opts.DelayedFunctionBodyParsing |= Args.hasArg(OPT_delayed_function_body_parsing);
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnableResilience |= Args.hasArg(OPT_enable_resilience);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -397,7 +397,7 @@ void CompilerInstance::createREPLFile(
 }
 
 std::unique_ptr<DelayedParsingCallbacks>
-CompilerInstance::computeDelayedParsingCallback() {
+CompilerInstance::computeDelayedParsingCallback(bool isPrimary) {
   if (Invocation.isCodeCompletion())
     return llvm::make_unique<CodeCompleteDelayedCallbacks>(
         SourceMgr.getCodeCompletionLoc());
@@ -427,13 +427,22 @@ void CompilerInstance::addMainFileToModule(
 void CompilerInstance::parseAndCheckTypes(
     const ImplicitImports &implicitImports) {
   SharedTimer timer("performSema-parseAndCheckTypes");
-  std::unique_ptr<DelayedParsingCallbacks> DelayedCB{
-      computeDelayedParsingCallback()};
+  // Delayed parsing callback for the primary file, or all files
+  // in non-WMO mode.
+  std::unique_ptr<DelayedParsingCallbacks> PrimaryDelayedCB{
+      computeDelayedParsingCallback(true)};
+
+  // Delayed parsing callback for non-primary files. Not used in
+  // WMO mode.
+  std::unique_ptr<DelayedParsingCallbacks> SecondaryDelayedCB{
+      computeDelayedParsingCallback(false)};
 
   PersistentParserState PersistentState;
 
   bool hadLoadError = parsePartialModulesAndLibraryFiles(
-      implicitImports, PersistentState, DelayedCB.get());
+      implicitImports, PersistentState,
+      PrimaryDelayedCB.get(),
+      SecondaryDelayedCB.get());
   if (Invocation.isCodeCompletion()) {
     // When we are doing code completion, make sure to emit at least one
     // diagnostic, so that ASTContext is marked as erroneous.  In this case
@@ -446,12 +455,12 @@ void CompilerInstance::parseAndCheckTypes(
 
   OptionSet<TypeCheckingFlags> TypeCheckOptions = computeTypeCheckingOptions();
 
-    // Type-check main file after parsing all other files so that
-    // it can use declarations from other files.
-    // In addition, the main file has parsing and type-checking
-    // interwined.
+  // Type-check main file after parsing all other files so that
+  // it can use declarations from other files.
+  // In addition, the main file has parsing and type-checking
+  // interwined.
   if (MainBufferID != NO_SUCH_BUFFER) {
-    parseAndTypeCheckMainFile(PersistentState, DelayedCB.get(),
+    parseAndTypeCheckMainFile(PersistentState, PrimaryDelayedCB.get(),
                               TypeCheckOptions);
   }
 
@@ -469,7 +478,7 @@ void CompilerInstance::parseAndCheckTypes(
   if (auto *stdlib = Context->getStdlibModule())
     Context->recordKnownProtocols(stdlib);
 
-  if (DelayedCB.get()) {
+  if (Invocation.isCodeCompletion()) {
     performDelayedParsing(MainModule, PersistentState,
                           Invocation.getCodeCompletionFactory());
   }
@@ -479,7 +488,8 @@ void CompilerInstance::parseAndCheckTypes(
 void CompilerInstance::parseLibraryFile(
     unsigned BufferID, const ImplicitImports &implicitImports,
     PersistentParserState &PersistentState,
-    DelayedParsingCallbacks *DelayedParseCB) {
+    DelayedParsingCallbacks *PrimaryDelayedCB,
+    DelayedParsingCallbacks *SecondaryDelayedCB) {
   SharedTimer timer("performSema-parseLibraryFile");
 
   auto *NextInput = new (*Context) SourceFile(
@@ -488,8 +498,13 @@ void CompilerInstance::parseLibraryFile(
   MainModule->addFile(*NextInput);
   addAdditionalInitialImportsTo(NextInput, implicitImports);
 
-  if (BufferID == PrimaryBufferID)
+  auto *DelayedCB = SecondaryDelayedCB;
+  if (BufferID == PrimaryBufferID) {
     setPrimarySourceFile(NextInput);
+    DelayedCB = PrimaryDelayedCB;
+  }
+  if (isWholeModuleCompilation())
+    DelayedCB = PrimaryDelayedCB;
 
   auto &Diags = NextInput->getASTContext().Diags;
   auto DidSuppressWarnings = Diags.getSuppressWarnings();
@@ -501,7 +516,7 @@ void CompilerInstance::parseLibraryFile(
     // Parser may stop at some erroneous constructions like #else, #endif
     // or '}' in some cases, continue parsing until we are done
     parseIntoSourceFile(*NextInput, BufferID, &Done, nullptr, &PersistentState,
-                        DelayedParseCB);
+                        DelayedCB);
   } while (!Done);
 
   Diags.setSuppressWarnings(DidSuppressWarnings);
@@ -530,7 +545,8 @@ OptionSet<TypeCheckingFlags> CompilerInstance::computeTypeCheckingOptions() {
 bool CompilerInstance::parsePartialModulesAndLibraryFiles(
     const ImplicitImports &implicitImports,
     PersistentParserState &PersistentState,
-    DelayedParsingCallbacks *DelayedParseCB) {
+    DelayedParsingCallbacks *PrimaryDelayedCB,
+    DelayedParsingCallbacks *SecondaryDelayedCB) {
   SharedTimer timer("performSema-parsePartialModulesAndLibraryFiles");
   bool hadLoadError = false;
   // Parse all the partial modules first.
@@ -545,7 +561,7 @@ bool CompilerInstance::parsePartialModulesAndLibraryFiles(
   for (auto BufferID : InputSourceCodeBufferIDs) {
     if (BufferID != MainBufferID) {
       parseLibraryFile(BufferID, implicitImports, PersistentState,
-                       DelayedParseCB);
+                       PrimaryDelayedCB, SecondaryDelayedCB);
     }
   }
   return hadLoadError;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -401,7 +401,7 @@ CompilerInstance::computeDelayedParsingCallback(bool isPrimary) {
   if (Invocation.isCodeCompletion())
     return llvm::make_unique<CodeCompleteDelayedCallbacks>(
         SourceMgr.getCodeCompletionLoc());
-  if (Invocation.isDelayedFunctionBodyParsing())
+  if (!isPrimary)
     return llvm::make_unique<AlwaysDelayedCallbacks>();
   return nullptr;
 }


### PR DESCRIPTION
In non-WMO mode, we spawn one frontend job per file but parse function bodies in all files in every job. This results in us doing a quadratic amount of work. Instead, use the same delayed parsing logic that we use for code completion to skip over function bodies in non-primary files.