### PR TITLE
[4.1] [sourcekitd] Be more aggresive with the semantic editor delay to avoid being throttled

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -720,6 +720,9 @@ handleSemanticRequest(RequestDict Req,
 
   llvm::SmallString<64> ErrBuf;
 
+  if (isSemanticEditorDisabled())
+      return Rec(createErrorRequestFailed("semantic editor is disabled"));
+
   if (ReqUID == RequestCodeComplete) {
     std::unique_ptr<llvm::MemoryBuffer>
     InputBuf = getInputBufForRequest(SourceFile, SourceText, ErrBuf);
@@ -766,9 +769,6 @@ handleSemanticRequest(RequestDict Req,
     if (HashOpt.hasValue()) Hash = *HashOpt;
     return Rec(indexSource(*SourceFile, Args, Hash));
   }
-
-  if (isSemanticEditorDisabled())
-      return Rec(createErrorRequestFailed("semantic editor is disabled"));
 
   if (ReqUID == RequestCursorInfo) {
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();


### PR DESCRIPTION
Set a minimum delay of 10 seconds for the semantic editor requests instead of starting from 0/1 second. This helps prevent us from being throttled by the system if we have multiple crashes in a row, which allows us to keep syntactic requests working. This trades off the minimum time it takes to recover e.g. code-completion after a crash in exchange for keeping our most basic functionality working.

rdar://18326221