### PR TITLE
[silgen] Add {ManagedValue,RValue}::ensurePlusOne(...).

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -195,3 +195,13 @@ void ManagedValue::dump(raw_ostream &os, unsigned indent) const {
     os << "<null>\n";
   }
 }
+
+ManagedValue ManagedValue::ensurePlusOne(SILGenFunction &SGF,
+                                         SILLocation loc) const {
+  // guaranteed-normal-args-todo: We only copy here when guaranteed normal args
+  // are explicitly enabled. Otherwise, this always just returns self.
+  if (SGF.getOptions().EnableGuaranteedNormalArguments && !hasCleanup()) {
+    return copy(SGF, loc);
+  }
+  return *this;
+}

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -271,6 +271,10 @@ public:
     return isLValue() ? *this : ManagedValue::forUnmanaged(getValue());
   }
 
+  /// If this managed value is a plus one value, return *this. If this is a plus
+  /// zero value, return a copy instead.
+  ManagedValue ensurePlusOne(SILGenFunction &SGF, SILLocation loc) const;
+
   /// Given a scalar value, materialize it into memory with the
   /// exact same level of cleanup it had before.
   ManagedValue materialize(SILGenFunction &SGF, SILLocation loc) const;

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -698,6 +698,12 @@ RValue RValue::copy(SILGenFunction &SGF, SILLocation loc) const & {
   return RValue(SGF, std::move(copiedValues), type, elementsToBeAdded);
 }
 
+RValue RValue::ensurePlusOne(SILGenFunction &SGF, SILLocation loc) && {
+  if (SGF.getOptions().EnableGuaranteedNormalArguments && isPlusZero(SGF))
+    return copy(SGF, loc);
+  return std::move(*this);
+}
+
 RValue RValue::borrow(SILGenFunction &SGF, SILLocation loc) const & {
   assert((isComplete() || isInSpecialState()) &&
          "can't borrow incomplete rvalue");

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -348,6 +348,10 @@ public:
   /// Emit an equivalent value with independent ownership.
   RValue copy(SILGenFunction &SGF, SILLocation loc) const &;
 
+  /// If this RValue is a +0 value, copy the RValue and return. Otherwise,
+  /// return std::move(*this);
+  RValue ensurePlusOne(SILGenFunction &SGF, SILLocation loc) &&;
+
   /// Borrow all subvalues of the rvalue.
   RValue borrow(SILGenFunction &SGF, SILLocation loc) const &;
 


### PR DESCRIPTION
This helper function returns *this if the value is already at +1. Otherwise, if
the value is a +0 value, we copy the value. Since I am using this initially for
some experiments, I am hiding it behind the enable guaranteed normal arguments
flag.

rdar://34222540
