### PR TITLE
NFC: repack decl base

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -228,10 +228,19 @@ struct OverloadSignature {
 /// Determine whether two overload signatures conflict.
 bool conflicting(const OverloadSignature& sig1, const OverloadSignature& sig2);
 
+#define BITFIELD_START(D, PD, C) \
+  enum { Num##D##Bits = Num##PD##Bits + C }; \
+  static_assert(Num##D##Bits <= 64, "fits in a uint64_t"); \
+  class D##Bitfields { \
+    friend class D; \
+    uint64_t : Num##PD##Bits
+
+#define BITFIELD_END }
+
 /// Decl - Base class for all declarations in Swift.
 class alignas(1 << DeclAlignInBits) Decl {
-  class DeclBitfields {
-    friend class Decl;
+  enum { Num_DeclBits = 0 };
+  BITFIELD_START(Decl, _Decl, 13);
     unsigned Kind : 6;
 
     /// \brief Whether this declaration is invalid.
@@ -260,14 +269,9 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// \brief Whether this declaration was added to the surrounding
     /// DeclContext of an active #if config clause.
     unsigned EscapedFromIfConfig : 1;
-  };
-  enum { NumDeclBits = 13 };
-  static_assert(NumDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class PatternBindingDeclBitfields {
-    friend class PatternBindingDecl;
-    unsigned : NumDeclBits;
-    
+  BITFIELD_START(PatternBindingDecl, Decl, 19);
     /// \brief Whether this pattern binding declares static variables.
     unsigned IsStatic : 1;
 
@@ -276,14 +280,11 @@ class alignas(1 << DeclAlignInBits) Decl {
 
     /// \brief The number of pattern binding declarations.
     unsigned NumPatternEntries : 16;
-  };
-  enum { NumPatternBindingDeclBits = NumDeclBits + 19 };
-  static_assert(NumPatternBindingDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
   
-  class ValueDeclBitfields {
-    friend class ValueDecl;
+  BITFIELD_START(ValueDecl, Decl, 3);
     friend class MemberLookupTable;
-    unsigned : NumDeclBits;
+
     unsigned AlreadyInLookupTable : 1;
 
     /// Whether we have already checked whether this declaration is a 
@@ -293,14 +294,9 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether the decl can be accessed by swift users; for instance,
     /// a.storage for lazy var a is a decl that cannot be accessed.
     unsigned IsUserAccessible : 1;
-  };
-  enum { NumValueDeclBits = NumDeclBits + 3 };
-  static_assert(NumValueDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class AbstractStorageDeclBitfields {
-    friend class AbstractStorageDecl;
-    unsigned : NumValueDeclBits;
-
+  BITFIELD_START(AbstractStorageDecl, ValueDecl, 7);
     /// Whether we are overridden later
     unsigned Overridden : 1;
 
@@ -312,14 +308,9 @@ class alignas(1 << DeclAlignInBits) Decl {
 
     /// The storage kind.
     unsigned StorageKind : 4;
-  };
-  enum { NumAbstractStorageDeclBits = NumValueDeclBits + 7 };
-  static_assert(NumAbstractStorageDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class VarDeclBitfields {
-    friend class VarDecl;
-    unsigned : NumAbstractStorageDeclBits;
-
+  BITFIELD_START(VarDecl, AbstractStorageDecl, 6);
     /// \brief Whether this property is a type property (currently unfortunately
     /// called 'static').
     unsigned IsStatic : 1;
@@ -339,29 +330,18 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// \brief Whether this is a property used in expressions in the debugger.
     /// It is up to the debugger to instruct SIL how to access this variable.
     unsigned IsDebuggerVar : 1;
+  BITFIELD_END;
 
-  };
-  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 6 };
-  static_assert(NumVarDeclBits <= 32, "fits in an unsigned");
-
-  class EnumElementDeclBitfields {
-    friend class EnumElementDecl;
-    unsigned : NumValueDeclBits;
-    
+  BITFIELD_START(EnumElementDecl, ValueDecl, 3);
     /// \brief Whether or not this element directly or indirectly references
     /// the enum type.
     unsigned Recursiveness : 2;
 
     /// \brief Whether or not this element has an associated value.
     unsigned HasArgumentType : 1;
-  };
-  enum { NumEnumElementDeclBits = NumValueDeclBits + 3 };
-  static_assert(NumEnumElementDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
   
-  class AbstractFunctionDeclBitfields {
-    friend class AbstractFunctionDecl;
-    unsigned : NumValueDeclBits;
-
+  BITFIELD_START(AbstractFunctionDecl, ValueDecl, 13);
     /// \see AbstractFunctionDecl::BodyKind
     unsigned BodyKind : 3;
 
@@ -382,72 +362,41 @@ class alignas(1 << DeclAlignInBits) Decl {
 
     /// The ResilienceExpansion to use for default arguments.
     unsigned DefaultArgumentResilienceExpansion : 1;
-  };
-  enum { NumAbstractFunctionDeclBits = NumValueDeclBits + 13 };
-  static_assert(NumAbstractFunctionDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class FuncDeclBitfields {
-    friend class FuncDecl;
-    unsigned : NumAbstractFunctionDeclBits;
-
+  BITFIELD_START(FuncDecl, AbstractFunctionDecl, 3);
     /// Whether this function is a 'static' method.
     unsigned IsStatic : 1;
 
     /// \brief Whether 'static' or 'class' was used.
     unsigned StaticSpelling : 2;
-  };
-  enum { NumFuncDeclBits = NumAbstractFunctionDeclBits + 3 };
-  static_assert(NumFuncDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class ConstructorDeclBitfields {
-    friend class ConstructorDecl;
-    unsigned : NumAbstractFunctionDeclBits;
-
+  BITFIELD_START(ConstructorDecl, AbstractFunctionDecl, 3);
     /// The body initialization kind (+1), or zero if not yet computed.
     ///
     /// This value is cached but is not serialized, because it is a property
     /// of the definition of the constructor that is useful only to semantic
     /// analysis and SIL generation.
     unsigned ComputedBodyInitKind : 3;
-  };
-  enum { NumConstructorDeclBits = NumAbstractFunctionDeclBits + 3 };
-  static_assert(NumConstructorDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class TypeDeclBitfields {
-    friend class TypeDecl;
-    unsigned : NumValueDeclBits;
-
+  BITFIELD_START(TypeDecl, ValueDecl, 1);
     /// Whether we have already checked the inheritance clause.
     ///
     /// FIXME: Is this too fine-grained?
     unsigned CheckedInheritanceClause : 1;
-  };
+  BITFIELD_END;
 
-  enum { NumTypeDeclBits = NumValueDeclBits + 1 };
-  static_assert(NumTypeDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_START(GenericTypeDecl, TypeDecl, 0);
+  BITFIELD_END;
 
-  class GenericTypeDeclBitfields {
-    friend class GenericTypeDecl;
-    unsigned : NumTypeDeclBits;
-  };
-
-  enum { NumGenericTypeDeclBits = NumTypeDeclBits };
-  static_assert(NumGenericTypeDeclBits <= 32, "fits in an unsigned");
-
-  class TypeAliasDeclBitfields {
-    friend class TypeAliasDecl;
-    unsigned : NumGenericTypeDeclBits;
-
+  BITFIELD_START(TypeAliasDecl, GenericTypeDecl, 1);
     /// Whether the typealias forwards perfectly to its underlying type.
     unsigned IsCompatibilityAlias : 1;
-  };
-  enum { NumTypeAliasDeclBits = NumGenericTypeDeclBits + 1 };
-  static_assert(NumTypeAliasDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class NominalTypeDeclBitFields {
-    friend class NominalTypeDecl;
-    unsigned : NumGenericTypeDeclBits;
-    
+  BITFIELD_START(NominalTypeDecl, GenericTypeDecl, 4);
     /// Whether or not the nominal type decl has delayed protocol or member
     /// declarations.
     unsigned HasDelayedMembers : 1;
@@ -462,14 +411,9 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether we have already validated all members of the type that
     /// affect layout.
     unsigned HasValidatedLayout : 1;
-  };
-  enum { NumNominalTypeDeclBits = NumGenericTypeDeclBits + 4 };
-  static_assert(NumNominalTypeDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class ProtocolDeclBitfields {
-    friend class ProtocolDecl;
-    unsigned : NumNominalTypeDeclBits;
-
+  BITFIELD_START(ProtocolDecl, NominalTypeDecl, 8);
     /// Whether the \c RequiresClass bit is valid.
     unsigned RequiresClassValid : 1;
 
@@ -490,14 +434,9 @@ class alignas(1 << DeclAlignInBits) Decl {
 
     /// The stage of the circularity check for this protocol.
     unsigned Circularity : 2;
-  };
-  enum { NumProtocolDeclBits = NumNominalTypeDeclBits + 8 };
-  static_assert(NumProtocolDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class ClassDeclBitfields {
-    friend class ClassDecl;
-    unsigned : NumNominalTypeDeclBits;
-
+  BITFIELD_START(ClassDecl, NominalTypeDecl, 8);
     /// The stage of the inheritance circularity check for this class.
     unsigned Circularity : 2;
 
@@ -520,70 +459,40 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// it is implicit. This bit is used during parsing and type-checking to
     /// control inserting the implicit destructor.
     unsigned HasDestructorDecl : 1;
+  BITFIELD_END;
 
-  };
-  enum { NumClassDeclBits = NumNominalTypeDeclBits + 8 };
-  static_assert(NumClassDeclBits <= 32, "fits in an unsigned");
-
-  class StructDeclBitfields {
-    friend class StructDecl;
-    unsigned : NumNominalTypeDeclBits;
-    
+  BITFIELD_START(StructDecl, NominalTypeDecl, 1);
     /// True if this struct has storage for fields that aren't accessible in
     /// Swift.
     unsigned HasUnreferenceableStorage : 1;
-  };
-  enum { NumStructDeclBits = NumNominalTypeDeclBits + 1 };
-  static_assert(NumStructDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
   
-  class EnumDeclBitfields {
-    friend class EnumDecl;
-    unsigned : NumNominalTypeDeclBits;
-    
+  BITFIELD_START(EnumDecl, NominalTypeDecl, 4);
     /// The stage of the raw type circularity check for this class.
     unsigned Circularity : 2;
 
     /// True if the enum has cases and at least one case has associated values.
     mutable unsigned HasAssociatedValues : 2;
-  };
-  enum { NumEnumDeclBits = NumNominalTypeDeclBits + 4 };
-  static_assert(NumEnumDeclBits <= 32, "fits in an unsigned");
-  
-  class PrecedenceGroupDeclBitfields {
-    friend class PrecedenceGroupDecl;
-    unsigned : NumDeclBits;
+  BITFIELD_END;
 
+  BITFIELD_START(PrecedenceGroupDecl, Decl, 11);
     /// The group's associativity.  A value of the Associativity enum.
     unsigned Associativity : 2;
 
     /// Is this an assignment operator?
     unsigned IsAssignment : 1;
-  };
-  enum { NumPrecedenceGroupDeclBits = NumDeclBits + 11 };
-  static_assert(NumPrecedenceGroupDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class AssociatedTypeDeclBitfields {
-    friend class AssociatedTypeDecl;
-    unsigned : NumTypeDeclBits;
+  BITFIELD_START(AssociatedTypeDecl, TypeDecl, 2);
     unsigned ComputedOverridden : 1;
     unsigned HasOverridden : 1;
-  };
-  enum { NumAssociatedTypeDeclBits = NumTypeDeclBits + 2 };
-  static_assert(NumAssociatedTypeDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class ImportDeclBitfields {
-    friend class ImportDecl;
-    unsigned : NumDeclBits;
-
+  BITFIELD_START(ImportDecl, Decl, 3);
     unsigned ImportKind : 3;
-  };
-  enum { NumImportDeclBits = NumDeclBits + 3 };
-  static_assert(NumImportDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class ExtensionDeclBitfields {
-    friend class ExtensionDecl;
-    unsigned : NumDeclBits;
-
+  BITFIELD_START(ExtensionDecl, Decl, 5);
     /// Whether we have already checked the inheritance clause.
     ///
     /// FIXME: Is this too fine-grained?
@@ -598,30 +507,20 @@ class alignas(1 << DeclAlignInBits) Decl {
 
     /// Whether there is are lazily-loaded conformances for this extension.
     unsigned HasLazyConformances : 1;
-  };
-  enum { NumExtensionDeclBits = NumDeclBits + 5 };
-  static_assert(NumExtensionDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class IfConfigDeclBitfields {
-    friend class IfConfigDecl;
-    unsigned : NumDeclBits;
-
+  BITFIELD_START(IfConfigDecl, Decl, 1);
     /// Whether this decl is missing its closing '#endif'.
     unsigned HadMissingEnd : 1;
-  };
-  enum { NumIfConfigDeclBits = NumDeclBits + 1 };
-  static_assert(NumIfConfigDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
-  class MissingMemberDeclBitfields {
-    friend class MissingMemberDecl;
-    unsigned : NumDeclBits;
-
+  BITFIELD_START(MissingMemberDecl, Decl, 3);
     unsigned NumberOfVTableEntries : 2;
     unsigned NumberOfFieldOffsetVectorEntries : 1;
-  };
-  enum { NumMissingMemberDeclBits = NumDeclBits + 3 };
-  static_assert(NumMissingMemberDeclBits <= 32, "fits in an unsigned");
+  BITFIELD_END;
 
+#undef BITFIELD_START
+#undef BITFIELD_END
 protected:
   union {
     DeclBitfields DeclBits;
@@ -636,7 +535,7 @@ protected:
     TypeDeclBitfields TypeDeclBits;
     GenericTypeDeclBitfields GenericTypeDeclBits;
     TypeAliasDeclBitfields TypeAliasDeclBits;
-    NominalTypeDeclBitFields NominalTypeDeclBits;
+    NominalTypeDeclBitfields NominalTypeDeclBits;
     ProtocolDeclBitfields ProtocolDeclBits;
     ClassDeclBitfields ClassDeclBits;
     StructDeclBitfields StructDeclBits;
@@ -647,10 +546,8 @@ protected:
     ExtensionDeclBitfields ExtensionDeclBits;
     IfConfigDeclBitfields IfConfigDeclBits;
     MissingMemberDeclBitfields MissingMemberDeclBits;
-    uint32_t OpaqueBits;
+    uint64_t OpaqueBits;
   };
-
-  // FIXME: Unused padding here.
 
   // Storage for the declaration attributes.
   DeclAttributes Attrs;

--- a/include/swift/AST/DefaultArgumentKind.h
+++ b/include/swift/AST/DefaultArgumentKind.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_DEFAULTARGUMENTKIND_H
 #define SWIFT_DEFAULTARGUMENTKIND_H
 
+#include <cstdint>
+
 namespace llvm {
 class StringRef;
 }
@@ -26,7 +28,7 @@ namespace swift {
 class Expr;
 
 /// Describes the kind of default argument a tuple pattern element has.
-enum class DefaultArgumentKind : unsigned {
+enum class DefaultArgumentKind : uint8_t {
   /// No default argument.
   None,
   /// A normal default argument.
@@ -51,6 +53,7 @@ enum class DefaultArgumentKind : unsigned {
   /// An empty dictionary literal.
   EmptyDictionary,
 };
+enum { NumDefaultArgumentKindBits = 4 };
 
 /// Retrieve the spelling of this default argument in source code, or
 /// an empty string if it has none.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4296,6 +4296,9 @@ ParamDecl::ParamDecl(Specifier specifier,
   SpecifierLoc(specifierLoc) {
     assert(specifier != Specifier::Var &&
            "'var' cannot appear on parameters; you meant 'inout'");
+  ParamDeclBits.IsTypeLocImplicit = false;
+  ParamDeclBits.defaultArgumentKind =
+    static_cast<unsigned>(DefaultArgumentKind::None);
 }
 
 /// Clone constructor, allocates a new ParamDecl identical to the first.
@@ -4310,9 +4313,9 @@ ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
     ArgumentName(PD->getArgumentName()),
     ArgumentNameLoc(PD->getArgumentNameLoc()),
     SpecifierLoc(PD->getSpecifierLoc()),
-    DefaultValueAndIsVariadic(nullptr, PD->DefaultValueAndIsVariadic.getInt()),
-    IsTypeLocImplicit(PD->IsTypeLocImplicit),
-    defaultArgumentKind(PD->defaultArgumentKind) {
+    DefaultValueAndIsVariadic(nullptr, PD->DefaultValueAndIsVariadic.getInt()) {
+  ParamDeclBits.IsTypeLocImplicit = PD->ParamDeclBits.IsTypeLocImplicit;
+  ParamDeclBits.defaultArgumentKind = PD->ParamDeclBits.defaultArgumentKind;
   typeLoc = PD->getTypeLoc().clone(PD->getASTContext());
   if (!withTypes && typeLoc.getTypeRepr())
     typeLoc.setType(Type());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5083,9 +5083,9 @@ ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
   setParameterLists(SelfDecl, BodyParams);
   
   ConstructorDeclBits.ComputedBodyInitKind = 0;
-  this->HasStubImplementation = 0;
-  this->InitKind = static_cast<unsigned>(CtorInitializerKind::Designated);
-  this->Failability = static_cast<unsigned>(Failability);
+  ConstructorDeclBits.HasStubImplementation = 0;
+  ConstructorDeclBits.InitKind = static_cast<unsigned>(CtorInitializerKind::Designated);
+  ConstructorDeclBits.Failability = static_cast<unsigned>(Failability);
 }
 
 void ConstructorDecl::setParameterLists(ParamDecl *selfDecl,


### PR DESCRIPTION
Take advantage of unused bits in the Decl base class to repack subclass bits to save memory.