### PR TITLE
[Foundation] Discontiguous data slices should not heap corrupt (#13252)

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
@@ -3721,6 +3722,25 @@ class TestData : TestDataSuper {
         }
         expectEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
     }
+
+    func test_byte_access_of_discontiguousData() {
+        var d = DispatchData.empty
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5]
+        for _ in 0..<3 {
+            bytes.withUnsafeBufferPointer {
+                d.append($0)
+            }
+        }
+        let ref = d as AnyObject
+        let data = ref as! Data
+
+        let cnt = data.count - 4
+        let t = data.dropFirst(4).withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+            return Data(bytes: bytes, count: cnt)
+        }
+
+        expectEqual(Data(bytes: [4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]), t)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -4037,6 +4057,7 @@ DataTests.test("test_validateMutation_slice_immutableBacking_withUnsafeMutableBy
 DataTests.test("test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
 DataTests.test("test_validateMutation_slice_customBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_customBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
+DataTests.test("test_byte_access_of_discontiguousData") { TestData().test_byte_access_of_discontiguousData() }
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
Explanation:
Byte access and methods that funnel to byte access for slices of discontiguous data (ala backed by dispatch_data_t) should void heap corruption and walking off the ends of buffers. The index calculation for slice region intersections of discontiguous data backed NSDatas that were bridged to swift as Data inappropriately would memcpy over the bounds of the allocation in specific cases. This change simplifies the logic for calculating the indexes and ranges and adds a test that would trigger one of the specific scenarios that would be affected.

The `withUnsafeBytes(in:, apply:)` internal method incorrectly handled discontiguous data backing when the slice region was used. This would potentially walk off the end of the buffer as well as grab incorrect byte offsets.

Scope:
This only applies to the mutation of slices of dispatch_data_t bridged to NSData bridged to Data.

Radar (and possibly SR Issue):
rdar://problem/35797359
https://bugs.swift.org/browse/SR-6515

Risk:
Low risk since this is not a common case of bridging from dispatch_data_t to NSData to Data and then slicing it. 

Reviewed by:
Michael Lehew Jr

Testing:
Additional unit tests were added to validate the correctness of this patch.