### PR TITLE
 Don't pass -Werror to ClangImporter's clang when Swift is used from LLDB

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -97,6 +97,9 @@ public:
   /// When set, don't look for or load adapter modules.
   bool DisableAdapterModules = false;
 
+  /// When set, don't enforce warnings with -Werror.
+  bool DebuggerSupport = false;
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -446,11 +446,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
   // Construct the invocation arguments for the current target.
   // Add target-independent options first.
   invocationArgStrs.insert(invocationArgStrs.end(), {
-      // Enable modules
-      "-fmodules",
-      "-Werror=non-modular-include-in-framework-module",
-      "-Xclang", "-fmodule-feature", "-Xclang", "swift",
-
       // Don't emit LLVM IR.
       "-fsyntax-only",
 
@@ -463,6 +458,18 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
       SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
   });
+
+  // Enable modules.
+  invocationArgStrs.insert(invocationArgStrs.end(), {
+      "-fmodules",
+      "-Xclang", "-fmodule-feature", "-Xclang", "swift"
+  });
+  // Don't enforce strict rules when inside the debugger to work around search
+  // path problems caused by a module existing in both the build/install
+  // directory and the source directory.
+  if (!importerOpts.DebuggerSupport)
+    invocationArgStrs.push_back(
+        "-Werror=non-modular-include-in-framework-module");
 
   if (LangOpts.EnableObjCInterop) {
     invocationArgStrs.insert(invocationArgStrs.end(),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1174,6 +1174,7 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     Opts.PCHDisableValidation |= Args.hasArg(OPT_pch_disable_validation);
   }
 
+  Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);
   return false;
 }
 

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -6,6 +6,11 @@
 // CHECK-native: error: could not build C module 'Foo'
 // CHECK-NOT: error
 
+// RUN: %target-swift-frontend -debugger-support -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --allow-empty --check-prefix=CHECK-DEBUGGER %s
+
+// CHECK-DEBUGGER-NOT: error:
+
+
 import Foo
 
 _ = Foo.x


### PR DESCRIPTION
Don't pass -Werror to ClangImporter's clang when Swift is used from within LLDB.

This works a around search path problems caused by a module existing
in both the build/install directory and the source directory.

<rdar://problem/35714074>

(cherry picked from commit 97f9e4e367dba59ba17d2c54c1eac8728e37f622)
