### PR TITLE
[build-script] Translate "RelWithDebInfo" to "Release" for Mac LLDB

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -323,7 +323,11 @@ function to_varname() {
 }
 
 function set_lldb_build_mode() {
-    LLDB_BUILD_MODE="CustomSwift-${LLDB_BUILD_TYPE}"
+    if [[ "${LLDB_BUILD_TYPE}" == "RelWithDebInfo" ]]; then
+      LLDB_BUILD_MODE="CustomSwift-Release"
+    else
+      LLDB_BUILD_MODE="CustomSwift-${LLDB_BUILD_TYPE}"
+    fi
 }
 
 function is_llvm_lto_enabled() {


### PR DESCRIPTION
Not all CMake configuration names are valid Xcode configurations at the moment, but Xcode's "Release" still includes debug info, so it's probably close enough.