### PR TITLE
[CMake] Windows stdlib cross-compilation fixes

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -734,6 +734,7 @@ function(_add_swift_library_single target name)
     swift_windows_generate_sdk_vfs_overlay(SWIFTLIB_SINGLE_VFS_OVERLAY_FLAGS)
     foreach(flag ${SWIFTLIB_SINGLE_VFS_OVERLAY_FLAGS})
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;${flag})
+      list(APPEND SWIFTLIB_SINGLE_C_COMPILE_FLAGS ${flag})
     endforeach()
     foreach(directory ${SWIFTLIB_INCLUDE})
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-I${directory})
@@ -1474,6 +1475,11 @@ function(add_swift_library name)
         continue()
       endif()
 
+      # TODO: Currently SwiftPrivate runs into linker problems on Windows. See SR-6489.
+      if ("${sdk}" STREQUAL "WINDOWS" AND "${name}" MATCHES "SwiftPrivate")
+        continue()
+      endif()
+
       set(THIN_INPUT_TARGETS)
 
       # For each architecture supported by this SDK
@@ -1611,6 +1617,19 @@ function(add_swift_library name)
            message("DISABLING AUTOLINK FOR swiftMediaPlayer")
            list(APPEND swiftlib_link_flags_all "-Xlinker" "-ignore_auto_link")
          endif()
+       endif()
+
+       # We unconditionally removed "-z,defs" from CMAKE_SHARED_LINKER_FLAGS in 
+       # swift_common_standalone_build_config_llvm within SwiftSharedCMakeConfig.cmake,
+       # where it was added by a call to HandleLLVMOptions. 
+       #
+       # Rather than applying it to all targets and libraries, we here add it back to 
+       # supported targets and libraries only. 
+       # This is needed for ELF targets only; however, RemoteMirror needs to build 
+       # with undefined symbols.
+       if("${SWIFT_SDK_${LFLAGS_SDK}_OBJECT_FORMAT}" STREQUAL "ELF" 
+          AND NOT "${name}" STREQUAL "swiftRemoteMirror")
+          list(APPEND swiftlib_link_flags_all "-Wl,-z,defs")
        endif()
 
         # Add this library variant.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1475,11 +1475,6 @@ function(add_swift_library name)
         continue()
       endif()
 
-      # TODO: Currently SwiftPrivate runs into linker problems on Windows. See SR-6489.
-      if ("${sdk}" STREQUAL "WINDOWS" AND "${name}" MATCHES "SwiftPrivate")
-        continue()
-      endif()
-
       set(THIN_INPUT_TARGETS)
 
       # For each architecture supported by this SDK

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -78,9 +78,17 @@ macro(swift_common_standalone_build_config_llvm product is_cross_compiling)
   include(AddSwiftTableGen) # This imports TableGen from LLVM.
   include(HandleLLVMOptions)
 
-  # HACK: this ugly tweaking is to prevent the propagation of the flag from LLVM
-  # into swift.  The use of this flag pollutes all targets, and we are not able
-  # to remove it on a per-target basis which breaks cross-compilation.
+  # HACK: Not all targets support -z,defs as a linker flag. 
+  #
+  # Normally, LLVM would only add it as an option for known ELF targets;
+  # however, due to the custom scheme Swift uses for cross-compilation, the 
+  # CMAKE_SHARED_LINKER_FLAGS are determined based on the host system and 
+  # then applied to all targets. This causes issues in cross-compiling to
+  # Windows from a Linux host.
+  # 
+  # To work around this, we unconditionally remove the flag here and then 
+  # selectively add it to the per-target link flags; this is currently done
+  # in add_swift_library within AddSwift.cmake.
   string(REGEX REPLACE "-Wl,-z,defs" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 
   set(PACKAGE_VERSION "${LLVM_PACKAGE_VERSION}")

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -1,6 +1,3 @@
-# HACK: Force this library to build with undefined symbols.
-string(REGEX REPLACE "-Wl,-z,defs" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
-
 # libswiftRemoteMirror.dylib should not have runtime dependencies; it's
 # always built as a shared library.
 if(SWIFT_BUILD_DYNAMIC_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)


### PR DESCRIPTION
This PR contains a few changes that are needed to make the Windows stdlib cross-compile from Linux.    

Namely, it:
- Ensures that `-Wl,-z,defs` is only added for non-Windows (and non-RemoteMirror) targets
- Skips building SwiftPrivate on Windows since that currently fails to link (I've filed [SR-6489](https://bugs.swift.org/browse/SR-6489) to track this)
- Remove the LLVM-provided `-std=` C++ flag and instead use CMake's `CXX_STANDARD` so that we can build against the Visual Studio 2017 headers (which require C++14). If someone can suggest a more elegant implementation than just replacing the string in `CMAKE_CXX_FLAGS` I'd be glad to hear it.