### PR TITLE
[build-script] Overzealous path expansion

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -298,7 +298,8 @@ def create_argument_parser():
            help='enable code coverage analysis in Swift (false, not-merged, '
                 'merged).')
 
-    option('--build-subdir', store_path,
+    option('--build-subdir', store,
+           metavar='PATH',
            help='name of the directory under $SWIFT_BUILD_ROOT where the '
                 'build products will be placed')
     option('--install-prefix', store_path,
@@ -315,7 +316,6 @@ def create_argument_parser():
     option('--darwin-xcrun-toolchain', store,
            default=defaults.DARWIN_XCRUN_TOOLCHAIN,
            help='the name of the toolchain to use on Darwin')
-    # TODO: Add executable check to store_path
     option('--cmake', store_path(executable=True),
            help='the path to a CMake executable that will be used to build '
                 'Swift')


### PR DESCRIPTION
# Purpose

This PR fixes some overzealous path expansion for the `--build-subdir` argument which attempts to expand the build subdirectory path as much as possible due to changes introduced yesterday by #13231. When the path is expanded out to an absolute path it will then cause all build directories to generate relative to where `build-script` was invoked, rather than the standard `build` directory above the Swift workspace.

rdar://35913659