### PR TITLE
IRGen: Fix a compiler memory leak by using the right parameter in a l…

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2016,7 +2016,7 @@ ProtocolInfo::getConformance(IRGenModule &IGM, ProtocolDecl *protocol,
   auto checkCache =
       [&](const ProtocolConformance *conf) -> Optional<ConformanceInfo *> {
     // Check whether we've already cached this.
-    auto it = Conformances.find(conformance);
+    auto it = Conformances.find(conf);
     if (it != Conformances.end())
       return it->second;
 


### PR DESCRIPTION
…ocal function

No test case. Caught by the LSAN bot.

rdar://35646380
