### PR TITLE
[stdlib] add more debug-mode range checking to UnsafeBufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -165,12 +165,16 @@ public struct Unsafe${Mutable}BufferPointer<Element>
 
   @_inlineable
   public func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
-    // NOTE: This method is a no-op for performance reasons.
+    // NOTE: In release mode, this method is a no-op for performance reasons.
+    _debugPrecondition(index >= bounds.lowerBound)
+    _debugPrecondition(index < bounds.upperBound)
   }
 
   @_inlineable
   public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
-    // NOTE: This method is a no-op for performance reasons.
+    // NOTE: In release mode, this method is a no-op for performance reasons.
+    _debugPrecondition(range.lowerBound >= bounds.lowerBound)
+    _debugPrecondition(range.upperBound <= bounds.upperBound)
   }
 
   public typealias Indices = CountableRange<Int>

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -326,6 +326,91 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(-1.0, allocated[count-1])
 }
 
+let bufCount = 4
+let sliceRange: Range = 1..<bufCount-1
+% for mutable in [True, False]:
+% for raw in [True, False]:
+% for action in ['read', 'change']:
+% if action != 'change' or mutable:
+for testIndex in (0..<bufCount) {
+% Type = 'Unsafe' + ('Mutable' if mutable else '') + ('Raw' if raw else '') + 'BufferPointer'
+  ${Type}TestSuite.test("${action}Element\(testIndex)ViaSlice") {
+% if raw:
+    let allocated = UnsafeMutableRawPointer.allocate(bytes: bufCount, alignedTo: 8)
+    for i in 0..<bufCount {
+      allocated.storeBytes(of: UInt8(i), toByteOffset: i, as: UInt8.self)
+    }
+% else:
+    let allocated = UnsafeMutablePointer<Int>.allocate(capacity: bufCount)
+    for i in 0..<bufCount { allocated[i] = i }
+% end # if mutable
+    defer { allocated.deallocate() }
+
+    let buffer = ${Type}(start: allocated, count: bufCount)
+    ${'var' if mutable else 'let'} slice = buffer[sliceRange]
+
+    if _isDebugAssertConfiguration(),
+       testIndex < sliceRange.lowerBound ||
+       testIndex >= sliceRange.upperBound {
+      expectCrashLater()
+    }
+% if action == 'read':
+    let value = slice[testIndex]
+    expectEqual(buffer[testIndex], value)
+% else:
+    slice[testIndex] = 103
+    expectEqual(buffer[testIndex], 103)
+% end # if action
+  }
+}
+% end # if action or mutable
+% end # for action
+% end # for raw
+% end # for mutable
+
+let testRanges = (0..<bufCount-1).map({ i -> Range<Int> in i..<i+2 })
+% for mutable in [True, False]:
+% for raw in [True, False]:
+% for action in ['read', 'change']:
+% if action != 'change' or mutable:
+for testRange in testRanges {
+% Type = 'Unsafe' + ('Mutable' if mutable else '') + ('Raw' if raw else '') + 'BufferPointer'
+  ${Type}TestSuite.test("${action}Slice\(testRange)ViaSlice") {
+% if raw:
+    let allocated = UnsafeMutableRawPointer.allocate(bytes: bufCount+2, alignedTo: 8)
+    for i in 0..<bufCount+2 {
+      allocated.storeBytes(of: UInt8(i), toByteOffset: i, as: UInt8.self)
+    }
+% else:
+    let allocated = UnsafeMutablePointer<Int>.allocate(capacity: bufCount+2)
+    for i in 0..<bufCount+2 { allocated[i] = i }
+% end # if mutable
+    defer { allocated.deallocate() }
+
+    let buffer = ${Type}(start: allocated, count: bufCount+2)
+    ${'var' if mutable else 'let'} slice = buffer[sliceRange]
+
+    if _isDebugAssertConfiguration(),
+      testRange.lowerBound < sliceRange.lowerBound ||
+      testRange.upperBound > sliceRange.upperBound {
+      expectCrashLater()
+    }
+
+% if action == 'read':
+    let value = slice[testRange]
+    expectEqualSequence(buffer[testRange], value)
+% else:
+    let sourceSlice = buffer[bufCount..<bufCount+2]
+    slice[testRange] = sourceSlice
+    expectEqualSequence(buffer[testRange], sourceSlice)
+% end # if action
+  }
+}
+% end # if action or mutable
+% end # for action
+% end # for raw
+% end # for mutable
+
 protocol SubscriptTest {
   static var start: Int { get }
   static var end: Int { get }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds `_debugPrecondition` calls to `_failEarlyRangeCheck` in `Unsafe{Mutable}BufferPointer`.

`_failEarlyRangeCheck` in `Slice` forwards to its Base. In the case of the UnsafeBufferPointers, that is an empty function. This means that one can use a Slice to get or set to any index of its base BufferPointer, not limited to the indices in the slice's `startIndex..<endIndex` range. While this is fine in release mode, this is surprising in debug mode, where the UnsafeBufferPointers do perform some range checking.

Should be merged after https://github.com/apple/swift/pull/12504

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6549](https://bugs.swift.org/browse/SR-6549).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->