### PR TITLE
Sema: Use the correct source range when emitting fixits for unresolved member expressions

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7362,14 +7362,16 @@ bool FailureDiagnosis::diagnoseMemberFailures(
   // and the source range for y.
   SourceRange memberRange;
   SourceLoc BaseLoc;
+  DeclNameLoc NameLoc;
 
   Type baseTy, baseObjTy;
   // UnresolvedMemberExpr doesn't have "base" expression,
   // it's represented as ".foo", which means that we need
   // to get base from the context.
-  if (isa<UnresolvedMemberExpr>(E)) {
+  if (auto *UME = dyn_cast<UnresolvedMemberExpr>(E)) {
     memberRange = E->getSourceRange();
     BaseLoc = E->getLoc();
+    NameLoc = UME->getNameLoc();
     baseTy = CS.getContextualType();
     if (!baseTy)
       return false;
@@ -7389,6 +7391,8 @@ bool FailureDiagnosis::diagnoseMemberFailures(
       locator = simplifyLocator(CS, locator, memberRange);
 
     BaseLoc = baseExpr->getLoc();
+    NameLoc = DeclNameLoc(memberRange.Start);
+
     // Retypecheck the anchor type, which is the base of the member expression.
     baseExpr =
         typeCheckArbitrarySubExprIndependently(baseExpr, TCC_AllowLValue);
@@ -7574,7 +7578,7 @@ bool FailureDiagnosis::diagnoseMemberFailures(
 
     // FIXME: Dig out the property DeclNameLoc.
     diagnoseUnviableLookupResults(result, baseObjTy, baseExpr, memberName,
-                                  DeclNameLoc(memberRange.Start), BaseLoc);
+                                  NameLoc, BaseLoc);
     return true;
   }
 

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -120,3 +120,18 @@ func takesAnyObjectArchetype<T : AnyObject>(_ t: T) {
   _ = t.rawPointer
   // expected-error@-1 {{value of type 'T' has no member 'rawPointer'}}
 }
+
+// Typo correction with an UnresolvedDotExpr.
+enum Foo {
+  // note: the fixit is actually for the line with the error below, but
+  // -verify mode is not smart enough for that yet.
+
+  case flashing // expected-note {{did you mean 'flashing'?}}{{8-15=flashing}}
+}
+
+func foo(_ a: Foo) {
+}
+
+func bar() {
+  foo(.flashin) // expected-error {{type 'Foo' has no member 'flashin'}}
+}


### PR DESCRIPTION
Fixes <rdar://problem/34421732>.