### PR TITLE
[stdlib] Conform Stride* types to RandomAccessCollection

### DIFF
--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -279,6 +279,46 @@ extension Decimal : Strideable {
     public func advanced(by n: Decimal) -> Decimal {
         return self + n
     }
+
+    public func _steps(to other: Decimal, by n: Decimal) -> Int {
+        // This is the generic floating-point algorithm, copied here because
+        // `Decimal` does not yet conform to `FloatingPoint`.
+        let distance = self.distance(to: other)
+        _precondition(n != 0 && distance != 0)
+        guard (n < 0) == (distance < 0) else { return 0 }
+
+        var low = 0, mid = Int.max / 2, high = Int.max
+        if n > 0 {
+            guard other <= _advanced(by: n, count: high) else {
+                fatalError("Steps from \(self) to \(other) exceed Int.max - 1")
+            }
+            while mid > low {
+                if _advanced(by: n, count: mid) < other {
+                    low = mid
+                } else {
+                    high = mid
+                }
+                mid = low + (high - low) / 2
+            }
+        } else {
+            guard other >= _advanced(by: n, count: high) else {
+                fatalError("Steps from \(self) to \(other) exceed Int.max - 1")
+            }
+            while mid > low {
+                if _advanced(by: n, count: mid) > other {
+                    low = mid
+                } else {
+                    high = mid
+                }
+                mid = low + (high - low) / 2
+            }
+        }
+        return low
+    }
+
+    public func _advanced(by n: Decimal, count i: Int) -> Decimal {
+        return advanced(by: Decimal(i) * n)
+    }
 }
 
 extension Decimal {

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -10,8 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Conforming types are notionally continuous, one-dimensional
-/// values that can be offset and measured.
+/// A notionally one-dimensional type that can be offset and measured.
 ///
 /// - Important: The `Strideable` protocol provides default implementations for
 ///   the equal-to (`==`) and less-than (`<`) operators that depend on the
@@ -25,19 +24,36 @@ public protocol Strideable : Comparable {
   /// Returns a stride `x` such that `self.advanced(by: x)` approximates
   /// `other`.
   ///
-  /// If `Stride` conforms to `Integer`, then `self.advanced(by: x) == other`.
+  /// If `Stride` conforms to `BinaryInteger`, then
+  /// `self.advanced(by: x) == other`.
   ///
   /// - Complexity: O(1).
   func distance(to other: Self) -> Stride
 
   /// Returns a `Self` `x` such that `self.distance(to: x)` approximates `n`.
   ///
-  /// If `Stride` conforms to `Integer`, then `self.distance(to: x) == n`.
+  /// If `Stride` conforms to `BinaryInteger`, then
+  /// `self.distance(to: x) == n`.
   ///
   /// - Complexity: O(1).
   func advanced(by n: Stride) -> Self
 
-  /// `_step` is an implementation detail of Strideable; do not use it directly.
+  /// Returns the greatest nonnegative integer `x` such that
+  /// `self._advanced(by: n, count: x)` lies in the half-open interval
+  /// [`self`, `other`).
+  func _steps(to other: Self, by n: Stride) -> Int
+
+  /// Returns a `Self` `x` such that `self.distance(to: x)` approximates
+  /// `repeatElement(n, count: i).reduce(0, +)`.
+  ///
+  /// If `Stride` conforms to `BinaryInteger`, then
+  /// `self.distance(to: x) == Stride(i) * n`.
+  ///
+  /// - Complexity: O(1).
+  func _advanced(by n: Stride, count i: Int) -> Self
+
+  /// `_step(after:from:by:)` is an implementation detail of Strideable; do not
+  /// use it directly.
   static func _step(
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
@@ -63,8 +79,8 @@ extension Strideable {
 %{
   # Strideable used to provide + and - unconditionally. With the updated
   # collection indexing model of Swift 3 this became unnecessary for integer
-  # types, and was deprecated, as it was a way to write mixed-type arithmetic
-  # expressions, that are otherwise are not allowed.
+  # types and was deprecated, as it was a way to write mixed-type arithmetic
+  # expressions that are otherwise are not allowed.
 }%
 % for Base, VersionInfo in [
 %   ('Strideable where Self : _Pointer', None),
@@ -126,24 +142,102 @@ extension Strideable {
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
   ) -> (index: Int?, value: Self) {
+    let i = current.index! + 1
+    return (i, start._advanced(by: distance, count: i))
+  }
+}
+
+extension Strideable where Stride : BinaryInteger {
+  @_inlineable
+  public func _steps(to other: Self, by n: Stride) -> Int {
+    let distance = self.distance(to: other)
+    _precondition(n != 0 && distance != 0)
+    guard (n < 0) == (distance < 0) else { return 0 }
+
+    guard let result = Int(exactly: (distance - 1) / n), result < Int.max else {
+      fatalError("Steps from \(self) to \(other) exceed Int.max - 1")
+    }
+    return result
+  }
+
+  @_inlineable
+  public func _advanced(by n: Stride, count i: Int) -> Self {
+    return advanced(by: Stride(i) * n)
+  }
+
+  @_inlineable
+  public static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self) {
     return (nil, current.value.advanced(by: distance))
   }
 }
 
 extension Strideable where Stride : FloatingPoint {
   @_inlineable
-  public static func _step(
-    after current: (index: Int?, value: Self),
-    from start: Self, by distance: Self.Stride
-  ) -> (index: Int?, value: Self) {
-    if let i = current.index {
-      return (i + 1, start.advanced(by: Stride(i + 1) * distance))
+  public func _steps(to other: Self, by n: Stride) -> Int {
+    let distance = self.distance(to: other)
+    _precondition(n != 0 && distance != 0)
+    guard (n < 0) == (distance < 0) else { return 0 }
+
+    // Note: For a floating-point type, striding from `self` to `other` by `n`
+    // may produce different values than striding from `other` to `self` by
+    // `-n`. This is why we cannot simply write
+    //
+    //   let (a, b, c) = self < other ? (self, other, n) : (other, self, -n)
+    //
+    // and proceed accordingly.
+
+    var low = 0, mid = Int.max / 2, high = Int.max
+    if n > 0 {
+      guard other <= _advanced(by: n, count: high) else {
+        fatalError("Steps from \(self) to \(other) exceed Int.max - 1")
+      }
+
+      // Note: For a floating-point type, it is possible that
+      // `a._advanced(by: b, count: i) == a._advanced(by: b, count: i + 1)` for
+      // some values of `a`, `b`, and `i`, due to rounding. This is why we must
+      // not stop our search prematurely if we find a value for `mid` such that
+      // `_advanced(by: n, count: mid) == other`.
+
+      while mid > low {
+        if _advanced(by: n, count: mid) < other {
+          low = mid
+        } else {
+          high = mid
+        }
+        mid = low + (high - low) / 2
+      }
+    } else {
+      guard other >= _advanced(by: n, count: high) else {
+        fatalError("Steps from \(self) to \(other) exceed Int.max - 1")
+      }
+      while mid > low {
+        if _advanced(by: n, count: mid) > other {
+          low = mid
+        } else {
+          high = mid
+        }
+        mid = low + (high - low) / 2
+      }
     }
-    // If current.index == nil, either we're just starting out (in which case
-    // the next index is 1), or we should proceed without an index just as
-    // though this floating point specialization doesn't exist.
-    return (current.value == start ? 1 : nil,
-            current.value.advanced(by: distance))
+    return low
+  }
+
+  @_inlineable
+  public func _advanced(by n: Stride, count i: Int) -> Self {
+    return advanced(by: Stride(i) * n)
+  }
+}
+
+extension Strideable where Self : FloatingPoint, Self == Stride {
+  @_inlineable
+  public func _advanced(by n: Stride, count i: Int) -> Self {
+    // When both Self and Stride are the same floating-point type, we should
+    // take advantage of fused multiply-add (where supported) to eliminate
+    // intermediate rounding error.
+    return addingProduct(Stride(i), n)
   }
 }
 
@@ -168,7 +262,7 @@ public struct StrideToIterator<Element : Strideable> : IteratorProtocol {
     self._start = _start
     _end = end
     _stride = stride
-    _current = (nil, _start)
+    _current = (0, _start)
   }
 
   /// Advances to the next element and returns it, or `nil` if no next element
@@ -187,11 +281,12 @@ public struct StrideToIterator<Element : Strideable> : IteratorProtocol {
   }
 }
 
-/// A `Sequence` of values formed by striding over a half-open interval.
+/// A `RandomAccessCollection` of values formed by striding over a half-open
+/// interval.
 @_fixed_layout
-public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
-  // FIXME: should really be a Collection, as it is multipass
-
+public struct StrideTo<
+  Element : Strideable
+> : RandomAccessCollection, CustomReflectable {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
@@ -242,124 +337,51 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
     return Mirror(self, children: ["from": _start, "to": _end, "by": _stride])
   }
 
-  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
-  // here until a proper Collection conformance is possible
-  @_inlineable
-  public var underestimatedCount: Int {
-    var it = self.makeIterator()
-    var count = 0
-    while it.next() != nil {
-      count += 1
-    }
-    return count
-  }
-}
-
-// FIXME(conditional-conformances): these extra types can easily be turned into
-// conditional extensions to StrideTo type
-% for Self, ElementConstraint, Where in [
-%   ('IntegerStrideToCollection', 'BinaryInteger', 'Element.Stride : BinaryInteger'),
-%   ('FloatingPointStrideToCollection', 'BinaryFloatingPoint', 'Element.Stride == Element'),
-% ]:
-%   ElementIsInteger = ElementConstraint == 'BinaryInteger'
-
-internal struct ${Self}<
-  Element : ${ElementConstraint}
-> : RandomAccessCollection, CustomReflectable
-where ${Where} {
-
 //===----------------------------------------------------------------------===//
-// This block is copied from StrideTo struct definition                       //
-//===----------------------------------------------------------------------===//
-  @_inlineable
-  public func makeIterator() -> StrideToIterator<Element> {
-    return StrideToIterator(_start: _start, end: _end, stride: _stride)
-  }
-
-  @_inlineable
-  public func _customContainsEquatableElement(
-    _ element: Element
-  ) -> Bool? {
-    if element < _start || _end <= element {
-      return false
-    }
-    return nil
-  }
-
-  @_inlineable
-  @_versioned
-  internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "Stride size must not be zero")
-    // At start, striding away from end is allowed; it just makes for an
-    // already-empty Sequence.
-    self._start = _start
-    self._end = end
-    self._stride = stride
-  }
-
-  @_versioned
-  internal let _start: Element
-
-  @_versioned
-  internal let _end: Element
-
-  @_versioned
-  internal let _stride: Element.Stride
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public var customMirror: Mirror {
-    return Mirror(self, children: ["from": _start, "to": _end, "by": _stride])
-  }
-//===----------------------------------------------------------------------===//
-// The end of the copied block
+// `RandomAccessCollection` conformance
 //===----------------------------------------------------------------------===//
 
-  // RandomAccessCollection conformance
   public typealias Index = Int
-  public typealias SubSequence = RandomAccessSlice<${Self}>
+  public typealias SubSequence = RandomAccessSlice<StrideTo<Element>>
   public typealias Indices = CountableRange<Int>
 
+  @_inlineable
   public var startIndex: Index { return 0 }
+
+  @_inlineable
   public var endIndex: Index { return count }
 
+  @_inlineable
   public var count: Int {
-    let (start, end, stride) =
-      (_stride > 0) ? (_start, _end, _stride) : (_end, _start, -_stride)
-%   if ElementIsInteger:
-    return Int((start.distance(to: end) - 1) / stride) + 1
-%   else:
-    let nonExactCount = (start.distance(to: end)) / stride
-    return Int(nonExactCount.rounded(.toNearestOrAwayFromZero))
-%   end
+    let distance = _start.distance(to: _end)
+    guard distance != 0 && (distance < 0) == (_stride < 0) else { return 0 }
+    return _start._steps(to: _end, by: _stride) + 1
   }
 
   public subscript(position: Index) -> Element {
-    _failEarlyRangeCheck(position, bounds: startIndex ..< endIndex)
-    return _indexToElement(position)
+    _failEarlyRangeCheck(position, bounds: startIndex..<endIndex)
+    return _start._advanced(by: _stride, count: position)
   }
 
-  public subscript(bounds: Range<Index>) -> RandomAccessSlice<${Self}> {
-    _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
+  public subscript(
+    bounds: Range<Index>
+  ) -> RandomAccessSlice<StrideTo<Element>> {
+    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
     return RandomAccessSlice(base: self, bounds: bounds)
   }
 
+  @_inlineable
   public func index(after i: Index) -> Index {
-    _failEarlyRangeCheck(i, bounds: startIndex-1 ..< endIndex)
-    return i+1
+    _failEarlyRangeCheck(i, bounds: (startIndex - 1)..<endIndex)
+    return i + 1
   }
 
+  @_inlineable
   public func index(before i: Index) -> Index {
-    _failEarlyRangeCheck(i, bounds: startIndex+1 ... endIndex)
-    return i-1
-  }
-
-  @inline(__always)
-  internal func _indexToElement(_ i: Index) -> Element {
-    return _start.advanced(by: Element.Stride(i) * _stride)
+    _failEarlyRangeCheck(i, bounds: (startIndex + 1)...endIndex)
+    return i - 1
   }
 }
-
-% end
 
 /// Returns the sequence of values (`self`, `self + stride`, `self +
 /// 2 * stride`, ... *last*) where *last* is the last value in the
@@ -395,7 +417,7 @@ public struct StrideThroughIterator<Element : Strideable> : IteratorProtocol {
     self._start = _start
     _end = end
     _stride = stride
-    _current = (nil, _start)
+    _current = (0, _start)
   }
 
   /// Advances to the next element and returns it, or `nil` if no next element
@@ -420,13 +442,12 @@ public struct StrideThroughIterator<Element : Strideable> : IteratorProtocol {
   }
 }
 
-/// A `Sequence` of values formed by striding over a closed interval.
+/// A `RandomAccessCollection` of values formed by striding over a closed
+/// interval.
 @_fixed_layout
 public struct StrideThrough<
   Element : Strideable
-> : Sequence, CustomReflectable {
-  // FIXME: should really be a CollectionType, as it is multipass
-
+> : RandomAccessCollection, CustomReflectable {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
@@ -474,106 +495,40 @@ public struct StrideThrough<
       children: ["from": _start, "through": _end, "by": _stride])
   }
 
-  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
-  // here until a proper Collection conformance is possible
-  @_inlineable
-  public var underestimatedCount: Int {
-    var it = self.makeIterator()
-    var count = 0
-    while it.next() != nil {
-      count += 1
-    }
-    return count
-  }
-}
-
-// FIXME(conditional-conformances): these extra types can easily be turned into
-// conditional extensions to StrideThrough type
-% for Self, ElementConstraint, Where in [
-%   ('IntegerStrideThroughCollection', 'BinaryInteger', 'Element.Stride : BinaryInteger'),
-%   ('FloatingPointStrideThroughCollection', 'BinaryFloatingPoint', 'Element.Stride == Element'),
-% ]:
-%   ElementIsInteger = ElementConstraint == 'BinaryInteger'
-
-internal struct ${Self}<
-  Element : ${ElementConstraint}
-> : RandomAccessCollection, CustomReflectable
-where ${Where} {
-
 //===----------------------------------------------------------------------===//
-// This block is copied from StrideThrough struct definition                  //
-//===----------------------------------------------------------------------===//
-  /// Returns an iterator over the elements of this sequence.
-  ///
-  /// - Complexity: O(1).
-  @_inlineable
-  public func makeIterator() -> StrideThroughIterator<Element> {
-    return StrideThroughIterator(_start: _start, end: _end, stride: _stride)
-  }
-
-  @_inlineable
-  public func _customContainsEquatableElement(
-    _ element: Element
-  ) -> Bool? {
-    if element < _start || _end < element {
-      return false
-    }
-    return nil
-  }
-
-  @_inlineable
-  @_versioned
-  internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "Stride size must not be zero")
-    self._start = _start
-    self._end = end
-    self._stride = stride
-  }
-
-  @_versioned
-  internal let _start: Element
-  @_versioned
-  internal let _end: Element
-  @_versioned
-  internal let _stride: Element.Stride
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public var customMirror: Mirror {
-    return Mirror(self,
-      children: ["from": _start, "through": _end, "by": _stride])
-  }
-//===----------------------------------------------------------------------===//
-// The end of the copied block
+// `RandomAccessCollection` conformance
 //===----------------------------------------------------------------------===//
 
