### PR TITLE
Add LLDB_Swift_DebugAssert_asan & LLDB_Swift_ReleaseAssert_asan

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1079,6 +1079,12 @@ mixin-preset=
 
 assertions
 
+[preset: LLDB_Swift_DebugAssert_asan]
+mixin-preset=
+    LLDB_Swift_DebugAssert
+
+enable-asan
+
 [preset: LLDB_Swift_DebugAssert_with_devices]
 mixin-preset=
     LLDB_Swift_DebugAssert
@@ -1095,6 +1101,12 @@ mixin-preset=
 
 release-debuginfo
 assertions
+
+[preset: LLDB_Swift_ReleaseAssert_asan]
+mixin-preset=
+    LLDB_Swift_ReleaseAssert
+
+enable-asan
 
 [preset: LLDB_Swift_ReleaseAssert_with_devices]
 mixin-preset=


### PR DESCRIPTION
presets for building lldb/llvm/clang/swift with ASAN enabled.

