### PR TITLE
[Syntax] Serveral improvements for Trivia lexing

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -517,12 +517,7 @@ private:
   void lexOperatorIdentifier();
   void lexHexNumber();
   void lexNumber();
-  void lexTrivia(syntax::TriviaList &T, bool StopAtFirstNewline = false);
-  Optional<syntax::TriviaPiece> lexWhitespace(bool StopAtFirstNewline);
-  Optional<syntax::TriviaPiece> lexComment();
-  Optional<syntax::TriviaPiece> lexSingleLineComment(syntax::TriviaKind Kind);
-  Optional<syntax::TriviaPiece> lexBlockComment(syntax::TriviaKind Kind);
-  Optional<syntax::TriviaPiece> lexDocComment();
+  void lexTrivia(syntax::TriviaList &T, bool IsForTrailingTrivia);
   static unsigned lexUnicodeEscape(const char *&CurPtr, Lexer *Diags);
 
   unsigned lexCharacter(const char *&CurPtr,

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -233,11 +233,8 @@ public:
     Result = NextToken;
     LeadingTriviaResult = {LeadingTrivia};
     TrailingTriviaResult = {TrailingTrivia};
-    if (Result.isNot(tok::eof)) {
-      LeadingTrivia.clear();
-      TrailingTrivia.clear();
+    if (Result.isNot(tok::eof))
       lexImpl();
-    }
   }
 
   void lex(Token &Result) {
@@ -288,8 +285,6 @@ public:
   void restoreState(State S, bool enableDiagnostics = false) {
     assert(S.isValid());
     CurPtr = getBufferPtrForSourceLoc(S.Loc);
-    LeadingTrivia.clear();
-    TrailingTrivia.clear();
     // Don't reemit diagnostics while readvancing the lexer.
     llvm::SaveAndRestore<DiagnosticEngine*>
       D(Diags, enableDiagnostics ? Diags : nullptr);

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -74,7 +74,8 @@ struct ObjectTraits<syntax::TriviaPiece> {
       case syntax::TriviaKind::LineComment:
       case syntax::TriviaKind::BlockComment:
       case syntax::TriviaKind::DocLineComment:
-      case syntax::TriviaKind::DocBlockComment: {
+      case syntax::TriviaKind::DocBlockComment:
+      case syntax::TriviaKind::GarbageText: {
         auto text = value.Text.str();
         out.mapRequired("value", text);
         break;
@@ -97,6 +98,7 @@ struct ScalarEnumerationTraits<syntax::TriviaKind> {
     out.enumCase(value, "DocLineComment", syntax::TriviaKind::DocLineComment);
     out.enumCase(value, "DocBlockComment", syntax::TriviaKind::DocBlockComment);
     out.enumCase(value, "Backtick", syntax::TriviaKind::Backtick);
+    out.enumCase(value, "GarbageText", syntax::TriviaKind::GarbageText);
   }
 };
 

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -152,6 +152,17 @@ struct TriviaPiece {
     return TriviaPiece {TriviaKind::Tab, Count, OwnedString{}};
   }
 
+  /// Return a piece of trivia for some number of vertical tab characters in a
+  /// row.
+  static TriviaPiece verticalTabs(unsigned Count) {
+    return TriviaPiece {TriviaKind::VerticalTab, Count, OwnedString{}};
+  }
+
+  /// Return a piece of trivia for some number of form-feed characters in a row.
+  static TriviaPiece formfeeds(unsigned Count) {
+    return TriviaPiece {TriviaKind::Formfeed, Count, OwnedString{}};
+  }
+
   /// Return a piece of trivia for some number of newline characters
   /// in a row.
   static TriviaPiece newlines(unsigned Count) {

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -85,6 +85,11 @@
 #include <vector>
 
 namespace swift {
+
+namespace json {
+template <class T> struct ObjectTraits;
+}
+
 namespace syntax {
 
 class AbsolutePosition;
@@ -136,73 +141,81 @@ enum class TriviaKind {
 ///
 /// In general, you should deal with the actual Trivia collection instead
 /// of individual pieces whenever possible.
-struct TriviaPiece {
+class TriviaPiece {
   TriviaKind Kind;
   unsigned Count;
   OwnedString Text;
 
-  TriviaPiece(const TriviaKind Kind, const unsigned Count,
-              const OwnedString Text)
-      : Kind(Kind), Count(Count), Text(Text) {}
+  TriviaPiece(const TriviaKind Kind, const OwnedString Text)
+      : Kind(Kind), Count(1), Text(Text) {}
+  TriviaPiece(const TriviaKind Kind, const unsigned Count)
+      : Kind(Kind), Count(Count), Text() {}
 
+  friend struct json::ObjectTraits<TriviaPiece>;
+
+public:
   /// Return a piece of trivia for some number of space characters in a row.
   static TriviaPiece spaces(unsigned Count) {
-    return TriviaPiece {TriviaKind::Space, Count, OwnedString{}};
+    return {TriviaKind::Space, Count};
   }
 
   /// Return a piece of trivia for some number of tab characters in a row.
   static TriviaPiece tabs(unsigned Count) {
-    return TriviaPiece {TriviaKind::Tab, Count, OwnedString{}};
+    return {TriviaKind::Tab, Count};
   }
 
   /// Return a piece of trivia for some number of vertical tab characters in a
   /// row.
   static TriviaPiece verticalTabs(unsigned Count) {
-    return TriviaPiece {TriviaKind::VerticalTab, Count, OwnedString{}};
+    return {TriviaKind::VerticalTab, Count};
   }
 
   /// Return a piece of trivia for some number of form-feed characters in a row.
   static TriviaPiece formfeeds(unsigned Count) {
-    return TriviaPiece {TriviaKind::Formfeed, Count, OwnedString{}};
+    return {TriviaKind::Formfeed, Count};
   }
 
   /// Return a piece of trivia for some number of newline characters
   /// in a row.
   static TriviaPiece newlines(unsigned Count) {
-    return TriviaPiece {TriviaKind::Newline, Count, OwnedString{}};
+    return {TriviaKind::Newline, Count};
   }
 
   /// Return a piece of trivia for a single line of ('//') developer comment.
   static TriviaPiece lineComment(const OwnedString Text) {
-    return TriviaPiece {TriviaKind::LineComment, 1, Text};
+    return {TriviaKind::LineComment, Text};
   }
 
   /// Return a piece of trivia for a block comment ('/* ... */')
   static TriviaPiece blockComment(const OwnedString Text) {
-    return TriviaPiece {TriviaKind::BlockComment, 1, Text};
+    return {TriviaKind::BlockComment, Text};
   }
 
   /// Return a piece of trivia for a single line of ('///') doc comment.
   static TriviaPiece docLineComment(const OwnedString Text) {
-    return TriviaPiece {TriviaKind::DocLineComment, 1, Text};
+    return {TriviaKind::DocLineComment, Text};
   }
 
   /// Return a piece of trivia for a documentation block comment ('/** ... */')
   static TriviaPiece docBlockComment(const OwnedString Text) {
-    return TriviaPiece {TriviaKind::DocBlockComment, 1, Text};
+    return {TriviaKind::DocBlockComment, Text};
   }
 
   /// Return a piece of trivia for any skipped garbage text.
   static TriviaPiece garbageText(const OwnedString Text) {
-    return TriviaPiece {TriviaKind::GarbageText, 1, Text};
+    return {TriviaKind::GarbageText, Text};
   }
 
   /// Return a piece of trivia for a single backtick '`' for escaping
   /// an identifier.
   static TriviaPiece backtick() {
-    return TriviaPiece {TriviaKind::Backtick, 1, OwnedString{}};
+    return {TriviaKind::Backtick, 1};
   }
 
+  /// Return kind of the trivia.
+  TriviaKind getKind() const { return Kind; }
+
+  /// Return textual length of the trivia.
   size_t getTextLength() const {
     switch (Kind) {
       case TriviaKind::LineComment:
@@ -360,7 +373,7 @@ struct Trivia {
     if (Count == 0) {
       return {};
     }
-    return {{ TriviaPiece {TriviaKind::Space, Count, OwnedString{}} }};
+    return {{TriviaPiece::spaces(Count)}};
   }
 
   /// Return a collection of trivia of some number of tab characters in a row.
@@ -368,7 +381,7 @@ struct Trivia {
     if (Count == 0) {
       return {};
     }
-    return {{ TriviaPiece {TriviaKind::Tab, Count, OwnedString{}} }};
+    return {{TriviaPiece::tabs(Count)}};
   }
 
   /// Return a collection of trivia of some number of newline characters
@@ -377,27 +390,27 @@ struct Trivia {
     if (Count == 0) {
       return {};
     }
-    return {{ TriviaPiece {TriviaKind::Newline, Count, OwnedString{}} }};
+    return {{TriviaPiece::newlines(Count)}};
   }
 
   /// Return a collection of trivia with a single line of ('//')
   // developer comment.
   static Trivia lineComment(const OwnedString Text) {
     assert(Text.str().startswith("//"));
-    return {{ TriviaPiece {TriviaKind::LineComment, 1, Text} }};
+    return {{TriviaPiece::lineComment(Text)}};
   }
 
   /// Return a collection of trivia with a block comment ('/* ... */')
   static Trivia blockComment(const OwnedString Text) {
     assert(Text.str().startswith("/*"));
     assert(Text.str().endswith("*/"));
-    return {{ TriviaPiece {TriviaKind::BlockComment, 1, Text} }};
+    return {{TriviaPiece::blockComment(Text)}};
   }
 
   /// Return a collection of trivia with a single line of ('///') doc comment.
   static Trivia docLineComment(const OwnedString Text) {
     assert(Text.str().startswith("///"));
-    return {{ TriviaPiece {TriviaKind::DocLineComment, 1, Text} }};
+    return {{TriviaPiece::docLineComment(Text)}};
   }
 
   /// Return a collection of trivia with a documentation block
@@ -405,21 +418,21 @@ struct Trivia {
   static Trivia docBlockComment(const OwnedString Text) {
     assert(Text.str().startswith("/**"));
     assert(Text.str().endswith("*/"));
-    return {{ TriviaPiece {TriviaKind::DocBlockComment, 1, Text} }};
+    return {{TriviaPiece::docBlockComment(Text)}};
   }
 
   /// Return a collection of trivia with any skipped garbage text.
   static Trivia garbageText(const OwnedString Text) {
     assert(Text.size() > 0);
-    return {{ TriviaPiece {TriviaKind::GarbageText, 1, Text} }};
+    return {{TriviaPiece::garbageText(Text)}};
   }
 
   /// Return a piece of trivia for a single backtick '`' for escaping
   /// an identifier.
   static Trivia backtick() {
-    return {{ TriviaPiece {TriviaKind::Backtick, 1, OwnedString{}} }};
+    return {{TriviaPiece::backtick()}};
   }
 };
-}
-}
+} // namespace syntax
+} // namespace swift
 #endif // SWIFT_SYNTAX_TRIVIA_H

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -118,6 +118,9 @@ enum class TriviaKind {
   /// A documentation block comment, starting with '/**' and ending with '*/.
   DocBlockComment,
 
+  /// Any skipped garbage text.
+  GarbageText,
+
   /// A backtick '`' character, used to escape identifiers.
   Backtick,
 };
@@ -189,6 +192,11 @@ struct TriviaPiece {
     return TriviaPiece {TriviaKind::DocBlockComment, 1, Text};
   }
 
+  /// Return a piece of trivia for any skipped garbage text.
+  static TriviaPiece garbageText(const OwnedString Text) {
+    return TriviaPiece {TriviaKind::GarbageText, 1, Text};
+  }
+
   /// Return a piece of trivia for a single backtick '`' for escaping
   /// an identifier.
   static TriviaPiece backtick() {
@@ -201,6 +209,7 @@ struct TriviaPiece {
       case TriviaKind::BlockComment:
       case TriviaKind::DocBlockComment:
       case TriviaKind::DocLineComment:
+      case TriviaKind::GarbageText:
         return Text.size();
       case TriviaKind::Newline:
       case TriviaKind::Space:
@@ -397,6 +406,12 @@ struct Trivia {
     assert(Text.str().startswith("/**"));
     assert(Text.str().endswith("*/"));
     return {{ TriviaPiece {TriviaKind::DocBlockComment, 1, Text} }};
+  }
+
+  /// Return a collection of trivia with any skipped garbage text.
+  static Trivia garbageText(const OwnedString Text) {
+    assert(Text.size() > 0);
+    return {{ TriviaPiece {TriviaKind::GarbageText, 1, Text} }};
   }
 
   /// Return a piece of trivia for a single backtick '`' for escaping

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2324,7 +2324,9 @@ Restart:
     NextToken.setAtStartOfLine(true);
     LLVM_FALLTHROUGH;
   case ' ':
-  case '\t': {
+  case '\t':
+  case '\v':
+  case '\f': {
     auto Char = CurPtr[-1];
     // Consume consective same characters.
     while (*CurPtr == Char)
@@ -2341,6 +2343,12 @@ Restart:
       break;
     case '\t':
       Pieces.push_back(TriviaPiece::tabs(Length));
+      break;
+    case '\v':
+      Pieces.push_back(TriviaPiece::verticalTabs(Length));
+      break;
+    case '\f':
+      Pieces.push_back(TriviaPiece::formfeeds(Length));
       break;
     default:
       llvm_unreachable("Invalid character for whitespace trivia");

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2058,6 +2058,10 @@ void Lexer::lexImpl() {
   assert(CurPtr >= BufferStart &&
          CurPtr <= BufferEnd && "Current pointer out of range!");
 
+  if (TriviaRetention == TriviaRetentionMode::WithTrivia) {
+    LeadingTrivia.clear();
+    TrailingTrivia.clear();
+  }
   NextToken.setAtStartOfLine(CurPtr == BufferStart);
 
   // Remember where we started so that we can find the comment range.

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2383,6 +2383,18 @@ Restart:
       goto Restart;
     }
     break;
+  case '#':
+    if (TriviaStart == BufferStart && *CurPtr == '!') {
+      // Hashbang '#!/path/to/swift'.
+      if (BufferID != SourceMgr.getHashbangBufferID())
+        diagnose(TriviaStart, diag::lex_hashbang_not_allowed);
+      skipUpToEndOfLine(); // NOTE: Don't use skipHashbang() here because it
+                           // consumes trailing newline.
+      size_t Length = CurPtr - TriviaStart;
+      Pieces.push_back(TriviaPiece::garbageText({TriviaStart, Length}));
+      goto Restart;
+    }
+    break;
   default:
     break;
   }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2316,6 +2316,8 @@ void Lexer::lexTrivia(syntax::TriviaList &Pieces, bool IsForTrailingTrivia) {
 Restart:
   const char *TriviaStart = CurPtr;
 
+  // TODO: Handle random nul('\0') character in the middle of a buffer.
+  // TODO: Handle invalid UTF8 sequence which is skipped in lexImpl().
   switch (*CurPtr++) {
   case '\n':
   case '\r':
@@ -2339,6 +2341,8 @@ Restart:
       break;
     case '\n':
     case '\r':
+      // FIXME: Distinguish CR and LF
+      // FIXME: CR+LF shoud form one trivia piece
       Pieces.push_back(TriviaPiece::newlines(Length));
       break;
     case '\t':

--- a/lib/Syntax/Trivia.cpp
+++ b/lib/Syntax/Trivia.cpp
@@ -77,6 +77,9 @@ void TriviaPiece::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     OS << "doc_block_comment" << Text.str();
     break;
   }
+  case TriviaKind::GarbageText:
+    OS << "garbage_text " << Text.str();
+    break;
   case TriviaKind::Backtick:
     OS << "backtick " << Count;
     break;
@@ -90,6 +93,7 @@ void TriviaPiece::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
   case TriviaKind::BlockComment:
   case TriviaKind::DocBlockComment:
   case TriviaKind::DocLineComment:
+  case TriviaKind::GarbageText:
     Pos.addText(Text.str());
     break;
   case TriviaKind::Newline:
@@ -126,6 +130,7 @@ void TriviaPiece::print(llvm::raw_ostream &OS) const {
   case TriviaKind::BlockComment:
   case TriviaKind::DocLineComment:
   case TriviaKind::DocBlockComment:
+  case TriviaKind::GarbageText:
     OS << Text.str();
     break;
   case TriviaKind::Backtick:

--- a/lib/Syntax/Trivia.cpp
+++ b/lib/Syntax/Trivia.cpp
@@ -166,7 +166,7 @@ void Trivia::print(llvm::raw_ostream &OS) const {
 TriviaList::const_iterator Trivia::find(const TriviaKind DesiredKind) const {
   return std::find_if(Pieces.begin(), Pieces.end(),
                       [=](const TriviaPiece &Piece) -> bool {
-                        return Piece.Kind == DesiredKind;
+                        return Piece.getKind() == DesiredKind;
                       });
 }
 

--- a/tools/SwiftSyntax/Trivia.swift
+++ b/tools/SwiftSyntax/Trivia.swift
@@ -58,6 +58,9 @@ public enum TriviaPiece: Codable {
     case "DocBlockComment":
       let value = try container.decode(String.self, forKey: .value)
       self = .docLineComment(value)
+    case "GarbageText":
+      let value = try container.decode(String.self, forKey: .value)
+      self = .garbageText(value)
     default:
       let context =
         DecodingError.Context(codingPath: [CodingKeys.kind],
@@ -81,6 +84,9 @@ public enum TriviaPiece: Codable {
     case .lineComment(let comment):
       try container.encode("LineComment", forKey: .kind)
       try container.encode(comment, forKey: .value)
+    case .garbageText(let text):
+      try container.encode("GarbageText", forKey: .kind)
+      try container.encode(text, forKey: .value)
     case .formfeeds(let count):
       try container.encode("Formfeed", forKey: .kind)
       try container.encode(count, forKey: .value)
@@ -132,6 +138,9 @@ public enum TriviaPiece: Codable {
 
   /// A documentation block comment, starting with '/**' and ending with '*/.
   case docBlockComment(String)
+
+  /// Any skipped text.
+  case garbageText(String)
 }
 
 extension TriviaPiece: TextOutputStreamable {
@@ -153,7 +162,8 @@ extension TriviaPiece: TextOutputStreamable {
     case let .lineComment(text),
          let .blockComment(text),
          let .docLineComment(text),
-         let .docBlockComment(text):
+         let .docBlockComment(text),
+         let .garbageText(text):
       target.write(text)
     }
   }
@@ -247,6 +257,11 @@ public struct Trivia: Codable {
   /// Return a piece of trivia for a documentation block comment ('/** ... */')
   public static func docBlockComment(_ text: String) -> Trivia {
     return [.docBlockComment(text)]
+  }
+
+  /// Return a piece of trivia for any garbage text.
+  public static func garbageText(_ text: String) -> Trivia {
+    return [.garbageText(text)]
   }
 }
 

--- a/unittests/Syntax/TriviaTests.cpp
+++ b/unittests/Syntax/TriviaTests.cpp
@@ -49,6 +49,12 @@ TEST(TriviaTests, Empty) {
     Trivia::docBlockComment("").print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }, "");
+  ASSERT_DEATH({
+    llvm::SmallString<1> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    Trivia::garbageText("").print(OS);
+    ASSERT_EQ(OS.str().str(), "");
+  }, "");
 #endif
   {
     llvm::SmallString<1> Scratch;
@@ -166,6 +172,7 @@ TEST(TriviaTests, Contains) {
   ASSERT_FALSE(Trivia().contains(TriviaKind::DocBlockComment));
   ASSERT_FALSE(Trivia().contains(TriviaKind::DocLineComment));
   ASSERT_FALSE(Trivia().contains(TriviaKind::Formfeed));
+  ASSERT_FALSE(Trivia().contains(TriviaKind::GarbageText));
   ASSERT_FALSE(Trivia().contains(TriviaKind::LineComment));
   ASSERT_FALSE(Trivia().contains(TriviaKind::Newline));
   ASSERT_FALSE(Trivia().contains(TriviaKind::Space));
@@ -176,6 +183,7 @@ TEST(TriviaTests, Contains) {
               .contains(TriviaKind::DocBlockComment));
   ASSERT_TRUE(Trivia::docLineComment("///")
               .contains(TriviaKind::DocLineComment));
+  ASSERT_TRUE(Trivia::garbageText("#!swift").contains(TriviaKind::GarbageText));
   ASSERT_TRUE(Trivia::lineComment("//").contains(TriviaKind::LineComment));
   ASSERT_TRUE(Trivia::newlines(1).contains(TriviaKind::Newline));
   ASSERT_TRUE(Trivia::spaces(1).contains(TriviaKind::Space));


### PR DESCRIPTION
Several improvements for Trivia to improve roundtrip-ness.

* Simplified `Lever::lexTrivia` function.
* Added lexing `'\v'`(`TriviaKind::VerticalTab`) and `'\f'`(`TriviaKind::Formfeed`) support.
* ~Added `TriviaKind::StartOfFile` that is convenient for `TokenSyntax::isAtStartOfLine()` implementation~.
* ~Added `TriviaKind::Hashbang` that is for `#!/path/to/swift`~
* Added `TriviaKind::GarbageText` for any skipped text, and use it for hashbang. e.g.`#!/path/to/swift`
* Privatized `TriviaPiece` constructor and member fields so that we don't accidentaly create invalid trivia piece like: ` { TriviaKind::lineComment, 6, "foobar" }`

TODO/FIXME:
* Handle random nul(`\0`) character in the middle of a buffer.
* Handle random invalid UTF8 sequence which is skipped (not tokenized as `tok::unknown`) in `lexImpl()`
* Distinguish between CR(`\r`) and LF(`\n`)
* Support DOS newline (CR+LF). This sequence should form one trivia piece (instead of 2).