### PR TITLE
[stubs] Implement unsigned/signed div/mod ti3 for Win64

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -323,6 +323,18 @@ swift::swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
 #endif
 }
 
+#if __has_attribute(__mode__)
+#define SWIFT_MODE_DI __attribute__((__mode__(DI)))
+#define SWIFT_MODE_TI __attribute__((__mode__(TI)))
+#else
+#define SWIFT_MODE_DI
+#define SWIFT_MODE_TI
+#endif
+
+typedef int ti_int SWIFT_MODE_TI;
+typedef unsigned tu_int SWIFT_MODE_TI;
+typedef int di_int SWIFT_MODE_DI;
+typedef unsigned du_int SWIFT_MODE_DI;
 
 // Although this builtin is provided by clang rt builtins,
 // it isn't provided by libgcc, which is the default
@@ -336,7 +348,6 @@ swift::swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
     (defined(__linux__) && defined(__s390x__)) || \
     (defined(__ANDROID__) && defined(__arm64__))
 
-typedef int ti_int __attribute__((__mode__(TI)));
 SWIFT_RUNTIME_STDLIB_INTERFACE
 ti_int
 __muloti4(ti_int a, ti_int b, int* overflow)
@@ -389,13 +400,7 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // some other lower-level architecture issue that I'm
 // missing.  Perhaps relevant bug report:
 // FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
-#if __has_attribute(__mode__)
-#define SWIFT_MODE_DI __attribute__((__mode__(DI)))
-#else
-#define SWIFT_MODE_DI
-#endif
 
-typedef int di_int SWIFT_MODE_DI;
 SWIFT_RUNTIME_STDLIB_INTERFACE
 di_int
 __mulodi4(di_int a, di_int b, int* overflow)
@@ -435,6 +440,286 @@ __mulodi4(di_int a, di_int b, int* overflow)
     }
     return result;
 }
