### PR TITLE
libSyntax: specialize struct declaration syntax node.

### DIFF
--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -143,6 +143,10 @@ struct SyntaxFactory {
   /// Creates an `==` operator token.
   static TokenSyntax makeEqualityOperator(
     const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+
+  /// Whether a node `Member` can serve as a member in a syntax collection of
+  /// the given syntax collection kind.
+  static bool canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member);
 };
 }
 }

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -171,6 +171,12 @@ public:
   /// are supported. See the implementation.
   void createNodeInPlace(SyntaxKind Kind);
 
+  /// Squshing nodes from the back of the pending syntax list to a given syntax
+  /// collection kind. If there're no nodes can fit into the collection kind,
+  /// this function does nothing. Otherwise, it creates a collection node in place
+  /// to contain all sequential suitable nodes from back.
+  void collectNodesInPlace(SyntaxKind ColletionKind);
+
   /// On destruction, construct a specified kind of RawSyntax node consuming the
   /// collected parts, then append it to the parent context.
   void setCreateSyntax(SyntaxKind Kind) {

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -85,6 +85,21 @@ SyntaxFactory::countChildren(SyntaxKind Kind){
   }
 }
 
+bool SyntaxFactory::
+canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
+  switch (CollectionKind) {
+% for node in SYNTAX_NODES:
+%     if node.is_syntax_collection():
+  case SyntaxKind::${node.syntax_kind}: {
+    return Member.is<${node.collection_element_type}>();
+  }
+%     end
+% end
+  default:
+    llvm_unreachable("Not collection kind.");
+  }
+}
+
 Optional<Syntax>
 SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
   switch(Kind) {

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -126,6 +126,21 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind) {
   }
 }
 
