### PR TITLE
stdlib: fix the build with macOS long tests

### DIFF
--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -119,3 +119,23 @@ bool _swift_dictionaryDownCastConditionalIndirect(OpaqueValue *destination,
                                         const void *targetKeyHashable) {
   abort();
 }
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+int _T0s13_getErrorCodeSiSPyxGs0B0RzlF(void *) {
+  abort();
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+void *_T0s23_getErrorDomainNSStringyXlSPyxGs0B0RzlF(void *) {
+  abort();
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+void *_T0s29_getErrorUserInfoNSDictionaryyXlSgSPyxGs0B0RzlF(void *) {
+  abort();
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+void *_T0s32_getErrorEmbeddedNSErrorIndirectyXlSgSPyxGs0B0RzlF(void *) {
+  abort();
+}


### PR DESCRIPTION
When building swift on macOS with long tests, the build would fail with
undefined references to these symbols.  The undefined symbols were
expected to be present in swiftCore against which we link.  However,
because the symbols are marked as internal, they would be dead stripped
before the dylib was constructed.  As a result, we would end up with
undefined references to these symbols.  Expose the additional internal
interfaces for now so that we can build the tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
