### PR TITLE
In Swift 3/4 mode, continue treating 'lazy override' as an override

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6623,18 +6623,22 @@ public:
       
       // Make sure that the overriding property doesn't have storage.
       if (overrideASD->hasStorage() && !overrideASD->hasObservers()) {
-        auto diagID = diag::override_with_stored_property;
+        bool downgradeToWarning = false;
         if (!TC.Context.isSwiftVersionAtLeast(5) &&
             overrideASD->getAttrs().hasAttribute<LazyAttr>()) {
           // Swift 4.0 had a bug where lazy properties were considered
           // computed by the time of this check. Downgrade this diagnostic to
           // a warning.
-          diagID = diag::override_with_stored_property_warn;
+          downgradeToWarning = true;
         }
+        auto diagID = downgradeToWarning ?
+            diag::override_with_stored_property_warn :
+            diag::override_with_stored_property;
         TC.diagnose(overrideASD, diagID,
                     overrideASD->getBaseName().getIdentifier());
         TC.diagnose(baseASD, diag::property_override_here);
-        return true;
+        if (!downgradeToWarning)
+          return true;
       }
 
       // Make sure that an observing property isn't observing something

--- a/test/Compatibility/attr_override_lazy.swift
+++ b/test/Compatibility/attr_override_lazy.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -swift-version 4 -emit-silgen %s | %FileCheck %s
+
+class Base {
+  var foo: Int { return 0 }
+  var bar: Int = 0
+}
+
+class Sub : Base {
+  lazy override var foo: Int = 1
+  lazy override var bar: Int = 1
+  func test() -> Int {
+    // CHECK-LABEL: sil {{.*}}@_T018attr_override_lazy3SubC4testSiyF
+    // CHECK: class_method %0 : $Sub, #Sub.foo!getter.1
+    // CHECK: class_method %0 : $Sub, #Sub.bar!getter.1
+    // CHECK: // end sil function '_T018attr_override_lazy3SubC4testSiyF'
+    return foo + bar // no ambiguity error here
+  }
+}
+
+// CHECK-LABEL: sil_vtable Sub {
+// CHECK: #Base.foo!getter.1: (Base) -> () -> Int : {{.*}} // Sub.foo.getter
+// CHECK: #Base.bar!getter.1: (Base) -> () -> Int : {{.*}} // Sub.bar.getter
+// CHECK: #Base.bar!setter.1: (Base) -> (Int) -> () : {{.*}} // Sub.bar.setter
+// CHECK: #Base.bar!materializeForSet.1: (Base) -> {{.*}} : {{.*}} // Sub.bar.materializeForSet
+// CHECK: }


### PR DESCRIPTION
Follow-up for #13304. Without this, the declaration would be accepted, but any uses of the overridden property would be treated as ambiguous because the property wouldn't really be marked as an override.

"Oops."

rdar://problem/35900345