### PR TITLE
nonmutating swapAt implementations for UnsafeMutable(Raw)BufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -351,6 +351,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   @_inlineable
   public func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
+    _debugPrecondition(i >= 0 && j >= 0)
+    _debugPrecondition(i < endIndex && j < endIndex)
     let pi = (_position! + i)
     let pj = (_position! + j)
     let tmp = pi.move()

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -337,6 +337,27 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     }
 %  end
   }
+% if mutable:
+
+  /// Exchanges the values at the specified indices of the buffer.
+  ///
+  /// Both parameters must be valid indices of the buffer, and not
+  /// equal to `endIndex`. Passing the same index as both `i` and `j` has no
+  /// effect.
+  ///
+  /// - Parameters:
+  ///   - i: The index of the first value to swap.
+  ///   - j: The index of the second value to swap.
+  @_inlineable
+  public func swapAt(_ i: Int, _ j: Int) {
+    guard i != j else { return }
+    let pi = (_position! + i)
+    let pj = (_position! + j)
+    let tmp = pi.move()
+    pi.moveInitialize(from: pj, count: 1)
+    pj.initialize(to: tmp, count: 1)
+  }
+% end # mutable
 }
 
 extension Unsafe${Mutable}BufferPointer {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -237,6 +237,8 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   @_inlineable
   public func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
+    _debugPrecondition(i >= 0 && j >= 0)
+    _debugPrecondition(i < endIndex && j < endIndex)
     let pi = (_position! + i)
     let pj = (_position! + j)
     let tmp = pi.load(fromByteOffset: 0, as: UInt8.self)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -223,6 +223,28 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
 %  end # mutable
   }
 
+% if mutable:
+  /// Exchanges the byte values at the specified indices
+  /// in this buffer's memory.
+  ///
+  /// Both parameters must be valid indices of the buffer, and not
+  /// equal to `endIndex`. Passing the same index as both `i` and `j` has no
+  /// effect.
+  ///
+  /// - Parameters:
+  ///   - i: The index of the first byte to swap.
+  ///   - j: The index of the second byte to swap.
+  @_inlineable
+  public func swapAt(_ i: Int, _ j: Int) {
+    guard i != j else { return }
+    let pi = (_position! + i)
+    let pj = (_position! + j)
+    let tmp = pi.load(fromByteOffset: 0, as: UInt8.self)
+    pi.copyMemory(from: pj, byteCount: MemoryLayout<UInt8>.size)
+    pj.storeBytes(of: tmp, toByteOffset: 0, as: UInt8.self)
+  }
+
+% end # mutable
   /// The number of bytes in the buffer.
   ///
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -829,6 +829,40 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/set
   expectEqual(1, buffer[3])
 }
 
+UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("nonmutating-swapAt") {
+% if IsRaw:
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+% else:
+  let buffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: 3)
+% end
+  defer { buffer.deallocate() }
+
+  buffer[0] = 0
+  buffer[1] = 1
+  buffer[2] = 2
+
+  buffer.swapAt(0, 0)
+  expectEqual(Array(buffer), [0, 1, 2])
+
+  buffer.swapAt(0, 2)
+  expectEqual(Array(buffer), [2, 1, 0])
+}
+
+% if not IsRaw:
+UnsafeMutableBufferPointerTestSuite.test("nonmutating-swapAt-withARC") {
+  let buffer = UnsafeMutableBufferPointer<String>.allocate(capacity: 3)
+  defer { buffer.deallocate() }
+
+  _ = buffer.initialize(from: (0..<3).map(String.init(describing:)))
+
+  buffer.swapAt(0, 0)
+  expectEqual(Array(buffer), ["0", "1", "2"])
+
+  buffer.swapAt(0, 2)
+  expectEqual(Array(buffer), ["2", "1", "0"])
+}
+% end
+
 % end # SelfName
 
 runAllTests()

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -831,11 +831,15 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/set
 
 UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("nonmutating-swapAt") {
 % if IsRaw:
-  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  let allocated = UnsafeMutableRawPointer.allocate(bytes: 4, alignedTo: 8)
+  let buffer = UnsafeMutableRawBufferPointer(start: allocated, count: 3)
+  allocated.storeBytes(of: UInt8.max, toByteOffset: 3, as: UInt8.self)
 % else:
-  let buffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: 3)
+  let allocated = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+  let buffer = UnsafeMutableBufferPointer(start: allocated, count: 3)
+  allocated[3] = Int.max
 % end
-  defer { buffer.deallocate() }
+  defer { allocated.deallocate() }
 
   buffer[0] = 0
   buffer[1] = 1
@@ -846,6 +850,11 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("nonmutating-s
 
   buffer.swapAt(0, 2)
   expectEqual(Array(buffer), [2, 1, 0])
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  buffer.swapAt(2, 3)
 }
 
 % if not IsRaw:


### PR DESCRIPTION
<!-- What's in this pull request? -->
The `BufferPointer` types currently use `MutableCollection`'s default implementation of `swapAt`, which is unnecessarily mutable and, in the case of `UnsafeMutableBufferPointer` does nothing to minimize ARC traffic. This PR introduces non-mutating implementations of `swapAt` for `UnsafeMutableBufferPointer` and `UnsafeMutableRawBufferPointer`, in the spirit of <https://github.com/apple/swift/pull/12504>. If this gets merged some new "un-mutated var" warnings may appear, but source code would otherwise be unaffected.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
