### PR TITLE
Raw string literals

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -103,6 +103,10 @@ ERROR(lex_unprintable_ascii_character,none,
       "unprintable ASCII character found in source file", ())
 ERROR(lex_invalid_utf8,none,
       "invalid UTF-8 found in source file", ())
+ERROR(lex_character_invalid_escape,none,
+      "invalid escape in character literal", ())
+ERROR(lex_character_not_codepoint,none,
+      "character not expressible as a single codepoint", ())
 ERROR(lex_single_quote_string,none,
       "single-quoted string literal found, use '\"'", ())
 ERROR(lex_invalid_curly_quote,none,

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -534,6 +534,7 @@ private:
                         bool RawString = false);
   void lexStringLiteral(bool RawString);
   void lexEscapedIdentifier();
+  void lexChar();
 
   void tryLexEditorPlaceholder();
   const char *findEndOfCurlyQuoteStringLiteral(const char*);

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -48,6 +48,7 @@ class Token {
   
   /// Modifiers for string literals
   unsigned MultilineString : 1;
+  unsigned RawString : 1;
 
   /// Text - The actual string covered by the token in the source buffer.
   StringRef Text;
@@ -65,7 +66,7 @@ public:
   Token(tok Kind, StringRef Text, unsigned CommentLength)
           : Kind(Kind), AtStartOfLine(false), CommentLength(CommentLength),
             EscapedIdentifier(false), MultilineString(false),
-            Text(Text) {}
+            RawString(false), Text(Text) {}
 
   Token(tok Kind, StringRef Text): Token(Kind, Text, 0) {};
 
@@ -288,16 +289,21 @@ public:
 
   /// \brief Set the token to the specified kind and source range.
   void setToken(tok K, StringRef T, unsigned CommentLength = 0,
-                bool MultilineString = false) {
+                bool MultilineString = false, bool RawString = false) {
     Kind = K;
     Text = T;
     this->CommentLength = CommentLength;
     EscapedIdentifier = false;
     this->MultilineString = MultilineString;
+    this->RawString = RawString;
   }
 
   bool IsMultilineString() const {
     return MultilineString;
+  }
+
+  bool IsRawString() const {
+    return RawString;
   }
 };
   

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -248,7 +248,8 @@ Token Lexer::getTokenAt(SourceLoc Loc) {
   return Result;
 }
 
