### PR TITLE
Fixes an invalid assert in No Payload Enum's collectArchetypeMetadata: the type itself might contain an Archetype. We need to check that it is not an Archetype itself

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -945,7 +945,7 @@ namespace {
         llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
         SILType T) const override {
       auto canType = T.getSwiftRValueType();
-      assert(!canType->hasArchetype() &&
+      assert(!canType->is<ArchetypeType>() &&
              "collectArchetypeMetadata: no archetype expected here");
     }
 

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1397,6 +1397,5 @@ void TypeInfo::collectArchetypeMetadata(
     llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
     SILType T) const {
   auto canType = T.getSwiftRValueType();
-  assert(!canType->getWithoutSpecifierType()->is<ArchetypeType>() &&
-         "Did not expect an ArchetypeType");
+  assert(!canType->is<ArchetypeType>() && "Did not expect an ArchetypeType");
 }


### PR DESCRIPTION
radar rdar://problem/35831517