### PR TITLE
Revert "[ConstraintSystem] Use semantics providing exprs when dealing…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -916,6 +916,18 @@ namespace {
         }
       }
       
+      // If the paren expr has a favored type, and the subExpr doesn't,
+      // propagate downwards. Otherwise, propagate upwards.
+      if (auto parenExpr = dyn_cast<ParenExpr>(expr)) {
+        if (!CS.getFavoredType(parenExpr->getSubExpr())) {
+          CS.setFavoredType(parenExpr->getSubExpr(),
+                            CS.getFavoredType(parenExpr));
+        } else if (!CS.getFavoredType(parenExpr)) {
+          CS.setFavoredType(parenExpr,
+                            CS.getFavoredType(parenExpr->getSubExpr()));
+        }
+      }
+      
       return { true, expr };
     }
     
@@ -1607,6 +1619,10 @@ namespace {
     }
 
     virtual Type visitParenExpr(ParenExpr *expr) {
+      if (auto favoredTy = CS.getFavoredType(expr->getSubExpr())) {
+        CS.setFavoredType(expr, favoredTy);
+      }
+
       auto &ctx = CS.getASTContext();
       auto parenType = CS.getType(expr->getSubExpr())->getInOutObjectType();
       auto parenFlags = ParameterTypeFlags().withInOut(expr->isSemanticallyInOutExpr());

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1561,11 +1561,11 @@ public:
   
   TypeBase* getFavoredType(Expr *E) {
     assert(E != nullptr);
-    return this->FavoredTypes[E->getSemanticsProvidingExpr()];
+    return this->FavoredTypes[E];
   }
   void setFavoredType(Expr *E, TypeBase *T) {
     assert(E != nullptr);
-    this->FavoredTypes[E->getSemanticsProvidingExpr()] = T;
+    this->FavoredTypes[E] = T;
   }
 
   /// Set the type in our type map for a given expression. The side

--- a/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
@@ -1,9 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asserts
 
-// FIXME: https://bugs.swift.org/browse/SR-6518
-// REQUIRES: SR6518
-
 class P {
   var x : Int = 0
   var y : Int = 1


### PR DESCRIPTION
… with favored types."

This reverts commit 2f80af15eca47aede4246da3bb1fc7613fd6c56e.

I expected this to have no effect, but it results in one of the
expression type checker tests taking longer, so that test was disabled.

This commit also re-enables the test since it now passes again.
