### PR TITLE
[Foundation] Discontiguous data slices should not heap corrupt

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
@@ -3733,12 +3734,12 @@ class TestData : TestDataSuper {
         let ref = d as AnyObject
         let data = ref as! Data
 
-        let cnt = bytes.count - 4
+        let cnt = data.count - 4
         let t = data.dropFirst(4).withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
             return Data(bytes: bytes, count: cnt)
         }
 
-        expectEqual(t, Data(bytes: [4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]))
+        expectEqual(Data(bytes: [4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]), t)
     }
 }
 

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -3722,7 +3722,7 @@ class TestData : TestDataSuper {
         expectEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
     }
 
-    func test_byte_access_of_discontiguousData {
+    func test_byte_access_of_discontiguousData() {
         var d = DispatchData.empty
         let bytes: [UInt8] = [0, 1, 2, 3, 4, 5]
         for _ in 0..<3 {

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -3721,6 +3721,25 @@ class TestData : TestDataSuper {
         }
         expectEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
     }
+
+    func test_byte_access_of_discontiguousData {
+        var d = DispatchData.empty
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5]
+        for _ in 0..<3 {
+            bytes.withUnsafeBufferPointer {
+                d.append($0)
+            }
+        }
+        let ref = d as AnyObject
+        let data = ref as! Data
+
+        let cnt = bytes.count - 4
+        let t = data.dropFirst(4).withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+            return Data(bytes: bytes, count: cnt)
+        }
+
+        expectEqual(t, Data(bytes: [4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]))
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -4037,6 +4056,7 @@ DataTests.test("test_validateMutation_slice_immutableBacking_withUnsafeMutableBy
 DataTests.test("test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
 DataTests.test("test_validateMutation_slice_customBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_customBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
+DataTests.test("test_byte_access_of_discontiguousData") { TestData().test_byte_access_of_discontiguousData() }
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
Byte access and methods that funnel to byte access for slices of discontiguous data (ala backed by dispatch_data_t) should void heap corruption and walking off the ends of buffers

<!-- What's in this pull request? -->
The `withUnsafeBytes(in:, apply:)` internal method incorrectly handled discontiguous data backing when the slice region was used. This would potentially walk off the end of the buffer as well as grab incorrect byte offsets.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://problem/35797359
https://bugs.swift.org/browse/SR-6515