### PR TITLE
[driver] Implement a Windows toolchain for cross-compiling

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -223,7 +223,9 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
   case llvm::Triple::FreeBSD:
     return llvm::make_unique<toolchains::GenericUnix>(*this, target);
   case llvm::Triple::Win32:
-    return llvm::make_unique<toolchains::Cygwin>(*this, target);
+    if (target.isWindowsCygwinEnvironment())
+      return llvm::make_unique<toolchains::Cygwin>(*this, target);
+    return llvm::make_unique<toolchains::Windows>(*this, target);
   case llvm::Triple::Haiku:
     return llvm::make_unique<toolchains::GenericUnix>(*this, target);
   default:

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -39,6 +39,20 @@ public:
       const override;
 };
 
+class LLVM_LIBRARY_VISIBILITY Windows : public ToolChain {
+protected:
+  InvocationInfo constructInvocation(const LinkJobAction &job,
+                                     const JobContext &context) const override;
+
+public:
+  Windows(const Driver &D, const llvm::Triple &Triple) : ToolChain(D, Triple) {}
+  ~Windows() = default;
+  bool sanitizerRuntimeLibExists(const llvm::opt::ArgList &args,
+                                 StringRef sanitizerLibName,
+                                 bool shared)
+      const override;
+};
+
 class LLVM_LIBRARY_VISIBILITY GenericUnix : public ToolChain {
 protected:
   InvocationInfo constructInvocation(const InterpretJobAction &job,

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -160,8 +160,8 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
     }
   }
 
