### PR TITLE
stdlib: improve modulemap for FreeBSD

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -36,6 +36,13 @@ module SwiftGlibc [system] {
   link "execinfo"
 % end
 
+% if CMAKE_SDK in ["FREEBSD"]:
+  module cdefs {
+    header "${GLIBC_INCLUDE_PATH}/sys/cdefs.h"
+    export *
+  }
+% end
+
   // C standard library
   module C {
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN", "HAIKU"]:
@@ -453,6 +460,9 @@ module SwiftGlibc [system] {
       }
       module types {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/types.h"
+% if CMAKE_SDK in ["FREEBSD"]:
+        header "${GLIBC_INCLUDE_PATH}/sys/_types.h"
+% end
         export *
       }
 % if CMAKE_SDK in ["FREEBSD"]:


### PR DESCRIPTION
Ensure that `sys/_types.h` is treated as part of the `sys.types` module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
