### PR TITLE
mixed_mode_class_with_missing_properties.swift: This test fails on i3…

### DIFF
--- a/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
+++ b/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: rdar://35747485
+// REQUIRES: optimized_stdlib
+
 import UsingObjCStuff
 
 print("Let's go") // CHECK: Let's go


### PR DESCRIPTION
…86 with an unoptimized stdlib

XFAIL it to unblock bots.

rdar://35747485
