### PR TITLE
stdlib: fix -Wnullability-completeness warning

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -394,7 +394,7 @@ public func sem_open(
 // Some platforms don't have `extern char** environ` imported from C.
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(PS4)
 public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
-  return _stdlib_getEnviron()
+  return _stdlib_getEnviron() ?? UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>(nil)
 }
 #elseif os(Linux)
 public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -124,7 +124,7 @@ int _stdlib_ioctlPtr(int fd, unsigned long int request, void* ptr);
 // Environment
 #if defined(__APPLE__) || defined(__FreeBSD__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-char * _Nullable *_stdlib_getEnviron();
+char * _Nullable * _Nullable _stdlib_getEnviron();
 #endif
 
 // System error numbers <errno.h>

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -171,14 +171,14 @@ int swift::_stdlib_ioctlPtr(int fd, unsigned long int request, void* ptr) {
 
 #if defined(__FreeBSD__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-char * _Nullable *swift::_stdlib_getEnviron() {
-  extern char **environ;
+char * _Nullable * _Nullable swift::_stdlib_getEnviron() {
+  extern char * _Nullable * _Nullable environ;
   return environ;
 }
 #elif defined(__APPLE__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-char * _Nullable *swift::_stdlib_getEnviron() {
-  extern char * _Nullable **_NSGetEnviron(void);
+char * _Nullable * _Nullable swift::_stdlib_getEnviron() {
+  extern char * _Nullable * _Nullable * _Nonnull _NSGetEnviron(void);
   return *_NSGetEnviron();
 }
 #endif


### PR DESCRIPTION
Annotate the return of `_NSGetEnviron` to be complete with nullability.
This would show up as warnings when building the shims.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
