### PR TITLE
Implement the DynamicLookupProtocol proposal.

### DIFF
--- a/include/swift/AST/DeclNameLoc.h
+++ b/include/swift/AST/DeclNameLoc.h
@@ -105,6 +105,14 @@ public:
     return getSourceLocs()[FirstArgumentLabelIndex + index];
   }
 
+  SourceLoc getStartLoc() const {
+    return getBaseNameLoc();
+  }
+
+  SourceLoc getEndLoc() const {
+    return NumArgumentLabels == 0 ? getBaseNameLoc() : getRParenLoc();
+  }
+  
   /// Retrieve the complete source range for this declaration name.
   SourceRange getSourceRange() const {
     if (NumArgumentLabels == 0) return getBaseNameLoc();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1368,6 +1368,9 @@ ERROR(cannot_use_nil_with_this_type,none,
 ERROR(use_of_equal_instead_of_equality,none,
       "use of '=' in a boolean context, did you mean '=='?", ())
 
+ERROR(type_invalid_conformance_dmlp,none,
+      "type %0 does not conform to `DynamicMemberLookupProtocol`; "
+      "subscript(dynamicMember:) should take a single string parameter", (Type))
 
 ERROR(protocol_does_not_conform_objc,none,
       "using %0 as a concrete type conforming to protocol %1 is not supported",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2339,7 +2339,10 @@ public:
 
   SourceLoc getLoc() const { return Index->getStartLoc(); }
   SourceLoc getStartLoc() const { return Base->getStartLoc(); }
-  SourceLoc getEndLoc() const { return Index->getEndLoc(); }
+  SourceLoc getEndLoc() const {
+    auto end = Index->getEndLoc();
+    return end.isValid() ? end : Base->getEndLoc();
+  }
   
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Subscript;
@@ -2396,7 +2399,7 @@ public:
                                : SubExpr->getStartLoc());
   }
   SourceLoc getEndLoc() const {
-    return NameLoc.getSourceRange().End ;
+    return NameLoc.getSourceRange().End;
   }
 
   SourceLoc getDotLoc() const { return DotLoc; }

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -57,6 +57,7 @@ PROTOCOL(Comparable)
 PROTOCOL(Error)
 PROTOCOL_(ErrorCodeProtocol)
 PROTOCOL(OptionSet)
+PROTOCOL(DynamicMemberLookupProtocol)
 
 PROTOCOL_(BridgedNSError)
 PROTOCOL_(BridgedStoredNSError)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5072,6 +5072,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::ExpressibleByBuiltinStringLiteral:
   case KnownProtocolKind::ExpressibleByBuiltinUTF16StringLiteral:
   case KnownProtocolKind::ExpressibleByBuiltinUnicodeScalarLiteral:
+  case KnownProtocolKind::DynamicMemberLookupProtocol:
   case KnownProtocolKind::OptionSet:
   case KnownProtocolKind::BridgedNSError:
   case KnownProtocolKind::BridgedStoredNSError:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1287,12 +1287,14 @@ namespace {
                          ArrayRef<Identifier> argLabels,
                          bool hasTrailingClosure,
                          ConstraintLocatorBuilder locator,
-                         bool isImplicit, AccessSemantics semantics) {
+                         bool isImplicit, AccessSemantics semantics,
+                         Optional<SelectedOverload> selected = None) {
       // Determine the declaration selected for this subscript operation.
-      auto selected = getOverloadChoiceIfAvailable(
-                        cs.getConstraintLocator(
-                          locator.withPathElement(
-                            ConstraintLocator::SubscriptMember)));
+      if (!selected)
+        selected = getOverloadChoiceIfAvailable(
+                          cs.getConstraintLocator(
+                            locator.withPathElement(
+                              ConstraintLocator::SubscriptMember)));
 
       // Handles situation where there was a solution available but it didn't
       // have a proper overload selected from subscript call, might be because
@@ -1421,30 +1423,47 @@ namespace {
         base = coerceImplicitlyUnwrappedOptionalToValue(base, objTy, locator);
         baseTy = cs.getType(base);
       }
-
-      // Figure out the index and result types.
-      auto subscriptTy = simplifyType(selected->openedType);
-      auto subscriptFnTy = subscriptTy->castTo<AnyFunctionType>();
-      auto resultTy = subscriptFnTy->getResult();
-
+      
+      
+      bool isDynamicMemberLookup =
+        choice.getKind() == OverloadChoiceKind::DynamicMemberLookup;
+      
+      auto locatorKind =
+        isDynamicMemberLookup ? ConstraintLocator::Member
+                              : ConstraintLocator::SubscriptMember;
       // If we opened up an existential when performing the subscript, open
       // the base accordingly.
-      auto knownOpened = solution.OpenedExistentialTypes.find(
+      auto knownOpened =
+        solution.OpenedExistentialTypes.find(
                            getConstraintSystem().getConstraintLocator(
-                             locator.withPathElement(
-                               ConstraintLocator::SubscriptMember)));
+                             locator.withPathElement(locatorKind)));
       if (knownOpened != solution.OpenedExistentialTypes.end()) {
         base = openExistentialReference(base, knownOpened->second, subscript);
         baseTy = knownOpened->second;
       }
 
-      // Coerce the index argument.
-      index = coerceCallArguments(index, subscriptFnTy, nullptr,
-                                  argLabels, hasTrailingClosure,
-                                  locator.withPathElement(
-                                    ConstraintLocator::SubscriptIndex));
-      if (!index)
-        return nullptr;
+      // Figure out the index and result types.
+      Type resultTy;
+      if (!isDynamicMemberLookup) {
+        auto subscriptTy = simplifyType(selected->openedType);
+        AnyFunctionType *subscriptFnTy = subscriptTy->castTo<AnyFunctionType>();
+        resultTy = subscriptFnTy->getResult();
+        
+        // Coerce the index argument.
+        index = coerceCallArguments(index, subscriptFnTy, nullptr,
+                                    argLabels, hasTrailingClosure,
+                                    locator.withPathElement(
+                                      ConstraintLocator::SubscriptIndex));
+        if (!index)
+          return nullptr;
+        
+      } else {
+        // If this is a DynamicMemberLookup, then the type of the selection is
+        // actually the property/result type, not the correct type.  That's
+        // fine though, and we already have the index type adjusted to the
+        // correct type expected by the subscript.
+        resultTy = simplifyType(selected->openedType);
+      }
 
       auto getType = [&](const Expr *E) -> Type {
         return cs.getType(E);
@@ -2630,7 +2649,8 @@ namespace {
         // before taking a single element.
         baseTy = cs.getType(base);
         if (!toType->hasLValueType() && baseTy->hasLValueType())
-          base = coerceToType(base, baseTy->getRValueType(), cs.getConstraintLocator(base));
+          base = coerceToType(base, baseTy->getRValueType(),
+                              cs.getConstraintLocator(base));
 
         return cs.cacheType(new (cs.getASTContext())
                             TupleElementExpr(base, dotLoc,
@@ -2638,15 +2658,39 @@ namespace {
                                              nameLoc.getBaseNameLoc(), toType));
       }
 
-      case OverloadChoiceKind::BaseType: {
+      case OverloadChoiceKind::BaseType:
         return base;
-      }
 
       case OverloadChoiceKind::KeyPathApplication:
         llvm_unreachable("should only happen in a subscript");
+          
+      case OverloadChoiceKind::DynamicMemberLookup: {
+        // Application of a DynamicMemberLookup result turns a member access of
+        // x.foo into x[dynamicMember: "foo"].
+        auto subscriptDecl = cast<SubscriptDecl>(selected.choice.getDecl());
+
+        // Build and type check the string literal index value to the specific
+        // string type expected by the subscript.
+        Expr *nameExpr = new (cs.getASTContext())
+          StringLiteralExpr(selected.choice.getName().getBaseIdentifier().str(),
+                            nameLoc.getStartLoc(), /*implicit*/true);
+        auto nameLabel = cs.getASTContext().getIdentifier("dynamicMember");
+        
+        auto stringType = subscriptDecl->getIndices()->get(0)->getTypeLoc();
+        (void)cs.TC.typeCheckExpression(nameExpr, dc, stringType,
+                                        CTP_CallArgument);
+        cs.cacheExprTypes(nameExpr);
+
+        // Build and return a subscript that uses this string as the index.
+        return buildSubscript(base, nameExpr, nameLabel,
+                              /*trailingClosure*/false,
+                              cs.getConstraintLocator(expr),
+                              /*isImplicit*/false,
+                              AccessSemantics::Ordinary, selected);
+      }
       }
 
-    llvm_unreachable("Unhandled OverloadChoiceKind in switch.");
+      llvm_unreachable("Unhandled OverloadChoiceKind in switch.");
     }
     
   public:
@@ -6263,7 +6307,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   // coercion.
   if (auto fromLValue = fromType->getAs<LValueType>()) {
     if (auto *toIO = toType->getAs<InOutType>()) {
-      // In an 'inout' operator like "++i", the operand is converted from
+      // In an 'inout' operator like "i += 1", the operand is converted from
       // an implicit lvalue to an inout argument.
       assert(toIO->getObjectType()->isEqual(fromLValue->getObjectType()));
       cs.propagateLValueAccessKind(expr, AccessKind::ReadWrite);
@@ -6417,7 +6461,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   }
 
   // Unresolved types come up in diagnostics for lvalue and inout types.
-  if (fromType->hasUnresolvedType() || toType->hasUnresolvedType())
+  if (fromType->hasUnresolvedType() || toType->hasUnresolvedType() ||
+      fromType->is<ErrorType>())
     return cs.cacheType(new (tc.Context)
                             UnresolvedTypeConversionExpr(expr, toType));
 
@@ -7925,7 +7970,8 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
 }
 
 Expr *
-Solution::convertBooleanTypeToBuiltinI1(Expr *expr, ConstraintLocator *locator) const {
+Solution::convertBooleanTypeToBuiltinI1(Expr *expr,
+                                        ConstraintLocator *locator) const {
   auto &cs = getConstraintSystem();
 
   // Load lvalues here.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -528,8 +528,9 @@ static bool diagnoseAmbiguity(ConstraintSystem &cs,
         break;
 
       case OverloadChoiceKind::KeyPathApplication:
-        // Skip key path applications, since we don't want them to noise up
-        // unrelated subscript diagnostics.
+      case OverloadChoiceKind::DynamicMemberLookup:
+        // Skip key path applications and dynamic member lookups, since we don't
+        // want them to noise up unrelated subscript diagnostics.
         break;
 
       case OverloadChoiceKind::BaseType:

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -147,6 +147,7 @@ static bool sameOverloadChoice(const OverloadChoice &x,
   case OverloadChoiceKind::DeclViaDynamic:
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaUnwrappedOptional:
+  case OverloadChoiceKind::DynamicMemberLookup:
     return sameDecl(x.getDecl(), y.getDecl());
 
   case OverloadChoiceKind::TupleIndex:
@@ -813,6 +814,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     case OverloadChoiceKind::Decl:
     case OverloadChoiceKind::DeclViaBridge:
     case OverloadChoiceKind::DeclViaUnwrappedOptional:
+    case OverloadChoiceKind::DynamicMemberLookup:
       break;
     }
     

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2896,6 +2896,30 @@ getArgumentLabels(ConstraintSystem &cs, ConstraintLocatorBuilder locator) {
   return known->second;
 }
 
+
+// Return true if the specified type conforms to the DynamicLookupMemberProtocol
+// or if it is a protocol that inherits from it.
+static bool containsOrConformsToDLMP(Type ty, DeclContext *DC,
+                                     Identifier name, TypeChecker &TC) {
+  auto DMLP =
+    TC.Context.getProtocol(KnownProtocolKind::DynamicMemberLookupProtocol);
+
+  auto conformance =
+    TC.conformsToProtocol(ty, DMLP, DC, ConformanceCheckFlags::InExpression);
+  
+  // If this type doesn't conform to it, check to see if this is an existential
+  // that contains it.
+  if (!conformance)
+    conformance =
+      TC.containsProtocol(ty, DMLP, DC, ConformanceCheckFlags::InExpression);
+  if (!conformance)
+    return false;
+  
+  // If we found something, make sure that it is a valid conformance.
+  return conformance->isAbstract() || !conformance->getConcrete()->isInvalid();
+}
+
+
 /// Given a ValueMember, UnresolvedValueMember, or TypeMember constraint,
 /// perform a lookup into the specified base type to find a candidate list.
 /// The list returned includes the viable candidates as well as the unviable
@@ -3283,6 +3307,40 @@ retry_after_fail:
           addChoice(getOverloadChoice(result.getValueDecl(),
                                       /*bridged*/false,
                                       /*isUnwrappedOptional=*/true));
+      }
+    }
+  }
+  
+  // If we're about to fail lookup, but we are looking for members in a type
+  // that conforms to DynamicMemberLookupProtocol, then we resolve the reference
+  // to the subscript(dynamicMember:) member, and pass the member name as a
+  // string.
+  if (constraintKind == ConstraintKind::ValueMember && hasInstanceMembers &&
+      memberName.isSimpleName() && !memberName.isSpecial()) {
+    auto name = memberName.getBaseIdentifier();
+    if (containsOrConformsToDLMP(instanceTy, DC, name, TC)) {
+      // Recursively look up the subscript(dynamicMember:)'s in this type.
+      auto subscriptName =
+        DeclName(getASTContext(), DeclBaseName::createSubscript(),
+                 getASTContext().getIdentifier("dynamicMember"));
+
+      auto subscripts = performMemberLookup(constraintKind,
+                                            subscriptName,
+                                            baseTy, functionRefKind,
+                                            memberLocator,
+                                            includeInaccessibleMembers);
+        
+      // Reflect the candidates found as DynamicMemberLookup results.
+      for (auto candidate : subscripts.ViableCandidates) {
+        auto decl = candidate.getDecl();
+        if (isAcceptableDynamicMemberLookupSubscript(decl, DC, TC))
+          result.addViable(OverloadChoice::getDynamicMemberLookup(baseTy,
+                                                                  decl, name));
+      }
+      for (auto candidate : subscripts.UnviableCandidates) {
+        auto decl = candidate.first.getDecl();
+        auto choice = OverloadChoice::getDynamicMemberLookup(baseTy, decl,name);
+        result.addUnviable(choice, candidate.second);
       }
     }
   }

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -358,6 +358,9 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
       Out << "decl-via-unwrapped-optional ";
       printDecl();
       break;
