### PR TITLE
NFC: Remove stale comment about DeclAttr 70

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -288,8 +288,6 @@ DECL_ATTR(_restatedObjCConformance, RestatedObjCConformance,
           OnProtocol | NotSerialized | LongAttribute | RejectByParser,
          /*Not serialized */ 70)
 
-// 70 is available; it was not a serialized attribute.
-
 // HACK: Attribute needed to preserve source compatibility by downgrading errors
 // due to an SDK change in Dispatch
 SIMPLE_DECL_ATTR(_downgrade_exhaustivity_check, DowngradeExhaustivityCheck,


### PR DESCRIPTION
You can see at the top of the diff that 70 is actually in use