### PR TITLE
[SE-0143] Put conditional conformances behind an "experimental" flag.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1368,6 +1368,9 @@ ERROR(cannot_use_nil_with_this_type,none,
 ERROR(use_of_equal_instead_of_equality,none,
       "use of '=' in a boolean context, did you mean '=='?", ())
 
+ERROR(experimental_conditional_conformances,none,
+      "conditional conformance of %0 to %1 depends on an experimental feature "
+      "(SE-0143)", (Type, Type))
 
 ERROR(protocol_does_not_conform_objc,none,
       "using %0 as a concrete type conforming to protocol %1 is not supported",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -132,6 +132,9 @@ namespace swift {
     /// was not compiled with -enable-testing.
     bool EnableTestableAttrRequiresTestableModule = true;
 
+    /// Whether SE-0143: Conditional Conformances are enabled.
+    bool EnableConditionalConformances = false;
+
     ///
     /// Flags for developers
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -281,6 +281,11 @@ def disable_swift_bridge_attr : Flag<["-"], "disable-swift-bridge-attr">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Disable using the swift bridge attribute">;
 
+def enable_experimental_conditional_conformances : Flag<["-"],
+  "enable-experimental-conditional-conformances">,
+  Flags<[FrontendOption]>,
+HelpText<"Enable experimental implementation of SE-0143: Conditional Conformances">;
+
 def enable_bridging_pch : Flag<["-"], "enable-bridging-pch">,
   Flags<[HelpHidden]>,
   HelpText<"Enable automatic generation of bridging PCH files">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -140,6 +140,9 @@ static void addCommonFrontendArgs(const ToolChain &TC,
                        options::OPT_warn_swift3_objc_inference_complete);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
+  inputArgs.AddLastArg(
+                     arguments,
+                     options::OPT_enable_experimental_conditional_conformances);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);
   inputArgs.AddLastArg(arguments, options::OPT_import_underlying_module);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -987,7 +987,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.EnableTargetOSChecking
       = A->getOption().matches(OPT_enable_target_os_checking);
   }
-  
+
+  Opts.EnableConditionalConformances |=
+  Args.hasArg(OPT_enable_experimental_conditional_conformances);
   Opts.EnableASTScopeLookup |= Args.hasArg(OPT_enable_astscope_lookup);
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.EnableConstraintPropagation |= Args.hasArg(OPT_propagate_constraints);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6966,6 +6966,20 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       }
     }
   }
+
+  // If conditional conformances are disabled, complain about any that
+  // occur.
+  if (!Context.LangOpts.EnableConditionalConformances) {
+    for (auto conformance : conformances) {
+      auto normal = dyn_cast<NormalProtocolConformance>(conformance);
+      if (!normal) continue;
+
+      if (normal->getConditionalRequirements().empty()) continue;
+
+      diagnose(normal->getLoc(), diag::experimental_conditional_conformances,
+               normal->getType(), normal->getProtocol()->getDeclaredType());
+    }
+  }
 }
 
 llvm::TinyPtrVector<ValueDecl *>

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -227,6 +227,8 @@ endif()
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
 list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-sil-ownership")
+list(APPEND swift_stdlib_compile_flags
+     "-enable-experimental-conditional-conformances")
 
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances -typecheck -debug-generic-signatures %s > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 {}

--- a/test/Generics/conditional_conformances_execute_smoke.swift
+++ b/test/Generics/conditional_conformances_execute_smoke.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -enable-experimental-conditional-conformances %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 // Smoke test to see that various conditional conformances correctly execute
 

