### PR TITLE
Revert "Large Types Lowering: workaround LLDB issue by adding debug_value_addr for some new alloc_stack instrs"

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1465,10 +1465,6 @@ static void setInstrUsers(StructLoweringState &pass, AllocStackInst *allocInstr,
       SILValue tgt = storeUser->getDest();
       createOutlinedCopyCall(copyBuilder, allocInstr, tgt, pass);
       storeUser->eraseFromParent();
-    } else if (auto *dbgInst = dyn_cast<DebugValueInst>(user)) {
-      SILBuilder dbgBuilder(dbgInst);
-      // We need to create a debug for the alloc stack as well for LLDB
-      dbgBuilder.createDebugValueAddr(dbgInst->getLoc(), allocInstr);
     }
   }
 }


### PR DESCRIPTION
Reverts apple/swift#13168

Per offline discussions we don't need the extra `debug_value_addr`