### PR TITLE
embed-bitcode.ll test: Use -Xllvm -debug-pass=Structure to dump the LLVM

### DIFF
--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -10,7 +10,7 @@
 ; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t2.o | %FileCheck -check-prefix=CHECK-CMD %s
 ; RUN: %FileCheck -check-prefix CHECK-COMPILER %s < %t.diags.txt
 
-; RUN: %swiftc_driver_plain -frontend -O -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -Xllvm -time-passes -o %t2-opt.o %t.bc -dump-clang-diagnostics 2> %t.diags-opt.txt
+; RUN: %swiftc_driver_plain -frontend -O -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -Xllvm -time-passes -o %t2-opt.o %t.bc -dump-clang-diagnostics -Xllvm -debug-pass=Structure 2> %t.diags-opt.txt
 ; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t2-opt.o | %FileCheck %s
 ; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t2-opt.o | %FileCheck -check-prefix=CHECK-CMD-OPT %s
 ; RUN: %FileCheck -check-prefix CHECK-COMPILER-OPT %s < %t.diags-opt.txt


### PR DESCRIPTION
passes

The test case looks for the Objective C ARC contraction pass. It uses
-Xllvm  -time-passes and then greps for the pass.  It seems that
-time-passes is not always printing the pass. Use -Xllvm
-debug-pass=Structure instead that should print the added passes
reliably.

rdar://35796399
