### PR TITLE
Normal Guaranteed Argument Support

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -117,6 +117,9 @@ public:
   /// conventions.
   bool EnableGuaranteedClosureContexts = true;
 
+  /// Emit normal function arguments using the +0 guaranteed convention.
+  bool EnableGuaranteedNormalArguments = false;
+
   /// Don't generate code using partial_apply in SIL generation.
   bool DisableSILPartialApply = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -263,6 +263,9 @@ def pch_disable_validation : Flag<["-"], "pch-disable-validation">,
 def enable_sil_ownership : Flag<["-"], "enable-sil-ownership">,
   HelpText<"Enable the SIL Ownership Model">;
 
+def enable_guaranteed_normal_arguments : Flag<["-"], "enable-guaranteed-normal-arguments">,
+  HelpText<"If set to true, all normal parameters (except to inits/setters) will be passed at +0">;
+
 def disable_mandatory_semantic_arc_opts : Flag<["-"], "disable-mandatory-semantic-arc-opts">,
   HelpText<"Disable the mandatory semantic arc optimizer">;
 

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -227,6 +227,10 @@ struct SILDeclRef {
   bool isFunc() const {
     return kind == Kind::Func;
   }
+
+  /// True if the SILDeclRef references a setter function.
+  bool isSetter() const;
+
   /// True if the SILDeclRef references a constructor entry point.
   bool isConstructor() const {
     return kind == Kind::Allocator || kind == Kind::Initializer;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1312,6 +1312,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.EnableMandatorySemanticARCOpts |=
       !Args.hasArg(OPT_disable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);
+  Opts.EnableGuaranteedNormalArguments |=
+      Args.hasArg(OPT_enable_guaranteed_normal_arguments);
 
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_path))
     Opts.OptRecordFile = A->getValue();

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -484,6 +484,12 @@ FuncDecl *SILDeclRef::getFuncDecl() const {
   return dyn_cast<FuncDecl>(getDecl());
 }
 
+bool SILDeclRef::isSetter() const {
+  if (!hasFuncDecl())
+    return false;
+  return getFuncDecl()->isSetter();
+}
+
 AbstractFunctionDecl *SILDeclRef::getAbstractFunctionDecl() const {
   return dyn_cast<AbstractFunctionDecl>(getDecl());
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1104,12 +1104,22 @@ public:
 };
 
 /// The default conventions for Swift initializing constructors.
+///
+/// Initializing constructors take all parameters (including) self at +1. This
+/// is because:
+///
+/// 1. We are likely to be initializing fields of self implying that the
+///    parameters are likely to be forwarded into memory without further
+///    copies.
+/// 2. Initializers must take 'self' at +1, since they will return it back
+///    at +1, and may chain onto Objective-C initializers that replace the
+///    instance.
 struct DefaultInitializerConventions : DefaultConventions {
-  using DefaultConventions::DefaultConventions;
+  DefaultInitializerConventions()
+      : DefaultConventions(NormalParameterConvention::Owned) {}
 
-  /// Initializers must take 'self' at +1, since they will return it back
-  /// at +1, and may chain onto Objective-C initializers that replace the
-  /// instance.
+  /// Initializers must take 'self' at +1, since they will return it back at +1,
+  /// and may chain onto Objective-C initializers that replace the instance.
   ParameterConvention
   getDirectSelfParameter(const AbstractionPattern &type) const override {
     return ParameterConvention::Direct_Owned;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1052,8 +1052,7 @@ class DefaultConventions : public Conventions {
   NormalParameterConvention normalParameterConvention;
 
 public:
-  DefaultConventions(NormalParameterConvention normalParameterConvention =
-                         NormalParameterConvention::Owned)
+  DefaultConventions(NormalParameterConvention normalParameterConvention)
       : Conventions(ConventionsKind::Default),
         normalParameterConvention(normalParameterConvention) {}
 
@@ -1190,6 +1189,14 @@ getSILFunctionTypeForAbstractCFunction(SILModule &M,
                                        AnyFunctionType::ExtInfo extInfo,
                                        Optional<SILDeclRef> constant);
 
+/// If EnableGuaranteedNormalArguments is set, return a default convention that
+/// uses guaranteed.
+static DefaultConventions getNormalArgumentConvention(SILModule &M) {
+  if (M.getOptions().EnableGuaranteedNormalArguments)
+    return DefaultConventions(NormalParameterConvention::Guaranteed);
+  return DefaultConventions(NormalParameterConvention::Owned);
+}
+
 static CanSILFunctionType getNativeSILFunctionType(
     SILModule &M, AbstractionPattern origType,
     CanAnyFunctionType substInterfaceType, AnyFunctionType::ExtInfo extInfo,
@@ -1233,8 +1240,8 @@ static CanSILFunctionType getNativeSILFunctionType(
     case SILDeclRef::Kind::IVarDestroyer:
     case SILDeclRef::Kind::EnumElement:
       return getSILFunctionType(M, origType, substInterfaceType, extInfo,
-                                DefaultConventions(), ForeignInfo(), constant,
-                                witnessMethodConformance);
+                                getNormalArgumentConvention(M), ForeignInfo(),
+                                constant, witnessMethodConformance);
     case SILDeclRef::Kind::Deallocator:
       return getSILFunctionType(M, origType, substInterfaceType, extInfo,
                                 DeallocatorConventions(), ForeignInfo(),


### PR DESCRIPTION
This PR contains support for enabling via the frontend option enable-guaranteed-normal-arguments for normal parameters to be emitted at +0 instead of +1.

rdar://34222540