--- a/test/Generics/conditional_conformances_operators.swift
+++ b/test/Generics/conditional_conformances_operators.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances -typecheck %s -verify
 
 // rdar://problem/35480952
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1 
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances -typecheck -debug-generic-signatures %s > %t.dump 2>&1 
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 { 

--- a/test/IRGen/conditional_conformances.swift
+++ b/test/IRGen/conditional_conformances.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_with_assoc.swift | %FileCheck %S/../Inputs/conditional_conformance_with_assoc.swift
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_subclass.swift | %FileCheck %S/../Inputs/conditional_conformance_subclass.swift
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_recursive.swift | %FileCheck %S/../Inputs/conditional_conformance_recursive.swift
+// RUN: %target-swift-frontend -enable-experimental-conditional-conformances -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift
+// RUN: %target-swift-frontend -enable-experimental-conditional-conformances -emit-ir %S/../Inputs/conditional_conformance_with_assoc.swift | %FileCheck %S/../Inputs/conditional_conformance_with_assoc.swift
+// RUN: %target-swift-frontend -enable-experimental-conditional-conformances -emit-ir %S/../Inputs/conditional_conformance_subclass.swift | %FileCheck %S/../Inputs/conditional_conformance_subclass.swift
+// RUN: %target-swift-frontend -enable-experimental-conditional-conformances -emit-ir %S/../Inputs/conditional_conformance_recursive.swift | %FileCheck %S/../Inputs/conditional_conformance_recursive.swift
 
 // Too many pointer-sized integers in the IR
 // REQUIRES: PTRSIZE=64

--- a/test/Interpreter/conditional_conformances.swift
+++ b/test/Interpreter/conditional_conformances.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // The file that's `main` needs to be called that.
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -D basic %t/main.swift %S/../Inputs/conditional_conformance_basic_conformances.swift -o %t/basic && %target-run %t/basic
-// RUN: %target-build-swift -D with_assoc %t/main.swift %S/../Inputs/conditional_conformance_with_assoc.swift -o %t/with_assoc && %target-run %t/with_assoc
-// RUN: %target-build-swift -D subclass %t/main.swift %S/../Inputs/conditional_conformance_subclass.swift -o %t/subclass && %target-run %t/subclass
+// RUN: %target-build-swift -enable-experimental-conditional-conformances -D basic %t/main.swift %S/../Inputs/conditional_conformance_basic_conformances.swift -o %t/basic && %target-run %t/basic
+// RUN: %target-build-swift -enable-experimental-conditional-conformances -D with_assoc %t/main.swift %S/../Inputs/conditional_conformance_with_assoc.swift -o %t/with_assoc && %target-run %t/with_assoc
+// RUN: %target-build-swift -enable-experimental-conditional-conformances -D subclass %t/main.swift %S/../Inputs/conditional_conformance_subclass.swift -o %t/subclass && %target-run %t/subclass
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/libBasic.%target-dylib-extension) %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
-// RUN: %target-build-swift-dylib(%t/libWithAssoc.%target-dylib-extension) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
-// RUN: %target-build-swift-dylib(%t/libSubclass.%target-dylib-extension) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
+// RUN: %target-build-swift-dylib(%t/libBasic.%target-dylib-extension) -enable-experimental-conditional-conformances %S/../Inputs/conditional_conformance_basic_conformances.swift -module-name Basic -emit-module -emit-module-path %t/Basic.swiftmodule
+// RUN: %target-build-swift-dylib(%t/libWithAssoc.%target-dylib-extension) -enable-experimental-conditional-conformances %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
+// RUN: %target-build-swift-dylib(%t/libSubclass.%target-dylib-extension) -enable-experimental-conditional-conformances %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
 // RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc -lSubclass %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
 // RUN: %target-run %t/conditional_conformances_modules %t/libBasic.%target-dylib-extension %t/libWithAssoc.%target-dylib-extension
 

--- a/test/Interpreter/conditional_conformances_smoke.swift
+++ b/test/Interpreter/conditional_conformances_smoke.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -enable-experimental-conditional-conformances %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -module-name=witness_tables | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=witness_tables | %FileCheck %s
+// RUN: %target-sil-opt -enable-experimental-conditional-conformances -assume-parsing-unqualified-ownership-sil %s -module-name=witness_tables | %target-sil-opt -enable-experimental-conditional-conformances -assume-parsing-unqualified-ownership-sil -module-name=witness_tables | %FileCheck %s
 
 protocol AssocReqt {
   func requiredMethod()

--- a/test/SILGen/conditional_conformance.swift
+++ b/test/SILGen/conditional_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-conditional-conformances -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 protocol P1 {
   func normal()

--- a/test/SILOptimizer/devirt_conditional_conformance.swift
+++ b/test/SILOptimizer/devirt_conditional_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-inline-generics=false -Xllvm -sil-disable-pass=GlobalOpt %s -emit-sil -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-conditional-conformances -O -Xllvm -sil-inline-generics=false -Xllvm -sil-disable-pass=GlobalOpt %s -emit-sil -sil-verify-all | %FileCheck %s
 
 
 public protocol Foo {

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances
 
 struct NotEquatable { }
 

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -138,7 +138,7 @@ func genericClassNotEquatable<T>(_ gc: GenericClass<T>, x: T, y: T) {
 
 extension Array where Element == String { }
 
-extension GenericClass : P3 where T : P3 { }
+extension GenericClass : P3 where T : P3 { } // expected-error{{conditional conformance of 'GenericClass<T>' to 'P3' depends on an experimental feature (SE-0143)}}
 
 extension GenericClass where Self : P3 { }
 // expected-error@-1{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}} {{30-34=GenericClass}}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-conditional-conformances -typecheck
 
 func markUsed<T>(_ t: T) {}
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -195,6 +195,12 @@ AssumeUnqualifiedOwnershipWhenParsing(
     "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden, llvm::cl::init(false),
     llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
 
+static llvm::cl::opt<bool>
+EnableExperimentalConditionalConformances(
+  "enable-experimental-conditional-conformances", llvm::cl::Hidden,
+  llvm::cl::init(false),
+  llvm::cl::desc("Enable experimental implementation of SE-0143: Conditional Conformances"));
+
 /// Regular expression corresponding to the value given in one of the
 /// -pass-remarks* command line flags. Passes whose name matches this regexp
 /// will emit a diagnostic.
@@ -298,7 +304,8 @@ int main(int argc, char **argv) {
     llvm::Triple(Target).isOSDarwin();
 
   Invocation.getLangOptions().EnableSILOpaqueValues = EnableSILOpaqueValues;
-
+  Invocation.getLangOptions().EnableConditionalConformances |=
+    EnableExperimentalConditionalConformances;
   Invocation.getLangOptions().OptimizationRemarkPassedPattern =
       createOptRemarkRegex(PassRemarksPassed);
   Invocation.getLangOptions().OptimizationRemarkMissedPattern =


### PR DESCRIPTION
Conditional conformances aren't quite ready yet for Swift 4.1, so
introduce the flag `-enable-experimental-conditional-conformances` to
enable conditional conformaces, and an error when one declares a
conditional conformance without specifying the flag.

Add this flag when building the standard library (which will vend
conditional conformances) and to all of the tests that need it.

Fixes rdar://problem/35728337.
