### PR TITLE
[master-next] Fix IRGen/builtin_math test failure due to LLVM sqrt intrinsic change

### DIFF
--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -24,6 +24,7 @@ public func test2(f : Double) -> Double {
 // CHECK: call double @sqrt
 
 public func test3(d : Double) -> Double {
+  // This call uses the sqrt function imported from C.
   return sqrt(d)
 }
 
@@ -31,6 +32,10 @@ public func test3(d : Double) -> Double {
 // CHECK: call float @llvm.sqrt.f32
 
 public func test4(f : Float) -> Float {
+  // This call does not match the signature for the C sqrt function
+  // (as opposed to sqrtf) so instead it gets compiled using the generic
+  // sqrt function from the stdlib's tgmath.swift. That translates to
+  // _stdlib_squareRootf and then to __builtin_sqrtf via SwiftShims.
   return sqrt(f)
 }
 

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -20,10 +20,6 @@ public func test2(f : Double) -> Double {
   return _exp(f)
 }
 
-// LLVM's sqrt intrinsic does not have the same semantics as libm's sqrt.
-// In particular, llvm.sqrt(negative) is documented as being undef, but
-// we want sqrt(negative) to be defined to be NaN for IEEE 754 conformance.
-
 // CHECK-LABEL: define {{.*}}test3
 // CHECK: call double @sqrt
 
@@ -32,7 +28,7 @@ public func test3(d : Double) -> Double {
 }
 
 // CHECK-LABEL: define {{.*}}test4
-// CHECK: call float @sqrtf
+// CHECK: call float @llvm.sqrt.f32
 
 public func test4(f : Float) -> Float {
   return sqrt(f)


### PR DESCRIPTION
This test used to check that sqrt() did not use the LLVM intrinsic because its behavior did not match IEEE 754 for negative inputs. That has now changed in recent versions of LLVM. There are still some differences in how the LLVM intrinsic handles errno, but that should not affect Swift. With Clang r319593, the test began to fail because __builtin_sqrtf gets translated to the LLVM intrinsic. Change the test to match.