### PR TITLE
Revert "[stdlib] Improve default implementation of Collection.distance(from:to:)"

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -1584,6 +1584,11 @@ extension TestSuite {
       .forEach(in: distanceFromToTests) {
       test in
       let c = toCollection(0..<20)
+      let backwards = (test.startOffset > test.endOffset)
+      if backwards && !collectionIsBidirectional {
+        expectCrashLater()
+      }
+
       let d = c.distance(
         from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
       expectEqual(

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -662,6 +662,8 @@ public struct ${Self}<T> : ${SelfProtocols} {
   public func distance(from start: ${Index}, to end: ${Index})
     -> IndexDistance {
 %     if Traversal == 'Forward':
+    _precondition(start <= end,
+      "Only BidirectionalCollections can have end come before start")
 %     end
     // FIXME: swift-3-indexing-model: perform a range check properly.
     if start != endIndex {

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -707,11 +707,16 @@ public protocol Collection: Sequence where SubSequence: Collection {
 
   /// Returns the distance between two indices.
   ///
+  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
+  /// `start` must be less than or equal to `end`.
+  ///
   /// - Parameters:
   ///   - start: A valid index of the collection.
   ///   - end: Another valid index of the collection. If `end` is equal to
   ///     `start`, the result is zero.
-  /// - Returns: The distance between `start` and `end`.
+  /// - Returns: The distance between `start` and `end`. The result can be
+  ///   negative only if the collection conforms to the
+  ///   `BidirectionalCollection` protocol.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
@@ -960,34 +965,30 @@ extension Collection {
 
   /// Returns the distance between two indices.
   ///
+  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
+  /// `start` must be less than or equal to `end`.
+  ///
   /// - Parameters:
   ///   - start: A valid index of the collection.
   ///   - end: Another valid index of the collection. If `end` is equal to
   ///     `start`, the result is zero.
-  /// - Returns: The distance between `start` and `end`.
+  /// - Returns: The distance between `start` and `end`. The result can be
+  ///   negative only if the collection conforms to the
+  ///   `BidirectionalCollection` protocol.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
   @_inlineable
   public func distance(from start: Index, to end: Index) -> IndexDistance {
-    var _start: Index
-    let _end: Index
-    let step: IndexDistance
-    if start > end {
-      _start = end
-      _end = start
-      step = -1
-    }
-    else {
-      _start = start
-      _end = end
-      step = 1
-    }
+    _precondition(start <= end,
+      "Only BidirectionalCollections can have end come before start")
+
+    var start = start
     var count: IndexDistance = 0
-    while _start != _end {
-      count += step
-      formIndex(after: &_start)
+    while start != end {
+      count = count + 1
+      formIndex(after: &start)
     }
     return count
   }


### PR DESCRIPTION
This reverts commit 72948cae9af6d4772f9be3f8be30bca63f078c68.
...which caused some unexplainable breakage in the CI builds.