### PR TITLE
 Revert "AST: UnboundGenericTypes are not legal SIL types"

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -433,9 +433,6 @@ static bool isLegalSILType(CanType type) {
   // L-values and inouts are not legal.
   if (!type->isMaterializable()) return false;
 
-  // Unbound generic types are not legal.
-  if (type->hasUnboundGenericType()) return false;
-
   // Function types must be lowered.
   if (isa<AnyFunctionType>(type)) return false;
 

--- a/test/DebugInfo/objc_generic_class_debug_info.swift
+++ b/test/DebugInfo/objc_generic_class_debug_info.swift
@@ -7,7 +7,12 @@ import Swift
 import Foundation
 import objc_generics
 
-extension GenericClass {
+public extension GenericClass {
   func method() {}
   class func classMethod() {}
+}
+
+public func takesFunction<T : AnyObject>(fn: @escaping (GenericClass<T>) -> ()) -> (GenericClass<T>) -> () {
+  let copy = fn
+  return copy
 }


### PR DESCRIPTION
Exposed by the source compatibility test suite. I added a reduced test case.

Fixes <rdar://problem/35729528>.