### PR TITLE
[ClangImporter] Don't use instance methods to suppress class methods

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6747,6 +6747,9 @@ enum MirrorImportComparison {
 static bool isMirrorImportSuppressedBy(ClangImporter::Implementation &importer,
                                        const clang::ObjCMethodDecl *first,
                                        const clang::ObjCMethodDecl *second) {
+  if (first->isInstanceMethod() != second->isInstanceMethod())
+    return false;
+
   auto firstProto = cast<clang::ObjCProtocolDecl>(first->getDeclContext());
   auto secondProto = cast<clang::ObjCProtocolDecl>(second->getDeclContext());
 

--- a/test/ClangImporter/Inputs/mirror_import_overrides_1.h
+++ b/test/ClangImporter/Inputs/mirror_import_overrides_1.h
@@ -21,3 +21,14 @@
 
 @interface Widget : NSObject<D>
 @end
+
+@protocol ClassAndInstance
+- (void)doClassAndInstanceThing __attribute__((swift_name("doClassAndInstanceThing()")));
++ (void)doClassAndInstanceThing __attribute__((swift_name("doClassAndInstanceThing()")));
+
+@property (readonly, nonnull) id classAndInstanceProp;
+@property (class, readonly, nonnull) id classAndInstanceProp;
+@end
+
+@interface Widget (ClassAndInstance) <ClassAndInstance>
+@end

--- a/test/ClangImporter/Inputs/mirror_import_overrides_2.h
+++ b/test/ClangImporter/Inputs/mirror_import_overrides_2.h
@@ -21,3 +21,14 @@
 
 @interface Widget : NSObject<D>
 @end
+
+@protocol ClassAndInstance
++ (void)doClassAndInstanceThing __attribute__((swift_name("doClassAndInstanceThing()")));
+- (void)doClassAndInstanceThing __attribute__((swift_name("doClassAndInstanceThing()")));
+
+@property (class, readonly, nonnull) id classAndInstanceProp;
+@property (readonly, nonnull) id classAndInstanceProp;
+@end
+
+@interface Widget (ClassAndInstance) <ClassAndInstance>
+@end

--- a/test/ClangImporter/mirror_import_overrides.swift
+++ b/test/ClangImporter/mirror_import_overrides.swift
@@ -10,3 +10,11 @@ func foo(widget: Widget) {
     context.operate()
   }
 }
+
+func allowClassAndInstance(widget: Widget) {
+  widget.doClassAndInstanceThing()
+  Widget.doClassAndInstanceThing()
+
+  _ = widget.classAndInstanceProp
+  _ = Widget.classAndInstanceProp
+}


### PR DESCRIPTION
(and vice versa)

Inadvertant fallout from #9681, which concerned accidental ambiguity when mirroring protocol methods onto an implementing class.

[SR-5959](https://bugs.swift.org/browse/SR-5959) / rdar://problem/34596043