### PR TITLE
[Diagnostics] Fix crash related to diagnostics of trailing closures

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5082,6 +5082,7 @@ bool FailureDiagnosis::diagnoseTrailingClosureErrors(ApplyExpr *callExpr) {
   if (!callExpr->hasTrailingClosure())
     return false;
 
+  auto *DC = CS.DC;
   auto *fnExpr = callExpr->getFn();
   auto *argExpr = callExpr->getArg();
 
@@ -5238,6 +5239,7 @@ bool FailureDiagnosis::diagnoseTrailingClosureErrors(ApplyExpr *callExpr) {
       auto expectedArgType = FunctionType::get(fnType->getInput(), resultType,
                                                fnType->getExtInfo());
 
+      llvm::SaveAndRestore<DeclContext *> SavedDC(CS.DC, DC);
       ClosureCalleeListener listener(expectedArgType, CS.getContextualType());
       return !typeCheckChildIndependently(callExpr->getFn(), Type(),
                                           CTP_CalleeResult, TCC_ForceRecheck,

--- a/validation-test/compiler_crashers_2_fixed/0132-rdar35699666.swift
+++ b/validation-test/compiler_crashers_2_fixed/0132-rdar35699666.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct A<T> {
+  private var b: [T]
+}
+
+func foo(v: [Int]) {
+  let _ = A(b: v.sorted { $0 < $1 }.map{ $0 })
+}


### PR DESCRIPTION
While trying to diagnose a problem related to contextual result type
of the trailing closure, don't assume that declaration context is properly
set, instead directly set it to correct one before running type-check.

Resolves: rdar://problem/35699666

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
