### PR TITLE
[Type checker] Don’t simplify to an error type.

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1755,7 +1755,7 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
             assocType->getDeclContext());
         auto result = assocType->getDeclaredInterfaceType().subst(subs);
 
-        if (result)
+        if (result && !result->hasError())
           return result;
       }
 


### PR DESCRIPTION
Type variables cannot be bound to error types, so don’t simplify to
them.

It's the one compiler change in https://github.com/apple/swift/pull/12913.