### PR TITLE
[4.1] [Type checker] Don't check near-miss candidates of the wrong kind.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6479,6 +6479,11 @@ static bool shouldWarnAboutPotentialWitness(
   if (groupChecker.isCoveredMember(witness))
     return false;
 
+  // If the kinds of the requirement and witness are different, there's
+  // nothing to warn about.
+  if (req->getKind() != witness->getKind())
+    return false;
+
   // If the warning couldn't be suppressed, don't warn.
   if (!canSuppressPotentialWitnessWarningWithMovement(req, witness) &&
       !canSuppressPotentialWitnessWarningWithNonObjC(req, witness))

--- a/validation-test/compiler_crashers_2_fixed/0133-rdar35832679.swift
+++ b/validation-test/compiler_crashers_2_fixed/0133-rdar35832679.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -emit-ir -o -
+
+func f() {
+  enum NotAnError: Swift.Error {
+    case nope(length: Int)
+  }
+}
+


### PR DESCRIPTION
- **Explanation**: Near-miss warnings would consider irrelevant declarations within the current scope, causing a compiler assertion.
- **Scope**: Only affects diagnostics, eliminating a crash that affected a project in the source compatibility suite.
- **Issue**: [SR-6334](https://bugs.swift.org/browse/SR-6334) / rdar://problem/35832679
- **Reviewed by**: @slavapestov   
- **Risk**: Very low. Early-exits from a diagnostic that was asserting.
- **Testing**: Added compiler regression tests, checked source compatibility suite.