### PR TITLE
Prefix opt-remark ID with sil "namespace"

### DIFF
--- a/lib/SIL/OptimizationRemark.cpp
+++ b/lib/SIL/OptimizationRemark.cpp
@@ -134,7 +134,7 @@ template <typename KindT> struct MappingTraits<Remark<KindT>> {
     // them.
     StringRef PassName = R.getPassName();
     io.mapRequired("Pass", PassName);
-    StringRef Id = R.getIdentifier();
+    std::string Id = (Twine("sil.") + R.getIdentifier()).str();
     io.mapRequired("Name", Id);
 
     SourceLoc Loc = R.getLocation();

--- a/test/Driver/opt-record.swift
+++ b/test/Driver/opt-record.swift
@@ -15,7 +15,7 @@ func foo() {
 public func bar() {
   // YAML:      --- !Passed
   // YAML-NEXT: Pass:            sil-inliner
-  // YAML-NEXT: Name:            Inlined
+  // YAML-NEXT: Name:            sil.Inlined
   // YAML-NEXT: DebugLoc:
   // YAML-NEXT:   File:            {{.*}}opt-record.swift
   // YAML-NEXT:   Line:            42

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -196,7 +196,7 @@ bb0:
   // REMARKS_PASSED: inliner_coldblocks.sil:223:3: remark: "update_global" inlined into "regular_large_callee" (cost = {{.*}}, benefit = {{.*}})
   // YAML:      --- !Passed
   // YAML-NEXT: Pass:            sil-inliner
-  // YAML-NEXT: Name:            Inlined
+  // YAML-NEXT: Name:            sil.Inlined
   // YAML-NEXT: DebugLoc:
   // YAML-NEXT:   File:            {{.*}}inliner_coldblocks.sil
   // YAML-NEXT:   Line:            223
@@ -236,7 +236,7 @@ bb0:
   // REMARKS_MISSED: inliner_coldblocks.sil:258:8: remark: Not profitable to inline function "regular_large_callee" (cost = {{.*}}, benefit = {{.*}})
   // YAML:      --- !Missed
   // YAML-NEXT: Pass:            sil-inliner
-  // YAML-NEXT: Name:            NoInlinedCost
+  // YAML-NEXT: Name:            sil.NoInlinedCost
   // YAML-NEXT: DebugLoc:
   // YAML-NEXT:   File:            {{.*}}inliner_coldblocks.sil
   // YAML-NEXT:   Line:            258

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -21,7 +21,7 @@ import Swift
 
 // YAML:      --- !Passed
 // YAML-NEXT: Pass:            sil-generic-specializer
-// YAML-NEXT: Name:            Specialized
+// YAML-NEXT: Name:            sil.Specialized
 // YAML-NEXT: DebugLoc:
 // YAML-NEXT:   File:            {{.*}}/specialize.sil
 // YAML-NEXT:   Line:            132
@@ -39,7 +39,7 @@ import Swift
 // YAML-NEXT: ...
 // YAML-NEXT: --- !Passed
 // YAML-NEXT: Pass:            sil-generic-specializer
-// YAML-NEXT: Name:            Specialized
+// YAML-NEXT: Name:            sil.Specialized
 // YAML-NEXT: DebugLoc:
 // YAML-NEXT:   File:            {{.*}}/specialize.sil
 // YAML-NEXT:   Line:            142

--- a/test/SILOptimizer/specialize_no_definition.sil
+++ b/test/SILOptimizer/specialize_no_definition.sil
@@ -8,7 +8,7 @@ sil_stage canonical
 
 // CHECK:      --- !Missed
 // CHECK-NEXT: Pass:            sil-generic-specializer
-// CHECK-NEXT: Name:            NoDef
+// CHECK-NEXT: Name:            sil.NoDef
 // CHECK-NEXT: DebugLoc:
 // CHECK-NEXT:   File:            {{.*}}/specialize_no_definition.sil
 // CHECK-NEXT:   Line:            36


### PR DESCRIPTION
This is so that we can unambiguously distinguish from LLVM opt remarks.
