### PR TITLE
[build-script] Argument Builder DSL Conversion: Episode 1

### DIFF
--- a/utils/build_swift/defaults.py
+++ b/utils/build_swift/defaults.py
@@ -12,6 +12,9 @@ Default option value definitions.
 
 __all__ = [
     # Command line configuarable
+    'BUILD_VARIANT',
+    'CMAKE_GENERATOR',
+    'COMPILER_VENDOR',
     'SWIFT_USER_VISIBLE_VERSION',
     'CLANG_USER_VISIBLE_VERSION',
     'SWIFT_ANALYZE_CODE_COVERAGE',

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -240,15 +240,9 @@ def create_argument_parser():
     in_group = builder.in_group
     mutually_exclusive_group = builder.mutually_exclusive_group
 
-    append = builder.actions.append
+    # Prepare DSL actions
     store = builder.actions.store
-    store_int = builder.actions.store_int
     store_path = builder.actions.store_path
-    store_true = builder.actions.store_true
-    store_false = builder.actions.store_false
-    toggle_true = builder.actions.toggle_true
-    toggle_false = builder.actions.toggle_false
-    unsupported = builder.actions.unsupported
 
     # -------------------------------------------------------------------------
     # Top-level options

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -814,28 +814,25 @@ def create_argument_parser():
         dest='lldb_assertions',
         help='disable assertions in LLDB')
 
-    # FIXME: This should be one option using choices=[...]
-    cmake_generator_group = parser.add_argument_group(
-        title='Select the CMake generator')
-    cmake_generator_group.add_argument(
-        '-x', '--xcode',
-        action='store_const',
-        const='Xcode',
-        dest='cmake_generator',
-        help="use CMake's Xcode generator (default is Ninja)")
-    cmake_generator_group.add_argument(
-        '-m', '--make',
-        action='store_const',
-        const='Unix Makefiles',
-        dest='cmake_generator',
-        help="use CMake's Makefile generator (default is Ninja)")
-    cmake_generator_group.add_argument(
-        '-e', '--eclipse',
-        action='store_const',
-        const='Eclipse CDT4 - Ninja',
-        dest='cmake_generator',
-        help="use CMake's Eclipse generator (default is Ninja)")
+    # -------------------------------------------------------------------------
+    in_group('Select the CMake generator')
 
+    set_defaults(cmake_generator=defaults.CMAKE_GENERATOR)
+
+    option(['-e', '--eclipse'], store('cmake_generator'),
+           const='Eclipse CDT4 - Ninja',
+           default=defaults.CMAKE_GENERATOR,
+           help="use CMake's Xcode generator (%(default)s by default)")
+    option(['-m', '--make'], store('cmake_generator'),
+           const='Unix Makefiles',
+           default=defaults.CMAKE_GENERATOR,
+           help="use CMake's Makefile generator (%(default)s by default)")
+    option(['-x', '--xcode'], store('cmake_generator'),
+           const='Xcode',
+           default=defaults.CMAKE_GENERATOR,
+           help="use CMake's Xcode generator (%(default)s by default)")
+
+    # -------------------------------------------------------------------------
     run_tests_group = parser.add_argument_group(
         title='Run tests')
 

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -1108,49 +1108,40 @@ def create_argument_parser():
            help='LLVM target generators to build')
 
     # -------------------------------------------------------------------------
