### PR TITLE
stdlib: Fix test cases Dictionary.swift and Set.swift

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3192,9 +3192,7 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration.U
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 3)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
+  expectAutoreleasedKeysAndValues(unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration.UseFromObjC") {
@@ -3206,9 +3204,7 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration.U
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 3)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
+  expectAutoreleasedKeysAndValues(unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Verbatim.KeyEnumerator.FastEnumeration_Empty") {
@@ -3293,9 +3289,7 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.KeyEnumerator.FastEnumeration.Use
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 3)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
+  expectAutoreleasedKeysAndValues(unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Custom.KeyEnumerator.FastEnumeration.UseFromSwift.Partial") {
@@ -3321,9 +3315,7 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.KeyEnumerator.FastEnumeration.Use
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 3)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 3))
+  expectAutoreleasedKeysAndValues(unopt: (3, 3))
 }
 
 DictionaryTestSuite.test("BridgedToObjC.Custom.FastEnumeration.UseFromSwift") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2209,9 +2209,7 @@ SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFr
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 0)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
+  expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFromObjC") {
@@ -2222,9 +2220,7 @@ SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFr
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 0)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
+  expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration_Empty") {
@@ -2247,9 +2243,7 @@ SetTestSuite.test("BridgedToObjC.Custom.ObjectEnumerator.FastEnumeration.UseFrom
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 0)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
+  expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Custom.ObjectEnumerator.FastEnumeration.UseFromSwift") {
@@ -2260,9 +2254,7 @@ SetTestSuite.test("BridgedToObjC.Custom.ObjectEnumerator.FastEnumeration.UseFrom
     s, { s.objectEnumerator() },
     { ($0 as! TestObjCKeyTy).value })
 
-  let autoreleased  = _isDebugAssertConfiguration() ?
-    (0, 0) : (3, 0)
-  expectAutoreleasedKeysAndValues(opt: autoreleased, unopt: (3, 0))
+  expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.FastEnumeration.UseFromSwift") {


### PR DESCRIPTION
After the llvm inliner fix to correctly handle notail calls we don't need this
anymore.

rdar://35639547