### PR TITLE
NFC: Use standardized locale header

### DIFF
--- a/stdlib/public/SDK/os/os_trace_blob.c
+++ b/stdlib/public/SDK/os/os_trace_blob.c
@@ -14,7 +14,7 @@
 #include <dispatch/dispatch.h>
 #include <os/base.h>
 #include <os/log.h>
-#include <xlocale.h>
+#include <locale.h>
 #include "os_trace_blob.h"
 
 OS_NOINLINE

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -65,7 +65,7 @@ static long double swift_strtold_l(const char *nptr,
 #define strtof_l swift_strtof_l
 #define strtold_l swift_strtold_l
 #else
-#include <xlocale.h>
+#include <locale.h>
 #endif
 #include <limits>
 #include <thread>


### PR DESCRIPTION
On Linux, glibc removed xlocale.h, which was non-standard.