-    android_group = parser.add_argument_group(
-        title='Build settings for Android')
-    android_group.add_argument(
-        '--android-ndk',
-        metavar='PATH',
-        help='An absolute path to the NDK that will be used as a libc '
-             'implementation for Android builds')
-    android_group.add_argument(
-        '--android-api-level',
-        default='21',
-        help='The Android API level to target when building for Android. '
-             'Currently only 21 or above is supported')
-    android_group.add_argument(
-        '--android-ndk-gcc-version',
-        choices=['4.8', '4.9'],
-        default='4.9',
-        help='The GCC version to use when building for Android. Currently '
-             'only 4.9 is supported. %(default)s is also the default value. '
-             'This option may be used when experimenting with versions '
-             'of the Android NDK not officially supported by Swift')
-    android_group.add_argument(
-        '--android-icu-uc',
-        metavar='PATH',
-        help='Path to a directory containing libicuuc.so')
-    android_group.add_argument(
-        '--android-icu-uc-include',
-        metavar='PATH',
-        help='Path to a directory containing headers for libicuuc')
-    android_group.add_argument(
-        '--android-icu-i18n',
-        metavar='PATH',
-        help='Path to a directory containing libicui18n.so')
-    android_group.add_argument(
-        '--android-icu-i18n-include',
-        metavar='PATH',
-        help='Path to a directory containing headers libicui18n')
-    android_group.add_argument(
-        '--android-deploy-device-path',
-        default=android.adb.commands.DEVICE_TEMP_DIR,
-        metavar='PATH',
-        help='Path on an Android device to which built Swift stdlib products '
-             'will be deployed. If running host tests, specify the "{}" '
-             'directory.'.format(android.adb.commands.DEVICE_TEMP_DIR))
+    in_group('Build settings for Android')
+
+    option('--android-ndk', store_path,
+           help='An absolute path to the NDK that will be used as a libc '
+                'implementation for Android builds')
+
+    option('--android-api-level', store,
+           default='21',
+           help='The Android API level to target when building for Android. '
+                'Currently only 21 or above is supported')
+
+    option('--android-ndk-gcc-version', store,
+           choices=['4.8', '4.9'],
+           default='4.9',
+           help='The GCC version to use when building for Android. Currently '
+                'only 4.9 is supported. %(default)s is also the default '
+                'value. This option may be used when experimenting with '
+                'versions of the Android NDK not officially supported by '
+                'Swift')
+
+    option('--android-icu-uc', store_path,
+           help='Path to a directory containing libicuuc.so')
+    option('--android-icu-uc-include', store_path,
+           help='Path to a directory containing headers for libicuuc')
+    option('--android-icu-i18n', store_path,
+           help='Path to a directory containing libicui18n.so')
+    option('--android-icu-i18n-include', store_path,
+           help='Path to a directory containing headers libicui18n')
+    option('--android-deploy-device-path', store_path,
+           default=android.adb.commands.DEVICE_TEMP_DIR,
+           help='Path on an Android device to which built Swift stdlib '
+                'products will be deployed. If running host tests, specify '
+                'the "{}" directory.'.format(
+                    android.adb.commands.DEVICE_TEMP_DIR))
 
     # -------------------------------------------------------------------------
     return builder.build()

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -793,15 +793,12 @@ def create_argument_parser():
 
     option(['-e', '--eclipse'], store('cmake_generator'),
            const='Eclipse CDT4 - Ninja',
-           default=defaults.CMAKE_GENERATOR,
-           help="use CMake's Xcode generator (%(default)s by default)")
+           help="use CMake's Eclipse generator (%(default)s by default)")
     option(['-m', '--make'], store('cmake_generator'),
            const='Unix Makefiles',
-           default=defaults.CMAKE_GENERATOR,
            help="use CMake's Makefile generator (%(default)s by default)")
     option(['-x', '--xcode'], store('cmake_generator'),
            const='Xcode',
-           default=defaults.CMAKE_GENERATOR,
            help="use CMake's Xcode generator (%(default)s by default)")
 
     # -------------------------------------------------------------------------

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -1101,12 +1101,11 @@ def create_argument_parser():
              'phone itself)')
 
     # -------------------------------------------------------------------------
-    llvm_group = parser.add_argument_group(
-        title='Build settings specific for LLVM')
-    llvm_group.add_argument(
-        '--llvm-targets-to-build',
-        default='X86;ARM;AArch64;PowerPC;SystemZ;Mips',
-        help='LLVM target generators to build')
+    in_group('Build settings specific for LLVM')
+
+    option('--llvm-targets-to-build', store,
+           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips',
+           help='LLVM target generators to build')
 
     # -------------------------------------------------------------------------
     android_group = parser.add_argument_group(

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -742,77 +742,55 @@ def create_argument_parser():
         help='build the Debug variant of libicu')
 
     # -------------------------------------------------------------------------
