### PR TITLE
[4.1] For 'lazy', make "cannot override with a stored property" a warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1877,6 +1877,8 @@ ERROR(override_property_type_mismatch,none,
       (Identifier, Type, Type))
 ERROR(override_with_stored_property,none,
       "cannot override with a stored property %0", (Identifier))
+WARNING(override_with_stored_property_warn,none,
+      "cannot override with a stored property %0", (Identifier))
 ERROR(observing_readonly_property,none,
       "cannot observe read-only property %0; it can't change", (Identifier))
 ERROR(override_mutable_with_readonly_property,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6623,7 +6623,15 @@ public:
       
       // Make sure that the overriding property doesn't have storage.
       if (overrideASD->hasStorage() && !overrideASD->hasObservers()) {
-        TC.diagnose(overrideASD, diag::override_with_stored_property,
+        auto diagID = diag::override_with_stored_property;
+        if (!TC.Context.isSwiftVersionAtLeast(5) &&
+            overrideASD->getAttrs().hasAttribute<LazyAttr>()) {
+          // Swift 4.0 had a bug where lazy properties were considered
+          // computed by the time of this check. Downgrade this diagnostic to
+          // a warning.
+          diagID = diag::override_with_stored_property_warn;
+        }
+        TC.diagnose(overrideASD, diagID,
                     overrideASD->getBaseName().getIdentifier());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 @override // expected-error {{'override' can only be specified on class members}} {{1-11=}} expected-error {{'override' is a declaration modifier, not an attribute}} {{1-2=}}
 func virtualAttributeCanNotBeUsedInSource() {}
@@ -95,7 +95,7 @@ class B : A {
   // Stored properties
   override var v8: Int { return 5 } // expected-error {{cannot override mutable property with read-only property 'v8'}}
   override var v9: Int // expected-error{{cannot override with a stored property 'v9'}}
-  lazy override var v10: Int = 5 // expected-error{{cannot override with a stored property 'v10'}}
+  lazy override var v10: Int = 5 // expected-warning{{cannot override with a stored property 'v10'}}
 
   override subscript (i: Int) -> String {
     get {


### PR DESCRIPTION
- **Explanation**: Previous versions of Swift accidentally treated lazy properties as computed properties because of how they were implemented. Now that we check this correctly, we've broken source compatibility. Downgrade the error to a warning in this case.
- **Scope**: Only affects properties marked both `override` and `lazy`.
- **Issue**: rdar://problem/35870371
- **Reviewed by**: @slavapestov 
- **Risk**: Very low. An error becomes a warning under a very safe condition. (The original change could have other effects we haven't discovered, but that's not the risk being evaluated here.)
- **Testing**: Added compiler regression tests.