### PR TITLE
[stdlib] Improve Collection.index(_:offsetBy:limitedBy:)

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1015,6 +1015,8 @@ extension Collection {
   internal func _advanceForward(
     _ i: Index, by n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
+    if i == limit { return i }
+
     _precondition(n >= 0,
       "Only BidirectionalCollections can be advanced by a negative amount")
 


### PR DESCRIPTION
When Collection.index(_:offsetBy:limitedBy:) is called with the index at
the limit, return it regardless of the offset.

This change relaxes the precondition that made it fail on forward
collections when the offset is negative.