+
+#if defined(_WIN64)
+
+#define CHAR_BIT      8         // number of bits in a char
+
+typedef union
+{
+    tu_int all;
+    struct
+    {
+        du_int low;
+        du_int high;
+    }s;
+} utwords;
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+tu_int
+__udivmodti4(tu_int a, tu_int b, tu_int* rem)
+{
+    const unsigned n_udword_bits = sizeof(du_int) * CHAR_BIT;
+    const unsigned n_utword_bits = sizeof(tu_int) * CHAR_BIT;
+    utwords n;
+    n.all = a;
+    utwords d;
+    d.all = b;
+    utwords q;
+    utwords r;
+    unsigned sr;
+    /* special cases, X is unknown, K != 0 */
+    if (n.s.high == 0)
+    {
+        if (d.s.high == 0)
+        {
+            /* 0 X
+             * ---
+             * 0 X
+             */
+            if (rem)
+                *rem = n.s.low % d.s.low;
+            return n.s.low / d.s.low;
+        }
+        /* 0 X
+         * ---
+         * K X
+         */
+        if (rem)
+            *rem = n.s.low;
+        return 0;
+    }
+    /* n.s.high != 0 */
+    if (d.s.low == 0)
+    {
+        if (d.s.high == 0)
+        {
+            /* K X
+             * ---
+             * 0 0
+             */
+            if (rem)
+                *rem = n.s.high % d.s.low;
+            return n.s.high / d.s.low;
+        }
+        /* d.s.high != 0 */
+        if (n.s.low == 0)
+        {
+            /* K 0
+             * ---
+             * K 0
+             */
+            if (rem)
+            {
+                r.s.high = n.s.high % d.s.high;
+                r.s.low = 0;
+                *rem = r.all;
+            }
+            return n.s.high / d.s.high;
+        }
+        /* K K
+         * ---
+         * K 0
+         */
+        if ((d.s.high & (d.s.high - 1)) == 0)     /* if d is a power of 2 */
+        {
+            if (rem)
+            {
+                r.s.low = n.s.low;
+                r.s.high = n.s.high & (d.s.high - 1);
+                *rem = r.all;
+            }
+            return n.s.high >> __builtin_ctzll(d.s.high);
+        }
+        /* K K
+         * ---
+         * K 0
+         */
+        sr = __builtin_clzll(d.s.high) - __builtin_clzll(n.s.high);
+        /* 0 <= sr <= n_udword_bits - 2 or sr large */
+        if (sr > n_udword_bits - 2)
+        {
+           if (rem)
+                *rem = n.all;
+            return 0;
+        }
+        ++sr;
+        /* 1 <= sr <= n_udword_bits - 1 */
+        /* q.all = n.all << (n_utword_bits - sr); */
+        q.s.low = 0;
+        q.s.high = n.s.low << (n_udword_bits - sr);
+        /* r.all = n.all >> sr; */
+        r.s.high = n.s.high >> sr;
+        r.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+    }
+    else  /* d.s.low != 0 */
+    {
+        if (d.s.high == 0)
+        {
+            /* K X
+             * ---
+             * 0 K
+             */
+            if ((d.s.low & (d.s.low - 1)) == 0)     /* if d is a power of 2 */
+            {
+                if (rem)
+                    *rem = n.s.low & (d.s.low - 1);
+                if (d.s.low == 1)
+                    return n.all;
+                sr = __builtin_ctzll(d.s.low);
+                q.s.high = n.s.high >> sr;
+                q.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+                return q.all;
+            }
+            /* K X
+             * ---
+             * 0 K
+             */
+            sr = 1 + n_udword_bits + __builtin_clzll(d.s.low)
+                                   - __builtin_clzll(n.s.high);
+            /* 2 <= sr <= n_utword_bits - 1
+             * q.all = n.all << (n_utword_bits - sr);
+             * r.all = n.all >> sr;
+             */
+            if (sr == n_udword_bits)
+            {
+                q.s.low = 0;
+                q.s.high = n.s.low;
+                r.s.high = 0;
+                r.s.low = n.s.high;
+            }
+            else if (sr < n_udword_bits)  // 2 <= sr <= n_udword_bits - 1
+            {
+                q.s.low = 0;
+                q.s.high = n.s.low << (n_udword_bits - sr);
+                r.s.high = n.s.high >> sr;
+                r.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+            }
+            else              // n_udword_bits + 1 <= sr <= n_utword_bits - 1
+            {
+                q.s.low = n.s.low << (n_utword_bits - sr);
+                q.s.high = (n.s.high << (n_utword_bits - sr)) |
+                           (n.s.low >> (sr - n_udword_bits));
+                r.s.high = 0;
+                r.s.low = n.s.high >> (sr - n_udword_bits);
+            }
+        }
+        else
+        {
+            /* K X
+             * ---
+             * K K
+             */
+            sr = __builtin_clzll(d.s.high) - __builtin_clzll(n.s.high);
+            /*0 <= sr <= n_udword_bits - 1 or sr large */
+            if (sr > n_udword_bits - 1)
+            {
+               if (rem)
+                    *rem = n.all;
+                return 0;
+            }
+            ++sr;
+            /* 1 <= sr <= n_udword_bits
+             * q.all = n.all << (n_utword_bits - sr);
+             * r.all = n.all >> sr;
+             */
+            q.s.low = 0;
+            if (sr == n_udword_bits)
+            {
+                q.s.high = n.s.low;
+                r.s.high = 0;
+                r.s.low = n.s.high;
+            }
+            else
+            {
+                r.s.high = n.s.high >> sr;
+                r.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+                q.s.high = n.s.low << (n_udword_bits - sr);
+            }
+        }
+    }
+    /* Not a special case
+     * q and r are initialized with:
+     * q.all = n.all << (n_utword_bits - sr);
+     * r.all = n.all >> sr;
+     * 1 <= sr <= n_utword_bits - 1
+     */
+    su_int carry = 0;
+    for (; sr > 0; --sr)
+    {
+        /* r:q = ((r:q)  << 1) | carry */
+        r.s.high = (r.s.high << 1) | (r.s.low  >> (n_udword_bits - 1));
+        r.s.low  = (r.s.low  << 1) | (q.s.high >> (n_udword_bits - 1));
+        q.s.high = (q.s.high << 1) | (q.s.low  >> (n_udword_bits - 1));
+        q.s.low  = (q.s.low  << 1) | carry;
+        /* carry = 0;
+         * if (r.all >= d.all)
+         * {
+         *     r.all -= d.all;
+         *      carry = 1;
+         * }
+         */
+        const ti_int s = (ti_int)(d.all - r.all - 1) >> (n_utword_bits - 1);
+        carry = s & 1;
+        r.all -= d.all & s;
+    }
+    q.all = (q.all << 1) | carry;
+    if (rem)
+        *rem = r.all;
+    return q.all;
+}
+
+/* Returns: a % b */
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+tu_int
+__umodti3(tu_int a, tu_int b)
+{
+    tu_int r;
+    __udivmodti4(a, b, &r);
+    return r;
+}
+
+/* Returns: a / b */
+
+SWIFT_RUNTIME_STDLIB_INTERFACE 
+tu_int
+__udivti3(tu_int a, tu_int b)
+{
+    return __udivmodti4(a, b, 0);
+}
+
+/*Returns: a % b */
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+ti_int
+__modti3(ti_int a, ti_int b)
+{
+    const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;
+    ti_int s = b >> bits_in_tword_m1;  /* s = b < 0 ? -1 : 0 */
+    b = (b ^ s) - s;                   /* negate if s == -1 */
+    s = a >> bits_in_tword_m1;         /* s = a < 0 ? -1 : 0 */
+    a = (a ^ s) - s;                   /* negate if s == -1 */
+    tu_int r;
+    __udivmodti4(a, b, &r);
+    return ((ti_int)r ^ s) - s;                /* negate if s == -1 */
+}
+
+/* Returns: a / b */
+
+COMPILER_RT_ABI ti_int
+__divti3(ti_int a, ti_int b)
+{
+    const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;
+    ti_int s_a = a >> bits_in_tword_m1;           /* s_a = a < 0 ? -1 : 0 */
+    ti_int s_b = b >> bits_in_tword_m1;           /* s_b = b < 0 ? -1 : 0 */
+    a = (a ^ s_a) - s_a;                         /* negate if s_a == -1 */
+    b = (b ^ s_b) - s_b;                         /* negate if s_b == -1 */
+    s_a ^= s_b;                                  /* sign of quotient */
+    return (__udivmodti4(a, b, (tu_int*)0) ^ s_a) - s_a;  /* negate if s_a == -1 */
+}
+
+#endif // defined(_WIN64)
 #endif
 
 #if defined(__CYGWIN__) || defined(_WIN32)

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -644,7 +644,7 @@ __udivmodti4(tu_int a, tu_int b, tu_int* rem)
      * r.all = n.all >> sr;
      * 1 <= sr <= n_utword_bits - 1
      */
