### PR TITLE
[stdlib] Make DoubleWidth conform to Unsigned/SignedInteger

### DIFF
--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -676,45 +676,7 @@ binaryOperators = [
   }
 }
 
-// FIXME(ABI) (Conditional Conformance):
-// DoubleWidth should conform to SignedInteger where Base : SignedInteger
-extension DoubleWidth where Base : SignedInteger {
-  /// Returns the additive inverse of the specified value.
-  ///
-  /// The negation operator (prefix `-`) returns the additive inverse of its
-  /// argument.
-  ///
-  ///     let x = 21 as DoubleWidth<Int>
-  ///     let y = -x
-  ///     // y == -21
-  ///
-  /// The resulting value must be representable in the same type as the
-  /// argument. In particular, negating a signed, fixed-width integer type's
-  /// minimum results in a value that cannot be represented.
-  ///
-  ///     let z = -DoubleWidth<Int>.min
-  ///     // Overflow error
-  ///
-  /// - Returns: The additive inverse of this value.
-  ///
-  /// - SeeAlso: `negate()`
-  @_inlineable // FIXME(sil-serialize-all)
-  public static prefix func - (_ operand: DoubleWidth) -> DoubleWidth {
-    return 0 - operand
-  }
-  
-  /// Replaces this value with its additive inverse.
-  ///
-  /// The following example uses the `negate()` method to negate the value of
-  /// an integer `x`:
-  ///
-  ///     var x = 21 as DoubleWidth<Int>
-  ///     x.negate()
-  ///     // x == -21
-  ///
-  /// - SeeAlso: The unary minus operator (`-`).
-  @_inlineable // FIXME(sil-serialize-all)
-  public mutating func negate() {
-    self = 0 - self
-  }
-}
+extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {}
+
+extension DoubleWidth : SignedNumeric, SignedInteger
+  where Base : SignedInteger {}

--- a/test/stdlib/DoubleWidth.swift
+++ b/test/stdlib/DoubleWidth.swift
@@ -15,6 +15,9 @@ typealias Int256 = DoubleWidth<Int128>
 typealias Int512 = DoubleWidth<Int256>
 typealias Int1024 = DoubleWidth<Int512>
 
+func checkSignedIntegerConformance<T: SignedInteger>(_ x: T) {}
+func checkUnsignedIntegerConformance<T: UnsignedInteger>(_ x: T) {}
+
 dwTests.test("Literals") {
   let w: DoubleWidth<UInt8> = 100
   expectTrue(w == 100 as Int)
@@ -339,6 +342,14 @@ dwTests.test("Words") {
     repeatElement(UInt.max, count: 1024 / UInt.bitWidth))
   expectEqualSequence((1 as Int1024).words,
     [1] + Array(repeating: 0, count: 1024 / UInt.bitWidth - 1))
+}
+
+dwTests.test("Conditional Conformance") {
+  checkSignedIntegerConformance(0 as Int128)
+  checkSignedIntegerConformance(0 as Int1024)
+
+  checkUnsignedIntegerConformance(0 as UInt128)
+  checkUnsignedIntegerConformance(0 as UInt1024)
 }
 
 runAllTests()


### PR DESCRIPTION
This makes `DoubleWidth` conform to the `SignedInteger` and `UnsignedInteger` protocols based on its base type. Does this fall under the rubric of obvious implications of conditional conformance?