### PR TITLE
 [Constraint solver] Check conditional requirements for type erasure.

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -983,13 +983,10 @@ ProtocolConformance::subst(Type substType,
       // the underlying class type.
       auto targetClass =
         inheritedConformance->getType()->getClassOrBoundGenericClass();
-      auto superclassType = substType;
-      while (superclassType->getClassOrBoundGenericClass() != targetClass)
-        superclassType = superclassType->getSuperclass();
+      auto superclassType = substType->getSuperclassForDecl(targetClass);
 
       // Substitute into the superclass.
-      newBase = inheritedConformance->subst(superclassType, subs,
-                                            conformances);
+      newBase = inheritedConformance->subst(superclassType, subs, conformances);
     } else {
       newBase = inheritedConformance;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2606,17 +2606,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
       // This conformance may be conditional, in which case we need to consider
       // those requirements as constraints too.
-      //
-      // If we've got a normal conformance, we must've started with `type` in
-      // the context that declares the conformance, and so these requirements
-      // are automatically satisfied, and thus we can skip adding them. (This
-      // hacks around some representational problems caused by requirements
-      // being stored as interface types and the normal conformance's type being
-      // a contextual type. Once the latter is fixed and everything is interface
-      // types, this shouldn't be necessary.)
-      if (conformance->isConcrete() &&
-          conformance->getConcrete()->getKind() !=
-              ProtocolConformanceKind::Normal) {
+      if (conformance->isConcrete()) {
         for (auto req : conformance->getConditionalRequirements()) {
           addConstraint(req, locator);
         }

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -323,3 +323,14 @@ struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-NEXT:   conforms_to: τ_0_0 P1
 // CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}
+
+// Checking of conditional requirements for existential conversions.
+func existential_good<T: P1>(_: T.Type) {
+  _ = Free<T>() as P2
+}
+
+func existential_bad<T>(_: T.Type) {
+  // FIXME: Poor diagnostic.
+  _ = Free<T>() as P2 // expected-error{{'Free<T>' is not convertible to 'P2'; did you mean to use 'as!' to force downcast?}}
+}
+


### PR DESCRIPTION
Rather than wantonly dropping the conditional requirements when checking
for type erasure, add them in the same way we do for (e.g.) conformance
checking for generics. Fixes rdar://problem/35480860.