### PR TITLE
[build-script] Add extra-stdlib-deployment-targets to build-util

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -269,6 +269,12 @@ class BuildScriptInvocation(object):
             args.stdlib_deployment_targets = [
                 target.name for target in stdlib_targets]
 
+        # Additional stdlib targets if we want to still build the default
+        # deployment targets as well.
+        if args.extra_stdlib_deployment_targets is not None:
+            args.stdlib_deployment_targets += \
+                args.extra_stdlib_deployment_targets
+
         # SwiftPM and XCTest have a dependency on Foundation.
         # On OS X, Foundation is built automatically using xcodebuild.
         # On Linux, we must ensure that it is built manually.

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -585,6 +585,12 @@ def create_argument_parser():
            help='list of targets to compile or cross-compile the Swift '
                 'standard library for. %(default)s by default.')
 
+    option('--extra-stdlib-deployment-targets', append,
+           type=argparse.ShellSplitType(),
+           default=None,
+           help='list of additional targets to cross-compile the Swift standard '
+                'library for in addition to default')
+
     option('--build-stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
            default=['all'],

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -119,6 +119,7 @@ EXPECTED_DEFAULTS = {
     'enable_ubsan': False,
     'export_compile_commands': False,
     'extra_cmake_options': [],
+    'extra_stdlib_deployment_targets': None,
     'extra_swift_args': [],
     'force_optimized_typechecker': False,
     'foundation_build_variant': 'Debug',
@@ -510,6 +511,7 @@ EXPECTED_OPTIONS = [
     AppendOption('--extra-cmake-options'),
     AppendOption('--extra-swift-args'),
     AppendOption('--stdlib-deployment-targets'),
+    AppendOption('--extra-stdlib-deployment-targets'),
     AppendOption('--test-paths'),
 
     UnsupportedOption('--build-jobs'),


### PR DESCRIPTION
Adds a new ```--extra-stdlib-deployment-targets``` arg that appends insteads of replaces the default archs to build the stdlib lib for, which can be an extensive list, especially on Darwin, to recreate.

Split from of #12955 