### PR TITLE
[silgen] Ensure that when we emit the return statement, we always hav…

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -388,7 +388,8 @@ void SILGenFunction::emitReturnExpr(SILLocation branchLoc,
   } else {
     // SILValue return.
     FullExpr scope(Cleanups, CleanupLocation(ret));
-    emitRValue(ret).forwardAll(*this, directResults);
+    RValue RV = emitRValue(ret).ensurePlusOne(*this, CleanupLocation(ret));
+    std::move(RV).forwardAll(*this, directResults);
   }
   Cleanups.emitBranchAndCleanups(ReturnDest, branchLoc, directResults);
 }


### PR DESCRIPTION
…e a plus one value afterwards.

This ensures that if we have a guaranteed value, we copy it before we feed it
into the return argument. If we have a trivial value or an owned value, we do
not perform the copy.

rdar://34222540