### PR TITLE
Revert "[stdlib] Temporarily exclude DoubleWidth from the standard library"

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -47,8 +47,7 @@ set(SWIFTLIB_ESSENTIAL
   CString.swift
   CTypes.swift
   DebuggerSupport.swift
-  # FIXME(double-width): <rdar://problem/32726173>
-  #DoubleWidth.swift.gyb
+  DoubleWidth.swift.gyb
   DropWhile.swift.gyb
   Dump.swift
   EmptyCollection.swift

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3378,15 +3378,14 @@ ${assignmentOperatorComment(x.operator, True)}
   ) -> (quotient: ${Self}, remainder: ${Self}) {
     // FIXME(integers): tests
 %   # 128 bit types are not provided by the 32-bit LLVM
-%   if word_bits == 32 and bits == 64:
-%   #if bits == 64: #FIXME(double-width): uncomment when DoubleWidth is back
-    // let lhs = DoubleWidth<${Self}>(dividend)
-    // let rhs = DoubleWidth<${Self}>(self)
+%   #if word_bits == 32 and bits == 64:
+%   if bits == 64:
+    let lhs = DoubleWidth<${Self}>(dividend)
+    let rhs = DoubleWidth<${Self}>(self)
 
-    // let (quotient, remainder) = lhs.quotientAndRemainder(dividingBy: rhs)
+    let (quotient, remainder) = lhs.quotientAndRemainder(dividingBy: rhs)
     // FIXME(integers): check for high words in quotient and remainder
-    // return (${Self}(quotient.low), ${Self}(remainder.low))
-    fatalError("Operation is not supported")
+    return (${Self}(quotient.low), ${Self}(remainder.low))
 %   else:
     // FIXME(integers): handle division by zero and overflows
     _precondition(self != 0, "Division by zero")

--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -54,5 +54,4 @@ class R<K: Hashable, V> {
 infix operator +=+ : AdditionPrecedence
 func +=+(_ lhs: Int, _ rhs: Int) -> Bool { return lhs == rhs }
 func +=+<T: BinaryInteger>(_ lhs: T, _ rhs: Int) -> Bool { return lhs == rhs }
-// FIXME: uncomment when <rdar://problem/32726173> is resolved and DoubleWidth is back
-// let _ = DoubleWidth<Int>(Int.min) - 1 +=+ Int.min // Ok
+let _ = DoubleWidth<Int>(Int.min) - 1 +=+ Int.min // Ok

--- a/test/stdlib/DoubleWidth.swift
+++ b/test/stdlib/DoubleWidth.swift
@@ -1,7 +1,5 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// FIXME(double-width): <rdar://problem/32726173>
-// REQUIRES: rdar32726173
 
 import StdlibUnittest
 


### PR DESCRIPTION
Reverts apple/swift#13182
And.... it's back