### PR TITLE
[silgen] When assigning into an lvalue, the value that we are storing…

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3358,7 +3358,7 @@ void SILGenFunction::emitAssignToLValue(SILLocation loc,
       std::move(component.asPhysical()).offset(*this, loc, destAddr,
                                                AccessKind::Write);
 
-    auto value = std::move(src).getAsRValue(*this);
+    auto value = std::move(src).getAsRValue(*this).ensurePlusOne(*this, loc);
     std::move(value).assignInto(*this, loc, finalDestAddr.getValue());
   } else {
     std::move(component.asLogical()).set(*this, loc, std::move(src), destAddr);


### PR DESCRIPTION
… must be at plus one.

This allows us to obey Semantic SIL when attempting to assign a guaranteed value
into a storage location.

rdar://34222540

----

Again, this is behind a flag, so current codegen shouldn't change.