### PR TITLE
Be way more conservative about marking dependencies as non-cascading

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -612,48 +612,23 @@ DeclContext::isCascadingContextForLookup(bool functionsAreNonCascading) const {
     // FIXME: Pattern initializers at top-level scope end up here.
     return true;
 
-  case DeclContextKind::AbstractFunctionDecl: {
+  case DeclContextKind::AbstractFunctionDecl:
     if (functionsAreNonCascading)
       return false;
-    auto *AFD = cast<AbstractFunctionDecl>(this);
-    if (AFD->hasAccess())
-      return AFD->getFormalAccess() > AccessLevel::FilePrivate;
     break;
-  }
 
-  case DeclContextKind::SubscriptDecl: {
-    auto *SD = cast<SubscriptDecl>(this);
-    if (SD->hasAccess())
-      return SD->getFormalAccess() > AccessLevel::FilePrivate;
+  case DeclContextKind::SubscriptDecl:
     break;
-  }
-      
+
   case DeclContextKind::Module:
   case DeclContextKind::FileUnit:
     return true;
 
-  case DeclContextKind::GenericTypeDecl: {
-    auto *nominal = cast<GenericTypeDecl>(this);
-    if (nominal->hasAccess())
-      return nominal->getFormalAccess() > AccessLevel::FilePrivate;
+  case DeclContextKind::GenericTypeDecl:
     break;
-  }
 
-  case DeclContextKind::ExtensionDecl: {
-    auto *extension = cast<ExtensionDecl>(this);
-    if (extension->hasDefaultAccessLevel())
-      return extension->getDefaultAccessLevel() > AccessLevel::FilePrivate;
-    // FIXME: duplicated from computeDefaultAccessLevel in TypeCheckDecl.cpp.
-    if (auto *AA = extension->getAttrs().getAttribute<AccessControlAttr>())
-      return AA->getAccess() > AccessLevel::FilePrivate;
-    if (Type extendedTy = extension->getExtendedType()) {
-
-      // Need to check if extendedTy is ErrorType
-      if (extendedTy->getAnyNominal())
-        return extendedTy->getAnyNominal()->isCascadingContextForLookup(true);
-    }
-    break;
-  }
+  case DeclContextKind::ExtensionDecl:
+    return true;
   }
 
   return getParent()->isCascadingContextForLookup(true);

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -342,8 +342,10 @@ void IterativeTypeChecker::processResolveTypeDecl(
         typeAliasDecl->getGenericParams() == nullptr) {
       TypeResolutionOptions options =
                                    TypeResolutionFlags::TypeAliasUnderlyingType;
-      if (typeAliasDecl->getFormalAccess() <= AccessLevel::FilePrivate)
+      if (!typeAliasDecl->getDeclContext()->isCascadingContextForLookup(
+            /*functionsAreNonCascading*/true)) {
         options |= TypeResolutionFlags::KnownNonCascadingDependency;
+      }
 
       // Note: recursion into old type checker is okay when passing in an
       // unsatisfied-dependency callback.

--- a/test/NameBinding/Dependencies/Inputs/InterestingType.swift
+++ b/test/NameBinding/Dependencies/Inputs/InterestingType.swift
@@ -1,0 +1,23 @@
+protocol IntMaker {}
+extension IntMaker {
+  func make() -> Int { return 0 }
+}
+
+protocol DoubleMaker {}
+extension DoubleMaker {
+  func make() -> Double { return 0 }
+}
+
+
+#if OLD
+typealias InterestingType = Int
+typealias InterestingProto = IntMaker
+
+#elseif NEW
+typealias InterestingType = Double
+typealias InterestingProto = DoubleMaker
+
+#else
+typealias InterestingType = ErrorMustSetOLDOrNew
+
+#endif

--- a/test/NameBinding/Dependencies/private-function-return-type.swift
+++ b/test/NameBinding/Dependencies/private-function-return-type.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private func testReturnType() -> InterestingType { fatalError() }
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = testReturnType() + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingType"

--- a/test/NameBinding/Dependencies/private-function.swift
+++ b/test/NameBinding/Dependencies/private-function.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private func testParamType(_: InterestingType) {}
+
+// CHECK-OLD: sil_global hidden @_T04main1x{{[^ ]+}} : ${{(@[a-zA-Z_]+ )?}}(Int) -> ()
+// CHECK-NEW: sil_global hidden @_T04main1x{{[^ ]+}} : ${{(@[a-zA-Z_]+ )?}}(Double) -> ()
+internal var x = testParamType
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingType"

--- a/test/NameBinding/Dependencies/private-protocol-conformer-ext.swift
+++ b/test/NameBinding/Dependencies/private-protocol-conformer-ext.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private struct Test {}
+extension Test : InterestingProto {}
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = Test().make() + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingProto"
+
+// CHECK-DEPS-LABEL: depends-member:
+// CHECK-DEPS: - ["4main{{8IntMaker|11DoubleMaker}}P", "make"]
+
+// CHECK-DEPS-LABEL: depends-nominal:
+// CHECK-DEPS: - "4main{{8IntMaker|11DoubleMaker}}P"

--- a/test/NameBinding/Dependencies/private-protocol-conformer.swift
+++ b/test/NameBinding/Dependencies/private-protocol-conformer.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private struct Test : InterestingProto {}
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = Test().make() + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingProto"
+
+// CHECK-DEPS-LABEL: depends-member:
+// CHECK-DEPS: - ["4main{{8IntMaker|11DoubleMaker}}P", "make"]
+
+// CHECK-DEPS-LABEL: depends-nominal:
+// CHECK-DEPS: - "4main{{8IntMaker|11DoubleMaker}}P"

--- a/test/NameBinding/Dependencies/private-struct-member.swift
+++ b/test/NameBinding/Dependencies/private-struct-member.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private struct Wrapper {
+  static func test() -> InterestingType { fatalError() }
+}
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = Wrapper.test() + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingType"

--- a/test/NameBinding/Dependencies/private-subscript.swift
+++ b/test/NameBinding/Dependencies/private-subscript.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+struct Wrapper {
+  fileprivate subscript() -> InterestingType { fatalError() }
+}
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = Wrapper()[] + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingType"

--- a/test/NameBinding/Dependencies/private-typealias.swift
+++ b/test/NameBinding/Dependencies/private-typealias.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private struct Wrapper {
+  static func test() -> InterestingType { fatalError() }
+}
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = Wrapper.test() + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingType"

--- a/test/NameBinding/Dependencies/private-var.swift
+++ b/test/NameBinding/Dependencies/private-var.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
+
+private var privateVar: InterestingType { fatalError() }
+
+// CHECK-OLD: sil_global @_T04main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @_T04main1x{{[^ ]+}} : $Double
+public var x = privateVar + 0
+
+// CHECK-DEPS-LABEL: depends-top-level:
+// CHECK-DEPS: - "InterestingType"

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -126,7 +126,7 @@ extension Bool {
 protocol ExpressibleByExtraFloatLiteral
     : ExpressibleByOtherFileAliasForFloatLiteral {
 }
-// CHECK-DAG: !private "ExpressibleByUnicodeScalarLiteral"
+// CHECK-DAG: - "ExpressibleByUnicodeScalarLiteral"
 private protocol ExpressibleByExtraCharLiteral : ExpressibleByUnicodeScalarLiteral {
 }
 
@@ -341,8 +341,8 @@ struct StructForDeclaringProperties {
 
 // CHECK-DAG: !private "privateTopLevel1"
 func private1(_ a: Int = privateTopLevel1()) {}
-// CHECK-DAG: !private "privateTopLevel2"
-// CHECK-DAG: !private "PrivateProto1"
+// CHECK-DAG: - "privateTopLevel2"
+// CHECK-DAG: - "PrivateProto1"
 private struct Private2 : PrivateProto1 {
   var private2 = privateTopLevel2()
 }
@@ -351,11 +351,11 @@ func outerPrivate3() {
   let _ = { privateTopLevel3() }
 }
 
-// CHECK-DAG: !private "PrivateTopLevelTy1"
+// CHECK-DAG: - "PrivateTopLevelTy1"
 private extension Use4 {
   var privateTy1: PrivateTopLevelTy1? { return nil }
 } 
-// CHECK-DAG: !private "PrivateTopLevelTy2"
+// CHECK-DAG: - "PrivateTopLevelTy2"
 // CHECK-DAG: "PrivateProto2"
 extension Private2 : PrivateProto2 {
   // FIXME: This test is supposed to check that we get this behavior /without/
@@ -367,21 +367,21 @@ func outerPrivateTy3() {
   func inner(_ a: PrivateTopLevelTy3?) {}
   inner(nil)
 }
-// CHECK-DAG: !private "PrivateTopLevelStruct3"
+// CHECK-DAG: - "PrivateTopLevelStruct3"
 private typealias PrivateTy4 = PrivateTopLevelStruct3.ValueType
-// CHECK-DAG: !private "PrivateTopLevelStruct4"
+// CHECK-DAG: - "PrivateTopLevelStruct4"
 private func privateTy5(_ x: PrivateTopLevelStruct4.ValueType) -> PrivateTopLevelStruct4.ValueType {
   return x
 }
 
 // Deliberately empty.
 private struct PrivateTy6 {}
-// CHECK-DAG: !private "PrivateProto3"
+// CHECK-DAG: - "PrivateProto3"
 extension PrivateTy6 : PrivateProto3 {}
 
 // CHECK-DAG: - "ProtoReferencedOnlyInGeneric"
 func genericTest<T: ProtoReferencedOnlyInGeneric>(_: T) {}
-// CHECK-DAG: !private "ProtoReferencedOnlyInPrivateGeneric"
+// CHECK-DAG: - "ProtoReferencedOnlyInPrivateGeneric"
 private func privateGenericTest<T: ProtoReferencedOnlyInPrivateGeneric>(_: T) {}
 
 struct PrivateStoredProperty {
@@ -436,8 +436,8 @@ struct Sentinel2 {}
 // CHECK-DAG: - ["4main15TopLevelStruct5V", "ValueType"]
 // CHECK-DAG: - !private ["4main21PrivateTopLevelStructV", "ValueType"]
 // CHECK-DAG: - !private ["4main22PrivateTopLevelStruct2V", "ValueType"]
-// CHECK-DAG: - !private ["4main22PrivateTopLevelStruct3V", "ValueType"]
-// CHECK-DAG: - !private ["4main22PrivateTopLevelStruct4V", "ValueType"]
+// CHECK-DAG: - ["4main22PrivateTopLevelStruct3V", "ValueType"]
+// CHECK-DAG: - ["4main22PrivateTopLevelStruct4V", "ValueType"]
 
 // CHECK-DAG: - ["4main14TopLevelProto1P", ""]
 // CHECK-DAG: - ["4main14TopLevelProto2P", ""]
@@ -463,13 +463,13 @@ struct Sentinel2 {}
 // CHECK: - !private "4main18OtherFileOuterTypeV"
 // CHECK: - !private "4main25OtherFileProtoImplementorV"
 // CHECK: - !private "4main26OtherFileProtoImplementor2V"
-// CHECK: - !private "4main13PrivateProto1P"
-// CHECK: - !private "4main13PrivateProto2P"
+// CHECK: - "4main13PrivateProto1P"
+// CHECK: - "4main13PrivateProto2P"
 // CHECK: - !private "4main13PrivateProto3P"
 // CHECK: - !private "4main21PrivateTopLevelStructV"
 // CHECK: - !private "4main22PrivateTopLevelStruct2V"
-// CHECK: - !private "4main22PrivateTopLevelStruct3V"
-// CHECK: - !private "4main22PrivateTopLevelStruct4V"
+// CHECK: - "4main22PrivateTopLevelStruct3V"
+// CHECK: - "4main22PrivateTopLevelStruct4V"
 // CHECK: - !private "4main26OtherFileSecretTypeWrapperV0dE0V"
 // CHECK: - !private "s10StrideableP"
 // CHECK: - "4main23TopLevelForMemberLookupV"

--- a/validation-test/SIL/crashers/039-swift-iterativetypechecker-processresolvetypedecl.sil
+++ b/validation-test/SIL/crashers/039-swift-iterativetypechecker-processresolvetypedecl.sil
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-struct I:b:typealias b:a
-typealias a=f

--- a/validation-test/SIL/crashers_fixed/039-swift-iterativetypechecker-processresolvetypedecl.sil
+++ b/validation-test/SIL/crashers_fixed/039-swift-iterativetypechecker-processresolvetypedecl.sil
@@ -1,0 +1,3 @@
+// RUN: not %target-sil-opt %s
+struct I:b:typealias b:a
+typealias a=f


### PR DESCRIPTION
Being part of the type of a private declaration isn't sufficient, because that could be used for the inferred type of a non-private variable/constant/property.

Also, introduce a new kind of dependency test that shows both that a file A changes its interface based on a change in another file B, and that the swiftdeps output for file A includes the dependency on file B as cascading.

[SR-6149](https://bugs.swift.org/browse/SR-6149) / rdar://problem/35007547