### PR TITLE
[runtime] Restore compatibility with glibc < 2.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,8 +851,6 @@ if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")
 endif()
 
-check_symbol_exists(getauxval "sys/auxv.h" HAVE_GETAUXVAL)
-
 #
 # Set up global CMake variables for API notes.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,6 +851,8 @@ if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")
 endif()
 
+check_symbol_exists(getauxval "sys/auxv.h" HAVE_GETAUXVAL)
+
 #
 # Set up global CMake variables for API notes.
 #

--- a/include/swift/Config.h.in
+++ b/include/swift/Config.h.in
@@ -8,4 +8,6 @@
 
 #cmakedefine HAVE_UNICODE_LIBEDIT 1
 
+#cmakedefine HAVE_GETAUXVAL 1
+
 #endif // SWIFT_CONFIG_H

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -23,6 +23,8 @@ set(section_magic_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_compile_flags
      "-D__SWIFT_CURRENT_DYLIB=swiftCore")
 
+check_symbol_exists(getauxval "sys/auxv.h" HAVE_GETAUXVAL)
+
 set(swift_runtime_objc_sources
     ErrorObject.mm
     SwiftObject.mm

--- a/stdlib/public/runtime/StaticBinaryELF.cpp
+++ b/stdlib/public/runtime/StaticBinaryELF.cpp
@@ -64,10 +64,8 @@ typedef Elf32_Section Elf_Section;
 
 extern const Elf_Ehdr elfHeader asm("__ehdr_start");
 
-static unsigned long getAuxVal(unsigned long type) {
-#if HAVE_GETAUXVAL
-  return getauxval(type);
-#else
+#if !HAVE_GETAUXVAL
+static unsigned long getauxval(unsigned long type) {
   struct AuxvEntry {
     unsigned long tag;
     unsigned long value;
@@ -90,8 +88,8 @@ static unsigned long getAuxVal(unsigned long type) {
   }
   close(fd);
   return 0;
-#endif
 }
+#endif
 
 class StaticBinaryELF {
 
@@ -149,7 +147,7 @@ public:
   StaticBinaryELF() {
     getExecutablePathName();
 
-    programHeaders = reinterpret_cast<const Elf_Phdr *>(getAuxVal(AT_PHDR));
+    programHeaders = reinterpret_cast<const Elf_Phdr *>(getauxval(AT_PHDR));
     if (programHeaders == nullptr) {
       return;
     }


### PR DESCRIPTION
Provide an alternative implementation for `getauxval()` function which was added to glibc 2.16 only. This allows Swift to be compiled on CentOS 6 which has glibc 2.12 only (CentOS 6 is maintained until 2020).
