### PR TITLE
Fix multi-arch cross-compiling

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -107,9 +107,9 @@ function(_add_variant_c_compile_link_flags)
 
   is_darwin_based_sdk("${CFLAGS_SDK}" IS_DARWIN)
   if(IS_DARWIN)
-    list(APPEND result "-isysroot" "${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
-  elseif(NOT SWIFT_COMPILER_IS_MSVC_LIKE AND NOT "${SWIFT_SDK_${CFLAGS_SDK}_PATH}" STREQUAL "/")
-    list(APPEND result "--sysroot=${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
+    list(APPEND result "-isysroot" "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_PATH}")
+  elseif(NOT SWIFT_COMPILER_IS_MSVC_LIKE AND NOT "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_PATH}" STREQUAL "/")
+    list(APPEND result "--sysroot=${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_PATH}")
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
@@ -277,9 +277,9 @@ function(_add_variant_swift_compile_flags
     sdk arch build_type enable_assertions result_var_name)
   set(result ${${result_var_name}})
 
-  # On Windows, we don't set SWIFT_SDK_WINDOWS_PATH, so don't include it.
+  # On Windows, we don't set SWIFT_SDK_WINDOWS_ARCH_{ARCH}_PATH, so don't include it.
   if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    list(APPEND result "-sdk" "${SWIFT_SDK_${sdk}_PATH}")
+    list(APPEND result "-sdk" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}")
   endif()
 
   if(BUILD_STANDALONE)
@@ -294,7 +294,7 @@ function(_add_variant_swift_compile_flags
   is_darwin_based_sdk("${sdk}" IS_DARWIN)
   if(IS_DARWIN)
     list(APPEND result
-        "-F" "${SWIFT_SDK_${sdk}_PATH}/../../../Developer/Library/Frameworks")
+        "-F" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/../../../Developer/Library/Frameworks")
   endif()
 
   is_build_type_optimized("${build_type}" optimized)
@@ -327,7 +327,7 @@ function(_add_variant_link_flags)
     ${ARGN})
 
   precondition(LFLAGS_SDK MESSAGE "Should specify an SDK")
-  precondition(LFLAGS_SDK MESSAGE "Should specify an architecture")
+  precondition(LFLAGS_ARCH MESSAGE "Should specify an architecture")
 
   set(result ${${LFLAGS_RESULT_VAR_NAME}})
   set(library_search_directories ${${LFLAGS_LIBRARY_SEARCH_DIRECTORIES_VAR_NAME}})
@@ -486,11 +486,8 @@ function(_add_swift_lipo_target)
         DEPENDS ${source_targets})
   else()
     # We don't know how to create fat binaries for other platforms.
-    add_custom_command_target(unused_var
-        COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${source_binaries}" "${LIPO_OUTPUT}"
-        CUSTOM_TARGET_NAME "${LIPO_TARGET}"
-        OUTPUT "${LIPO_OUTPUT}"
-        DEPENDS ${source_targets})
+    message(FATAL_ERROR
+        "It's not possible to build a universal binary for a non-Darwin platform")
   endif()
 endfunction()
 
@@ -1055,8 +1052,17 @@ function(_add_swift_library_single target name)
   set(link_flags ${SWIFTLIB_SINGLE_LINK_FLAGS})
   set(library_search_directories
       "${SWIFTLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}"
-      "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}"
+      "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}")
+
+  if(IS_DARWIN)
+    # Since we lipo each arch together on Darwin, search in the common directory
+    list(APPEND library_search_directories
       "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
+  else()
+    # No fat binaries on other archs so search in an arch specific directory
+    list(APPEND library_search_directories
+      "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}/${SWIFTLIB_SINGLE_ARCHITECTURE}")
+  endif()
 
   # Add variant-specific flags.
   if(SWIFTLIB_SINGLE_TARGET_LIBRARY)
@@ -1197,8 +1203,18 @@ function(_add_swift_library_single target name)
         COMPILE_FLAGS " ${c_compile_flags}")
     set(library_search_directories
         "${SWIFTSTATICLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}"
-        "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}"
+        "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}")
+
+    if(IS_DARWIN)
+      # Darwin lipos each arch into a lib in the root directory so search there.
+      list(APPEND library_search_directories
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
+    else()
+      # Other platforms search in an arch specific directory.
+      list(APPEND library_search_directories
+        "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}/${SWIFTLIB_SINGLE_ARCHITECTURE}")
+    endif()
+
     swift_target_link_search_directories("${target_static}" "${library_search_directories}")
     target_link_libraries("${target_static}" PRIVATE
         ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
@@ -1453,11 +1469,13 @@ function(add_swift_library name)
         continue()
       endif()
 
+      is_darwin_based_sdk("${sdk}" IS_DARWIN)
       set(THIN_INPUT_TARGETS)
 
       # For each architecture supported by this SDK
       foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
         # Configure variables for this subdirectory.
+        set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
         set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
         set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
         set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
@@ -1582,9 +1600,9 @@ function(add_swift_library name)
         # Add PrivateFrameworks, rdar://28466433
         set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
         if(SWIFTLIB_IS_SDK_OVERLAY)
-          list(APPEND swiftlib_swift_compile_flags_all "-Fsystem" "${SWIFT_SDK_${sdk}_PATH}/System/Library/PrivateFrameworks/")
+          list(APPEND swiftlib_swift_compile_flags_all "-Fsystem" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/System/Library/PrivateFrameworks/")
         endif()
-       
+
        if("${sdk}" STREQUAL "IOS_SIMULATOR")
          if("${name}" STREQUAL "swiftMediaPlayer")
            message("DISABLING AUTOLINK FOR swiftMediaPlayer")
@@ -1631,47 +1649,107 @@ function(add_swift_library name)
         )
 
         if(NOT SWIFTLIB_OBJECT_LIBRARY)
-          # Add dependencies on the (not-yet-created) custom lipo target.
-          foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
-            if (NOT "${DEP}" STREQUAL "icucore")
-              add_dependencies(${VARIANT_NAME}
-                "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
-            endif()
-          endforeach()
-
-          if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC)
+          # On Darwin we use lipo'd libraries for dependencies.
+          # On other targets without universal binaries we just install the target lib
+          if (IS_DARWIN)
             # Add dependencies on the (not-yet-created) custom lipo target.
             foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
               if (NOT "${DEP}" STREQUAL "icucore")
-                add_dependencies("${VARIANT_NAME}-static"
-                  "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-static")
+                add_dependencies(${VARIANT_NAME}
+                  "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
               endif()
             endforeach()
-          endif()
 
-          # Note this thin library.
-          list(APPEND THIN_INPUT_TARGETS ${VARIANT_NAME})
+            if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC)
+              # Add dependencies on the (not-yet-created) custom lipo target.
+              foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
+                if (NOT "${DEP}" STREQUAL "icucore")
+                  add_dependencies("${VARIANT_NAME}-static"
+                    "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-static")
+                endif()
+              endforeach()
+            endif()
+            # Note this thin library.
+            list(APPEND THIN_INPUT_TARGETS ${VARIANT_NAME})
+          else()
+
+            foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
+              if (NOT "${DEP}" STREQUAL "icucore")
+                add_dependencies(${VARIANT_NAME}
+                  "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+              endif()
+            endforeach()
+
+            if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC)
+              foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
+                if (NOT "${DEP}" STREQUAL "icucore")
+                  add_dependencies("${VARIANT_NAME}-static"
+                    "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}-static")
+                endif()
+              endforeach()
+            endif()
+
+            if(SWIFTLIB_TARGET_LIBRARY)
+              foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+                set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+                if(TARGET "swift-stdlib${VARIANT_SUFFIX}" AND TARGET "swift-test-stdlib${VARIANT_SUFFIX}")
+                  add_dependencies("swift-stdlib${VARIANT_SUFFIX}"
+                    "${VARIANT_NAME}")
+                  if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC)
+                    add_dependencies("swift-stdlib${VARIANT_SUFFIX}"
+                      "${VARIANT_NAME}-static")
+                  endif()
+
+                  if((NOT "${name}" STREQUAL "swiftStdlibCollectionUnittest") AND
+                     (NOT "${name}" STREQUAL "swiftStdlibUnicodeUnittest"))
+                    add_dependencies("swift-test-stdlib${VARIANT_SUFFIX}"
+                        "${VARIANT_NAME}")
+                    if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC)
+                      add_dependencies("swift-test-stdlib${VARIANT_SUFFIX}"
+                        "${VARIANT_NAME}-static")
+                    endif()
+                  endif()
+                endif()
+
+                # For all other targets we just install the lib at the arch subdirectory
+                if(SWIFTLIB_SHARED)
+                  set(resource_dir "swift")
+                  set(file_permissions
+                      OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                      GROUP_READ GROUP_EXECUTE
+                      WORLD_READ WORLD_EXECUTE)
+                  set(install_libpath
+                    "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${CMAKE_SHARED_LIBRARY_PREFIX}${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+                else()
+                  set(resource_dir "swift_static")
+                  set(file_permissions
+                      OWNER_READ OWNER_WRITE
+                      GROUP_READ
+                      WORLD_READ)
+                  set(install_libpath
+                    "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+                endif()
+
+                swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                  FILES "${install_libpath}"
+                  DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}"
+                  PERMISSIONS ${file_permissions})
+              endforeach()
+            endif()
+          endif()
         endif()
       endforeach()
 
-      if(NOT SWIFTLIB_OBJECT_LIBRARY)
+      # Only Darwin supports univeral binaries.
+      if (NOT SWIFTLIB_OBJECT_LIBRARY AND IS_DARWIN)
         # Determine the name of the universal library.
         if(SWIFTLIB_SHARED)
-          if("${sdk}" STREQUAL "WINDOWS")
-            set(UNIVERSAL_LIBRARY_NAME
-              "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${name}.dll")
-          else()
-            set(UNIVERSAL_LIBRARY_NAME
-              "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-          endif()
+          set(UNIVERSAL_LIBRARY_NAME
+            "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
         else()
-          if("${sdk}" STREQUAL "WINDOWS")
-            set(UNIVERSAL_LIBRARY_NAME
-              "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${name}.lib")
-          else()
-            set(UNIVERSAL_LIBRARY_NAME
-              "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-          endif()
+          set(UNIVERSAL_LIBRARY_NAME
+            "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
         endif()
 
         set(lipo_target "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
@@ -1710,7 +1788,7 @@ function(add_swift_library name)
                 GROUP_READ
                 WORLD_READ)
           endif()
-
+          # On Darwin we install the lipo'd universal binary
           swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
               FILES "${UNIVERSAL_LIBRARY_NAME}"
               DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}"
@@ -1824,7 +1902,7 @@ function(add_swift_library name)
           LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
           RUNTIME DESTINATION bin)
       swift_is_installing_component(dev is_installing)
-      
+
       if(NOT is_installing)
         set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
       else()
@@ -1872,8 +1950,16 @@ function(_add_swift_executable_single name)
   set(link_flags)
 
   # Prepare linker search directories.
-  set(library_search_directories
+  is_darwin_based_sdk("${SWIFTEXE_SINGLE_SDK}" IS_DARWIN)
+  if (IS_DARWIN)
+    # On darwin we search for fat libs at the root dir
+    set(library_search_directories
         "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
+  else()
+    # Other platforms we search for libs in arch specific directory
+    set(library_search_directories
+        "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}/${SWIFTEXE_SINGLE_ARCHITECTURE}")
+  endif()
 
   # Add variant-specific flags.
   _add_variant_c_compile_flags(
@@ -1899,7 +1985,6 @@ function(_add_swift_executable_single name)
     list(APPEND link_flags "-Wl,-no_pie")
   endif()
 
-  is_darwin_based_sdk("${SWIFTEXE_SINGLE_SDK}" IS_DARWIN)
   if(IS_DARWIN)
     list(APPEND link_flags
         "-Xlinker" "-rpath"
@@ -1908,12 +1993,19 @@ function(_add_swift_executable_single name)
 
   # Find the names of dependency library targets.
   #
-  # We don't add the ${ARCH} to the target suffix because we want to link
+  # On Darwin, we don't add the ${ARCH} to the target suffix because we want to link
   # against fat libraries.
-  _list_add_string_suffix(
+  if (IS_DARWIN)
+    _list_add_string_suffix(
       "${SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES}"
       "-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}"
       SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES_TARGETS)
+  else()
+    _list_add_string_suffix(
+      "${SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES}"
+      "-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTEXE_SINGLE_ARCHITECTURE}"
+      SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES_TARGETS)
+  endif()
 
   handle_swift_sources(
       dependency_target
@@ -2023,12 +2115,20 @@ function(add_swift_target_executable name)
         add_dependencies("swift-test-stdlib${VARIANT_SUFFIX}" ${VARIANT_NAME})
       endif()
 
-      # Don't add the ${arch} to the suffix.  We want to link against fat
+      # On Darwin, don't add the ${arch} to the suffix.  We want to link against fat
       # libraries.
-      _list_add_string_suffix(
+      if (IS_DARWIN)
+        _list_add_string_suffix(
           "${SWIFTEXE_TARGET_DEPENDS}"
           "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
           SWIFTEXE_TARGET_DEPENDS_with_suffix)
+      else()
+        _list_add_string_suffix(
+          "${SWIFTEXE_TARGET_DEPENDS}"
+          "${VARIANT_SUFFIX}"
+          SWIFTEXE_TARGET_DEPENDS_with_suffix)
+      endif()
+
       _add_swift_executable_single(
           ${VARIANT_NAME}
           ${SWIFTEXE_TARGET_SOURCES}
@@ -2147,7 +2247,7 @@ function(add_swift_host_tool executable)
 
     swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
       is_installing)
-  
+
     if(NOT is_installing)
       set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${executable})
     else()

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -22,7 +22,9 @@ function(_report_sdk prefix)
       message(STATUS "  ${arch} LIB: ${${arch}_LIB}")
     endforeach()
   else()
-    message(STATUS "  Path: ${SWIFT_SDK_${prefix}_PATH}")
+    foreach(arch ${SWIFT_SDK_${prefix}_ARCHITECTURES})
+      message(STATUS "  ${arch} Path: ${SWIFT_SDK_${prefix}_ARCH_${ARCH}_PATH}")
+    endforeach()
   endif()
   message(STATUS "  Version: ${SWIFT_SDK_${prefix}_VERSION}")
   message(STATUS "  Build number: ${SWIFT_SDK_${prefix}_BUILD_NUMBER}")
@@ -122,6 +124,9 @@ macro(configure_sdk_darwin
   set(SWIFT_SDK_${prefix}_OBJECT_FORMAT "MACHO")
 
   foreach(arch ${architectures})
+    # On Darwin, all archs share the same SDK path.
+    set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "${SWIFT_SDK_${prefix}_PATH}")
+
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
         "${arch}-apple-${SWIFT_SDK_${prefix}_TRIPLE_NAME}${SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION}")
   endforeach()
@@ -137,8 +142,10 @@ macro(configure_sdk_unix
   # Note: this has to be implemented as a macro because it sets global
   # variables.
 
+  # Todo: this only supports building an SDK for one target arch only.
+
   set(SWIFT_SDK_${prefix}_NAME "${name}")
-  set(SWIFT_SDK_${prefix}_PATH "${sdkpath}")
+  set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "${sdkpath}")
   set(SWIFT_SDK_${prefix}_VERSION "don't use")
   set(SWIFT_SDK_${prefix}_BUILD_NUMBER "don't use")
   set(SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION "don't use")
@@ -186,6 +193,7 @@ macro(configure_sdk_windows prefix sdk_name environment architectures)
       set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
           "${arch}-unknown-windows-${environment}")
     endif()
+    set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "/")
   endforeach()
 
   # Add this to the list of known SDKs.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1016,6 +1016,17 @@ static void getRuntimeLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
                           getPlatformNameForTriple(TC.getTriple()));
 }
 
+/// Get the runtime library link path with the target triple's specific arch
+/// library folder.
+static void getRuntimeLibraryPathWithArch(SmallVectorImpl<char> &runtimeLibPath,
+                                           const llvm::opt::ArgList &args,
+                                           const ToolChain &TC) {
+  getRuntimeLibraryPath(runtimeLibPath, args, TC);
+  llvm::sys::path::append(runtimeLibPath,
+    swift::getMajorArchitectureName(TC.getTriple()));
+
+}
+
 static void getClangLibraryPathOnDarwin(SmallVectorImpl<char> &libPath,
                                         const ArgList &args,
                                         const ToolChain &TC) {
@@ -1037,8 +1048,8 @@ static void getClangLibraryPathOnLinux(SmallVectorImpl<char> &libPath,
 /// Get the runtime library link path for static linking,
 /// which is platform-specific and found relative to the compiler.
 static void getRuntimeStaticLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
-                                  const llvm::opt::ArgList &args,
-                                  const ToolChain &TC) {
+                                        const llvm::opt::ArgList &args,
+                                        const ToolChain &TC) {
   // FIXME: Duplicated from CompilerInvocation, but in theory the runtime
   // library link path and the standard library module import path don't
   // need to be the same.
@@ -1054,6 +1065,18 @@ static void getRuntimeStaticLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
   }
   llvm::sys::path::append(runtimeLibPath,
                           getPlatformNameForTriple(TC.getTriple()));
+}
+
+/// Get the runtime library path with the target triple's arch specific
+/// directory.
+static void getRuntimeStaticLibraryPathWithArch(
+    SmallVectorImpl<char> &runtimeLibPath,
+    const llvm::opt::ArgList &args,
+    const ToolChain &TC) {
+  getRuntimeStaticLibraryPath(runtimeLibPath, args, TC);
+  llvm::sys::path::append(runtimeLibPath,
+    swift::getMajorArchitectureName(TC.getTriple()));
+
 }
 
 ToolChain::InvocationInfo
@@ -1477,7 +1500,7 @@ toolchains::GenericUnix::constructInvocation(const InterpretJobAction &job,
   InvocationInfo II = ToolChain::constructInvocation(job, context);
 
   SmallString<128> runtimeLibraryPath;
-  getRuntimeLibraryPath(runtimeLibraryPath, context.Args, *this);
+  getRuntimeLibraryPathWithArch(runtimeLibraryPath, context.Args, *this);
 
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "LD_LIBRARY_PATH",
                                      ":", options::OPT_L, context.Args,
@@ -1610,10 +1633,10 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   }
 
   SmallString<128> SharedRuntimeLibPath;
-  getRuntimeLibraryPath(SharedRuntimeLibPath, context.Args, *this);
+  getRuntimeLibraryPathWithArch(SharedRuntimeLibPath, context.Args, *this);
 
   SmallString<128> StaticRuntimeLibPath;
-  getRuntimeStaticLibraryPath(StaticRuntimeLibPath, context.Args, *this);
+  getRuntimeStaticLibraryPathWithArch(StaticRuntimeLibPath, context.Args, *this);
 
   // Add the runtime library link path, which is platform-specific and found
   // relative to the compiler.
@@ -1627,8 +1650,6 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   }
 
   SmallString<128> swiftrtPath = SharedRuntimeLibPath;
-  llvm::sys::path::append(swiftrtPath,
-                          swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(swiftrtPath, "swiftrt.o");
   Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
 
@@ -1664,6 +1685,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(StaticRuntimeLibPath));
 
     SmallString<128> linkFilePath = StaticRuntimeLibPath;
+    llvm::sys::path::remove_filename(linkFilePath); // remove arch name
     llvm::sys::path::append(linkFilePath, "static-executable-args.lnk");
     auto linkFile = linkFilePath.str();
 
@@ -1677,6 +1699,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(StaticRuntimeLibPath));
 
     SmallString<128> linkFilePath = StaticRuntimeLibPath;
+    llvm::sys::path::remove_filename(linkFilePath); // remove arch name
     llvm::sys::path::append(linkFilePath, "static-stdlib-args.lnk");
     auto linkFile = linkFilePath.str();
     if (llvm::sys::fs::is_regular_file(linkFile)) {
@@ -1711,6 +1734,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {
     SmallString<128> LibProfile(SharedRuntimeLibPath);
+    llvm::sys::path::remove_filename(LibProfile); // remove arch name
     llvm::sys::path::remove_filename(LibProfile); // remove platform name
     llvm::sys::path::append(LibProfile, "clang", "lib");
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -45,10 +45,19 @@ static void updateRuntimeLibraryPath(SearchPathOptions &SearchPathOpts,
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
 
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
-  SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  if (Triple.isOSDarwin()) {
+    // On Darwin the library search path is where we store fat binaries.
+    SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  }
 
   llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
   SearchPathOpts.RuntimeLibraryImportPath = LibPath.str();
+  if (!Triple.isOSDarwin()) {
+    // On platforms without fat binaries, we use the arch specific
+    // directory for searching for binaries. This is the same as the import
+    // path for modules.
+    SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  }
 }
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -53,20 +53,24 @@ foreach(sdk ${SWIFT_SDKS})
       set(GLIBC_INCLUDE_PATH "/system/develop/headers/posix")
       set(GLIBC_ARCH_INCLUDE_PATH "/system/develop/headers/posix")
       set(GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH "/system/develop/headers/")
+      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "/system/develop/headers/")
     else()
       # Determine the location of glibc headers based on the target.
       set(GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH "/usr/include")
-      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH ${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH})
-    endif()
+      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
 
-    # Some SDKs place their headers in architecture-specific subfolders.
-    if((${sdk} STREQUAL "LINUX" OR ${sdk} STREQUAL "FREEBSD") AND CMAKE_LIBRARY_ARCHITECTURE)
-      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
-    endif()
+      # Some SDKs place their headers in architecture-specific subfolders.
+      if(("${sdk}" STREQUAL "LINUX" OR "${sdk}" STREQUAL "FREEBSD") AND CMAKE_LIBRARY_ARCHITECTURE)
+        set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
+      endif()
 
-    if(NOT "${sdk}" STREQUAL "HAIKU")
-      set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_PATH}/${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
-      set(GLIBC_ARCH_INCLUDE_PATH "${SWIFT_SDK_${sdk}_PATH}/${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}")
+      set(GLIBC_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
+      set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}")
+
+      if(NOT "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}" STREQUAL "/")
+        set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_INCLUDE_PATH}")
+        set(GLIBC_ARCH_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_ARCH_INCLUDE_PATH}")
+      endif()
     endif()
 
     set(glibc_modulemap_source "glibc.modulemap.gyb")
@@ -88,7 +92,7 @@ foreach(sdk ${SWIFT_SDKS})
 
     # If this SDK is a target for a non-native host, create a native modulemap
     # without a sysroot prefix. This is the one we'll install instead.
-    if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_PATH}" STREQUAL "/")
+    if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${arch}_PATH}" STREQUAL "/")
 
       set(glibc_sysroot_relative_modulemap_out "${module_dir}/sysroot-relative-modulemaps/glibc.modulemap")
       handle_gyb_source_single(glibc_modulemap_native_target
@@ -106,7 +110,7 @@ foreach(sdk ${SWIFT_SDKS})
     # FIXME: When SDK is a cross-compile target (SDK != Host), the generated
     #        modulemap will be relative to the Host, with hardcoded paths.
     #        It is not relocatable to the target platform itself.
-    #        This only affects ANDROID right now, but could affect cross-compiled LINUX targets
+    #        This affects any cross-compiled targets that use glibc.modulemap
 
     swift_install_in_component(sdk-overlay
         FILES "${glibc_modulemap_out}"

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -38,6 +38,15 @@ module SwiftGlibc [system] {
 
   // C standard library
   module C {
+% if CMAKE_SDK in ["LINUX", "ANDROID", "CYGWIN"]:
+    module features {
+% if CMAKE_SDK == "LINUX":
+      header "${GLIBC_INCLUDE_PATH}/stdc-predef.h"
+% end
+      header "${GLIBC_INCLUDE_PATH}/features.h"
+      export *
+    }
+% end
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN", "HAIKU"]:
     module complex {
       header "${GLIBC_INCLUDE_PATH}/complex.h"
@@ -67,13 +76,6 @@ module SwiftGlibc [system] {
 % if CMAKE_SDK == "HAIKU":
     module pty {
       header "${GLIBC_INCLUDE_PATH}/../bsd/pty.h"
-      export *
-    }
-% end
-
-% if CMAKE_SDK in ["LINUX", "ANDROID", "CYGWIN"]:
-    module features {
-      header "${GLIBC_INCLUDE_PATH}/features.h"
       export *
     }
 % end

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -238,11 +238,6 @@ if(SWIFT_CHECK_ESSENTIAL_STDLIB)
 endif()
 
 
-set(shared_only_libs)
-if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-   list(APPEND shared_only_libs swiftImageInspectionShared)
-endif()
-
 add_swift_library(swiftCore ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
   ${SWIFTLIB_SOURCES}
   # The copy_shim_headers target dependency is required to let the
@@ -257,6 +252,5 @@ add_swift_library(swiftCore ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STD
   LINK_FLAGS ${swift_core_link_flags}
   PRIVATE_LINK_LIBRARIES ${swift_core_private_link_libraries}
   INCORPORATE_OBJECT_LIBRARIES swiftRuntime swiftStdlibStubs
-  INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY ${shared_only_libs}
   FRAMEWORK_DEPENDS ${swift_core_framework_depends}
   INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -80,43 +80,34 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/include)
 
-set(sdk "${SWIFT_HOST_VARIANT_SDK}")
-if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
-  list(REMOVE_ITEM swift_runtime_sources ImageInspectionELF.cpp)
+if(SWIFT_BUILD_STATIC_STDLIB)
   set(static_binary_lnk_file_list)
-  string(TOLOWER "${sdk}" lowercase_sdk)
+  foreach(sdk ${SWIFT_SDKS}) 
+    if(NOT "${sdk}" STREQUAL "LINUX" AND
+       NOT "${sdk}" STREQUAL "FREEBSD" AND
+       NOT "${sdk}" STREQUAL "ANDROID")
+      continue()
+    endif()
 
-  # These two libraries are only used with the static swiftcore
-  add_swift_library(swiftImageInspectionShared STATIC
-    ImageInspectionELF.cpp
-    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags})
-  set_target_properties(swiftImageInspectionShared PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
+    string(TOLOWER "${sdk}" lowercase_sdk)
+    # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
+    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    add_custom_command_target(swift_static_binary_${sdk}_args
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DEPENDS
+        "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
 
-  # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-  set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
-  add_custom_command_target(swift_static_binary_${sdk}_args
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy
-      "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk"
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    OUTPUT
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DEPENDS
-      "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
-
-  list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
-  swift_install_in_component(stdlib
-    FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DESTINATION "lib/swift_static/${lowercase_sdk}")
+    list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
+    swift_install_in_component(stdlib
+      FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DESTINATION "lib/swift_static/${lowercase_sdk}")
+  endforeach()
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
-
-  add_swift_library(swiftImageInspectionShared OBJECT_LIBRARY TARGET_LIBRARY
-    ImageInspectionELF.cpp
-    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags}
-    INSTALL_IN_COMPONENT never_install)
 endif()
 
 add_swift_library(swiftRuntime OBJECT_LIBRARY TARGET_LIBRARY

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,9 +201,18 @@ foreach(SDK ${SWIFT_SDKS})
       list(APPEND test_dependencies "touch-covering-tests")
     endif()
 
-    set(validation_test_dependencies
+    is_darwin_based_sdk("${SDK}" IS_DARWIN)
+    if (IS_DARWIN)
+      # use lipo targets as dependencies
+      set(validation_test_dependencies
         "swiftStdlibCollectionUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
         "swiftStdlibUnicodeUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
+    else()
+      # use arch specific targets as dependencies on platforms without fat binaries
+      set(validation_test_dependencies
+        "swiftStdlibCollectionUnittest${VARIANT_SUFFIX}"
+        "swiftStdlibUnicodeUnittest${VARIANT_SUFFIX}")
+    endif()
 
     set(command_upload_stdlib)
     set(command_upload_swift_reflection_test)

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -3,5 +3,5 @@
 
 // RUN: %swift_driver -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s
 
-// CHECK: {{^/foo/:[^:]+/lib/swift/linux$}}
-// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux}}
+// CHECK: {{^/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux/x86_64}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -18,8 +18,8 @@
 // CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux{{$}}
-// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux{{$|:}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$|:}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ %s | %FileCheck -check-prefix=CHECK-L %s
 // CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx$}}
@@ -59,9 +59,9 @@
 // CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}
-// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux($|:)}}
+// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64($|:)}}
 
 // RUN: env LD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-unknown-linux-gnu -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-LINUX-COMPLEX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/$}}
-// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/($|:)}}
+// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/$}}
+// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/($|:)}}

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -1,11 +1,6 @@
 if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
    ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
 
-  set(swift_runtime_test_extra_libraries)
-  if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    list(APPEND swift_runtime_test_extra_libraries swiftImageInspectionShared)
-  endif()
-
   add_subdirectory(LongTests)
 
   set(PLATFORM_SOURCES)
@@ -51,7 +46,6 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   target_link_libraries(SwiftRuntimeTests
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
-    ${swift_runtime_test_extra_libraries}
     )
 endif()
 

--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -64,7 +64,6 @@ function write_linkfile {
 -latomic
 -lswiftCore
 -latomic
--lswiftImageInspectionShared
 $ICU_LIBS
 -Xlinker
 -export-dynamic

--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -1,6 +1,5 @@
 -static
 -lswiftCore
--lswiftImageInspectionStatic
 -Xlinker
 --defsym=__import_pthread_self=pthread_self
 -Xlinker

--- a/validation-test/execution/interpret-with-dependencies-linux.swift
+++ b/validation-test/execution/interpret-with-dependencies-linux.swift
@@ -8,9 +8,9 @@
 // CHECK: {{okay}}
 
 // Now test a dependency on a library in the compiler's resource directory.
-// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
-// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/
-// RUN: ln -s %platform-module-dir/../* %t/rsrc/%target-sdk-name/
+// RUN: %empty-directory(%t/rsrc/%target-sdk-name/%target-cpu)
+// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/%target-cpu
+// RUN: ln -s %platform-module-dir/../%target-cpu/* %t/rsrc/%target-sdk-name/%target-cpu
 // RUN: ln -s %platform-module-dir/../../shims %t/rsrc/
 // RUN: %empty-directory(%t/other)
 // RUN: ln -s %t/libfoo.so %t/other


### PR DESCRIPTION
On platforms without fat binaries (anything but Darwin), we now build
and install stdlibs for each arch in it's own folder. Namely
lib/swift/\<platform\>/\<arch\> instead of lib/swift/\<platform\>.

(Split from #12955)