### PR TITLE
[SILGen] Emit inherited protocols too if necessary

### DIFF
--- a/test/SILGen/Inputs/protocol_imported_type.h
+++ b/test/SILGen/Inputs/protocol_imported_type.h
@@ -1,0 +1,4 @@
+typedef enum __attribute__((flag_enum)) SomeOptions {
+  SomeOptionsFoo = 1,
+  SomeOptionsBar = 2
+} SomeOptions;

--- a/test/SILGen/Inputs/protocol_imported_type_helper.swift
+++ b/test/SILGen/Inputs/protocol_imported_type_helper.swift
@@ -1,0 +1,3 @@
+extension SomeOptions: Hashable {
+  public var hashValue: Int { return rawValue.hashValue }
+}

--- a/test/SILGen/external-associated-type-conformance.swift
+++ b/test/SILGen/external-associated-type-conformance.swift
@@ -3,10 +3,12 @@
 
 extension BadError: LocalizedError {}
 
-// -- The _BridgedStoredNSError conformance...
+// This conformance...
+// CHECK-LABEL: sil_witness_table shared [serialized] BadError.Code: _ErrorCodeProtocol module __ObjC 
+
+// ...is used by the _BridgedStoredNSError conformance
 // CHECK-LABEL: sil_witness_table shared [serialized] BadError: _BridgedStoredNSError module __ObjC {
-// -- uses the `Code` type's _ErrorCodeProtocol conformance...
 // CHECK:           associated_type_protocol (Code: _ErrorCodeProtocol): BadError.Code: _ErrorCodeProtocol module __ObjC
 // CHECK:       }
-// -- so we have to emit that too
-// CHECK-LABEL: sil_witness_table shared [serialized] BadError.Code: _ErrorCodeProtocol module __ObjC 
+
+// ...so we have to emit both.

--- a/test/SILGen/protocol_imported_type.swift
+++ b/test/SILGen/protocol_imported_type.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-silgen -disable-objc-attr-requires-foundation-module -enable-sil-ownership -import-objc-header %S/Inputs/protocol_imported_type.h -primary-file %s %S/Inputs/protocol_imported_type_helper.swift -o %t.sil -module-name main
+// RUN: %FileCheck %s < %t.sil
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.sil
+
+func test(map: [SomeOptions: Int]) {
+  _ = map[.foo]
+}
+
+// CHECK-DAG: sil_witness_table shared [serialized] SomeOptions: Equatable module __ObjC
+// CHECK-DAG: sil_witness_table shared [serialized] SomeOptions: RawRepresentable module __ObjC
+// NEGATIVE-NOT: SomeOptions: Hashable


### PR DESCRIPTION
As the test case shows, a regular, unique protocol conformance in another file might depend on a `linkonce_odr` conformance synthesized on behalf of the Clang importer. This should keep us from trying to reference these conformances across translation units (#12126).

rdar://problem/34722172