-    assertions_group = parser.add_mutually_exclusive_group(required=False)
-    assertions_group.add_argument(
-        '--assertions',
-        action='store_const',
-        const=True,
-        dest='assertions',
-        help='enable assertions in all projects')
-    assertions_group.add_argument(
-        '--no-assertions',
-        action='store_const',
-        const=False,
-        dest='assertions',
-        help='disable assertions in all projects')
+    # Assertions group
+
+    with mutually_exclusive_group():
+        set_defaults(assertions=True)
+
+        # TODO: Convert to store_true
+        option('--assertions', store,
+               const=True,
+               help='enable assertions in all projects')
+
+        # TODO: Convert to store_false
+        option('--no-assertions', store('assertions'),
+               const=False,
+               help='disable assertions in all projects')
 
     # -------------------------------------------------------------------------
-    assertions_override_group = parser.add_argument_group(
-        title='Control assertions in a specific project')
-    assertions_override_group.add_argument(
-        '--cmark-assertions',
-        action='store_const',
-        const=True,
-        dest='cmark_assertions',
-        help='enable assertions in CommonMark')
-    assertions_override_group.add_argument(
-        '--llvm-assertions',
-        action='store_const',
-        const=True,
-        dest='llvm_assertions',
-        help='enable assertions in LLVM')
-    assertions_override_group.add_argument(
-        '--no-llvm-assertions',
-        action='store_const',
-        const=False,
-        dest='llvm_assertions',
-        help='disable assertions in LLVM')
-    assertions_override_group.add_argument(
-        '--swift-assertions',
-        action='store_const',
-        const=True,
-        dest='swift_assertions',
-        help='enable assertions in Swift')
-    assertions_override_group.add_argument(
-        '--no-swift-assertions',
-        action='store_const',
-        const=False,
-        dest='swift_assertions',
-        help='disable assertions in Swift')
-    assertions_override_group.add_argument(
-        '--swift-stdlib-assertions',
-        action='store_const',
-        const=True,
-        dest='swift_stdlib_assertions',
-        help='enable assertions in the Swift standard library')
-    assertions_override_group.add_argument(
-        '--no-swift-stdlib-assertions',
-        action='store_const',
-        const=False,
-        dest='swift_stdlib_assertions',
-        help='disable assertions in the Swift standard library')
-    assertions_override_group.add_argument(
-        '--lldb-assertions',
-        action='store_const',
-        const=True,
-        dest='lldb_assertions',
-        help='enable assertions in LLDB')
-    assertions_override_group.add_argument(
-        '--no-lldb-assertions',
-        action='store_const',
-        const=False,
-        dest='lldb_assertions',
-        help='disable assertions in LLDB')
+    in_group('Control assertions in a specific project')
+
+    option('--cmark-assertions', store,
+           const=True,
+           help='enable assertions in CommonMark')
+
+    option('--llvm-assertions', store,
+           const=True,
+           help='enable assertions in LLVM')
+    option('--no-llvm-assertions', store('llvm_assertions'),
+           const=False,
+           help='disable assertions in LLVM')
+
+    option('--swift-assertions', store,
+           const=True,
+           help='enable assertions in Swift')
+    option('--no-swift-assertions', store('swift_assertions'),
+           const=False,
+           help='disable assertions in Swift')
+
+    option('--swift-stdlib-assertions', store,
+           const=True,
+           help='enable assertions in the Swift standard library')
+    option('--no-swift-stdlib-assertions', store('swift_stdlib_assertions'),
+           const=False,
+           help='disable assertions in the Swift standard library')
+
+    option('--lldb-assertions', store,
+           const=True,
+           help='enable assertions in LLDB')
+    option('--no-lldb-assertions', store('lldb_assertions'),
+           const=False,
+           help='disable assertions in LLDB')
 
     # -------------------------------------------------------------------------
     in_group('Select the CMake generator')


### PR DESCRIPTION
# Purpose

This PR begins the conversion to the new argument builder DSL. There's no real functional changes, just converting to the more expressive builder system and adding some visual separators between argument groups. More conversion PRs are to follow until all the arguments are converted.

rdar://34336890 