### PR TITLE
Include module in demangled name in opt remarks

### DIFF
--- a/lib/SIL/OptimizationRemark.cpp
+++ b/lib/SIL/OptimizationRemark.cpp
@@ -44,15 +44,18 @@ Argument::Argument(StringRef Key, unsigned long long N)
     : Key(Key), Val(llvm::utostr(N)) {}
 
 Argument::Argument(StringRef Key, SILFunction *F)
-    : Key(Key),
-      Val((Twine("\"") +
-           Demangle::demangleSymbolAsString(
-               F->getName(),
-               Demangle::DemangleOptions::SimplifiedUIDemangleOptions()) +
-           "\"")
-              .str()) {
-  if (F->hasLocation())
-    Loc = F->getLocation().getSourceLoc();
+    : Key(Key) {
+      auto DO = Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
+      // Enable module names so that we have a way of filtering out
+      // stdlib-related remarks.
+      DO.DisplayModuleNames = true;
+
+      Val = (Twine("\"") + Demangle::demangleSymbolAsString(F->getName(), DO) +
+             "\"")
+                .str();
+
+      if (F->hasLocation())
+        Loc = F->getLocation().getSourceLoc();
 }
 
 template <typename DerivedT> std::string Remark<DerivedT>::getMsg() const {

--- a/test/Driver/opt-record.swift
+++ b/test/Driver/opt-record.swift
@@ -22,13 +22,13 @@ public func bar() {
   // YAML-NEXT:   Column:          3
   // YAML-NEXT: Function:        'bar()'
   // YAML-NEXT: Args:
-  // YAML-NEXT:   - Callee:          '"foo()"'
+  // YAML-NEXT:   - Callee:          '"optrecordmod.foo()"'
   // YAML-NEXT:     DebugLoc:
   // YAML-NEXT:       File:            {{.*}}opt-record.swift
   // YAML-NEXT:       Line:            11
   // YAML-NEXT:       Column:          6
   // YAML-NEXT:   - String:          ' inlined into '
-  // YAML-NEXT:   - Caller:          '"bar()"'
+  // YAML-NEXT:   - Caller:          '"optrecordmod.bar()"'
   // YAML-NEXT:     DebugLoc:
   // YAML-NEXT:       File:            {{.*}}opt-record.swift
   // YAML-NEXT:       Line:            15

--- a/test/Driver/opt-remark.swift
+++ b/test/Driver/opt-remark.swift
@@ -38,11 +38,11 @@ func small() {
 
 func foo() {
   // REMARK_MISSED-NOT: remark: {{.*}} inlined
-  // REMARK_MISSED: opt-remark.swift:43:2: remark: Not profitable to inline function "big()" (cost = {{.*}}, benefit = {{.*}})
+  // REMARK_MISSED: opt-remark.swift:43:2: remark: Not profitable to inline function "null.big()" (cost = {{.*}}, benefit = {{.*}})
   // REMARK_MISSED-NOT: remark: {{.*}} inlined
 	big()
   // REMARK_PASSED-NOT: remark: Not profitable
-  // REMARK_PASSED: opt-remark.swift:47:3: remark: "small()" inlined into "foo()" (cost = {{.*}}, benefit = {{.*}})
+  // REMARK_PASSED: opt-remark.swift:47:3: remark: "null.small()" inlined into "null.foo()" (cost = {{.*}}, benefit = {{.*}})
   // REMARK_PASSED-NOT: remark: Not profitable
   small()
 }


### PR DESCRIPTION
This allows filtering noisy generic specialization and inlining remarks for
stdlib functions based on the module name.
