### PR TITLE
[stdlib] Implement sequence/collection methods for searching from the end

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -149,7 +149,7 @@ public struct FindTest {
 
   public init(
     expected: Int?, element: Int, sequence: [Int],
-    expectedLeftoverSequence: [Int],
+    expectedLeftoverSequence: [Int] = [],
     file: String = #file, line: UInt = #line
   ) {
     self.expected = expected
@@ -579,6 +579,68 @@ public let findTests = [
 
   FindTest(
     expected: 1,
+    element: 2020,
+    sequence: [ 1010, 2020, 3030, 2020, 4040 ],
+    expectedLeftoverSequence: [ 3030, 2020, 4040 ]),
+]
+
+public let findLastTests = [
+  FindTest(
+    expected: nil,
+    element: 42,
+    sequence: [],
+    expectedLeftoverSequence: []),
+
+  FindTest(
+    expected: nil,
+    element: 42,
+    sequence: [ 1010 ],
+    expectedLeftoverSequence: []),
+  FindTest(
+    expected: 0,
+    element: 1010,
+    sequence: [ 1010 ],
+    expectedLeftoverSequence: []),
+
+  FindTest(
+    expected: nil,
+    element: 42,
+    sequence: [ 1010, 1010 ],
+    expectedLeftoverSequence: []),
+  FindTest(
+    expected: 1,
+    element: 1010,
+    sequence: [ 1010, 1010 ],
+    expectedLeftoverSequence: [ 1010 ]),
+
+  FindTest(
+    expected: nil,
+    element: 42,
+    sequence: [ 1010, 2020, 3030, 4040 ],
+    expectedLeftoverSequence: []),
+  FindTest(
+    expected: 0,
+    element: 1010,
+    sequence: [ 1010, 2020, 3030, 4040 ],
+    expectedLeftoverSequence: [ ]),
+  FindTest(
+    expected: 1,
+    element: 2020,
+    sequence: [ 1010, 2020, 3030, 4040 ],
+    expectedLeftoverSequence: [ 3030, 4040 ]),
+  FindTest(
+    expected: 2,
+    element: 3030,
+    sequence: [ 1010, 2020, 3030, 4040 ],
+    expectedLeftoverSequence: [ 4040 ]),
+  FindTest(
+    expected: 3,
+    element: 4040,
+    sequence: [ 1010, 2020, 3030, 4040 ],
+    expectedLeftoverSequence: []),
+
+  FindTest(
+    expected: 3,
     element: 2020,
     sequence: [ 1010, 2020, 3030, 2020, 4040 ],
     expectedLeftoverSequence: [ 3030, 2020, 4040 ]),

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -584,68 +584,6 @@ public let findTests = [
     expectedLeftoverSequence: [ 3030, 2020, 4040 ]),
 ]
 
-public let findLastTests = [
-  FindTest(
-    expected: nil,
-    element: 42,
-    sequence: [],
-    expectedLeftoverSequence: []),
-
-  FindTest(
-    expected: nil,
-    element: 42,
-    sequence: [ 1010 ],
-    expectedLeftoverSequence: []),
-  FindTest(
-    expected: 0,
-    element: 1010,
-    sequence: [ 1010 ],
-    expectedLeftoverSequence: []),
-
-  FindTest(
-    expected: nil,
-    element: 42,
-    sequence: [ 1010, 1010 ],
-    expectedLeftoverSequence: []),
-  FindTest(
-    expected: 1,
-    element: 1010,
-    sequence: [ 1010, 1010 ],
-    expectedLeftoverSequence: [ 1010 ]),
-
-  FindTest(
-    expected: nil,
-    element: 42,
-    sequence: [ 1010, 2020, 3030, 4040 ],
-    expectedLeftoverSequence: []),
-  FindTest(
-    expected: 0,
-    element: 1010,
-    sequence: [ 1010, 2020, 3030, 4040 ],
-    expectedLeftoverSequence: [ ]),
-  FindTest(
-    expected: 1,
-    element: 2020,
-    sequence: [ 1010, 2020, 3030, 4040 ],
-    expectedLeftoverSequence: [ 3030, 4040 ]),
-  FindTest(
-    expected: 2,
-    element: 3030,
-    sequence: [ 1010, 2020, 3030, 4040 ],
-    expectedLeftoverSequence: [ 4040 ]),
-  FindTest(
-    expected: 3,
-    element: 4040,
-    sequence: [ 1010, 2020, 3030, 4040 ],
-    expectedLeftoverSequence: []),
-
-  FindTest(
-    expected: 3,
-    element: 2020,
-    sequence: [ 1010, 2020, 3030, 2020, 4040 ],
-    expectedLeftoverSequence: [ 3030, 2020, 4040 ]),
-]
-
 public let unionTests = [
   CollectionBinaryOperationTest(expected: [1, 2, 3, 4, 5], lhs: [1, 3, 5], rhs: [2, 4]),
   CollectionBinaryOperationTest(expected: [3, 5], lhs: [3], rhs: [5])

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -311,6 +311,7 @@ where Bound : Strideable, Bound.Stride : SignedInteger
 
   @inlinable
   public func _customLastIndexOfEquatableElement(_ element: Bound) -> Index?? {
+    // The first and last elements are the same because each element is unique.
     return _customIndexOfEquatableElement(element)
   }
 }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -308,6 +308,11 @@ where Bound : Strideable, Bound.Stride : SignedInteger
     return lowerBound <= element && element <= upperBound
               ? .inRange(element) : nil
   }
+
+  @inlinable
+  public func _customLastIndexOfEquatableElement(_ element: Bound) -> Index?? {
+    return _customIndexOfEquatableElement(element)
+  }
 }
 
 extension Comparable {  

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -621,8 +621,8 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///   of the collection.
   var count: Int { get }
   
-  // The following requirements enable dispatching for firstIndex(of:) when
-  // the element type is Equatable.
+  // The following requirements enable dispatching for firstIndex(of:) and
+  // lastIndex(of:) when the element type is Equatable.
 
   /// Returns `Optional(Optional(index))` if an element was found
   /// or `Optional(nil)` if an element was determined to be missing;
@@ -630,6 +630,18 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///
   /// - Complexity: O(*n*)
   func _customIndexOfEquatableElement(_ element: Element) -> Index??
+
+  /// Customization point for `Collection.lastIndex(of:)`.
+  ///
+  /// Define this method if the collection can find an element in less than
+  /// O(*n*) by exploiting collection-specific knowledge.
+  ///
+  /// - Returns: `nil` if a linear search should be attempted instead,
+  ///   `Optional(nil)` if the element was not found, or
+  ///   `Optional(Optional(index))` if an element was found.
+  ///
+  /// - Complexity: Hopefully less than O(`count`).
+  func _customLastIndexOfEquatableElement(_ element: Element) -> Index??
 
   /// The first element of the collection.
   ///
@@ -1194,6 +1206,22 @@ extension Collection {
   @inlinable
   public // dispatching
   func _customIndexOfEquatableElement(_: Iterator.Element) -> Index?? {
+    return nil
+  }
+
+  /// Customization point for `Collection.lastIndex(of:)`.
+  ///
+  /// Define this method if the collection can find an element in less than
+  /// O(*n*) by exploiting collection-specific knowledge.
+  ///
+  /// - Returns: `nil` if a linear search should be attempted instead,
+  ///   `Optional(nil)` if the element was not found, or
+  ///   `Optional(Optional(index))` if an element was found.
+  ///
+  /// - Complexity: Hopefully less than O(`count`).
+  @inlinable
+  public // dispatching
+  func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
     return nil
   }
 }

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -123,6 +123,97 @@ extension Collection {
 }
 
 //===----------------------------------------------------------------------===//