-void Lexer::formToken(tok Kind, const char *TokStart, bool MultilineString) {
+void Lexer::formToken(tok Kind, const char *TokStart,
+                      bool MultilineString, bool RawString) {
   assert(CurPtr >= BufferStart &&
          CurPtr <= BufferEnd && "Current pointer out of range!");
 
@@ -267,7 +268,8 @@ void Lexer::formToken(tok Kind, const char *TokStart, bool MultilineString) {
   if (!MultilineString)
     lexTrivia(TrailingTrivia, /* StopAtFirstNewline */ true);
 
-  NextToken.setToken(Kind, TokenText, CommentLength, MultilineString);
+  NextToken.setToken(Kind, TokenText, CommentLength,
+                     MultilineString, RawString);
   if (!MultilineString)
     if (!TrailingTrivia.empty() &&
         TrailingTrivia.front().Kind == syntax::TriviaKind::Backtick)
@@ -1223,7 +1225,8 @@ static bool maybeConsumeNewlineEscape(const char *&CurPtr, ssize_t Offset) {
 ///   character_escape  ::= [\][\] | [\]t | [\]n | [\]r | [\]" | [\]' | [\]0
 ///   character_escape  ::= unicode_character_escape
 unsigned Lexer::lexCharacter(const char *&CurPtr, char StopQuote,
-                             bool EmitDiagnostics, bool MultilineString) {
+                             bool EmitDiagnostics, bool MultilineString,
+                             bool RawString) {
   const char *CharStart = CurPtr;
 
   switch (*CurPtr++) {
@@ -1272,6 +1275,8 @@ unsigned Lexer::lexCharacter(const char *&CurPtr, char StopQuote,
       diagnose(CurPtr-1, diag::lex_unterminated_string);
     return ~1U;
   case '\\':  // Escapes.
+    if (RawString)
+      return '\\';
     break;
   }
   
@@ -1499,7 +1504,7 @@ getMultilineTrailingIndent(const Token &Str, DiagnosticEngine *Diags) {
       auto string = StringRef(start, end - start);
 
       // Disallow escaped newline in the last line.
-      if (Diags) {
+      if (Diags && !Str.IsRawString()) {
         auto *Ptr = start - 1;
         if (*Ptr == '\n') --Ptr;
         if (*Ptr == '\r') --Ptr;
@@ -1655,7 +1660,7 @@ static void validateMultilineIndents(const Token &Str,
 /// lexStringLiteral:
 ///   string_literal ::= ["]([^"\\\n\r]|character_escape)*["]
 ///   string_literal ::= ["]["]["].*["]["]["] - approximately
-void Lexer::lexStringLiteral() {
+void Lexer::lexStringLiteral(bool RawString) {
   const char *TokStart = CurPtr-1;
   assert((*TokStart == '"' || *TokStart == '\'') && "Unexpected start");
   // NOTE: We only allow single-quote string literals so we can emit useful
@@ -1697,7 +1702,8 @@ void Lexer::lexStringLiteral() {
       return formToken(tok::unknown, TokStart);
     }
 
-    unsigned CharValue = lexCharacter(CurPtr, *TokStart, true, MultilineString);
+    unsigned CharValue = lexCharacter(CurPtr, *TokStart, true,
+                                      MultilineString, RawString);
     wasErroneous |= CharValue == ~1U;
 
     // If this is the end of string, we are done.  If it is a normal character
@@ -1745,7 +1751,8 @@ void Lexer::lexStringLiteral() {
       if (MultilineString) {
         if (*CurPtr == '"' && *(CurPtr + 1) == '"' && *(CurPtr + 2) != '"') {
           CurPtr += 2;
-          formToken(tok::string_literal, TokStart, MultilineString);
+          formToken(tok::string_literal, TokStart,
+                    MultilineString, RawString);
           if (Diags)
             validateMultilineIndents(NextToken, Diags);
           return;
@@ -1754,7 +1761,8 @@ void Lexer::lexStringLiteral() {
           continue;
       }
 
-      return formToken(tok::string_literal, TokStart, MultilineString);
+      return formToken(tok::string_literal, TokStart,
+                       MultilineString, RawString);
     }
   }
 }
@@ -1923,7 +1931,8 @@ StringRef Lexer::getEncodedStringSegment(StringRef Bytes,
                                          SmallVectorImpl<char> &TempString,
                                          bool IsFirstSegment,
                                          bool IsLastSegment,
-                                         unsigned IndentToStrip) {
+                                         unsigned IndentToStrip,
+                                         bool RawString) {
 
   TempString.clear();
   // Note that it is always safe to read one over the end of "Bytes" because
@@ -1950,7 +1959,7 @@ StringRef Lexer::getEncodedStringSegment(StringRef Bytes,
       continue;
     }
 
-    if (CurChar != '\\') {
+    if (CurChar != '\\' || RawString) {
       TempString.push_back(CurChar);
       continue;
     }
@@ -2021,6 +2030,7 @@ void Lexer::getStringLiteralSegments(
   // Are substitutions required either for indent stripping or line ending
   // normalization?
   bool MultilineString = Str.IsMultilineString(), IsFirstSegment = true;
+  bool RawString = Str.IsRawString();
   unsigned IndentToStrip = 0;
   if (MultilineString)
     IndentToStrip = 
@@ -2032,7 +2042,7 @@ void Lexer::getStringLiteralSegments(
   const char *SegmentStartPtr = Bytes.begin();
   const char *BytesPtr = SegmentStartPtr;
   // FIXME: Use SSE to scan for '\'.
-  while (BytesPtr != Bytes.end()) {
+  while (BytesPtr != Bytes.end() && !RawString) {
     char CurChar = *BytesPtr++;
     if (CurChar != '\\')
       continue;
@@ -2046,7 +2056,8 @@ void Lexer::getStringLiteralSegments(
     Segments.push_back(
         StringSegment::getLiteral(getSourceLoc(SegmentStartPtr),
                                   BytesPtr-SegmentStartPtr-2,
-                                  IsFirstSegment, false, IndentToStrip));
+                                  IsFirstSegment, false, IndentToStrip,
+                                  RawString));
     IsFirstSegment = false;
 
     // Find the closing ')'.
@@ -2069,7 +2080,8 @@ void Lexer::getStringLiteralSegments(
   Segments.push_back(
       StringSegment::getLiteral(getSourceLoc(SegmentStartPtr),
                                 Bytes.end()-SegmentStartPtr,
-                                IsFirstSegment, true, IndentToStrip));
+                                IsFirstSegment, true, IndentToStrip,
+                                RawString));
 }
 
 
@@ -2281,13 +2293,20 @@ Restart:
   case '&': case '|':  case '^': case '~': case '.':
     return lexOperatorIdentifier();
 
+  case 'r':
+    if (CurPtr[0] == '"') {
+      CurPtr++;
+      return lexStringLiteral(true);
+    }
+    LLVM_FALLTHROUGH;
+
   case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G':
   case 'H': case 'I': case 'J': case 'K': case 'L': case 'M': case 'N':
   case 'O': case 'P': case 'Q': case 'R': case 'S': case 'T': case 'U':
   case 'V': case 'W': case 'X': case 'Y': case 'Z':
   case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g':
   case 'h': case 'i': case 'j': case 'k': case 'l': case 'm': case 'n':
-  case 'o': case 'p': case 'q': case 'r': case 's': case 't': case 'u':
+  case 'o': case 'p': case 'q': case 's': case 't': case 'u':
   case 'v': case 'w': case 'x': case 'y': case 'z':
   case '_':
     return lexIdentifier();
@@ -2301,7 +2320,7 @@ Restart:
 
   case '"':
   case '\'':
-    return lexStringLiteral();
+    return lexStringLiteral(false);
       
   case '`':
     return lexEscapedIdentifier();

--- a/test/Parse/raw_string.swift
+++ b/test/Parse/raw_string.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+
+import Swift
+
+// ===---------- Raw mode unescaping strings --------===
+
+_ = r"ab\c\r\n\(var)\"
+
+// CHECK: "ab\\c\\r\\n\\(var)\\"
+
+_ = r"""
+    "One"\r\n
+    \(var)
+    """
+
+// CHECK: "\"One\"\\r\\n\n\\(var)"
+
+_ = r"""
+    One\
+    Two\
+    """
+
+// CHECK: "One\\\nTwo\\"


### PR DESCRIPTION
A minor change to the lexer to allow entry of “raw” string literals where the \ character has no special role in escaping. To be discussed on S/E once I have the PR #.

Resolves #48912.