### PR TITLE
[SwiftDemangle] NFC: Increase portability via C standard APIs

### DIFF
--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -3,11 +3,6 @@ add_swift_library(swiftDemangle SHARED
   MangleHack.cpp
   LINK_LIBRARIES swiftDemangling)
 
-# We don't need to link against libbsd on MacOS and FreeBSD.
-if (NOT APPLE AND (NOT SWIFT_HOST_VARIANT STREQUAL "freebsd"))
-  target_link_libraries(swiftDemangle PRIVATE bsd)
-endif()
-
 swift_install_in_component(compiler
     TARGETS swiftDemangle
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"

--- a/lib/SwiftDemangle/SwiftDemangle.cpp
+++ b/lib/SwiftDemangle/SwiftDemangle.cpp
@@ -17,9 +17,6 @@
 
 #include "swift/Demangling/Demangle.h"
 #include "swift/SwiftDemangle/SwiftDemangle.h"
-#if defined(__linux__) || defined(_WIN32)
-#include <bsd/string.h>
-#endif
 
 static size_t swift_demangle_getDemangledName_Options(const char *MangledName,
     char *OutputBuffer, size_t Length,
@@ -36,8 +33,10 @@ static size_t swift_demangle_getDemangledName_Options(const char *MangledName,
   if (Result == MangledName)
     return 0; // Not a mangled name
 
-  // Copy the result to an output buffer.
-  return strlcpy(OutputBuffer, Result.c_str(), Length);
+  // Copy the result to an output buffer and ensure '\0' termination.
+  auto Dest = strncpy(OutputBuffer, Result.c_str(), Length);
+  Dest[Length - 1] = '\0';
+  return Result.length();
 }
 
 size_t swift_demangle_getDemangledName(const char *MangledName,


### PR DESCRIPTION
Not every Linux distribution has the `libbsd` package installed.