### PR TITLE
[silgen] When emitting convertBridgeObjectToRef, forward ownership th…

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4159,13 +4159,13 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
                               firstLevelResult.foreignSelf, uncurriedArgs,
                               uncurriedLoc, formalApplyType);
 
-  // Emit the uncurried call.
+  // If we have a late emitter, just delegate to that emitter and return.
   if (specializedEmitter.isLateEmitter()) {
     auto emitter = specializedEmitter.getLateEmitter();
+    ManagedValue mv = emitter(SGF, *uncurriedLoc, callee.getSubstitutions(),
+                              uncurriedArgs, uncurriedContext);
     firstLevelResult.value =
-        RValue(SGF, *uncurriedLoc, formalApplyType.getResult(),
-               emitter(SGF, uncurriedLoc.getValue(), callee.getSubstitutions(),
-                       uncurriedArgs, uncurriedContext));
+        RValue(SGF, *uncurriedLoc, formalApplyType.getResult(), mv);
     return firstLevelResult;
   }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -731,6 +731,14 @@ void SILGenBuilder::createStoreBorrowOrTrivial(SILLocation loc,
   createStoreBorrow(loc, value, address);
 }
 
+ManagedValue SILGenBuilder::createBridgeObjectToRef(SILLocation loc,
+                                                    ManagedValue mv,
+                                                    SILType destType) {
+  CleanupCloner cloner(*this, mv);
+  SILValue result = createBridgeObjectToRef(loc, mv.forward(SGF), destType);
+  return cloner.clone(result);
+}
+
 //===----------------------------------------------------------------------===//
 //                            Switch Enum Builder
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -323,6 +323,10 @@ public:
   using SILBuilder::createValueMetatype;
   ManagedValue createValueMetatype(SILLocation loc, SILType metatype,
                                    ManagedValue base);
+
+  using SILBuilder::createBridgeObjectToRef;
+  ManagedValue createBridgeObjectToRef(SILLocation loc, ManagedValue mv,
+                                       SILType destType);
 };
 
 class SwitchCaseFullExpr;

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -718,11 +718,10 @@ static ManagedValue emitBuiltinCastReferenceFromBridgeObject(
     SILValue result = SILUndef::get(destType, SGF.SGM.M);
     return ManagedValue::forUnmanaged(result);
   }
-  
-  SILValue result = SGF.B.createBridgeObjectToRef(loc, args[0].forward(SGF),
-                                                  destType);
-  return SGF.emitManagedRValueWithCleanup(result);
+
+  return SGF.B.createBridgeObjectToRef(loc, args[0], destType);
 }
+
 static ManagedValue emitBuiltinCastBitPatternFromBridgeObject(
                                                   SILGenFunction &SGF,
                                                   SILLocation loc,


### PR DESCRIPTION
…rough the instruction rather than unconditionally adding a cleanup.

Otherwise, we may put cleanups on borrowed values.

rdar://34222540

----

This is coming up a bunch more since we are calling builtins with `@guaranteed` parameters instead of `@owned` parameters. We may want to have builtins have their own convention. Not sure yet (depends how much breaks). This should be NFC without normal arguments being at +0.