### PR TITLE
Revert "[CSGen] Fix `LinkedExprAnalyzer` greedy operator linking"

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -408,11 +408,6 @@ namespace {
       // argument types, we can directly simplify the associated constraint
       // graph.
       auto simplifyBinOpExprTyVars = [&]() {
-        // Don't attempt to do linking if there are
-        // literals intermingled with other inferred types.
-        if (lti.haveLiteral())
-          return;
-
         for (auto binExp1 : lti.binaryExprs) {
           for (auto binExp2 : lti.binaryExprs) {
             if (binExp1 == binExp2)

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -176,21 +176,3 @@ func + (lhs: B_28688585, rhs: B_28688585) -> B_28688585 {
 
 let var_28688585 = D_28688585(value: 1)
 _ = var_28688585 + var_28688585 + var_28688585 // Ok
-
-// rdar://problem/35740653 - Fix `LinkedExprAnalyzer` greedy operator linking
-
-struct S_35740653 {
-  var v: Double = 42
-
-  static func value(_ value: Double) -> S_35740653 {
-    return S_35740653(v: value)
-  }
-
-  static func / (lhs: S_35740653, rhs: S_35740653) -> Double {
-     return lhs.v / rhs.v
-  }
-}
-
-func rdar35740653(val: S_35740653) {
-  let _ = 0...Int(val / .value(1.0 / 42.0)) // Ok
-}


### PR DESCRIPTION
This reverts commit 29ea599f30e4f8e93e12e792673c3c5624da21ee.

SR-6505

