### PR TITLE
[gardening] fix an inconsistency

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -820,7 +820,7 @@ public struct ${Self}<Pointee>
 %  if mutable:
   /// For a pointer `p`, the memory at `p + i` must be initialized when reading
   /// the value by using the subscript. When the subscript is used as the left
-  /// side of an assignment, the memory at `p + i` must be uninitialized or
+  /// side of an assignment, the memory at `p + i` must be initialized or
   /// the pointer's `Pointee` type must be a trivial type.
   ///
   /// Do not assign an instance of a nontrivial type through the subscript to


### PR DESCRIPTION
This doc-comment's two paragraphs said in the first that the memory must be uninitialized before assignment, and in the second that it cannot be uninitialized. The first paragraph was wrong.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->