### PR TITLE
Fix test to avoid checking for named IR values

### DIFF
--- a/test/DebugInfo/linetable-cleanups.swift
+++ b/test/DebugInfo/linetable-cleanups.swift
@@ -20,10 +20,10 @@ func main() {
 // CHECK: call {{.*}}void @_T04main8markUsedyxlF
 // CHECK: br label
 // CHECK: <label>:
-// CHECK: call %Ts16IndexingIteratorVySaySiGG* @_T0s16IndexingIteratorVySaySiGGWh0_(%Ts16IndexingIteratorVySaySiGG* %"$element$generator"), !dbg ![[LOOPHEADER_LOC:.*]]
+// CHECK: call %Ts16IndexingIteratorVySaySiGG* @_T0s16IndexingIteratorVySaySiGGWh0_(%Ts16IndexingIteratorVySaySiGG* %{{.*}}), !dbg ![[LOOPHEADER_LOC:.*]]
 // CHECK: call {{.*}}void @_T04main8markUsedyxlF
 // The cleanups should share the line number with the ret stmt.
-// CHECK:  call %TSa* @_T0SaySiGWh0_(%TSa* %b), !dbg ![[CLEANUPS:.*]]
+// CHECK:  call %TSa* @_T0SaySiGWh0_(%TSa* %{{.*}}), !dbg ![[CLEANUPS:.*]]
 // CHECK-NEXT:  !dbg ![[CLEANUPS]]
 // CHECK-NEXT:  llvm.lifetime.end
 // CHECK-NEXT:  load


### PR DESCRIPTION
The previous change to the DebugInfo/linetable-cleanups.swift test
introduced FileCheck patterns with references to named IR values. In a
release build, the values are anonymous, so those patterns do not match.
rdar://problem/35639381