### PR TITLE
[ConstraintSystem] Improve type parameter requirement locators

### DIFF
--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -77,6 +77,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case OpenedGeneric:
     case KeyPathComponent:
     case ConditionalRequirement:
+    case TypeParameterRequirement:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -242,6 +243,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case ConditionalRequirement:
       out << "conditional requirement #" << llvm::utostr(elt.getValue());
+      break;
+
+    case TypeParameterRequirement:
+      out << "type parameter requirement #" << llvm::utostr(elt.getValue());
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -125,6 +125,8 @@ public:
     KeyPathComponent,
     /// The Nth conditional requirement in the parent locator's conformance.
     ConditionalRequirement,
+    /// A single requirement placed on the type parameters.
+    TypeParameterRequirement,
   };
 
   /// \brief Determine the number of numeric values used for the given path
@@ -164,6 +166,7 @@ public:
     case TupleElement:
     case KeyPathComponent:
     case ConditionalRequirement:
+    case TypeParameterRequirement:
       return 1;
 
     case ApplyArgToParam:
@@ -217,6 +220,7 @@ public:
     case Witness:
     case KeyPathComponent:
     case ConditionalRequirement:
+    case TypeParameterRequirement:
       return 0;
 
     case FunctionArgument:
@@ -351,6 +355,10 @@ public:
     /// Get a path element for a conditional requirement.
     static PathElement getConditionalRequirementComponent(unsigned index) {
       return PathElement(ConditionalRequirement, index);
+    }
+
+    static PathElement getTypeRequirementComponent(unsigned index) {
+      return PathElement(TypeParameterRequirement, index);
     }
 
     /// \brief Retrieve the kind of path element.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1051,7 +1051,10 @@ void ConstraintSystem::openGeneric(
   bindArchetypesFromContext(*this, outerDC, locatorPtr, replacements);
 
   // Add the requirements as constraints.
-  for (auto req : sig->getRequirements()) {
+  auto requirements = sig->getRequirements();
+  for (unsigned pos = 0, n = requirements.size(); pos != n; ++pos) {
+    const auto &req = requirements[pos];
+
     Optional<Requirement> openedReq;
     auto openedFirst = openType(req.getFirstType(), replacements);
 
@@ -1078,7 +1081,11 @@ void ConstraintSystem::openGeneric(
       openedReq = Requirement(kind, openedFirst, req.getLayoutConstraint());
       break;
     }
-    addConstraint(*openedReq, locatorPtr);
+
+    addConstraint(
+        *openedReq,
+        locator.withPathElement(ConstraintLocator::OpenedGeneric)
+            .withPathElement(LocatorPathElt::getTypeRequirementComponent(pos)));
   }
 }
 


### PR DESCRIPTION
When opening generic types with type parameter requirements,
add information about requirement location to the locator of each
generated constraint to make it easier to extract such information
if needed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