+void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind) {
+  assert(isCollectionKind(ColletionKind));
+  assert(isTopOfContextStack());
+  if (!Enabled)
+    return;
+  auto Count = std::count_if(Parts.rbegin(), Parts.rend(),
+                             [&](const RC<RawSyntax> &Raw) {
+    return SyntaxFactory::canServeAsCollectionMember(ColletionKind,
+                                                     make<Syntax>(Raw));
+  });
+  if (Count) {
+    createNodeInPlace(ColletionKind, Count);
+  }
+}
+
 namespace {
 RC<RawSyntax> bridgeAs(SyntaxContextKind Kind, ArrayRef<RC<RawSyntax>> Parts) {
   if (Parts.size() == 1) {

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -14,8 +14,22 @@
                   "kind": "DeclarationStmt",
                   "layout": [
                     {
-                      "kind": "UnknownDecl",
+                      "kind": "StructDecl",
                       "layout": [
+                        {
+                          "kind": "AttributeList",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "DeclModifier",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
                         {
                           "tokenKind": {
                             "kind": "kw_struct"
@@ -61,6 +75,27 @@
                             }
                           ],
                           "presence": "Present"
+                        },
+                        {
+                          "kind": "GenericParameterClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "TypeInheritanceClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "GenericWhereClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
                         },
                         {
                           "kind": "MemberDeclBlock",
@@ -124,8 +159,22 @@
                   "kind": "DeclarationStmt",
                   "layout": [
                     {
-                      "kind": "UnknownDecl",
+                      "kind": "StructDecl",
                       "layout": [
+                        {
+                          "kind": "AttributeList",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "DeclModifier",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
                         {
                           "tokenKind": {
                             "kind": "kw_struct"
@@ -159,6 +208,27 @@
                             }
                           ],
                           "presence": "Present"
+                        },
+                        {
+                          "kind": "GenericParameterClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "TypeInheritanceClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "GenericWhereClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
                         },
                         {
                           "kind": "MemberDeclBlock",

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -14,8 +14,22 @@
                   "kind": "DeclarationStmt",
                   "layout": [
                     {
-                      "kind": "UnknownDecl",
+                      "kind": "StructDecl",
                       "layout": [
+                        {
+                          "kind": "AttributeList",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "DeclModifier",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
                         {
                           "tokenKind": {
                             "kind": "kw_struct"
@@ -61,6 +75,27 @@
                             }
                           ],
                           "presence": "Present"
+                        },
+                        {
+                          "kind": "GenericParameterClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "TypeInheritanceClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
+                        },
+                        {
+                          "kind": "GenericWhereClause",
+                          "layout": [
+
+                          ],
+                          "presence": "Missing"
                         },
                         {
                           "kind": "MemberDeclBlock",

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -63,26 +63,32 @@ typealias B = (<MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgument
 typealias C = <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>
 typealias D = <DictionaryType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>]</DictionaryType>
 typealias E = <MetatypeType><OptionalType><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>?</OptionalType>.Protocol</MetatypeType>
-typealias F = <MetatypeType><ImplicitlyUnwrappedOptionalType><ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>!</ImplicitlyUnwrappedOptionalType>.Type</MetatypeType>
+typealias F = <MetatypeType><ImplicitlyUnwrappedOptionalType><ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>!</ImplicitlyUnwrappedOptionalType>.Type</MetatypeType><StructDecl>
 
-struct foo <MemberDeclBlock>{
-  struct foo <MemberDeclBlock>{
+struct foo <MemberDeclBlock>{<StructDecl>
+  struct foo <MemberDeclBlock>{<StructDecl>
     struct foo <MemberDeclBlock>{
       func foo() <CodeBlock>{
       }</CodeBlock>
-    }</MemberDeclBlock>
-  }</MemberDeclBlock>
-  struct foo <MemberDeclBlock>{}</MemberDeclBlock>
-}</MemberDeclBlock>
+    }</MemberDeclBlock></StructDecl>
+  }</MemberDeclBlock></StructDecl><StructDecl>
+  struct foo <MemberDeclBlock>{}</MemberDeclBlock></StructDecl>
+}</MemberDeclBlock></StructDecl><StructDecl>
 
-struct foo <MemberDeclBlock>{<Attribute>
+struct foo <MemberDeclBlock>{<StructDecl><Attribute>
   @available(*, unavailable)</Attribute>
-  struct foo <MemberDeclBlock>{}</MemberDeclBlock><DeclModifier>
+  struct foo <MemberDeclBlock>{}</MemberDeclBlock></StructDecl><DeclModifier>
   public </DeclModifier>class foo {<Attribute>
     @available(*, unavailable)</Attribute><Attribute>
     @objc(fooObjc)</Attribute><DeclModifier>
     private </DeclModifier><DeclModifier>static </DeclModifier>func foo() <CodeBlock>{}</CodeBlock>
   }
-}</MemberDeclBlock>
+}</MemberDeclBlock></StructDecl><StructDecl>
 
-struct S<GenericParameterClause><<GenericParameter>A, </GenericParameter><GenericParameter>B, </GenericParameter><GenericParameter>C, </GenericParameter><GenericParameter><Attribute>@objc </Attribute>D</GenericParameter>> </GenericParameterClause><GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>:<SimpleTypeIdentifier>B</SimpleTypeIdentifier>, </ConformanceRequirement><SameTypeRequirement><SimpleTypeIdentifier>B</SimpleTypeIdentifier>==<SimpleTypeIdentifier>C</SimpleTypeIdentifier>, </SameTypeRequirement><ConformanceRequirement><SimpleTypeIdentifier>A </SimpleTypeIdentifier>: <SimpleTypeIdentifier>C</SimpleTypeIdentifier>, </ConformanceRequirement><SameTypeRequirement><MemberTypeIdentifier><SimpleTypeIdentifier>B</SimpleTypeIdentifier>.C </MemberTypeIdentifier>== <MemberTypeIdentifier><SimpleTypeIdentifier>D</SimpleTypeIdentifier>.A</MemberTypeIdentifier>, </SameTypeRequirement><ConformanceRequirement><MemberTypeIdentifier><SimpleTypeIdentifier>A</SimpleTypeIdentifier>.B</MemberTypeIdentifier>: <MemberTypeIdentifier><SimpleTypeIdentifier>C</SimpleTypeIdentifier>.D </MemberTypeIdentifier></ConformanceRequirement></GenericWhereClause><MemberDeclBlock>{}</MemberDeclBlock>
+struct S<GenericParameterClause><<GenericParameter>A, </GenericParameter><GenericParameter>B, </GenericParameter><GenericParameter>C, </GenericParameter><GenericParameter><Attribute>@objc </Attribute>D</GenericParameter>> </GenericParameterClause><GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>:<SimpleTypeIdentifier>B</SimpleTypeIdentifier>, </ConformanceRequirement><SameTypeRequirement><SimpleTypeIdentifier>B</SimpleTypeIdentifier>==<SimpleTypeIdentifier>C</SimpleTypeIdentifier>, </SameTypeRequirement><ConformanceRequirement><SimpleTypeIdentifier>A </SimpleTypeIdentifier>: <SimpleTypeIdentifier>C</SimpleTypeIdentifier>, </ConformanceRequirement><SameTypeRequirement><MemberTypeIdentifier><SimpleTypeIdentifier>B</SimpleTypeIdentifier>.C </MemberTypeIdentifier>== <MemberTypeIdentifier><SimpleTypeIdentifier>D</SimpleTypeIdentifier>.A</MemberTypeIdentifier>, </SameTypeRequirement><ConformanceRequirement><MemberTypeIdentifier><SimpleTypeIdentifier>A</SimpleTypeIdentifier>.B</MemberTypeIdentifier>: <MemberTypeIdentifier><SimpleTypeIdentifier>C</SimpleTypeIdentifier>.D </MemberTypeIdentifier></ConformanceRequirement></GenericWhereClause><MemberDeclBlock>{}</MemberDeclBlock></StructDecl><StructDecl><DeclModifier>
+
+private </DeclModifier>struct S<GenericParameterClause><<GenericParameter>A, </GenericParameter><GenericParameter>B</GenericParameter>></GenericParameterClause><TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Base </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>: <SimpleTypeIdentifier>B </SimpleTypeIdentifier></ConformanceRequirement></GenericWhereClause><MemberDeclBlock>{<StructDecl><DeclModifier>
+  private </DeclModifier>struct S<TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>A</SimpleTypeIdentifier>, </InheritedType><InheritedType><SimpleTypeIdentifier>B </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{}</MemberDeclBlock></StructDecl>
+}</MemberDeclBlock></StructDecl>
+
+protocol P<TypeInheritanceClause>: <InheritedType>class </InheritedType></TypeInheritanceClause>{}

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -86,3 +86,9 @@ struct foo {
 }
 
 struct S<A, B, C, @objc D> where A:B, B==C, A : C, B.C == D.A, A.B: C.D {}
+
+private struct S<A, B>: Base where A: B {
+  private struct S: A, B {}
+}
+
+protocol P: class {}

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -81,11 +81,20 @@ DECL_NODES = [
              Child('Detail', kind='TokenList'),
          ]),
 
+    Node('InheritedType', kind='Syntax',
+         children=[
+            Child('TypeName', kind='Type'),
+            Child('TrailingComma', kind='CommaToken', is_optional=True),
+         ]),
+
+    Node('InheritedTypeList', kind='SyntaxCollection',
+         element='InheritedType'),
+
     # type-inheritance-clause -> ':' type
     Node('TypeInheritanceClause', kind='Syntax',
          children=[
              Child('Colon', kind='ColonToken'),
-             Child('InheritedType', kind='Type'),
+             Child('InheritedTypeCollection', kind='InheritedTypeList'),
          ]),
 
     # struct-declaration -> attributes? access-level-modifier?
@@ -99,7 +108,7 @@ DECL_NODES = [
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
-             Child('AccessLevelModifier', kind='AccessLevelModifier',
+             Child('AccessLevelModifier', kind='DeclModifier',
                    is_optional=True),
              Child('StructKeyword', kind='StructToken'),
              Child('Identifier', kind='IdentifierToken'),


### PR DESCRIPTION
To construct struct syntax, this patch first specialized type
inheritance clause. For protocol's class requirement, we currently
treat it as an unknown type.

This patch also teaches SyntaxParsingContext to collect syntax nodes
from back in place. This is useful to squash multiple decl modifiers
for declarations like function. This is not used for struct declaration
because only accessibility modifier is allowed.