### PR TITLE
benchmarks: Mark some unstable benchmarks as unstable.

### DIFF
--- a/benchmark/single-source/DeadArray.swift
+++ b/benchmark/single-source/DeadArray.swift
@@ -16,7 +16,7 @@ import TestsUtils
 public let DeadArray = BenchmarkInfo(
   name: "DeadArray",
   runFunction: run_DeadArray,
-  tags: [.regression])
+  tags: [.regression, .unstable])
 
 @inline(__always)
 func debug(_ m:String) {}

--- a/benchmark/single-source/DropLast.swift
+++ b/benchmark/single-source/DropLast.swift
@@ -51,7 +51,7 @@ public let DropLast = [
   BenchmarkInfo(
     name: "DropLastArray",
     runFunction: run_DropLastArray,
-    tags: [.validation, .api, .Array]),
+    tags: [.validation, .api, .Array, .unstable]),
   BenchmarkInfo(
     name: "DropLastCountableRangeLazy",
     runFunction: run_DropLastCountableRangeLazy,

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -47,7 +47,7 @@ public let DropLast = [
   BenchmarkInfo(
     name: "DropLast${Name}",
     runFunction: run_DropLast${Name},
-    tags: [.validation, .api${', .Array' if Name == 'Array' else ''}]),
+    tags: [.validation, .api${', .Array, .unstable' if Name == 'Array' else ''}]),
 % end
 ]
 

--- a/benchmark/single-source/DropWhile.swift
+++ b/benchmark/single-source/DropWhile.swift
@@ -51,7 +51,7 @@ public let DropWhile = [
   BenchmarkInfo(
     name: "DropWhileArray",
     runFunction: run_DropWhileArray,
-    tags: [.validation, .api, .Array]),
+    tags: [.validation, .api, .Array, .unstable]),
   BenchmarkInfo(
     name: "DropWhileCountableRangeLazy",
     runFunction: run_DropWhileCountableRangeLazy,

--- a/benchmark/single-source/DropWhile.swift.gyb
+++ b/benchmark/single-source/DropWhile.swift.gyb
@@ -47,7 +47,7 @@ public let DropWhile = [
   BenchmarkInfo(
     name: "DropWhile${Name}",
     runFunction: run_DropWhile${Name},
-    tags: [.validation, .api${', .Array' if Name == 'Array' else ''}]),
+    tags: [.validation, .api${', .Array, .unstable' if Name == 'Array' else ''}]),
 % end
 ]
 

--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -23,15 +23,15 @@ public let ObjectiveCBridging = [
   BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectToString, tags: [.validation, .bridging, .String]),
   BenchmarkInfo(name: "ObjectiveCBridgeFromNSArrayAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSArrayAnyObjectToStringForced, tags: [.validation, .bridging, .String]),
   BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObject", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObject, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectForced", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectForced, tags: [.validation, .bridging]),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectForced", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectForced, tags: [.validation, .bridging, .unstable]),
   BenchmarkInfo(name: "ObjectiveCBridgeToNSDictionary", runFunction: run_ObjectiveCBridgeToNSDictionary, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToString, tags: [.validation, .bridging, .String]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced, tags: [.validation, .bridging, .String]),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToString, tags: [.validation, .bridging, .String, .unstable]),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced, tags: [.validation, .bridging, .String, .unstable]),
   BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObject", runFunction: run_ObjectiveCBridgeFromNSSetAnyObject, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectForced", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectForced, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeToNSSet", runFunction: run_ObjectiveCBridgeToNSSet, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToString", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToString, tags: [.validation, .bridging, .String]),
-  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced, tags: [.validation, .bridging, .String]),
+  BenchmarkInfo(name: "ObjectiveCBridgeFromNSSetAnyObjectToStringForced", runFunction: run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced, tags: [.validation, .bridging, .String, .unstable]),
 ]
 
 #if _runtime(_ObjC)

