### PR TITLE
[libSyntax] Support TypeExpr

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/Basic/EditorPlaceholder.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Syntax/SyntaxBuilders.h"
 #include "swift/Syntax/SyntaxFactory.h"
 #include "swift/Syntax/TokenSyntax.h"
 #include "swift/Syntax/SyntaxParsingContext.h"
@@ -1563,6 +1564,11 @@ Parser::parseExprPostfixWithoutSuffix(Diag<> ID, bool isExprBasic) {
   case tok::kw_Any: { // Any
     auto SynResult = parseAnyType();
     auto expr = new (Context) TypeExpr(TypeLoc(SynResult.getAST()));
+    if (SynResult.hasSyntax()) {
+      TypeExprSyntaxBuilder Builder;
+      Builder.useType(SynResult.getSyntax());
+      SyntaxContext->addSyntax(Builder.build());
+    }
     Result = makeParserResult(expr);
     break;
   }

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -49,6 +49,7 @@ class C {
   }</CodeBlock>
 
   func foo3() <CodeBlock>{<SequenceExpr><DiscardAssignmentExpr>
+    _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ArrayExpr>[<ArrayElement><TypeExpr><SimpleTypeIdentifier>Any</SimpleTypeIdentifier></TypeExpr></ArrayElement>]</ArrayExpr>()</SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><MemberAccessExpr><MemberAccessExpr><IdentifierExpr>a</IdentifierExpr>.a</MemberAccessExpr>.a</MemberAccessExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><MemberAccessExpr><IdentifierExpr>a</IdentifierExpr>.b</MemberAccessExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><MemberAccessExpr><IntegerLiteralExpr>1</IntegerLiteralExpr>.a</MemberAccessExpr></SequenceExpr><MemberAccessExpr><MemberAccessExpr><MemberAccessExpr><TupleExpr>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -49,6 +49,7 @@ class C {
   }
 
   func foo3() {
+    _ = [Any]()
     _ = a.a.a
     _ = a.b
     _ = 1.a

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -256,4 +256,10 @@ EXPR_NODES = [
                    ]),
              Child("TypeName", kind='Type')
          ]),
+
+    # Type
+    Node('TypeExpr', kind='Expr',
+         children=[
+             Child('Type', kind='Type'),
+         ]),
 ]


### PR DESCRIPTION
For now, it's just for `Any` at expression position.

CC: @nkcsgexi 
