### PR TITLE
[libSyntax] Support parsing type-identifier

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -31,6 +31,7 @@
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Parse/Token.h"
 #include "swift/Parse/ParserResult.h"
+#include "swift/Parse/SyntaxParserResult.h"
 #include "swift/Syntax/SyntaxParsingContext.h"
 #include "swift/Config.h"
 #include "llvm/ADT/SetVector.h"
@@ -58,6 +59,7 @@ namespace swift {
     class AbsolutePosition;
     struct RawTokenSyntax;
     enum class SyntaxKind;
+    class TypeSyntax;
   }// end of syntax namespace
 
   /// Different contexts in which BraceItemList are parsed.
@@ -949,7 +951,7 @@ public:
 
   ParserResult<TypeRepr> parseTypeIdentifier();
   ParserResult<TypeRepr> parseOldStyleProtocolComposition();
-  ParserResult<CompositionTypeRepr> parseAnyType();
+  SyntaxParserResult<syntax::TypeSyntax, CompositionTypeRepr> parseAnyType();
   ParserResult<TypeRepr> parseSILBoxType(GenericParamList *generics,
                                          const TypeAttributes &attrs,
                                          Optional<Scope> &GenericsScope);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -949,7 +949,7 @@ public:
                              SourceLoc &LAngleLoc,
                              SourceLoc &RAngleLoc);
 
