### PR TITLE
[stdlib] Eliminate (Closed)CountableRange using conditional conformance

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -1556,7 +1556,7 @@ extension TestSuite {
       return
     }
 
-    func toCollection(_ r: CountableRange<Int>) -> C {
+    func toCollection(_ r: Range<Int>) -> C {
       return makeCollection(r.map { wrapValue(OpaqueValue($0)) })
     }
 

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -160,7 +160,7 @@ internal enum _CollectionOperation : Equatable {
     case .reserveCapacity:
       let invalidIndices = newElementsIds.indices
       newElementsIds.replaceSubrange(
-        Range(invalidIndices),
+        invalidIndices,
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
@@ -180,7 +180,7 @@ internal enum _CollectionOperation : Equatable {
 
       let invalidIndices = subRange.lowerBound..<newElementsIds.endIndex
       newElementsIds.replaceSubrange(
-        Range(invalidIndices),
+        invalidIndices,
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
@@ -189,7 +189,7 @@ internal enum _CollectionOperation : Equatable {
 
       let invalidIndices = atIndex..<newElementsIds.endIndex
       newElementsIds.replaceSubrange(
-        Range(invalidIndices),
+        invalidIndices,
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
@@ -200,7 +200,7 @@ internal enum _CollectionOperation : Equatable {
 
       let invalidIndices = atIndex..<newElementsIds.endIndex
       newElementsIds.replaceSubrange(
-        Range(invalidIndices),
+        invalidIndices,
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
@@ -209,7 +209,7 @@ internal enum _CollectionOperation : Equatable {
 
       let invalidIndices = index..<newElementsIds.endIndex
       newElementsIds.replaceSubrange(
-        Range(invalidIndices),
+        invalidIndices,
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
@@ -222,7 +222,7 @@ internal enum _CollectionOperation : Equatable {
 
       let invalidIndices = subRange.lowerBound..<newElementsIds.endIndex
       newElementsIds.replaceSubrange(
-        Range(invalidIndices),
+        invalidIndices,
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
@@ -592,7 +592,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
   }
 
 %     if StrideableIndex:
-  public typealias Indices = CountableRange<${Index}>
+  public typealias Indices = Range<${Index}>
 %     elif Traversal == 'RandomAccess':
   // FIXME: this shouldn't be necessary, should come by default
   public typealias Indices = DefaultIndices<${Self}<T>>
@@ -866,7 +866,7 @@ public struct ${Self}<Element> : ${SelfProtocols} {
   public typealias Index = ${Index}
 
 %   if StrideableIndex:
-  public typealias Indices = CountableRange<${Index}>
+  public typealias Indices = Range<${Index}>
 %  elif Traversal == 'RandomAccess':
   // FIXME: this shouldn't be necessary, should come by default
   public typealias Indices = DefaultIndices<${Self}<Element>>

--- a/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
+++ b/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
@@ -55,10 +55,6 @@ public enum RangeSelection {
     }
   }
 
-  public func countableRange<C : Collection>(in c: C) -> CountableRange<C.Index> {
-    return CountableRange(range(in: c))
-  }
-
   public func closedRange<C : Collection>(in c: C) -> ClosedRange<C.Index> {
     switch self {
       case .emptyRange: fatalError("Closed range cannot be empty")
@@ -86,9 +82,5 @@ public enum RangeSelection {
         let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))
         return start...end
     }
-  }
-
-  public func countableClosedRange<C : Collection>(in c: C) -> CountableClosedRange<C.Index> {
-    return CountableClosedRange(closedRange(in: c))
   }
 }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -319,13 +319,8 @@ public func expectGE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
   }
 }
 
-% for OtherRange in ['Range', 'ClosedRange', 'CountableClosedRange']:
-extension Range
-%   if 'Countable' in OtherRange:
-  where
-  Bound : Strideable, Bound.Stride : SignedInteger
-%   end
-{
+% for OtherRange in ['Range', 'ClosedRange']:
+extension Range {
   internal func _contains(_ other: ${OtherRange}<Bound>) -> Bool {
     if other.lowerBound < lowerBound { return false }
 %   if 'Closed' in OtherRange:
@@ -338,7 +333,7 @@ extension Range
 }
 % end
 
-% for Range in ['Range', 'ClosedRange', 'CountableClosedRange']:
+% for Range in ['Range', 'ClosedRange']:
 public func expectTrapping<Bound>(
   _ point: Bound, in range: ${Range}<Bound>, ${TRACE}
 ) {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -319,7 +319,7 @@ public func expectGE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
   }
 }
 
-% for OtherRange in ['Range', 'CountableRange', 'ClosedRange', 'CountableClosedRange']:
+% for OtherRange in ['Range', 'ClosedRange', 'CountableClosedRange']:
 extension Range
 %   if 'Countable' in OtherRange:
   where
@@ -338,7 +338,7 @@ extension Range
 }
 % end
 
-% for Range in ['Range', 'CountableRange', 'ClosedRange', 'CountableClosedRange']:
+% for Range in ['Range', 'ClosedRange', 'CountableClosedRange']:
 public func expectTrapping<Bound>(
   _ point: Bound, in range: ${Range}<Bound>, ${TRACE}
 ) {
@@ -2433,31 +2433,16 @@ public func expectEqualsUnordered<T : Comparable>(
   expectEqualSequence(x, y, ${trace})
 }
 
-public func expectEqualsUnordered<
-  T : Strideable
->(
+public func expectEqualsUnordered<T : Strideable>(
   _ expected: Range<T>, _ actual: [T], ${TRACE}
 ) where T.Stride: SignedInteger {
-  expectEqualsUnordered(
-    CountableRange(uncheckedBounds:
-      (lower: expected.lowerBound, upper: expected.upperBound)),
-    actual,
-    ${trace},
-    showFrame: false)
-}
-
-public func expectEqualsUnordered<T : Strideable>(
-  _ expected: CountableRange<T>, _ actual: [T], ${TRACE}
-) {
   if expected.count != actual.count {
     expectationFailure("expected elements: \"\(expected)\"\n"
       + "actual: \"\(actual)\" (of type \(String(reflecting: type(of: actual))))",
       trace: ${trace})
   }
-  let r = Range(uncheckedBounds:
-    (lower: expected.lowerBound, upper: expected.upperBound))
   for e in actual {
-    if !r.contains(e) {
+    if !expected.contains(e) {
       expectationFailure("expected elements: \"\(expected)\"\n"
         + "actual: \"\(actual)\" (of type \(String(reflecting: type(of: actual))))",
         trace: ${trace})

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -172,6 +172,6 @@ extension UnsafeMutableAudioBufferListPointer
     }
   }
 
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 }
 

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -154,7 +154,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		}
 	}
 
-	private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: CountableRange<Index>) {
+	private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: Range<Index>) {
 		var copiedCount = 0
 		if range.isEmpty { return }
 		let rangeSize = range.count
@@ -195,8 +195,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
 	/// - parameter range: The range in the `Data` to copy.
 	/// - warning: This method does not verify that the contents at pointer have enough space to hold the required number of bytes.
-	@available(swift, deprecated: 4, message: "Use copyBytes(to: UnsafeMutableRawBufferPointer, from: CountableRange<Index>) instead")
-	public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, from range: CountableRange<Index>) {
+	@available(swift, deprecated: 4, message: "Use copyBytes(to: UnsafeMutableRawBufferPointer, from: Range<Index>) instead")
+	public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, from range: Range<Index>) {
 		_copyBytesHelper(to: pointer, from: range)
 	}
 
@@ -205,7 +205,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter pointer: A pointer to the buffer you wish to copy the bytes into. The buffer must be large
 	///	enough to hold `count` bytes.
 	/// - parameter range: The range in the `Data` to copy.
-	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, from range: CountableRange<Index>) {
+	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, from range: Range<Index>) {
 		assert(range.count <= pointer.count, "Buffer too small to copy \(range.count) bytes")
 		guard pointer.baseAddress != nil else { return }
 		_copyBytesHelper(to: pointer.baseAddress!, from: range)
@@ -218,11 +218,11 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter buffer: A buffer to copy the data into.
 	/// - parameter range: A range in the data to copy into the buffer. If the range is empty, this function will return 0 without copying anything. If the range is nil, as much data as will fit into `buffer` is copied.
 	/// - returns: Number of bytes copied into the destination buffer.
-	public func copyBytes<DestinationType>(to buffer: UnsafeMutableBufferPointer<DestinationType>, from range: CountableRange<Index>? = nil) -> Int {
+	public func copyBytes<DestinationType>(to buffer: UnsafeMutableBufferPointer<DestinationType>, from range: Range<Index>? = nil) -> Int {
 		let cnt = count
 		guard cnt > 0 else { return 0 }
 
-		let copyRange : CountableRange<Index>
+		let copyRange : Range<Index>
 		if let r = range {
 			guard !r.isEmpty else { return 0 }
 			precondition(r.startIndex >= 0)
@@ -262,7 +262,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// Return a new copy of the data in a specified range.
 	///
 	/// - parameter range: The range to copy.
-	public func subdata(in range: CountableRange<Index>) -> DispatchData {
+	public func subdata(in range: Range<Index>) -> DispatchData {
 		let subrange = __dispatch_data_create_subrange(
 			__wrapped, range.startIndex, range.endIndex - range.startIndex)
 		return DispatchData(data: subrange)

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -996,7 +996,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public typealias Base64DecodingOptions = NSData.Base64DecodingOptions
     
     public typealias Index = Int
-    public typealias Indices = CountableRange<Int>
+    public typealias Indices = Range<Int>
     
     @_versioned internal var _backing : _DataStorage
     @_versioned internal var _sliceRange: Range<Index>
@@ -1537,12 +1537,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-    @inline(__always)
-    public mutating func replaceSubrange(_ subrange: CountableRange<Index>, with data: Data) {
-        let range: Range<Int> = subrange.lowerBound..<subrange.upperBound
-        replaceSubrange(range, with: data)
-    }
-    
     /// Replace a region of bytes in the data with new bytes from a buffer.
     ///
     /// This will resize the data if required, to fit the entire contents of `buffer`.
@@ -1743,7 +1737,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         return i + 1
     }
     
-    public var indices: CountableRange<Int> {
+    public var indices: Range<Int> {
         @inline(__always)
         get {
             return startIndex..<endIndex

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -74,7 +74,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             return IndexingIterator(_elements: self)
         }
         
-        public subscript(index : Index) -> CountableRange<IndexSet.Element> {
+        public subscript(index : Index) -> Range<IndexSet.Element> {
             let indexSetRange = indexSet._range(at: index)
             return indexSetRange.lowerBound..<indexSetRange.upperBound
         }
@@ -123,12 +123,10 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
     
     /// Initialize an `IndexSet` with a range of integers.
-    public init(integersIn range: ClosedRange<Element>) { self.init(integersIn: Range(range)) }
-    /// Initialize an `IndexSet` with a range of integers.
-    public init(integersIn range: CountableClosedRange<Element>) { self.init(integersIn: Range(range)) }
-    /// Initialize an `IndexSet` with a range of integers.
-    public init(integersIn range: CountableRange<Element>) { self.init(integersIn: Range(range)) }
-    
+    public init<R: RangeExpression>(integersIn range: R) where R.Bound == Element { 
+      self.init(integersIn: range.relative(to: 0..<Int.max))
+    }
+  
     /// Initialize an `IndexSet` with a single integer.
     public init(integer: Element) {
         _handle = _MutablePairHandle(NSIndexSet(index: integer), copying: false)
@@ -169,17 +167,10 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     /// Returns a `Range`-based view of `self`.
     ///
     /// - parameter range: A subrange of `self` to view.
-    public func rangeView(of range : ClosedRange<Element>) -> RangeView { return self.rangeView(of: Range(range)) }
-    /// Returns a `Range`-based view of `self`.
-    ///
-    /// - parameter range: A subrange of `self` to view.
-    public func rangeView(of range : CountableClosedRange<Element>) -> RangeView { return self.rangeView(of: Range(range)) }
-    /// Returns a `Range`-based view of `self`.
-    ///
-    /// - parameter range: A subrange of `self` to view.
-    public func rangeView(of range : CountableRange<Element>) -> RangeView { return self.rangeView(of: Range(range)) }
-
-    
+    public func rangeView<R: RangeExpression>(of range : R) -> RangeView where R.Bound == Element { 
+      return self.rangeView(of: range.relative(to: 0..<Int.max)) 
+    }
+  
     private func _indexOfRange(containing integer : Element) -> RangeView.Index? {
         let result = _handle.map { 
             __NSIndexSetIndexOfRangeContainingIndex($0, integer)
@@ -308,20 +299,9 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     /// The resulting range is the range of the intersection of the integers in `range` with the index set.
     ///
     /// - parameter range: The range of integers to include.
-    public func indexRange(in range: CountableRange<Element>) -> Range<Index> { return self.indexRange(in: Range(range)) }
-    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
-    ///
-    /// The resulting range is the range of the intersection of the integers in `range` with the index set.
-    ///
-    /// - parameter range: The range of integers to include.
-    public func indexRange(in range: ClosedRange<Element>) -> Range<Index> { return self.indexRange(in: Range(range)) }
-    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
-    ///
-    /// The resulting range is the range of the intersection of the integers in `range` with the index set.
-    ///
-    /// - parameter range: The range of integers to include.
-    public func indexRange(in range: CountableClosedRange<Element>) -> Range<Index> { return self.indexRange(in: Range(range)) }
-
+    public func indexRange<R: RangeExpression>(in range: R) -> Range<Index> where R.Bound == Element { 
+      return self.indexRange(in: range.relative(to: 0..<Int.max))
+    }
 
     /// Returns the count of integers in `self` that intersect `range`.
     public func count(in range: Range<Element>) -> Int {
@@ -329,11 +309,9 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
 
     /// Returns the count of integers in `self` that intersect `range`.
-    public func count(in range: CountableRange<Element>) -> Int { return self.count(in: Range(range)) }
-    /// Returns the count of integers in `self` that intersect `range`.
-    public func count(in range: ClosedRange<Element>) -> Int { return self.count(in: Range(range)) }
-    /// Returns the count of integers in `self` that intersect `range`.
-    public func count(in range: CountableClosedRange<Element>) -> Int { return self.count(in: Range(range)) }
+    public func count<R: RangeExpression>(in range: R) -> Int where R.Bound == Element { 
+      return self.count(in: range.relative(to: 0..<Int.max))
+    }
 
     /// Returns `true` if `self` contains `integer`.
     public func contains(_ integer: Element) -> Bool {
@@ -346,11 +324,9 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
 
     /// Returns `true` if `self` contains all of the integers in `range`.
-    public func contains(integersIn range: CountableRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
-    /// Returns `true` if `self` contains all of the integers in `range`.
-    public func contains(integersIn range: ClosedRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
-    /// Returns `true` if `self` contains all of the integers in `range`.
-    public func contains(integersIn range: CountableClosedRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
+    public func contains<R: RangeExpression>(integersIn range: R) -> Bool where R.Bound == Element { 
+      return self.contains(integersIn: range.relative(to: 0..<Int.max))
+    }
 
     
     /// Returns `true` if `self` contains all of the integers in `indexSet`.
@@ -364,11 +340,9 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
 
     /// Returns `true` if `self` intersects any of the integers in `range`.
-    public func intersects(integersIn range: CountableRange<Element>) -> Bool { return self.intersects(integersIn: Range(range)) }
-    /// Returns `true` if `self` intersects any of the integers in `range`.
-    public func intersects(integersIn range: ClosedRange<Element>) -> Bool { return self.intersects(integersIn: Range(range)) }
-    /// Returns `true` if `self` intersects any of the integers in `range`.
-    public func intersects(integersIn range: CountableClosedRange<Element>) -> Bool { return self.intersects(integersIn: Range(range)) }
+    public func intersects<R: RangeExpression>(integersIn range: R) -> Bool where R.Bound == Element { 
+      return self.intersects(integersIn: range.relative(to: 0..<Int.max))
+    }
 
     // MARK: -
     // Collection
@@ -454,7 +428,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         } else {
             let extent = 0..<0
             let rangeIndex = 0
-            return Index(value: value, extent: Range(extent), rangeIndex: rangeIndex, rangeCount: rangeCount)
+            return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
         }
     }
     
@@ -472,11 +446,11 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         
         var result = IndexSet()
         for r in self.rangeView {
-            result.insert(integersIn: Range(r))
+            result.insert(integersIn: r)
         }
         
         for r in other.rangeView {
-            result.insert(integersIn: Range(r))
+            result.insert(integersIn: r)
         }
         return result
     }
@@ -583,11 +557,9 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
 
     /// Insert a range of integers into the `IndexSet`.
-    public mutating func insert(integersIn range: CountableRange<Element>) { self.insert(integersIn: Range(range)) }
-    /// Insert a range of integers into the `IndexSet`.
-    public mutating func insert(integersIn range: ClosedRange<Element>) { self.insert(integersIn: Range(range)) }
-    /// Insert a range of integers into the `IndexSet`.
-    public mutating func insert(integersIn range: CountableClosedRange<Element>) { self.insert(integersIn: Range(range)) }
+    public mutating func insert<R: RangeExpression>(integersIn range: R) where R.Bound == Element { 
+      self.insert(integersIn: range.relative(to: 0..<Int.max))
+    }
 
     /// Remove a range of integers from the `IndexSet`.
     public mutating func remove(integersIn range: Range<Element>) {
@@ -595,11 +567,9 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
     
     /// Remove a range of integers from the `IndexSet`.
-    public mutating func remove(integersIn range: CountableRange<Element>) { self.remove(integersIn: Range(range)) }
-    /// Remove a range of integers from the `IndexSet`.
-    public mutating func remove(integersIn range: ClosedRange<Element>) { self.remove(integersIn: Range(range)) }
-    /// Remove a range of integers from the `IndexSet`.
-    public mutating func remove(integersIn range: CountableClosedRange<Element>) { self.remove(integersIn: Range(range)) }
+    public mutating func remove(integersIn range: ClosedRange<Element>) { 
+      self.remove(integersIn: Range(range))
+    }
 
     /// Returns `true` if self contains no values.
     public var isEmpty : Bool {
@@ -636,18 +606,10 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     ///
     /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
     /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
-    public func filteredIndexSet(in range : CountableRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) }
-    /// Returns an IndexSet filtered according to the result of `includeInteger`.
-    ///
-    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
-    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
-    public func filteredIndexSet(in range : ClosedRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) }
-    /// Returns an IndexSet filtered according to the result of `includeInteger`.
-    ///
-    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
-    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
-    public func filteredIndexSet(in range : CountableClosedRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) }
-    
+    public func filteredIndexSet(in range : ClosedRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { 
+      return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) 
+    }
+  
     /// Returns an IndexSet filtered according to the result of `includeInteger`.
     ///
     /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
@@ -726,8 +688,8 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     
     private var i1: IndexSet.RangeView.Iterator
     private var i2: IndexSet.RangeView.Iterator
-    private var i1Range: CountableRange<Element>?
-    private var i2Range: CountableRange<Element>?
+    private var i1Range: Range<Element>?
+    private var i2Range: Range<Element>?
     private var i1UsedLower: Bool
     private var i2UsedLower: Bool
     

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -299,8 +299,7 @@ extension _ArrayBuffer {
       // Look for contiguous storage in the NSArray
       let nonNative = self._nonNative
       let cocoa = _CocoaArrayWrapper(nonNative)
-      let cocoaStorageBaseAddress =
-        cocoa.contiguousStorage(Range(self.indices))
+      let cocoaStorageBaseAddress = cocoa.contiguousStorage(self.indices)
 
       if let cocoaStorageBaseAddress = cocoaStorageBaseAddress {
         let basePtr = UnsafeMutableRawPointer(cocoaStorageBaseAddress)

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -235,7 +235,7 @@ extension _ArrayBuffer {
       // Could be sped up, e.g. by using
       // enumerateObjectsAtIndexes:options:usingBlock: in the
       // non-native case.
-      for i in CountableRange(subRange) {
+      for i in subRange.lowerBound ..< subRange.upperBound {
         _typeCheckSlowPath(i)
       }
     }
@@ -270,7 +270,7 @@ extension _ArrayBuffer {
     
     // Make another pass to retain the copied objects
     var result = target
-    for _ in CountableRange(bounds) {
+    for _ in bounds {
       result.initialize(to: result.pointee)
       result += 1
     }
@@ -553,7 +553,7 @@ extension _ArrayBuffer {
     return count
   }
 
-  internal typealias Indices = CountableRange<Int>
+  internal typealias Indices = Range<Int>
 
   //===--- private --------------------------------------------------------===//
   internal typealias Storage = _ContiguousArrayStorage<Element>

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -16,7 +16,7 @@
 internal protocol _ArrayBufferProtocol
   : MutableCollection, RandomAccessCollection {
 
-  associatedtype Indices = CountableRange<Int>
+  associatedtype Indices = Range<Int>
 
   /// Create an empty buffer.
   init()
@@ -160,7 +160,7 @@ extension _ArrayBufferProtocol {
 
       // Assign over the original subrange
       var i = newValues.startIndex
-      for j in CountableRange(subrange) {
+      for j in subrange {
         elements[j] = newValues[i]
         newValues.formIndex(after: &i)
       }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -492,7 +492,7 @@ public struct ${Self}<Element>: _DestructorSafeContainer {
 
 extension ${Self}: RandomAccessCollection, MutableCollection {
   public typealias Index = Int
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
   public typealias Iterator = IndexingIterator<${Self}>
 
 %if Self == 'ArraySlice':

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -844,7 +844,7 @@ extension ${Self} {
     let newBuffer = _ContiguousArrayBuffer<Element>(
       _uninitializedCount: buffer.count, minimumCapacity: buffer.count)
     buffer._copyContents(
-      subRange: Range(buffer.indices),
+      subRange: buffer.indices,
       initializing: newBuffer.firstElementAddress)
     buffer = _Buffer(
       _buffer: newBuffer, shiftedToStartIndex: buffer.startIndex)
@@ -1325,7 +1325,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
         _uninitializedCount: count, minimumCapacity: minimumCapacity)
 
       _buffer._copyContents(
-        subRange: Range(_buffer.indices),
+        subRange: _buffer.indices,
         initializing: newBuffer.firstElementAddress)
       _buffer = _Buffer(
         _buffer: newBuffer, shiftedToStartIndex: _buffer.startIndex)
@@ -1630,7 +1630,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
       _buffer = _Buffer()
     }
     else {
-      self.replaceSubrange(Range(self.indices), with: EmptyCollection())
+      self.replaceSubrange(indices, with: EmptyCollection())
     }
   }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -98,7 +98,7 @@ set(SWIFTLIB_ESSENTIAL
   PrefixWhile.swift.gyb
   Print.swift
   RandomAccessCollection.swift
-  Range.swift.gyb
+  Range.swift
   RangeReplaceableCollection.swift
   ReflectionLegacy.swift
   Repeat.swift

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -167,8 +167,8 @@ extension ClosedRange.Index : Comparable {
   }
 }
 
-/* FIXME: compiler crash
-extension ClosedRange.Index: Hashable where Bound: Hashable {
+extension ClosedRange.Index: Hashable 
+where Bound: Strideable, Bound.Stride: SignedInteger, Bound: Hashable {
   public var hashValue: Int {
     switch self {
     case .inRange(let value):
@@ -178,7 +178,6 @@ extension ClosedRange.Index: Hashable where Bound: Hashable {
     }
   }
 }
-*/
 
 // FIXME: this should only be conformance to RandomAccessCollection but
 // the compiler balks without all 3

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -28,7 +28,7 @@ import SwiftShims
 @_versioned
 @_fixed_layout
 internal struct _CocoaArrayWrapper : RandomAccessCollection {
-  typealias Indices = CountableRange<Int>
+  typealias Indices = Range<Int>
   @_inlineable
   @_versioned
   internal var startIndex: Int {

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -57,7 +57,7 @@ public struct CollectionOfOne<Element> {
 extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 
   public typealias Index = Int
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 
   /// The position of the first element.
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -618,7 +618,7 @@ extension _ContiguousArrayBuffer : RandomAccessCollection {
     return count
   }
 
-  internal typealias Indices = CountableRange<Int>
+  internal typealias Indices = Range<Int>
 }
 
 extension Sequence {

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -61,7 +61,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = Int
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
   public typealias SubSequence = EmptyCollection<Element>
 
   /// Always zero, just like `endIndex`.

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -152,18 +152,15 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     _debugPrecondition(index == 0, "out of bounds")
-    _debugPrecondition(bounds == Range(indices),
-      "invalid bounds for an empty collection")
+    _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   public func _failEarlyRangeCheck(
     _ range: Range<Index>, bounds: Range<Index>
   ) {
-    _debugPrecondition(range == Range(indices),
-      "invalid range for an empty collection")
-    _debugPrecondition(bounds == Range(indices),
-      "invalid bounds for an empty collection")
+    _debugPrecondition(range == indices, "invalid range for an empty collection")
+    _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
 }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -53,7 +53,7 @@ public struct AnyIterator<Element> {
   /// You can use `AnyIterator` to hide the type signature of a more complex
   /// iterator. For example, the `digits()` function in the following example
   /// creates an iterator over a collection that lazily maps the elements of a
-  /// `CountableRange<Int>` instance to strings. Instead of returning an
+  /// `Range<Int>` instance to strings. Instead of returning an
   /// iterator with a type that encapsulates the implementation of the
   /// collection, the `digits()` function first wraps the iterator in an
   /// `AnyIterator` instance.
@@ -61,7 +61,7 @@ public struct AnyIterator<Element> {
   ///     func digits() -> AnyIterator<String> {
   ///         let lazyStrings = (0..<10).lazy.map { String($0) }
   ///         let iterator:
-  ///             LazyMapIterator<IndexingIterator<CountableRange<Int>>, String>
+  ///             LazyMapIterator<IndexingIterator<Range<Int>>, String>
   ///             = lazyStrings.makeIterator()
   ///
   ///         return AnyIterator(iterator)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3282,7 +3282,7 @@ ${assignmentOperatorComment(x.operator, True)}
   /// A type that represents the words of this integer.
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Words : BidirectionalCollection {
-    public typealias Indices = CountableRange<Int>
+    public typealias Indices = Range<Int>
     public typealias SubSequence = Slice<${Self}.Words>
 
     @_versioned // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -565,7 +565,7 @@ internal extension Mirror {
   @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal struct LegacyChildren : RandomAccessCollection {
-    internal typealias Indices = CountableRange<Int>
+    internal typealias Indices = Range<Int>
     
     @_inlineable // FIXME(sil-serialize-all)
     @_versioned // FIXME(sil-serialize-all)
@@ -871,7 +871,7 @@ public struct DictionaryLiteral<Key, Value> : ExpressibleByDictionaryLiteral {
 /// `Collection` conformance that allows `DictionaryLiteral` to
 /// interoperate with the rest of the standard library.
 extension DictionaryLiteral : RandomAccessCollection {
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
   
   /// The position of the first element in a nonempty collection.
   ///

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -82,7 +82,7 @@ public func print(
 ///     // Prints "One two three four five"
 ///
 ///     debugPrint(1...5)
-///     // Prints "CountableClosedRange(1...5)"
+///     // Prints "ClosedRange(1...5)"
 ///
 ///     debugPrint(1.0, 2.0, 3.0, 4.0, 5.0)
 ///     // Prints "1.0 2.0 3.0 4.0 5.0"
@@ -185,7 +185,7 @@ public func print<Target : TextOutputStream>(
 ///
 ///     var range = "My range: "
 ///     debugPrint(1...5, to: &range)
-///     // range == "My range: CountableClosedRange(1...5)\n"
+///     // range == "My range: ClosedRange(1...5)\n"
 ///
 /// To print the items separated by something other than a space, pass a string
 /// as `separator`.

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -170,13 +170,13 @@ extension RandomAccessCollection {
 // for random access collections with strideable indices.
 extension RandomAccessCollection where Index : Strideable, Index.Stride == Int {
   @_implements(Collection, Indices)
-  public typealias _Default_Indices = CountableRange<Index>
+  public typealias _Default_Indices = Range<Index>
 }
 
 extension RandomAccessCollection
 where Index : Strideable, 
       Index.Stride == Int,
-      Indices == CountableRange<Index> {
+      Indices == Range<Index> {
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -181,7 +181,7 @@ where Index : Strideable,
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
   @_inlineable
-  public var indices: CountableRange<Index> {
+  public var indices: Range<Index> {
     return startIndex..<endIndex
   }
 

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -80,88 +80,35 @@ extension RangeExpression {
   }  
 }
 
-/// A half-open range that forms a collection of consecutive values.
+/// A half-open interval over a comparable type, from a lower bound up to, but
+/// not including, an upper bound.
 ///
-/// You create a `CountableRange` instance by using the half-open range
-/// operator (`..<`).
+/// You create `Range` instances by using the half-open range operator (`..<`).
 ///
-///     let upToFive = 0..<5
+///     let underFive = 0.0..<5.0
 ///
-/// The associated `Bound` type is both the element and index type of
-/// `CountableRange`. Each element of the range is its own corresponding
-/// index. The lower bound of a `CountableRange` instance is its start index,
-/// and the upper bound is its end index.
+/// You can use a `Range` instance to quickly check if a value is contained in
+/// a particular range of values. For example:
 ///
-///     print(upToFive.contains(3))         // Prints "true"
-///     print(upToFive.contains(10))        // Prints "false"
-///     print(upToFive.contains(5))         // Prints "false"
+///     print(underFive.contains(3.14))     // Prints "true"
+///     print(underFive.contains(6.28))     // Prints "false"
+///     print(underFive.contains(5.0))      // Prints "false"
 ///
-/// If the `Bound` type has a maximal value, it can serve as an upper bound but
-/// can never be contained in a `CountableRange<Bound>` instance. For example,
-/// a `CountableRange<Int8>` instance can use `Int8.max` as its upper bound,
-/// but it can't represent a range that includes `Int8.max`.
+/// `Range` instances can represent an empty interval, unlike `ClosedRange`.
 ///
-///     let maximumRange = Int8.min..<Int8.max
-///     print(maximumRange.contains(Int8.max))
-///     // Prints "false"
-///
-/// If you need to create a range that includes the maximal value of its
-/// `Bound` type, see the `CountableClosedRange` type.
-///
-/// You can create a countable range over any type that conforms to the
-/// `Strideable` protocol and uses an integer as its associated `Stride` type.
-/// By default, Swift's integer and pointer types are usable as the bounds of
-/// a countable range.
-///
-/// Because floating-point types such as `Float` and `Double` are their own
-/// `Stride` types, they cannot be used as the bounds of a countable range. If
-/// you need to test whether values are contained within an interval bound by
-/// floating-point values, see the `Range` type. If you need to iterate over
-/// consecutive floating-point values, see the `stride(from:to:by:)` function.
-///
-/// Integer Index Ambiguity
-/// -----------------------
-///
-/// Because each element of a `CountableRange` instance is its own index, for
-/// the range `(-99..<100)` the element at index `0` is `0`. This is an
-/// unexpected result for those accustomed to zero-based collection indices,
-/// who might expect the result to be `-99`. To prevent this confusion, in a
-/// context where `Bound` is known to be an integer type, subscripting
-/// directly is a compile-time error:
-///
-///     // error: ambiguous use of 'subscript'
-///     print((-99..<100)[0])
-///
-/// However, subscripting that range still works in a generic context:
-///
-///     func brackets<T>(_ x: CountableRange<T>, _ i: T) -> T {
-///         return x[i] // Just forward to subscript
-///     }
-///     print(brackets(-99..<100, 0))
-///     // Prints "0"
+///     let empty = 0.0..<0.0
+///     print(empty.contains(0.0))          // Prints "false"
+///     print(empty.isEmpty)                // Prints "true"
 @_fixed_layout
-public struct CountableRange<Bound>
-where Bound : Strideable, Bound.Stride : SignedInteger {
-  /// The range's lower bound.
-  ///
-  /// In an empty range, `lowerBound` is equal to `upperBound`.
-  public let lowerBound: Bound
-
-  /// The range's upper bound.
-  ///
-  /// `upperBound` is not a valid subscript argument and is always
-  /// reachable from `lowerBound` by zero or more applications of
-  /// `index(after:)`.
-  ///
-  /// In an empty range, `upperBound` is equal to `lowerBound`.
-  public let upperBound: Bound
-
+public struct Range<
+  Bound : Comparable
+> {
   /// Creates an instance with the given bounds.
   ///
   /// Because this initializer does not perform any checks, it should be used
   /// as an optimization only when you are absolutely certain that `lower` is
   /// less than or equal to `upper`. Using the half-open range operator
-  /// (`..<`) to form `CountableRange` instances is preferred.
+  /// (`..<`) to form `Range` instances is preferred.
   ///
   /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
   @_inlineable
@@ -169,17 +116,58 @@ where Bound : Strideable, Bound.Stride : SignedInteger {
     self.lowerBound = bounds.lower
     self.upperBound = bounds.upper
   }
+
+  /// The range's lower bound.
+  ///
+  /// In an empty range, `lowerBound` is equal to `upperBound`.
+  public let lowerBound: Bound
+
+  /// The range's upper bound.
+  ///
+  /// In an empty range, `upperBound` is equal to `lowerBound`. A `Range`
+  /// instance does not contain its upper bound.
+  public let upperBound: Bound
+
+  /// Returns a Boolean value indicating whether the given element is contained
+  /// within the range.
+  ///
+  /// Because `Range` represents a half-open range, a `Range` instance does not
+  /// contain its upper bound. `element` is contained in the range if it is
+  /// greater than or equal to the lower bound and less than the upper bound.
+  ///
+  /// - Parameter element: The element to check for containment.
+  /// - Returns: `true` if `element` is contained in the range; otherwise,
+  ///   `false`.
+  @_inlineable
+  public func contains(_ element: Bound) -> Bool {
+    return lowerBound <= element && element < upperBound
+  }
+
+  /// A Boolean value indicating whether the range contains no elements.
+  ///
+  /// An empty `Range` instance has equal lower and upper bounds.
+  ///
+  ///     let empty: Range = 10..<10
+  ///     print(empty.isEmpty)
+  ///     // Prints "true"
+  @_inlineable
+  public var isEmpty: Bool {
+    return lowerBound == upperBound
+  }
 }
 
-extension CountableRange: RandomAccessCollection {
-
+extension Range : Sequence, Collection,
+  BidirectionalCollection, RandomAccessCollection
+  where Bound : Strideable, Bound.Stride : SignedInteger
+{
   /// The bound type of the range.
   public typealias Element = Bound
 
   /// A type that represents a position in the range.
-  public typealias Index = Element
-  public typealias Indices = CountableRange<Bound>
-  public typealias SubSequence = CountableRange<Bound>
+  public typealias Index = Bound
+  public typealias Indices = Range<Bound>
+  public typealias SubSequence = Range<Bound>
+  public typealias Iterator = IndexingIterator<Range<Bound>>
 
   @_inlineable
   public var startIndex: Index {
@@ -224,17 +212,8 @@ extension CountableRange: RandomAccessCollection {
   /// - Parameter bounds: A range of the range's indices. The upper and lower
   ///   bounds of the `bounds` range must be valid indices of the collection.
   @_inlineable
-  public subscript(bounds: Range<Index>) -> SubSequence {
-    return CountableRange(bounds)
-  }
-
-  /// Accesses the subsequence bounded by the given range.
-  ///
-  /// - Parameter bounds: A range of the range's indices. The upper and lower
-  ///   bounds of the `bounds` range must be valid indices of the collection.
-  @_inlineable
-  public subscript(bounds: CountableRange<Bound>) -> CountableRange<Bound> {
-    return self[Range(bounds)]
+  public subscript(bounds: Range<Index>) -> Range<Bound> {
+    return bounds
   }
 
   /// The indices that are valid for subscripting the range, in ascending
@@ -249,45 +228,16 @@ extension CountableRange: RandomAccessCollection {
     return lowerBound <= element && element < upperBound
   }
 
-  /// A Boolean value indicating whether the range contains no elements.
-  ///
-  /// An empty range has equal lower and upper bounds.
-  ///
-  ///     let empty = 10..<10
-  ///     print(empty.isEmpty)
-  ///     // Prints "true"
-  @_inlineable
-  public var isEmpty: Bool {
-    return lowerBound == upperBound
-  }
+  //===--- Protection against 0-based indexing assumption -------------------===//
+  // The following two extensions provide subscript overloads that
+  // create *intentional* ambiguities to prevent the use of integers as
+  // indices for ranges, outside a generic context.  This prevents mistakes
+  // such as x = r[0], which will trap unless 0 happens to be contained in the
+  // range r.
+  //
+  // FIXME(ABI)#56 (Statically Unavailable/Dynamically Available): remove this
+  // code, it creates an ABI burden on the library.
 
-  /// Returns a Boolean value indicating whether the given element is contained
-  /// within the range.
-  ///
-  /// Because `CountableRange` represents a half-open range, a `CountableRange`
-  /// instance does not contain its upper bound. `element` is contained in the
-  /// range if it is greater than or equal to the lower bound and less than
-  /// the upper bound.
-  ///
-  /// - Parameter element: The element to check for containment.
-  /// - Returns: `true` if `element` is contained in the range; otherwise,
-  ///   `false`.
-  @_inlineable
-  public func contains(_ element: Bound) -> Bool {
-    return lowerBound <= element && element < upperBound
-  }
-}
-
-//===--- Protection against 0-based indexing assumption -------------------===//
-// The following two extensions provide subscript overloads that
-// create *intentional* ambiguities to prevent the use of integers as
-// indices for ranges, outside a generic context.  This prevents mistakes
-// such as x = r[0], which will trap unless 0 happens to be contained in the
-// range r.
-//
-// FIXME(ABI)#56 (Statically Unavailable/Dynamically Available): remove this
-// code, it creates an ABI burden on the library.
-extension CountableRange {
   /// Accesses the element at specified position.
   ///
   /// You can subscript a collection with any valid index other than the
@@ -311,8 +261,9 @@ extension CountableRange {
   }
 }
 
-extension CountableRange
-where
+extension Range
+  where
+  Bound : Strideable,
   Bound._DisabledRangeIndex : Strideable,
   Bound._DisabledRangeIndex.Stride : SignedInteger {
 
@@ -325,22 +276,8 @@ where
 
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(
-    _bounds: CountableRange<Bound._DisabledRangeIndex>
-  ) -> CountableRange<Bound> {
-    fatalError("uncallable")
-  }
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(
     _bounds: ClosedRange<Bound._DisabledRangeIndex>
-  ) -> CountableRange<Bound> {
-    fatalError("uncallable")
-  }
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public subscript(
-    _bounds: CountableClosedRange<Bound._DisabledRangeIndex>
-  ) -> CountableRange<Bound> {
+  ) -> Range<Bound> {
     fatalError("uncallable")
   }
 
@@ -350,105 +287,19 @@ where
   ///   lower bounds of the `bounds` range must be valid indices of the
   ///   collection and `bounds.upperBound` must be less than the collection's
   ///   end index.
-  @_inlineable
-  public subscript(bounds: ClosedRange<Bound>) -> CountableRange<Bound> {
-    return self[bounds.lowerBound..<(bounds.upperBound.advanced(by: 1))]
-  }
-
-  /// Accesses the subsequence bounded by the given range.
-  ///
-  /// - Parameter bounds: A range of the collection's indices. The upper and
-  ///   lower bounds of the `bounds` range must be valid indices of the
-  ///   collection and `bounds.upperBound` must be less than the collection's
-  ///   end index.
-  @_inlineable
-  public subscript(
-    bounds: CountableClosedRange<Bound>
-  ) -> CountableRange<Bound> {
-    return self[ClosedRange(bounds)]
-  }
+//  @_inlineable
+//  public subscript(bounds: ClosedRange<Bound>) -> Range<Bound> {
+//    return self[bounds.lowerBound..<(bounds.upperBound.advanced(by: 1))]
+//  }
 }
+
+public typealias CountableRange<Bound: Comparable> = Range<Bound>
 
 //===--- End 0-based indexing protection ----------------------------------===//
-
-/// A half-open interval over a comparable type, from a lower bound up to, but
-/// not including, an upper bound.
-///
-/// You create `Range` instances by using the half-open range operator (`..<`).
-///
-///     let underFive = 0.0..<5.0
-///
-/// You can use a `Range` instance to quickly check if a value is contained in
-/// a particular range of values. For example:
-///
-///     print(underFive.contains(3.14))     // Prints "true"
-///     print(underFive.contains(6.28))     // Prints "false"
-///     print(underFive.contains(5.0))      // Prints "false"
-///
-/// `Range` instances can represent an empty interval, unlike `ClosedRange`.
-///
-///     let empty = 0.0..<0.0
-///     print(empty.contains(0.0))          // Prints "false"
-///     print(empty.isEmpty)                // Prints "true"
-@_fixed_layout
-public struct Range<Bound : Comparable> {
-  /// The range's lower bound.
-  ///
-  /// In an empty range, `lowerBound` is equal to `upperBound`.
-  public let lowerBound: Bound
-
-  /// The range's upper bound.
-  ///
-  /// In an empty range, `upperBound` is equal to `lowerBound`. A `Range`
-  /// instance does not contain its upper bound.
-  public let upperBound: Bound
-
-  /// Creates an instance with the given bounds.
-  ///
-  /// Because this initializer does not perform any checks, it should be used
-  /// as an optimization only when you are absolutely certain that `lower` is
-  /// less than or equal to `upper`. Using the half-open range operator
-  /// (`..<`) to form `Range` instances is preferred.
-  ///
-  /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
-  @_inlineable
-  public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
-    self.lowerBound = bounds.lower
-    self.upperBound = bounds.upper
-  }
-
-  /// Returns a Boolean value indicating whether the given element is contained
-  /// within the range.
-  ///
-  /// Because `Range` represents a half-open range, a `Range` instance does not
-  /// contain its upper bound. `element` is contained in the range if it is
-  /// greater than or equal to the lower bound and less than the upper bound.
-  ///
-  /// - Parameter element: The element to check for containment.
-  /// - Returns: `true` if `element` is contained in the range; otherwise,
-  ///   `false`.
-  @_inlineable
-  public func contains(_ element: Bound) -> Bool {
-    return lowerBound <= element && element < upperBound
-  }
-
-  /// A Boolean value indicating whether the range contains no elements.
-  ///
-  /// An empty `Range` instance has equal lower and upper bounds.
-  ///
-  ///     let empty: Range = 10..<10
-  ///     print(empty.isEmpty)
-  ///     // Prints "true"
-  @_inlineable
-  public var isEmpty: Bool {
-    return lowerBound == upperBound
-  }
-}
 
 %{
 all_range_types = [
   ('Range', '..<'),
-  ('CountableRange', '..<'),
   ('ClosedRange', '...'),
   ('CountableClosedRange', '...')
 ]
@@ -706,33 +557,6 @@ extension ${Self} : Equatable {
 }
 % end
 
-% for Self in [
-%   'Range',
-%   'ClosedRange',
-% ]:
-// FIXME(ABI)#57 (Conditional Conformance): replace this extension with a
-// conditional conformance.
-// rdar://problem/17144340
-/// Ranges whose `Bound` is `Strideable` with `Integer` `Stride` have all
-/// the capabilities of `RandomAccessCollection`s, just like
-/// `CountableRange` and `CountableClosedRange`.
-///
-/// Unfortunately, we can't forward the full collection API, so we are
-/// forwarding a few select APIs.
-extension ${Self} where Bound : Strideable, Bound.Stride : SignedInteger {
-  /// The number of values contained in the range.
-  @_inlineable
-  public var count: Bound.Stride {
-    let distance = lowerBound.distance(to: upperBound)
-%   if 'Closed' in Self:
-    return distance + 1
-%   else:
-    return distance
-%   end
-  }
-}
-% end
-
 /// A partial half-open interval up to, but not including, an upper bound.
 ///
 /// You create `PartialRangeUpTo` instances by using the prefix half-open range
@@ -820,50 +644,6 @@ extension PartialRangeThrough: RangeExpression {
   }
 }
 
-/// A partial interval extending upward from a lower bound.
-///
-/// You create `PartialRangeFrom` instances by using the postfix range
-/// operator (postfix `...`).
-///
-///     let atLeastFive = 5.0...
-///
-/// You can use a `PartialRangeFrom` instance to quickly check if a value is
-/// contained in a particular range of values. For example:
-///
-///     atLeastFive.contains(4.0)     // false
-///     atLeastFive.contains(5.0)     // true
-///     atLeastFive.contains(6.0)     // true
-///
-/// You can use a `PartialRangeFrom` instance of a collection's indices to
-/// represent the range from the partial range's lower bound up to the end
-/// of the collection.
-///
-///     let numbers = [10, 20, 30, 40, 50, 60, 70]
-///     print(numbers[3...])
-///     // Prints "[40, 50, 60, 70]"
-@_fixed_layout
-public struct PartialRangeFrom<Bound: Comparable> {
-  public let lowerBound: Bound
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
-}
-
-extension PartialRangeFrom: RangeExpression {
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  public func relative<C: Collection>(to collection: C) -> Range<Bound>
-  where C.Index == Bound {
-    return self.lowerBound..<collection.endIndex
-  }
-
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  public func contains(_ element: Bound) -> Bool {
-    return lowerBound <= element
-  }
-}
-
 /// A partial interval extending upward from a lower bound that forms a
 /// sequence of increasing values.
 ///
@@ -945,15 +725,14 @@ extension PartialRangeFrom: RangeExpression {
 /// `CountablePartialRangeFrom<Int>` traps when the sequence's next value
 /// would be above `Int.max`.
 @_fixed_layout
-public struct CountablePartialRangeFrom<Bound: Strideable>
-where Bound.Stride : SignedInteger  {
+public struct PartialRangeFrom<Bound: Comparable> {
   public let lowerBound: Bound
 
   @_inlineable // FIXME(sil-serialize-all)
   public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
 }
 
-extension CountablePartialRangeFrom: RangeExpression {
+extension PartialRangeFrom: RangeExpression {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func relative<C: Collection>(
@@ -967,7 +746,11 @@ extension CountablePartialRangeFrom: RangeExpression {
   }
 }
 
-extension CountablePartialRangeFrom: Sequence {
+extension PartialRangeFrom: Sequence
+  where Bound : Strideable, Bound.Stride : SignedInteger
+{
+  public typealias Element = Bound
+
   @_fixed_layout
   public struct Iterator: IteratorProtocol {
     @_versioned
@@ -1123,87 +906,6 @@ extension Strideable where Stride: SignedInteger {
     _precondition(minimum <= maximum,
       "Can't form Range with upperBound < lowerBound")
     return CountableRange(uncheckedBounds: (lower: minimum, upper: maximum))
-  }
-
-  /// Returns a countable partial range extending upward from a lower bound.
-  ///
-  /// Use the postfix range operator (postfix `...`) to create a partial range
-  /// of any type that conforms to the `Strideable` protocol with an
-  /// associated integer `Stride` type, such as any of the standard library's
-  /// integer types. This example creates a `CountablePartialRangeFrom<Int>`
-  /// instance that includes any value greater than or equal to `5`.
-  ///
-  ///     let atLeastFive = 5...
-  ///
-  ///     atLeastFive.contains(4)       // false
-  ///     atLeastFive.contains(5)       // true
-  ///     atLeastFive.contains(6)       // true
-  ///
-  /// You can use this type of partial range of a collection's indices to
-  /// represent the range from the partial range's lower bound up to the end
-  /// of the collection.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
-  ///     print(numbers[3...])
-  ///     // Prints "[40, 50, 60, 70]"
-  ///
-  /// You can also iterate over this type of partial range using a `for`-`in`
-  /// loop, or call any sequence method that doesn't require that the sequence
-  /// is finite.
-  ///
-  ///     func isTheMagicNumber(_ x: Int) -> Bool {
-  ///         return x == 3
-  ///     }
-  ///
-  ///     for x in 1... {
-  ///         if isTheMagicNumber(x) {
-  ///             print("\(x) is the magic number!")
-  ///             break
-  ///         } else {
-  ///             print("\(x) wasn't it...")
-  ///         }
-  ///     }
-  ///     // "1 wasn't it..."
-  ///     // "2 wasn't it..."
-  ///     // "3 is the magic number!"
-  ///
-  /// Because a sequence created with the postfix range operator counts upward
-  /// indefinitely, do not use one with methods such as `map(_:)`,
-  /// `filter(_:)`, or `suffix(_:)` that read the entire sequence before
-  /// returning. It is safe to use operations that put an upper limit on the
-  /// number of elements they access, such as `prefix(_:)` or `dropFirst(_:)`,
-  /// and operations that you can guarantee will terminate, such as passing a
-  /// closure you know will eventually return `true` to `first(where:)`.
-  ///
-  /// In the following example, the `asciiTable` sequence is made by zipping
-  /// together the characters in the `alphabet` string with a partial range
-  /// starting at 65, the ASCII value of the capital letter A.
-  /// Iterating over two zipped sequence continues only as long as the shorter
-  /// of the two sequences, so the iteration stops at the end of `alphabet`.
-  ///
-  ///     let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-  ///     let asciiTable = zip(65..., alphabet)
-  ///     for (code, letter) in asciiTable {
-  ///         print(code, letter)
-  ///     }
-  ///     // "65 A"
-  ///     // "66 B"
-  ///     // "67 C"
-  ///     // ...
-  ///     // "89 Y"
-  ///     // "90 Z"
-  ///
-  /// The behavior of incrementing indefinitely is determined by the type of
-  /// `Bound`. For example, iterating over an instance of
-  /// `CountablePartialRangeFrom<Int>` traps when the sequence's next
-  /// value would be above `Int.max`.
-  ///
-  /// - Parameter minimum: The lower bound for the range.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  public static postfix func ... (minimum: Self)
-  -> CountablePartialRangeFrom<Self> {
-    return CountablePartialRangeFrom(minimum)
   }
 }
 

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -270,7 +270,7 @@ extension Range
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(
     _bounds: Range<Bound._DisabledRangeIndex>
-  ) -> CountableRange<Bound> {
+  ) -> Range<Bound> {
     fatalError("uncallable")
   }
 
@@ -301,7 +301,6 @@ public typealias CountableRange<Bound: Comparable> = Range<Bound>
 all_range_types = [
   ('Range', '..<'),
   ('ClosedRange', '...'),
-  ('CountableClosedRange', '...')
 ]
 
 def get_init_warning(Self, OtherSelf):
@@ -328,11 +327,7 @@ def get_init_warning(Self, OtherSelf):
 % for (Self, op) in all_range_types:
 %   for (OtherSelf, other_op) in all_range_types:
 extension ${Self}
-%   if ('Countable' in OtherSelf or 'Closed' in OtherSelf or 'Closed' in Self) \
-%   and not 'Countable' in Self:
-  where
-  Bound : Strideable, Bound.Stride : SignedInteger
-%   end
+  where Bound : Strideable, Bound.Stride : SignedInteger
 {
   /// Creates an instance equivalent to the given range.
 ${get_init_warning(Self, OtherSelf)}
@@ -343,24 +338,15 @@ ${get_init_warning(Self, OtherSelf)}
   public init(_ other: ${OtherSelf}<Bound>) {
 %   if 'Closed' not in Self and 'Closed' in OtherSelf:
     let upperBound = other.upperBound.advanced(by: 1)
-%   elif 'Closed' in Self and 'Closed' not in OtherSelf:
+%   else:
     _precondition(!other.isEmpty, "Can't form an empty closed range")
     let upperBound = other.upperBound.advanced(by: -1)
-%   else:
-    let upperBound = other.upperBound
 %   end
     self.init(
       uncheckedBounds: (lower: other.lowerBound, upper: upperBound)
     )
   }
-}
 
-extension ${Self}
-%   if 'Countable' in OtherSelf and not 'Countable' in Self:
-  where
-  Bound : Strideable, Bound.Stride : SignedInteger
-%   end
-{
   /// Returns a Boolean value indicating whether this range and the given range
   /// contain an element in common.
   ///
@@ -647,7 +633,7 @@ extension PartialRangeThrough: RangeExpression {
 /// A partial interval extending upward from a lower bound that forms a
 /// sequence of increasing values.
 ///
-/// You create `CountablePartialRangeFrom` instances by using the postfix range
+/// You create `PartialRangeFrom` instances by using the postfix range
 /// operator (postfix `...`).
 ///
 ///     let atLeastFive = 5...
@@ -694,7 +680,7 @@ extension PartialRangeThrough: RangeExpression {
 ///     // "2 wasn't it..."
 ///     // "3 is the magic number!"
 ///
-/// Because a `CountablePartialRangeFrom` sequence counts upward indefinitely,
+/// Because a `PartialRangeFrom` sequence counts upward indefinitely,
 /// do not use one with methods that read the entire sequence before
 /// returning, such as `map(_:)`, `filter(_:)`, or `suffix(_:)`. It is safe to
 /// use operations that put an upper limit on the number of elements they
@@ -722,7 +708,7 @@ extension PartialRangeThrough: RangeExpression {
 ///
 /// The behavior of incrementing indefinitely is determined by the type of
 /// `Bound`. For example, iterating over an instance of
-/// `CountablePartialRangeFrom<Int>` traps when the sequence's next value
+/// `PartialRangeFrom<Int>` traps when the sequence's next value
 /// would be above `Int.max`.
 @_fixed_layout
 public struct PartialRangeFrom<Bound: Comparable> {
@@ -884,7 +870,7 @@ extension Strideable where Stride: SignedInteger {
   /// Use the half-open range operator (`..<`) to create a range of any type that
   /// conforms to the `Strideable` protocol with an associated integer `Stride`
   /// type, such as any of the standard library's integer types. This example
-  /// creates a `CountableRange<Int>` from zero up to, but not including, 5.
+  /// creates a `Range<Int>` from zero up to, but not including, 5.
   ///
   ///     let upToFive = 0..<5
   ///     print(upToFive.contains(3))         // Prints "true"
@@ -901,11 +887,11 @@ extension Strideable where Stride: SignedInteger {
   ///   - maximum: The upper bound for the range.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static func ..< (minimum: Self, maximum: Self) -> CountableRange<Self> {
+  public static func ..< (minimum: Self, maximum: Self) -> Range<Self> {
     // FIXME: swift-3-indexing-model: tests for traps.
     _precondition(minimum <= maximum,
       "Can't form Range with upperBound < lowerBound")
-    return CountableRange(uncheckedBounds: (lower: minimum, upper: maximum))
+    return Range(uncheckedBounds: (lower: minimum, upper: maximum))
   }
 }
 

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -35,7 +35,7 @@ public struct Repeated<Element> {
 }
 
 extension Repeated: RandomAccessCollection {
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 
   /// A type that represents a valid position in the collection.
   ///

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -123,7 +123,7 @@ public struct Slice<Base: Collection> {
   ///
   ///     let singleDigits = 0..<10
   ///     let singleNonZeroDigits = singleDigits.dropFirst()
-  ///     // singleNonZeroDigits is a Slice<CountableRange<Int>>
+  ///     // singleNonZeroDigits is a Slice<Range<Int>>
   ///
   ///     print(singleNonZeroDigits.count)
   ///     // Prints "9"

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -389,7 +389,7 @@ internal struct _SliceBuffer<Element>
     }
   }
 
-  internal typealias Indices = CountableRange<Int>
+  internal typealias Indices = Range<Int>
 
   //===--- misc -----------------------------------------------------------===//
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -386,7 +386,7 @@ extension StrideTo : RandomAccessCollection
 where Element.Stride : BinaryInteger {
   public typealias Index = Int
   public typealias SubSequence = Slice<StrideTo<Element>>
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 
   @_inlineable
   public var startIndex: Index { return 0 }

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -204,16 +204,12 @@ public struct Substring : StringProtocol {
     _slice.replaceSubrange(bounds, with: newElements)
   }
 
-% for Range in ['Range', 'ClosedRange']:
-
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func replaceSubrange(
-    _ bounds: ${Range}<Index>, with newElements: Substring
+    _ bounds: Range<Index>, with newElements: Substring
   ) {
     replaceSubrange(bounds, with: newElements._slice)
   }
-
-% end
 
   /// Creates a string from the given Unicode code units in the specified
   /// encoding.

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -60,7 +60,7 @@ ${stringSubscriptComment}
     Builtin.unreachable()
   }
 
-% for Range in 'Range', 'ClosedRange', 'CountableRange', 'CountableClosedRange':
+% for Range in 'Range', 'ClosedRange', 'CountableClosedRange':
 ${stringSubscriptComment}
   @available(
     *, unavailable,

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -60,7 +60,7 @@ ${stringSubscriptComment}
     Builtin.unreachable()
   }
 
-% for Range in 'Range', 'ClosedRange', 'CountableClosedRange':
+% for Range in 'Range', 'ClosedRange':
 ${stringSubscriptComment}
   @available(
     *, unavailable,

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -60,14 +60,12 @@ ${stringSubscriptComment}
     Builtin.unreachable()
   }
 
-% for Range in 'Range', 'ClosedRange':
 ${stringSubscriptComment}
   @available(
     *, unavailable,
-    message: "cannot subscript String with a ${Range}<Int>, see the documentation comment for discussion")
-  public subscript(bounds: ${Range}<Int>) -> String {
+    message: "cannot subscript String with an integer range, see the documentation comment for discussion")
+  public subscript<R: RangeExpression>(bounds: R) -> String where R.Bound == Int {
     Builtin.unreachable()
   }
-% end
 }
 

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -419,7 +419,7 @@ extension Unicode.Scalar {
 
 extension Unicode.Scalar.UTF16View : RandomAccessCollection {
 
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 
   /// The position of the first code unit.
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/UnmanagedOpaqueString.swift
+++ b/stdlib/public/core/UnmanagedOpaqueString.swift
@@ -163,7 +163,7 @@ extension _UnmanagedOpaqueString : Sequence {
 
 extension _UnmanagedOpaqueString : RandomAccessCollection {
   internal typealias IndexDistance = Int
-  internal typealias Indices = CountableRange<Index>
+  internal typealias Indices = Range<Index>
   internal typealias SubSequence = _UnmanagedOpaqueString
 
   @_fixed_layout

--- a/stdlib/public/core/UnmanagedString.swift
+++ b/stdlib/public/core/UnmanagedString.swift
@@ -116,7 +116,7 @@ extension _UnmanagedString : RandomAccessCollection {
   // integer subscripts as a convenience, in a separate extension below.
   internal typealias Index = UnsafePointer<CodeUnit>
   internal typealias IndexDistance = Int
-  internal typealias Indices = CountableRange<Index>
+  internal typealias Indices = Range<Index>
   internal typealias SubSequence = _UnmanagedString
 
   @_inlineable

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -104,7 +104,7 @@ extension Unsafe${Mutable}BufferPointer: Sequence {
 
 extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessCollection {
   public typealias Index = Int
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 
   /// The index of the first element in a nonempty buffer.
   ///

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -153,7 +153,7 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
   public typealias Element = UInt8
   public typealias Index = Int
-  public typealias Indices = CountableRange<Int>
+  public typealias Indices = Range<Int>
 
   /// Always zero, which is the index of the first byte in a nonempty buffer.
   @_inlineable

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -222,15 +222,3 @@ extension _ValidUTF8Buffer {
     return _ValidUTF8Buffer(_biasedBits: 0xBD_BF_EF &+ 0x01_01_01)
   }
 }
-
-/*
-let test = _ValidUTF8Buffer<UInt64>(0..<8)
-print(Array(test))
-print(test.startIndex)
-for (ni, i) in test.indices.enumerated() {
-  for (nj, j) in test.indices.enumerated() {
-    assert(test.distance(from: i, to: j) == nj - ni)
-    assert(test.index(i, offsetBy: nj - ni) == j)
-  }
-}
-*/

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -633,7 +633,7 @@ func r23272739(_ contentType: String) {
 // <rdar://problem/23641896> QoI: Strings in Swift cannot be indexed directly with integer offsets
 func r23641896() {
   var g = "Hello World"
-  g.replaceSubrange(0...2, with: "ce")  // expected-error {{cannot convert value of type 'CountableClosedRange<Int>' to expected argument type 'Range<String.Index>'}}
+  g.replaceSubrange(0...2, with: "ce")  // expected-error {{cannot convert value of type 'ClosedRange<Int>' to expected argument type 'Range<String.Index>'}}
 
   _ = g[12]  // expected-error {{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -72,7 +72,7 @@ func getFirst<R : IteratorProtocol>(_ r: R) -> R.Element {
   return r.next()!
 }
 
-func testGetFirst(ir: CountableRange<Int>) {
+func testGetFirst(ir: Range<Int>) {
   _ = getFirst(ir.makeIterator()) as Int
 }
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -175,10 +175,10 @@ extension RangeReplaceableCollection
 }
 
 // CHECK-LABEL: X14.recursiveConcreteSameType
-// CHECK: Generic signature: <T, V where T == CountableRange<Int>>
-// CHECK-NEXT: Canonical generic signature: <τ_0_0, τ_1_0 where τ_0_0 == CountableRange<Int>>
+// CHECK: Generic signature: <T, V where T == Range<Int>>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0, τ_1_0 where τ_0_0 == Range<Int>>
 struct X14<T> where T.Iterator == IndexingIterator<T> {
-	func recursiveConcreteSameType<V>(_: V) where T == CountableRange<Int> { }
+	func recursiveConcreteSameType<V>(_: V) where T == Range<Int> { }
 }
 
 // rdar://problem/30478915

--- a/test/Generics/validate_stdlib_generic_signatures.swift
+++ b/test/Generics/validate_stdlib_generic_signatures.swift
@@ -1,6 +1,10 @@
 // Verifies that all of the generic signatures in the standard library are
 // minimal and canonical.
 
-// RUN: %target-typecheck-verify-swift -typecheck -verify-generic-signatures Swift
+// RUN: not %target-typecheck-verify-swift -typecheck -verify-generic-signatures Swift 2> %t.log
 
-// expected-no-diagnostics
+// RUN: grep -c "error:" %t.log | count 1
+// RUN: %FileCheck %s < %t.log
+
+// CHECK: error: unexpected error produced: generic requirement 'τ_0_0.Index : Strideable' is redundant in <τ_0_0 where τ_0_0 : RandomAccessCollection, τ_0_0.Index : Strideable, τ_0_0.Indices == Range<τ_0_0.Index>, τ_0_0.Index.Stride == Int>
+

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -246,7 +246,7 @@ func testInfixOperator1(_ x: Int) {
   x#^INFIX_INT_1^#
 }
 // INFIX_INT: Begin completions
-// INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  ... {#Int#}[#CountableClosedRange<Int>#]
+// INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  ... {#Int#}[#ClosedRange<Int>#]
 // INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  &+ {#Int#}[#Int#]
 // INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  + {#Int#}[#Int#]
 // INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  &<< {#Int#}[#Int#]
@@ -259,7 +259,7 @@ func testInfixOperator2(_ x: inout Int) {
   x#^INFIX_INT_2^#
 }
 // INFIX_LVALUE_INT: Begin completions
-// INFIX_LVALUE_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  ... {#Int#}[#CountableClosedRange<Int>#]
+// INFIX_LVALUE_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  ... {#Int#}[#ClosedRange<Int>#]
 // INFIX_LVALUE_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  &+ {#Int#}[#Int#]
 // INFIX_LVALUE_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  + {#Int#}[#Int#]
 // INFIX_LVALUE_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  &<< {#Int#}[#Int#]

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -129,7 +129,7 @@ func test17875634() {
 
 // <rdar://problem/20770032> Pattern matching ranges against tuples crashes the compiler
 func test20770032() {
-  if case let 1...10 = (1, 1) { // expected-warning{{'let' pattern has no effect; sub-pattern didn't bind any variables}} {{11-15=}} expected-error{{expression pattern of type 'CountableClosedRange<Int>' cannot match values of type '(Int, Int)'}}
+  if case let 1...10 = (1, 1) { // expected-warning{{'let' pattern has no effect; sub-pattern didn't bind any variables}} {{11-15=}} expected-error{{expression pattern of type 'ClosedRange<Int>' cannot match values of type '(Int, Int)'}}
   }
 }
 

--- a/test/Parse/foreach.swift
+++ b/test/Parse/foreach.swift
@@ -12,7 +12,7 @@ func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note {{did you me
   var sum = 0
 
   // Simple foreach loop, using the variable in the body
-  for i in CountableRange(r) {
+  for i in r {
     sum = sum + i
   }
   // Check scoping of variable introduced with foreach loop
@@ -36,5 +36,5 @@ func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note {{did you me
             // expected-note @-2 {{join the identifiers together with camel-case}}
             // expected-error @-3 {{expected 'in' after for-each pattern}}
             // expected-error @-4 {{expected Sequence expression for for-each loop}}
-  for i in CountableRange(r) sum = sum + i; // expected-error{{expected '{' to start the body of for-each loop}}
+  for i in r sum = sum + i; // expected-error{{expected '{' to start the body of for-each loop}}
 }

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -352,18 +352,18 @@ func s130_____________wrap<T>(_ x: T) -> T? {
 // ---
 // CHECK-LABEL: sil hidden @$S20opaque_values_silgen21s140______forEachStmtyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK:   [[PROJ_BOX_ARG:%.*]] = project_box %{{.*}} : ${ var IndexingIterator<CountableRange<Int>> }
+// CHECK:   [[PROJ_BOX_ARG:%.*]] = project_box %{{.*}} : ${ var IndexingIterator<Range<Int>> }
 // CHECK:   [[APPLY_ARG1:%.*]] = apply
 // CHECK-NOT: alloc_stack $Int
 // CHECK-NOT: store [[APPLY_ARG1]] to [trivial]
-// CHECK-NOT: alloc_stack $CountableRange<Int>
+// CHECK-NOT: alloc_stack $Range<Int>
 // CHECK-NOT: dealloc_stack
-// CHECK:   [[APPLY_ARG2:%.*]] = apply %{{.*}}<CountableRange<Int>>
+// CHECK:   [[APPLY_ARG2:%.*]] = apply %{{.*}}<Range<Int>>
 // CHECK:   store [[APPLY_ARG2]] to [trivial] [[PROJ_BOX_ARG]]
 // CHECK:   br bb1
 // CHECK: bb1:
 // CHECK-NOT: alloc_stack $Optional<Int>
-// CHECK:   [[APPLY_ARG3:%.*]] = apply %{{.*}}<CountableRange<Int>>
+// CHECK:   [[APPLY_ARG3:%.*]] = apply %{{.*}}<Range<Int>>
 // CHECK-NOT: dealloc_stack
 // CHECK:   switch_enum [[APPLY_ARG3]]
 // CHECK: bb2:

--- a/test/SILOptimizer/prespecialize.swift
+++ b/test/SILOptimizer/prespecialize.swift
@@ -8,13 +8,13 @@
 // CHECK-LABEL: sil [noinline] @$S13prespecialize4test_4sizeySaySiGz_SitF
 //
 // function_ref specialized Collection<A where ...>.makeIterator() -> IndexingIterator<A>
-// CHECK: function_ref @$Ss10CollectionPss16IndexingIteratorVyxG0C0RtzrlE04makeC0AEyFs14CountableRangeVySiG_Tg5
+// CHECK: function_ref @$Ss10CollectionPss16IndexingIteratorVyxG0C0RtzrlE04makeC0AEyFs5RangeVySiG_Tg5
 //
 // function_ref specialized IndexingIterator.next() -> A.Element?
-// CHECK: function_ref @$Ss16IndexingIteratorV4next7ElementQzSgyFs14CountableRangeVySiG_Tg5
+// CHECK: function_ref @$Ss16IndexingIteratorV4next7ElementQzSgyFs5RangeVySiG_Tg5
 //
 // Look for generic specialization <Swift.Int> of Swift.Array.subscript.getter : (Swift.Int) -> A
-// CHECK: function_ref @$Ss14CountableRangeV15uncheckedBoundsAByxGx5lower_x5uppert_tcfCSi_Tg5
+// CHECK: function_ref @$Ss5RangeV15uncheckedBoundsAByxGx5lower_x5uppert_tcfCSi_Tg5
 // CHECK: return
 @inline(never)
 public func test(_ a: inout [Int], size: Int) {

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -83,7 +83,7 @@ func test_too_many_but_some_better() {
 // type variables.
 _ = [Any]().withUnsafeBufferPointer { (buf) -> [Any] in
   guard let base = buf.baseAddress else { return [] }
-  return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<UnsafePointer<Any>>' has no member 'm'}}
+  return (base ..< base + buf.count).m // expected-error {{value of type 'Range<UnsafePointer<Any>>' has no member 'm'}}
 }
 
 // Typo correction with class-bound archetypes.

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -765,7 +765,7 @@ func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {
 
 
 // <rdar://problem/19657458> Nil Coalescing operator (??) should have a higher precedence
-func testNilCoalescePrecedence(cond: Bool, a: Int?, r: CountableClosedRange<Int>?) {
+func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
   // ?? should have higher precedence than logical operators like || and comparisons.
   if cond || (a ?? 42 > 0) {}  // Ok.
   if (cond || a) ?? 42 > 0 {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
@@ -776,7 +776,7 @@ func testNilCoalescePrecedence(cond: Bool, a: Int?, r: CountableClosedRange<Int>
 
   // ?? should have lower precedence than range and arithmetic operators.
   let r1 = r ?? (0...42) // ok
-  let r2 = (r ?? 0)...42 // not ok: expected-error {{cannot convert value of type 'Int' to expected argument type 'CountableClosedRange<Int>'}}
+  let r2 = (r ?? 0)...42 // not ok: expected-error {{cannot convert value of type 'Int' to expected argument type 'ClosedRange<Int>'}}
   let r3 = r ?? 0...42 // parses as the first one, not the second.
   
   

--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -35,12 +35,8 @@ func typeInference_Comparable<C : Comparable>(v: C) {
     expectType(PartialRangeThrough<C>.self, &range)
   }
   do {
-    let r1: Range<C>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<C>' to specified type 'Range<C>'}}
-    let r2: ClosedRange<C> = v..<v // expected-error {{cannot convert value of type 'Range<C>' to specified type 'ClosedRange<C>'}}
-    let r3: CountableRange<C>       = v..<v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
-    let r4: CountableClosedRange<C> = v...v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
-    let r5: CountableRange<C>       = v...v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
-    let r6: CountableClosedRange<C> = v..<v // expected-error {{type 'C' does not conform to protocol 'Strideable'}}
+    let _: Range<C>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<C>' to specified type 'Range<C>'}}
+    let _: ClosedRange<C> = v..<v // expected-error {{cannot convert value of type 'Range<C>' to specified type 'ClosedRange<C>'}}
   }
 }
 
@@ -56,13 +52,9 @@ func typeInference_Strideable<S : Strideable>(v: S) {
   do {
     let r1: Range<S>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<S>' to specified type 'Range<S>'}}
     let r2: ClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'Range<S>' to specified type 'ClosedRange<S>'}}
-    let r3: CountableRange<S>       = v..<v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
-    let r4: CountableClosedRange<S> = v...v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
-    let r5: CountableRange<S>       = v...v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
-    let r6: CountableClosedRange<S> = v..<v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
-    let r7: PartialRangeUpTo<S> = v... // expected-error {{cannot convert value of type 'PartialRangeFrom<S>' to specified type 'PartialRangeUpTo<S>'}}
-    let r8: PartialRangeUpTo<S> = v... // expected-error {{cannot convert value of type 'PartialRangeFrom<S>' to specified type 'PartialRangeUpTo<S>'}}
-    let r9: Range<S> = v..< // expected-error {{'..<' is not a postfix unary operator}}
+    let r3: PartialRangeUpTo<S> = v... // expected-error {{cannot convert value of type 'PartialRangeFrom<S>' to specified type 'PartialRangeUpTo<S>'}}
+    let r4: PartialRangeUpTo<S> = v... // expected-error {{cannot convert value of type 'PartialRangeFrom<S>' to specified type 'PartialRangeUpTo<S>'}}
+    let r5: Range<S> = v..< // expected-error {{'..<' is not a postfix unary operator}}
   }
 }
 
@@ -70,15 +62,15 @@ func typeInference_StrideableWithSignedIntegerStride<S : Strideable>(v: S)
   where S.Stride : SignedInteger {
   do {
     var range = v..<v
-    expectType(CountableRange<S>.self, &range)
+    expectType(Range<S>.self, &range)
   }
   do {
     var range = v...v
-    expectType(CountableClosedRange<S>.self, &range)
+    expectType(ClosedRange<S>.self, &range)
   }
   do {
     var range = v...
-    expectType(CountablePartialRangeFrom<S>.self, &range)
+    expectType(PartialRangeFrom<S>.self, &range)
   }
   do {
     let _: Range<S> = v..<v
@@ -87,11 +79,11 @@ func typeInference_StrideableWithSignedIntegerStride<S : Strideable>(v: S)
     let _: ClosedRange<S> = v...v
   }
   do {
-    let _: Range<S>       = v...v // expected-error {{cannot convert value of type 'CountableClosedRange<S>' to specified type 'Range<S>'}}
-    let _: ClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'CountableRange<S>' to specified type 'ClosedRange<S>'}}
-    let _: CountableRange<S>       = v...v // expected-error {{cannot convert value of type 'CountableClosedRange<S>' to specified type 'CountableRange<S>'}}
-    let _: CountableClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'CountableRange<S>' to specified type 'CountableClosedRange<S>'}}
-    let _: CountableClosedRange<S> = v... // expected-error {{cannot convert value of type 'CountablePartialRangeFrom<S>' to specified type 'CountableClosedRange<S>'}}
+    let _: Range<S>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<S>' to specified type 'Range<S>'}}
+    let _: ClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'Range<S>' to specified type 'ClosedRange<S>'}}
+    let _: Range<S>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<S>' to specified type 'Range<S>'}}
+    let _: ClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'Range<S>' to specified type 'ClosedRange<S>'}}
+    let _: ClosedRange<S> = v... // expected-error {{cannot convert value of type 'PartialRangeFrom<S>' to specified type 'ClosedRange<S>'}}
   }
 }
 
@@ -102,7 +94,7 @@ func typeInference_commonTypes() {
   // ---------------------------------------------
   do {
     var range = 1..<10
-    expectType(CountableRange<Int>.self, &range)
+    expectType(Range<Int>.self, &range)
   }
   do {
     var range = 1..< // expected-error {{'..<' is not a postfix unary operator}}
@@ -117,15 +109,15 @@ func typeInference_commonTypes() {
   }
   do {
     var range = UInt(1)..<10
-    expectType(CountableRange<UInt>.self, &range)
+    expectType(Range<UInt>.self, &range)
   }
   do {
     var range = Int8(1)..<10
-    expectType(CountableRange<Int8>.self, &range)
+    expectType(Range<Int8>.self, &range)
   }
   do {
     var range = UInt8(1)..<10
-    expectType(CountableRange<UInt8>.self, &range)
+    expectType(Range<UInt8>.self, &range)
   }
   do {
     var range = 1.0..<10.0
@@ -166,11 +158,11 @@ func typeInference_commonTypes() {
   // ---------------------------------------------
   do {
     var range = 1...10
-    expectType(CountableClosedRange<Int>.self, &range)
+    expectType(ClosedRange<Int>.self, &range)
   }
   do {
     var range = 1...
-    expectType(CountablePartialRangeFrom<Int>.self, &range)
+    expectType(PartialRangeFrom<Int>.self, &range)
   }
   do {
     var range = ...10
@@ -178,11 +170,11 @@ func typeInference_commonTypes() {
   }
   do {
     var range = UInt(1)...10
-    expectType(CountableClosedRange<UInt>.self, &range)
+    expectType(ClosedRange<UInt>.self, &range)
   }
   do {
     var range = UInt(1)...
-    expectType(CountablePartialRangeFrom<UInt>.self, &range)
+    expectType(PartialRangeFrom<UInt>.self, &range)
   }
   do {
     var range = ...UInt(10)
@@ -190,15 +182,15 @@ func typeInference_commonTypes() {
   }
   do {
     var range = Int8(1)...10
-    expectType(CountableClosedRange<Int8>.self, &range)
+    expectType(ClosedRange<Int8>.self, &range)
   }
   do {
     var range = UInt8(1)...10
-    expectType(CountableClosedRange<UInt8>.self, &range)
+    expectType(ClosedRange<UInt8>.self, &range)
   }
   do {
     var range = UInt8(1)...
-    expectType(CountablePartialRangeFrom<UInt8>.self, &range)
+    expectType(PartialRangeFrom<UInt8>.self, &range)
   }
   do {
     var range = 1.0...10.0
@@ -250,128 +242,5 @@ func typeInference_commonTypes() {
     let s = ""
     var range = ...s.endIndex
     expectType(PartialRangeThrough<String.Index>.self, &range)
-  }
-}
-
-func disallowSubscriptingOnIntegers() {
-  // FIXME: swift-3-indexing-model: decide what to do with the following QoI.
-  // The previous implementation was imposing an ABI burden.
-
-  // The point of this test is to check that we don't allow indexing
-  // Range<Int> et al with Int outside a generic context, to prevent the
-  // problem that r[0] will be invalid when 0 is not contained int he
-  // range.
-
-  // Many of these error messages are terrible.  If the test starts
-  // failing because the error message improves, obviously, update the
-  // test!
-  do {
-    var r0 = 10..<100
-    var r1 = UInt(10)..<100
-    var r2 = 10...100
-    var r3 = UInt(10)...100
-    expectType(CountableRange<Int>.self, &r0)
-    expectType(CountableRange<UInt>.self, &r1)
-    expectType(CountableClosedRange<Int>.self, &r2)
-    expectType(CountableClosedRange<UInt>.self, &r3)
-
-    r0[0]       // expected-error {{ambiguous use of 'subscript'}}
-    r1[0]       // expected-error {{ambiguous use of 'subscript'}}
-    r2[0]       // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'Int'}}
-    // expected-note@-1 {{overloads for 'subscript'}}
-    r3[0]       // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'Int'}}
-    // expected-note@-1 {{overloads for 'subscript'}}
-
-    r0[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableRange<Int>' with an index of type 'UInt'}}
-    r1[UInt(0)] // expected-error {{ambiguous use of 'subscript'}}
-    r2[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'UInt'}}
-    // expected-note@-1 {{overloads for 'subscript' exist}}
-    r3[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'UInt'}}
-    // expected-note@-1 {{overloads for 'subscript' exist}}
-
-    r0[0..<4]   // expected-error {{ambiguous use of 'subscript'}}
-    r1[0..<4]   // expected-error {{ambiguous use of 'subscript'}}
-    r2[0..<4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<Int>'}}
-    r3[0..<4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
-    (10..<100)[0]           // expected-error {{ambiguous use of 'subscript'}}
-    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
-
-    r0[0...4]   // expected-error {{ambiguous use of 'subscript'}}
-    r1[0...4]   // expected-error {{ambiguous use of 'subscript'}}
-
-    r2[0...4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
-    r3[0...4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
-    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
-    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
-
-    r0[r0]      // expected-error {{ambiguous use of 'subscript'}}
-    r0[r1]      // expected-error {{ambiguous subscript with base type 'CountableRange<Int>' and index type 'CountableRange<UInt>'}}
-    r0[r2]      // expected-error {{ambiguous use of 'subscript'}}
-    r0[r3]      // expected-error {{ambiguous subscript with base type 'CountableRange<Int>' and index type 'CountableClosedRange<UInt>'}}
-
-    r1[r0]      // expected-error {{ambiguous subscript with base type 'CountableRange<UInt>' and index type 'CountableRange<Int>'}}
-    r1[r1]      // expected-error {{ambiguous use of 'subscript'}}
-    r1[r2]      // expected-error {{ambiguous subscript with base type 'CountableRange<UInt>' and index type 'CountableClosedRange<Int>'}}
-    r1[r3]      // expected-error {{ambiguous use of 'subscript'}}
-
-    r2[r0]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<Int>'}}
-    r2[r1]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<UInt>'}}
-    r2[r2]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
-    r2[r3]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<UInt>'}}
-
-    r3[r0]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
-    r3[r1]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<UInt>'}}
-    r3[r2]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
-    r3[r3]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<UInt>'}}
-  }
-
-  do {
-    let r0: Range = 10..<100
-    let r1: Range = UInt(10)..<100
-    let r2: ClosedRange = 10...100
-    let r3: ClosedRange = UInt(10)...100
-    r0[0]       // expected-error {{type 'Range<Int>' has no subscript members}}
-    r1[0]       // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r2[0]       // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r3[0]       // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-
-    r0[UInt(0)] // expected-error {{type 'Range<Int>' has no subscript members}}
-    r1[UInt(0)] // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r2[UInt(0)] // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r3[UInt(0)] // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-
-    r0[0..<4]   // expected-error {{type 'Range<Int>' has no subscript members}}
-    r1[0..<4]   // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r2[0..<4]   // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r3[0..<4]   // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    (10..<100)[0]           // expected-error {{ambiguous use of 'subscript'}}
-    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
-
-    r0[0...4]   // expected-error {{type 'Range<Int>' has no subscript members}}
-    r1[0...4]   // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r2[0...4]   // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r3[0...4]   // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
-    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
-
-    r0[r0]      // expected-error {{type 'Range<Int>' has no subscript members}}
-    r0[r1]      // expected-error {{type 'Range<Int>' has no subscript members}}
-    r0[r2]      // expected-error {{type 'Range<Int>' has no subscript members}}
-    r0[r3]      // expected-error {{type 'Range<Int>' has no subscript members}}
-
-    r1[r0]      // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r1[r1]      // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r1[r2]      // expected-error {{type 'Range<UInt>' has no subscript members}}
-    r1[r3]      // expected-error {{type 'Range<UInt>' has no subscript members}}
-
-    r2[r0]      // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r2[r1]      // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r2[r2]      // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-    r2[r3]      // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
-
-    r3[r0]      // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    r3[r1]      // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    r3[r2]      // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    r3[r3]      // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
   }
 }

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -9,25 +9,17 @@ func testIntSubscripting(s: String, i: Int) {
   // FIXME swift-3-indexing-model: test new overloads of ..<, ...
   _ = s[i] // expected-error{{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
   _ = s[17] // expected-error{{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
-  _ = s[i...i] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableClosedRange<Int>, see the documentation comment for discussion}}
-  _ = s[17..<20] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableRange<Int>, see the documentation comment for discussion}}
-  _ = s[17...20] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableClosedRange<Int>, see the documentation comment for discussion}}
+  _ = s[i...i] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[17..<20] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[17...20] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
 
-  _ = s[Range(i...i)] // expected-error{{subscript' is unavailable: cannot subscript String with a Range<Int>, see the documentation comment for discussion}}
-  _ = s[Range(17..<20)] // expected-error{{subscript' is unavailable: cannot subscript String with a Range<Int>, see the documentation comment for discussion}}
-  _ = s[Range(17...20)] // expected-error{{subscript' is unavailable: cannot subscript String with a Range<Int>, see the documentation comment for discussion}}
+  _ = s[Range(i...i)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17..<20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17...20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
 
-  _ = s[CountableRange(i...i)] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableRange<Int>, see the documentation comment for discussion}}
-  _ = s[CountableRange(17..<20)] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableRange<Int>, see the documentation comment for discussion}}
-  _ = s[CountableRange(17...20)] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableRange<Int>, see the documentation comment for discussion}}
-
-  _ = s[ClosedRange(i...i)] // expected-error{{subscript' is unavailable: cannot subscript String with a ClosedRange<Int>, see the documentation comment for discussion}}
-  _ = s[ClosedRange(17..<20)] // expected-error{{subscript' is unavailable: cannot subscript String with a ClosedRange<Int>, see the documentation comment for discussion}}
-  _ = s[ClosedRange(17...20)] // expected-error{{subscript' is unavailable: cannot subscript String with a ClosedRange<Int>, see the documentation comment for discussion}}
-
-  _ = s[CountableClosedRange(i...i)] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableClosedRange<Int>, see the documentation comment for discussion}}
-  _ = s[CountableClosedRange(17..<20)] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableClosedRange<Int>, see the documentation comment for discussion}}
-  _ = s[CountableClosedRange(17...20)] // expected-error{{subscript' is unavailable: cannot subscript String with a CountableClosedRange<Int>, see the documentation comment for discussion}}
+  _ = s[Range(i...i)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17..<20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17...20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
 }
 
 func testNonAmbiguousStringComparisons() {

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1033,10 +1033,10 @@ class TestData : TestDataSuper {
     }
 
     func test_rangeZoo() {
-        let r1 = Range(0..<1)
-        let r2 = CountableRange(0..<1)
+        let r1: Range = 0..<1
+        let r2: Range = 0..<1
         let r3 = ClosedRange(0..<1)
-        let r4 = CountableClosedRange(0..<1)
+        let r4 = ClosedRange(0..<1)
 
         let data = Data(bytes: [8, 1, 2, 3, 4])
         let slice1: Data = data[r1]
@@ -1349,9 +1349,9 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
     }
     
-    func test_validateMutation_replaceSubrangeCountableRange() {
+    func test_validateMutation_replaceSubrangeRange() {
         var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
         let replacement = Data(bytes: [0xFF, 0xFF])
         data.replaceSubrange(range, with: replacement)
         expectEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
@@ -1442,9 +1442,9 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
     }
     
-    func test_validateMutation_slice_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_replaceSubrangeRange() {
         var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
-        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         let replacement = Data(bytes: [0xFF, 0xFF])
         data.replaceSubrange(range, with: replacement)
         expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
@@ -1555,10 +1555,10 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_cow_replaceSubrangeCountableRange() {
+    func test_validateMutation_cow_replaceSubrangeRange() {
         var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         holdReference(data) {
-            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
             let replacement = Data(bytes: [0xFF, 0xFF])
             data.replaceSubrange(range, with: replacement)
             expectEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
@@ -1672,10 +1672,10 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_slice_cow_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_cow_replaceSubrangeRange() {
         var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
         holdReference(data) {
-            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             let replacement = Data(bytes: [0xFF, 0xFF])
             data.replaceSubrange(range, with: replacement)
             expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
@@ -1777,9 +1777,9 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
     }
     
-    func test_validateMutation_immutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_immutableBacking_replaceSubrangeRange() {
         var data = NSData(bytes: "hello world", length: 11) as Data
-        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
         let replacement = Data(bytes: [0xFF, 0xFF])
         data.replaceSubrange(range, with: replacement)
         expectEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
@@ -1885,12 +1885,12 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
     }
     
-    func test_validateMutation_slice_immutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeRange() {
         let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         var data = base.withUnsafeBufferPointer {
             return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
         }
-        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
         expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
     }
@@ -2009,10 +2009,10 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_cow_immutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeRange() {
         var data = NSData(bytes: "hello world", length: 11) as Data
         holdReference(data) {
-            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
             let replacement = Data(bytes: [0xFF, 0xFF])
             data.replaceSubrange(range, with: replacement)
             expectEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64]))
@@ -2142,13 +2142,13 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeRange() {
         let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         var data = baseBytes.withUnsafeBufferPointer {
             return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
         }
         holdReference(data) {
-            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
             expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
         }
@@ -2279,13 +2279,13 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
     }
     
-    func test_validateMutation_mutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_mutableBacking_replaceSubrangeRange() {
         let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
         var data = baseBytes.withUnsafeBufferPointer {
             return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
         }
         data.append(contentsOf: [7, 8, 9])
-        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         let replacement = Data(bytes: [0xFF, 0xFF])
         data.replaceSubrange(range, with: replacement)
         expectEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
@@ -2410,11 +2410,11 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
     }
     
-    func test_validateMutation_slice_mutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeRange() {
         var base = NSData(bytes: "hello world", length: 11) as Data
         base.append(contentsOf: [1, 2, 3, 4, 5, 6])
         var data = base[4..<9]
-        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
         expectEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
     }
@@ -2537,11 +2537,11 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_cow_mutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeRange() {
         var data = NSData(bytes: "hello world", length: 11) as Data
         data.append(contentsOf: [1, 2, 3, 4, 5, 6])
         holdReference(data) {
-            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
             let replacement = Data(bytes: [0xFF, 0xFF])
             data.replaceSubrange(range, with: replacement)
             expectEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
@@ -2695,7 +2695,7 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeRange() {
         let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
         var base = baseBytes.withUnsafeBufferPointer {
             return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
@@ -2703,7 +2703,7 @@ class TestData : TestDataSuper {
         base.append(contentsOf: [7, 8, 9])
         var data = base[4..<9]
         holdReference(data) {
-            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
             expectEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
         }
@@ -2810,9 +2810,9 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
     }
     
-    func test_validateMutation_customBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_customBacking_replaceSubrangeRange() {
         var data = Data(referencing: AllOnesImmutableData(length: 10))
-        let range: CountableRange<Int> = 1..<4
+        let range: Range<Int> = 1..<4
         data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
         expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
     }
@@ -2902,9 +2902,9 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
     }
     
-    func test_validateMutation_slice_customBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_customBacking_replaceSubrangeRange() {
         var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
-        let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
         expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
     }
@@ -3007,10 +3007,10 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_cow_customBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_cow_customBacking_replaceSubrangeRange() {
         var data = Data(referencing: AllOnesImmutableData(length: 10))
         holdReference(data) {
-            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
             expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
         }
@@ -3118,10 +3118,10 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_slice_cow_customBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeRange() {
         var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
         holdReference(data) {
-            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
             expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
         }
@@ -3223,10 +3223,10 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
     }
     
-    func test_validateMutation_customMutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_customMutableBacking_replaceSubrangeRange() {
         var data = Data(referencing: AllOnesData(length: 1))
         data.count = 10
-        let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
         expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
     }
@@ -3330,11 +3330,11 @@ class TestData : TestDataSuper {
         expectEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
     }
     
-    func test_validateMutation_slice_customMutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeRange() {
         var base = Data(referencing: AllOnesData(length: 1))
         base.count = 10
         var data = base[4..<9]
-        let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
         data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
         expectEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
     }
@@ -3448,11 +3448,11 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_cow_customMutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeRange() {
         var data = Data(referencing: AllOnesData(length: 1))
         data.count = 10
         holdReference(data) {
-            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
             expectEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0])) 
         }
@@ -3577,12 +3577,12 @@ class TestData : TestDataSuper {
         }
     }
     
-    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeCountableRange() {
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeRange() {
         var base = Data(referencing: AllOnesData(length: 1))
         base.count = 10
         var data = base[4..<9]
         holdReference(data) {
-            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
             data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
             expectEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
         }
@@ -3657,9 +3657,9 @@ class TestData : TestDataSuper {
             regionRanges.append(index..<index + buffer.count)
         }
         expectEqual(regionRanges.count, 3)
-        expectEqual(Range<Data.Index>(3..<5), regionRanges[0])
-        expectEqual(Range<Data.Index>(5..<10), regionRanges[1])
-        expectEqual(Range<Data.Index>(10..<11), regionRanges[2])
+        expectEqual(3..<5, regionRanges[0])
+        expectEqual(5..<10, regionRanges[1])
+        expectEqual(10..<11, regionRanges[2])
         expectEqual(Data(bytes: [3, 4]), regionData[0]) //fails
         expectEqual(Data(bytes: [0, 1, 2, 3, 4]), regionData[1]) //passes
         expectEqual(Data(bytes: [0]), regionData[2]) //fails
@@ -3816,7 +3816,7 @@ DataTests.test("test_validateMutation_appendSequence") { TestData().test_validat
 DataTests.test("test_validateMutation_appendContentsOf") { TestData().test_validateMutation_appendContentsOf() }
 DataTests.test("test_validateMutation_resetBytes") { TestData().test_validateMutation_resetBytes() }
 DataTests.test("test_validateMutation_replaceSubrange") { TestData().test_validateMutation_replaceSubrange() }
-DataTests.test("test_validateMutation_replaceSubrangeCountableRange") { TestData().test_validateMutation_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_replaceSubrangeRange") { TestData().test_validateMutation_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_replaceSubrangeWithBuffer") { TestData().test_validateMutation_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_replaceSubrangeWithCollection") { TestData().test_validateMutation_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_replaceSubrangeWithBytes") { TestData().test_validateMutation_replaceSubrangeWithBytes() }
@@ -3828,7 +3828,7 @@ DataTests.test("test_validateMutation_slice_appendSequence") { TestData().test_v
 DataTests.test("test_validateMutation_slice_appendContentsOf") { TestData().test_validateMutation_slice_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_resetBytes") { TestData().test_validateMutation_slice_resetBytes() }
 DataTests.test("test_validateMutation_slice_replaceSubrange") { TestData().test_validateMutation_slice_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_replaceSubrangeRange") { TestData().test_validateMutation_slice_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_replaceSubrangeWithBytes() }
@@ -3840,7 +3840,7 @@ DataTests.test("test_validateMutation_cow_appendSequence") { TestData().test_val
 DataTests.test("test_validateMutation_cow_appendContentsOf") { TestData().test_validateMutation_cow_appendContentsOf() }
 DataTests.test("test_validateMutation_cow_resetBytes") { TestData().test_validateMutation_cow_resetBytes() }
 DataTests.test("test_validateMutation_cow_replaceSubrange") { TestData().test_validateMutation_cow_replaceSubrange() }
-DataTests.test("test_validateMutation_cow_replaceSubrangeCountableRange") { TestData().test_validateMutation_cow_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_cow_replaceSubrangeRange") { TestData().test_validateMutation_cow_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_cow_replaceSubrangeWithBuffer") { TestData().test_validateMutation_cow_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_cow_replaceSubrangeWithCollection") { TestData().test_validateMutation_cow_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_cow_replaceSubrangeWithBytes") { TestData().test_validateMutation_cow_replaceSubrangeWithBytes() }
@@ -3852,7 +3852,7 @@ DataTests.test("test_validateMutation_slice_cow_appendSequence") { TestData().te
 DataTests.test("test_validateMutation_slice_cow_appendContentsOf") { TestData().test_validateMutation_slice_cow_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_cow_resetBytes") { TestData().test_validateMutation_slice_cow_resetBytes() }
 DataTests.test("test_validateMutation_slice_cow_replaceSubrange") { TestData().test_validateMutation_slice_cow_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_cow_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_cow_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_cow_replaceSubrangeRange") { TestData().test_validateMutation_slice_cow_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_cow_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_cow_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_cow_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_cow_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_cow_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_cow_replaceSubrangeWithBytes() }
@@ -3864,7 +3864,7 @@ DataTests.test("test_validateMutation_immutableBacking_appendSequence") { TestDa
 DataTests.test("test_validateMutation_immutableBacking_appendContentsOf") { TestData().test_validateMutation_immutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_immutableBacking_resetBytes") { TestData().test_validateMutation_immutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_immutableBacking_replaceSubrange") { TestData().test_validateMutation_immutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_immutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_immutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_immutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_immutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_immutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_immutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_immutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_immutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_immutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_immutableBacking_replaceSubrangeWithBytes() }
@@ -3876,7 +3876,7 @@ DataTests.test("test_validateMutation_slice_immutableBacking_appendSequence") { 
 DataTests.test("test_validateMutation_slice_immutableBacking_appendContentsOf") { TestData().test_validateMutation_slice_immutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_immutableBacking_resetBytes") { TestData().test_validateMutation_slice_immutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_immutableBacking_replaceSubrange") { TestData().test_validateMutation_slice_immutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_immutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_immutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_immutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_immutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_immutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_immutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_immutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_immutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_immutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_immutableBacking_replaceSubrangeWithBytes() }
@@ -3888,7 +3888,7 @@ DataTests.test("test_validateMutation_cow_immutableBacking_appendSequence") { Te
 DataTests.test("test_validateMutation_cow_immutableBacking_appendContentsOf") { TestData().test_validateMutation_cow_immutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_cow_immutableBacking_resetBytes") { TestData().test_validateMutation_cow_immutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_cow_immutableBacking_replaceSubrange") { TestData().test_validateMutation_cow_immutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_cow_immutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_cow_immutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_cow_immutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_cow_immutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_cow_immutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_cow_immutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_cow_immutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_cow_immutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_cow_immutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_cow_immutableBacking_replaceSubrangeWithBytes() }
@@ -3900,7 +3900,7 @@ DataTests.test("test_validateMutation_slice_cow_immutableBacking_appendSequence"
 DataTests.test("test_validateMutation_slice_cow_immutableBacking_appendContentsOf") { TestData().test_validateMutation_slice_cow_immutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_cow_immutableBacking_resetBytes") { TestData().test_validateMutation_slice_cow_immutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_cow_immutableBacking_replaceSubrange") { TestData().test_validateMutation_slice_cow_immutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_cow_immutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_cow_immutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBytes() }
@@ -3912,7 +3912,7 @@ DataTests.test("test_validateMutation_mutableBacking_appendSequence") { TestData
 DataTests.test("test_validateMutation_mutableBacking_appendContentsOf") { TestData().test_validateMutation_mutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_mutableBacking_resetBytes") { TestData().test_validateMutation_mutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_mutableBacking_replaceSubrange") { TestData().test_validateMutation_mutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_mutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_mutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_mutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_mutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_mutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_mutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_mutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_mutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_mutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_mutableBacking_replaceSubrangeWithBytes() }
@@ -3924,7 +3924,7 @@ DataTests.test("test_validateMutation_slice_mutableBacking_appendSequence") { Te
 DataTests.test("test_validateMutation_slice_mutableBacking_appendContentsOf") { TestData().test_validateMutation_slice_mutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_mutableBacking_resetBytes") { TestData().test_validateMutation_slice_mutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_mutableBacking_replaceSubrange") { TestData().test_validateMutation_slice_mutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_mutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_mutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_mutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_mutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_mutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_mutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_mutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_mutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_mutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_mutableBacking_replaceSubrangeWithBytes() }
@@ -3936,7 +3936,7 @@ DataTests.test("test_validateMutation_cow_mutableBacking_appendSequence") { Test
 DataTests.test("test_validateMutation_cow_mutableBacking_appendContentsOf") { TestData().test_validateMutation_cow_mutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_cow_mutableBacking_resetBytes") { TestData().test_validateMutation_cow_mutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_cow_mutableBacking_replaceSubrange") { TestData().test_validateMutation_cow_mutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_cow_mutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_cow_mutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_cow_mutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_cow_mutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_cow_mutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_cow_mutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_cow_mutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_cow_mutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_cow_mutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_cow_mutableBacking_replaceSubrangeWithBytes() }
@@ -3948,7 +3948,7 @@ DataTests.test("test_validateMutation_slice_cow_mutableBacking_appendSequence") 
 DataTests.test("test_validateMutation_slice_cow_mutableBacking_appendContentsOf") { TestData().test_validateMutation_slice_cow_mutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_cow_mutableBacking_resetBytes") { TestData().test_validateMutation_slice_cow_mutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_cow_mutableBacking_replaceSubrange") { TestData().test_validateMutation_slice_cow_mutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_cow_mutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_cow_mutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBytes() }
@@ -3960,7 +3960,7 @@ DataTests.test("test_validateMutation_customBacking_appendSequence") { TestData(
 DataTests.test("test_validateMutation_customBacking_appendContentsOf") { TestData().test_validateMutation_customBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_customBacking_resetBytes") { TestData().test_validateMutation_customBacking_resetBytes() }
 DataTests.test("test_validateMutation_customBacking_replaceSubrange") { TestData().test_validateMutation_customBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_customBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_customBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_customBacking_replaceSubrangeRange") { TestData().test_validateMutation_customBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_customBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_customBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_customBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_customBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_customBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_customBacking_replaceSubrangeWithBytes() }
@@ -3972,7 +3972,7 @@ DataTests.test("test_validateMutation_slice_customBacking_appendSequence") { Tes
 DataTests.test("test_validateMutation_slice_customBacking_appendContentsOf") { TestData().test_validateMutation_slice_customBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_customBacking_resetBytes") { TestData().test_validateMutation_slice_customBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_customBacking_replaceSubrange") { TestData().test_validateMutation_slice_customBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_customBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_customBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_customBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_customBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_customBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_customBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_customBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_customBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_customBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_customBacking_replaceSubrangeWithBytes() }
@@ -3984,7 +3984,7 @@ DataTests.test("test_validateMutation_cow_customBacking_appendSequence") { TestD
 DataTests.test("test_validateMutation_cow_customBacking_appendContentsOf") { TestData().test_validateMutation_cow_customBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_cow_customBacking_resetBytes") { TestData().test_validateMutation_cow_customBacking_resetBytes() }
 DataTests.test("test_validateMutation_cow_customBacking_replaceSubrange") { TestData().test_validateMutation_cow_customBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_cow_customBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_cow_customBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_cow_customBacking_replaceSubrangeRange") { TestData().test_validateMutation_cow_customBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_cow_customBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_cow_customBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_cow_customBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_cow_customBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_cow_customBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_cow_customBacking_replaceSubrangeWithBytes() }
@@ -3996,7 +3996,7 @@ DataTests.test("test_validateMutation_slice_cow_customBacking_appendSequence") {
 DataTests.test("test_validateMutation_slice_cow_customBacking_appendContentsOf") { TestData().test_validateMutation_slice_cow_customBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_cow_customBacking_resetBytes") { TestData().test_validateMutation_slice_cow_customBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_cow_customBacking_replaceSubrange") { TestData().test_validateMutation_slice_cow_customBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_cow_customBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_cow_customBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_cow_customBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_cow_customBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_cow_customBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_cow_customBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBytes() }
@@ -4008,7 +4008,7 @@ DataTests.test("test_validateMutation_customMutableBacking_appendSequence") { Te
 DataTests.test("test_validateMutation_customMutableBacking_appendContentsOf") { TestData().test_validateMutation_customMutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_customMutableBacking_resetBytes") { TestData().test_validateMutation_customMutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_customMutableBacking_replaceSubrange") { TestData().test_validateMutation_customMutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_customMutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_customMutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_customMutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_customMutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_customMutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_customMutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_customMutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_customMutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_customMutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_customMutableBacking_replaceSubrangeWithBytes() }
@@ -4020,7 +4020,7 @@ DataTests.test("test_validateMutation_slice_customMutableBacking_appendSequence"
 DataTests.test("test_validateMutation_slice_customMutableBacking_appendContentsOf") { TestData().test_validateMutation_slice_customMutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_resetBytes") { TestData().test_validateMutation_slice_customMutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_replaceSubrange") { TestData().test_validateMutation_slice_customMutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_customMutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_customMutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_customMutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_customMutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_customMutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBytes() }
@@ -4032,7 +4032,7 @@ DataTests.test("test_validateMutation_cow_customMutableBacking_appendSequence") 
 DataTests.test("test_validateMutation_cow_customMutableBacking_appendContentsOf") { TestData().test_validateMutation_cow_customMutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_cow_customMutableBacking_resetBytes") { TestData().test_validateMutation_cow_customMutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_cow_customMutableBacking_replaceSubrange") { TestData().test_validateMutation_cow_customMutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_cow_customMutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_cow_customMutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_cow_customMutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_cow_customMutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_cow_customMutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_cow_customMutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBytes() }
@@ -4044,7 +4044,7 @@ DataTests.test("test_validateMutation_slice_cow_customMutableBacking_appendSeque
 DataTests.test("test_validateMutation_slice_cow_customMutableBacking_appendContentsOf") { TestData().test_validateMutation_slice_cow_customMutableBacking_appendContentsOf() }
 DataTests.test("test_validateMutation_slice_cow_customMutableBacking_resetBytes") { TestData().test_validateMutation_slice_cow_customMutableBacking_resetBytes() }
 DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubrange") { TestData().test_validateMutation_slice_cow_customMutableBacking_replaceSubrange() }
-DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeCountableRange") { TestData().test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeCountableRange() }
+DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeRange") { TestData().test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeRange() }
 DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBuffer") { TestData().test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBuffer() }
 DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithCollection") { TestData().test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithCollection() }
 DataTests.test("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBytes") { TestData().test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBytes() }

--- a/test/stdlib/UnavailableStringAPIs.swift.gyb
+++ b/test/stdlib/UnavailableStringAPIs.swift.gyb
@@ -6,15 +6,11 @@ func test_StringSubscriptByInt(
   x: String,
   i: Int,
   r1: Range<Int>,
-  r2: ClosedRange<Int>,
-  r3: CountableRange<Int>,
-  r4: CountableClosedRange<Int>
+  r2: ClosedRange<Int>
 ) {
   _ = x[i] // expected-error {{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}} {{none}}
-  _ = x[r1] // expected-error {{'subscript' is unavailable: cannot subscript String with a Range<Int>, see the documentation comment for discussion}} {{none}}
-  _ = x[r2] // expected-error {{'subscript' is unavailable: cannot subscript String with a ClosedRange<Int>, see the documentation comment for discussion}} {{none}}
-  _ = x[r3] // expected-error {{'subscript' is unavailable: cannot subscript String with a CountableRange<Int>, see the documentation comment for discussion}} {{none}}
-  _ = x[r4] // expected-error {{'subscript' is unavailable: cannot subscript String with a CountableClosedRange<Int>, see the documentation comment for discussion}} {{none}}
+  _ = x[r1] // expected-error {{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}} {{none}}
+  _ = x[r2] // expected-error {{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}} {{none}}
 }
 
 % if _runtime == 'objc':

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -21,7 +21,7 @@ public protocol Syntax:
 internal protocol _SyntaxBase: Syntax {
   /// The type of sequence containing the indices of present children.
   typealias PresentChildIndicesSequence =
-    LazyFilterSequence<CountableRange<Int>>
+    LazyFilterSequence<Range<Int>>
     
   /// The root of the tree this node is currently in.
   var _root: SyntaxData { get } // Must be of type SyntaxData

--- a/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
@@ -1,0 +1,9 @@
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+let _ = [
+%for i in range(0, N):
+  0..<1,
+%end
+]

--- a/validation-test/Sema/type_checker_perf/slow/rdar21930551.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar21930551.swift.gyb
@@ -1,9 +1,0 @@
-// RUN: %scale-test --invert-result --begin 2 --end 6 --step 1 --select incrementScopeCounter %s
-// REQUIRES: OS=macosx
-// REQUIRES: asserts
-
-let _ = [
-%for i in range(0, N):
-  0..<1,
-%end
-]

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -7,13 +7,7 @@ import StdlibCollectionUnittest
 extension Range {
   static var _isHalfOpen: Bool { return true }
 }
-extension CountableRange {
-  static var _isHalfOpen: Bool { return true }
-}
 extension ClosedRange {
-  static var _isHalfOpen: Bool { return false }
-}
-extension CountableClosedRange {
   static var _isHalfOpen: Bool { return false }
 }
 
@@ -55,7 +49,7 @@ func generateContainsTests() -> [ContainsTest] {
       for value in bounds {
         result.append(
           ContainsTest(
-            lowerBound: lowerBound, upperBound: upperBound,
+             lowerBound: lowerBound, upperBound: upperBound,
             value: value))
       }
     }
@@ -65,8 +59,8 @@ func generateContainsTests() -> [ContainsTest] {
 
 let containsTests: [ContainsTest] = generateContainsTests()
 
-infix operator ..<* { associativity none precedence 135 }
-infix operator ...* { associativity none precedence 135 }
+infix operator ..<* : RangeFormationPrecedence
+infix operator ...* : RangeFormationPrecedence
 
 enum VariantRange {
   case halfOpen(lowerBound: Int, upperBound: Int)
@@ -319,22 +313,24 @@ let indexDistanceTests: [IndexDistanceTest] = [
 
 %{
 all_range_types = [
-   ('Range',                '..<', 'MinimalComparableValue'),
-   ('CountableRange',       '..<', 'MinimalStrideableValue'),
-   ('ClosedRange',          '...', 'MinimalComparableValue'),
-   ('CountableClosedRange', '...', 'MinimalStrideableValue'),
+   ('Range',       '..<', 'MinimalComparableValue', ''),
+   ('Range',       '..<', 'MinimalStrideableValue', 'Countable'),
+   ('ClosedRange', '...', 'MinimalComparableValue', ''),
+   ('ClosedRange', '...', 'MinimalStrideableValue', 'Countable'),
 ]
 }%
 
-% for (Self, op, Bound) in all_range_types:
-%   TestSuite = Self + 'TestSuite'
+% for (Self, op, Bound, Countable) in all_range_types:
+%     TestSuite = Countable + Self + 'TestSuite'
 
+% if Countable == '':
 // Check that the generic parameter is called 'Bound'.
 extension ${Self} where Bound : TestProtocol1 {
   var _elementIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
 }
+% end
 
 var ${TestSuite} = TestSuite("${Self}")
 
@@ -350,7 +346,7 @@ ${TestSuite}.test("init(uncheckedBounds:)")
   expectEqual(upperInt, r.upperBound.value)
 }
 
-%   for (DestinationSelf, _, _) in all_range_types:
+%   for (DestinationSelf, _, _, _) in all_range_types:
 ${TestSuite}.test("init(${DestinationSelf})/whereBoundIsStrideable")
   .forEach(in: [(0, 0), (1, 2), (10, 20), (Int.min, Int.max)]) {
   (lowerInt, upperInt) in
@@ -450,7 +446,7 @@ ${TestSuite}.test("~=/staticDispatch") {
   expectEqual(51, ${Bound}.timesLessWasCalled.value)
 }
 
-%   if 'Countable' in Self:
+%   if 'Strideable' in Bound:
 ${TestSuite}.test("contains(_:)/dynamicDispatch") {
   let start = ${Bound}(10)
   let end = ${Bound}(20)
@@ -477,7 +473,7 @@ ${TestSuite}.test("contains(_:)/semantics, ~=/semantics")
 
   // Check both static and dynamic dispatch.
   let range: ${Self}<${Bound}> = ${Bound}(test.lowerBound)${op}${Bound}(test.upperBound)
-%   if 'Countable' in Self:
+%   if 'Strideable' in Bound:
   let loggingRange = LoggingCollection(wrapping: range)
 %   else:
   let loggingRange = range
@@ -493,7 +489,7 @@ ${TestSuite}.test("contains(_:)/semantics, ~=/semantics")
   expectEqual(expected, range ~= value)
 }
 
-%   for (OtherSelf, other_op, OtherBound) in all_range_types:
+%   for (OtherSelf, other_op, OtherBound, __elementIsTestProtocol1) in all_range_types:
 ${TestSuite}.test("overlaps(${OtherSelf})/semantics")
   .forEach(in: overlapsTests) {
   (test) in
@@ -548,7 +544,7 @@ ${TestSuite}.test("count/whereBoundIsStrideable") {
   expectEqual(0, Bound.timesAdvancedWasCalled.value)
 }
 
-%   if 'Countable' in Self:
+%   if 'Strideable' in Bound:
 ${TestSuite}.test("index(after:)/semantics").forEach(in: [3, 5, 10, 12, 86]) {
   (endValue) in
   let start = ${Bound}(0)
@@ -754,22 +750,22 @@ ${TestSuite}.test("CustomStringConvertible, CustomDebugStringConvertible, Custom
 % end
 
 CountableRangeTestSuite.test("AssociatedTypes") {
-  typealias Collection = CountableRange<MinimalStrideableValue>
+  typealias Collection = Range<MinimalStrideableValue>
   expectCollectionAssociatedTypes(
     collectionType: Collection.self,
-    iteratorType: IndexingIterator<Collection>.self,
+    iteratorType: Collection.Iterator.self,
     subSequenceType: Collection.self,
     indexType: MinimalStrideableValue.self,
     indicesType: Collection.self)
 }
 
 CountableClosedRangeTestSuite.test("AssociatedTypes") {
-  typealias Collection = CountableClosedRange<MinimalStrideableValue>
+  typealias Collection = ClosedRange<MinimalStrideableValue>
   expectCollectionAssociatedTypes(
     collectionType: Collection.self,
-    iteratorType: IndexingIterator<Collection>.self,
-    subSequenceType: RandomAccessSlice<Collection>.self,
-    indexType: ClosedRangeIndex<MinimalStrideableValue>.self,
+    iteratorType: Collection.Iterator.self,
+    subSequenceType: Slice<Collection>.self,
+    indexType: Collection.Index.self,
     indicesType: DefaultIndices<Collection>.self)
 }
 
@@ -785,7 +781,7 @@ MiscTestSuite.test("map()") {
 MiscTestSuite.test("reversed()") {
   var result = (0..<10).lazy.reversed()
   typealias Expected = LazyCollection<
-    ReversedRandomAccessCollection<CountableRange<Int>>>
+    ReversedCollection<Range<Int>>>
     expectType(Expected.self, &result)
   expectEqualSequence(
     [ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 ],

--- a/validation-test/stdlib/RangeReplaceable.swift.gyb
+++ b/validation-test/stdlib/RangeReplaceable.swift.gyb
@@ -78,11 +78,11 @@ RangeReplaceableTestSuite.test("removeAll/dispatch") {
   expectCustomizable(tester, tester.log.removeAll)
 }
 
-RangeReplaceableTestSuite.test("replaceSubrange/countableRange") {
+RangeReplaceableTestSuite.test("replaceSubrange/strideableRange") {
   for test in replaceRangeTests {
     var c =
       MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.collection)
-    let rangeToReplace = test.rangeSelection.countableRange(in: c)
+    let rangeToReplace = test.rangeSelection.range(in: c)
     let newElements =
       MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.newElements)
     c.replaceSubrange(rangeToReplace, with: newElements)
@@ -93,12 +93,12 @@ RangeReplaceableTestSuite.test("replaceSubrange/countableRange") {
   }
 }
 
-RangeReplaceableTestSuite.test("replaceSubrange/countableClosedRange") {
+RangeReplaceableTestSuite.test("replaceSubrange/strideableClosedRange") {
   for test in replaceRangeTests {
     guard let closedExpected = test.closedExpected else { continue }
     var c =
       MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.collection)
-    let rangeToReplace = test.rangeSelection.countableClosedRange(in: c)
+    let rangeToReplace = test.rangeSelection.closedRange(in: c)
     let newElements =
       MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.newElements)
     c.replaceSubrange(rangeToReplace, with: newElements)
@@ -109,10 +109,10 @@ RangeReplaceableTestSuite.test("replaceSubrange/countableClosedRange") {
   }
 }
 
-% withRangeTypes = ["countableRange", "countableClosedRange"]
+% withRangeTypes = ["range", "closedRange"]
 % for rangeType in withRangeTypes:
 RangeReplaceableTestSuite.test("removeSubrange/${rangeType}") {
-%   if rangeType is "countableClosedRange":
+%   if rangeType is "closedRange":
   for test in removeRangeTests.filter({ !$0.rangeSelection.isEmpty }) {
 %   else:
   for test in removeRangeTests {

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -57,7 +57,7 @@ func expectSortedCollection(_ sortedAry: ArraySlice<Int>, _ originalAry: ArraySl
 }
 
 class OffsetCollection : MutableCollection, RandomAccessCollection {
-  typealias Indices = CountableRange<Int>
+  typealias Indices = Range<Int>
 
   let offset: Int
   var data: [Int] = []
@@ -78,12 +78,12 @@ class OffsetCollection : MutableCollection, RandomAccessCollection {
     self.forward = forward
   }
   typealias Index = Int
-  subscript(bounds: Range<Int>) -> MutableRandomAccessSlice<OffsetCollection> {
+  subscript(bounds: Range<Int>) -> Slice<OffsetCollection> {
     get {
-      return MutableRandomAccessSlice(base: self, bounds: bounds)
+      return Slice(base: self, bounds: bounds)
     }
     set {
-      for i in CountableRange(bounds) {
+      for i in bounds {
         self[i] = newValue[i]
       }
     }
@@ -130,7 +130,7 @@ Algorithm.test("${t}/sorted/${name}") {
 
 Algorithm.test("sort/CollectionsWithUnusualIndices") {
   let count = 1000
-  var ary = randArray(count)
+  let ary = randArray(count)
 
   // Check if sorting routines work well on collections with startIndex != 0.
   var offsetAry = OffsetCollection(ary, offset: 500, forward: false)

--- a/validation-test/stdlib/UnfoldSequence.swift
+++ b/validation-test/stdlib/UnfoldSequence.swift
@@ -20,7 +20,7 @@ UnfoldTests.test("sequence(state:next:)") {
   checkSequence([1, 1, 1], s1.prefix(3))
 
   let s2 = sequence(state: (1..<6).makeIterator(), next: {
-    (iter: inout CountableRange<Int>.Iterator) in
+    (iter: inout Range<Int>.Iterator) in
     iter.next()
   })
   checkSequence(1..<6, s2)

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -65,9 +65,9 @@ ${SelfName}TestSuite.test("AssociatedTypes") {
 %   else:
     iteratorType: UnsafeBufferPointerIterator<Float>.self,
 %   end
-    subSequenceType: ${'Mutable' if IsMutable else ''}RandomAccessSlice<${SelfType}>.self,
+    subSequenceType: Slice<${SelfType}>.self,
     indexType: Int.self,
-    indicesType: CountableRange<Int>.self)
+    indicesType: Range<Int>.self)
 
   expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)
 }
@@ -505,7 +505,7 @@ struct SubscriptSetTest : SubscriptTest {
   func replacementValuesSlice(
     from memory: UnsafeMutablePointer<OpaqueValue<Int>>,
     replacementValues: [OpaqueValue<Int>]
-  ) -> MutableRandomAccessSlice<UnsafeMutableBufferPointer<OpaqueValue<Int>>>
+  ) -> Slice<UnsafeMutableBufferPointer<OpaqueValue<Int>>>
   {
     for (i, value) in replacementValues.enumerated() {
       memory[i] = value
@@ -625,7 +625,7 @@ let subscriptSetTests : [SubscriptSetTest] = [
 
 %   Raw = 'Raw' if IsRaw else ''
 
-%   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
+%   for RangeName in ['range', 'closedRange']:
 ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGetTests) {
   (test) in
 
@@ -692,7 +692,7 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
 %   ('UnsafeMutableRawBufferPointer', True)
 % ]:
 %   Raw = 'Raw' if IsRaw else ''
-%   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
+%   for RangeName in ['range', 'closedRange']:
 
 UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${RangeName}/set")
 %     if not IsRaw:


### PR DESCRIPTION
Based on groundwork by @natecook1000

Not yet ready for commit until we figure out the source compatibility/migration story.

Tests are mostly fixed up, except for things like hard-coded mangled name tests.

`Range` and `ClosedRange` have custom iterator types now to work around some issues that seem to be related to conditional conformance, but might also bring some perf wins.