### PR TITLE
NFC: Use standardized locale header

### DIFF
--- a/stdlib/public/SDK/os/os_trace_blob.c
+++ b/stdlib/public/SDK/os/os_trace_blob.c
@@ -14,7 +14,10 @@
 #include <dispatch/dispatch.h>
 #include <os/base.h>
 #include <os/log.h>
+#include <locale.h>
+#if !defined(__linux__)
 #include <xlocale.h>
+#endif
 #include "os_trace_blob.h"
 
 OS_NOINLINE

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -64,6 +64,8 @@ static long double swift_strtold_l(const char *nptr,
 #define strtod_l swift_strtod_l
 #define strtof_l swift_strtof_l
 #define strtold_l swift_strtold_l
+#elif defined(__linux__)
+#include <locale.h>
 #else
 #include <xlocale.h>
 #endif


### PR DESCRIPTION
On Linux, glibc removed xlocale.h, which was non-standard.