### PR TITLE
[rvalue] Add a conversion to bool for RValue.

### DIFF
--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -184,6 +184,14 @@ public:
   /// been added.
   explicit RValue(CanType type);
 
+  /// Return true if the rvalue was null-initialized. The intention is so one
+  /// can trampoline RValue results using if statements, i.e.:
+  ///
+  /// if (RValue rv = foo()) {
+  ///   return rv;
+  /// }
+  operator bool() const & { return isComplete() || isInContext(); }
+
   /// True if the rvalue has been completely initialized by adding all its
   /// elements.
   bool isComplete() const & { return elementsToBeAdded == 0; }


### PR DESCRIPTION
This lets you conditionally trampoline RValue results using if statements, e.g.:

```
if (RValue rv = foo()) {
  return rv;
}
```

----

I wrote this originally as part of an experiment. Seems generally useful.