### PR TITLE
[build-script] Argument Builder DSL Conversion: Episode 3

### DIFF
--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -23,8 +23,8 @@ from argparse import ONE_OR_MORE, OPTIONAL, SUPPRESS, ZERO_OR_MORE
 
 from .actions import Action, Nargs
 from .parser import ArgumentParser
-from .types import (BoolType, ClangVersionType, PathType, RegexType,
-                    ShellSplitType, SwiftVersionType)
+from .types import (BoolType, ClangVersionType, CompilerVersion, PathType,
+                    RegexType, ShellSplitType, SwiftVersionType)
 
 
 __all__ = [
@@ -39,6 +39,7 @@ __all__ = [
     'RawDescriptionHelpFormatter',
     'RawTextHelpFormatter',
 
+    'CompilerVersion',
     'BoolType',
     'FileType',
     'PathType',

--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -180,7 +180,7 @@ class StoreAction(Action):
 
         if 'choices' in kwargs:
             kwargs['nargs'] = Nargs.OPTIONAL
-        if 'const' in kwargs:
+        elif 'const' in kwargs:
             kwargs['nargs'] = Nargs.ZERO
 
         super(StoreAction, self).__init__(
@@ -242,8 +242,11 @@ class StorePathAction(StoreAction):
     """
 
     def __init__(self, option_strings, **kwargs):
+        assert_exists = kwargs.pop('exists', False)
+        assert_executable = kwargs.pop('executable', False)
+
         kwargs['nargs'] = Nargs.SINGLE
-        kwargs['type'] = PathType()
+        kwargs['type'] = PathType(assert_exists, assert_executable)
         kwargs.setdefault('metavar', 'PATH')
 
         super(StorePathAction, self).__init__(

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -175,7 +175,7 @@ class ClangVersionType(RegexType):
 
     def __call__(self, value):
         matches = super(ClangVersionType, self).__call__(value)
-        components = filter(None, matches.group(1, 2, 3, 5))
+        components = filter(lambda x: x is not None, matches.group(1, 2, 3, 5))
 
         return CompilerVersion(components)
 
@@ -195,7 +195,7 @@ class SwiftVersionType(RegexType):
 
     def __call__(self, value):
         matches = super(SwiftVersionType, self).__call__(value)
-        components = filter(None, matches.group(1, 2, 4))
+        components = filter(lambda x: x is not None, matches.group(1, 2, 4))
 
         return CompilerVersion(components)
 

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -21,6 +21,8 @@ from . import ArgumentTypeError
 
 
 __all__ = [
+    'CompilerVersion',
+
     'BoolType',
     'PathType',
     'RegexType',
@@ -31,6 +33,44 @@ __all__ = [
 
 
 # -----------------------------------------------------------------------------
+
+class CompilerVersion(object):
+    """Wrapper type around compiler version strings.
+    """
+
+    def __init__(self, *components):
+        if len(components) == 1:
+            if isinstance(components[0], str):
+                components = components[0].split('.')
+            elif isinstance(components[0], list):
+                components = tuple(components[0])
+            elif isinstance(components[0], tuple):
+                components = components[0]
+
+        if len(components) == 0:
+            raise ValueError('compiler version cannot be empty')
+
+        self.components = tuple(int(part) for part in components)
+
+    def __eq__(self, other):
+        return self.components == other.components
+
+    def __str__(self):
+        return '.'.join([str(part) for part in self.components])
+
+
+# -----------------------------------------------------------------------------
+
+def _repr(cls, args):
+    """Helper function for implementing __repr__ methods on *Type classes.
+    """
+
+    _args = []
+    for key, value in args.viewitems():
+        _args.append('{}={}'.format(key, repr(value)))
+
+    return '{}({})'.format(type(cls).__name__, ', '.join(_args))
+
 
 class BoolType(object):
     """Argument type used to validate an input string as a bool-like type.
@@ -55,6 +95,12 @@ class BoolType(object):
         else:
             raise ArgumentTypeError('{} is not a boolean value'.format(value))
 
+    def __repr__(self):
+        return _repr(self, {
+            'true_values': self._true_values,
+            'false_values': self._false_values,
+        })
+
 
 class PathType(object):
     """PathType denotes a valid path-like object. When called paths will be
@@ -63,24 +109,27 @@ class PathType(object):
     """
 
     def __init__(self, assert_exists=False, assert_executable=False):
-        if assert_executable:
-            assert_exists = True
-
-        self.assert_exists = assert_exists
-        self.assert_executable = assert_executable
+        self._assert_exists = assert_exists
+        self._assert_executable = assert_executable
 
     def __call__(self, path):
         path = os.path.expanduser(path)
         path = os.path.abspath(path)
         path = os.path.realpath(path)
 
-        if self.assert_exists and not os.path.exists(path):
+        if self._assert_exists and not os.path.exists(path):
             raise ArgumentTypeError('{} does not exists'.format(path))
 
-        if self.assert_executable and not PathType._is_executable(path):
+        if self._assert_executable and not PathType._is_executable(path):
             raise ArgumentTypeError('{} is not an executable'.format(path))
 
         return path
+
+    def __repr__(self):
+        return _repr(self, {
+            'assert_exists': self._assert_exists,
+            'assert_executable': self._assert_executable,
+        })
 
     @staticmethod
     def _is_executable(path):
@@ -101,7 +150,13 @@ class RegexType(object):
         if matches is None:
             raise ArgumentTypeError(self._error_message, value)
 
-        return value
+        return matches
+
+    def __repr__(self):
+        return _repr(self, {
+            'regex': self._regex,
+            'error_message': self._error_message,
+        })
 
 
 class ClangVersionType(RegexType):
@@ -118,6 +173,12 @@ class ClangVersionType(RegexType):
             ClangVersionType.VERSION_REGEX,
             ClangVersionType.ERROR_MESSAGE)
 
+    def __call__(self, value):
+        matches = super(ClangVersionType, self).__call__(value)
+        components = filter(None, matches.group(1, 2, 3, 5))
+
+        return CompilerVersion(components)
+
 
 class SwiftVersionType(RegexType):
     """Argument type used to validate Swift version strings.
@@ -131,6 +192,12 @@ class SwiftVersionType(RegexType):
         super(SwiftVersionType, self).__init__(
             SwiftVersionType.VERSION_REGEX,
             SwiftVersionType.ERROR_MESSAGE)
+
+    def __call__(self, value):
+        matches = super(SwiftVersionType, self).__call__(value)
+        components = filter(None, matches.group(1, 2, 4))
+
+        return CompilerVersion(components)
 
 
 class ShellSplitType(object):
@@ -151,3 +218,6 @@ class ShellSplitType(object):
         lex.whitespace_split = True
         lex.whitespace += ','
         return list(lex)
+
+    def __repr__(self):
+        return _repr(self, {})

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -62,18 +62,29 @@ class PathType(object):
     by the path exists.
     """
 
-    def __init__(self, assert_exists=False):
+    def __init__(self, assert_exists=False, assert_executable=False):
+        if assert_executable:
+            assert_exists = True
+
         self.assert_exists = assert_exists
+        self.assert_executable = assert_executable
 
     def __call__(self, path):
         path = os.path.expanduser(path)
         path = os.path.abspath(path)
         path = os.path.realpath(path)
 
-        if self.assert_exists:
-            assert os.path.exists(path)
+        if self.assert_exists and not os.path.exists(path):
+            raise ArgumentTypeError('{} does not exists'.format(path))
+
+        if self.assert_executable and not PathType._is_executable(path):
+            raise ArgumentTypeError('{} is not an executable'.format(path))
 
         return path
+
+    @staticmethod
+    def _is_executable(path):
+        return os.path.isfile(path) and os.access(path, os.X_OK)
 
 
 class RegexType(object):

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -42,9 +42,7 @@ class CompilerVersion(object):
         if len(components) == 1:
             if isinstance(components[0], str):
                 components = components[0].split('.')
-            elif isinstance(components[0], list):
-                components = tuple(components[0])
-            elif isinstance(components[0], tuple):
+            elif isinstance(components[0], (list, tuple)):
                 components = components[0]
 
         if len(components) == 0:

--- a/utils/build_swift/defaults.py
+++ b/utils/build_swift/defaults.py
@@ -6,9 +6,14 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+
 """
 Default option value definitions.
 """
+
+
+from .argparse import CompilerVersion
+
 
 __all__ = [
     # Command line configuarable
@@ -35,8 +40,8 @@ BUILD_VARIANT = 'Debug'
 CMAKE_GENERATOR = 'Ninja'
 
 COMPILER_VENDOR = 'none'
-SWIFT_USER_VISIBLE_VERSION = '4.1'
-CLANG_USER_VISIBLE_VERSION = '5.0.0'
+SWIFT_USER_VISIBLE_VERSION = CompilerVersion('4.1')
+CLANG_USER_VISIBLE_VERSION = CompilerVersion('5.0.0')
 SWIFT_ANALYZE_CODE_COVERAGE = 'false'
 
 DARWIN_XCRUN_TOOLCHAIN = 'default'

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -255,20 +255,15 @@ class TestStorePathAction(TestCase):
         self.assertIsInstance(action.type, PathType)
 
     def test_exists(self):
-        pass
+        action = actions.StorePathAction(['--foo'], dests=['foo'], exists=True)
+
+        self.assertTrue(action.type.assert_exists)
 
     def test_executable(self):
-        parser = ArgumentParser()
-        parser.add_argument('--foo', action=actions.StorePathAction,
-                            executable=True)
+        action = actions.StorePathAction(['--foo'], dests=['foo'],
+                                         executable=True)
 
-        bash_path = '/bin/bash'
-        if os.path.exists(bash_path) and os.access(bash_path, os.X_OK):
-            with self.assertNotRaises(ArgumentTypeError):
-                parser.parse_args(['--foo', bash_path])
-
-        with self.assertRaises(SystemExit):
-            parser.parse_args(['--foo', __file__])
+        self.assertTrue(action.type.assert_executable)
 
 
 class TestToggleTrueAction(TestCase):

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -7,11 +7,9 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-import os
-
 from ..utils import TestCase, redirect_stderr
-from ...argparse import (ArgumentParser, ArgumentTypeError, BoolType, Nargs,
-                         PathType, SUPPRESS, actions)
+from ...argparse import (ArgumentParser, BoolType, Nargs, PathType, SUPPRESS,
+                         actions)
 
 
 # -----------------------------------------------------------------------------
@@ -257,13 +255,13 @@ class TestStorePathAction(TestCase):
     def test_exists(self):
         action = actions.StorePathAction(['--foo'], dests=['foo'], exists=True)
 
-        self.assertTrue(action.type.assert_exists)
+        self.assertTrue(action.type._assert_exists)
 
     def test_executable(self):
         action = actions.StorePathAction(['--foo'], dests=['foo'],
                                          executable=True)
 
-        self.assertTrue(action.type.assert_executable)
+        self.assertTrue(action.type._assert_executable)
 
 
 class TestToggleTrueAction(TestCase):

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -7,9 +7,11 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
+import os
+
 from ..utils import TestCase, redirect_stderr
-from ...argparse import (ArgumentParser, BoolType, Nargs, PathType, SUPPRESS,
-                         actions)
+from ...argparse import (ArgumentParser, ArgumentTypeError, BoolType, Nargs,
+                         PathType, SUPPRESS, actions)
 
 
 # -----------------------------------------------------------------------------
@@ -251,6 +253,22 @@ class TestStorePathAction(TestCase):
 
         self.assertEqual(action.nargs, Nargs.SINGLE)
         self.assertIsInstance(action.type, PathType)
+
+    def test_exists(self):
+        pass
+
+    def test_executable(self):
+        parser = ArgumentParser()
+        parser.add_argument('--foo', action=actions.StorePathAction,
+                            executable=True)
+
+        bash_path = '/bin/bash'
+        if os.path.exists(bash_path) and os.access(bash_path, os.X_OK):
+            with self.assertNotRaises(ArgumentTypeError):
+                parser.parse_args(['--foo', bash_path])
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(['--foo', __file__])
 
 
 class TestToggleTrueAction(TestCase):

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -90,12 +90,25 @@ class TestPathType(TestCase):
     def test_assert_exists(self):
         path_type = types.PathType(assert_exists=True)
 
-        with self.assertNotRaises(AssertionError):
+        with self.assertNotRaises(ArgumentTypeError):
             path_type(__file__)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ArgumentTypeError):
             path_type('/nonsensisal/path/')
             path_type('~/not-a-real/path to a file')
+
+    def test_assert_executable(self):
+        path_type = types.PathType(assert_executable=True)
+
+        self.assertTrue(path_type.assert_exists)
+
+        bash_path = '/bin/bash'
+        if os.path.isfile(bash_path) and os.access(bash_path, os.X_OK):
+            with self.assertNotRaises(ArgumentTypeError):
+                path_type(bash_path)
+
+        with self.assertRaises(ArgumentTypeError):
+            path_type(__file__)
 
 
 class TestRegexType(TestCase):

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -15,6 +15,66 @@ from ...argparse import ArgumentTypeError, types
 
 # -----------------------------------------------------------------------------
 
+class TestCompilerVersion(TestCase):
+
+    def test_init_valid_value(self):
+        version = types.CompilerVersion(1, 0, 0, 1)
+        self.assertEqual(version.components, (1, 0, 0, 1))
+
+    def test_init_list(self):
+        version = types.CompilerVersion([1, 0, 0])
+        self.assertEqual(version.components, (1, 0, 0))
+
+        with self.assertNotRaises(ValueError):
+            types.CompilerVersion([1, 0])
+            types.CompilerVersion([2, 3, 4])
+            types.CompilerVersion([3, 1, 4, 1, 5, 9])
+
+    def test_init_tuple(self):
+        version = types.CompilerVersion((1, 0, 0))
+        self.assertEqual(version.components, (1, 0, 0))
+
+        with self.assertNotRaises(ValueError):
+            types.CompilerVersion((1, 0))
+            types.CompilerVersion((2, 3, 4))
+            types.CompilerVersion((3, 1, 4, 1, 5, 9))
+
+    def test_init_str(self):
+        version = types.CompilerVersion('1.0.0')
+        self.assertEqual(version.components, (1, 0, 0))
+
+        with self.assertNotRaises(ValueError):
+            types.CompilerVersion('1.0')
+            types.CompilerVersion('2.3.4')
+            types.CompilerVersion('3.1.4.1.5.9')
+
+    def test_init_invalid_value(self):
+        with self.assertRaises(ValueError):
+            types.CompilerVersion()
+            types.CompilerVersion([])
+            types.CompilerVersion(())
+            types.CompilerVersion('')
+            types.CompilerVersion(True)
+            types.CompilerVersion('a')
+            types.CompilerVersion(dict())
+
+    def test_eq(self):
+        v1 = types.CompilerVersion('1.0.0')
+        v2 = types.CompilerVersion('1.2.4.8')
+
+        self.assertEqual(v1, v1)
+        self.assertEqual(v2, v2)
+        self.assertNotEqual(v1, v2)
+        self.assertNotEqual(v2, v1)
+
+    def test_str(self):
+        version = types.CompilerVersion('1.0.0')
+        self.assertEqual(str(version), '1.0.0')
+
+        version = types.CompilerVersion('1.0.0.1')
+        self.assertEqual(str(version), '1.0.0.1')
+
+
 class TestBoolType(TestCase):
 
     def test_true_values(self):
@@ -100,8 +160,6 @@ class TestPathType(TestCase):
     def test_assert_executable(self):
         path_type = types.PathType(assert_executable=True)
 
-        self.assertTrue(path_type.assert_exists)
-
         bash_path = '/bin/bash'
         if os.path.isfile(bash_path) and os.access(bash_path, os.X_OK):
             with self.assertNotRaises(ArgumentTypeError):
@@ -135,6 +193,14 @@ class TestClangVersionType(TestCase):
     def test_valid_clang_version(self):
         clang_version_type = types.ClangVersionType()
 
+        version = clang_version_type('1.0.0')
+        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertEqual(version.components, (1, 0, 0))
+
+        version = clang_version_type('1.0.0.1')
+        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertEqual(version.components, (1, 0, 0, 1))
+
         with self.assertNotRaises(ArgumentTypeError):
             clang_version_type('1.0.0')
             clang_version_type('3.0.2.1')
@@ -155,6 +221,14 @@ class TestSwiftVersionType(TestCase):
 
     def test_valid_swift_version(self):
         swift_version_type = types.SwiftVersionType()
+
+        version = swift_version_type('1.0')
+        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertEqual(version.components, (1, 0))
+
+        version = swift_version_type('1.0.1')
+        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertEqual(version.components, (1, 0, 1))
 
         with self.assertNotRaises(ArgumentTypeError):
             swift_version_type('1.0')

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -75,6 +75,8 @@ def type_shell_split(string):
 _register(type, 'shell_split', type_shell_split)
 
 
+# NOTE: This class is deprecated, use the analgous class with the same name
+# in utils/build_swift/argparse/types.py instead.
 class CompilerVersion(object):
     """A typed representation of a compiler version."""
 

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -114,7 +114,8 @@ class CMake(object):
                    "Debug;Release;MinSizeRel;RelWithDebInfo")
 
         if args.clang_user_visible_version:
-            major, minor, patch, _ = args.clang_user_visible_version.components
+            major, minor, patch = \
+                args.clang_user_visible_version.components[0:3]
             define("LLVM_VERSION_MAJOR:STRING", major)
             define("LLVM_VERSION_MINOR:STRING", minor)
             define("LLVM_VERSION_PATCH:STRING", patch)


### PR DESCRIPTION
This PR is the third and final part of #13117 and similarly doesn't contain any real functional changes. I did have to add support for asserting a path contains an executable in both the `PathType` and `StorePathAction` classes and I've added associated tests. I've also converted the top-level arguments to the new builder DSL, which means that all the argument definitions are now in the builder DSL. All the unit-tests still pass which makes me confident that this PR is low risk.

rdar://34336890