### PR TITLE
[AST] Fix a crash when conformance lookup fails during substitution.

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -224,7 +224,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
            substType->castTo<ArchetypeType>()->getSuperclass()) &&
           !substType->isTypeParameter() &&
           !substType->isExistentialType()) {
-        return *M->lookupConformance(substType, proto);
+        return M->lookupConformance(substType, proto);
       }
 
       return ProtocolConformanceRef(proto);

--- a/validation-test/compiler_crashers_2_fixed/0131-sr6466.swift
+++ b/validation-test/compiler_crashers_2_fixed/0131-sr6466.swift
@@ -1,0 +1,28 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+protocol DC {
+  init()
+}
+
+protocol P {
+  associatedtype A: DC
+
+  func f() -> A
+}
+
+protocol Q: P {
+  associatedtype A
+}
+
+extension Q {
+  func f() -> A { return A() }
+}
+
+struct X<T> { }
+
+extension X: P where T: P {
+  typealias A = T.A
+}
+
+extension X: Q where T: Q {
+}


### PR DESCRIPTION
The enclosing conformance-lookup operation can fail (i.e., it returns
Optional), but the nested call was force-unwrapping the optional from
an inner call for no particular reason. Stop doing that.

Note that the offending code is still something that should go away in
time, so this is merely polishing the band-aid to avoid a crash that
occurs often with conditional conformances.

Resolves [SR-6466](https://bugs.swift.org/browse/SR-6466).
