### PR TITLE
Blocks can only be converted to AnyObject with a cast under ObjCInterop

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -665,10 +665,11 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
   // The destination type should be AnyObject in this case.
   assert(bridgedType->isEqual(SGF.getASTContext().getAnyObjectType()));
 
-  // Blocks bridge to id with a cast.
+  // Blocks bridge to id with a cast under ObjCInterop.
   if (auto nativeFnType = dyn_cast<AnyFunctionType>(nativeType)) {
     if (nativeFnType->getRepresentation() ==
-          FunctionTypeRepresentation::Block) {
+          FunctionTypeRepresentation::Block &&
+        SGF.getASTContext().LangOpts.EnableObjCInterop) {
       return SGF.B.createBlockToAnyObject(loc, v, loweredBridgedTy);
     }
   }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -726,6 +726,7 @@ ManagedValue SILGenBuilder::createBridgeObjectToRef(SILLocation loc,
 ManagedValue SILGenBuilder::createBlockToAnyObject(SILLocation loc,
                                                    ManagedValue v,
                                                    SILType destType) {
+  assert(SGF.getASTContext().LangOpts.EnableObjCInterop);
   assert(destType.isAnyObject());
   assert(v.getType().is<SILFunctionType>());
   assert(v.getType().castTo<SILFunctionType>()->getRepresentation() ==

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -523,8 +523,9 @@ ManagedValue Transform::transform(ManagedValue v,
                                    SGF.getLoweredLoadableType(outputSubstType));
   }
 
-  // - block to AnyObject conversion
-  if (outputSubstType->isAnyObject()) {
+  // - block to AnyObject conversion (under ObjC interop)
+  if (outputSubstType->isAnyObject() &&
+      SGF.getASTContext().LangOpts.EnableObjCInterop) {
     if (auto inputFnType = dyn_cast<AnyFunctionType>(inputSubstType)) {
       if (inputFnType->getRepresentation() == FunctionTypeRepresentation::Block)
         return SGF.B.createBlockToAnyObject(Loc, v, loweredResultTy);


### PR DESCRIPTION
I don't think there's a way to test this right now because we only support SwiftValue-style ``any as AnyObject`` or ``block as AnyObject`` under ObjCInterop, but it's certainly more future-proof.