### PR TITLE
copy_addr outline: fix a bug wherein a record type contains a resilient archetype as one of its fields

### DIFF
--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -177,6 +177,18 @@ public:
     emitStoreEnumTagSinglePayloadCall(IGF, T, whichCase, numEmptyCases, enumAddr);
   }
 
+  void collectArchetypeMetadata(
+      IRGenFunction &IGF,
+      llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
+      SILType T) const override {
+    if (!T.hasArchetype()) {
+      return;
+    }
+    auto canType = T.getSwiftRValueType();
+    auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
+    assert(metadata && "Expected Type Metadata Ref");
+    typeToMetadataVec.insert(std::make_pair(canType, metadata));
+  }
 };
 
 }


### PR DESCRIPTION
radar rdar://problem/35646279

Fixes a crash in Swift CI's resilience bot: a record type contained a resilient type as one of its field, said type contains an archetype with metadata, we should pass said metadata ref to the outlined copy_addr function