### PR TITLE
[shims] Fix Windows errno() and _stdlib_open

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -53,6 +53,8 @@ typedef      long int __swift_ssize_t;
 typedef __swift_uint32_t __swift_mode_t;
 #elif defined(__APPLE__)
 typedef __swift_uint16_t __swift_mode_t;
+#elif defined(_WIN32)
+typedef __swift_int32_t __swift_mode_t;
 #else  // just guessing
 typedef __swift_uint16_t __swift_mode_t;
 #endif
@@ -128,12 +130,10 @@ char * _Nullable *_stdlib_getEnviron();
 #endif
 
 // System error numbers <errno.h>
-#if !defined(_WIN32) || defined(__CYGWIN__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
 int _stdlib_getErrno();
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void _stdlib_setErrno(int value);
-#endif
 
 // Non-standard extensions
 SWIFT_READNONE SWIFT_RUNTIME_STDLIB_INTERNAL

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -120,8 +120,8 @@ int swift::_stdlib_close(int fd) {
 // Windows
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
-int swift::_stdlib_open(const char *path, int oflag, int mode) {
-  return _open(path, oflag, mode);
+int swift::_stdlib_open(const char *path, int oflag, __swift_mode_t mode) {
+  return _open(path, oflag, static_cast<int>(mode));
 }
 
 #else
@@ -183,6 +183,9 @@ char * _Nullable *swift::_stdlib_getEnviron() {
 }
 #endif
 
+// not Windows
+#endif
+
 SWIFT_RUNTIME_STDLIB_INTERNAL
 int swift::_stdlib_getErrno() {
   return errno;
@@ -193,8 +196,6 @@ void swift::_stdlib_setErrno(int value) {
   errno = value;
 }
 
-// not Windows
-#endif
 
 
 #if defined(__APPLE__)

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -183,8 +183,7 @@ char * _Nullable *swift::_stdlib_getEnviron() {
 }
 #endif
 
-// not Windows
-#endif
+#endif // !(defined(_WIN32) && !defined(__CYGWIN__))
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 int swift::_stdlib_getErrno() {


### PR DESCRIPTION
`_stdlib_getErrno()`, `_stdlib_setErrno()`, and `_stdlib_open` were failing to compile for Windows. 

To address this, correctly define `__swift_mode_t` on Windows and remove the  platform-specific exclusion of `errno.h` since the Windows 10 SDK provides it.