### PR TITLE
[AST] NFC: Make RecursiveTypeProperties have a natural size

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -123,7 +123,7 @@ public:
   };
 
 private:
-  unsigned Bits : BitWidth;
+  unsigned Bits;
 
 public:
   RecursiveTypeProperties() : Bits(0) {}
@@ -376,6 +376,7 @@ protected:
 
   void setRecursiveProperties(RecursiveTypeProperties properties) {
     TypeBaseBits.Properties = properties.getBits();
+    assert(TypeBaseBits.Properties == properties.getBits() && "Bits dropped!");
   }
 
 public:


### PR DESCRIPTION
This is a minor performance optimization.