### PR TITLE
[build-script] Better metavar formatting

### DIFF
--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -76,8 +76,10 @@ class Action(argparse.Action):
         dests = dests or dest
         if dests == argparse.SUPPRESS:
             dests = []
+            metavar = metavar or ''
         elif isinstance(dests, str):
             dests = [dests]
+            metavar = metavar or dests[0].upper()
 
         super(Action, self).__init__(
             option_strings=option_strings,
@@ -242,6 +244,7 @@ class StorePathAction(StoreAction):
     def __init__(self, option_strings, **kwargs):
         kwargs['nargs'] = Nargs.SINGLE
         kwargs['type'] = PathType()
+        kwargs.setdefault('metavar', 'PATH')
 
         super(StorePathAction, self).__init__(
             option_strings=option_strings,


### PR DESCRIPTION
# Purpose

This PR updates the action class hierarchy in the `argparse` overlay module to have more default metavars and to populate the underlying `argparse.Action` `dest` attribute such that we can leverage the default metavar formatting.