### PR TITLE
[Name lookup] Allow where clauses to find typealiases declared in a protocol.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1686,10 +1686,11 @@ ERROR(requires_not_suitable_archetype,none,
       "type %0 in conformance requirement does not refer to a "
       "generic parameter or associated type",
       (TypeLoc))
-ERROR(requires_no_same_type_archetype,none,
-      "neither type in same-type refers to a generic parameter or "
-      "associated type",
-      ())
+WARNING(requires_no_same_type_archetype,none,
+        "neither type in same-type constraint (%0 or %1) refers to a "
+        "generic parameter  or associated type",
+        (Type, Type))
+
 ERROR(requires_generic_params_made_equal,none,
       "same-type requirement makes generic parameters %0 and %1 equivalent",
       (Type, Type))

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4131,19 +4131,6 @@ ConstraintResult GenericSignatureBuilder::addSameTypeRequirement(
                                       diagnoseMismatch);
 }
 
-/// Determine whether the given type has a type parameter or directly
-/// references a deprecated typealias.
-static bool hasTypeParameterOrIsDeprecatedTypealias(Type type){
-  if (type->hasTypeParameter()) return true;
-
-  if (auto typeAlias = dyn_cast<NameAliasType>(type.getPointer())) {
-    return typeAlias->getDecl()->getAttrs().getDeprecated(
-                                                      type->getASTContext());
-  }
-
-  return false;
-}
-
 ConstraintResult GenericSignatureBuilder::addSameTypeRequirementDirect(
     ResolvedType type1, ResolvedType type2,
     FloatingRequirementSource source,
@@ -4298,21 +4285,16 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
   }
 
   case RequirementReprKind::SameType: {
-    // Require that at least one side of the requirement contain a type
-    // parameter or directly reference a deprecated declaration.
-    if (!hasTypeParameterOrIsDeprecatedTypealias(Req->getFirstType()) &&
-        !hasTypeParameterOrIsDeprecatedTypealias(Req->getSecondType())) {
-      if (!Req->getFirstType()->hasError() &&
-          !Req->getSecondType()->hasError()) {
-        Impl->HadAnyError = true;
-
-        Diags.diagnose(Req->getEqualLoc(),
-                       diag::requires_no_same_type_archetype)
-          .highlight(Req->getFirstTypeLoc().getSourceRange())
-          .highlight(Req->getSecondTypeLoc().getSourceRange());
-      }
-
-      return ConstraintResult::Concrete;
+    // Warn if neither side of the requirement contains a type parameter.
+    if (!Req->getFirstType()->hasTypeParameter() &&
+        !Req->getSecondType()->hasTypeParameter() &&
+        !Req->getFirstType()->hasError() &&
+        !Req->getSecondType()->hasError()) {
+      Diags.diagnose(Req->getEqualLoc(),
+                     diag::requires_no_same_type_archetype,
+                     Req->getFirstType(), Req->getSecondType())
+        .highlight(Req->getFirstTypeLoc().getSourceRange())
+        .highlight(Req->getSecondTypeLoc().getSourceRange());
     }
 
     auto firstType = subst(Req->getFirstType());

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -371,3 +371,10 @@ struct StructTakingP1<T: P1> { }
 func resultTypeSuppress<T: P1>() -> StructTakingP1<T> {
   return StructTakingP1()
 }
+
+// Check directly-concrete same-type constraints
+typealias NotAnInt = Double
+
+extension X11 where NotAnInt == Int { }
+// expected-warning@-1{{neither type in same-type constraint ('NotAnInt' (aka 'Double') or 'Int') refers to a generic parameter  or associated type}}
+// expected-error@-2{{generic signature requires types 'NotAnInt' (aka 'Double') and 'Int' to be the same}}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -268,7 +268,7 @@ extension P10 {
   typealias U = Float
 }
 
-extension P10 where T == Int { } // expected-error{{neither type in same-type refers to a generic parameter or associated type}}
+extension P10 where T == Int { } // expected-warning{{neither type in same-type constraint ('P10.T' (aka 'Int') or 'Int') refers to a generic parameter  or associated type}}
 
 extension P10 where A == X<T> { }
 
@@ -277,3 +277,4 @@ extension P10 where A == X<U> { } // expected-error{{use of undeclared type 'U'}
 extension P10 where A == X<Self.U> { }
 
 extension P10 where V == Int { } // expected-warning 3{{'V' is deprecated: just use Int, silly}}
+// expected-warning@-1{{neither type in same-type constraint ('P10.V' (aka 'Int') or 'Int') refers to a generic parameter  or associated type}}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -252,3 +252,28 @@ protocol P9 {
 
 func testT9a<T: P9, U>(_: T, _: U) where T.A == U { }
 func testT9b<T: P9>(_: T) where T.A == Float { } // expected-error{{'T.A' cannot be equal to both 'Float' and 'P9.A' (aka 'Int')}}
+
+
+struct X<T> { }
+
+protocol P10 {
+  associatedtype A
+  typealias T = Int
+
+  @available(*, deprecated, message: "just use Int, silly")
+  typealias V = Int
+}
+
+extension P10 {
+  typealias U = Float
+}
+
+extension P10 where T == Int { } // expected-error{{neither type in same-type refers to a generic parameter or associated type}}
+
+extension P10 where A == X<T> { }
+
+extension P10 where A == X<U> { } // expected-error{{use of undeclared type 'U'}}
+
+extension P10 where A == X<Self.U> { }
+
+extension P10 where V == Int { } // expected-warning 3{{'V' is deprecated: just use Int, silly}}

--- a/validation-test/compiler_crashers_2_fixed/0133-rdar35832679.swift
+++ b/validation-test/compiler_crashers_2_fixed/0133-rdar35832679.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-ir -o -
 
 func f() {
-		enum NotAnError: Swift.Error {
-			case nope(length: Int)
-		}
+  enum NotAnError: Swift.Error {
+    case nope(length: Int)
+  }
 }
 


### PR DESCRIPTION
Within the where clause of (e.g.) an extension, unqualified name lookup is
permitted to find associated types. Extend this to also include finding
type aliases declared within the protocol itself.

While here, downgrade the "neither type in a same-type constraint has a generic parameter" error to a warning. It didn't need to be an error anyway (all of the other redundant-constraint diagnostics are warnings), and it affects source compatibility for cases where there are existing extensions containing `where IndexDistance == Int`.

Fixes rdar://problem/35490504, and is part of providing source compatibility for [SE-0191: Eliminate `IndexDistance` from `Collection`](https://github.com/apple/swift-evolution/blob/master/proposals/0191-eliminate-indexdistance.md)..