### PR TITLE
 [AST] Properly adjust substitution type for inherited conformances.

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -979,7 +979,17 @@ ProtocolConformance::subst(Type substType,
       = cast<InheritedProtocolConformance>(this)->getInheritedConformance();
     ProtocolConformance *newBase;
     if (inheritedConformance->getType()->isSpecialized()) {
-      newBase = inheritedConformance->subst(substType, subs, conformances);
+      // Follow the substituted type up the superclass chain until we reach
+      // the underlying class type.
+      auto targetClass =
+        inheritedConformance->getType()->getClassOrBoundGenericClass();
+      auto superclassType = substType;
+      while (superclassType->getClassOrBoundGenericClass() != targetClass)
+        superclassType = superclassType->getSuperclass();
+
+      // Substitute into the superclass.
+      newBase = inheritedConformance->subst(superclassType, subs,
+                                            conformances);
     } else {
       newBase = inheritedConformance;
     }

--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/libBasic.%target-dylib-extension) %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
 // RUN: %target-build-swift-dylib(%t/libWithAssoc.%target-dylib-extension) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
-// FIXME: currently fails due to incorrect modeling of type parameters in inherited conformances.
-// %target-build-swift-dylib(%t/libSubclass.%target-dylib-extension) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
-// RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
+// RUN: %target-build-swift-dylib(%t/libSubclass.%target-dylib-extension) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
+// RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc -lSubclass %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/conditional_conformances_modules %t/libBasic.%target-dylib-extension %t/libWithAssoc.%target-dylib-extension
 
 // REQUIRES: executable_test
@@ -12,8 +11,7 @@
 
 import Basic
 import WithAssoc
-// FIXME: see above
-// import Subclass
+import Subclass
 
 
 public func basic_single_generic<T: Basic.P2>(_: T.Type) {
@@ -52,8 +50,6 @@ public func with_assoc_concrete_concrete() {
   WithAssoc.takes_p1(WithAssoc.Double<WithAssoc.IsAlsoP2, WithAssoc.IsP3>.self)
 }
 
-/*
-FIXME: see above
 public func subclass_subclassgeneric_generic<T: Subclass.P2>(_: T.Type) {
   Subclass.takes_p1(Subclass.SubclassGeneric<T>.self)
 }
@@ -66,7 +62,6 @@ public func subclass_subclassconcrete() {
 public func subclass_subclassgenericconcrete() {
   Subclass.takes_p1(Subclass.SubclassGenericConcrete.self)
 }
-*/
 
 
 basic_single_generic(Basic.IsP2.self)
@@ -82,10 +77,7 @@ with_assoc_concrete_generic(WithAssoc.IsP3.self)
 with_assoc_concrete_concrete()
 
 
-/*
-FIXME: see above
 subclass_subclassgeneric_generic(Subclass.IsP2.self)
 subclass_subclassgeneric_concrete()
 subclass_subclassconcrete()
 subclass_subclassgenericconcrete()
-*/

--- a/validation-test/compiler_crashers_2_fixed/0130-rdar35632543.swift
+++ b/validation-test/compiler_crashers_2_fixed/0130-rdar35632543.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+public protocol ObservableType {
+  associatedtype E
+}
+
+public protocol SubjectType : ObservableType {
+  associatedtype SubjectObserverType : ObserverType
+}
+
+extension ObservableType {
+  public func multicast<S: SubjectType>(_ subject: S) -> Observable<S.E> {
+    while true {}
+  }
+}
+
+
+extension ObservableType {
+  public func publish() -> Observable<E> {
+    return self.multicast(PublishSubject())
+  }
+}
+
+public class Observable<Element> : ObservableType {
+  public typealias E = Element
+}
+
+public protocol ObserverType {
+  associatedtype E
+}
+
+public final class PublishSubject<Element> : Observable<Element>, SubjectType, ObserverType
+{
+  public typealias SubjectObserverType = PublishSubject<Element>
+}
+


### PR DESCRIPTION
When we substitute into an inherited conformance, make sure that we
follow the superclass chain from the new conforming type up to the
matching superclass *before* doing the substitution.

Fixes rdar://problem/35632543. Also add a test for the related but already-fixed rdar://problem/35480728.