+// lastIndex(of:)/lastIndex(where:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection {
+  /// Returns the last element of the sequence that satisfies the given
+  /// predicate.
+  ///
+  /// This example uses the `last(where:)` method to find the last
+  /// negative number in an array of integers:
+  ///
+  ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
+  ///     if let lastNegative = numbers.last(where: { $0 < 0 }) {
+  ///         print("The last negative number is \(firstNegative).")
+  ///     }
+  ///     // Prints "The last negative number is -6."
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence as
+  ///   its argument and returns a Boolean value indicating whether the
+  ///   element is a match.
+  /// - Returns: The last element of the sequence that satisfies `predicate`,
+  ///   or `nil` if there is no element that satisfies `predicate`.
+  @inlinable
+  public func last(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Element? {
+    return try lastIndex(where: predicate).map { self[$0] }
+  }
+
+  /// Returns the index of the last element in the collection that matches the
+  /// given predicate.
+  ///
+  /// You can use the predicate to find an element of a type that doesn't
+  /// conform to the `Equatable` protocol or to find an element that matches
+  /// particular criteria. This example finds the index of the last name that
+  /// begins with the letter "A":
+  ///
+  ///     let students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
+  ///     if let i = students.lastIndex(where: { $0.hasPrefix("A") }) {
+  ///         print("\(students[i]) starts with 'A'!")
+  ///     }
+  ///     // Prints "Akosua starts with 'A'!"
+  ///
+  /// - Parameter predicate: A closure that takes an element as its argument
+  ///   and returns a Boolean value that indicates whether the passed element
+  ///   represents a match.
+  /// - Returns: The index of the last element in the collection that matches
+  ///   `predicate`, or `nil` if no elements match.
+  @inlinable
+  public func lastIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    var i = endIndex
+    while i != startIndex {
+      formIndex(before: &i)
+      if try predicate(self[i]) {
+        return i
+      }
+    }
+    return nil
+  }
+}
+
+extension BidirectionalCollection where Element : Equatable {
+  /// Returns the last index where the specified value appears in the
+  /// collection.
+  ///
+  /// After using `lastIndex(of:)` to find the position of the last instance of
+  /// a particular element in a collection, you can use it to access the
+  /// element by subscripting. This example shows how you can modify one of
+  /// the names in an array of students.
+  ///
+  ///     var students = ["Ben", "Ivy", "Jordell", "Ben", "Maxime"]
+  ///     if let i = students.lastIndex(of: "Ben") {
+  ///         students[i] = "Benjamin"
+  ///     }
+  ///     print(students)
+  ///     // Prints "["Ben", "Ivy", "Jordell", "Benjamin", "Max"]"
+  ///
+  /// - Parameter element: An element to search for in the collection.
+  /// - Returns: The last index where `element` is found. If `element` is not
+  ///   found in the collection, returns `nil`.
+  @inlinable
+  public func lastIndex(of element: Element) -> Index? {
+    if let result = _customLastIndexOfEquatableElement(element) {
+      return result
+    }
+    return lastIndex(where: { $0 == element })
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // partition(by:)
 //===----------------------------------------------------------------------===//
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1263,6 +1263,11 @@ extension Dictionary {
     }
 
     @inlinable // FIXME(sil-serialize-all)
+    public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+      return _customIndexOfEquatableElement(element)
+    }
+
+    @inlinable // FIXME(sil-serialize-all)
     public static func ==(lhs: Keys, rhs: Keys) -> Bool {
       // Equal if the two dictionaries share storage.
       if case (.native(let lhsNative), .native(let rhsNative)) =

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1264,6 +1264,7 @@ extension Dictionary {
 
     @inlinable // FIXME(sil-serialize-all)
     public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+      // The first and last elements are the same because each element is unique.
       return _customIndexOfEquatableElement(element)
     }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -349,6 +349,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   // TODO: swift-3-indexing-model: forward the following methods.
   /*
   func _customIndexOfEquatableElement(element: Element) -> Index??
+  func _customLastIndexOfEquatableElement(element: Element) -> Index??
   */
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -327,6 +327,12 @@ extension LazyFilterCollection : LazyCollectionProtocol {
   public subscript(bounds: Range<Index>) -> SubSequence {
     return SubSequence(_base: _base[bounds], _predicate)
   }
+  
+  @inlinable
+  public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+    guard _predicate(element) else { return .some(nil) }
+    return _base._customLastIndexOfEquatableElement(element)
+  }
 }
 
 extension LazyFilterCollection : BidirectionalCollection

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -174,18 +174,31 @@ extension LazyCollection : Collection {
     return _base.count
   }
 
-  // The following requirement enables dispatching for index(of:) when
-  // the element type is Equatable.
+  // The following requirement enables dispatching for firstIndex(of:) and
+  // lastIndex(of:) when the element type is Equatable.
 
   /// Returns `Optional(Optional(index))` if an element was found;
-  /// `nil` otherwise.
+  /// `Optional(nil)` if the element doesn't exist in the collection;
+  /// `nil` if a search was not performed.
   ///
-  /// - Complexity: O(*n*)
+  /// - Complexity: Better than O(*n*)
   @inlinable
   public func _customIndexOfEquatableElement(
     _ element: Element
   ) -> Index?? {
     return _base._customIndexOfEquatableElement(element)
+  }
+
+  /// Returns `Optional(Optional(index))` if an element was found;
+  /// `Optional(nil)` if the element doesn't exist in the collection;
+  /// `nil` if a search was not performed.
+  ///
+  /// - Complexity: Better than O(*n*)
+  @inlinable
+  public func _customLastIndexOfEquatableElement(
+    _ element: Element
+  ) -> Index?? {
+    return _base._customLastIndexOfEquatableElement(element)
   }
 
   /// Returns the first element of `self`, or `nil` if `self` is empty.

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -257,6 +257,7 @@ where Bound : Strideable, Bound.Stride : SignedInteger
 
   @inlinable
   public func _customLastIndexOfEquatableElement(_ element: Bound) -> Index?? {
+    // The first and last elements are the same because each element is unique.
     return _customIndexOfEquatableElement(element)
   }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -255,6 +255,11 @@ where Bound : Strideable, Bound.Stride : SignedInteger
     return lowerBound <= element && element < upperBound ? element : nil
   }
 
+  @inlinable
+  public func _customLastIndexOfEquatableElement(_ element: Bound) -> Index?? {
+    return _customIndexOfEquatableElement(element)
+  }
+
   /// Accesses the element at specified position.
   ///
   /// You can subscript a collection with any valid index other than the

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -364,6 +364,7 @@ extension Set: Collection {
   public func _customLastIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
+    // The first and last elements are the same because each element is unique.
     return _customIndexOfEquatableElement(member)
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -360,6 +360,13 @@ extension Set: Collection {
     return Optional(firstIndex(of: member))
   }
 
+  @inlinable // FIXME(sil-serialize-all)
+  public func _customLastIndexOfEquatableElement(
+     _ member: Element
+    ) -> Index?? {
+    return _customIndexOfEquatableElement(member)
+  }
+
   /// The number of elements in the set.
   ///
   /// - Complexity: O(1).


### PR DESCRIPTION
This implements the new `last...` methods as extensions on `BidirectionalCollection`, which partially implements [SE-204](https://github.com/apple/swift-evolution/blob/master/proposals/0204-add-last-methods.md). The protocol requirements for `Sequence` and `Collection` as described in the proposal need to wait until there's a solution for picking up the specialized versions in types that conditionally conform to `BidirectionalCollection`. 