-    su_int carry = 0;
+    unsigned int carry = 0;
     for (; sr > 0; --sr)
     {
         /* r:q = ((r:q)  << 1) | carry */
@@ -707,7 +707,8 @@ __modti3(ti_int a, ti_int b)
 
 /* Returns: a / b */
 
-COMPILER_RT_ABI ti_int
+SWIFT_RUNTIME_STDLIB_INTERFACE
+ti_int
 __divti3(ti_int a, ti_int b)
 {
     const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -348,6 +348,10 @@ typedef unsigned du_int SWIFT_MODE_DI;
     (defined(__linux__) && defined(__s390x__)) || \
     (defined(__ANDROID__) && defined(__arm64__))
 
+#if !(__has_attribute(__mode__))
+#error "The __mode__ attribute is required."
+#endif    
+
 SWIFT_RUNTIME_STDLIB_INTERFACE
 ti_int
 __muloti4(ti_int a, ti_int b, int* overflow)
@@ -401,6 +405,10 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // missing.  Perhaps relevant bug report:
 // FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
 
+#if !(__has_attribute(__mode__))
+#error "The __mode__ attribute is required."
+#endif
+
 SWIFT_RUNTIME_STDLIB_INTERFACE
 di_int
 __mulodi4(di_int a, di_int b, int* overflow)
@@ -442,6 +450,10 @@ __mulodi4(di_int a, di_int b, int* overflow)
 }
 
 #if defined(_WIN64)
+
+#if !(__has_attribute(__mode__))
+#error "The __mode__ attribute is required."
+#endif
 
 typedef union
 {

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -443,8 +443,6 @@ __mulodi4(di_int a, di_int b, int* overflow)
 
 #if defined(_WIN64)
 
-#define CHAR_BIT      8         // number of bits in a char
-
 typedef union
 {
     tu_int all;


### PR DESCRIPTION
On Windows 64-bit, the `dividingFullWidth` method on `UInt64` and `Int64` causes LLVM to emit references to `udivti3`, `umodti3`, `divti3`, and `modti3`, which are undefined on Windows. Provide an implementation here based on Compiler-RT.

This is an alternative fix to https://github.com/apple/swift/pull/13234.

cc @gparker42 