### PR TITLE
[Parse] Support importing operator functions

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2680,7 +2680,7 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   }
 
   std::vector<std::pair<Identifier, SourceLoc>> ImportPath;
-  do {
+  while (true) {
     if (Tok.is(tok::code_complete)) {
       consumeToken();
       if (CodeCompletion) {
@@ -2692,7 +2692,11 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
     if (parseAnyIdentifier(ImportPath.back().first,
                            diag::expected_identifier_in_decl, "import"))
       return nullptr;
-  } while (consumeIf(tok::period));
+
+    if (!startsWithSymbol(Tok, '.'))
+      break;
+    consumeStartingCharacterOfCurrentToken(tok::period);
+  }
 
   if (Tok.is(tok::code_complete)) {
     // We omit the code completion token if it immediately follows the module

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -2,6 +2,7 @@
 // RUN: echo "public struct X {}; public var x = X()" | %target-swift-frontend -module-name import_builtin -parse-stdlib -emit-module -o %t -
 // RUN: echo "public func foo() -> Int { return false }" > %t/import_text.swift
 // RUN: echo "public func pho$(printf '\xC3\xBB')x() -> Int { return false }" > %t/fran$(printf '\xC3\xA7')ais.swift
+// RUN: echo "infix operator <-->; public func <-->(l: Int, r: Int) -> Int { return 1 }" > %t/oper_func.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal -verify-ignore-unknown
 
 // -verify-ignore-unknown is for:
@@ -66,5 +67,8 @@ var _ : Int = foo()
 
 import français
 import func français.phoûx
+
+import func oper_func.<-->
+var _:Int  = 1 <--> 2
 
 import main // expected-warning {{file 'import.swift' is part of module 'main'; ignoring import}}


### PR DESCRIPTION
Support:
```swift
import func SomeModule.<->
```

Previously, you were required to write like:
```swift
import func SomeModule . <->
```
Otherwise:
```
error: expected module name in import declaration
import func SomeFunc.<->
            ^
error: expected module name in import declaration
import func SomeFunc .<->
            ^
error: extraneous whitespace after '.' is not permitted
import func SomeFunc. <->
                    ^~
```
