### PR TITLE
[runtime] Always use SwiftCC

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -102,6 +102,11 @@
 #define SWIFT_CONTEXT __attribute__((swift_context))
 #define SWIFT_ERROR_RESULT __attribute__((swift_error_result))
 #define SWIFT_INDIRECT_RESULT __attribute__((swift_indirect_result))
+#else
+#define SWIFT_CC_swift
+#define SWIFT_CONTEXT
+#define SWIFT_ERROR_RESULT
+#define SWIFT_INDIRECT_RESULT
 #endif
 
 #define SWIFT_CC_SwiftCC SWIFT_CC_swift

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -108,7 +108,7 @@ static void addInoutParameterAttributes(IRGenModule &IGM,
 
 static llvm::CallingConv::ID getFreestandingConvention(IRGenModule &IGM) {
   // TODO: use a custom CC that returns three scalars efficiently
-  return SWIFT_LLVM_CC(SwiftCC);
+  return IGM.SwiftCC;
 }
 
 /// Expand the requirements of the given abstract calling convention
@@ -146,8 +146,6 @@ static void addIndirectResultAttributes(IRGenModule &IGM,
 
 void IRGenModule::addSwiftSelfAttributes(llvm::AttributeList &attrs,
                                          unsigned argIndex) {
-  if (!UseSwiftCC)
-    return;
   llvm::AttrBuilder b;
   b.addAttribute(llvm::Attribute::SwiftSelf);
   attrs = attrs.addAttributes(this->LLVMContext,
@@ -160,7 +158,7 @@ void IRGenModule::addSwiftErrorAttributes(llvm::AttributeList &attrs,
   // We create a shadow stack location of the swifterror parameter for the
   // debugger on such platforms and so we can't mark the parameter with a
   // swifterror attribute.
-  if (!UseSwiftCC || !this->IsSwiftErrorInRegister)
+  if (!this->IsSwiftErrorInRegister)
     return;
 
   llvm::AttrBuilder b;

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -397,8 +397,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   else
     RegisterPreservingCC = DefaultCC;
 
-  SwiftCC = SWIFT_LLVM_CC(SwiftCC);
-  UseSwiftCC = (SwiftCC == llvm::CallingConv::Swift);
+  SwiftCC = llvm::CallingConv::Swift;
 
   if (IRGen.Opts.DebugInfoKind > IRGenDebugInfoKind::None)
     DebugInfo = IRGenDebugInfo::createIRGenDebugInfo(IRGen.Opts, *CI, *this,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -509,7 +509,6 @@ public:
   llvm::CallingConv::ID DefaultCC;     /// default calling convention
   llvm::CallingConv::ID RegisterPreservingCC; /// lightweight calling convention
   llvm::CallingConv::ID SwiftCC;     /// swift calling convention
-  bool UseSwiftCC;
 
   Signature getAssociatedTypeMetadataAccessFunctionSignature();
   Signature getAssociatedTypeWitnessTableAccessFunctionSignature();

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -46,6 +46,22 @@
 
 using namespace swift;
 
+// Check to make sure the runtime is being built with a compiler that
+// supports the Swift calling convention.
+//
+// If the Swift calling convention is not in use, functions such as 
+// swift_allocBox and swift_makeBoxUnique that rely on their return value 
+// being passed in a register to be compatible with Swift may miscompile on
+// some platforms and silently fail.
+#if !__has_attribute(swiftcall)
+#error "The runtime must be built with a compiler that supports swiftcall."
+#endif
+
+// Check that the user isn't manually disabling SWIFTCALL.
+#if defined(SWIFT_USE_SWIFTCALL) && !SWIFT_USE_SWIFTCALL
+#error "SWIFT_USE_SWIFTCALL=0 is not supported; swiftcall must always be used."
+#endif
+
 /// Returns true if the pointer passed to a native retain or release is valid.
 /// If false, the operation should immediately return.
 static inline bool isValidPointerForNativeRetain(const void *p) {


### PR DESCRIPTION
Once https://github.com/apple/swift/pull/13299 is merged, it will silently cause issues on some platforms if the Swift calling convention is not available.

Therefore, since every platform that Swift supports also supports the Swift calling convention, we should always use the Swift calling convention, as per discussion at https://github.com/apple/swift/pull/13299#discussion_r155401298.

To do this, I've split some of the runtime `Config.h` header (which was being included by some sources outside of the stdlib/runtime) out into a new`PublicConfig.h` header, which can safely be included in non-runtime code whether or not the host compiler supports `swiftcall`.

I've added checks within the internal `Config.h` header that the compiler in use for the runtime supports `swiftcall`. I've also removed any `UseSwiftCC` checks as they're now redundant.