-  ParserResult<TypeRepr> parseTypeIdentifier();
+  SyntaxParserResult<syntax::TypeSyntax, TypeRepr> parseTypeIdentifier();
   ParserResult<TypeRepr> parseOldStyleProtocolComposition();
   SyntaxParserResult<syntax::TypeSyntax, CompositionTypeRepr> parseAnyType();
   ParserResult<TypeRepr> parseSILBoxType(GenericParamList *generics,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -591,7 +591,8 @@ public:
 
   /// \brief Consume the starting character of the current token, and split the
   /// remainder of the token into a new token (or tokens).
-  SourceLoc consumeStartingCharacterOfCurrentToken();
+  SourceLoc
+  consumeStartingCharacterOfCurrentToken(tok Kind = tok::oper_binary_unspaced);
 
   swift::ScopeInfo &getScopeInfo() { return State->getScopeInfo(); }
 

--- a/include/swift/Parse/SyntaxParserResult.h
+++ b/include/swift/Parse/SyntaxParserResult.h
@@ -1,0 +1,52 @@
+//===--- SyntaxParserResult.h - Syntax Parser Result Wrapper ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/Optional.h"
+#include "swift/Parse/ParserResult.h"
+
+namespace swift {
+
+template <typename Syntax, typename AST> class SyntaxParserResult {
+  llvm::Optional<Syntax> SyntaxNode;
+  ParserResult<AST> ASTResult;
+
+public:
+  SyntaxParserResult(std::nullptr_t = nullptr)
+      : SyntaxNode(None), ASTResult(nullptr) {}
+  SyntaxParserResult(llvm::Optional<Syntax> SyntaxNode, AST *ASTNode)
+      : SyntaxNode(SyntaxNode), ASTResult(ASTNode) {}
+
+  bool isNull() const { return ASTResult.isNull(); }
+  bool isNonNull() const { return ASTResult.isNonNull(); }
+  bool isParseError() const { return ASTResult.isParseError(); }
+  bool hasCodeCompletion() const { return ASTResult.hasCodeCompletion(); }
+
+  AST *getAST() const { return ASTResult.get(); }
+
+  bool hasSyntax() const {
+    return SyntaxNode.hasValue();
+  }
+
+  Syntax getSyntax() const {
+    assert(SyntaxNode.hasValue() && "getSyntax from None value");
+    return *SyntaxNode;
+  }
+};
+
+/// Create a successful parser result.
+template <typename Syntax, typename AST>
+static inline SyntaxParserResult<Syntax, AST>
+makeSyntaxResult(llvm::Optional<Syntax> SyntaxNode, AST *ASTNode) {
+  return SyntaxParserResult<Syntax, AST>(SyntaxNode, ASTNode);
+}
+
+} // namespace swift

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -116,20 +116,20 @@ struct SyntaxFactory {
 
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
-  static TypeIdentifierSyntax makeTypeIdentifier(OwnedString TypeName,
+  static TypeSyntax makeTypeIdentifier(OwnedString TypeName,
     const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
 
   /// Creates a GenericParameterSyntax with no inheritance clause and an
   /// optional trailing comma.
-  static GenericParameterSyntax makeGenericParameter(TypeIdentifierSyntax Type,
+  static GenericParameterSyntax makeGenericParameter(TokenSyntax Name,
     llvm::Optional<TokenSyntax> TrailingComma);
 
   /// Creates a TypeIdentifierSyntax for the `Any` type.
-  static TypeIdentifierSyntax makeAnyTypeIdentifier(
+  static TypeSyntax makeAnyTypeIdentifier(
     const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
 
   /// Creates a TypeIdentifierSyntax for the `Self` type.
-  static TypeIdentifierSyntax makeSelfTypeIdentifier(
+  static TypeSyntax makeSelfTypeIdentifier(
     const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
 
   /// Creates a TokenSyntax for the `Type` identifier.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1559,8 +1559,8 @@ Parser::parseExprPostfixWithoutSuffix(Diag<> ID, bool isExprBasic) {
     break;
 
   case tok::kw_Any: { // Any
-    ParserResult<TypeRepr> repr = parseAnyType();
-    auto expr = new (Context) TypeExpr(TypeLoc(repr.get()));
+    auto SynResult = parseAnyType();
+    auto expr = new (Context) TypeExpr(TypeLoc(SynResult.getAST()));
     Result = makeParserResult(expr);
     break;
   }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -576,7 +576,7 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
     // operator token, and a single one at that (which means
     // peekToken().is(tok::identifier) is incorrect: it is true for .?.foo).
     auto position = getParserPosition();
-    auto dotLoc = consumeStartingCharacterOfCurrentToken();
+    auto dotLoc = consumeStartingCharacterOfCurrentToken(tok::period);
     if (Tok.is(tok::identifier))
       backtrackToPosition(position);
 
@@ -1747,7 +1747,8 @@ Parser::parseExprPostfixWithoutSuffix(Diag<> ID, bool isExprBasic) {
     // as such.
     if (isCollectionLiteralStartingWithLSquareLit()) {
       // Split the token into two.
-      SourceLoc LSquareLoc = consumeStartingCharacterOfCurrentToken();
+      SourceLoc LSquareLoc =
+          consumeStartingCharacterOfCurrentToken(tok::l_square);
       // Consume the '[' token.
       Result = parseExprCollection(LSquareLoc);
       break;

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -18,6 +18,9 @@
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Syntax/SyntaxBuilders.h"
+#include "swift/Syntax/SyntaxNodes.h"
+#include "swift/Syntax/SyntaxParsingContext.h"
 using namespace swift;
 
 /// parseGenericParameters - Parse a sequence of generic parameters, e.g.,
@@ -248,7 +251,10 @@ ParserStatus Parser::parseGenericWhereClause(
   FirstTypeInComplete = false;
   do {
     // Parse the leading type-identifier.
-    ParserResult<TypeRepr> FirstType = parseTypeIdentifier();
+    auto FirstTypeResult = parseTypeIdentifier();
+    if (FirstTypeResult.hasSyntax())
+      SyntaxContext->addSyntax(FirstTypeResult.getSyntax());
+    ParserResult<TypeRepr> FirstType = FirstTypeResult.getASTResult();
 
     if (FirstType.hasCodeCompletion()) {
       Status.setHasCodeCompletion();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1082,13 +1082,13 @@ bool Parser::isImplicitlyUnwrappedOptionalToken(const Token &T) const {
 
 SourceLoc Parser::consumeOptionalToken() {
   assert(isOptionalToken(Tok) && "not a '?' token?!");
-  return consumeStartingCharacterOfCurrentToken();
+  return consumeStartingCharacterOfCurrentToken(tok::question_postfix);
 }
 
 SourceLoc Parser::consumeImplicitlyUnwrappedOptionalToken() {
   assert(isImplicitlyUnwrappedOptionalToken(Tok) && "not a '!' token?!");
   // If the text of the token is just '!', grab the next token.
-  return consumeStartingCharacterOfCurrentToken();
+  return consumeStartingCharacterOfCurrentToken(tok::exclaim_postfix);
 }
 
 /// Parse a single optional suffix, given that we are looking at the

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -513,16 +513,17 @@ Parser::ParserPosition Parser::getParserPositionAfterFirstCharacter(Token T) {
   return ParserPosition(NewState, Loc);
 }
 
-SourceLoc Parser::consumeStartingCharacterOfCurrentToken() {
+SourceLoc Parser::consumeStartingCharacterOfCurrentToken(tok Kind) {
   // Consumes one-character token (like '?', '<', '>' or '!') and returns
   // its location.
 
   // Current token can be either one-character token we want to consume...
   if (Tok.getLength() == 1) {
+    Tok.setKind(Kind);
     return consumeToken();
   }
 
-  markSplitToken(tok::oper_binary_unspaced, Tok.getText().substr(0, 1));
+  markSplitToken(Kind, Tok.getText().substr(0, 1));
 
   // ... or a multi-character token with the first character being the one that
   // we want to consume as a separate token.
@@ -542,12 +543,12 @@ void Parser::markSplitToken(tok Kind, StringRef Txt) {
 
 SourceLoc Parser::consumeStartingLess() {
   assert(startsWithLess(Tok) && "Token does not start with '<'");
-  return consumeStartingCharacterOfCurrentToken();
+  return consumeStartingCharacterOfCurrentToken(tok::l_angle);
 }
 
 SourceLoc Parser::consumeStartingGreater() {
   assert(startsWithGreater(Tok) && "Token does not start with '>'");
-  return consumeStartingCharacterOfCurrentToken();
+  return consumeStartingCharacterOfCurrentToken(tok::r_angle);
 }
 
 void Parser::skipSingle() {

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -53,6 +53,9 @@ static void printSyntaxKind(SyntaxKind Kind, llvm::raw_ostream &OS,
 
 } // end of anonymous namespace
 void RawSyntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {
+  if (isMissing())
+    return;
+
   const bool PrintKind = Opts.PrintSyntaxKind && !isToken() &&
     !isTrivialSyntaxKind(Kind);
   if (PrintKind) {

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -306,23 +306,23 @@ TupleTypeElementSyntax SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
 }
 
 GenericParameterSyntax
-SyntaxFactory::makeGenericParameter(TypeIdentifierSyntax Type,
+SyntaxFactory::makeGenericParameter(TokenSyntax Name,
   llvm::Optional<TokenSyntax> TrailingComma) {
-  return makeGenericParameter(Type, None, None, TrailingComma);
+  return makeGenericParameter(Name, None, None, TrailingComma);
 }
 
-TypeIdentifierSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
+TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
     const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
   auto identifier = makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia);
-  return makeTypeIdentifier(identifier, None, None, None);
+  return makeSimpleTypeIdentifier(identifier, None);
 }
 
-TypeIdentifierSyntax SyntaxFactory::makeAnyTypeIdentifier(
+TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(
     const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
   return makeTypeIdentifier("Any", LeadingTrivia, TrailingTrivia);
 }
 
-TypeIdentifierSyntax SyntaxFactory::makeSelfTypeIdentifier(
+TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(
     const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
   return makeTypeIdentifier("Self", LeadingTrivia, TrailingTrivia);
 }

--- a/lib/Syntax/SyntaxKind.cpp.gyb
+++ b/lib/Syntax/SyntaxKind.cpp.gyb
@@ -80,7 +80,9 @@ bool isUnknownKind(SyntaxKind Kind) {
   return Kind == SyntaxKind::Unknown ||
          Kind == SyntaxKind::UnknownDecl ||
          Kind == SyntaxKind::UnknownExpr ||
-         Kind == SyntaxKind::UnknownStmt;
+         Kind == SyntaxKind::UnknownStmt ||
+         Kind == SyntaxKind::UnknownType ||
+         Kind == SyntaxKind::UnknownPattern;
 }
 } // end namespace syntax
 } // end namespace swift

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -4,11 +4,11 @@
 // RUN: diff -u %S/Outputs/round_trip_parse_gen.swift.withkinds %t.withkinds
 
 class C {
-  func bar(_ a: Int) <CodeBlock>{}</CodeBlock>
-  func bar1(_ a: Float) -> Float <CodeBlock>{ <ReturnStmt>return <SequenceExpr><PrefixOperatorExpr>-<FloatLiteralExpr>0.6 </FloatLiteralExpr></PrefixOperatorExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><FloatLiteralExpr>0.1 </FloatLiteralExpr><BinaryOperatorExpr>- </BinaryOperatorExpr><FloatLiteralExpr>0.3 </FloatLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
-  func bar2(a: Int, b: Int, c:Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
-  func bar3(a: Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
-  func bar4(_ a: Int) -> Int <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
+  func bar(_ a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) <CodeBlock>{}</CodeBlock>
+  func bar1(_ a: <SimpleTypeIdentifier>Float<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Float  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><PrefixOperatorExpr>-<FloatLiteralExpr>0.6 </FloatLiteralExpr></PrefixOperatorExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><FloatLiteralExpr>0.1 </FloatLiteralExpr><BinaryOperatorExpr>- </BinaryOperatorExpr><FloatLiteralExpr>0.3 </FloatLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
+  func bar2(a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>, b: <SimpleTypeIdentifier>Int <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>, c:<SimpleTypeIdentifier>Int <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
+  func bar3(a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
+  func bar4(_ a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
   func foo() <CodeBlock>{
     var a = <StringLiteralExpr>/*comment*/"ab\(x)c"</StringLiteralExpr>/*comment*/
     var b = <PrefixOperatorExpr>/*comment*/+<IntegerLiteralExpr>2</IntegerLiteralExpr></PrefixOperatorExpr><IdentifierExpr>/*comment*/
@@ -33,8 +33,8 @@ class C {
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><DictionaryExpr>[<DictionaryElement><StringLiteralExpr>"a"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>), </DictionaryElement><DictionaryElement><StringLiteralExpr>"b"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>), </DictionaryElement><DictionaryElement><StringLiteralExpr>"c"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>), </DictionaryElement><DictionaryElement><StringLiteralExpr>"d"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>)</DictionaryElement>]</DictionaryExpr></SequenceExpr><IdentifierExpr>
     foo</IdentifierExpr>(<FunctionCallArgument><NilLiteralExpr>nil</NilLiteralExpr>, </FunctionCallArgument><FunctionCallArgument><NilLiteralExpr>nil</NilLiteralExpr>, </FunctionCallArgument><FunctionCallArgument><NilLiteralExpr>nil</NilLiteralExpr></FunctionCallArgument>)
   }</CodeBlock>
-  func boolAnd() -> Bool <CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>&& </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
-  func boolOr() -> Bool <CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>|| </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
+  func boolAnd() -> <SimpleTypeIdentifier>Bool <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>&& </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
+  func boolOr() -> <SimpleTypeIdentifier>Bool <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>|| </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
 
   func foo2() <CodeBlock>{<SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
@@ -55,3 +55,6 @@ class C {
     (<TupleElement><SequenceExpr><IntegerLiteralExpr>1 </IntegerLiteralExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><IntegerLiteralExpr>1</IntegerLiteralExpr></SequenceExpr></TupleElement>)</TupleExpr>.a</MemberAccessExpr>.b</MemberAccessExpr>.foo</MemberAccessExpr>
   }</CodeBlock>
 }
+
+typealias A = <SimpleTypeIdentifier>Any<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>
+typealias B = (<MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element<GenericArgumentClause></GenericArgumentClause></MemberTypeIdentifier>)

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -4,11 +4,11 @@
 // RUN: diff -u %S/Outputs/round_trip_parse_gen.swift.withkinds %t.withkinds
 
 class C {
-  func bar(_ a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) <CodeBlock>{}</CodeBlock>
-  func bar1(_ a: <SimpleTypeIdentifier>Float<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Float  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><PrefixOperatorExpr>-<FloatLiteralExpr>0.6 </FloatLiteralExpr></PrefixOperatorExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><FloatLiteralExpr>0.1 </FloatLiteralExpr><BinaryOperatorExpr>- </BinaryOperatorExpr><FloatLiteralExpr>0.3 </FloatLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
-  func bar2(a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>, b: <SimpleTypeIdentifier>Int <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>, c:<SimpleTypeIdentifier>Int <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
-  func bar3(a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
-  func bar4(_ a: <SimpleTypeIdentifier>Int<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int  <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
+  func bar(_ a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>) <CodeBlock>{}</CodeBlock>
+  func bar1(_ a: <SimpleTypeIdentifier>Float</SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Float </SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><PrefixOperatorExpr>-<FloatLiteralExpr>0.6 </FloatLiteralExpr></PrefixOperatorExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><FloatLiteralExpr>0.1 </FloatLiteralExpr><BinaryOperatorExpr>- </BinaryOperatorExpr><FloatLiteralExpr>0.3 </FloatLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
+  func bar2(a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, b: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, c:<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
+  func bar3(a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
+  func bar4(_ a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>) -> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>
   func foo() <CodeBlock>{
     var a = <StringLiteralExpr>/*comment*/"ab\(x)c"</StringLiteralExpr>/*comment*/
     var b = <PrefixOperatorExpr>/*comment*/+<IntegerLiteralExpr>2</IntegerLiteralExpr></PrefixOperatorExpr><IdentifierExpr>/*comment*/
@@ -33,8 +33,8 @@ class C {
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><DictionaryExpr>[<DictionaryElement><StringLiteralExpr>"a"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>), </DictionaryElement><DictionaryElement><StringLiteralExpr>"b"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>), </DictionaryElement><DictionaryElement><StringLiteralExpr>"c"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>), </DictionaryElement><DictionaryElement><StringLiteralExpr>"d"</StringLiteralExpr>: <IdentifierExpr>bar3</IdentifierExpr>(<FunctionCallArgument>a:<IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>)</DictionaryElement>]</DictionaryExpr></SequenceExpr><IdentifierExpr>
     foo</IdentifierExpr>(<FunctionCallArgument><NilLiteralExpr>nil</NilLiteralExpr>, </FunctionCallArgument><FunctionCallArgument><NilLiteralExpr>nil</NilLiteralExpr>, </FunctionCallArgument><FunctionCallArgument><NilLiteralExpr>nil</NilLiteralExpr></FunctionCallArgument>)
   }</CodeBlock>
-  func boolAnd() -> <SimpleTypeIdentifier>Bool <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>&& </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
-  func boolOr() -> <SimpleTypeIdentifier>Bool <GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>|| </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
+  func boolAnd() -> <SimpleTypeIdentifier>Bool </SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>&& </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
+  func boolOr() -> <SimpleTypeIdentifier>Bool </SimpleTypeIdentifier><CodeBlock>{ <ReturnStmt>return <SequenceExpr><BooleanLiteralExpr>true </BooleanLiteralExpr><BinaryOperatorExpr>|| </BinaryOperatorExpr><BooleanLiteralExpr>false </BooleanLiteralExpr></SequenceExpr></ReturnStmt>}</CodeBlock>
 
   func foo2() <CodeBlock>{<SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>1 </IntegerLiteralExpr>: <IntegerLiteralExpr>0</IntegerLiteralExpr></TernaryExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
@@ -44,7 +44,7 @@ class C {
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><TupleExpr>(<TupleElement><IntegerLiteralExpr>1</IntegerLiteralExpr></TupleElement>)</TupleExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><TupleExpr>(<TupleElement>first: <IntegerLiteralExpr>1</IntegerLiteralExpr></TupleElement>)</TupleExpr></SequenceExpr>
     if <PrefixOperatorExpr>!<BooleanLiteralExpr>true </BooleanLiteralExpr></PrefixOperatorExpr><CodeBlock>{<ReturnStmt>
-      return<Expr></Expr></ReturnStmt>
+      return</ReturnStmt>
     }</CodeBlock>
   }</CodeBlock>
 
@@ -56,5 +56,5 @@ class C {
   }</CodeBlock>
 }
 
-typealias A = <SimpleTypeIdentifier>Any<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier>
-typealias B = (<MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any<GenericArgumentClause></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element<GenericArgumentClause></GenericArgumentClause></MemberTypeIdentifier>)
+typealias A = <SimpleTypeIdentifier>Any</SimpleTypeIdentifier>
+typealias B = (<MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any</SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element</MemberTypeIdentifier>)

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -55,3 +55,6 @@ class C {
     (1 + 1).a.b.foo
   }
 }
+
+typealias A = Any
+typealias B = (Array<Array<Any>>.Element)

--- a/tools/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -137,30 +137,30 @@ public enum SyntaxFactory {
                                 type: type, comma: comma)
   }
 
-  public static func makeGenericParameter(type: TypeIdentifierSyntax,
+  public static func makeGenericParameter(name: TokenSyntax,
       trailingComma: TokenSyntax) -> GenericParameterSyntax {
-    return makeGenericParameter(typeIdentifier: type, colon: nil,
+    return makeGenericParameter(name: name, colon: nil,
                                 inheritedType: nil,
                                 trailingComma: trailingComma)
   }
 
-  public static func makeTypeIdentifier(_ typeName: String,
+  public static func makeTypeIdentifier(_ name: String,
     leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TypeIdentifierSyntax {
-    let identifier = makeIdentifier(typeName, leadingTrivia: leadingTrivia, 
+    trailingTrivia: Trivia = []) -> TypeSyntax {
+    let identifier = makeIdentifier(name, leadingTrivia: leadingTrivia, 
                                     trailingTrivia: trailingTrivia)
-    return makeTypeIdentifier(typeName:identifier, genericArgumentClause: nil,
-                              period: nil, typeIdentifier: nil)
+    return makeSimpleTypeIdentifier(name: identifier,
+                                    genericArgumentClause: nil)
   }
 
   public static func makeAnyTypeIdentifier(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TypeIdentifierSyntax {
+    trailingTrivia: Trivia = []) -> TypeSyntax {
     return makeTypeIdentifier("Any", leadingTrivia: leadingTrivia, 
                               trailingTrivia: trailingTrivia)
   }
 
   public static func makeSelfTypeIdentifier(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TypeIdentifierSyntax {
+    trailingTrivia: Trivia = []) -> TypeSyntax {
     return makeTypeIdentifier("Self", leadingTrivia: leadingTrivia, 
                               trailingTrivia: trailingTrivia)
   }

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -80,9 +80,9 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
     auto Typealias =
       SyntaxFactory::makeTypealiasKeyword({}, { Trivia::spaces(1) });
     auto Subsequence = SyntaxFactory::makeIdentifier("MyCollection", {}, {});
-    auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
+    auto ElementName = SyntaxFactory::makeIdentifier("Element", {}, {});
     auto ElementParam =
-      SyntaxFactory::makeGenericParameter(ElementType, None, None, None);
+      SyntaxFactory::makeGenericParameter(ElementName, None, None, None);
     auto LeftAngle = SyntaxFactory::makeLeftAngleToken({}, {});
     auto RightAngle = SyntaxFactory::makeRightAngleToken({}, Trivia::spaces(1));
     auto GenericParams = GenericParameterClauseSyntaxBuilder()
@@ -91,6 +91,7 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
       .addGenericParameter(ElementParam)
       .build();
     auto Assignment = SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
+    auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
     auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
 
     auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
@@ -100,8 +101,8 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
       .build();
 
     auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-    auto Array_Int = SyntaxFactory::makeTypeIdentifier(Array, GenericArgs,
-                                                       None, None);
+    auto Array_Int =
+        SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
 
     SyntaxFactory::makeTypealiasDecl(None, None, Typealias,
                                      Subsequence, GenericParams,
@@ -116,9 +117,9 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
   auto Typealias =
     SyntaxFactory::makeTypealiasKeyword({}, { Trivia::spaces(1) });
   auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", {}, {});
-  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
+  auto ElementName = SyntaxFactory::makeIdentifier("Element", {}, {});
   auto ElementParam =
-    SyntaxFactory::makeGenericParameter(ElementType, None, None, None);
+      SyntaxFactory::makeGenericParameter(ElementName, None, None, None);
   auto LeftAngle = SyntaxFactory::makeLeftAngleToken({}, {});
   auto RightAngle =
     SyntaxFactory::makeRightAngleToken({}, { Trivia::spaces(1) });
@@ -129,6 +130,7 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
     .build();
   auto Equal = SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
 
+  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {} , {});
   auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
   auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
@@ -137,8 +139,7 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
     .build();
 
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-  auto Array_Int = SyntaxFactory::makeTypeIdentifier(Array, GenericArgs,
-                                                     None, None);
+  auto Array_Int = SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
 
   {
     SmallString<1> Scratch;
@@ -162,9 +163,8 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   auto Typealias =
     SyntaxFactory::makeTypealiasKeyword({}, { Trivia::spaces(1) });
   auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", {}, {});
-  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
-  auto ElementParam =
-    SyntaxFactory::makeGenericParameter(ElementType, None);
+  auto ElementName = SyntaxFactory::makeIdentifier("Element", {}, {});
+  auto ElementParam = SyntaxFactory::makeGenericParameter(ElementName, None);
   auto LeftAngle = SyntaxFactory::makeLeftAngleToken({}, {});
   auto RightAngle =
     SyntaxFactory::makeRightAngleToken({}, { Trivia::spaces(1) });
@@ -176,6 +176,7 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   auto Equal =
     SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
 
+  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
   auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
 
   auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
@@ -185,8 +186,7 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
     .build();
 
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-  auto Array_Int = SyntaxFactory::makeTypeIdentifier(Array, GenericArgs,
-                                                     None, None);
+  auto Array_Int = SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
 
   TypealiasDeclSyntaxBuilder()
     .useTypealiasKeyword(Typealias)
@@ -497,8 +497,8 @@ GenericParameterClauseSyntax getCannedGenericParams() {
 
   auto LAngle = SyntaxFactory::makeLeftAngleToken({}, {});
   auto RAngle = SyntaxFactory::makeRightAngleToken({}, {});
-  auto TType = SyntaxFactory::makeTypeIdentifier("T", {}, {});
-  auto UType = SyntaxFactory::makeTypeIdentifier("U", {}, {});
+  auto TType = SyntaxFactory::makeIdentifier("T", {}, {});
+  auto UType = SyntaxFactory::makeIdentifier("U", {}, {});
 
   auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
   auto T = SyntaxFactory::makeGenericParameter(TType, Comma);

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -62,7 +62,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
   {
     auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
     auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
-    auto IntType = SyntaxFactory::makeTypeIdentifier(Int, None, None, None);
+    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
     auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
     GenericArgumentClauseSyntaxBuilder ArgBuilder;
     ArgBuilder
@@ -92,7 +92,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
 TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
   auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
-  auto IntType = SyntaxFactory::makeTypeIdentifier(Int, None, None, None);
+  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
   auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder;
   ArgBuilder
@@ -129,7 +129,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
 TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
   auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
-  auto IntType = SyntaxFactory::makeTypeIdentifier(Int, None, None, None);
+  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
   auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder;
   ArgBuilder

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -200,12 +200,11 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     Builder.useLeftParen(SyntaxFactory::makeLeftParenToken({}, {}));
     auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
     auto IntId = SyntaxFactory::makeIdentifier("Int", {}, {});
-    auto IntType = SyntaxFactory::makeTypeIdentifier(IntId, None, None, None);
+    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(IntId, None);
     auto Int = SyntaxFactory::makeTupleTypeElement(IntType);
     auto IntWithComma = SyntaxFactory::makeTupleTypeElement(IntType, Comma);
     auto StringId = SyntaxFactory::makeIdentifier("String", {}, {});
-    auto StringType = SyntaxFactory::makeTypeIdentifier(StringId, None,
-                                                        None, None);
+    auto StringType = SyntaxFactory::makeSimpleTypeIdentifier(StringId, None);
     auto String = SyntaxFactory::makeTupleTypeElement(StringType, Comma);
     Builder.addTupleTypeElement(IntWithComma);
     Builder.addTupleTypeElement(String);

--- a/unittests/Syntax/UnknownSyntaxTests.cpp
+++ b/unittests/Syntax/UnknownSyntaxTests.cpp
@@ -13,7 +13,7 @@ SymbolicReferenceExprSyntax getCannedSymbolicRef() {
   // First, make a symbolic reference to an 'Array<Int>'
   auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
   auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
-  auto IntType = SyntaxFactory::makeTypeIdentifier(Int, None, None, None);
+  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
   auto IntArg = SyntaxFactory::makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder;
   ArgBuilder

--- a/utils/gyb_syntax_support/GenericNodes.py
+++ b/utils/gyb_syntax_support/GenericNodes.py
@@ -16,13 +16,13 @@ GENERIC_NODES = [
     # same-type-requirement -> type-identifier == type
     Node('SameTypeRequirement', kind='Syntax',
          children=[
-             Child('LeftTypeIdentifier', kind='TypeIdentifier'),
+             Child('LeftTypeIdentifier', kind='Type'),
              Child('EqualityToken', kind='Token',
                    token_choices=[
                        'SpacedBinaryOperatorToken',
                        'UnspacedBinaryOperatorToken',
                    ]),
-             Child('RightTypeIdentifier', kind='TypeIdentifier'),
+             Child('RightTypeIdentifier', kind='Type'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),
@@ -35,7 +35,7 @@ GENERIC_NODES = [
     #                    | type-name : protocol-composition-type
     Node('GenericParameter', kind='Syntax',
          children=[
-             Child('TypeIdentifier', kind='TypeIdentifier'),
+             Child('Name', kind='IdentifierToken'),
              Child('Colon', kind='ColonToken',
                    is_optional=True),
              Child('InheritedType', kind='Type',
@@ -55,9 +55,9 @@ GENERIC_NODES = [
     # conformance-requirement -> type-identifier : type-identifier
     Node('ConformanceRequirement', kind='Syntax',
          children=[
-             Child('LeftTypeIdentifier', kind='TypeIdentifier'),
+             Child('LeftTypeIdentifier', kind='Type'),
              Child('Colon', kind='ColonToken'),
-             Child('RightTypeIdentifier', kind='TypeIdentifier'),
+             Child('RightTypeIdentifier', kind='Type'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -5,7 +5,7 @@ PATTERN_NODES = [
     # enum-case-pattern -> type-identifier? '.' identifier tuple-pattern?
     Node('EnumCasePattern', kind='Pattern',
          children=[
-             Child('TypeIdentifier', kind='TypeIdentifier',
+             Child('Type', kind='Type',
                    is_optional=True),
              Child('Period', kind='PeriodToken'),
              Child('CaseName', kind='IdentifierToken'),

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -2,6 +2,39 @@ from Child import Child
 from Node import Node  # noqa: I201
 
 TYPE_NODES = [
+    # simple-type-identifier -> identifier generic-argument-clause?
+    Node('SimpleTypeIdentifier', kind='Type',
+         children=[
+             Child('Name', kind='Token',
+                   token_choices=[
+                       'IdentifierToken',
+                       'CapitalSelfToken',
+                       'AnyToken',
+                   ]),
+             Child('GenericArgumentClause', kind='GenericArgumentClause',
+                   is_optional=True),
+         ]),
+
+    # member-type-identifier -> type '.' identifier generic-argument-clause?
+    Node('MemberTypeIdentifier', kind='Type',
+         children=[
+             Child('BaseType', kind='Type'),
+             Child('Period', kind='Token',
+                   token_choices=[
+                       'PeriodToken',
+                       'PrefixPeriodToken',
+                   ]),
+             Child('Name', kind='Token',
+                   token_choices=[
+                       'IdentifierToken',
+                       'CapitalSelfToken',
+                       'AnyToken',
+                   ]),
+             Child('GenericArgumentClause', kind='GenericArgumentClause',
+                   is_optional=True),
+         ]),
+
+
     # metatype-type -> type '.' 'Type'
     #                | type '.' 'Protocol
     Node('MetatypeType', kind='Type',
@@ -102,7 +135,7 @@ TYPE_NODES = [
     # protocol-composition-element -> type-identifier '&'
     Node('ProtocolCompositionElement', kind='Syntax',
          children=[
-             Child('ProtocolType', kind='TypeIdentifier'),
+             Child('ProtocolType', kind='Type'),
              Child('Ampersand', kind='AmpersandToken',
                    is_optional=True),
          ]),
@@ -149,19 +182,6 @@ TYPE_NODES = [
          children=[
              Child('ValueType', kind='Type'),
              Child('QuestionMark', kind='PostfixQuestionMarkToken'),
-         ]),
-
-    # type-identifier -> identifier generic-argument-clause? '.'?
-    #   type-identifier?
-    Node('TypeIdentifier', kind='Type',
-         children=[
-             Child('TypeName', kind='IdentifierToken'),
-             Child('GenericArgumentClause', kind='GenericArgumentClause',
-                   is_optional=True),
-             Child('Period', kind='PeriodToken',
-                   is_optional=True),
-             Child('TypeIdentifier', kind='TypeIdentifier',
-                   is_optional=True),
          ]),
 
     # function-type-argument-list -> function-type-argument


### PR DESCRIPTION
CC: @nkcsgexi 

* The first commit is for split token.
  Previously, the split token was always tokenized as `tok::oper_binary_unspaced`.
  We wan't to specify the kind of token.
* The second commit is the main commit on this PR.
  It uses `SyntaxBuilder` for building libSyntax nodes.
