### PR TITLE
[parser] '@available' attributes written in code should not be 'implicit'

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1013,7 +1013,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                      /*Obsoleted=*/clang::VersionTuple(),
                                      /*ObsoletedRange=*/SourceRange(),
                                      PlatformAgnostic,
-                                     /*Implicit=*/true));
+                                     /*Implicit=*/false));
       }
 
       if (!consumeIf(tok::r_paren)) {

--- a/test/IDE/print_swift_module_with_available.swift
+++ b/test/IDE/print_swift_module_with_available.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/mymod.swiftmodule -module-name mymod %s
+// RUN: %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=mymod -I %t -source-filename=%s > %t.syn.txt
+// RUN: %FileCheck %s -check-prefix=CHECK1 < %t.syn.txt
+
+// REQUIRES: OS=macosx
+
+@available(OSX 10.11, iOS 8.0, *)
+public class C1 {
+}
+
+@available(OSX 10.12, *)
+public extension C1 {
+  func ext_foo() {}
+}
+
+// CHECK1: @available(OSX 10.11, iOS 8.0, *)
+// CHECK1-NEXT: public class C1 {
+
+// CHECK1: @available(OSX 10.12, *)
+// CHECK1-NEXT: extension C1 {


### PR DESCRIPTION
'implicit' implies it was not written by the user. This was preventing printing '@available'
for interfaces of Swift code (e.g. from overlays).

rdar://35778715
