### PR TITLE
[4.1] [PrintAsObjC] Reintroduce +new when reintroducing -init

### DIFF
--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -433,6 +433,41 @@ class MyObject : NSObject {}
   @objc class Subclass : NestedSuperclass {}
 }
 
+// CHECK-LABEL: @interface NewBanned
+// CHECK-NEXT: - (nonnull instancetype)initWithArbitraryArgument:(NSInteger)arbitraryArgument OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)init SWIFT_UNAVAILABLE;
+// CHECK-NEXT: + (nonnull instancetype)new SWIFT_UNAVAILABLE;
+// CHECK-NEXT: @end
+@objc class NewBanned : NSObject {
+  init(arbitraryArgument: Int) { super.init() }
+}
+
+// CHECK-LABEL: @interface NewBanned
+// CHECK-NEXT: - (nonnull instancetype)initWithDifferentArbitraryArgument:(NSInteger)differentArbitraryArgument OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithArbitraryArgument:(NSInteger)arbitraryArgument SWIFT_UNAVAILABLE;
+// CHECK-NEXT: @end
+@objc class NewBannedStill : NewBanned {
+  init(differentArbitraryArgument: Int) { super.init(arbitraryArgument: 0) }
+}
+
+// CHECK-LABEL: @interface NewUnbanned
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: + (nonnull instancetype)new;
+// CHECK-NEXT: - (nonnull instancetype)initWithArbitraryArgument:(NSInteger)arbitraryArgument SWIFT_UNAVAILABLE;
+// CHECK-NEXT: @end
+@objc class NewUnbanned : NewBanned {
+  init() { super.init(arbitraryArgument: 0) }
+}
+
+// CHECK-LABEL: @interface NewUnbannedDouble
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: + (nonnull instancetype)new;
+// CHECK-NEXT: - (nonnull instancetype)initWithDifferentArbitraryArgument:(NSInteger)differentArbitraryArgument SWIFT_UNAVAILABLE;
+// CHECK-NEXT: @end
+@objc class NewUnbannedDouble : NewBannedStill {
+  init() { super.init(differentArbitraryArgument: 0) }
+}
+
 // NEGATIVE-NOT: @interface Private :
 private class Private : A1 {}
 

--- a/validation-test/PrintAsObjC/Inputs/reintroduced-new.swift
+++ b/validation-test/PrintAsObjC/Inputs/reintroduced-new.swift
@@ -1,0 +1,8 @@
+import ObjectiveC
+
+public class Base : NSObject {
+  public init(foo: Int) { super.init() }
+}
+public class Sub: Base {
+  @objc public init() { super.init(foo: 0) }
+}

--- a/validation-test/PrintAsObjC/reintroduced-new.m
+++ b/validation-test/PrintAsObjC/reintroduced-new.m
@@ -1,0 +1,26 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../../test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/reintroduced-new.swift -disable-objc-attr-requires-foundation-module -module-name main
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module
+// RUN: not %clang -fsyntax-only -x objective-c %s -include %t/generated.h -fobjc-arc -fmodules -Werror -isysroot %S/../../test/Inputs/clang-importer-sdk 2>&1 | %FileCheck %s
+
+// CHECK-NOT: error:
+
+void test() {
+  // CHECK: :[[@LINE+1]]:{{[0-9]+}}: error: 'init' is unavailable
+  (void)[[Base alloc] init];
+   // CHECK-NOT: error:
+  (void)[[Sub alloc] init];
+  // CHECK: :[[@LINE+1]]:{{[0-9]+}}: error: 'new' is unavailable
+  (void)[Base new];
+   // CHECK-NOT: error:
+  (void)[Sub new];
+}
+
+// CHECK-NOT: error:


### PR DESCRIPTION
- **Explanation**: An unavailable `-init` makes `+new` unavailable, but reintroducing it in a subclass should reintroduce `+new` if the root class is NSObject (where `+new` is implemented).
- **Scope**: Only affects classes that implement a non-overriding `init()` exposed to Objective-C
- **Issue**: ~rdar://problem/35914080~ rdar://problem/35941258
- **Reviewed by**: @DougGregor, @JaviSoto  
- **Risk**: Low. Only affects ObjC printing, not any run-time behavior.
- **Testing**: Added compiler regression tests.