### PR TITLE
[stdlib] Disable 128-bit div/mod on 64-bit Windows

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3390,6 +3390,13 @@ ${assignmentOperatorComment(x.operator, True)}
 %   else:
     // FIXME(integers): handle division by zero and overflows
     _precondition(self != 0, "Division by zero")
+
+%   if dbits == 128:
+#if os(Windows)
+      fatalError("Operation is not supported")
+#else
+%   end
+
     let lhsHigh = Builtin.${z}ext_Int${bits}_Int${dbits}(dividend.high._value)
     let shift = Builtin.zextOrBitCast_Int8_Int${dbits}(UInt8(${bits})._value)
     let lhsHighShifted = Builtin.shl_Int${dbits}(lhsHigh, shift)
@@ -3406,6 +3413,10 @@ ${assignmentOperatorComment(x.operator, True)}
       Builtin.truncOrBitCast_Int${dbits}_Int${bits}(remainder_))
 
     return (quotient: quotient, remainder: remainder)
+
+%   if dbits == 128:
+#endif // os(Windows)
+%   end
 %   end
   }
 


### PR DESCRIPTION
64-bit Windows doesn't support the 128-bit operations `udivti3`, `umodti3`, `divti3`, or `modti3`, which LLVM emits upon encountering this function. Disable `dividingFullWidth` on Win64 as a temporary fix.

Longer term, Compiler-RT should be amended to support 128-bit operations on Windows (since it's currently gated on being LP64 while Windows uses LLP64). We can then link against the Compiler-RT runtime support library.