### PR TITLE
[stdlib] Replace various uses of BlahSlice with Slice to reduce warnings

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -15,7 +15,7 @@ from gyb_stdlib_unittest_support import TRACE, stackTrace, trace
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
-    sliceTypeName,
+    collectionTypeName,
     protocolsForCollectionFeatures
 )
 }%
@@ -508,8 +508,7 @@ Int64 distances.
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
 %       for StrideableIndex in [ False, True ]:
-%         SelfSlice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
-%         Self = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
+%         Self = 'Minimal' + collectionTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
 %         Self += 'WithStrideableIndex' if StrideableIndex else ''
 %         SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
 %         Index = 'MinimalStrideableIndex' if StrideableIndex else 'MinimalIndex'
@@ -701,10 +700,10 @@ public struct ${Self}<T> : ${SelfProtocols} {
 %     end
   }
 
-  public subscript(bounds: Range<${Index}>) -> ${SelfSlice}<${Self}<T>> {
+  public subscript(bounds: Range<${Index}>) -> Slice<${Self}<T>> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      return ${SelfSlice}(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
 %     if Mutable:
     set {
@@ -853,10 +852,9 @@ public struct DefaultedSequence<Element> : Sequence {
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
 %       for StrideableIndex in [ False, True ]:
-%         SelfSlice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
-%         Self = 'Defaulted' + SelfSlice.replace('Slice', 'Collection')
+%         Self = 'Defaulted' + collectionTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
 %         Self += 'WithStrideableIndex' if StrideableIndex else ''
-%         Base = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
+%         Base = 'Minimal' + collectionTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
 %         Base += 'WithStrideableIndex' if StrideableIndex else ''
 %         SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
 %         Index = 'MinimalStrideableIndex' if StrideableIndex else 'MinimalIndex'
@@ -973,10 +971,10 @@ public struct ${Self}<Element> : ${SelfProtocols} {
     // FIXME: swift-3-indexing-model: use defaults.
 //     if Self not in ['DefaultedCollection', 'DefaultedBidirectionalCollection', 'DefaultedRandomAccessCollection', 'DefaultedMutableCollection', 'DefaultedRangeReplaceableCollection']:
 
-  public subscript(bounds: Range<${Index}>) -> ${SelfSlice}<${Self}<Base.Element>> {
+  public subscript(bounds: Range<${Index}>) -> Slice<${Self}<Base.Element>> {
     get {
       // FIXME: swift-3-indexing-model: range check.
-      return ${SelfSlice}(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
 %     if Mutable:
     set {

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -163,9 +163,9 @@ extension UnsafeMutableAudioBufferListPointer
   }
 
   public subscript(bounds: Range<Int>)
-    -> MutableRandomAccessSlice<UnsafeMutableAudioBufferListPointer> {
+    -> Slice<UnsafeMutableAudioBufferListPointer> {
     get {
-      return MutableRandomAccessSlice(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
     set {
       _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -255,8 +255,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		return ptr!.load(fromByteOffset: index - offset, as: UInt8.self)
 	}
 
-	public subscript(bounds: Range<Int>) -> RandomAccessSlice<DispatchData> {
-		return RandomAccessSlice(base: self, bounds: bounds)
+	public subscript(bounds: Range<Int>) -> Slice<DispatchData> {
+		return Slice(base: self, bounds: bounds)
 	}
 
 	/// Return a new copy of the data in a specified range.

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -79,8 +79,8 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             return indexSetRange.lowerBound..<indexSetRange.upperBound
         }
         
-        public subscript(bounds: Range<Index>) -> BidirectionalSlice<RangeView> {
-            return BidirectionalSlice(base: self, bounds: bounds)
+        public subscript(bounds: Range<Index>) -> Slice<RangeView> {
+            return Slice(base: self, bounds: bounds)
         }
 
         public func index(after i: Index) -> Index {
@@ -237,8 +237,8 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         return index.value
     }
 
-    public subscript(bounds: Range<Index>) -> BidirectionalSlice<IndexSet> {
-        return BidirectionalSlice(base: self, bounds: bounds)
+    public subscript(bounds: Range<Index>) -> Slice<IndexSet> {
+        return Slice(base: self, bounds: bounds)
     }
 
     // We adopt the default implementation of subscript(range: Range<Index>) from MutableCollection

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -14,7 +14,6 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
-    sliceTypeName
 )
 }%
 
@@ -157,7 +156,6 @@ extension LazySequenceProtocol where Element : Sequence {
 %   if traversal == 'Bidirectional':
 %     constraints = '%(Base)sIterator.Element : BidirectionalCollection'
 %   Index = Collection + 'Index'
-%   Slice = sliceTypeName(traversal=traversal, mutable=False, rangeReplaceable=False)
 /// A position in a `${Collection}`.
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct ${Index}<BaseElements>

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -25,7 +25,6 @@ from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
     defaultIndicesForTraversal,
-    sliceTypeName
 )
 
 }%

--- a/utils/gyb_stdlib_support.py
+++ b/utils/gyb_stdlib_support.py
@@ -22,8 +22,8 @@ def collectionForTraversal(traversal):  # noqa (N802 function name should be low
         raise ValueError("Unknown traversal %r" % traversal)
 
 
-def sliceTypeName(traversal, mutable, rangeReplaceable):  # noqa (N802)
-    name = collectionForTraversal(traversal).replace('Collection', 'Slice')
+def collectionTypeName(traversal, mutable, rangeReplaceable):  # noqa (N802)
+    name = collectionForTraversal(traversal)
     if rangeReplaceable:
         name = 'RangeReplaceable' + name
     if mutable:

--- a/validation-test/StdlibUnittest/SequencesCollections.swift.gyb
+++ b/validation-test/StdlibUnittest/SequencesCollections.swift.gyb
@@ -7,7 +7,8 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
-    protocolsForCollectionFeatures
+    protocolsForCollectionFeatures,
+    collectionTypeName
 )
 
 }%

--- a/validation-test/StdlibUnittest/SequencesCollections.swift.gyb
+++ b/validation-test/StdlibUnittest/SequencesCollections.swift.gyb
@@ -7,7 +7,6 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
-    sliceTypeName,
     protocolsForCollectionFeatures
 )
 
@@ -22,8 +21,7 @@ import StdlibCollectionUnittest
 // This comment is a workaround for <rdar://problem/18900352> gyb miscompiles nested loops
 %  for mutable in [ False, True ]:
 // This comment is a workaround for <rdar://problem/18900352> gyb miscompiles nested loops
-%    SelfSlice = sliceTypeName(traversal=traversal, mutable=mutable, rangeReplaceable=False)
-%    Self = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
+%    Self = 'Minimal' + collectionTypeName(traversal=traversal, mutable=mutable, rangeReplaceable=False)
 
 var ${Self}TestSuite = TestSuite("${Self}")
 
@@ -116,8 +114,7 @@ ${Self}TestSuite.test("subscript(_:Index)/Set/DifferentCollections") {
 %end
 
 %for traversal in TRAVERSALS:
-%  SelfSlice = sliceTypeName(traversal=traversal, mutable=False, rangeReplaceable=True)
-%  Self = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
+%  Self = 'Minimal' + collectionTypeName(traversal=traversal, mutable=False, rangeReplaceable=True)
 
 func getTwoInterchangeable${Self}(_ elements: [Int])
   -> (${Self}<OpaqueValue<Int>>, ${Self}<OpaqueValue<Int>>) {

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -7,7 +7,6 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
-    sliceTypeName
 )
 
 import itertools
@@ -32,10 +31,10 @@ def all_tests():
     test.base_kind = base_kind
     test.mutable = mutable
     test.range_replaceable = range_replaceable
-    test.base = base_kind + sliceTypeName(
+    test.base = base_kind + collectionTypeName(
       traversal=traversal,
       mutable=mutable,
-      rangeReplaceable=range_replaceable).replace('Slice', 'Collection')
+      rangeReplaceable=range_replaceable)
     test.name = test.base + '.swift'
     test.ref_name = test.base + 'OfRef.swift'
     yield test

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -7,7 +7,7 @@
 
 % import os.path
 % import gyb
-% from gyb_stdlib_support import TRAVERSALS, collectionForTraversal, sliceTypeName, defaultIndicesForTraversal
+% from gyb_stdlib_support import TRAVERSALS, collectionForTraversal, defaultIndicesForTraversal
 
 import StdlibUnittest
 import StdlibCollectionUnittest
@@ -829,7 +829,6 @@ func ==(lhs: FatalIndex, rhs: FatalIndex) -> Bool { fatalError() }
 % for Traversal in TRAVERSALS:
 %   Collection = collectionForTraversal(Traversal)
 %   Self = 'Fatal' + Collection
-%   Slice = sliceTypeName(Traversal, False, False)
 %   Indices = defaultIndicesForTraversal(Traversal)
 
 struct ${Self}<T> : ${Collection} {
@@ -847,7 +846,7 @@ CollectionTypeTests.test("AssociatedTypes/${Collection}") {
   expectCollectionAssociatedTypes(
     collectionType: C.self,
     iteratorType: IndexingIterator<C>.self,
-    subSequenceType: ${Slice}<C>.self,
+    subSequenceType: Slice<C>.self,
     indexType: FatalIndex.self,
     indexDistanceType: Int.self,
     indicesType: ${Indices}<C>.self)

--- a/validation-test/stdlib/Join.swift.gyb
+++ b/validation-test/stdlib/Join.swift.gyb
@@ -255,14 +255,14 @@ var JoinTestSuite = TestSuite("Join")
 
 from gyb_stdlib_support import (
     TRAVERSALS,
-    sliceTypeName
+    collectionTypeName
 )
 
 from itertools import product
 
 base_kinds = [ 'Defaulted', 'Minimal' ]
 collections = [
-  (base_kind + sliceTypeName(traversal=traversal, mutable=False, rangeReplaceable=True).replace('Slice', 'Collection'), traversal)
+  (base_kind + collectionTypeName(traversal=traversal, mutable=False, rangeReplaceable=True), traversal)
     for base_kind, traversal in product(base_kinds, TRAVERSALS)
 ]
 other_array_types = [ 'Array', 'ArraySlice', 'ContiguousArray' ]

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -5,8 +5,8 @@
 %{
 from gyb_stdlib_support import (
     TRAVERSALS,
-    sliceTypeName,
-    defaultIndicesForTraversal
+    defaultIndicesForTraversal,
+    collectionTypeName
 )
 }%
 
@@ -48,13 +48,12 @@ var SliceTests = TestSuite("Collection")
 % for Traversal in TRAVERSALS:
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
-%       Slice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
-%       Collection = 'Minimal' + Slice.replace('Slice', 'Collection')
+%       Collection = 'Minimal' + collectionTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
 
-SliceTests.test("${Slice}/AssociatedTypes") {
+SliceTests.test("${Collection}.Slice/AssociatedTypes") {
  do {
     typealias Collection = ${Collection}<OpaqueValue<Int>>
-    typealias CollectionSlice = ${Slice}<Collection>
+    typealias CollectionSlice = Slice<Collection>
     expectSliceType(CollectionSlice.self)
     expectCollectionAssociatedTypes(
       collectionType: CollectionSlice.self,
@@ -76,11 +75,12 @@ SliceTests.test("${Slice}/AssociatedTypes") {
   }
 }
 
-SliceTests.test("${Slice}/init(base:bounds:)") {
+SliceTests.test("${Collection}.Slice/init(base:bounds:)") {
   for test in subscriptRangeTests {
     let base = ${Collection}(elements: test.collection)
-    var slice = ${Slice}(base: base, bounds: test.bounds(in: base))
-    expectType(${Slice}<${Collection}<OpaqueValue<Int>>>.self, &slice)
+    var slice = Slice(base: base, bounds: test.bounds(in: base))
+    expectType(Slice<${Collection}<OpaqueValue<Int>>>.self, &slice)
+    expectType(${Collection}<OpaqueValue<Int>>.SubSequence.self, &slice)
 
     checkCollection(
       test.expected,
@@ -91,19 +91,20 @@ SliceTests.test("${Slice}/init(base:bounds:)") {
 }
 
 % if RangeReplaceable == False and Mutable == False:
-SliceTests.test("${Slice}/baseProperty") {
+SliceTests.test("${Collection}.Slice/baseProperty") {
   let referenceCollection = ReferenceCollection()
-  let testSlice = ${Slice}(base: referenceCollection, bounds: 0..<1)
+  let testSlice = Slice(base: referenceCollection, bounds: 0..<1)
   expectTrue(testSlice.base === referenceCollection)
 }
 % end
 
-SliceTests.test("${Slice}.{startIndex,endIndex}") {
+SliceTests.test("${Collection}.Slice.{startIndex,endIndex}") {
   for test in subscriptRangeTests {
     let c = ${Collection}(elements: test.collection)
     let bounds = test.bounds(in: c)
-    var slice = ${Slice}(base: c, bounds: bounds)
-    expectType(${Slice}<${Collection}<OpaqueValue<Int>>>.self, &slice)
+    var slice = Slice(base: c, bounds: bounds)
+    expectType(Slice<${Collection}<OpaqueValue<Int>>>.self, &slice)
+    expectType(${Collection}<OpaqueValue<Int>>.SubSequence.self, &slice)
 
     expectEqual(bounds.lowerBound, slice.startIndex)
     expectEqual(bounds.upperBound, slice.endIndex)

--- a/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
@@ -7,7 +7,7 @@
 from gyb_stdlib_support import (
     TRAVERSALS,
     collectionForTraversal,
-    sliceTypeName
+    collectionTypeName
 )
 
 import itertools
@@ -34,11 +34,11 @@ def all_tests():
     test.base_kind = base_kind
     test.mutable = mutable
     test.range_replaceable = range_replaceable
-    test.base_slice = sliceTypeName(
+    test.base = base_kind + collectionTypeName(
       traversal=traversal,
       mutable=mutable,
       rangeReplaceable=range_replaceable)
-    test.base = base_kind + test.base_slice.replace('Slice', 'Collection')
+
     for name, prefix, suffix in [
       ('FullWidth', '[]', '[]'),
       ('WithPrefix', '[-9999, -9998, -9997]', '[]'),


### PR DESCRIPTION
Now that `Slice` is conditionally conforming to protocols based on its base, various uses of specific slices can be replaced, suppressing deprecation warnings.

Note, the validation tests generated by `validation-test/stdlib/Slice/Inputs/Template.swift.gyb` are still using the old slice types. That needs a bit more work to fix.