### PR TITLE
[stdlib] Add conditional Lazy conformance to Slice when Base is Lazy

### DIFF
--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -266,6 +266,9 @@ extension ${TraversalCollection} where Self : LazyCollectionProtocol {
 
 % end
 
+extension Slice: LazySequenceProtocol where Base: LazySequenceProtocol { }
+extension Slice: LazyCollectionProtocol where Base: LazyCollectionProtocol { }
+
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/test/stdlib/LazySlice.swift
+++ b/test/stdlib/LazySlice.swift
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var tests = TestSuite("LazySlice")
+
+tests.test("CommuteLazyness") {
+  let a = [1,2,3].lazy
+  let b = a[...]
+  var c = b.filter { $0 == 0 }
+  // NOTE, this test will fail once lazy collectionness becomes a conditiona
+  // conformance, and will need updating to be a LazyBidirectional thingy
+  expectType(LazyFilterBidirectionalCollection<Slice<LazyRandomAccessCollection<[Int]>>>.self, &c)
+}
+
+runAllTests()


### PR DESCRIPTION
This is a bug fix for slices of lazy collections, which currently revert to being eager. Now we have conditional conformance, we can conditionally conform `Slice` to be lazy when its `Base` is lazy.

Note, `LazyCollectionProtocol` might end up going away too in which case this code can be simplified.