### PR TITLE
[4.1] [CSGen] Fix `LinkedExprAnalyzer` greedy operator linking

### DIFF
--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -176,3 +176,21 @@ func + (lhs: B_28688585, rhs: B_28688585) -> B_28688585 {
 
 let var_28688585 = D_28688585(value: 1)
 _ = var_28688585 + var_28688585 + var_28688585 // Ok
+
+// rdar://problem/35740653 - Fix `LinkedExprAnalyzer` greedy operator linking
+
+struct S_35740653 {
+  var v: Double = 42
+
+  static func value(_ value: Double) -> S_35740653 {
+    return S_35740653(v: value)
+  }
+
+  static func / (lhs: S_35740653, rhs: S_35740653) -> Double {
+     return lhs.v / rhs.v
+  }
+}
+
+func rdar35740653(val: S_35740653) {
+  let _ = 0...Int(val / .value(1.0 / 42.0)) // Ok
+}

--- a/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 6 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Let's not attempt to link arithmetic operators together in
presence of concrete and literal (int, float, string) types.

Resolves: rdar://problem/35740653
(cherry picked from commit 0783890b0351dfddc5082f0f34505daef81a1ae3)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
