### PR TITLE
[SE-0143] [IRGen] Bind conditional requirements for witness table accessors.

### DIFF
--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -29,6 +29,7 @@ namespace irgen {
   class IRGenFunction;
   class IRGenModule;
   enum class ValueWitness : unsigned;
+  class StackAddress;
   class WitnessIndex;
 
   /// Return the size of a fixed buffer.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1492,6 +1492,13 @@ getAssociatedTypeMetadataAccessFunction(AssociatedType requirement,
   Address destTable(parameters.claimNext(), IGM.getPointerAlignment());
   setProtocolWitnessTableName(IGM, destTable.getAddress(), ConcreteType,
                               requirement.getSourceProtocol());
+  IGF.bindLocalTypeDataFromSelfWitnessTable(
+          &Conformance,
+          destTable.getAddress(),
+          [&](CanType type) {
+            return Conformance.getDeclContext()->mapTypeIntoContext(type)
+                     ->getCanonicalType();
+          });
 
   // If the associated type is directly fulfillable from the type,
   // we don't need a cache entry.
@@ -1605,6 +1612,13 @@ getAssociatedTypeWitnessTableAccessFunction(AssociatedConformance requirement,
   Address destTable(parameters.claimNext(), IGM.getPointerAlignment());
   setProtocolWitnessTableName(IGM, destTable.getAddress(), ConcreteType,
                               Conformance.getProtocol());
+  IGF.bindLocalTypeDataFromSelfWitnessTable(
+          &Conformance,
+          destTable.getAddress(),
+          [&](CanType type) {
+            return Conformance.getDeclContext()->mapTypeIntoContext(type)
+                     ->getCanonicalType();
+          });
 
   ProtocolDecl *associatedProtocol = requirement.getAssociatedRequirement();
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1552,7 +1552,7 @@ getOrCreateWitnessTableAccessFunction(IRGenModule &IGM, CanType type,
   // function.
   auto rootConformance = conformance->getRootNormalConformance();
   if (rootConformance->witnessTableAccessorRequiresArguments()) {
-    return getWitnessTableLazyAccessFunction(IGM, rootConformance, type);
+    return getWitnessTableLazyAccessFunction(IGM, conformance, type);
   } else {
     return IGM.getAddrOfWitnessTableAccessFunction(rootConformance,
                                                    NotForDefinition);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/ClangImporter/ClangModule.h"
@@ -73,10 +74,6 @@
 
 using namespace swift;
 using namespace irgen;
-
-// Return the offset one should do on a witness table pointer to retrieve the
-// `index`th piece of private data.
-static int privateIndexToTableOffset(unsigned index) { return -1 - (int)index; }
 
 namespace {
 
@@ -574,30 +571,12 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       }
 
       if (conformance.isConcrete()) {
-        // Now bind all the conditional witness tables that can be pulled out of
-        // the self witness table.
-        SILWitnessTable::enumerateWitnessTableConditionalConformances(
-            conformance.getConcrete(),
-            [&](unsigned index, CanType type, ProtocolDecl *proto) {
-              auto archetype = getTypeInContext(type);
-              if (isa<ArchetypeType>(archetype)) {
-                WitnessIndex wIndex(privateIndexToTableOffset(index),
-                                    /*prefix*/ false);
-
-                auto table =
-                    emitInvariantLoadOfOpaqueWitness(IGF, selfTable, wIndex);
-                table =
-                    IGF.Builder.CreateBitCast(table, IGF.IGM.WitnessTablePtrTy);
-                setProtocolWitnessTableName(IGF.IGM, table, archetype, proto);
-
-                IGF.setUnscopedLocalTypeData(
-                    archetype,
-                    LocalTypeDataKind::forAbstractProtocolWitnessTable(proto),
-                    table);
-              }
-
-              return /*finished?*/ false;
-            });
+        IGF.bindLocalTypeDataFromSelfWitnessTable(
+                                          conformance.getConcrete(),
+                                          selfTable,
+                                          [this](CanType type) {
+                                            return getTypeInContext(type);
+                                          });
       }
       return;
     }
@@ -1017,7 +996,7 @@ public:
 };
 
 static std::pair<llvm::Value *, llvm::Value *>
-emitConditionalConformancesBuffer(IRGenFunction &IGF,
+emitConditionalConformancesBuffer(IRGenFunction &IGF, CanType conformingType,
                                   const ProtocolConformance *conformance) {
   // Pointers to the witness tables, in the right order, which will be included
   // in the buffer that gets passed to the witness table accessor.
@@ -1025,6 +1004,30 @@ emitConditionalConformancesBuffer(IRGenFunction &IGF,
 
   auto subMap = conformance->getSubstitutions(IGF.IGM.getSwiftModule());
   auto rootConformance = conformance->getRootNormalConformance();
+
+  // Find the generic environment into which the witness table should be
+  // mapped.
+  // FIXME: Passing conformingType down for just this purpose feels like a
+  // hack.
+  if (conformingType->hasArchetype() &&
+      conformance->getType()->hasTypeParameter()) {
+    GenericEnvironment *conformingTypeEnv = nullptr;
+    conformingType.findIf([&](Type type) {
+      if (auto archetype = type->getAs<ArchetypeType>()) {
+        conformingTypeEnv = archetype->getGenericEnvironment();
+        return conformingTypeEnv != nullptr;
+      }
+
+      return false;
+    });
+
+    if (conformingTypeEnv) {
+      subMap = subMap.subst([&](SubstitutableType *dependentType) {
+            return conformingTypeEnv->mapTypeIntoContext(Type(dependentType));
+          },
+          LookUpConformanceInModule(IGF.getSwiftModule()));
+    }
+  }
 
   SILWitnessTable::enumerateWitnessTableConditionalConformances(
       rootConformance, [&](unsigned, CanType type, ProtocolDecl *proto) {
@@ -1078,7 +1081,7 @@ static llvm::Value *emitWitnessTableAccessorCall(
 
     llvm::Value *conditionalTables, *numConditionalTables;
     std::tie(conditionalTables, numConditionalTables) =
-        emitConditionalConformancesBuffer(IGF, conformance);
+        emitConditionalConformancesBuffer(IGF, conformingType, conformance);
 
     call = IGF.Builder.CreateCall(
         accessor, {*srcMetadataCache, conditionalTables, numConditionalTables});
@@ -1414,7 +1417,8 @@ public:
                                         unsigned index) {
       assert(index < NextPrivateDataIndex);
       return IGF.Builder.CreateConstArrayGEP(
-          table, privateIndexToTableOffset(index), IGF.IGM.getPointerSize());
+          table, privateWitnessTableIndexToTableOffset(index),
+          IGF.IGM.getPointerSize());
     }
 
     const FulfillmentMap &getFulfillmentMap() {
@@ -2412,7 +2416,7 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
         LocalTypeDataKind::forAbstractProtocolWitnessTable(conformingProto);
 
     if (source) {
-      WitnessIndex index(privateIndexToTableOffset(reqtIndex),
+      WitnessIndex index(privateWitnessTableIndexToTableOffset(reqtIndex),
                          /*prefix*/ false);
 
       source = emitInvariantLoadOfOpaqueWitness(IGF, source, index);

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -73,6 +73,12 @@ namespace irgen {
                                              llvm::Value *wtable,
                                              AssociatedType associatedType);
 
+  // Return the offset one should do on a witness table pointer to retrieve the
+  // `index`th piece of private data.
+  inline int privateWitnessTableIndexToTableOffset(unsigned index) {
+    return -1 - (int)index;
+  }
+
   /// Add the witness parameters necessary for calling a function with
   /// the given generics clause.
   void expandPolymorphicSignature(IRGenModule &IGM,

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -472,6 +472,13 @@ public:
   void bindLocalTypeDataFromTypeMetadata(CanType type, IsExact_t isExact,
                                          llvm::Value *metadata);
 
+  /// Given the witness table parameter, bind local type data for
+  /// the witness table itself and any conditional requirements.
+  void bindLocalTypeDataFromSelfWitnessTable(
+                const ProtocolConformance *conformance,
+                llvm::Value *selfTable,
+                llvm::function_ref<CanType (CanType)> mapTypeIntoContext);
+
   void setDominanceResolver(DominanceResolverFunction resolver) {
     assert(DominanceResolver == nullptr);
     DominanceResolver = resolver;

--- a/test/IRGen/conditional_conformances.swift
+++ b/test/IRGen/conditional_conformances.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift
 // RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_with_assoc.swift | %FileCheck %S/../Inputs/conditional_conformance_with_assoc.swift
 // RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_subclass.swift | %FileCheck %S/../Inputs/conditional_conformance_subclass.swift
+// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_recursive.swift | %FileCheck %S/../Inputs/conditional_conformance_recursive.swift
 
 // Too many pointer-sized integers in the IR
 // REQUIRES: PTRSIZE=64

--- a/test/Inputs/conditional_conformance_recursive.swift
+++ b/test/Inputs/conditional_conformance_recursive.swift
@@ -14,6 +14,15 @@ extension Wrapper: P2 where T: P2 {
   typealias B = T.A
 }
 
+protocol P3: P2 where A: P3 { }
+
+extension Wrapper: P3 where T: P3 { }
+
+// instantiation function for Wrapper<T>: P3
+// CHECK-LABEL: define internal void @_T033conditional_conformance_recursive7WrapperVyxGAA2P3A2aERzrlWI
+// CHECK-NOT: ret
+// CHECK: call i8** @_T033conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa
+
 // associated type metadata accessor for B in Wrapper<T>: P2
 // CHECK-LABEL: define internal %swift.type* @_T033conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1BWt
 // CHECK:   [[T_TO_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** [[WRAPPER_T_TO_P2:%.*]], i32 -1

--- a/test/Inputs/conditional_conformance_recursive.swift
+++ b/test/Inputs/conditional_conformance_recursive.swift
@@ -1,0 +1,36 @@
+protocol P1 {
+  associatedtype A: P1
+}
+
+protocol P2: P1 where A: P2 {
+  associatedtype B
+}
+
+struct Wrapper<T: P1>: P1 {
+  typealias A = Wrapper<T>
+}
+
+extension Wrapper: P2 where T: P2 {
+  typealias B = T.A
+}
+
+// associated type metadata accessor for B in Wrapper<T>: P2
+// CHECK-LABEL: define internal %swift.type* @_T033conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1BWt
+// CHECK:   [[T_TO_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** [[WRAPPER_T_TO_P2:%.*]], i32 -1
+// CHECK:   [[T_TO_P2_VAL:%.*]] = load i8*, i8** [[T_TO_P2_PTR]]
+// CHECK:   [[T_TO_P2:%.*]] = bitcast i8* [[T_TO_P2_VAL]] to i8**
+// CHECK:   [[T_TO_P1_VAL:%.*]] = load i8*, i8** [[T_TO_P2]]
+// CHECK:   [[T_TO_P1:%.*]] = bitcast i8* [[T_TO_P1_VAL]] to i8**
+// CHECK:   [[WRAPPER_T_TYPE:%.*]] = bitcast %swift.type* [[WRAPPER_T:%.*]] to %swift.type**
+// CHECK:   [[T_TYPE_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[WRAPPER_T_TYPE]], i64 2
+// CHECK:   [[T_TYPE:%.*]] = load %swift.type*, %swift.type** [[T_TYPE_PTR]]
+// CHECK:   [[T_B_TYPE_ACCESSOR_PTR:%.*]] = load i8*, i8** [[T_TO_P1]], align 8
+// CHECK:   [[T_B_TYPE_ACCESSOR:%.*]] = bitcast i8* [[T_B_TYPE_ACCESSOR_PTR]] to %swift.type* (%swift.type*, i8**)*
+// CHECK:   [[T_A_TYPE:%.*]] = call %swift.type* [[T_B_TYPE_ACCESSOR]](%swift.type* [[T_TYPE]], i8** [[T_TO_P1]])
+// CHECK:   ret %swift.type* [[T_A_TYPE]]
+
+// associated type witness table accessor for A : P2 in Wrapper<T>: P2
+// CHECK-LABEL: define internal i8** @_T033conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1A_AaEPWT
+// CHECK: [[CONDITIONAL_REQ_BUFFER:%.*]] = alloca [1 x i8**]
+// CHECK: [[FIRST_REQ:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[CONDITIONAL_REQ_BUFFER]]
+// CHECK: call i8** @_T033conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa(%swift.type* [[WRAPPER_TO_A:%.*]], i8*** [[FIRST_REQ]], i64 1)


### PR DESCRIPTION
<!-- What's in this pull request? -->
When emitting a witness table accessor (e.g., an associated type metadata
or associated type conformance accessor) or instantiation function for a conditional conformance,
bind the conditional requirements so we can refer to them within that
function. Witness methods get this behavior already through the `SelfWitnessTable` parameter, but everything that works with witness tables involving conditional requirements needs it.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6478](https://bugs.swift.org/browse/SR-6478).