### PR TITLE
resolve-crashes.py: remove "REQUIRES: asserts" as well

### DIFF
--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -35,15 +35,20 @@ for line in sys.stdin:
         git_mv_cmd = 'git mv %s %s' % (from_filename, to_filename)
         execute_cmd(git_mv_cmd)
 
-        # Replace "not --crash" with "not", and remove XFAIL lines.
+        # Replace "not --crash" with "not".
         sed_replace_not_cmd = 'sed -e "s/not --crash/not/" -i "" %s' % (
             to_filename)
         execute_cmd(sed_replace_not_cmd)
 
         # Remove "// XFAIL: whatever" lines.
-        sed_remove_xfail_cmd = 'sed -e "s/^\\/\\/.*XFAIL.*$//g" -i "" %s' % (
+        sed_remove_xfail_cmd = 'sed -e "s|^//.*XFAIL.*$||g" -i "" %s' % (
             to_filename)
         execute_cmd(sed_remove_xfail_cmd)
+
+        # Remove "// REQUIRES: asserts" lines.
+        sed_remove_requires_asserts_cmd = \
+            'sed -e "s|^//.*REQUIRES: asserts.*$||g" -i "" %s' % (to_filename)
+        execute_cmd(sed_remove_requires_asserts_cmd)
 
         # "git add" the result.
         git_add_cmd = 'git add %s' % (to_filename)


### PR DESCRIPTION
We keep doing this by hand and there's no reason to do so.