### PR TITLE
Update a test so that it is not broken by function merging.

### DIFF
--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -22,16 +22,16 @@
 import Foundation
 
 class C { 
-  @objc func cInstanceMethod() { }
-  @objc class func cClassMethod() { }
-  @objc func cInstanceOverride() { }
-  @objc class func cClassOverride() { }
+  @objc func cInstanceMethod() -> Int { return 1 }
+  @objc class func cClassMethod() -> Int { return 2 }
+  @objc func cInstanceOverride() -> Int { return 3 }
+  @objc class func cClassOverride() -> Int { return 4 }
 }
 class D : C {
-  @objc func dInstanceMethod() { }
-  @objc class func dClassMethod() { }
-  @objc override func cInstanceOverride() { }
-  @objc override class func cClassOverride() { }
+  @objc func dInstanceMethod() -> Int { return 5 }
+  @objc class func dClassMethod() -> Int { return 6 }
+  @objc override func cInstanceOverride() -> Int { return 7 }
+  @objc override class func cClassOverride() -> Int { return 8 }
 }
 
 @_silgen_name("TestSwiftObjectNSObject") 


### PR DESCRIPTION
Something has changed with newer versions of LLVM so that the
stdlib/SwiftObjectNSObject.swift test fails on the master-next branch
because the @objc thunk functions all get merged together. That is a good
thing for code size but it breaks some of the checks in this test that
compare the function pointers to verify that overrides are correct.
Make each function different so they cannot be merged.

rdar://problem/35134245