### PR TITLE
For 'lazy', make "cannot override with a stored property" a warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1873,6 +1873,8 @@ ERROR(override_property_type_mismatch,none,
       (Identifier, Type, Type))
 ERROR(override_with_stored_property,none,
       "cannot override with a stored property %0", (Identifier))
+WARNING(override_with_stored_property_warn,none,
+      "cannot override with a stored property %0", (Identifier))
 ERROR(observing_readonly_property,none,
       "cannot observe read-only property %0; it can't change", (Identifier))
 ERROR(override_mutable_with_readonly_property,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6629,7 +6629,15 @@ public:
       
       // Make sure that the overriding property doesn't have storage.
       if (overrideASD->hasStorage() && !overrideASD->hasObservers()) {
-        TC.diagnose(overrideASD, diag::override_with_stored_property,
+        auto diagID = diag::override_with_stored_property;
+        if (!TC.Context.isSwiftVersionAtLeast(5) &&
+            overrideASD->getAttrs().hasAttribute<LazyAttr>()) {
+          // Swift 4.0 had a bug where lazy properties were considered
+          // computed by the time of this check. Downgrade this diagnostic to
+          // a warning.
+          diagID = diag::override_with_stored_property_warn;
+        }
+        TC.diagnose(overrideASD, diagID,
                     overrideASD->getBaseName().getIdentifier());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 @override // expected-error {{'override' can only be specified on class members}} {{1-11=}} expected-error {{'override' is a declaration modifier, not an attribute}} {{1-2=}}
 func virtualAttributeCanNotBeUsedInSource() {}
@@ -95,7 +95,7 @@ class B : A {
   // Stored properties
   override var v8: Int { return 5 } // expected-error {{cannot override mutable property with read-only property 'v8'}}
   override var v9: Int // expected-error{{cannot override with a stored property 'v9'}}
-  lazy override var v10: Int = 5 // expected-error{{cannot override with a stored property 'v10'}}
+  lazy override var v10: Int = 5 // expected-warning{{cannot override with a stored property 'v10'}}
 
   override subscript (i: Int) -> String {
     get {


### PR DESCRIPTION
Previous versions of Swift accidentally treated lazy properties as computed properties because of how they were implemented. Now that we check this correctly, we've broken source compatibility. Downgrade the error to a warning in this case.

(Arguably we could *allow* overriding with a stored property. The original concerns were that you could accidentally end up with extra storage you didn't need, and that observing accessors would behave differently based on whether or not the property was overriding. But there's at least no ambiguity for 'lazy', which can't have observing accessors today.)

rdar://problem/35870371