### PR TITLE
[silgen] Refactor emitClassConstructorInitializer into a helper struc…

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -739,6 +739,19 @@ ManagedValue SILGenBuilder::createBridgeObjectToRef(SILLocation loc,
   return cloner.clone(result);
 }
 
+void SILGenBuilder::createBranch(SILLocation returnLoc, SILBasicBlock *block,
+                                 ManagedValue mv) {
+  createBranch(returnLoc, block, mv.forward(SGF));
+}
+
+void SILGenBuilder::createReturn(SILLocation returnLoc, ManagedValue mv) {
+  createReturn(returnLoc, mv.forward(SGF));
+}
+
+void SILGenBuilder::createDebugValue(SILLocation loc, ManagedValue mv) {
+  createDebugValue(loc, mv.getValue());
+}
+
 //===----------------------------------------------------------------------===//
 //                            Switch Enum Builder
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -327,6 +327,15 @@ public:
   using SILBuilder::createBridgeObjectToRef;
   ManagedValue createBridgeObjectToRef(SILLocation loc, ManagedValue mv,
                                        SILType destType);
+  using SILBuilder::createBranch;
+  void createBranch(SILLocation returnLoc, SILBasicBlock *block,
+                    ManagedValue mv);
+
+  using SILBuilder::createReturn;
+  void createReturn(SILLocation returnLoc, ManagedValue mv);
+
+  using SILBuilder::createDebugValue;
+  void createDebugValue(SILLocation loc, ManagedValue mv);
 };
 
 class SwitchCaseFullExpr;


### PR DESCRIPTION
…t ClassConstructorInitializerEmitter.

This refactor makes it easier to understand what is actually happening since it
gives names to the individual subroutines instead of forcing the reader to infer
the purpose of the inline subroutine (i.e. I refactored the code so I could
understand it).

rdar://34222540