### PR TITLE
[TypeChecker] SR-5984 Error message for accidentally calling function in #selector(foo()) could suggest removing parens

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3756,6 +3756,13 @@ namespace {
           continue;
         }
 
+        if (auto call = dyn_cast<CallExpr>(subExpr)) {
+          if (call->getNumArguments() == 0) {
+            subExpr = call->getFn();
+            continue;
+          }
+        }
+
         // Look through implicit conversions.
         if (auto conversion = dyn_cast<ImplicitConversionExpr>(subExpr)) {
           subExpr = conversion->getSubExpr();

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -35,6 +35,16 @@ class C1 {
     let testVariable = 1 // expected-note{{'testVariable' declared here}}
     _ = #selector(testVariable) // expected-error{{argument of '#selector' cannot refer to variable 'testVariable'}}
   }
+
+  @objc func testParen_a() {
+    _ = #selector(testParen_a())
+  }
+
+  @objc func testParen_b(a: A?) {
+    // expected-error@+1 {{argument of '#selector' does not refer to an '@objc' method, property, or initializer}}
+    _ = #selector(testParen_b(a: nil))
+  }
+
 }
 
 @objc protocol P1 {


### PR DESCRIPTION
Followed the comment by @jckarter on the ticket.
> I feel like we should just also accept the syntax with the parens. It's not ambiguous with anything.

Resolves [SR-5984](https://bugs.swift.org/browse/SR-5984)