### PR TITLE
[stdlib] perf improvement for _copyCollectionToContiguousArray

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -696,9 +696,11 @@ internal func _copyCollectionToContiguousArray<
   var p = result.firstElementAddress
   var i = source.startIndex
   var buffer = UnsafeMutableBufferPointer(start: p, count: count)
-  source._copyContents(initializing: buffer)
-
+  var (iterator, index) = source._copyContents(initializing: buffer)
+  
   _expectEnd(of: source, is: source.index(i, offsetBy: count))
+  _expectEnd(of: buffer, is: index)
+  _sanityCheck(iterator.next() == nil)
 
   return ContiguousArray(_buffer: result)
 }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -695,12 +695,8 @@ internal func _copyCollectionToContiguousArray<
 
   var p = result.firstElementAddress
   var i = source.startIndex
-  for _ in 0..<count {
-    // FIXME(performance): use _copyContents(initializing:).
-    p.initialize(to: source[i])
-    source.formIndex(after: &i)
-    p += 1
-  }
+  var buffer = UnsafeMutableBufferPointer(start: p, count: count)
+  source._copyContents(initializing: buffer)
   _expectEnd(of: source, is: i)
   return ContiguousArray(_buffer: result)
 }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -697,7 +697,9 @@ internal func _copyCollectionToContiguousArray<
   var i = source.startIndex
   var buffer = UnsafeMutableBufferPointer(start: p, count: count)
   source._copyContents(initializing: buffer)
-  _expectEnd(of: source, is: i)
+
+  _expectEnd(of: source, is: source.index(i, offsetBy: count))
+
   return ContiguousArray(_buffer: result)
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1424,17 +1424,17 @@ extension Sequence {
   public func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
-      var it = self.makeIterator()
-      guard var ptr = buffer.baseAddress else { return (it,buffer.startIndex) }
-      for idx in buffer.startIndex..<buffer.count {
-        guard let x = it.next() else {
-          return (it, idx)
-        }
-        ptr.initialize(to: x)
-        ptr += 1
+    var it = self.makeIterator()
+    guard var ptr = buffer.baseAddress else { return (it,buffer.startIndex) }
+    for idx in buffer.startIndex..<buffer.count {
+      guard let x = it.next() else {
+        return (it, idx)
       }
-      return (it,buffer.endIndex)
+      ptr.initialize(to: x)
+      ptr += 1
     }
+    return (it, buffer.endIndex)
+  }
 }
 
 // FIXME(ABI)#182

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -68,7 +68,7 @@ CopyToNativeArrayBufferTests.test("Collection._copyToContiguousArray()") {
     expectEqual(0, c.timesMakeIteratorCalled.value)
     expectEqual(0, c.timesStartIndexCalled.value)
     let copy = c._copyToContiguousArray()
-    expectEqual(0, c.timesMakeIteratorCalled.value)
+    expectEqual(1, c.timesMakeIteratorCalled.value)
     expectNotEqual(0, c.timesStartIndexCalled.value)
     expectEqualSequence(
       Array(10..<27),
@@ -82,7 +82,7 @@ CopyToNativeArrayBufferTests.test("Collection._copyToContiguousArray()") {
     expectEqual(0, wrapped.timesMakeIteratorCalled.value)
     expectEqual(0, wrapped.timesStartIndexCalled.value)
     let copy = s._copyToContiguousArray()
-    expectEqual(0, wrapped.timesMakeIteratorCalled.value)
+    expectEqual(1, wrapped.timesMakeIteratorCalled.value)
     expectNotEqual(0, wrapped.timesStartIndexCalled.value)
 
     expectEqualSequence(

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -2366,9 +2366,9 @@ for (step, evilBoundsCheck) in [ (1, true), (-1, false), (-1, true) ] {
     : "invalid Collection: count differed in successive traversals"
 
   let constructionMessage =
-    /*_isStdlibInternalChecksEnabled() && !evilBoundsCheck && step <= 0
-      ? "_UnsafePartiallyInitializedContiguousArrayBuffer has no more capacity"
-      :*/ message
+    _isDebugAssertConfiguration() && evilBoundsCheck && step <= 0
+      ? "invalid Collection: count differed in successive traversals"
+      : message
 
   // The invalid Collection error is a _debugPreconditon that will only fire
   // in a Debug assert configuration.


### PR DESCRIPTION
Using` _copyContents` should be faster than a `for` loop that wraps calls to `initialize(to:)`

rdar://problem/21988792