### PR TITLE
[CMake] Add swift-syntax-generated-headers to the global dependencies

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -57,8 +57,6 @@ add_swift_library(swiftAST STATIC
   TypeRepr.cpp
   TypeWalker.cpp
   USRGeneration.cpp
-  DEPENDS
-    swift-syntax-generated-headers
 
   LINK_LIBRARIES
     swiftMarkup

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,6 +10,9 @@
 # directory.
 list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen clang-tablegen-targets)
 
+# Add generated libSyntax headers to global dependencies.
+list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
+
 add_subdirectory(AST)
 add_subdirectory(ASTSectionImporter)
 add_subdirectory(Basic)

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -16,7 +16,6 @@ add_swift_library(swiftClangImporter STATIC
   ImportName.cpp
   ImportType.cpp
   SwiftLookupTable.cpp
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftAST
     swiftParse

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -16,7 +16,7 @@ set(swiftDriver_targetDefines)
 
 add_swift_library(swiftDriver STATIC
   ${swiftDriver_sources}
-  DEPENDS swift-syntax-generated-headers SwiftOptions
+  DEPENDS SwiftOptions
   LINK_LIBRARIES swiftAST swiftBasic swiftFrontend swiftOption)
 
 # Generate the static-stdlib-args.lnk file used by -static-stdlib option

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -7,7 +7,6 @@ add_swift_library(swiftFrontend STATIC
   SerializedDiagnosticConsumer.cpp
   DEPENDS
     SwiftOptions
-    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftSIL
     swiftMigrator

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -13,8 +13,6 @@ add_swift_library(swiftIDE STATIC
   IDETypeChecking.cpp
   APIDigesterData.cpp
   SourceEntityWalker.cpp
-  DEPENDS
-    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftFrontend
     swiftClangImporter

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_swift_library(swiftImmediate STATIC
   Immediate.cpp
   REPL.cpp
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftIDE
     swiftFrontend

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -44,8 +44,6 @@ add_swift_library(swiftMigrator STATIC
   RewriteBufferEditsReceiver.cpp
   TupleSplatMigratorPass.cpp
   TypeOfMigratorPass.cpp
-  DEPENDS
-    swift-syntax-generated-headers
   LINK_LIBRARIES swiftSyntax swiftIDE)
 
 add_dependencies(swiftMigrator

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -11,8 +11,6 @@ add_swift_library(swiftParse STATIC
   ParseType.cpp
   PersistentParserState.cpp
   Scope.cpp
-  DEPENDS
-    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftAST
     swiftSyntax

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_swift_library(swiftParseSIL STATIC
   ParseSIL.cpp
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftParse
     swiftSema

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_library(swiftPrintAsObjC STATIC
   PrintAsObjC.cpp
-
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftIDE
     swiftFrontend

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -19,5 +19,4 @@ add_swift_library(swiftSILOptimizer STATIC
   ${MANDATORY_SOURCES}
   ${TRANSFORMS_SOURCES}
   ${IPO_SOURCES}
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBRARIES swiftSIL)

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -54,8 +54,6 @@ add_swift_library(swiftSema STATIC
   TypeCheckSwitchStmt.cpp
   TypeCheckType.cpp
   TypeChecker.cpp
-  DEPENDS
-    swift-syntax-generated-headers
   LINK_LIBRARIES
     swiftParse
     swiftAST

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -12,6 +12,4 @@ add_swift_library(swiftSyntax STATIC
   Syntax.cpp
   SyntaxData.cpp
   UnknownSyntax.cpp
-  SyntaxParsingContext.cpp
-  DEPENDS
-    swift-syntax-generated-headers)
+  SyntaxParsingContext.cpp)

--- a/tools/SourceKit/lib/Support/CMakeLists.txt
+++ b/tools/SourceKit/lib/Support/CMakeLists.txt
@@ -15,6 +15,5 @@ endif()
 
 add_sourcekit_library(SourceKitSupport
   ${SourceKitSupport_sources}
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBS ${SOURCEKIT_SUPPORT_DEPEND}
 )

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -8,7 +8,6 @@ add_sourcekit_library(SourceKitSwiftLang
   SwiftIndexing.cpp
   SwiftLangSupport.cpp
   SwiftSourceDocInfo.cpp
-  DEPENDS swift-syntax-generated-headers
   LINK_LIBS
     SourceKitCore swiftDriver swiftFrontend swiftClangImporter swiftIDE
     swiftAST swiftMarkup swiftParse swiftParseSIL swiftSIL swiftSILGen


### PR DESCRIPTION
Add `swift-syntax-generated-headers` to `LLVM_COMMON_DEPENDS`.

This is basically a workaround that prevents dependency failures to `swift-syntax-generated-headers`. It's not optimal, but it should resolve the problem we've experienced several times. ( https://github.com/apple/swift/pull/11226 https://github.com/apple/swift/pull/11284 https://github.com/apple/swift/pull/11289 https://github.com/apple/swift/pull/12689 https://github.com/apple/swift/pull/13203 )

rdar://problem/35802223
