### PR TITLE
[stdlib][NFC][WIP] Reorganize stdlib struct definitions

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -90,9 +90,7 @@ public func max<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 /// To create an instance of `EnumeratedIterator`, call
 /// `enumerated().makeIterator()` on a sequence or collection.
 @_fixed_layout
-public struct EnumeratedIterator<
-  Base : IteratorProtocol
-> : IteratorProtocol, Sequence {
+public struct EnumeratedIterator<Base: IteratorProtocol> {
   @_versioned
   internal var _base: Base
   @_versioned
@@ -105,7 +103,9 @@ public struct EnumeratedIterator<
     self._base = _base
     self._count = 0
   }
+}
 
+extension EnumeratedIterator: IteratorProtocol, Sequence {
   /// The type of element returned by `next()`.
   public typealias Element = (offset: Int, element: Base.Element)
 
@@ -139,7 +139,7 @@ public struct EnumeratedIterator<
 ///     // Prints "0: foo"
 ///     // Prints "1: bar"
 @_fixed_layout
-public struct EnumeratedSequence<Base : Sequence> : Sequence {
+public struct EnumeratedSequence<Base: Sequence> {
   @_versioned
   internal var _base: Base
 
@@ -149,7 +149,9 @@ public struct EnumeratedSequence<Base : Sequence> : Sequence {
   internal init(_base: Base) {
     self._base = _base
   }
+}
 
+extension EnumeratedSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   @_inlineable
   public func makeIterator() -> EnumeratedIterator<Base.Iterator> {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -455,13 +455,44 @@ if True:
 
 ${SelfDocComment}
 @_fixed_layout
-public struct ${Self}<Element>
-  : RandomAccessCollection,
-    MutableCollection,
-    _DestructorSafeContainer
-{
+public struct ${Self}<Element>: _DestructorSafeContainer {
+  %if Self == 'Array':
+  #if _runtime(_ObjC)
+    internal typealias _Buffer = _ArrayBuffer<Element>
+  #else
+    internal typealias _Buffer = _ContiguousArrayBuffer<Element>
+  #endif
+  %elif Self == 'ArraySlice':
+    internal typealias _Buffer = _SliceBuffer<Element>
+  %else:
+    internal typealias _Buffer = _${Self.strip('_')}Buffer<Element>
+  %end
 
+  @_versioned
+  internal var _buffer: _Buffer
+
+  /// Initialization from an existing buffer does not have "array.init"
+  /// semantics because the caller may retain an alias to buffer.
+  @_inlineable
+  @_versioned
+  internal init(_buffer: _Buffer) {
+    self._buffer = _buffer
+  }
+
+  %if Self == 'ArraySlice':
+  /// Initialization from an existing buffer does not have "array.init"
+  /// semantics because the caller may retain an alias to buffer.
+  @_inlineable
+  @_versioned
+  internal init(_buffer buffer: _ContiguousArrayBuffer<Element>) {
+    self.init(_buffer: _Buffer(_buffer: buffer, shiftedToStartIndex: 0))
+  }
+  %end
+}
+
+extension ${Self}: RandomAccessCollection, MutableCollection {
   public typealias Index = Int
+  public typealias Indices = CountableRange<Int>
   public typealias Iterator = IndexingIterator<${Self}>
 
 %if Self == 'ArraySlice':
@@ -662,8 +693,6 @@ public struct ${Self}<Element>
     // NOTE: This method is a no-op for performance reasons.
   }
 
-  public typealias Indices = CountableRange<Int>
-
   /// Accesses the element at the specified position.
   ///
   /// The following example uses indexed subscripting to update an array's
@@ -751,9 +780,10 @@ public struct ${Self}<Element>
       }
     }
   }
+}
 
-  //===--- private --------------------------------------------------------===//
-
+//===--- private helpers---------------------------------------------------===//
+extension ${Self} {
   /// Returns `true` if the array is native and does not need a deferred
   /// type check.  May be hoisted by the optimizer, which means its
   /// results may be stale by the time they are used if there is an
@@ -906,40 +936,6 @@ public struct ${Self}<Element>
   internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
     return _buffer.subscriptBaseAddress + index
   }
-
-%if Self == 'Array':
-#if _runtime(_ObjC)
-  internal typealias _Buffer = _ArrayBuffer<Element>
-#else
-  internal typealias _Buffer = _ContiguousArrayBuffer<Element>
-#endif
-%elif Self == 'ArraySlice':
-  internal typealias _Buffer = _SliceBuffer<Element>
-%else:
-  internal typealias _Buffer = _${Self.strip('_')}Buffer<Element>
-%end
-
-  /// Initialization from an existing buffer does not have "array.init"
-  /// semantics because the caller may retain an alias to buffer.
-
-  @_inlineable
-  @_versioned
-  internal init(_buffer: _Buffer) {
-    self._buffer = _buffer
-  }
-
-%if Self == 'ArraySlice':
-  /// Initialization from an existing buffer does not have "array.init"
-  /// semantics because the caller may retain an alias to buffer.
-  @_inlineable
-  @_versioned
-  internal init(_buffer buffer: _ContiguousArrayBuffer<Element>) {
-    self.init(_buffer: _Buffer(_buffer: buffer, shiftedToStartIndex: 0))
-  }
-%end
-
-  @_versioned
-  internal var _buffer: _Buffer
 }
 
 extension ${Self} : ExpressibleByArrayLiteral {

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -384,7 +384,7 @@ internal var _nilNativeObject: AnyObject? {
 /// already have writeback-scoped lifetime.
 @_fixed_layout
 public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
-  : Equatable, _Pointer {
+  :  _Pointer {
 
   public let _rawValue: Builtin.RawPointer
 
@@ -508,7 +508,9 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
     guard let unwrapped = from else { return nil }
     self.init(unwrapped)
   }
+}
 
+extension AutoreleasingUnsafeMutablePointer: Equatable {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public static func == (

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -87,7 +87,7 @@ public typealias CBool = Bool
 /// Opaque pointers are used to represent C pointers to types that
 /// cannot be represented in Swift, such as incomplete struct types.
 @_fixed_layout
-public struct OpaquePointer : Hashable {
+public struct OpaquePointer {
   @_versioned
   internal var _rawValue: Builtin.RawPointer
 
@@ -147,7 +147,16 @@ public struct OpaquePointer : Hashable {
     guard let unwrapped = from else { return nil }
     self.init(unwrapped)
   }
+}
 
+extension OpaquePointer: Equatable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func == (lhs: OpaquePointer, rhs: OpaquePointer) -> Bool {
+    return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
+  }
+}
+
+extension OpaquePointer: Hashable {
   /// The pointer's hash value.
   ///
   /// The hash value is not guaranteed to be stable across different
@@ -192,13 +201,6 @@ extension UInt {
   @_inlineable // FIXME(sil-serialize-all)
   public init(bitPattern pointer: OpaquePointer?) {
     self.init(bitPattern: UnsafeRawPointer(pointer))
-  }
-}
-
-extension OpaquePointer : Equatable {
-  @_inlineable // FIXME(sil-serialize-all)
-  public static func == (lhs: OpaquePointer, rhs: OpaquePointer) -> Bool {
-    return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
   }
 }
 

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -12,7 +12,10 @@
 
 /// An iterator that produces one or fewer instances of `Element`.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct IteratorOverOne<Element> : IteratorProtocol, Sequence {
+public struct IteratorOverOne<Element> {
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _elements: Element?
+
   /// Construct an instance that generates `_element!`, or an empty
   /// sequence if `_element == nil`.
   @_inlineable // FIXME(sil-serialize-all)
@@ -20,7 +23,9 @@ public struct IteratorOverOne<Element> : IteratorProtocol, Sequence {
   init(_elements: Element?) {
     self._elements = _elements
   }
+}
 
+extension IteratorOverOne: IteratorProtocol, Sequence {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -34,23 +39,25 @@ public struct IteratorOverOne<Element> : IteratorProtocol, Sequence {
     _elements = nil
     return result
   }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _elements: Element?
 }
 
 /// A collection containing a single element of type `Element`.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct CollectionOfOne<Element>
-  : MutableCollection, RandomAccessCollection {
+public struct CollectionOfOne<Element> {
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _element: Element
 
   /// Creates an instance containing just `element`.
   @_inlineable // FIXME(sil-serialize-all)
   public init(_ element: Element) {
     self._element = element
   }
+}
+
+extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 
   public typealias Index = Int
+  public typealias Indices = CountableRange<Int>
 
   /// The position of the first element.
   @_inlineable // FIXME(sil-serialize-all)
@@ -81,8 +88,6 @@ public struct CollectionOfOne<Element>
     _precondition(i == endIndex)
     return startIndex
   }
-
-  public typealias Indices = CountableRange<Int>
 
   /// Returns an iterator over the elements of this sequence.
   ///
@@ -129,9 +134,6 @@ public struct CollectionOfOne<Element>
   public var count: Int {
     return 1
   }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _element: Element
 }
 
 extension CollectionOfOne : CustomDebugStringConvertible {

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -19,11 +19,15 @@
 
 /// An iterator that never produces an element.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct EmptyIterator<Element> : IteratorProtocol, Sequence {
+public struct EmptyIterator<Element> {
+  // no properties
+  
   /// Creates an instance.
   @_inlineable // FIXME(sil-serialize-all)
   public init() {}
+}
 
+extension EmptyIterator: IteratorProtocol, Sequence {
   /// Returns `nil`, indicating that there are no more elements.
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func next() -> Element? {
@@ -33,20 +37,23 @@ public struct EmptyIterator<Element> : IteratorProtocol, Sequence {
 
 /// A collection whose element type is `Element` but that is always empty.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct EmptyCollection<Element> :
-  RandomAccessCollection, MutableCollection
-{
+public struct EmptyCollection<Element> {
+  // no properties
+
+  /// Creates an instance.
+  @_inlineable // FIXME(sil-serialize-all)
+  public init() {}
+}
+
+extension EmptyCollection: RandomAccessCollection, MutableCollection {
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = Int
   public typealias IndexDistance = Int
+  public typealias Indices = CountableRange<Int>
   public typealias SubSequence = EmptyCollection<Element>
-
-  /// Creates an instance.
-  @_inlineable // FIXME(sil-serialize-all)
-  public init() {}
 
   /// Always zero, just like `endIndex`.
   @_inlineable // FIXME(sil-serialize-all)
@@ -155,8 +162,6 @@ public struct EmptyCollection<Element> :
     _debugPrecondition(bounds == Range(indices),
       "invalid bounds for an empty collection")
   }
-
-  public typealias Indices = CountableRange<Int>
 }
 
 extension EmptyCollection : Equatable {

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -43,7 +43,10 @@ internal func _abstract(
 /// iterator having the same `Element` type, hiding the specifics of the
 /// underlying `IteratorProtocol`.
 @_fixed_layout
-public struct AnyIterator<Element> : IteratorProtocol {
+public struct AnyIterator<Element> {
+  @_versioned
+  internal let _box: _AnyIteratorBoxBase<Element>
+
   /// Creates an iterator that wraps a base iterator but whose type depends
   /// only on the base iterator's element type.
   ///
@@ -96,7 +99,9 @@ public struct AnyIterator<Element> : IteratorProtocol {
   internal init(_box: _AnyIteratorBoxBase<Element>) {
     self._box = _box
   }
+}
 
+extension AnyIterator: IteratorProtocol {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -105,14 +110,11 @@ public struct AnyIterator<Element> : IteratorProtocol {
   public func next() -> Element? {
     return _box.next()
   }
-
-  @_versioned
-  internal let _box: _AnyIteratorBoxBase<Element>
 }
 
 /// Every `IteratorProtocol` can also be a `Sequence`.  Note that
 /// traversing the sequence consumes the iterator.
-extension AnyIterator : Sequence {}
+extension AnyIterator: Sequence { }
 
 @_versioned
 @_fixed_layout
@@ -722,23 +724,23 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
 
 @_versioned
 @_fixed_layout
-internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
-  : Sequence {
+internal struct _ClosureBasedSequence<Iterator : IteratorProtocol> {
+  @_versioned
+  internal var _makeUnderlyingIterator: () -> Iterator
 
   @_versioned
   @_inlineable
   internal init(_ makeUnderlyingIterator: @escaping () -> Iterator) {
     self._makeUnderlyingIterator = makeUnderlyingIterator
   }
+}
 
+extension _ClosureBasedSequence: Sequence {
   @_versioned
   @_inlineable
   internal func makeIterator() -> Iterator {
     return _makeUnderlyingIterator()
   }
-
-  @_versioned
-  internal var _makeUnderlyingIterator: () -> Iterator
 }
 
 /// A type-erased sequence.
@@ -748,15 +750,10 @@ internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
 /// underlying sequence.
 //@_versioned
 @_fixed_layout
-public struct AnySequence<Element> : Sequence {
-  /// Creates a new sequence that wraps and forwards operations to `base`.
-  @_inlineable
-  public init<S : Sequence>(_ base: S)
-    where
-    S.Element == Element {
-    self._box = _SequenceBox(_base: base)
-  }
-
+public struct AnySequence<Element> {
+  @_versioned
+  internal let _box: _AnySequenceBox<Element>
+  
   /// Creates a sequence whose `makeIterator()` method forwards to
   /// `makeUnderlyingIterator`.
   @_inlineable
@@ -766,16 +763,23 @@ public struct AnySequence<Element> : Sequence {
     self.init(_ClosureBasedSequence(makeUnderlyingIterator))
   }
 
-  public typealias Iterator = AnyIterator<Element>
-
   @_versioned
   @_inlineable
   internal init(_box: _AnySequenceBox<Element>) {
     self._box = _box
   }
+}
 
-  @_versioned
-  internal let _box: _AnySequenceBox<Element>
+extension  AnySequence: Sequence {
+  public typealias Iterator = AnyIterator<Element>
+
+  /// Creates a new sequence that wraps and forwards operations to `base`.
+  @_inlineable
+  public init<S : Sequence>(_ base: S)
+    where
+    S.Element == Element {
+    self._box = _SequenceBox(_base: base)
+  }
 }
 
 % for Kind in ['Sequence', 'Collection', 'BidirectionalCollection', 'RandomAccessCollection']:
@@ -952,6 +956,9 @@ internal final class _IndexBox<
 /// A wrapper over an underlying index that hides the specific underlying type.
 @_fixed_layout
 public struct AnyIndex {
+  @_versioned
+  internal var _box: _AnyIndexBox
+
   /// Creates a new index wrapping `base`.
   @_inlineable
   public init<BaseIndex : Comparable>(_ base: BaseIndex) {
@@ -969,9 +976,6 @@ public struct AnyIndex {
   internal var _typeID: ObjectIdentifier {
     return _box._typeID
   }
-
-  @_versioned
-  internal var _box: _AnyIndexBox
 }
 
 extension AnyIndex : Comparable {
@@ -1024,19 +1028,25 @@ protocol _AnyCollectionProtocol : Collection {
 /// same `Element` type, hiding the specifics of the underlying
 /// collection.
 @_fixed_layout
-public struct ${Self}<Element>
-  : _AnyCollectionProtocol, ${SelfProtocol} {
-
-  public typealias Indices
-    = Default${Traversal.replace('Forward', '')}Indices<${Self}>
-
-  public typealias Iterator = AnyIterator<Element>
+public struct ${Self}<Element> {
+  @_versioned
+  internal let _box: _${Self}Box<Element>
 
   @_versioned
   @_inlineable
   internal init(_box: _${Self}Box<Element>) {
     self._box = _box
   }
+}
+
+extension ${Self}: ${SelfProtocol} {
+  public typealias Indices
+    = Default${Traversal.replace('Forward', '')}Indices<${Self}>
+
+  public typealias Iterator = AnyIterator<Element>
+  public typealias Index = AnyIndex
+  public typealias IndexDistance = Int64
+  public typealias SubSequence = ${Self}<Element> 
 
 %   for SubTraversal in TRAVERSALS[ti:]:
 %     SubProtocol = collectionForTraversal(SubTraversal)
@@ -1046,10 +1056,7 @@ public struct ${Self}<Element>
   ///
   /// - Complexity: O(1).
   @_inlineable
-  public init<C : ${SubProtocol}>(_ base: C)
-  where
-    C.Element == Element
-     {
+  public init<C : ${SubProtocol}>(_ base: C) where C.Element == Element {
     // Traversal: ${Traversal}
     // SubTraversal: ${SubTraversal}
     self._box = _${SubProtocol}Box<C>(
@@ -1060,9 +1067,7 @@ public struct ${Self}<Element>
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public init(
-    _ other: Any${SubProtocol}<Element>
-  ) {
+  public init(_ other: Any${SubProtocol}<Element>) {
     self._box = other._box
   }
 %   end
@@ -1075,9 +1080,7 @@ public struct ${Self}<Element>
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public init?(
-    _ other: Any${collectionForTraversal(SuperTraversal)}<Element>
-  ) {
+  public init?(_ other: Any${collectionForTraversal(SuperTraversal)}<Element>) {
     guard let box =
       other._box as? _${Self}Box<Element> else {
       return nil
@@ -1086,14 +1089,11 @@ public struct ${Self}<Element>
   }
 %   end
 
-  public typealias Index = AnyIndex
-  public typealias IndexDistance = Int64
-
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
   @_inlineable
-  public var startIndex: AnyIndex {
+  public var startIndex: Index {
     return AnyIndex(_box: _box._startIndex)
   }
 
@@ -1103,7 +1103,7 @@ public struct ${Self}<Element>
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
   @_inlineable
-  public var endIndex: AnyIndex {
+  public var endIndex: Index {
     return AnyIndex(_box: _box._endIndex)
   }
 
@@ -1112,18 +1112,18 @@ public struct ${Self}<Element>
   /// - Precondition: `position` indicates a valid position in `self` and
   ///   `position != endIndex`.
   @_inlineable
-  public subscript(position: AnyIndex) -> Element {
+  public subscript(position: Index) -> Element {
     return _box[position._box]
   }
 
   @_inlineable
-  public subscript(bounds: Range<AnyIndex>) -> ${Self}<Element> {
+  public subscript(bounds: Range<Index>) -> SubSequence {
     return ${Self}(_box:
       _box[start: bounds.lowerBound._box, end: bounds.upperBound._box])
   }
 
   @_inlineable
-  public func _failEarlyRangeCheck(_ index: AnyIndex, bounds: Range<AnyIndex>) {
+  public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     // Do nothing.  Doing a range check would involve unboxing indices,
     // performing dynamic dispatch etc.  This seems to be too costly for a fast
     // range check for QoI purposes.
@@ -1137,12 +1137,12 @@ public struct ${Self}<Element>
   }
 
   @_inlineable
-  public func index(after i: AnyIndex) -> AnyIndex {
+  public func index(after i: Index) -> Index {
     return AnyIndex(_box: _box._index(after: i._box))
   }
 
   @_inlineable
-  public func formIndex(after i: inout AnyIndex) {
+  public func formIndex(after i: inout Index) {
     if _isUnique(&i._box) {
       _box._formIndex(after: i._box)
     }
@@ -1152,22 +1152,20 @@ public struct ${Self}<Element>
   }
 
   @_inlineable
-  public func index(_ i: AnyIndex, offsetBy n: Int64) -> AnyIndex {
+  public func index(_ i: Index, offsetBy n: Int64) -> Index {
     return AnyIndex(_box: _box._index(i._box, offsetBy: n))
   }
 
   @_inlineable
   public func index(
-    _ i: AnyIndex,
-    offsetBy n: Int64,
-    limitedBy limit: AnyIndex
-  ) -> AnyIndex? {
+    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+  ) -> Index? {
     return _box._index(i._box, offsetBy: n, limitedBy: limit._box)
       .map { AnyIndex(_box:$0) }
   }
 
   @_inlineable
-  public func formIndex(_ i: inout AnyIndex, offsetBy n: Int64) {
+  public func formIndex(_ i: inout Index, offsetBy n: IndexDistance) {
     if _isUnique(&i._box) {
       return _box._formIndex(&i._box, offsetBy: n)
     } else {
@@ -1177,9 +1175,9 @@ public struct ${Self}<Element>
 
   @_inlineable
   public func formIndex(
-    _ i: inout AnyIndex,
-    offsetBy n: Int64,
-    limitedBy limit: AnyIndex
+    _ i: inout Index,
+    offsetBy n: IndexDistance,
+    limitedBy limit: Index
   ) -> Bool {
     if _isUnique(&i._box) {
       return _box._formIndex(&i._box, offsetBy: n, limitedBy: limit._box)
@@ -1193,7 +1191,7 @@ public struct ${Self}<Element>
   }
 
   @_inlineable
-  public func distance(from start: AnyIndex, to end: AnyIndex) -> Int64 {
+  public func distance(from start: Index, to end: Index) -> IndexDistance {
     return _box._distance(from: start._box, to: end._box)
   }
 
@@ -1207,7 +1205,7 @@ public struct ${Self}<Element>
 % end
   /// - Complexity: ${'O(1)' if Traversal == 'RandomAccess' else 'O(*n*)'}
   @_inlineable
-  public var count: Int64 {
+  public var count: IndexDistance {
     return _box._count
   }
 
@@ -1218,12 +1216,12 @@ public struct ${Self}<Element>
 
 %   if Traversal == 'Bidirectional' or Traversal == 'RandomAccess':
   @_inlineable
-  public func index(before i: AnyIndex) -> AnyIndex {
+  public func index(before i: Index) -> Index {
     return AnyIndex(_box: _box._index(before: i._box))
   }
 
   @_inlineable
-  public func formIndex(before i: inout AnyIndex) {
+  public func formIndex(before i: inout Index) {
     if _isUnique(&i._box) {
       _box._formIndex(before: i._box)
     }
@@ -1237,15 +1235,14 @@ public struct ${Self}<Element>
     return _box._last
   }
 %   end
+}
 
+extension ${Self}: _AnyCollectionProtocol {
   /// Uniquely identifies the stored underlying collection.
   @_inlineable
   public // Due to language limitations only
   var _boxID: ObjectIdentifier {
     return ObjectIdentifier(_box)
   }
-
-  @_versioned
-  internal let _box: _${Self}Box<Element>
 }
 % end

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -15,20 +15,9 @@
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct ObjectIdentifier : Hashable {
+public struct ObjectIdentifier {
   @_versioned // FIXME(sil-serialize-all)
   internal let _value: Builtin.RawPointer
-
-  // FIXME: Better hashing algorithm
-  /// The identifier's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program.  Do not persist the hash value across
-  /// program runs.
-  @_inlineable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return Int(Builtin.ptrtoint_Word(_value))
-  }
 
   /// Creates an instance that uniquely identifies the given class instance.
   ///
@@ -80,15 +69,30 @@ extension ObjectIdentifier : CustomDebugStringConvertible {
   }
 }
 
-extension ObjectIdentifier : Comparable {
+extension ObjectIdentifier: Equatable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func == (x: ObjectIdentifier, y: ObjectIdentifier) -> Bool {
+    return Bool(Builtin.cmp_eq_RawPointer(x._value, y._value))
+  }
+}
+
+extension ObjectIdentifier: Comparable {
   @_inlineable // FIXME(sil-serialize-all)
   public static func < (lhs: ObjectIdentifier, rhs: ObjectIdentifier) -> Bool {
     return UInt(bitPattern: lhs) < UInt(bitPattern: rhs)
   }
+}
 
+extension ObjectIdentifier: Hashable {
+  // FIXME: Better hashing algorithm
+  /// The identifier's hash value.
+  ///
+  /// The hash value is not guaranteed to be stable across different
+  /// invocations of the same program.  Do not persist the hash value across
+  /// program runs.
   @_inlineable // FIXME(sil-serialize-all)
-  public static func == (x: ObjectIdentifier, y: ObjectIdentifier) -> Bool {
-    return Bool(Builtin.cmp_eq_RawPointer(x._value, y._value))
+  public var hashValue: Int {
+    return Int(Builtin.ptrtoint_Word(_value))
   }
 }
 

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -140,10 +140,8 @@ extension RangeExpression {
 ///     print(brackets(-99..<100, 0))
 ///     // Prints "0"
 @_fixed_layout
-public struct CountableRange<Bound> : RandomAccessCollection
-  where
-  Bound : Strideable, Bound.Stride : SignedInteger {
-
+public struct CountableRange<Bound>
+where Bound : Strideable, Bound.Stride : SignedInteger {
   /// The range's lower bound.
   ///
   /// In an empty range, `lowerBound` is equal to `upperBound`.
@@ -158,13 +156,31 @@ public struct CountableRange<Bound> : RandomAccessCollection
   /// In an empty range, `upperBound` is equal to `lowerBound`.
   public let upperBound: Bound
 
+  /// Creates an instance with the given bounds.
+  ///
+  /// Because this initializer does not perform any checks, it should be used
+  /// as an optimization only when you are absolutely certain that `lower` is
+  /// less than or equal to `upper`. Using the half-open range operator
+  /// (`..<`) to form `CountableRange` instances is preferred.
+  ///
+  /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
+  @_inlineable
+  public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    self.lowerBound = bounds.lower
+    self.upperBound = bounds.upper
+  }
+}
+
+extension CountableRange: RandomAccessCollection {
+
   /// The bound type of the range.
   public typealias Element = Bound
 
   /// A type that represents a position in the range.
   public typealias Index = Element
-
   public typealias IndexDistance = Bound.Stride
+  public typealias Indices = CountableRange<Bound>
+  public typealias SubSequence = CountableRange<Bound>
 
   @_inlineable
   public var startIndex: Index {
@@ -204,14 +220,12 @@ public struct CountableRange<Bound> : RandomAccessCollection
     return start.distance(to: end)
   }
 
-  public typealias SubSequence = CountableRange<Bound>
-
   /// Accesses the subsequence bounded by the given range.
   ///
   /// - Parameter bounds: A range of the range's indices. The upper and lower
   ///   bounds of the `bounds` range must be valid indices of the collection.
   @_inlineable
-  public subscript(bounds: Range<Index>) -> CountableRange<Bound> {
+  public subscript(bounds: Range<Index>) -> SubSequence {
     return CountableRange(bounds)
   }
 
@@ -224,27 +238,11 @@ public struct CountableRange<Bound> : RandomAccessCollection
     return self[Range(bounds)]
   }
 
-  public typealias Indices = CountableRange<Bound>
-
   /// The indices that are valid for subscripting the range, in ascending
   /// order.
   @_inlineable
   public var indices: Indices {
     return self
-  }
-
-  /// Creates an instance with the given bounds.
-  ///
-  /// Because this initializer does not perform any checks, it should be used
-  /// as an optimization only when you are absolutely certain that `lower` is
-  /// less than or equal to `upper`. Using the half-open range operator
-  /// (`..<`) to form `CountableRange` instances is preferred.
-  ///
-  /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
-  @_inlineable
-  public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
-    self.lowerBound = bounds.lower
-    self.upperBound = bounds.upper
   }
 
   @_inlineable
@@ -315,7 +313,7 @@ extension CountableRange {
 }
 
 extension CountableRange
-  where
+where
   Bound._DisabledRangeIndex : Strideable,
   Bound._DisabledRangeIndex.Stride : SignedInteger {
 
@@ -394,9 +392,18 @@ extension CountableRange
 ///     print(empty.contains(0.0))          // Prints "false"
 ///     print(empty.isEmpty)                // Prints "true"
 @_fixed_layout
-public struct Range<
-  Bound : Comparable
-> {
+public struct Range<Bound : Comparable> {
+  /// The range's lower bound.
+  ///
+  /// In an empty range, `lowerBound` is equal to `upperBound`.
+  public let lowerBound: Bound
+
+  /// The range's upper bound.
+  ///
+  /// In an empty range, `upperBound` is equal to `lowerBound`. A `Range`
+  /// instance does not contain its upper bound.
+  public let upperBound: Bound
+
   /// Creates an instance with the given bounds.
   ///
   /// Because this initializer does not perform any checks, it should be used
@@ -410,17 +417,6 @@ public struct Range<
     self.lowerBound = bounds.lower
     self.upperBound = bounds.upper
   }
-
-  /// The range's lower bound.
-  ///
-  /// In an empty range, `lowerBound` is equal to `upperBound`.
-  public let lowerBound: Bound
-
-  /// The range's upper bound.
-  ///
-  /// In an empty range, `upperBound` is equal to `lowerBound`. A `Range`
-  /// instance does not contain its upper bound.
-  public let upperBound: Bound
 
   /// Returns a Boolean value indicating whether the given element is contained
   /// within the range.
@@ -760,12 +756,14 @@ extension ${Self} where Bound : Strideable, Bound.Stride : SignedInteger {
 ///     print(numbers[..<3])
 ///     // Prints "[10, 20, 30]"
 @_fixed_layout
-public struct PartialRangeUpTo<Bound: Comparable>: RangeExpression {
-  @_inlineable // FIXME(sil-serialize-all)
-  public init(_ upperBound: Bound) { self.upperBound = upperBound }
-  
+public struct PartialRangeUpTo<Bound: Comparable> {
   public let upperBound: Bound
   
+  @_inlineable // FIXME(sil-serialize-all)
+  public init(_ upperBound: Bound) { self.upperBound = upperBound }
+}
+
+extension PartialRangeUpTo: RangeExpression {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
@@ -802,12 +800,14 @@ public struct PartialRangeUpTo<Bound: Comparable>: RangeExpression {
 ///     print(numbers[...3])
 ///     // Prints "[10, 20, 30, 40]"
 @_fixed_layout
-public struct PartialRangeThrough<Bound: Comparable>: RangeExpression {  
-  @_inlineable // FIXME(sil-serialize-all)
-  public init(_ upperBound: Bound) { self.upperBound = upperBound }
-  
+public struct PartialRangeThrough<Bound: Comparable> {  
   public let upperBound: Bound
   
+  @_inlineable // FIXME(sil-serialize-all)
+  public init(_ upperBound: Bound) { self.upperBound = upperBound }
+}
+
+extension PartialRangeThrough: RangeExpression {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
@@ -843,19 +843,21 @@ public struct PartialRangeThrough<Bound: Comparable>: RangeExpression {
 ///     print(numbers[3...])
 ///     // Prints "[40, 50, 60, 70]"
 @_fixed_layout
-public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
+public struct PartialRangeFrom<Bound: Comparable> {
+  public let lowerBound: Bound
+
   @_inlineable // FIXME(sil-serialize-all)
   public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
-  
-  public let lowerBound: Bound
-  
+}
+
+extension PartialRangeFrom: RangeExpression {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
     return self.lowerBound..<collection.endIndex
   }
-  
+
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func contains(_ element: Bound) -> Bool {
@@ -944,12 +946,15 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
 /// `CountablePartialRangeFrom<Int>` traps when the sequence's next value
 /// would be above `Int.max`.
 @_fixed_layout
-public struct CountablePartialRangeFrom<
-  Bound: Strideable
->: RangeExpression where Bound.Stride : SignedInteger  {
+public struct CountablePartialRangeFrom<Bound: Strideable>
+where Bound.Stride : SignedInteger  {
+  public let lowerBound: Bound
+
   @_inlineable // FIXME(sil-serialize-all)
   public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
-  public let lowerBound: Bound
+}
+
+extension CountablePartialRangeFrom: RangeExpression {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func relative<C: Collection>(
@@ -966,6 +971,8 @@ public struct CountablePartialRangeFrom<
 extension CountablePartialRangeFrom: Sequence {
   @_fixed_layout
   public struct Iterator: IteratorProtocol {
+    @_versioned
+    internal var _current: Bound
     @_inlineable
     public init(_current: Bound) { self._current = _current }
     @_inlineable
@@ -973,8 +980,6 @@ extension CountablePartialRangeFrom: Sequence {
       defer { _current = _current.advanced(by: 1) }
       return _current
     }
-    @_versioned
-    internal var _current: Bound
   }
   @_inlineable
   public func makeIterator() -> Iterator { 

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -26,8 +26,15 @@
 ///     // "Humperdinck"
 ///     // "Humperdinck"
 @_fixed_layout
-public struct Repeated<Element> : RandomAccessCollection {
+public struct Repeated<Element> {
+  /// The number of elements in this collection.
+  public let count: Int
 
+  /// The value of every element in this collection.
+  public let repeatedValue: Element
+}
+
+extension Repeated: RandomAccessCollection {
   public typealias Indices = CountableRange<Int>
 
   /// A type that represents a valid position in the collection.
@@ -75,12 +82,6 @@ public struct Repeated<Element> : RandomAccessCollection {
     _precondition(position >= 0 && position < count, "Index out of range")
     return repeatedValue
   }
-
-  /// The number of elements in this collection.
-  public let count: Int
-
-  /// The value of every element in this collection.
-  public let repeatedValue: Element
 }
 
 /// Creates a collection containing the specified number of the given element.

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -164,7 +164,9 @@ extension ReversedIndex : Hashable where Base.Index : Hashable {
 ///
 /// - See also: `ReversedRandomAccessCollection`
 @_fixed_layout
-public struct ReversedCollection<Base: BidirectionalCollection>: BidirectionalCollection {
+public struct ReversedCollection<Base: BidirectionalCollection> {
+  public let _base: Base
+
   /// Creates an instance that presents the elements of `base` in
   /// reverse order.
   ///
@@ -174,13 +176,14 @@ public struct ReversedCollection<Base: BidirectionalCollection>: BidirectionalCo
   internal init(_base: Base) {
     self._base = _base
   }
+}
 
+extension ReversedCollection: BidirectionalCollection {
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = ReversedIndex<Base>
-
   public typealias IndexDistance = Base.IndexDistance
 
   @_fixed_layout
@@ -262,8 +265,6 @@ public struct ReversedCollection<Base: BidirectionalCollection>: BidirectionalCo
   public subscript(bounds: Range<Index>) -> Slice<ReversedCollection> {
     return Slice(base: self, bounds: bounds)
   }
-
-  public let _base: Base
 }
 
 extension ReversedCollection: RandomAccessCollection where Base: RandomAccessCollection { }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1433,15 +1433,18 @@ extension Sequence {
 ///
 ///     for x in IteratorSequence(i) { ... }
 @_fixed_layout
-public struct IteratorSequence<
-  Base : IteratorProtocol
-> : IteratorProtocol, Sequence {
+public struct IteratorSequence<Base : IteratorProtocol> {
+  @_versioned
+  internal var _base: Base
+
   /// Creates an instance whose iterator is a copy of `base`.
   @_inlineable
   public init(_ base: Base) {
     _base = base
   }
+}
 
+extension IteratorSequence: IteratorProtocol, Sequence {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -1453,7 +1456,4 @@ public struct IteratorSequence<
   public mutating func next() -> Base.Element? {
     return _base.next()
   }
-
-  @_versioned
-  internal var _base: Base
 }

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -81,6 +81,12 @@
 ///   requirements into account.
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct Slice<Base: Collection> {
+  public var _startIndex: Base.Index
+  public var _endIndex: Base.Index
+
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _base: Base
+
   /// Creates a view into the given collection that allows access to elements
   /// within the specified range.
   ///
@@ -106,12 +112,6 @@ public struct Slice<Base: Collection> {
     self._startIndex = bounds.lowerBound
     self._endIndex = bounds.upperBound
   }
-
-  public var _startIndex: Base.Index
-  public var _endIndex: Base.Index
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _base: Base
 
   /// The underlying collection of the slice.
   ///

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -163,7 +163,7 @@ extension Strideable where Self : FloatingPoint, Self == Stride {
 
 /// An iterator for `StrideTo<Element>`.
 @_fixed_layout
-public struct StrideToIterator<Element : Strideable> : IteratorProtocol {
+public struct StrideToIterator<Element : Strideable> {
   @_versioned
   internal let _start: Element
 
@@ -184,12 +184,13 @@ public struct StrideToIterator<Element : Strideable> : IteratorProtocol {
     _stride = stride
     _current = (0, _start)
   }
+}
 
+extension StrideToIterator: IteratorProtocol {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
-
   @_inlineable
   public mutating func next() -> Element? {
     let result = _current.value
@@ -202,16 +203,49 @@ public struct StrideToIterator<Element : Strideable> : IteratorProtocol {
 }
 
 /// A `Sequence` of values formed by striding over a half-open interval.
+// FIXME: should really be a Collection, as it is multipass
 @_fixed_layout
-public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
-  // FIXME: should really be a Collection, as it is multipass
+public struct StrideTo<Element : Strideable> {
+  @_versioned
+  internal let _start: Element
 
+  @_versioned
+  internal let _end: Element
+
+  @_versioned
+  internal let _stride: Element.Stride
+
+  @_inlineable
+  @_versioned
+  internal init(_start: Element, end: Element, stride: Element.Stride) {
+    _precondition(stride != 0, "Stride size must not be zero")
+    // At start, striding away from end is allowed; it just makes for an
+    // already-empty Sequence.
+    self._start = _start
+    self._end = end
+    self._stride = stride
+  }
+}
+
+extension StrideTo: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
   @_inlineable
   public func makeIterator() -> StrideToIterator<Element> {
     return StrideToIterator(_start: _start, end: _end, stride: _stride)
+  }
+
+  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
+  // here until a proper Collection conformance is possible
+  @_inlineable
+  public var underestimatedCount: Int {
+    var it = self.makeIterator()
+    var count = 0
+    while it.next() != nil {
+      count += 1
+    }
+    return count
   }
 
   @_inlineable
@@ -230,42 +264,12 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
     }
     return nil
   }
+}
 
-  @_inlineable
-  @_versioned
-  internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "Stride size must not be zero")
-    // At start, striding away from end is allowed; it just makes for an
-    // already-empty Sequence.
-    self._start = _start
-    self._end = end
-    self._stride = stride
-  }
-
-  @_versioned
-  internal let _start: Element
-
-  @_versioned
-  internal let _end: Element
-
-  @_versioned
-  internal let _stride: Element.Stride
-
+extension StrideTo: CustomReflectable {
   @_inlineable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, children: ["from": _start, "to": _end, "by": _stride])
-  }
-
-  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
-  // here until a proper Collection conformance is possible
-  @_inlineable
-  public var underestimatedCount: Int {
-    var it = self.makeIterator()
-    var count = 0
-    while it.next() != nil {
-      count += 1
-    }
-    return count
   }
 }
 
@@ -326,7 +330,7 @@ public func stride<T>(
 
 /// An iterator for `StrideThrough<Element>`.
 @_fixed_layout
-public struct StrideThroughIterator<Element : Strideable> : IteratorProtocol {
+public struct StrideThroughIterator<Element : Strideable> {
   @_versioned
   internal let _start: Element
 
@@ -350,7 +354,9 @@ public struct StrideThroughIterator<Element : Strideable> : IteratorProtocol {
     _stride = stride
     _current = (0, _start)
   }
+}
 
+extension StrideThroughIterator: IteratorProtocol {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -374,18 +380,45 @@ public struct StrideThroughIterator<Element : Strideable> : IteratorProtocol {
 }
 
 /// A `Sequence` of values formed by striding over a closed interval.
+// FIXME: should really be a CollectionType, as it is multipass
 @_fixed_layout
-public struct StrideThrough<
-  Element : Strideable
-> : Sequence, CustomReflectable {
-  // FIXME: should really be a CollectionType, as it is multipass
+public struct StrideThrough<Element: Strideable> {
+  @_versioned
+  internal let _start: Element
+  @_versioned
+  internal let _end: Element
+  @_versioned
+  internal let _stride: Element.Stride
+  
+  @_inlineable
+  @_versioned
+  internal init(_start: Element, end: Element, stride: Element.Stride) {
+    _precondition(stride != 0, "Stride size must not be zero")
+    self._start = _start
+    self._end = end
+    self._stride = stride
+  }
+}
 
+extension StrideThrough: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
   @_inlineable
   public func makeIterator() -> StrideThroughIterator<Element> {
     return StrideThroughIterator(_start: _start, end: _end, stride: _stride)
+  }
+
+  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
+  // here until a proper Collection conformance is possible
+  @_inlineable
+  public var underestimatedCount: Int {
+    var it = self.makeIterator()
+    var count = 0
+    while it.next() != nil {
+      count += 1
+    }
+    return count
   }
 
   @_inlineable
@@ -404,39 +437,13 @@ public struct StrideThrough<
     }
     return nil
   }
+}
 
-  @_inlineable
-  @_versioned
-  internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "Stride size must not be zero")
-    self._start = _start
-    self._end = end
-    self._stride = stride
-  }
-
-  @_versioned
-  internal let _start: Element
-  @_versioned
-  internal let _end: Element
-  @_versioned
-  internal let _stride: Element.Stride
-
+extension StrideThrough: CustomReflectable {
   @_inlineable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self,
       children: ["from": _start, "through": _end, "by": _stride])
-  }
-
-  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
-  // here until a proper Collection conformance is possible
-  @_inlineable
-  public var underestimatedCount: Int {
-    var it = self.makeIterator()
-    var count = 0
-    while it.next() != nil {
-      count += 1
-    }
-    return count
   }
 }
 

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -272,8 +272,7 @@
 ///       let numberPointer = Unsafe${Mutable}Pointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @_fixed_layout
-public struct ${Self}<Pointee>
-  : Strideable, Hashable, _Pointer {
+public struct ${Self}<Pointee>: _Pointer {
 
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int
@@ -851,11 +850,45 @@ public struct ${Self}<Pointee>
     }
 %  end
   }
+}
 
-  //
-  // Protocol conformance
-  //
+extension ${Self}: Equatable {
+  // - Note: Strideable's implementation is potentially less efficient and cannot
+  //   handle misaligned pointers.
+  /// Returns a Boolean value indicating whether two pointers are equal.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
+  ///   otherwise, `false`.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func == (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
+    return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
+  }
+}
 
+extension ${Self}: Comparable {
+  // - Note: Strideable's implementation is potentially less efficient and
+  // cannot handle misaligned pointers.
+  //
+  // - Note: This is an unsigned comparison unlike Strideable's implementation.
+  /// Returns a Boolean value indicating whether the first pointer references
+  /// an earlier memory location than the second pointer.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` references a memory address earlier than
+  ///   `rhs`; otherwise, `false`.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func < (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
+    return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
+  }
+}
+extension ${Self}: Hashable {
   /// The pointer's hash value.
   ///
   /// The hash value is not guaranteed to be stable across different
@@ -865,7 +898,9 @@ public struct ${Self}<Pointee>
   public var hashValue: Int {
     return Int(bitPattern: self)
   }
-
+}
+  
+extension ${Self}: Strideable {
   /// Returns a pointer to the next consecutive instance.
   ///
   /// The resulting pointer must be within the bounds of the same allocation as
@@ -964,44 +999,10 @@ extension ${Self} : CustomPlaygroundQuickLookable {
   }
 }
 
+// - Note: The following family of operator overloads are redundant
+//   with Strideable. However, optimizer improvements are needed
+//   before they can be removed without affecting performance.
 extension ${Self} {
-  // - Note: Strideable's implementation is potentially less efficient and cannot
-  //   handle misaligned pointers.
-  /// Returns a Boolean value indicating whether two pointers are equal.
-  ///
-  /// - Parameters:
-  ///   - lhs: A pointer.
-  ///   - rhs: Another pointer.
-  /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
-  ///   otherwise, `false`.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  public static func == (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
-    return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
-  }
-
-  // - Note: Strideable's implementation is potentially less efficient and
-  // cannot handle misaligned pointers.
-  //
-  // - Note: This is an unsigned comparison unlike Strideable's implementation.
-  /// Returns a Boolean value indicating whether the first pointer references
-  /// an earlier memory location than the second pointer.
-  ///
-  /// - Parameters:
-  ///   - lhs: A pointer.
-  ///   - rhs: Another pointer.
-  /// - Returns: `true` if `lhs` references a memory address earlier than
-  ///   `rhs`; otherwise, `false`.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  public static func < (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
-    return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
-  }
-
-  // - Note: The following family of operator overloads are redundant
-  //   with Strideable. However, optimizer improvements are needed
-  //   before they can be removed without affecting performance.
-
   /// Creates a new pointer, offset from a pointer by a specified number of
   /// instances of the pointer's `Pointee` type.
   ///

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -93,19 +93,17 @@
 ///     destBytes[0..<n] = someBytes[n..<(n + n)]
 % end
 @_fixed_layout
-public struct Unsafe${Mutable}RawBufferPointer
-  : ${Mutable}Collection, RandomAccessCollection {
-  // TODO: Specialize `index` and `formIndex` and
-  // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
+public struct Unsafe${Mutable}RawBufferPointer {
+  @_versioned
+  internal let _position, _end: Unsafe${Mutable}RawPointer?
+}
 
-  public typealias Index = Int
-  public typealias IndexDistance = Int
-  public typealias SubSequence = ${Mutable}Slice<${Self}>
+extension Unsafe${Mutable}RawBufferPointer: Sequence {
+  public typealias SubSequence = Slice<${Self}>
 
   /// An iterator over the bytes viewed by a raw buffer pointer.
   @_fixed_layout
   public struct Iterator : IteratorProtocol, Sequence {
-
     /// Advances to the next byte and returns it, or `nil` if no next byte
     /// exists.
     ///
@@ -133,6 +131,105 @@ public struct Unsafe${Mutable}RawBufferPointer
     }
   }
 
+  /// Returns an iterator over the bytes of this sequence.
+  @_inlineable
+  public func makeIterator() -> Iterator {
+    return Iterator(_position: _position, _end: _end)
+  }
+}
+
+extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
+  // TODO: Specialize `index` and `formIndex` and
+  // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
+  public typealias Element = UInt8
+  public typealias Index = Int
+  public typealias IndexDistance = Int
+  public typealias Indices = CountableRange<Int>
+
+  /// Always zero, which is the index of the first byte in a nonempty buffer.
+  @_inlineable
+  public var startIndex: Index {
+    return 0
+  }
+
+  /// The "past the end" position---that is, the position one greater than the
+  /// last valid subscript argument.
+  ///
+  /// The `endIndex` property of an `Unsafe${Mutable}RawBufferPointer`
+  /// instance is always identical to `count`.
+  @_inlineable
+  public var endIndex: Index {
+    return count
+  }
+
+  @_inlineable
+  public var indices: Indices {
+    return startIndex..<endIndex
+  }
+
+  /// Accesses the byte at the given offset in the memory region as a `UInt8`
+  /// value.
+  ///
+  /// - Parameter i: The offset of the byte to access. `i` must be in the range
+  ///   `0..<count`.
+  @_inlineable
+  public subscript(i: Int) -> Element {
+    get {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      return _position!.load(fromByteOffset: i, as: UInt8.self)
+    }
+%  if mutable:
+    nonmutating set {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
+    }
+%  end # mutable
+  }
+
+  /// Accesses the bytes in the specified memory region.
+  ///
+  /// - Parameter bounds: The range of byte offsets to access. The upper and
+  ///   lower bounds of the range must be in the range `0...count`.
+  @_inlineable
+  public subscript(bounds: Range<Int>) -> SubSequence {
+    get {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      return Slice(base: self, bounds: bounds)
+    }
+%  if mutable:
+    nonmutating set {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(bounds.count == newValue.count)
+
+      if !newValue.isEmpty {
+        (baseAddress! + bounds.lowerBound).copyMemory(
+          from: newValue.base.baseAddress! + newValue.startIndex,
+          byteCount: newValue.count)
+      }
+    }
+%  end # mutable
+  }
+
+  /// The number of bytes in the buffer.
+  ///
+  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
+  /// a buffer can have a `count` of zero even with a non-`nil` base address.
+  @_inlineable
+  public var count: Int {
+    if let pos = _position {
+      return _end! - pos
+    }
+    return 0
+  }
+}
+
+extension Unsafe${Mutable}RawBufferPointer: RandomAccessCollection { }
+
+extension Unsafe${Mutable}RawBufferPointer {
 %  if mutable:
   @available(swift, deprecated: 4.1, obsoleted: 5.0.0, renamed: "allocate(byteCount:alignment:)")
   public static func allocate(count: Int) -> UnsafeMutableRawBufferPointer { 
@@ -413,89 +510,9 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///
   /// - Parameter slice: The raw buffer slice to rebase.
   @_inlineable
-  public init(
-    rebasing slice: Slice<UnsafeMutableRawBufferPointer>
-  ) {
+  public init(rebasing slice: Slice<UnsafeMutableRawBufferPointer>) {
     self.init(start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)
-  }
-
-  /// Always zero, which is the index of the first byte in a nonempty buffer.
-  @_inlineable
-  public var startIndex: Int {
-    return 0
-  }
-
-  /// The "past the end" position---that is, the position one greater than the
-  /// last valid subscript argument.
-  ///
-  /// The `endIndex` property of an `Unsafe${Mutable}RawBufferPointer`
-  /// instance is always identical to `count`.
-  @_inlineable
-  public var endIndex: Int {
-    return count
-  }
-
-  public typealias Indices = CountableRange<Int>
-
-  @_inlineable
-  public var indices: Indices {
-    return startIndex..<endIndex
-  }
-
-  /// Accesses the byte at the given offset in the memory region as a `UInt8`
-  /// value.
-  ///
-  /// - Parameter i: The offset of the byte to access. `i` must be in the range
-  ///   `0..<count`.
-  @_inlineable
-  public subscript(i: Int) -> UInt8 {
-    get {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
-      return _position!.load(fromByteOffset: i, as: UInt8.self)
-    }
-%  if mutable:
-    nonmutating set {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
-      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
-    }
-%  end # mutable
-  }
-
-  /// Accesses the bytes in the specified memory region.
-  ///
-  /// - Parameter bounds: The range of byte offsets to access. The upper and
-  ///   lower bounds of the range must be in the range `0...count`.
-  @_inlineable
-  public subscript(
-    bounds: Range<Int>
-  ) -> Slice<Unsafe${Mutable}RawBufferPointer> {
-    get {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
-      return Slice(base: self, bounds: bounds)
-    }
-%  if mutable:
-    nonmutating set {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
-      _debugPrecondition(bounds.count == newValue.count)
-
-      if !newValue.isEmpty {
-        (baseAddress! + bounds.lowerBound).copyMemory(
-          from: newValue.base.baseAddress! + newValue.startIndex,
-          byteCount: newValue.count)
-      }
-    }
-%  end # mutable
-  }
-
-  /// Returns an iterator over the bytes of this sequence.
-  @_inlineable
-  public func makeIterator() -> Iterator {
-    return Iterator(_position: _position, _end: _end)
   }
 
   /// A pointer to the first byte of the buffer.
@@ -505,18 +522,6 @@ public struct Unsafe${Mutable}RawBufferPointer
   @_inlineable
   public var baseAddress: Unsafe${Mutable}RawPointer? {
     return _position
-  }
-
-  /// The number of bytes in the buffer.
-  ///
-  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
-  /// a buffer can have a `count` of zero even with a non-`nil` base address.
-  @_inlineable
-  public var count: Int {
-    if let pos = _position {
-      return _end! - pos
-    }
-    return 0
   }
 
   %  if mutable:
@@ -649,9 +654,6 @@ public struct Unsafe${Mutable}RawBufferPointer
     return Unsafe${Mutable}BufferPointer<T>(
       start: Unsafe${Mutable}Pointer<T>(base._rawValue), count: capacity)
   }
-  
-  @_versioned
-  internal let _position, _end: Unsafe${Mutable}RawPointer?
 }
 
 extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -895,6 +895,7 @@ public struct Unsafe${Mutable}RawPointer: _Pointer {
     _memmove(dest: self, src: source, size: UInt(byteCount))
   }
 %  end # mutable
+}
 
 extension ${Self}: Strideable {
   /// Returns the distance from this pointer to the given pointer.

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -219,7 +219,7 @@
 ///       let numberPointer = ${Self}(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @_fixed_layout
-public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
+public struct Unsafe${Mutable}RawPointer: _Pointer {
   /// The underlying raw pointer.
   /// Implements conformance to the public protocol `_Pointer`.
   public let _rawValue: Builtin.RawPointer
@@ -896,20 +896,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   }
 %  end # mutable
 
-  //
-  // Protocol conformance
-  //
-
-  /// The pointer's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program.  Do not persist the hash value across
-  /// program runs.
-  @_inlineable
-  public var hashValue: Int {
-    return Int(bitPattern: self)
-  }
-
+extension ${Self}: Strideable {
   /// Returns the distance from this pointer to the given pointer.
   ///
   /// With pointers `p` and `q`, the result of `p.distance(to: q)` is
@@ -941,7 +928,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   }
 }
 
-extension ${Self} {
+extension ${Self}: Equatable {
   // - Note: This may be more efficient than Strideable's implementation
   //   calling ${Self}.distance().
   /// Returns a Boolean value indicating whether two pointers are equal.
@@ -956,7 +943,9 @@ extension ${Self} {
   public static func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
   }
+}
 
+extension ${Self}: Comparable {
   // - Note: This is an unsigned comparison unlike Strideable's
   //   implementation.
   /// Returns a Boolean value indicating whether the first pointer references
@@ -971,6 +960,18 @@ extension ${Self} {
   @_transparent
   public static func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
+  }
+}
+
+extension ${Self}: Hashable {
+  /// The pointer's hash value.
+  ///
+  /// The hash value is not guaranteed to be stable across different
+  /// invocations of the same program.  Do not persist the hash value across
+  /// program runs.
+  @_inlineable
+  public var hashValue: Int {
+    return Int(bitPattern: self)
   }
 }
 

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -17,9 +17,7 @@
 //
 //===----------------------------------------------------------------------===//
 @_fixed_layout
-public struct _ValidUTF8Buffer<
-  Storage: UnsignedInteger & FixedWidthInteger
-> {
+public struct _ValidUTF8Buffer<Storage: UnsignedInteger & FixedWidthInteger> {
   public typealias Element = Unicode.UTF8.CodeUnit
   internal typealias _Storage = Storage
   

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -50,11 +50,16 @@ public func zip<Sequence1, Sequence2>(
 
 /// An iterator for `Zip2Sequence`.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct Zip2Iterator<
-  Iterator1 : IteratorProtocol, Iterator2 : IteratorProtocol
-> : IteratorProtocol {
+public struct Zip2Iterator<Iterator1: IteratorProtocol, Iterator2: IteratorProtocol> {
   /// The type of element returned by `next()`.
   public typealias Element = (Iterator1.Element, Iterator2.Element)
+
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _baseStream1: Iterator1
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _baseStream2: Iterator2
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _reachedEnd: Bool = false
 
   /// Creates an instance around a pair of underlying iterators.
   @_inlineable // FIXME(sil-serialize-all)
@@ -62,7 +67,9 @@ public struct Zip2Iterator<
   internal init(_ iterator1: Iterator1, _ iterator2: Iterator2) {
     (_baseStream1, _baseStream2) = (iterator1, iterator2)
   }
+}
 
+extension Zip2Iterator: IteratorProtocol {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -87,13 +94,6 @@ public struct Zip2Iterator<
 
     return (element1, element2)
   }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _baseStream1: Iterator1
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _baseStream2: Iterator2
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _reachedEnd: Bool = false
 }
 
 /// A sequence of pairs built out of two underlying sequences.
@@ -116,18 +116,16 @@ public struct Zip2Iterator<
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence>
-  : Sequence {
+public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
+  @_versioned // FIXME(sil-serialize-all)
+  internal let _sequence1: Sequence1
+  @_versioned // FIXME(sil-serialize-all)
+  internal let _sequence2: Sequence2
 
-    
   @available(*, deprecated, renamed: "Sequence1.Iterator")
   public typealias Stream1 = Sequence1.Iterator
   @available(*, deprecated, renamed: "Sequence2.Iterator")
   public typealias Stream2 = Sequence2.Iterator
-
-  /// A type whose instances can produce the elements of this
-  /// sequence, in order.
-  public typealias Iterator = Zip2Iterator<Sequence1.Iterator, Sequence2.Iterator>
 
   /// Creates an instance that makes pairs of elements from `sequence1` and
   /// `sequence2`.
@@ -136,6 +134,12 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence>
   init(_sequence1 sequence1: Sequence1, _sequence2 sequence2: Sequence2) {
     (_sequence1, _sequence2) = (sequence1, sequence2)
   }
+}
+
+extension Zip2Sequence: Sequence {
+  /// A type whose instances can produce the elements of this
+  /// sequence, in order.
+  public typealias Iterator = Zip2Iterator<Sequence1.Iterator, Sequence2.Iterator>
 
   /// Returns an iterator over the elements of this sequence.
   @_inlineable // FIXME(sil-serialize-all)
@@ -144,9 +148,4 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence>
       _sequence1.makeIterator(),
       _sequence2.makeIterator())
   }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal let _sequence1: Sequence1
-  @_versioned // FIXME(sil-serialize-all)
-  internal let _sequence2: Sequence2
 }

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
@@ -8,6 +8,8 @@
 // RUN: %target-swift-frontend -typecheck -I %t -enable-named-lazy-member-loading -stats-output-dir %t/stats-post %s
 // RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
 
+// REQUIRES: rdar35799113
+
 import NamedLazyMembers
 
 public func test(i: DerivedClass.derivedMemberType1) -> DerivedClass.derivedMemberType1 {

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -2,3 +2,6 @@
 // RUN: %sourcekitd-test -req=doc-info -module Foo -- -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         %mcp_opt %clang-importer-sdk | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
+//
+// REQUIRES: rdar35799113
+//

--- a/test/SourceKit/InterfaceGen/gen_swift_type.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_type.swift
@@ -5,6 +5,8 @@
 // RUN: %sourcekitd-test -req=interface-gen -usr _TtGC14gen_swift_type1DCS_2T1_ %s -- %s | %FileCheck -check-prefix=CHECK5 %s
 // RUN: %sourcekitd-test -req=interface-gen -usr _TtGC14gen_swift_type1DSi_ %s -- %s | %FileCheck -check-prefix=CHECK6 %s
 
+// REQUIRES: rdar35799113
+
 public struct A {
 	public func fa() {}
 }


### PR DESCRIPTION
This is a (hopefully :) NFC to reorganize the public structs in the standard library to:
 * hoist stored properties to the top
 * factor out conformances into separate extensions

This is in preparation for various audits and changes that need to be done on the standard library in preparation for ABI stability, as well as to eliminate some of the recently introduced false positive near-miss warnings.

I'm trying to follow these general rules:
 * close a struct's definition early – mostly keep it to just stored properties and basic inits, possibly some internal/`_`-ed protocol conformances
 * if needed, before the stored properties, define types/typealiases for them
 * split out multiple conformances into separate extensions
 * except where not possible (i.e. `Collection`/`MutableCollection`) or where that means breaking up lots of very similar definitions (i.e. don't split out `Bidirectional`/`RandomAccess` conformance)
* associated type defs at the top of each conformance
 * group together similar definitions i.e. `Equatable`/`Comparable`/`Hashable` should be together
 * internal structs can still declare and conform in one if they're small

I'm leaving a few files alone because of inflight changes elsewhere, to avoid merge conflicts.