-  // RandomAccessCollection conformance
   public typealias Index = ClosedRangeIndex<Int>
   public typealias IndexDistance = Int
-  public typealias SubSequence = RandomAccessSlice<${Self}>
+  public typealias SubSequence = RandomAccessSlice<StrideThrough<Element>>
 
   @_inlineable
-  public var startIndex: Index { return ClosedRangeIndex(0) }
+  public var startIndex: Index {
+    let distance = _start.distance(to: _end)
+    return distance == 0 || (distance < 0) == (_stride < 0)
+      ? ClosedRangeIndex(0) : ClosedRangeIndex()
+  }
+
   @_inlineable
   public var endIndex: Index { return ClosedRangeIndex() }
 
   @_inlineable
   public var count: Int {
-    let (start, end, stride) =
-      (_stride > 0) ? (_start, _end, _stride) : (_end, _start, -_stride)
-%   if ElementIsInteger:
-    return Int(start.distance(to: end) / stride) + 1
-%   else:
-    let nonExactCount = start.distance(to: end) / stride
-    return Int(nonExactCount.rounded(.toNearestOrAwayFromZero)) + 1
-%   end
+    let distance = _start.distance(to: _end)
+    guard distance != 0 else { return 1 }
+    guard (distance < 0) == (_stride < 0) else { return 0 }
+    let i = _start._steps(to: _end, by: _stride) + 1
+    return _start._advanced(by: _stride, count: i) == _end ? i + 1 : i
   }
 
   public subscript(position: Index) -> Element {
-    let offset = Element.Stride(position._dereferenced) * _stride
-    return _start.advanced(by: offset)
+    return _start._advanced(by: _stride, count: position._dereferenced)
   }
 
