### PR TITLE
Sanitize Malformed Casts

### DIFF
--- a/lib/Sema/CSDiag.h
+++ b/lib/Sema/CSDiag.h
@@ -25,7 +25,9 @@ namespace swift {
   /// Rewrite any type variables & archetypes in the specified type with
   /// UnresolvedType.
   Type replaceTypeParametersWithUnresolved(Type ty);
-  Type replaceTypeVariablesWithUnresolved(Type ty);
+  /// Rewrite any type variables & archetypes in the specified type with
+  /// another type.
+  Type replaceTypeVariablesIn(Type ty, Type replacement);
   
 };
 

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -629,7 +629,8 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
       for (auto &C : candidates) {
         C.level += 1;
         
-        baseType = replaceTypeVariablesWithUnresolved(baseType);
+        baseType = replaceTypeVariablesIn(baseType,
+                                          CS.getASTContext().TheUnresolvedType);
         
         // Compute a new substituted type if we have a base type to apply.
         if (baseType && C.level == 1 && C.getDecl()) {
@@ -817,7 +818,8 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
     // it to get a simpler and more concrete type.
     //
     if (baseType) {
-      auto substType = replaceTypeVariablesWithUnresolved(baseType);
+      auto &ctx = CS.getASTContext();
+      auto substType = replaceTypeVariablesIn(baseType, ctx.TheUnresolvedType);
       if (substType)
         substType = substType
         ->getWithoutSpecifierType()

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3289,6 +3289,13 @@ public:
     for (auto E : Exprs) {
       if (E->getType() && E->getType()->hasTypeVariable())
         E->setType(Type());
+      
+      // Type checking can open type variables into casts.  Erase those now.
+      if (auto *ECE = dyn_cast<ExplicitCastExpr>(E)) {
+        Type CastTy = ECE->getCastTypeLoc().getType();
+        if (CastTy && CastTy->hasTypeVariable())
+          ECE->getCastTypeLoc().setType(Type(), /*validated=*/true);
+      }
     }
 
     for (auto TL : TypeLocs) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1567,6 +1567,13 @@ void CleanupIllFormedExpressionRAII::doIt(Expr *expr, ASTContext &Context) {
       Type type = expr->getType();
       if (type && type->hasTypeVariable())
         expr->setType(ErrorType::get(context));
+      // Type checking can open type variables into casts.  Erase those now.
+      if (auto *ECE = dyn_cast<ExplicitCastExpr>(expr)) {
+        Type CastTy = ECE->getCastTypeLoc().getType();
+        if (CastTy && CastTy->hasTypeVariable())
+          ECE->getCastTypeLoc().setType(ErrorType::get(context),
+                                        /*validated=*/true);
+      }
 
       return { true, expr };
     }

--- a/validation-test/compiler_crashers_fixed/28823-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
+++ b/validation-test/compiler_crashers_fixed/28823-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{[Int?as?ManagedBuffer}{
+
+// RUN: not %target-swift-frontend %s -emit-ir
+{{}as ManagedBuffer}{

--- a/validation-test/compiler_crashers_fixed/28856-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28856-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{{}as ManagedBuffer}{
+
+// RUN: not %target-swift-frontend %s -emit-ir
+{[Int?as?ManagedBuffer}{


### PR DESCRIPTION
It is never safe to spawn a new constraint system in the presence of
free type variables.  In this case, if CSDiag re-typechecks a closure
involving any type variables in a bound generic type, the type checker
would skip opening those type variables into the constraint system on
the second go-around but would still create constraints referencing the
variables as though they were a part of its domain.

<strike>Cutting this off at the source (re)-causes a bunch of diagnostic regressions that
require attention.</strike>