### PR TITLE
[SwiftSyntax] Add contextual_keyword and string_interpolation_anchor token kinds

### DIFF
--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -9,6 +9,11 @@ import SwiftSyntax
 
 var ParseFile = TestSuite("ParseFile")
 
+struct Foo {
+  public let x: Int
+  private(set) var y: [Bool]
+}
+
 ParseFile.test("ParseSingleFile") {
   let currentFile = URL(fileURLWithPath: #file)
   expectDoesNotThrow({

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -137,6 +137,8 @@ SYNTAX_TOKENS = [
     Token('IntegerLiteral', 'integer_literal'),
     Token('FloatingLiteral', 'floating_literal'),
     Token('StringLiteral', 'string_literal'),
+    Token('StringInterpolationAnchor', 'string_interpolation_anchor'),
+    Token('ContextualKeyword', 'contextual_keyword'),
 ]
 
 SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This patch fixes a regression introduced in #11809 when two new token types were introduced without being added to `Token.py`. This also adds a test that includes contextual keywords that will not fail now that this is implemented.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->