### PR TITLE
[SourceKit] fix -Wqual-cast warning

### DIFF
--- a/tools/SourceKit/include/SourceKit/Support/ThreadSafeRefCntPtr.h
+++ b/tools/SourceKit/include/SourceKit/Support/ThreadSafeRefCntPtr.h
@@ -120,7 +120,8 @@ public:
   }
 
   operator llvm::IntrusiveRefCntPtr<T>() const {
-    llvm::sys::ScopedLock L(*getMutex((void*)this));
+    llvm::sys::ScopedLock L(*getMutex(
+        reinterpret_cast<void *>(const_cast<ThreadSafeRefCntPtr *>(this))));
     llvm::IntrusiveRefCntPtr<T> Ref(Obj.load());
     return Ref;
   }


### PR DESCRIPTION
When building SourceKit on Linux, this would result in a number of
-Wqual-cast warnings due to the `const` being dropped.  Add an explicit
cast.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
