### PR TITLE
[CMake] Add dependencies for swift-syntax-generated-headers

### DIFF
--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -5,7 +5,9 @@ add_swift_library(swiftFrontend STATIC
   FrontendOptions.cpp
   PrintingDiagnosticConsumer.cpp
   SerializedDiagnosticConsumer.cpp
-  DEPENDS SwiftOptions
+  DEPENDS
+    SwiftOptions
+    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftSIL
     swiftMigrator

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -44,6 +44,8 @@ add_swift_library(swiftMigrator STATIC
   RewriteBufferEditsReceiver.cpp
   TupleSplatMigratorPass.cpp
   TypeOfMigratorPass.cpp
+  DEPENDS
+    swift-syntax-generated-headers
   LINK_LIBRARIES swiftSyntax swiftIDE)
 
 add_dependencies(swiftMigrator


### PR DESCRIPTION
This should fix some CI errors we are observing lately.

rdar://problem/35725453