+    case OverloadChoiceKind::DynamicMemberLookup:
+      Out << "dynamic member lookup '" << overload.getName() << "'";
+      break;
     case OverloadChoiceKind::BaseType:
       Out << "base type";
       break;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1505,7 +1505,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaDynamic:
-  case OverloadChoiceKind::DeclViaUnwrappedOptional: {
+  case OverloadChoiceKind::DeclViaUnwrappedOptional:
+  case OverloadChoiceKind::DynamicMemberLookup: {
     bool isDynamicResult
       = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
     // Retrieve the type of a reference to the specific declaration choice.
@@ -1568,7 +1569,12 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     if (choice.getDecl()->getAttrs().isUnavailable(getASTContext())) {
       increaseScore(SK_Unavailable);
     }
-
+    
+    // If this is a dynamic member lookup, then the decl we have is for the
+    // subscript(dynamicMember:) member, but the type we need to return is the
+    // result of the subscript.  Dig through it.
+    if (kind == OverloadChoiceKind::DynamicMemberLookup)
+      refType = refType->castTo<FunctionType>()->getResult();
     break;
   }
 
@@ -1620,6 +1626,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 
     // Increase the score so that actual subscripts get preference.
     increaseScore(SK_KeyPathSubscript);
+    break;
   }
   }
   assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");