--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -18,7 +18,7 @@ import ObjectiveCTests
 
 public let ObjectiveCBridgingStubs = [
   BenchmarkInfo(name: "ObjectiveCBridgeStubDataAppend", runFunction: run_ObjectiveCBridgeStubDataAppend, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubDateAccess", runFunction: run_ObjectiveCBridgeStubDateAccess, tags: [.validation, .bridging]),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubDateAccess", runFunction: run_ObjectiveCBridgeStubDateAccess, tags: [.validation, .bridging, .unstable]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubDateMutation", runFunction: run_ObjectiveCBridgeStubDateMutation, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubFromArrayOfNSString", runFunction: run_ObjectiveCBridgeStubFromArrayOfNSString, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDate", runFunction: run_ObjectiveCBridgeStubFromNSDate, tags: [.validation, .bridging]),

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -24,11 +24,11 @@ import ObjectiveCTests
 public let ObjectiveCNoBridgingStubs = [
   BenchmarkInfo(name: "ObjectiveCBridgeStubToNSStringRef", runFunction: run_ObjectiveCBridgeStubToNSStringRef, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubToNSDateRef", runFunction: run_ObjectiveCBridgeStubToNSDateRef, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateRefAccess", runFunction: run_ObjectiveCBridgeStubNSDateRefAccess, tags: [.validation, .bridging]),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateRefAccess", runFunction: run_ObjectiveCBridgeStubNSDateRefAccess, tags: [.validation, .bridging, .unstable]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubNSDateMutationRef", runFunction: run_ObjectiveCBridgeStubNSDateMutationRef, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubNSDataAppend", runFunction: run_ObjectiveCBridgeStubNSDataAppend, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSStringRef", runFunction: run_ObjectiveCBridgeStubFromNSStringRef, tags: [.validation, .bridging]),
-  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDateRef", runFunction: run_ObjectiveCBridgeStubFromNSDateRef, tags: [.validation, .bridging]),
+  BenchmarkInfo(name: "ObjectiveCBridgeStubFromNSDateRef", runFunction: run_ObjectiveCBridgeStubFromNSDateRef, tags: [.validation, .bridging, .unstable]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubURLAppendPathRef", runFunction: run_ObjectiveCBridgeStubURLAppendPathRef, tags: [.validation, .bridging]),
 ]
 

--- a/benchmark/single-source/ProtocolDispatch.swift
+++ b/benchmark/single-source/ProtocolDispatch.swift
@@ -15,7 +15,7 @@ import TestsUtils
 public let ProtocolDispatch = BenchmarkInfo(
   name: "ProtocolDispatch",
   runFunction: run_ProtocolDispatch,
-  tags: [.validation, .abstraction])
+  tags: [.validation, .abstraction, .unstable])
 
 @inline(never)
 public func run_ProtocolDispatch(_ N: Int) {

--- a/benchmark/single-source/ProtocolDispatch2.swift
+++ b/benchmark/single-source/ProtocolDispatch2.swift
@@ -20,7 +20,7 @@ import Foundation
 public let ProtocolDispatch2 = BenchmarkInfo(
   name: "ProtocolDispatch2",
   runFunction: run_ProtocolDispatch2,
-  tags: [.validation, .abstraction])
+  tags: [.validation, .abstraction, .unstable])
 
 protocol Pingable { func ping() -> Int;  func pong() -> Int}
 

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -86,11 +86,6 @@ struct Test {
   }
 }
 
-// Legacy test dictionaries.
-public var precommitTests: [BenchmarkInfo] = []
-public var otherTests: [BenchmarkInfo] = []
-public var stringTests: [BenchmarkInfo] = []
-
 // We should migrate to a collection of BenchmarkInfo.
 public var registeredBenchmarks: [BenchmarkInfo] = []
 
@@ -231,22 +226,12 @@ struct TestConfig {
   }
 
   mutating func findTestsToRun() {
-    // Begin by creating a set of our non-legacy registeredBenchmarks
-    var allTests = Set(registeredBenchmarks)
-
-    // Merge legacy benchmark info into allTests. If we already have a
-    // registered benchmark info, formUnion leaves this alone. This allows for
-    // us to perform incremental work.
-    for testList in [precommitTests, otherTests, stringTests] {
-      allTests.formUnion(testList)
-    }
-
     let benchmarkNameFilter = Set(filters)
 
     // t is needed so we don't capture an ivar of a mutable inout self.
     let t = tags
     let st = skipTags
-    let filteredTests = Array(allTests.filter { benchInfo in
+    let filteredTests = Array(registeredBenchmarks.filter { benchInfo in
       if !t.isSubset(of: benchInfo.tags) {
         return false
       }

--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -189,12 +189,10 @@ Entities
   entity-spec ::= 'Te' bridge-spec           // outlined objective c method call
 
   entity-spec ::= decl-name function-signature generic-signature? 'F'    // function
-  entity-spec ::= storage-spec
+  entity-spec ::= type file-discriminator? 'i' ACCESSOR                  // subscript
+  entity-spec ::= decl-name type 'v' ACCESSOR                            // variable
   entity-spec ::= decl-name type 'fp'                // generic type parameter
   entity-spec ::= decl-name type 'fo'                // enum element (currently not used)
-
-  storage-spec ::= type file-discriminator? 'i' ACCESSOR
-  storage-spec ::= decl-name type 'v' ACCESSOR
 
   ACCESSOR ::= 'm'                           // materializeForSet
   ACCESSOR ::= 's'                           // setter


### PR DESCRIPTION
Which excludes them from the list of executed benchmarks.

And  remove legacy benchmark lists in Driver. They are not used anymore.