### PR TITLE
test: disable LSAN test on Linux

### DIFF
--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -9,6 +9,8 @@
 // For now restrict this test to platforms where we know this test will pass
 // REQUIRES: CPU=x86_64
 
+// UNSUPPORTED: OS=linux-gnu
+
 func sayHello() {
   print("Hello")
 }


### PR DESCRIPTION
This is a follow up to 5fbf769b2a8831dcd5d942dac517426d38ff6905.  The
explicit `ASAN_OPTIONS=` during the test run will re-enable LSAN
detection which is known to be currently leaky on Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
