### PR TITLE
IRGen: Followup fixes for handling subclasses of mixed-mode classes with missing ivars.

### DIFF
--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -179,6 +179,13 @@ namespace irgen {
   /// \p conformingType.
   bool doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
                                                      CanType conformingType);
+  
+  /// If the superclass came from another module, we may have dropped
+  /// stored properties due to the Swift language version availability of
+  /// their types. In these cases we can't precisely lay out the ivars in
+  /// the class object at compile time so we need to do runtime layout.
+  bool classHasIncompleteLayout(IRGenModule &IGM,
+                                ClassDecl *theClass);
 } // end namespace irgen
 } // end namespace swift
 

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
@@ -6,6 +6,8 @@
 
 // REQUIRES: objc_interop
 
+sil_stage canonical
+
 import Swift
 import UsingObjCStuff
 
@@ -13,7 +15,12 @@ class SubButtHolder: ButtHolder {
   var w: Double = 0
 }
 
+class SubSubButtHolder: SubButtHolder {
+  var v: Double = 0
+}
+
 sil_vtable SubButtHolder {}
+sil_vtable SubSubButtHolder {}
 
 // CHECK-LABEL: define {{.*}} @getHolder
 sil @getHolder: $@convention(thin) () -> @owned ButtHolder {
@@ -28,5 +35,11 @@ entry:
   // CHECK: [[ALIGN:%.*]] = zext i16 [[ALIGN16]] to [[WORD:i32|i64]]
   // CHECK: call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[METADATA]], [[WORD]] [[SIZE]], [[WORD]] [[ALIGN]])
   %x = alloc_ref $ButtHolder
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @_T04main13SubButtHolderCMa()
+  // CHECK: call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
+  %y = alloc_ref $SubButtHolder
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @_T04main03SubB10ButtHolderCMa()
+  // CHECK: call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
+  %z = alloc_ref $SubSubButtHolder
   return %x : $ButtHolder
 }

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V3
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V4
 
 // REQUIRES: objc_interop
 
@@ -66,3 +66,10 @@ public func invokeMethod(on holder: SubButtHolder) {
   // CHECK: call swiftcc void [[IMPL]]
   holder.subVirtual()
 }
+
+// CHECK-V3-LABEL: define private void @initialize_metadata_SubButtHolder
+// CHECK-V3:   call %swift.type* @swift_initClassMetadata_UniversalStrategy
+
+// CHECK-V3-LABEL: define private void @initialize_metadata_SubSubButtHolder
+// CHECK-V3:   call %swift.type* @swift_initClassMetadata_UniversalStrategy
+

--- a/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
+++ b/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
@@ -10,9 +10,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME: rdar://35747485
-// REQUIRES: optimized_stdlib
-
 import UsingObjCStuff
 
 print("Let's go") // CHECK: Let's go


### PR DESCRIPTION
Following up on the fixes for rdar://problem/35330067. If a class inherits a class from another module with missing fields, we need to treat its size and alignment as opaque, just like the base class itself. We also need to lay out such  class at runtime, since we don't know the size, alignment, or field offsets at compile time; relying on the ObjC runtime alone will slide the ivar offsets, but not the Swift instance size and alignment. Fixes rdar://problem/35747485.
