### PR TITLE
Make Metal(Kit) overlays build in Swift 4 mode

### DIFF
--- a/stdlib/public/SDK/Metal/CMakeLists.txt
+++ b/stdlib/public/SDK/Metal/CMakeLists.txt
@@ -4,7 +4,7 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_library(swiftMetal ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Metal.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation CoreGraphics Dispatch Foundation IOKit ObjectiveC XPC # auto-updated

--- a/stdlib/public/SDK/Metal/Metal.swift
+++ b/stdlib/public/SDK/Metal/Metal.swift
@@ -17,7 +17,7 @@
 extension MTLBlitCommandEncoder {
     
     public func fill(buffer: MTLBuffer, range: Range<Int>, value: UInt8) {
-        fill(buffer: buffer, range: NSMakeRange(range.lowerBound, range.count), value: value)
+        __fill(buffer, range: NSMakeRange(range.lowerBound, range.count), value: value)
     }
 }
 
@@ -28,13 +28,13 @@ extension MTLBuffer {
 #if os(OSX)
     @available(macOS, introduced: 10.11)
     public func didModifyRange(_ range: Range<Int>) {
-        didModifyRange(NSMakeRange(range.lowerBound, range.count))
+        __didModifyRange(NSMakeRange(range.lowerBound, range.count))
     }
 #endif
     
     @available(macOS 10.12, iOS 10.0, tvOS 10.0, *)
     public func addDebugMarker(_ marker: String, range: Range<Int>) {
-        addDebugMarker(marker, range: NSMakeRange(range.lowerBound, range.count))
+        __addDebugMarker(marker, range: NSMakeRange(range.lowerBound, range.count))
     }
 }
 
@@ -44,28 +44,28 @@ extension MTLComputeCommandEncoder {
     
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func useResources(_ resources: [MTLResource], usage: MTLResourceUsage) {
-        useResources(resources, count: resources.count, usage: usage)
+        __use(resources, count: resources.count, usage: usage)
     }
     
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func useHeaps(_ heaps: [MTLHeap]) {
-        useHeaps(heaps, count: heaps.count)
+        __use(heaps, count: heaps.count)
     }
     
     public func setBuffers(_ buffers: [MTLBuffer?], offsets: [Int], range: Range<Int>) {
-        setBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
+        __setBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setTextures(_ textures: [MTLTexture?], range: Range<Int>) {
-        setTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
+        __setTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setSamplerStates(_ samplers: [MTLSamplerState?], range: Range<Int>) {
-        setSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
+        __setSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setSamplerStates(_ samplers: [MTLSamplerState?], lodMinClamps: [Float], lodMaxClamps: [Float], range: Range<Int>) {
-        setSamplerStates(samplers, lodMinClamps: lodMinClamps, lodMaxClamps: lodMaxClamps, with: NSMakeRange(range.lowerBound, range.count))
+        __setSamplerStates(samplers, lodMinClamps: lodMinClamps, lodMaxClamps: lodMaxClamps, with: NSMakeRange(range.lowerBound, range.count))
     }
 }
 
@@ -76,7 +76,7 @@ extension MTLDevice {
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func getDefaultSamplePositions(sampleCount: Int) -> [MTLSamplePosition] {
         var positions = [MTLSamplePosition](repeating: MTLSamplePosition(x: 0,y: 0), count: sampleCount)
-        getDefaultSamplePositions(&positions, count: sampleCount)
+        __getDefaultSamplePositions(&positions, count: sampleCount)
         return positions
     }
 }
@@ -87,7 +87,7 @@ extension MTLDevice {
 public func MTLCopyAllDevicesWithObserver(handler: @escaping MTLDeviceNotificationHandler) -> (devices:[MTLDevice], observer:NSObject) {
     var resultTuple: (devices:[MTLDevice], observer:NSObject)
     resultTuple.observer = NSObject()
-    resultTuple.devices = MTLCopyAllDevicesWithObserver(AutoreleasingUnsafeMutablePointer<NSObjectProtocol?>(&resultTuple.observer), handler)
+    resultTuple.devices = __MTLCopyAllDevicesWithObserver(AutoreleasingUnsafeMutablePointer<NSObjectProtocol?>(&resultTuple.observer), handler)
     return resultTuple
 }
 #endif
@@ -97,7 +97,7 @@ public func MTLCopyAllDevicesWithObserver(handler: @escaping MTLDeviceNotificati
 extension MTLFunctionConstantValues {
     
     public func setConstantValues(_ values: UnsafeRawPointer, type: MTLDataType, range: Range<Int>) {
-        setConstantValues(values, type: type, with: NSMakeRange(range.lowerBound, range.count))
+        __setConstantValues(values, type: type, with: NSMakeRange(range.lowerBound, range.count))
     }
     
 }
@@ -107,15 +107,15 @@ extension MTLFunctionConstantValues {
 extension MTLArgumentEncoder {
     
     public func setBuffers(_ buffers: [MTLBuffer?], offsets: [Int], range: Range<Int>) {
-        setBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
+        __setBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setTextures(_ textures: [MTLTexture?], range: Range<Int>) {
-        setTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
+        __setTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setSamplerStates(_ samplers: [MTLSamplerState?], range: Range<Int>) {
-        setSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
+        __setSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
     }
 }
 
@@ -125,56 +125,56 @@ extension MTLRenderCommandEncoder {
     
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func useResources(_ resources: [MTLResource], usage: MTLResourceUsage) {
-        useResources(resources, count: resources.count, usage: usage)
+        __use(resources, count: resources.count, usage: usage)
     }
     
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func useHeaps(_ heaps: [MTLHeap]) {
-        useHeaps(heaps, count: heaps.count)
+        __use(heaps, count: heaps.count)
     }
     
 #if os(OSX)
     @available(macOS 10.13, *)
     public func setViewports(_ viewports: [MTLViewport]) {
-        setViewports(viewports, count: viewports.count)
+        __setViewports(viewports, count: viewports.count)
     }
     
     @available(macOS 10.13, *)
     public func setScissorRects(_ scissorRects: [MTLScissorRect]) {
-        setScissorRects(scissorRects, count: scissorRects.count)
+        __setScissorRects(scissorRects, count: scissorRects.count)
     }
 #endif
     
     public func setVertexBuffers(_ buffers: [MTLBuffer?], offsets: [Int], range: Range<Int>) {
-        setVertexBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
+        __setVertexBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setVertexTextures(_ textures: [MTLTexture?], range: Range<Int>) {
-        setVertexTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
+        __setVertexTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setVertexSamplerStates(_ samplers: [MTLSamplerState?], range: Range<Int>) {
-        setVertexSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
+        __setVertexSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setVertexSamplerStates(_ samplers: [MTLSamplerState?], lodMinClamps: [Float], lodMaxClamps: [Float], range: Range<Int>) {
-        setVertexSamplerStates(samplers, lodMinClamps: lodMinClamps, lodMaxClamps: lodMaxClamps, with: NSMakeRange(range.lowerBound, range.count))
+        __setVertexSamplerStates(samplers, lodMinClamps: lodMinClamps, lodMaxClamps: lodMaxClamps, with: NSMakeRange(range.lowerBound, range.count))
     }
 
     public func setFragmentBuffers(_ buffers: [MTLBuffer?], offsets: [Int], range: Range<Int>) {
-        setFragmentBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
+        __setFragmentBuffers(buffers, offsets: offsets, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setFragmentTextures(_ textures: [MTLTexture?], range: Range<Int>) {
-        setFragmentTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
+        __setFragmentTextures(textures, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setFragmentSamplerStates(_ samplers: [MTLSamplerState?], range: Range<Int>) {
-        setFragmentSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
+        __setFragmentSamplerStates(samplers, with: NSMakeRange(range.lowerBound, range.count))
     }
     
     public func setFragmentSamplerStates(_ samplers: [MTLSamplerState?], lodMinClamps: [Float], lodMaxClamps: [Float], range: Range<Int>) {
-        setFragmentSamplerStates(samplers, lodMinClamps: lodMinClamps, lodMaxClamps: lodMaxClamps, with: NSMakeRange(range.lowerBound, range.count))
+        __setFragmentSamplerStates(samplers, lodMinClamps: lodMinClamps, lodMaxClamps: lodMaxClamps, with: NSMakeRange(range.lowerBound, range.count))
     }
 
 #if os(iOS)
@@ -207,14 +207,14 @@ extension MTLRenderPassDescriptor {
     
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func setSamplePositions(_ positions: [MTLSamplePosition]) {
-        setSamplePositions(positions, count: positions.count)
+        __setSamplePositions(positions, count: positions.count)
     }
     
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, *)
     public func getSamplePositions() -> [MTLSamplePosition] {
-        let numPositions = getSamplePositions(nil, count: 0)
+        let numPositions = __getSamplePositions(nil, count: 0)
         var positions = [MTLSamplePosition](repeating: MTLSamplePosition(x: 0,y: 0), count: numPositions)
-        getSamplePositions(&positions, count: numPositions)
+        __getSamplePositions(&positions, count: numPositions)
         return positions
     }
     
@@ -226,6 +226,6 @@ extension MTLTexture {
     
     @available(macOS 10.11, iOS 9.0, tvOS 9.0, *)
     public func makeTextureView(pixelFormat: MTLPixelFormat, textureType: MTLTextureType, levels levelRange: Range<Int>, slices sliceRange: Range<Int>) -> MTLTexture? {
-        return makeTextureView(pixelFormat: pixelFormat, textureType: textureType, levels: NSMakeRange(levelRange.lowerBound, levelRange.count), slices: NSMakeRange(sliceRange.lowerBound, sliceRange.count))
+        return __newTextureView(with: pixelFormat, textureType: textureType, levels: NSMakeRange(levelRange.lowerBound, levelRange.count), slices: NSMakeRange(sliceRange.lowerBound, sliceRange.count))
     }
 }

--- a/stdlib/public/SDK/MetalKit/CMakeLists.txt
+++ b/stdlib/public/SDK/MetalKit/CMakeLists.txt
@@ -4,7 +4,7 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_library(swiftMetalKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     MetalKit.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreFoundation CoreGraphics CoreImage Dispatch Foundation IOKit Metal ModelIO ObjectiveC QuartzCore simd XPC # auto-updated

--- a/stdlib/public/SDK/MetalKit/MetalKit.swift
+++ b/stdlib/public/SDK/MetalKit/MetalKit.swift
@@ -17,7 +17,7 @@
 extension MTKMesh {
     public class func newMeshes(asset: MDLAsset, device: MTLDevice) throws -> (modelIOMeshes: [MDLMesh], metalKitMeshes: [MTKMesh]) {
         var modelIOMeshes: NSArray?
-        var metalKitMeshes = try MTKMesh.newMeshes(from: asset, device: device, sourceMeshes: &modelIOMeshes)
+        let metalKitMeshes = try MTKMesh.__newMeshes(from: asset, device: device, sourceMeshes: &modelIOMeshes)
         return (modelIOMeshes: modelIOMeshes as! [MDLMesh], metalKitMeshes: metalKitMeshes)
     }
 }
@@ -26,7 +26,7 @@ extension MTKMesh {
 @available(macOS 10.12, iOS 10.0, tvOS 10.0, *)
 public func MTKModelIOVertexDescriptorFromMetalWithError(_ metalDescriptor: MTLVertexDescriptor) throws -> MDLVertexDescriptor {
     var error: NSError? = nil
-    let result = MTKModelIOVertexDescriptorFromMetalWithError(metalDescriptor, &error)
+    let result = __MTKModelIOVertexDescriptorFromMetalWithError(metalDescriptor, &error)
     if let error = error {
         throw error
     }
@@ -37,7 +37,7 @@ public func MTKModelIOVertexDescriptorFromMetalWithError(_ metalDescriptor: MTLV
 @available(macOS 10.12, iOS 10.0, tvOS 10.0, *)
 public func MTKMetalVertexDescriptorFromModelIOWithError(_ modelIODescriptor: MDLVertexDescriptor) throws -> MTLVertexDescriptor? {
     var error: NSError? = nil
-    let result = MTKMetalVertexDescriptorFromModelIOWithError(modelIODescriptor, &error)
+    let result = __MTKMetalVertexDescriptorFromModelIOWithError(modelIODescriptor, &error)
     if let error = error {
         throw error
     }


### PR DESCRIPTION
In https://github.com/apple/swift/pull/12608, we changed the SDK overlays to build in Swift 4 mode. We left some of them in Swift 3 mode temporarily.

This change makes the Metal and MetalKit SDK overlays build in Swift 4 mode too.