@@ -1808,13 +1815,16 @@ DeclName OverloadChoice::getName() const {
     case OverloadChoiceKind::DeclViaUnwrappedOptional:
       return getDecl()->getFullName();
       
-    case OverloadChoiceKind::KeyPathApplication: {
+    case OverloadChoiceKind::KeyPathApplication:
       // TODO: This should probably produce subscript(keyPath:), but we
       // don't currently pre-filter subscript overload sets by argument
       // keywords, so "subscript" is still the name that keypath subscripts
       // are looked up by.
       return DeclBaseName::createSubscript();
-    }
+    
+    case OverloadChoiceKind::DynamicMemberLookup:
+      return DeclName(DynamicNameAndFRK.getPointer());
+      
     case OverloadChoiceKind::BaseType:
     case OverloadChoiceKind::TupleIndex:
       llvm_unreachable("no name!");

--- a/lib/Sema/OverloadChoice.h
+++ b/lib/Sema/OverloadChoice.h
@@ -46,6 +46,8 @@ enum class OverloadChoiceKind : int {
   BaseType,
   /// \brief The overload choice selects a key path subscripting operation.
   KeyPathApplication,
+  /// \brief The member is looked up through DynamicMemberLookupProtocol.
+  DynamicMemberLookup,
   /// \brief The overload choice selects a particular declaration that
   /// was found by bridging the base value type to its Objective-C
   /// class type.
@@ -86,24 +88,30 @@ class OverloadChoice {
   typedef llvm::PointerEmbeddedInt<uint32_t, 29>
     OverloadChoiceKindWithTupleIndex;
   
-  /// \brief Either the declaration pointer or the overload choice kind.  The
-  /// second case is represented as an OverloadChoiceKind, but has additional
-  /// values at the top end that represent the tuple index.
+  /// Depending on the OverloadChoiceKind, this could be one of two cases:
+  /// 1) A ValueDecl for the cases that match to a Decl.  The exactly kind of
+  ///    decl reference is disambiguated with the DeclKind bits in
+  ///    BaseAndDeclKind.
+  /// 2) An OverloadChoiceKindWithTupleIndex if this is an overload kind without
+  ///    a decl (e.g., a BaseType, keypath, tuple, etc).
+  ///
   llvm::PointerUnion<ValueDecl*, OverloadChoiceKindWithTupleIndex> DeclOrKind;
 
-  /// The kind of function reference.
-  /// FIXME: This needs two bits. Can we pack them somewhere?
-  FunctionRefKind TheFunctionRefKind;
-
+  /// This holds the kind of function reference (Unapplied, SingleApply,
+  /// DoubleApply, Compound).  If this OverloadChoice represents a
+  /// DynamicMemberLookup result, then this holds the identifier for the
+  /// original member being looked up.
+  llvm::PointerIntPair<Identifier, 2, FunctionRefKind> DynamicNameAndFRK;
+  
 public:
   OverloadChoice()
-    : BaseAndDeclKind(nullptr, 0), DeclOrKind(0),
-      TheFunctionRefKind(FunctionRefKind::Unapplied) {}
+    : BaseAndDeclKind(nullptr, 0), DeclOrKind(),
+      DynamicNameAndFRK(Identifier(), FunctionRefKind::Unapplied) {}
 
   OverloadChoice(Type base, ValueDecl *value,
                  FunctionRefKind functionRefKind)
     : BaseAndDeclKind(base, 0),
-      TheFunctionRefKind(functionRefKind) {
+      DynamicNameAndFRK(Identifier(), functionRefKind) {
     assert(!base || !base->hasTypeParameter());
     assert((reinterpret_cast<uintptr_t>(value) & (uintptr_t)0x03) == 0 &&
            "Badly aligned decl");
@@ -113,7 +121,7 @@ public:
 
   OverloadChoice(Type base, OverloadChoiceKind kind)
       : BaseAndDeclKind(base, 0), DeclOrKind(uint32_t(kind)),
-        TheFunctionRefKind(FunctionRefKind::Unapplied) {
+        DynamicNameAndFRK(Identifier(), FunctionRefKind::Unapplied) {
     assert(base && "Must have a base type for overload choice");
     assert(!base->hasTypeParameter());
     assert(kind != OverloadChoiceKind::Decl &&
@@ -126,7 +134,7 @@ public:
   OverloadChoice(Type base, unsigned index)
       : BaseAndDeclKind(base, 0),
         DeclOrKind(uint32_t(OverloadChoiceKind::TupleIndex)+index),
-        TheFunctionRefKind(FunctionRefKind::Unapplied) {
+        DynamicNameAndFRK(Identifier(), FunctionRefKind::Unapplied) {
     assert(base->getRValueType()->is<TupleType>() && "Must have tuple type");
   }
 
@@ -134,7 +142,7 @@ public:
     return BaseAndDeclKind.getPointer().isNull() &&
            BaseAndDeclKind.getInt() == 0 &&
            DeclOrKind.isNull() &&
-           TheFunctionRefKind == FunctionRefKind::Unapplied;
+           DynamicNameAndFRK.getInt() == FunctionRefKind::Unapplied;
   }
 
   /// Retrieve an overload choice for a declaration that was found via
@@ -145,7 +153,7 @@ public:
     result.BaseAndDeclKind.setPointer(base);
     result.BaseAndDeclKind.setInt(IsDeclViaDynamic);
     result.DeclOrKind = value;
-    result.TheFunctionRefKind = functionRefKind;
+    result.DynamicNameAndFRK.setInt(functionRefKind);
     return result;
   }
 
@@ -157,7 +165,7 @@ public:
     result.BaseAndDeclKind.setPointer(base);
     result.BaseAndDeclKind.setInt(IsDeclViaBridge);
     result.DeclOrKind = value;
-    result.TheFunctionRefKind = functionRefKind;
+    result.DynamicNameAndFRK.setInt(functionRefKind);
     return result;
   }
 
@@ -170,7 +178,18 @@ public:
     result.BaseAndDeclKind.setPointer(base);
     result.BaseAndDeclKind.setInt(IsDeclViaUnwrappedOptional);
     result.DeclOrKind = value;
-    result.TheFunctionRefKind = functionRefKind;
+    result.DynamicNameAndFRK.setInt(functionRefKind);
+    return result;
+  }
+  
+  /// Retrieve an overload choice for a declaration that was found via
+  /// dynamic lookup.  The ValueDecl is the subscript(dynamicMember:)
+  static OverloadChoice getDynamicMemberLookup(Type base, ValueDecl *value,
+                                               Identifier name) {
+    OverloadChoice result;
+    result.BaseAndDeclKind.setPointer(base);
+    result.DeclOrKind = value;
+    result.DynamicNameAndFRK.setPointer(name);
     return result;
   }
 
@@ -181,6 +200,9 @@ public:
   
   /// \brief Determines the kind of overload choice this is.
   OverloadChoiceKind getKind() const {
+    if (!DynamicNameAndFRK.getPointer().empty())
+      return OverloadChoiceKind::DynamicMemberLookup;
+    
     if (DeclOrKind.is<ValueDecl*>()) {
       switch (BaseAndDeclKind.getInt()) {
       case IsDeclViaBridge: return OverloadChoiceKind::DeclViaBridge;
@@ -190,7 +212,6 @@ public:
       default: return OverloadChoiceKind::Decl;
       }
     }
-
     uint32_t kind = DeclOrKind.get<OverloadChoiceKindWithTupleIndex>();
     if (kind >= (uint32_t)OverloadChoiceKind::TupleIndex)
       return OverloadChoiceKind::TupleIndex;
@@ -226,7 +247,7 @@ public:
 
   FunctionRefKind getFunctionRefKind() const {
     assert(isDecl() && "only makes sense for declaration choices");
-    return TheFunctionRefKind;
+    return DynamicNameAndFRK.getInt();
   }
 };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3043,6 +3043,12 @@ void Solution::dump(raw_ostream &out) const {
           << choice.getBaseType()->getString() << "\n";
       break;
 
+    case OverloadChoiceKind::DynamicMemberLookup:
+      out << "dynamic member lookup root "
+          << choice.getBaseType()->getString()
+          << " name='" << choice.getName() << "'\n";
+      break;
+  
     case OverloadChoiceKind::TupleIndex:
       out << "tuple " << choice.getBaseType()->getString() << " index "
         << choice.getTupleIndex() << "\n";
@@ -3215,6 +3221,12 @@ void ConstraintSystem::print(raw_ostream &out) {
       case OverloadChoiceKind::KeyPathApplication:
         out << "key path application root "
             << choice.getBaseType()->getString() << "\n";
+        break;
+
+      case OverloadChoiceKind::DynamicMemberLookup:
+        out << "dynamic member lookup:"
+            << choice.getBaseType()->getString() << "  name="
+            << choice.getName() << "\n";
         break;
 
       case OverloadChoiceKind::TupleIndex:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2548,6 +2548,13 @@ public:
   const StringRef Message;
 };
 
+/// Given a subscript defined as "subscript(dynamicMember:)->T", return true if
+/// it is an acceptable implementation of the DynamicMemberLookupProtocol
+/// requirement.
+bool isAcceptableDynamicMemberLookupSubscript(ValueDecl *decl,
+                                              DeclContext *DC,
+                                              TypeChecker &TC);
+  
 } // end namespace swift
 
 #endif

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -178,6 +178,22 @@ public func != <T : Equatable>(lhs: T, rhs: T) -> Bool
   return lhs.rawValue != rhs.rawValue
 }
 
+/// Types type conform to this protocol have the behavior that member lookup -
+/// accessing `someval.member` will always succeed.  Failures to find normally
+/// declared members of `member` will be turned into subscript references using
+/// the `someval[dynamicMember: member]` member.
+///
+public protocol DynamicMemberLookupProtocol {
+  // Implementations of this protocol must have a subscript(dynamicMember:)
+  // implementation where the keyword type is some type that is
+  // ExpressibleByStringLiteral.  It can be get-only or get/set which defines
+  // the mutability of the resultant dynamic properties.
+
+  // subscript<KeywordType: ExpressibleByStringLiteral, LookupValue>
+  //   (dynamicMember name: KeywordType) -> LookupValue { get }
+}
+
+
 /// A type that can be initialized using the nil literal, `nil`.
 ///
 /// `nil` has a specific meaning in Swift---the absence of a value. Only the

--- a/test/decl/protocol/special/DynamicMemberLookupProtocol.swift
+++ b/test/decl/protocol/special/DynamicMemberLookupProtocol.swift
@@ -1,0 +1,189 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+var global = 42
+
+struct Gettable : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: StaticString) -> Int {
+    return 42
+  }
+}
+struct Settable : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: StaticString) -> Int {
+    get {return 42}
+    set {}
+  }
+}
+
+struct MutGettable : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: StaticString) -> Int {
+    mutating get {
+      return 42
+    }
+  }
+}
+
+
+struct NonMutSettable : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: StaticString) -> Int {
+    get { return 42 }
+    nonmutating set {}
+  }
+}
+
+func test_function(b: Settable) {
+  var bm = b
+  bm.flavor = global
+}
+
+func test(a: Gettable, b: Settable, c: MutGettable, d: NonMutSettable) {
+  global = a.wyverns
+  a.flavor = global    // expected-error {{cannot assign to property: 'a' is a 'let' constant}}
+  
+  global = b.flavor
+  b.universal = global // expected-error {{cannot assign to property: 'b' is a 'let' constant}}
+  b.thing += 1         // expected-error {{left side of mutating operator isn't mutable: 'b' is a 'let' constant}}
+
+  var bm = b
+  global = bm.flavor
+  bm.universal = global
+  bm.thing += 1
+  
+  var cm = c
+  global = c.dragons  // expected-error {{cannot use mutating getter on immutable value: 'c' is a 'let' constant}}
+  global = c[dynamicMember: "dragons"] // expected-error {{cannot use mutating getter on immutable value: 'c' is a 'let' constant}}
+  global = cm.dragons
+  c.woof = global // expected-error {{cannot use mutating getter on immutable value: 'c' is a 'let' constant}}
+  
+  var dm = d
+  global = d.dragons  // ok
+  global = dm.dragons // ok
+  d.woof = global     // ok
+  dm.woof = global    // ok
+}
+
+
+func test_iuo(a : Gettable!, b : Settable!) {
+  global = a.wyverns
+  a.flavor = global  // expected-error {{cannot assign to property: 'a' is a 'let' constant}}
+  
+  global = b.flavor
+  b.universal = global // expected-error {{cannot assign to property: 'b' is a 'let' constant}}
+  
+  var bm : Settable! = b
+  
+  global = bm.flavor
+  bm.universal = global
+}
+
+
+struct FnTest : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: StaticString) -> (_ a : Int)->() {
+    return { a in () }
+  }
+}
+func test_function(x : FnTest) {
+  x.phunky(12)
+}
+func test_function_iuo(x : FnTest!) {
+  x.flavor(12)
+}
+
+
+//===----------------------------------------------------------------------===//
+// Error cases
+//===----------------------------------------------------------------------===//
+
+// Subscript index must be ExpressibleByStringLiteral.
+struct Invalid1 : DynamicMemberLookupProtocol {
+  // expected-error @+1 {{type 'Invalid1' does not conform to `DynamicMemberLookupProtocol`; subscript(dynamicMember:) should take a single string parameter}}
+  subscript(dynamicMember member: Int) -> Int {
+    return 42
+  }
+}
+
+// Subscript may not be variadic.
+struct Invalid2 : DynamicMemberLookupProtocol {
+  // expected-error @+1 {{type 'Invalid2' does not conform to `DynamicMemberLookupProtocol`; subscript(dynamicMember:) should take a single string parameter}}
+  subscript(dynamicMember member: String...) -> Int {
+    return 42
+  }
+}
+
+// References to overloads are resolved just like normal subscript lookup:
+// they are either contextually disambiguated or are invalid.
+struct Ambiguity : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: String) -> Int {
+    return 42
+  }
+  subscript(dynamicMember member: String) -> Float {
+    return 42
+  }
+}
+
+func testAmbiguity(a : Ambiguity) {
+  let _ : Int = a.flexibility
+  let _ : Float = a.dynamism
+  _ = a.dynamism  // expected-error {{ambiguous use of 'subscript(dynamicMember:)'}}
+}
+
+//===----------------------------------------------------------------------===//
+// Test Existential
+//===----------------------------------------------------------------------===//
+
+protocol PyVal : DynamicMemberLookupProtocol {
+  subscript(dynamicMember member: StaticString) -> PyVal { get nonmutating set }
+}
+extension PyVal {
+  subscript(dynamicMember member: StaticString) -> PyVal {
+    get { fatalError() } nonmutating set {}
+  }
+}
+
+extension Int : PyVal {}
+
+func testMutableExistential(a : PyVal) -> PyVal {
+  a.x.y = 123
+  return a.foo.bar.baz
+}
+
+//===----------------------------------------------------------------------===//
+// JSON example
+//===----------------------------------------------------------------------===//
+
+enum JSON {
+  case IntValue(Int)
+  case StringValue(String)
+  case ArrayValue(Array<JSON>)
+  case DictionaryValue(Dictionary<String, JSON>)
+}
+
+extension JSON : DynamicMemberLookupProtocol {
+  var stringValue : String? {
+    if case .StringValue(let str) = self {
+      return str
+    }
+    return nil
+  }
+  subscript(index: Int) -> JSON? {
+    if case .ArrayValue(let arr) = self {
+      return index < arr.count ? arr[index] : nil
+    }
+    return nil
+  }
+  subscript(key: String) -> JSON? {
+    if case .DictionaryValue(let dict) = self {
+      return dict[key]
+    }
+    return nil
+  }
+  
+  subscript(dynamicMember member: String) -> JSON? {
+    if case .DictionaryValue(let dict) = self {
+      return dict[member]
+    }
+    return nil
+  }
+}
+func test_json_example(x : JSON) -> String? {
+  _ = x.name?.first
+  return x.name?.first?.stringValue
+}


### PR DESCRIPTION
This is an implementation of the DynamicLookupProtocol that I am proposing for inclusion in Swift.  It has no known implementation problems, but I absolutely welcome feedback on the implementation approach.

The approach is straight-forward.  It does not bloat any core data structures and is not invasive into the compiler.  High points of the patch:
- Add the new protocol to the standard library.
- When ConstraintSystem::performMemberLookup is about to fail a value member lookup, check to see if the base type conforms to DynamicMemberLookupProtocol.  If so, add the subscript(dynamicMember:) implementations to the candidate set as a new OverloadChoice::DynamicMemberLookup kind.
- CSApply handles OverloadChoiceKind::DynamicMemberLookup by calling buildSubscript().
- Add a test case handling many weird cases I could think of.