-  // Sanitizers are only supported on Linux or Darwin.
-  if (!(Triple.isOSDarwin() || Triple.isOSLinux())) {
+  // Check that we're one of the known supported targets for sanitizers.
+  if (!(Triple.isOSDarwin() || Triple.isOSLinux() || Triple.isOSWindows())) {
     SmallString<128> b;
     Diags.diagnose(SourceLoc(), diag::error_unsupported_opt_for_target,
       (A->getOption().getPrefixedName() +

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -33,6 +33,9 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.cygwin.txt
 // RUN: %FileCheck -check-prefix CYGWIN-x86_64 %s < %t.cygwin.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.windows.txt
+// RUN: %FileCheck -check-prefix WINDOWS-x86_64 %s < %t.windows.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-unknown-linux-gnu %s -Lbar -o dynlib.out 2>&1 > %t.linux.dynlib.txt
 // RUN: %FileCheck -check-prefix LINUX_DYNLIB-x86_64 %s < %t.linux.dynlib.txt
 
@@ -61,6 +64,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_LINUX %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_WINDOWS %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_WINDOWS %s
 
 // Here we specify an output file name using '-o'. For ease of writing these
 // tests, we happen to specify the same file name as is inferred in the
@@ -239,6 +243,20 @@
 // CYGWIN-x86_64-DAG: -lboo
 // CYGWIN-x86_64-DAG: -Xlinker -undefined
 // CYGWIN-x86_64: -o linker
+
+// WINDOWS-x86_64: swift
+// WINDOWS-x86_64: -o [[OBJECTFILE:.*]]
+
+// WINDOWS-x86_64: clang++{{"? }}
+// WINDOWS-x86_64-DAG: [[OBJECTFILE]]
+// WINDOWS-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift/windows/x86_64]]
+// WINDOWS-x86_64-DAG: -F foo -iframework car -F cdr
+// WINDOWS-x86_64-DAG: -framework bar
+// WINDOWS-x86_64-DAG: -L baz
+// WINDOWS-x86_64-DAG: -lboo
+// WINDOWS-x86_64-DAG: -Xlinker -undefined
+// WINDOWS-x86_64: -o linker
+
 
 // COMPLEX: bin/ld{{"? }}
 // COMPLEX-DAG: -dylib

--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -18,6 +18,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
 
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-unknown-linux-gnu %s | %FileCheck -check-prefix=CHECK -check-prefix=LINUX %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-unknown-windows-msvc %s | %FileCheck -check-prefix=CHECK -check-prefix=WINDOWS %s
 
 // CHECK: swift
 // CHECK: -profile-generate
@@ -46,6 +47,10 @@
 // LINUX: clang++{{"? }}
 // LINUX: lib/swift/clang/lib/linux/libclang_rt.profile-x86_64.a
 // LINUX: -u__llvm_profile_runtime
+
+// WINDOWS: clang++{{"? }}
+// WINDOWS: lib/swift/clang/lib/windows/clang_rt.profile-x86_64.lib
+// WINDOWS: -u__llvm_profile_runtime
 
 // RUN: not %swiftc_driver -driver-print-jobs -profile-generate -profile-use=/dev/null %s 2>&1 | %FileCheck -check-prefix=MIX_GEN_USE %s
 // MIX_GEN_USE: conflicting options '-profile-generate' and '-profile-use'

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -7,6 +7,7 @@
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target i386-apple-watchos2.0 %s   | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS_SIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=ASAN_LINUX %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=ASAN_WINDOWS %s
 
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=TSAN -check-prefix=TSAN_OSX %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=TSAN_OSX_32 %s
@@ -16,6 +17,7 @@
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target i386-apple-watchos2.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_watchOS_SIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target armv7k-apple-watchos2.0 %s 2>&1  | %FileCheck -check-prefix=TSAN_watchOS %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=TSAN_WINDOWS %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=TSAN_LINUX %s
 
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,unknown %s 2>&1 | %FileCheck -check-prefix=BADARG %s
@@ -41,6 +43,7 @@
 // ASAN_watchOS_SIM: lib/swift/clang/lib/darwin/libclang_rt.asan_watchossim_dynamic.dylib
 // ASAN_watchOS: lib/swift/clang/lib/darwin/libclang_rt.asan_watchos_dynamic.dylib
 // ASAN_LINUX: lib/swift/clang/lib/linux/libclang_rt.asan-x86_64.a
+// ASAN_WINDOWS: lib/swift/clang/lib/windows/clang_rt.asan-x86_64.lib
 
 // ASAN: -rpath @executable_path
 
@@ -57,6 +60,7 @@
 // TSAN_watchOS: unsupported option '-sanitize=thread' for target 'armv7k-apple-watchos2.0'
 // FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
 // TSAN_LINUX: lib/swift/clang/lib/linux/libclang_rt.tsan-x86_64.a
+// TSAN_WINDOWS: unsupported option '-sanitize=thread' for target 'x86_64-unknown-windows-msvc'
 
 // TSAN: -rpath @executable_path
 

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -1,6 +1,7 @@
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9  -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix OSX
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix LINUX 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-freebsd   -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix FREEBSD
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9     -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix OSX
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu    -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix LINUX 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-freebsd      -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix FREEBSD
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix WINDOWS 
 
 // RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-apple-macosx10.9  -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix OSX
 // RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-unknown-linux-gnu -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix LINUX
@@ -32,6 +33,15 @@
 // FREEBSD: -sdk {{.*}}/Inputs/clang-importer-sdk
 // FREEBSD: bin/{{.+}} {{.*}}swiftrt.o
 // FREEBSD: {{-syslibroot|--sysroot}} {{.*}}/Inputs/clang-importer-sdk
+
+// WINDOWS-NOT: warning: no such SDK:
+// WINDOWS: bin/swift
+// WINDOWS: Driver/sdk.swift
+// WINDOWS: -sdk {{.*}}/Inputs/clang-importer-sdk
+// WINDOWS-NEXT: bin/swift
+// WINDOWS: -sdk {{.*}}/Inputs/clang-importer-sdk
+// WINDOWS: bin/{{.+}} {{.*}}swiftrt.o
+// WINDOWS: {{-I}} {{.*}}/Inputs/clang-importer-sdk
 
 // RUN: %swift_driver -driver-print-jobs -repl -sdk %S/Inputs/nonexistent-sdk 2>&1 | %FileCheck %s --check-prefix=SDKWARNING
 // RUN: %swift_driver -driver-print-jobs -sdk %S/Inputs/nonexistent-sdk 2>&1 | %FileCheck %s --check-prefix=SDKWARNING


### PR DESCRIPTION
In this PR, I've implemented an initial Windows toolchain that has been tested to work in cross-compiling from Linux to Windows. 

When combined with https://github.com/apple/swift/pull/13140, this enables an invocation like:

```
swift -target x86_64-unknown-windows-msvc -use-ld=lld main.swift -o SwiftTest.exe
```

to produce a Windows executable (note that the executable itself will still run into separate issues).

I've followed the pattern of the `GenericUnix` toolchain here, which *does* mean there's currently a fair amount of code duplication. I don't know how much will need to change for native builds, and nor do I know how many of the extra arguments (such as ASAN or producing a static executable) will work as-is. However, I thought that Windows is sufficiently different enough from the existing OSes to justify its own toolchain and expect it to diverge further as it is expanded, making this a good starting point.