-  public subscript(bounds: Range<Index>) -> RandomAccessSlice<${Self}> {
+  public subscript(
+    bounds: Range<Index>
+  ) -> RandomAccessSlice<StrideThrough<Element>> {
     return RandomAccessSlice(base: self, bounds: bounds)
   }
 
@@ -604,16 +559,13 @@ where ${Where} {
   // FIXME(ABI)#175 (Type checker)
   @_inlineable
   public // WORKAROUND: needed because of rdar://25584401
-  var indices: DefaultRandomAccessIndices<${Self}> {
+  var indices: DefaultRandomAccessIndices<StrideThrough<Element>> {
     return DefaultRandomAccessIndices(
       _elements: self,
       startIndex: self.startIndex,
       endIndex: self.endIndex)
   }
-
 }
-
-% end
 
 /// Returns the sequence of values (`self`, `self + stride`, `self +
 /// 2 * stride`, ... *last*) where *last* is the last value in the
@@ -626,4 +578,3 @@ public func stride<T>(
 ) -> StrideThrough<T> {
   return StrideThrough(_start: start, end: end, stride: stride)
 }
-

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -188,12 +188,20 @@ StrideTestSuite.test("FloatingPointStride") {
   expectEqual([ 1.4, 2.4, 3.4 ], result)
 }
 
-StrideTestSuite.test("ErrorAccumulation") {
-  let a = Array(stride(from: Float(1.0), through: Float(2.0), by: Float(0.1)))
+StrideTestSuite.test("FloatingPointStride/rounding error") {
+  // Ensure that there is no error accumulation
+  let a = Array(stride(from: 1 as Float, through: 2, by: 0.1))
   expectEqual(11, a.count)
-  expectEqual(Float(2.0), a.last)
-  let b = Array(stride(from: Float(1.0), to: Float(10.0), by: Float(0.9)))
+  expectEqual(2 as Float, a.last)
+  let b = Array(stride(from: 1 as Float, to: 10, by: 0.9))
   expectEqual(10, b.count)
+
+  // Ensure that there is no intermediate rounding error on supported platforms
+  if (-0.2).addingProduct(0.2, 6) == 1 {
+    let c = Array(stride(from: -0.2, through: 1, by: 0.2))
+    expectEqual(7, c.count)
+    expectEqual(1 as Double, c.last)
+  }
 }
 
 func strideIteratorTest<
@@ -226,5 +234,57 @@ StrideTestSuite.test("StrideToIterator/past end/backward") {
   strideIteratorTest(stride(from: 3, to: 0, by: -1), nonNilResults: 3)
 }
 
-runAllTests()
+StrideTestSuite.test("RandomAccessCollection") {
+  func check<T : RandomAccessCollection>(_ c: T) where T.Element : Numeric {
+    let a = Array(c)
+    expectEqual(a.count, Int(c.count))
+    for (i, j) in zip(0..., c.indices) {
+      // Ensure that the subscript always returns the same value as the iterator
+      expectEqual(a[i], c[j])
+    }
+  }
 
+  let x = [
+    stride(from: 0, to: 0, by: 2),
+    stride(from: 0, to: 0, by: -2),
+    stride(from: 0, to: 20, by: 2),
+    stride(from: 0, to: -20, by: 2),
+    stride(from: 20, to: 0, by: 2),
+    stride(from: -20, to: 0, by: 2),
+    stride(from: 0, to: 20, by: -2),
+    stride(from: 0, to: -20, by: -2),
+    stride(from: 20, to: 0, by: -2),
+    stride(from: -20, to: 0, by: -2),
+  ]
+  x.forEach(check)
+
+  let y = [
+    stride(from: 0, through: 0, by: 2),
+    stride(from: 0, through: 0, by: -2),
+    stride(from: 0, through: 20, by: 2),
+    stride(from: 0, through: -20, by: 2),
+    stride(from: 20, through: 0, by: 2),
+    stride(from: -20, through: 0, by: 2),
+    stride(from: 0, through: 20, by: -2),
+    stride(from: 0, through: -20, by: -2),
+    stride(from: 20, through: 0, by: -2),
+    stride(from: -20, through: 0, by: -2),
+  ]
+  y.forEach(check)
+
+  let z = [
+    stride(from: -0.2, to: -0.2, by: 0.2),
+    stride(from: -0.2, to: -0.2, by: -0.2),
+    stride(from: -0.2, to: 1.2, by: 0.2),
+    stride(from: -0.2, to: -1.2, by: 0.2),
+    stride(from: 1.2, to: -0.2, by: 0.2),
+    stride(from: -1.2, to: -0.2, by: 0.2),
+    stride(from: -0.2, to: 1.2, by: -0.2),
+    stride(from: -0.2, to: -1.2, by: -0.2),
+    stride(from: 1.2, to: -0.2, by: -0.2),
+    stride(from: -1.2, to: -0.2, by: -0.2),
+  ]
+  z.forEach(check)
+}
+
+runAllTests()


### PR DESCRIPTION
This PR subsumes #13007 and makes substantial changes to `Stride{To|Through}`.

By providing the necessary facilities on `Strideable` with complete default implementations for all new underscored APIs when constrained to `Stride : BinaryInteger` and `Stride : FloatingPoint`, this design enables **unconditional** conformance of `Stride{To|Through}` to `RandomAccessCollection` as originally envisioned.

The design provides a new implementation for `count` and for subscript access. For floating-point `count`, it checks boundary conditions and then performs a binary search over the range `0..<Int.max`, thereby avoiding a naive O(N) implementation. The resulting function should therefore be reasonably efficient while guaranteeing correctness.

Since all types here are `@_fixed_layout`, `count` remains a computed property. Although reasonably implemented, the overhead of checking bounds on every subscript access would be felt without optimization. It remains to be seen whether the compiler can successfully elide repeated checks.
