### PR TITLE
SIL: Correct handling of bridging casts with address-only types.

### DIFF
--- a/test/SILOptimizer/bridged_casts_folding.sil
+++ b/test/SILOptimizer/bridged_casts_folding.sil
@@ -1,0 +1,101 @@
+// RUN: %target-swift-frontend -O -enable-sil-ownership -emit-sil %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+sil_stage raw
+
+import Swift
+import Foundation
+
+class NSObjectSubclass : NSObject {}
+sil_vtable NSObjectSubclass {}
+
+// CHECK-LABEL: sil @anyhashable_cast_unconditional
+// CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    [[CAST:%.*]] = unconditional_checked_cast [[BRIDGED]] : $NSObject to $NSObjectSubclass
+sil @anyhashable_cast_unconditional : $@convention(thin) (@in AnyHashable) -> @owned NSObjectSubclass {
+entry(%0 : @trivial $*AnyHashable):
+  %1 = alloc_stack $NSObjectSubclass
+  unconditional_checked_cast_addr AnyHashable in %0 : $*AnyHashable
+                               to NSObjectSubclass in %1 : $*NSObjectSubclass
+  %3 = load [take] %1 : $*NSObjectSubclass
+  dealloc_stack %1 : $*NSObjectSubclass
+  return %3 : $NSObjectSubclass
+}
+
+// CHECK-LABEL: sil @anyhashable_cast_take_always
+// CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to $NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+sil @anyhashable_cast_take_always : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
+entry(%0 : @trivial $*AnyHashable, %1 : @owned $NSObjectSubclass):
+  %2 = alloc_stack $NSObjectSubclass
+  checked_cast_addr_br take_always AnyHashable in %0 : $*AnyHashable
+                 to NSObjectSubclass in %2 : $*NSObjectSubclass, bb1, bb2
+
+bb1:
+  %4 = load [take] %2 : $*NSObjectSubclass
+  destroy_value %1 : $NSObjectSubclass
+  br bb3(%4 : $NSObjectSubclass)
+
+bb2:
+  br bb3(%1 : $NSObjectSubclass)
+  
+bb3(%8 : @owned $NSObjectSubclass):
+  dealloc_stack %2 : $*NSObjectSubclass
+  return %8 : $NSObjectSubclass
+}
+
+// CHECK-LABEL: sil @anyhashable_cast_take_on_success
+// CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
+// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to $NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK:       [[YES]]{{.*}}:
+// CHECK-NEXT:    destroy_addr %0
+sil @anyhashable_cast_take_on_success : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
+entry(%0 : @trivial $*AnyHashable, %1 : @owned $NSObjectSubclass):
+  %2 = alloc_stack $NSObjectSubclass
+  checked_cast_addr_br take_on_success AnyHashable in %0 : $*AnyHashable
+                 to NSObjectSubclass in %2 : $*NSObjectSubclass, bb1, bb2
+
+bb1:
+  %4 = load [take] %2 : $*NSObjectSubclass
+  destroy_value %1 : $NSObjectSubclass
+  br bb3(%4 : $NSObjectSubclass)
+
+bb2:
+  destroy_addr %0 : $*AnyHashable
+  br bb3(%1 : $NSObjectSubclass)
+  
+bb3(%8 : @owned $NSObjectSubclass):
+  dealloc_stack %2 : $*NSObjectSubclass
+  return %8 : $NSObjectSubclass
+}
+
+// CHECK-LABEL: sil @anyhashable_cast_copy_on_success
+// CHECK:         copy_addr %0 to [initialization] [[TEMP:%.*]] : $*AnyHashable
+// CHECK-NEXT:    [[BRIDGED:%.*]] = apply {{.*}}([[TEMP]])
+// CHECK-NEXT:    destroy_addr [[TEMP]]
+// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to $NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK:       [[YES]]{{.*}}:
+// CHECK-NEXT:    dealloc_stack [[TEMP]]
+// CHECK:       [[NO]]{{.*}}:
+// CHECK-NEXT:    dealloc_stack [[TEMP]]
+sil @anyhashable_cast_copy_on_success : $@convention(thin) (@in_guaranteed AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
+entry(%0 : @trivial $*AnyHashable, %1 : @owned $NSObjectSubclass):
+  %2 = alloc_stack $NSObjectSubclass
+  checked_cast_addr_br copy_on_success AnyHashable in %0 : $*AnyHashable
+                 to NSObjectSubclass in %2 : $*NSObjectSubclass, bb1, bb2
+
+bb1:
+  %4 = load [take] %2 : $*NSObjectSubclass
+  destroy_value %1 : $NSObjectSubclass
+  br bb3(%4 : $NSObjectSubclass)
+
+bb2:
+  br bb3(%1 : $NSObjectSubclass)
+  
+bb3(%8 : @owned $NSObjectSubclass):
+  dealloc_stack %2 : $*NSObjectSubclass
+  return %8 : $NSObjectSubclass
+}

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -904,7 +904,8 @@ var anyHashable: AnyHashable = 0
 // CHECK-LABEL: _T021bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF
 // CHECK: [[GLOBAL:%[0-9]+]] = global_addr @_T021bridged_casts_folding11anyHashables03AnyE0Vv
 // CHECK: function_ref @_T0s11AnyHashableV10FoundationE19_bridgeToObjectiveCSo8NSObjectCyF
-// CHECK-NEXT: apply
+// CHECK-NEXT: apply %3(%1)
+// CHECK-NEXT: destroy_addr %1
 // CHECK-NEXT: unconditional_checked_cast {{%.*}} : $NSObject to $NSObjectSubclass
 @inline(never)
 public func testUncondCastSwiftToSubclass() -> NSObjectSubclass {


### PR DESCRIPTION
We would leak AnyHashable or other bridged address-only value types when turning a take-always cast into a bridging call, since the bridging method takes the value as guaranteed and we didn't arrange to destroy the value after the bridging happened. The code had unnecessarily different paths for indirect and direct arguments, and furthermore, has an untestable path for when the self argument of the bridging method is taken at +1 (when it's currently only ever +0). Join up the direct and indirect logic, and move the handling of differences down to where we introduce retain/releases so that we generate in-memory operations when appropriate. Fixes SR-6465 | rdar://problem/35678523.