### PR TITLE
[stdlib] Remove iterator type workaround from `ClosedRange`

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -85,40 +85,6 @@ extension ClosedRangeIndex : Comparable {
   }
 }
 
-// FIXME(ABI)#175 (Type checker)
-// WORKAROUND: needed because of rdar://25584401
-/// An iterator over the elements of a `CountableClosedRange` instance.
-@_fixed_layout
-public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
-  where
-  Bound : Strideable, Bound.Stride : SignedInteger {
-
-  @_inlineable
-  @_versioned
-  internal init(_range r: CountableClosedRange<Bound>) {
-    _nextResult = r.lowerBound
-    _upperBound = r.upperBound
-  }
-
-  @_inlineable
-  public func makeIterator() -> ClosedRangeIterator {
-    return self
-  }
-
-  @_inlineable
-  public mutating func next() -> Bound? {
-    let r = _nextResult
-    if let x = r {
-      _nextResult = x == _upperBound ? nil : x.advanced(by: 1)
-    }
-    return r
-  }
-  @_versioned
-  internal var _nextResult: Bound?
-  @_versioned
-  internal let _upperBound: Bound
-}
-
 /// A closed range that forms a collection of consecutive values.
 ///
 /// You create a `CountableClosedRange` instance by using the closed range
@@ -186,17 +152,6 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
   public typealias Index = ClosedRangeIndex<Bound>
 
   public typealias IndexDistance = Bound.Stride
-
-  // FIXME(ABI)#175 (Type checker)
-  // WORKAROUND: needed because of rdar://25584401
-  public typealias Iterator = ClosedRangeIterator<Bound>
-
-  // FIXME(ABI)#175 (Type checker)
-  // WORKAROUND: needed because of rdar://25584401
-  @_inlineable
-  public func makeIterator() -> ClosedRangeIterator<Bound> {
-    return ClosedRangeIterator(_range: self)
-  }
 
   /// The position of the first element in the range.
   @_inlineable
@@ -297,16 +252,6 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
   public subscript(bounds: Range<Index>)
     -> RandomAccessSlice<CountableClosedRange<Bound>> {
     return RandomAccessSlice(base: self, bounds: bounds)
-  }
-
-  // FIXME(ABI)#175 (Type checker)
-  @_inlineable
-  public // WORKAROUND: needed because of rdar://25584401
-  var indices: DefaultRandomAccessIndices<CountableClosedRange<Bound>> {
-    return DefaultRandomAccessIndices(
-      _elements: self,
-      startIndex: self.startIndex,
-      endIndex: self.endIndex)
   }
 
   /// Creates an instance with the given bounds.

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -600,17 +600,6 @@ where ${Where} {
       _preconditionFailure("Incrementing past end index")
     }
   }
-
-  // FIXME(ABI)#175 (Type checker)
-  @_inlineable
-  public // WORKAROUND: needed because of rdar://25584401
-  var indices: DefaultRandomAccessIndices<${Self}> {
-    return DefaultRandomAccessIndices(
-      _elements: self,
-      startIndex: self.startIndex,
-      endIndex: self.endIndex)
-  }
-
 }
 
 % end

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -768,7 +768,7 @@ CountableClosedRangeTestSuite.test("AssociatedTypes") {
   typealias Collection = CountableClosedRange<MinimalStrideableValue>
   expectCollectionAssociatedTypes(
     collectionType: Collection.self,
-    iteratorType: ClosedRangeIterator<MinimalStrideableValue>.self,
+    iteratorType: IndexingIterator<Collection>.self,
     subSequenceType: RandomAccessSlice<Collection>.self,
     indexType: ClosedRangeIndex<MinimalStrideableValue>.self,
     indexDistanceType: MinimalStrideableValue.Stride.self,


### PR DESCRIPTION
After changes to stdlib and type-checker related to removing
of the `_Strideable` it's now possible to properly support
iterator types for *ClosedRange without any workarounds.

Resolves: rdar://problem/25584401

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
