### PR TITLE
 Fix the debug info generated by the LoadableByAddress transformation.

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -103,7 +103,7 @@ insertDeallocStackAtEndOf(SmallVectorImpl<SILInstruction *> &FunctionExits,
                           AllocStackInst *AllocStack) {
   // Insert dealloc_stack in the exit blocks.
   for (auto *Exit : FunctionExits) {
-    SILBuilder Builder(Exit);
+    SILBuilderWithScope Builder(Exit);
     Builder.createDeallocStack(AllocStack->getLoc(), AllocStack);
   }
 }

--- a/test/DebugInfo/LoadableByAddress.swift
+++ b/test/DebugInfo/LoadableByAddress.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend %s -module-name A -emit-ir -g -o - | %FileCheck %s
+// REQUIRES: CPU=x86_64
+public struct Continuation<A> {
+   private let magicToken = "Hello World"
+   fileprivate let f: (() -> A)?
+
+  public func run() {}
+}
+
+public typealias ContinuationU = Continuation<()>
+
+// CHECK: %2 = alloca %T1A12ContinuationV, align 8
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata %T1A12ContinuationV* %2,
+// CHECK-SAME:    metadata ![[X:.*]], metadata !DIExpression())
+// CHECK: ![[X]] = !DILocalVariable(name: "x",
+
+public func f<A>(_ xs: [Continuation<A>]) -> (() -> A?) {
+   return {
+       for x in xs {
+           x.run()
+       }
+       return nil
+   }
+}
+


### PR DESCRIPTION
And unbreak the LLDB testsuite.

This patch fixes three problems with the original implementation:
- Use SILBuilderWithScope instead of SILBuilder to avoid holes in the
  lexical scopes.
- Use an artificial location for stores to the alloca to avoid the debugger
  stopping before the variable is initialized.
- Recognize debug_value_addr instructions referring to an alloc_stack
  instruction to avoid introducing an extra indirection in the debug info.

rdar://problem/31975108
