### PR TITLE
stdlib: stub additional interfaces for macOS builds

### DIFF
--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -121,6 +121,17 @@ bool _swift_dictionaryDownCastConditionalIndirect(OpaqueValue *destination,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+void _bridgeNonVerbatimBoxedValue(const OpaqueValue *, OpaqueValue *,
+                                  const Metadata) {
+  abort();
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+void _bridgeNonVerbatimFromObjectiveCToAny(HeapObject *, OpaqueValue *) {
+  abort();
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 int _T0s13_getErrorCodeSiSPyxGs0B0RzlF(void *) {
   abort();
 }
@@ -139,3 +150,4 @@ SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 void *_T0s32_getErrorEmbeddedNSErrorIndirectyXlSgSPyxGs0B0RzlF(void *) {
   abort();
 }
+


### PR DESCRIPTION
When building the SwiftRuntimeLongTests on macOS, the link would fail
due to undefined symbols:

  Undefined symbols for architecture x86_64:
    "__bridgeNonVerbatimBoxedValue", referenced from:
        tryBridgeNonVerbatimFromObjectiveCUniversal(swift::HeapObject*, swift::TargetMetadata<swift::InProcess> const*, swift::OpaqueValue*) in Casting.cpp.o
    "__bridgeNonVerbatimFromObjectiveCToAny", referenced from:
        tryBridgeNonVerbatimFromObjectiveCUniversal(swift::HeapObject*, swift::TargetMetadata<swift::InProcess> const*, swift::OpaqueValue*) in Casting.c

Provide stubs for these to allow the link to pass once again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
