### PR TITLE
Serialization: Fix module format version number

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 340; // Last change: remove 'volatile' bit from witness_method
+const uint16_t VERSION_MINOR = 390; // Last change: remove 'volatile' bit from witness_method
 
 using DeclIDField = BCFixed<31>;
 


### PR DESCRIPTION
I made a typo in https://github.com/apple/swift/pull/13159.
389 is followed by 390 and not 340.