### PR TITLE
[sil-opaque-values] Fix EscapeAnalysis to track opaque values.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -667,8 +667,8 @@ private:
 
   /// Callee analysis, used for determining the callees at call sites.
   BasicCalleeAnalysis *BCA;
-  
-  /// Returns true if \p V is a "pointer" value.
+
+  /// Returns true if \p V may encapsulate a "pointer" value.
   /// See EscapeAnalysis::NodeType::Value.
   bool isPointer(ValueBase *V);
 

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1014,9 +1014,22 @@ static bool linkBBArgs(SILBasicBlock *BB) {
   return true;
 }
 
-/// Returns true if the type \p Ty is a reference or transitively contains
+/// Returns true if the type \p Ty is a reference or may transitively contains
 /// a reference, i.e. if it is a "pointer" type.
-static bool isOrContainsReference(SILType Ty, SILModule *Mod) {
+static bool mayContainReference(SILType Ty, SILModule *Mod) {
+  // Opaque types may contain a reference. Speculatively track them too.
+  //
+  // 1. It may be possible to optimize opaque values based on known mutation
+  // points.
+  //
+  // 2. A specialized function may call a generic function passing a conrete
+  // reference type via incomplete specialization.
+  //
+  // 3. A generic function may call a specialized function taking a concrete
+  // reference type via devirtualization.
+  if (Ty.isAddressOnly(*Mod))
+    return true;
+
   if (Ty.hasReferenceSemantics())
     return true;
 
@@ -1025,22 +1038,22 @@ static bool isOrContainsReference(SILType Ty, SILModule *Mod) {
 
   if (auto *Str = Ty.getStructOrBoundGenericStruct()) {
     for (auto *Field : Str->getStoredProperties()) {
-      if (isOrContainsReference(Ty.getFieldType(Field, *Mod), Mod))
+      if (mayContainReference(Ty.getFieldType(Field, *Mod), Mod))
         return true;
     }
     return false;
   }
   if (auto TT = Ty.getAs<TupleType>()) {
     for (unsigned i = 0, e = TT->getNumElements(); i != e; ++i) {
-      if (isOrContainsReference(Ty.getTupleElementType(i), Mod))
+      if (mayContainReference(Ty.getTupleElementType(i), Mod))
         return true;
     }
     return false;
   }
   if (auto En = Ty.getEnumOrBoundGenericEnum()) {
     for (auto *ElemDecl : En->getAllElements()) {
-      if (ElemDecl->hasAssociatedValues() &&
-          isOrContainsReference(Ty.getEnumElementType(ElemDecl, *Mod), Mod))
+      if (ElemDecl->hasAssociatedValues()
+          && mayContainReference(Ty.getEnumElementType(ElemDecl, *Mod), Mod))
         return true;
     }
     return false;
@@ -1054,7 +1067,7 @@ bool EscapeAnalysis::isPointer(ValueBase *V) {
   if (Iter != isPointerCache.end())
     return Iter->second;
 
-  bool IP = (Ty.isAddress() || isOrContainsReference(Ty, M));
+  bool IP = (Ty.isAddress() || mayContainReference(Ty, M));
   isPointerCache[Ty] = IP;
   return IP;
 }
@@ -1768,7 +1781,8 @@ bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
       CallerReturnVal = cast<ApplyInst>(AS);
     }
     CGNode *CallerRetNd = CallerGraph->getNode(CallerReturnVal, this);
-    Callee2CallerMapping.add(RetNd, CallerRetNd);
+    if (CallerRetNd)
+      Callee2CallerMapping.add(RetNd, CallerRetNd);
   }
   return CallerGraph->mergeFrom(CalleeGraph, Callee2CallerMapping);
 }


### PR DESCRIPTION
This is trivially tested by simply building generic code with opaque values at
-O.
