### PR TITLE
[stdlib] Explicitly mark Float80 unavailable, when it is

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1354,7 +1354,9 @@ extension ${Self} : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLit
   }
 }
 
+% if bits != 80:
 #if !os(Windows) && (arch(i386) || arch(x86_64))
+% end
 
 % builtinFloatLiteralBits = 80
 extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
@@ -1373,6 +1375,7 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
   }
 }
 
+% if bits != 80:
 #else
 
 % builtinFloatLiteralBits = 64
@@ -1393,6 +1396,7 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
 }
 
 #endif
+% end
 
 extension ${Self} : Hashable {
   /// The number's hash value.
@@ -1519,7 +1523,7 @@ extension ${Self} {
 %   srcBits = src_type.bits
 %   That = src_type.stdlib_name
 
-%   if srcBits == 80:
+%   if (srcBits == 80) and (bits != 80):
 #if !os(Windows) && (arch(i386) || arch(x86_64))
 %   end
 
@@ -1584,7 +1588,7 @@ extension ${Self} {
     }
   }
 
-%   if srcBits == 80:
+%   if (srcBits == 80) and (bits != 80):
 #endif
 %   end
 % end
@@ -1721,6 +1725,18 @@ extension ${Self} {
 }
 
 % if bits == 80:
+#else
+${SelfDocComment}
+@_fixed_layout
+@available(*, unavailable, message: "available only #if !os(Windows) && (arch(i386) || arch(x86_64))")
+public struct ${Self} {
+/// Creates a value initialized to zero.
+@_inlineable // FIXME(sil-serialize-all)
+@_transparent
+public init() {
+fatalError("${Self} is not available")
+}
+}
 #endif
 % end
 % end # for bits in all_floating_point_types

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1726,17 +1726,19 @@ extension ${Self} {
 
 % if bits == 80:
 #else
+
 ${SelfDocComment}
 @_fixed_layout
 @available(*, unavailable, message: "available only #if !os(Windows) && (arch(i386) || arch(x86_64))")
 public struct ${Self} {
-/// Creates a value initialized to zero.
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public init() {
-fatalError("${Self} is not available")
+  /// Creates a value initialized to zero.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public init() {
+    fatalError("${Self} is not available")
+  }
 }
-}
+
 #endif
 % end
 % end # for bits in all_floating_point_types

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1729,7 +1729,7 @@ extension ${Self} {
 
 ${SelfDocComment}
 @_fixed_layout
-@available(*, unavailable, message: "available only #if !os(Windows) && (arch(i386) || arch(x86_64))")
+@available(*, unavailable, message: "Float80 is only available on non-Windows x86 targets.")
 public struct ${Self} {
   /// Creates a value initialized to zero.
   @_inlineable // FIXME(sil-serialize-all)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR causes a Float80 type to be explicitly marked unavailable, instead of being simply absent.
It also adds extra conditionals to not generate `#if`s within an `#if` checking the same condition.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6009](https://bugs.swift.org/browse/SR-6009).

I think I did everything, but this is my first contribution to swift.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->