### PR TITLE
Add LLDB_Swift_DebugAssert_asan & LLDB_Swift_ReleaseAssert_asan

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1050,6 +1050,12 @@ mixin-preset=
 
 assertions
 
+[preset: LLDB_Swift_DebugAssert_asan]
+mixin-preset=
+    LLDB_Swift_DebugAssert
+
+enable-asan
+
 [preset: LLDB_Swift_DebugAssert_with_devices]
 mixin-preset=
     LLDB_Swift_DebugAssert
@@ -1066,6 +1072,12 @@ mixin-preset=
 
 release-debuginfo
 assertions
+
+[preset: LLDB_Swift_ReleaseAssert_asan]
+mixin-preset=
+    LLDB_Swift_ReleaseAssert
+
+enable-asan
 
 [preset: LLDB_Swift_ReleaseAssert_with_devices]
 mixin-preset=


### PR DESCRIPTION
presets for building lldb/llvm/clang/swift with ASAN enabled.

(cherry picked from commit 8b4036d0acf998d2db90d701c787e54177dea24a)
