### PR TITLE
[4.1][stdlib] Eliminate IndexDistance

### DIFF
--- a/benchmark/single-source/StaticArray.swift
+++ b/benchmark/single-source/StaticArray.swift
@@ -58,7 +58,6 @@ struct StaticArray<
   func count() -> Int { return values.count() }
 
   typealias Index = Int
-  typealias IndexDistance = Int
   let startIndex: Int = 0
   var endIndex: Int { return count()}
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -56,11 +56,11 @@ public func check${inc.capitalize()}rementable<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection: BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
-  ${end}Index: Instances.Iterator.Element, ${TRACE}
+  ${end}Index: Instances.Element, ${TRACE}
 ) where
   Instances : Collection,
   BaseCollection : ${protocol},
-  Instances.Iterator.Element == BaseCollection.Index {
+  Instances.Element == BaseCollection.Index {
 
   checkEquatable(instances, oracle: equalityOracle, ${trace})
   for i in instances {
@@ -82,20 +82,20 @@ internal func _checkIncrementalAdvance<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection : BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
-  limit: Instances.Iterator.Element,
-  sign: BaseCollection.IndexDistance, // 1 or -1
-  next: (Instances.Iterator.Element) -> Instances.Iterator.Element,
+  limit: Instances.Element,
+  sign: Int, // 1 or -1
+  next: (Instances.Element) -> Instances.Element,
   ${TRACE}
 ) where
   Instances : Collection,
   BaseCollection : Collection,
-  Instances.Iterator.Element == BaseCollection.Index {
+  Instances.Element == BaseCollection.Index {
   for i in instances {
-    let d: BaseCollection.IndexDistance = sign > 0 ?
+    let d: Int = sign > 0 ?
       baseCollection.distance(from: i, to: limit) :
       -baseCollection.distance(from: limit, to: i)
 
-    var offset: BaseCollection.IndexDistance = 0
+    var offset: Int = 0
     for _ in 0...Int64(d * sign) {
       let j = baseCollection.index(i, offsetBy: offset)
       let k = baseCollection.index(i, offsetBy: offset + sign, limitedBy: limit) ?? limit
@@ -119,11 +119,11 @@ public func checkForwardIndex<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection: BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
-  endIndex: Instances.Iterator.Element, ${TRACE}
+  endIndex: Instances.Element, ${TRACE}
 ) where
   Instances : Collection,
   BaseCollection : Collection,
-  Instances.Iterator.Element == BaseCollection.Index {
+  Instances.Element == BaseCollection.Index {
 
   checkIncrementable(instances, of: baseCollection,
     equalityOracle: equalityOracle, endIndex: endIndex, ${trace})
@@ -144,13 +144,13 @@ public func checkBidirectionalIndex<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection: BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
-  startIndex: Instances.Iterator.Element,
-  endIndex: Instances.Iterator.Element,
+  startIndex: Instances.Element,
+  endIndex: Instances.Element,
   ${TRACE}
 ) where
   Instances: Collection,
   BaseCollection : BidirectionalCollection,
-  Instances.Iterator.Element == BaseCollection.Index {
+  Instances.Element == BaseCollection.Index {
 
   checkForwardIndex(instances, of: baseCollection,
     equalityOracle: equalityOracle, endIndex: endIndex)
@@ -176,9 +176,9 @@ public func checkRandomAccessIndex<Instances, Distances, BaseCollection>(
   _ instances: Instances, distances: Distances,
   of baseCollection: BaseCollection,
   distanceOracle:
-    (Instances.Index, Instances.Index) -> Distances.Iterator.Element,
+    (Instances.Index, Instances.Index) -> Distances.Element,
   advanceOracle:
-    (Instances.Index, Distances.Index) -> Instances.Iterator.Element,
+    (Instances.Index, Distances.Index) -> Instances.Element,
   startIndex: Instances.Iterator.Element,
   endIndex: Instances.Iterator.Element,
   ${TRACE}
@@ -186,8 +186,8 @@ public func checkRandomAccessIndex<Instances, Distances, BaseCollection>(
   Instances : Collection,
   Distances : Collection,
   BaseCollection : RandomAccessCollection,
-  Instances.Iterator.Element == BaseCollection.Index,
-  Distances.Iterator.Element == BaseCollection.IndexDistance {
+  Instances.Element == BaseCollection.Index,
+  Distances.Element == Int {
 
   checkBidirectionalIndex(instances, of: baseCollection,
     equalityOracle: { distanceOracle($0, $1) == 0 },
@@ -207,16 +207,16 @@ public func checkAdvancesAndDistances<Instances, Distances, BaseCollection>(
   _ instances: Instances, distances: Distances,
   of baseCollection: BaseCollection,
   distanceOracle:
-    (Instances.Index, Instances.Index) -> Distances.Iterator.Element,
+    (Instances.Index, Instances.Index) -> Distances.Element,
   advanceOracle:
-    (Instances.Index, Distances.Index) -> Instances.Iterator.Element,
+    (Instances.Index, Distances.Index) -> Instances.Element,
   ${TRACE}
 ) where
   Instances : Collection,
   Distances : Collection,
   BaseCollection : Collection,
-  Instances.Iterator.Element == BaseCollection.Index,
-  Distances.Iterator.Element == BaseCollection.IndexDistance {
+  Instances.Element == BaseCollection.Index,
+  Distances.Element == Int {
 
   checkComparable(
     instances,
@@ -246,7 +246,7 @@ public func checkAdvancesAndDistances<Instances, Distances, BaseCollection>(
 // picked up when the caller passes a literal), and another that
 // accepts any appropriate Collection type.
 % for genericParam, Element, Expected in [
-%   ('Expected: Collection',  'Expected.Iterator.Element',  'Expected'),
+%   ('Expected: Collection',  'Expected.Element',  'Expected'),
 %   ('Element'             ,  'Element'                  ,  'Array<Element>')]:
 
 // Top-level check for Collection instances. Alias for checkForwardCollection.
@@ -257,7 +257,7 @@ public func checkCollection<${genericParam}, C : Collection>(
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) where C.Iterator.Element == ${Element} {
+) where C.Element == ${Element} {
 
   checkForwardCollection(expected, collection, message(),
     stackTrace: stackTrace, showFrame: showFrame, file: file, line: line,
@@ -276,7 +276,7 @@ public func check${Traversal}Collection<
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
 ) where
-  C.Iterator.Element == ${Element},
+  C.Element == ${Element},
   ${Element} : Equatable {
 
   check${Traversal}Collection(
@@ -296,7 +296,7 @@ public func check${Traversal}Collection<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
-  C.Iterator.Element == ${Element} {
+  C.Element == ${Element} {
 
   checkOneLevelOf${Traversal}Collection(expected, collection, ${trace},
     resiliencyChecks: resiliencyChecks, sameValue: sameValue)
@@ -324,7 +324,7 @@ public func checkOneLevelOf${Traversal}Collection<
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) where C.Iterator.Element == ${Element} {
+) where C.Element == ${Element} {
 
   // A `Collection` is a multi-pass `Sequence`.
   for _ in 0..<3 {
@@ -370,7 +370,7 @@ public func checkOneLevelOf${Traversal}Collection<
 
 %     else:
 %       assert(Traversal == 'RandomAccess')
-  typealias Distance = C.IndexDistance
+  typealias Distance = Int
 
   let count: Distance  = collection.count
   let offset0 = min(5, count)
@@ -501,7 +501,7 @@ ${genericParam}, S : ${TraversalCollection}
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
-  S.Iterator.Element == ${Element} {
+  S.Element == ${Element} {
 
   let expectedArray = Array(expected)
 
@@ -564,14 +564,14 @@ public func checkRangeReplaceable<C, N>(
 ) where
   C : RangeReplaceableCollection,
   N : Collection,
-  C.Iterator.Element : Equatable,
-  C.Iterator.Element == N.Iterator.Element {
+  C.Element : Equatable,
+  C.Element == N.Element {
 
   typealias A = C
 
   // First make an independent copy of the array that we can use for
   // comparison later.
-  let source = Array<A.Iterator.Element>(makeCollection())
+  let source = Array<A.Element>(makeCollection())
 
   for (ix, i) in source.indices.enumerated() {
     for (jx_, j) in (i..<source.endIndex).enumerated() {

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -1198,10 +1198,10 @@ extension TestSuite {
 
     // FIXME: swift-3-indexing-model -
     //   enhance the following for negative direction?
-    //          advance(i: Index, by n: IndexDistance) -> Index
+    //          advance(i: Index, by n: Int) -> Index
     //          advance(
-    //             i: Index, by n: IndexDistance, limitedBy: Index) -> Index
-    //          distance(from start: Index, to end: Index) -> IndexDistance
+    //             i: Index, by n: Int, limitedBy: Index) -> Index
+    //          distance(from start: Index, to end: Index) -> Int
 
     //===------------------------------------------------------------------===//
     // last

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -414,9 +414,7 @@ public struct ${Self}<
     return base.isEmpty
   }
 
-  public typealias IndexDistance = Base.IndexDistance
-
-  public var count: IndexDistance {
+  public var count: Int {
     Log.count[selfType] += 1
     return base.count
   }
@@ -433,19 +431,19 @@ public struct ${Self}<
     return base.first
   }
 
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     Log.advance[selfType] += 1
     return base.index(i, offsetBy: n)
   }
 
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     Log.advanceLimit[selfType] += 1
     return base.index(i, offsetBy: n, limitedBy: limit)
   }
 
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     Log.distance[selfType] += 1
     return base.distance(from: start, to: end)
   }
@@ -558,7 +556,7 @@ public struct ${Self}<
     base.replaceSubrange(bounds, with: newElements)
   }
 
-  public mutating func reserveCapacity(_ n: IndexDistance) {
+  public mutating func reserveCapacity(_ n: Int) {
     Log.reserveCapacity[selfType] += 1
     base.reserveCapacity(n)
   }
@@ -601,8 +599,8 @@ public struct ${Self}<
   public typealias Log = MutableCollectionLog
 
   public typealias SubSequence = Base.SubSequence
-
   public typealias Iterator = Base.Iterator
+  public typealias Element = Base.Element
 
   public init(wrapping base: Base) {
     self.base = base
@@ -613,6 +611,7 @@ public struct ${Self}<
   }
 
   public typealias Index = Base.Index
+  public typealias Indices = Base.Indices
 
   public var startIndex: Index {
     return base.startIndex
@@ -621,8 +620,12 @@ public struct ${Self}<
   public var endIndex: Index {
     return base.endIndex
   }
-
-  public subscript(position: Index) -> Base.Iterator.Element {
+  
+  public var indices: Indices {
+    return base.indices
+  }
+  
+  public subscript(position: Index) -> Element {
     get {
       return base[position]
     }
@@ -650,11 +653,11 @@ public struct ${Self}<
   }
 %     end
 
-  public func index(_ i: Index, offsetBy n: Base.IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return base.index(i, offsetBy: n)
   }
 
-  public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return base.distance(from: start, to: end)
   }
 

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -497,13 +497,6 @@ extension MinimalStrideableIndex : Strideable {
 // Minimal***[Mutable]?Collection
 //===----------------------------------------------------------------------===//
 
-/*
-FIXME: swift-3-indexing-model: generate three variants, with Int, Int8 and
-Int64 distances.
-
-  public typealias Distance = {Distance}
-*/
-
 % for Traversal in TRAVERSALS:
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
@@ -546,10 +539,6 @@ public struct ${Self}<T> : ${SelfProtocols} {
     }
   }
 
-%     if StrideableIndex:
-  public typealias Indices = CountableRange<${Index}>
-%     end
-
 %     if RangeReplaceable:
   public init() {
     self.underestimatedCount = 0
@@ -574,7 +563,6 @@ public struct ${Self}<T> : ${SelfProtocols} {
   }
 
   public typealias Index = ${Index}
-  public typealias IndexDistance = Int
 
   internal func _index(forPosition i: Int) -> ${Index} {
     return ${Index}(
@@ -603,6 +591,13 @@ public struct ${Self}<T> : ${SelfProtocols} {
     timesEndIndexCalled.value += 1
     return _uncheckedIndex(forPosition: _elements.endIndex)
   }
+
+%     if StrideableIndex:
+  public typealias Indices = CountableRange<${Index}>
+%     elif Traversal == 'RandomAccess':
+  // FIXME: this shouldn't be necessary, should come by default
+  public typealias Indices = DefaultRandomAccessIndices<${Self}<T>>
+%     end
 
   public func _failEarlyRangeCheck(
     _ index: ${Index},
@@ -661,7 +656,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
 %     end
 
   public func distance(from start: ${Index}, to end: ${Index})
-    -> IndexDistance {
+    -> Int {
 %     if Traversal == 'Forward':
     _precondition(start <= end,
       "Only BidirectionalCollections can have end come before start")
@@ -676,7 +671,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
     return end.position - start.position
   }
 
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
 %     if Traversal == 'Forward':
     _precondition(n >= 0,
       "Only BidirectionalCollections can be advanced by a negative amount")
@@ -871,10 +866,12 @@ public struct ${Self}<Element> : ${SelfProtocols} {
   public typealias Base = ${Base}<Element>
   public typealias Iterator = MinimalIterator<Element>
   public typealias Index = ${Index}
-  public typealias IndexDistance = Int
 
 %   if StrideableIndex:
   public typealias Indices = CountableRange<${Index}>
+%  elif Traversal == 'RandomAccess':
+  // FIXME: this shouldn't be necessary, should come by default
+  public typealias Indices = DefaultRandomAccessIndices<${Self}<Element>>
 %   end
 
 %   if Mutable or RangeReplaceable:
@@ -934,11 +931,11 @@ public struct ${Self}<Element> : ${SelfProtocols} {
 
 %       if Traversal == 'RandomAccess':
   public func distance(from start: ${Index}, to end: ${Index})
-    -> IndexDistance {
+    -> Int {
     return base.distance(from: start, to: end)
   }
 
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return base.index(i, offsetBy: n)
   }
 %       end

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -415,7 +415,6 @@ public func expectCollectionAssociatedTypes<X : Collection>(
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type,
   indexType: X.Index.Type,
-  indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
 ) {}
 
@@ -426,7 +425,6 @@ public func expectBidirectionalCollectionAssociatedTypes<X : BidirectionalCollec
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type,
   indexType: X.Index.Type,
-  indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
 ) {}
 
@@ -437,7 +435,6 @@ public func expectRandomAccessCollectionAssociatedTypes<X : RandomAccessCollecti
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type,
   indexType: X.Index.Type,
-  indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
 ) {}
 
@@ -2433,7 +2430,7 @@ public func expectEqualsUnordered<
   T : Strideable
 >(
   _ expected: Range<T>, _ actual: [T], ${TRACE}
-) where T.Stride : SignedInteger {
+) where T.Stride: SignedInteger {
   expectEqualsUnordered(
     CountableRange(uncheckedBounds:
       (lower: expected.lowerBound, upper: expected.upperBound)),

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -147,7 +147,7 @@ extension BidirectionalCollection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     if n >= 0 {
       return _advanceForward(i, by: n)
     }
@@ -160,7 +160,7 @@ extension BidirectionalCollection {
 
   @_inlineable // FIXME(sil-serialize-all)
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     if n >= 0 {
       return _advanceForward(i, by: n, limitedBy: limit)
@@ -176,19 +176,19 @@ extension BidirectionalCollection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     var start = start
-    var count: IndexDistance = 0
+    var count = 0
 
     if start < end {
       while start != end {
-        count += 1 as IndexDistance
+        count += 1
         formIndex(after: &start)
       }
     }
     else if start > end {
       while start != end {
-        count -= 1 as IndexDistance
+        count -= 1
         formIndex(before: &start)
       }
     }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -173,7 +173,6 @@ extension CountableClosedRange: RandomAccessCollection {
 
   /// A type that represents a position in the range.
   public typealias Index = ClosedRangeIndex<Bound>
-  public typealias IndexDistance = Bound.Stride
 
   /// The position of the first element in the range.
   @_inlineable
@@ -213,12 +212,12 @@ extension CountableClosedRange: RandomAccessCollection {
   }
 
   @_inlineable
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     switch i._value {
     case .inRange(let x):
       let d = x.distance(to: upperBound)
       if n <= d {
-        let newPosition = x.advanced(by: n)
+        let newPosition = x.advanced(by: numericCast(n))
         _precondition(newPosition >= lowerBound,
           "Advancing past start index")
         return ClosedRangeIndex(newPosition)
@@ -230,24 +229,24 @@ extension CountableClosedRange: RandomAccessCollection {
         return i
       } 
       if n < 0 {
-        return index(ClosedRangeIndex(upperBound), offsetBy: (n + 1))
+        return index(ClosedRangeIndex(upperBound), offsetBy: numericCast(n + 1))
       }
       _preconditionFailure("Advancing past end index")
     }
   }
 
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     switch (start._value, end._value) {
     case let (.inRange(left), .inRange(right)):
       // in range <--> in range
-      return left.distance(to: right)
+      return numericCast(left.distance(to: right))
     case let (.inRange(left), .pastEnd):
       // in range --> end
-      return 1 + left.distance(to: upperBound)
+      return numericCast(1 + left.distance(to: upperBound))
     case let (.pastEnd, .inRange(right)):
       // in range <-- end
-      return upperBound.distance(to: right) - 1
+      return numericCast(upperBound.distance(to: right) - 1)
     case (.pastEnd, .pastEnd):
       // end <--> end
       return 0

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -358,7 +358,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// "past the end" position that's not valid for use as a subscript
   /// argument.
   associatedtype Index : Comparable
- 
+
   /// The position of the first element in a nonempty collection.
   ///
   /// If the collection is empty, `startIndex` is equal to `endIndex`.
@@ -381,10 +381,6 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// If the collection is empty, `endIndex` is equal to `startIndex`.
   var endIndex: Index { get }
 
-  /// A type that represents the number of steps between a pair of
-  /// indices.
-  associatedtype IndexDistance : SignedInteger = Int
-
   /// A type that provides the collection's iteration interface and
   /// encapsulates its iteration state.
   ///
@@ -405,9 +401,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// This associated type appears as a requirement in the `Sequence`
   /// protocol, but it is restated here with stricter constraints. In a
   /// collection, the subsequence should also conform to `Collection`.
-  associatedtype SubSequence = Slice<Self>
-    where SubSequence.Index == Index,
-          SubSequence.IndexDistance == IndexDistance
+  associatedtype SubSequence = Slice<Self> where SubSequence.Index == Index
 
   /// Accesses the element at the specified position.
   ///
@@ -612,7 +606,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
   ///   of the collection.
-  var count: IndexDistance { get }
+  var count: Int { get }
   
   // The following requirement enables dispatching for index(of:) when
   // the element type is Equatable.
@@ -659,7 +653,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  func index(_ i: Index, offsetBy n: IndexDistance) -> Index
+  func index(_ i: Index, offsetBy n: Int) -> Index
 
   /// Returns an index that is the specified distance from the given index,
   /// unless that distance is beyond a given limiting index.
@@ -702,7 +696,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
   func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index?
 
   /// Returns the distance between two indices.
@@ -721,7 +715,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
-  func distance(from start: Index, to end: Index) -> IndexDistance
+  func distance(from start: Index, to end: Index) -> Int
 
   /// Performs a range check in O(1), or a no-op when a range check is not
   /// implementable in O(1).
@@ -782,6 +776,9 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   func formIndex(after i: inout Index)
+
+  @available(swift, deprecated, message: "all index distances are now of type Int")
+  typealias IndexDistance = Int
 }
 
 /// Default implementation for forward collections.
@@ -861,7 +858,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
   @_inlineable
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return self._advanceForward(i, by: n)
   }
 
@@ -907,7 +904,7 @@ extension Collection {
   ///   value of `n`.
   @_inlineable
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     return self._advanceForward(i, by: n, limitedBy: limit)
   }
@@ -926,7 +923,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
   @_inlineable
-  public func formIndex(_ i: inout Index, offsetBy n: IndexDistance) {
+  public func formIndex(_ i: inout Index, offsetBy n: Int) {
     i = index(i, offsetBy: n)
   }
 
@@ -953,7 +950,7 @@ extension Collection {
   ///   value of `n`.
   @_inlineable
   public func formIndex(
-    _ i: inout Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: inout Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Bool {
     if let advancedIndex = index(i, offsetBy: n, limitedBy: limit) {
       i = advancedIndex
@@ -980,12 +977,12 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     _precondition(start <= end,
       "Only BidirectionalCollections can have end come before start")
 
     var start = start
-    var count: IndexDistance = 0
+    var count = 0
     while start != end {
       count = count + 1
       formIndex(after: &start)
@@ -997,7 +994,7 @@ extension Collection {
   @_inlineable
   @_versioned
   @inline(__always)
-  internal func _advanceForward(_ i: Index, by n: IndexDistance) -> Index {
+  internal func _advanceForward(_ i: Index, by n: Int) -> Index {
     _precondition(n >= 0,
       "Only BidirectionalCollections can be advanced by a negative amount")
 
@@ -1013,7 +1010,7 @@ extension Collection {
   @_versioned
   @inline(__always)
   internal func _advanceForward(
-    _ i: Index, by n: IndexDistance, limitedBy limit: Index
+    _ i: Index, by n: Int, limitedBy limit: Index
   ) -> Index? {
     _precondition(n >= 0,
       "Only BidirectionalCollections can be advanced by a negative amount")
@@ -1167,7 +1164,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
   ///   of the collection.
   @_inlineable
-  public var count: IndexDistance {
+  public var count: Int {
     return distance(from: startIndex, to: endIndex)
   }
 
@@ -1701,9 +1698,30 @@ extension Collection {
   // guarantees of Swift 3, but it cannot due to a bug.
   @available(*, unavailable, renamed: "Iterator")
   public typealias Generator = Iterator
-}
 
-extension Collection {
   @available(swift, deprecated: 3.2, renamed: "Element")
   public typealias _Element = Element
+
+  @available(*, deprecated, message: "all index distances are now of type Int")
+  public func index<T: BinaryInteger>(_ i: Index, offsetBy n: T) -> Index {
+    return index(i, offsetBy: Int(n))
+  }
+  /* FIXME: crashes the compiler
+  @available(*, deprecated, message: "all index distances are now of type Int")
+  public func formIndex<T: BinaryInteger>(_ i: Index, offsetBy n: T) {
+    return formIndex(i, offsetBy: Int(n))
+  }
+  @available(*, deprecated, message: "all index distances are now of type Int")
+  public func index<T: BinaryInteger>(_ i: Index, offsetBy n: T, limitedBy limit: Index) -> Index {
+    return index(i, offsetBy: Int(n), limitedBy: limit)
+  }
+  */
+  @available(*, deprecated, message: "all index distances are now of type Int")
+  public func formIndex<T: BinaryInteger>(_ i: inout Index, offsetBy n: T, limitedBy limit: Index) -> Bool {
+    return formIndex(&i, offsetBy: Int(n), limitedBy: limit)
+  }
+  @available(*, deprecated, message: "all index distances are now of type Int")
+  public func distance<T: BinaryInteger>(from start: Index, to end: Index) -> T {
+    return numericCast(distance(from: start, to: end) as Int)
+  }
 }

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -51,7 +51,6 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = Int
-  public typealias IndexDistance = Int
   public typealias Indices = CountableRange<Int>
   public typealias SubSequence = EmptyCollection<Element>
 
@@ -124,14 +123,14 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     _debugPrecondition(i == startIndex && n == 0, "Index out of range")
     return i
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     _debugPrecondition(i == startIndex && limit == startIndex,
       "Index out of range")
@@ -140,7 +139,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
 
   /// The distance between two indexes (always zero).
   @_inlineable // FIXME(sil-serialize-all)
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     _debugPrecondition(start == 0, "From must be startIndex (or endIndex)")
     _debugPrecondition(end == 0, "To must be endIndex (or startIndex)")
     return 0

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -331,7 +331,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @_versioned
   @_inlineable
   internal func _index(
-    _ i: _AnyIndexBox, offsetBy n: Int64
+    _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
     _abstract()
   }
@@ -339,21 +339,21 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @_versioned
   @_inlineable
   internal func _index(
-    _ i: _AnyIndexBox, offsetBy n: Int64, limitedBy limit: _AnyIndexBox
+    _ i: _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
     _abstract()
   }
 
   @_versioned
   @_inlineable
-  internal func _formIndex(_ i: inout _AnyIndexBox, offsetBy n: Int64) {
+  internal func _formIndex(_ i: inout _AnyIndexBox, offsetBy n: Int) {
     _abstract()
   }
 
   @_versioned
   @_inlineable
   internal func _formIndex(
-    _ i: inout _AnyIndexBox, offsetBy n: Int64, limitedBy limit: _AnyIndexBox
+    _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     _abstract()
   }
@@ -362,7 +362,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @_inlineable
   internal func _distance(
     from start: _AnyIndexBox, to end: _AnyIndexBox
-  ) -> Int64 {
+  ) -> Int {
     _abstract()
   }
 
@@ -381,7 +381,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
-  internal var _count: Int64 { _abstract() }
+  internal var _count: Int { _abstract() }
 
   // TODO: swift-3-indexing-model: forward the following methods.
   /*
@@ -628,7 +628,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_versioned
   @_inlineable
   internal override func _index(
-    _ i: _AnyIndexBox, offsetBy n: Int64
+    _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
   }
@@ -637,7 +637,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_inlineable
   internal override func _index(
     _ i: _AnyIndexBox,
-    offsetBy n: Int64,
+    offsetBy n: Int,
     limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
     return _base.index(
@@ -650,7 +650,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_versioned
   @_inlineable
   internal override func _formIndex(
-    _ i: inout _AnyIndexBox, offsetBy n: Int64
+    _ i: inout _AnyIndexBox, offsetBy n: Int
   ) {
     if let box = i as? _IndexBox<S.Index> {
       return _base.formIndex(&box._base, offsetBy: numericCast(n))
@@ -661,7 +661,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_versioned
   @_inlineable
   internal override func _formIndex(
-    _ i: inout _AnyIndexBox, offsetBy n: Int64, limitedBy limit: _AnyIndexBox
+    _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     if let box = i as? _IndexBox<S.Index> {
       return _base.formIndex(
@@ -677,13 +677,13 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   internal override func _distance(
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
-  ) -> Int64 {
+  ) -> Int {
     return numericCast(_base.distance(from: _unbox(start), to: _unbox(end)))
   }
 
   @_versioned
   @_inlineable
-  internal override var _count: Int64 {
+  internal override var _count: Int {
     return numericCast(_base.count)
   }
 
@@ -1045,7 +1045,6 @@ extension ${Self}: ${SelfProtocol} {
 
   public typealias Iterator = AnyIterator<Element>
   public typealias Index = AnyIndex
-  public typealias IndexDistance = Int64
   public typealias SubSequence = ${Self}<Element> 
 
 %   for SubTraversal in TRAVERSALS[ti:]:
@@ -1152,20 +1151,20 @@ extension ${Self}: ${SelfProtocol} {
   }
 
   @_inlineable
-  public func index(_ i: Index, offsetBy n: Int64) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return AnyIndex(_box: _box._index(i._box, offsetBy: n))
   }
 
   @_inlineable
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     return _box._index(i._box, offsetBy: n, limitedBy: limit._box)
       .map { AnyIndex(_box:$0) }
   }
 
   @_inlineable
-  public func formIndex(_ i: inout Index, offsetBy n: IndexDistance) {
+  public func formIndex(_ i: inout Index, offsetBy n: Int) {
     if _isUnique(&i._box) {
       return _box._formIndex(&i._box, offsetBy: n)
     } else {
@@ -1176,7 +1175,7 @@ extension ${Self}: ${SelfProtocol} {
   @_inlineable
   public func formIndex(
     _ i: inout Index,
-    offsetBy n: IndexDistance,
+    offsetBy n: Int,
     limitedBy limit: Index
   ) -> Bool {
     if _isUnique(&i._box) {
@@ -1191,7 +1190,7 @@ extension ${Self}: ${SelfProtocol} {
   }
 
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return _box._distance(from: start._box, to: end._box)
   }
 
@@ -1205,7 +1204,7 @@ extension ${Self}: ${SelfProtocol} {
 % end
   /// - Complexity: ${'O(1)' if Traversal == 'RandomAccess' else 'O(*n*)'}
   @_inlineable
-  public var count: IndexDistance {
+  public var count: Int {
     return _box._count
   }
 

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -151,7 +151,6 @@ public struct ${Self}<
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = Base.Index
 
-  public typealias IndexDistance = Base.IndexDistance
 
   /// Creates an instance containing the elements of `base` that
   /// satisfy `isIncluded`.

--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -42,7 +42,6 @@ internal struct _FixedArray${N}<T> {
 
 extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
   internal typealias Index = Int
-  internal typealias IndexDistance = Int
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
@@ -57,7 +56,7 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
   }
 
   @_versioned // FIXME(sil-serialize-all)
-  internal var count : IndexDistance { return _FixedArray${N}._arraySize }
+  internal var count : Int { return _FixedArray${N}._arraySize }
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -263,8 +263,6 @@ public struct ${Collection}<Base> : ${collectionForTraversal(traversal)}
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = ${Index}<Base>
 
-  public typealias IndexDistance = Base.IndexDistance
-
   /// Creates a flattened view of `base`.
   @_inlineable // FIXME(sil-serialize-all)
   public init(_ base: Base) {

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -39,8 +39,7 @@ extension DefaultIndices: Collection {
   public typealias Element = Elements.Index
   public typealias Indices = DefaultIndices<Elements>
   public typealias SubSequence = DefaultIndices<Elements>
-	public typealias IndexDistance = Elements.IndexDistance
-	public typealias Iterator = IndexingIterator<DefaultIndices<Elements>>
+  public typealias Iterator = IndexingIterator<DefaultIndices<Elements>>
 
   @_inlineable
   public var startIndex: Index {

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2898,6 +2898,9 @@ public struct ${Self}
   : FixedWidthInteger, ${Unsigned}Integer,
     _ExpressibleByBuiltinIntegerLiteral {
 
+  public typealias IntegerLiteralType = ${Self}
+
+
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public init(_builtinIntegerLiteral x: _MaxBuiltinIntegerType) {

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -182,7 +182,7 @@ extension ${Self} : ${TraversalCollection} {
   /// - Complexity: O(1) if `Self` conforms to `RandomAccessCollection`;
   ///   O(*n*) otherwise.
   @_inlineable
-  public var count: Base.IndexDistance {
+  public var count: Int {
     return _base.count
   }
 
@@ -208,21 +208,21 @@ extension ${Self} : ${TraversalCollection} {
 
   // TODO: swift-3-indexing-model - add docs
   @_inlineable
-  public func index(_ i: Index, offsetBy n: Base.IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return _base.index(i, offsetBy: n)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @_inlineable
   public func index(
-    _ i: Index, offsetBy n: Base.IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     return _base.index(i, offsetBy: n, limitedBy: limit)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return _base.distance(from:start, to: end)
   }
 

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -155,8 +155,6 @@ public struct ${Self}<
     return SubSequence(_base: _base[bounds], transform: _transform)
   }
 
-  public typealias IndexDistance = Base.IndexDistance
-
   public typealias Indices = Base.Indices
 
   @_inlineable
@@ -178,7 +176,7 @@ public struct ${Self}<
   /// - Complexity: O(1) if `Index` conforms to `RandomAccessIndex`; O(*n*)
   ///   otherwise.
   @_inlineable
-  public var count: Base.IndexDistance {
+  public var count: Int {
     return _base.count
   }
 
@@ -191,19 +189,19 @@ public struct ${Self}<
 %   end
 
   @_inlineable
-  public func index(_ i: Index, offsetBy n: Base.IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return _base.index(i, offsetBy: n)
   }
 
   @_inlineable
   public func index(
-    _ i: Index, offsetBy n: Base.IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     return _base.index(i, offsetBy: n, limitedBy: limit)
   }
 
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return _base.distance(from: start, to: end)
   }
 
@@ -282,7 +280,7 @@ extension LazyMapCollection {
   public static func + <
     Other : LazyCollectionProtocol
   >(lhs: LazyMapCollection, rhs: Other) -> [Element]
-  where Other.Element == Element, Other.IndexDistance == IndexDistance {
+  where Other.Element == Element {
     var result: [Element] = []
     result.reserveCapacity(numericCast(lhs.count + rhs.count))
     result.append(contentsOf: lhs)

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -485,7 +485,7 @@ extension Mirror {
       if case let label as String = e {
         position = children.index { $0.label == label } ?? children.endIndex
       }
-      else if let offset = (e as? Int).map({ Int64($0) }) ?? (e as? Int64) {
+      else if let offset = e as? Int {
         position = children.index(children.startIndex,
           offsetBy: offset,
           limitedBy: children.endIndex) ?? children.endIndex

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -155,7 +155,7 @@ extension RandomAccessCollection {
   /// - Complexity: O(1)
   @_inlineable
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     // FIXME: swift-3-indexing-model: tests.
     let l = distance(from: i, to: limit)
@@ -168,7 +168,7 @@ extension RandomAccessCollection {
 
 extension RandomAccessCollection
 where Index : Strideable, 
-      Index.Stride == IndexDistance,
+      Index.Stride == Int,
       Indices == CountableRange<Index> {
 
   /// The indices that are valid for subscripting the collection, in ascending

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -178,7 +178,6 @@ extension CountableRange: RandomAccessCollection {
 
   /// A type that represents a position in the range.
   public typealias Index = Element
-  public typealias IndexDistance = Bound.Stride
   public typealias Indices = CountableRange<Bound>
   public typealias SubSequence = CountableRange<Bound>
 
@@ -208,16 +207,16 @@ extension CountableRange: RandomAccessCollection {
   }
 
   @_inlineable
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    let r = i.advanced(by: n)
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    let r = i.advanced(by: numericCast(n))
     _precondition(r >= lowerBound)
     _precondition(r <= upperBound)
     return r
   }
 
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
-    return start.distance(to: end)
+  public func distance(from start: Index, to end: Index) -> Int {
+    return numericCast(start.distance(to: end))
   }
 
   /// Accesses the subsequence bounded by the given range.

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -132,7 +132,7 @@ where SubSequence: RangeReplaceableCollection
   /// less storage than requested, or to take no action at all.
   ///
   /// - Parameter n: The requested number of elements to store.
-  mutating func reserveCapacity(_ n: IndexDistance)
+  mutating func reserveCapacity(_ n: Int)
 
   //===--- Derivable Requirements -----------------------------------------===//
 
@@ -648,7 +648,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Parameter n: The requested number of elements to store.
   @_inlineable
-  public mutating func reserveCapacity(_ n: IndexDistance) {}
+  public mutating func reserveCapacity(_ n: Int) {}
 }
 
 extension RangeReplaceableCollection where SubSequence == Self {

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -184,7 +184,6 @@ extension ReversedCollection: BidirectionalCollection {
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = ReversedIndex<Base>
-  public typealias IndexDistance = Base.IndexDistance
 
   @_fixed_layout
   public struct Iterator : IteratorProtocol, Sequence {
@@ -237,14 +236,14 @@ extension ReversedCollection: BidirectionalCollection {
   }
 
   @_inlineable
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
     return ReversedIndex(_base.index(i.base, offsetBy: -n))
   }
 
   @_inlineable
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
     return _base.index(i.base, offsetBy: -n, limitedBy: limit.base)
@@ -252,7 +251,7 @@ extension ReversedCollection: BidirectionalCollection {
   }
 
   @_inlineable
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return _base.distance(from: end.base, to: start.base)
   }
 

--- a/stdlib/public/core/SentinelCollection.swift
+++ b/stdlib/public/core/SentinelCollection.swift
@@ -64,8 +64,6 @@ where IsSentinel.Input == Base.Iterator.Element {
   @_versioned // FIXME(sil-serialize-all)
   internal var _base : Base
   
-  internal typealias IndexDistance = Base.IndexDistance
-
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal func makeIterator() -> _SentinelIterator<Base.Iterator, IsSentinel> {

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -140,7 +140,6 @@ public struct Slice<Base: Collection> {
 extension Slice: Collection {
   public typealias Index = Base.Index
   public typealias Indices = Base.Indices
-  public typealias IndexDistance = Base.IndexDistance  
   public typealias Element = Base.Element
   public typealias SubSequence = Slice<Base>
   public typealias Iterator = IndexingIterator<Slice<Base>>
@@ -188,21 +187,21 @@ extension Slice: Collection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(i, offsetBy: n)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(i, offsetBy: n, limitedBy: limit)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     // FIXME: swift-3-indexing-model: range check.
     return _base.distance(from: start, to: end)
   }
@@ -292,12 +291,12 @@ extension Slice: RangeReplaceableCollection where Base: RangeReplaceableCollecti
   ) where C : Collection, C.Element == Base.Element {
 
     // FIXME: swift-3-indexing-model: range check.
-    let sliceOffset: IndexDistance =
+    let sliceOffset =
       _base.distance(from: _base.startIndex, to: _startIndex)
-    let newSliceCount: IndexDistance =
+    let newSliceCount =
       _base.distance(from: _startIndex, to: subRange.lowerBound)
       + _base.distance(from: subRange.upperBound, to: _endIndex)
-      + (numericCast(newElements.count) as IndexDistance)
+      + (numericCast(newElements.count) as Int)
     _base.replaceSubrange(subRange, with: newElements)
     _startIndex = _base.index(_base.startIndex, offsetBy: sliceOffset)
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -306,9 +305,8 @@ extension Slice: RangeReplaceableCollection where Base: RangeReplaceableCollecti
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func insert(_ newElement: Base.Element, at i: Index) {
     // FIXME: swift-3-indexing-model: range check.
-    let sliceOffset: IndexDistance =
-      _base.distance(from: _base.startIndex, to: _startIndex)
-    let newSliceCount: IndexDistance = count + 1
+    let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
+    let newSliceCount = count + 1
     _base.insert(newElement, at: i)
     _startIndex = _base.index(_base.startIndex, offsetBy: sliceOffset)
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -319,10 +317,8 @@ extension Slice: RangeReplaceableCollection where Base: RangeReplaceableCollecti
   where S: Collection, S.Element == Base.Element {
 
     // FIXME: swift-3-indexing-model: range check.
-    let sliceOffset: IndexDistance =
-      _base.distance(from: _base.startIndex, to: _startIndex)
-    let newSliceCount: IndexDistance =
-      count + (numericCast(newElements.count) as IndexDistance)
+    let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
+    let newSliceCount = count + newElements.count
     _base.insert(contentsOf: newElements, at: i)
     _startIndex = _base.index(_base.startIndex, offsetBy: sliceOffset)
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -331,9 +327,8 @@ extension Slice: RangeReplaceableCollection where Base: RangeReplaceableCollecti
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func remove(at i: Index) -> Base.Element {
     // FIXME: swift-3-indexing-model: range check.
-    let sliceOffset: IndexDistance =
-      _base.distance(from: _base.startIndex, to: _startIndex)
-    let newSliceCount: IndexDistance = count - 1
+    let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
+    let newSliceCount = count - 1
     let result = _base.remove(at: i)
     _startIndex = _base.index(_base.startIndex, offsetBy: sliceOffset)
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -343,9 +338,8 @@ extension Slice: RangeReplaceableCollection where Base: RangeReplaceableCollecti
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func removeSubrange(_ bounds: Range<Index>) {
     // FIXME: swift-3-indexing-model: range check.
-    let sliceOffset: IndexDistance =
-      _base.distance(from: _base.startIndex, to: _startIndex)
-    let newSliceCount: IndexDistance =
+    let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
+    let newSliceCount =
       count - distance(from: bounds.lowerBound, to: bounds.upperBound)
     _base.removeSubrange(bounds)
     _startIndex = _base.index(_base.startIndex, offsetBy: sliceOffset)
@@ -362,10 +356,10 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
   ) where C : Collection, C.Element == Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if subRange.lowerBound == _base.startIndex {
-      let newSliceCount: IndexDistance =
+      let newSliceCount =
         _base.distance(from: _startIndex, to: subRange.lowerBound)
         + _base.distance(from: subRange.upperBound, to: _endIndex)
-        + (numericCast(newElements.count) as IndexDistance)
+        + (numericCast(newElements.count) as Int)
       _base.replaceSubrange(subRange, with: newElements)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -374,7 +368,7 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
       let lastValidIndex = _base.index(before: subRange.lowerBound)
       let newEndIndexOffset =
         _base.distance(from: subRange.upperBound, to: _endIndex)
-        + (numericCast(newElements.count) as IndexDistance) + 1
+        + (numericCast(newElements.count) as Int) + 1
       _base.replaceSubrange(subRange, with: newElements)
       if shouldUpdateStartIndex {
         _startIndex = _base.index(after: lastValidIndex)
@@ -387,7 +381,7 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
   public mutating func insert(_ newElement: Base.Element, at i: Index) {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
-      let newSliceCount: IndexDistance = count + 1
+      let newSliceCount = count + 1
       _base.insert(newElement, at: i)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -408,8 +402,7 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
   where S : Collection, S.Element == Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
-      let newSliceCount: IndexDistance =
-        count + (numericCast(newElements.count) as IndexDistance)
+      let newSliceCount = count + numericCast(newElements.count)
       _base.insert(contentsOf: newElements, at: i)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -418,7 +411,7 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
       let lastValidIndex = _base.index(before: i)
       let newEndIndexOffset =
         _base.distance(from: i, to: _endIndex)
-        + (numericCast(newElements.count) as IndexDistance) + 1
+        + numericCast(newElements.count) + 1
       _base.insert(contentsOf: newElements, at: i)
       if shouldUpdateStartIndex {
         _startIndex = _base.index(after: lastValidIndex)
@@ -431,7 +424,7 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
   public mutating func remove(at i: Index) -> Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
-      let newSliceCount: IndexDistance = count - 1
+      let newSliceCount = count - 1
       let result = _base.remove(at: i)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -453,17 +446,16 @@ where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
   public mutating func removeSubrange(_ bounds: Range<Index>) {
     // FIXME: swift-3-indexing-model: range check.
     if bounds.lowerBound == _base.startIndex {
-      let newSliceCount: IndexDistance =
-        count
-        - _base.distance(from: bounds.lowerBound, to: bounds.upperBound)
+      let newSliceCount =
+        count - _base.distance(from: bounds.lowerBound, to: bounds.upperBound)
       _base.removeSubrange(bounds)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
     } else {
       let shouldUpdateStartIndex = bounds.lowerBound == _startIndex
       let lastValidIndex = _base.index(before: bounds.lowerBound)
-      let newEndIndexOffset: Base.IndexDistance =
-        _base.distance(from: bounds.lowerBound, to: _endIndex)
+      let newEndIndexOffset =
+          _base.distance(from: bounds.lowerBound, to: _endIndex)
         - _base.distance(from: bounds.lowerBound, to: bounds.upperBound)
         + 1
       _base.removeSubrange(bounds)

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -452,7 +452,6 @@ extension StrideThrough: CustomReflectable {
 extension StrideThrough : RandomAccessCollection
 where Element.Stride : BinaryInteger {
   public typealias Index = ClosedRangeIndex<Int>
-  public typealias IndexDistance = Int
   public typealias SubSequence = Slice<StrideThrough<Element>>
 
   @_inlineable

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -211,7 +211,6 @@ extension String._CharacterView : BidirectionalCollection {
   }
   
   public typealias Index = String.Index
-  public typealias IndexDistance = Int
 
   /// The position of the first character in a nonempty character view.
   /// 

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -11,13 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 extension String : StringProtocol, RangeReplaceableCollection {  
-  /// A type that represents the number of steps between two `String.Index`
-  /// values, where one value is reachable from the other.
-  ///
-  /// In Swift, *reachability* refers to the ability to produce one value from
-  /// the other through zero or more applications of `index(after:)`.
-  public typealias IndexDistance = _CharacterView.IndexDistance
-
   public typealias SubSequence = Substring
 
   /// Creates a string representing the given character repeated the specified
@@ -128,7 +121,7 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return _characters.index(i, offsetBy: n)
   }
 
@@ -171,7 +164,7 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
   @_inlineable // FIXME(sil-serialize-all)
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     return _characters.index(i, offsetBy: n, limitedBy: limit)
   }
@@ -186,7 +179,7 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the resulting distance.
   @_inlineable // FIXME(sil-serialize-all)
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return _characters.distance(from: start, to: end)
   }
 

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -105,7 +105,6 @@ extension String {
     CustomDebugStringConvertible {
 
     public typealias Index = String.Index
-    public typealias IndexDistance = Int
 
     /// The position of the first code unit if the `String` is
     /// nonempty; identical to `endIndex` otherwise.
@@ -164,7 +163,7 @@ extension String {
 
     // TODO: swift-3-indexing-model - add docs
     @_inlineable // FIXME(sil-serialize-all)
-    public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+    public func index(_ i: Index, offsetBy n: Int) -> Index {
       // FIXME: swift-3-indexing-model: range check i?
       return Index(encodedOffset: i.encodedOffset.advanced(by: n))
     }
@@ -172,7 +171,7 @@ extension String {
     // TODO: swift-3-indexing-model - add docs
     @_inlineable // FIXME(sil-serialize-all)
     public func index(
-      _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+      _ i: Index, offsetBy n: Int, limitedBy limit: Index
     ) -> Index? {
       // FIXME: swift-3-indexing-model: range check i?
       let d = i.encodedOffset.distance(to: limit.encodedOffset)
@@ -184,7 +183,7 @@ extension String {
 
     // TODO: swift-3-indexing-model - add docs
     @_inlineable // FIXME(sil-serialize-all)
-    public func distance(from start: Index, to end: Index) -> IndexDistance {
+    public func distance(from start: Index, to end: Index) -> Int {
       // FIXME: swift-3-indexing-model: range check start and end?
       return start.encodedOffset.distance(to: end.encodedOffset)
     }
@@ -448,7 +447,6 @@ extension String.UTF16View : CustomPlaygroundQuickLookable {
 
 extension String.UTF16View.Indices : BidirectionalCollection {
   public typealias Index = String.UTF16View.Index
-  public typealias IndexDistance = String.UTF16View.IndexDistance
   public typealias Indices = String.UTF16View.Indices
   public typealias SubSequence = String.UTF16View.Indices
 
@@ -519,14 +517,14 @@ extension String.UTF16View.Indices : BidirectionalCollection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     // FIXME: swift-3-indexing-model: range check i?
     return _elements.index(i, offsetBy: n)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     // FIXME: swift-3-indexing-model: range check i?
     return _elements.index(i, offsetBy: n, limitedBy: limit)
@@ -534,7 +532,7 @@ extension String.UTF16View.Indices : BidirectionalCollection {
 
   // TODO: swift-3-indexing-model - add docs
   @_inlineable // FIXME(sil-serialize-all)
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     // FIXME: swift-3-indexing-model: range check start and end?
     return _elements.distance(from: start, to: end)
   }
@@ -554,14 +552,14 @@ extension String.UTF16View {
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional index")
   public func index(
-    _ i: Index?, offsetBy n: IndexDistance) -> Index {
+    _ i: Index?, offsetBy n: Int) -> Index {
     return index(i!, offsetBy: n)
   }
   @_inlineable // FIXME(sil-serialize-all)
   @available(
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional indices")
-  public func distance(from i: Index?, to j: Index?) -> IndexDistance {
+  public func distance(from i: Index?, to j: Index?) -> Int {
     return distance(from: i!, to: j!)
   }
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -120,7 +120,6 @@ extension String {
     }
 
     public typealias Index = String.Index
-    public typealias IndexDistance = Int
 
     /// The position of the first code unit if the UTF-8 view is
     /// nonempty.
@@ -273,7 +272,7 @@ extension String {
     }
     
     @_inlineable // FIXME(sil-serialize-all)
-    public func distance(from i: Index, to j: Index) -> IndexDistance {
+    public func distance(from i: Index, to j: Index) -> Int {
       if _fastPath(_core.isASCII) {
         return j.encodedOffset - i.encodedOffset
       }
@@ -284,8 +283,8 @@ extension String {
     @_inlineable // FIXME(sil-serialize-all)
     @_versioned
     @inline(__always)
-    internal func _forwardDistance(from i: Index, to j: Index) -> IndexDistance {
-      var r: IndexDistance = j._transcodedOffset - i._transcodedOffset
+    internal func _forwardDistance(from i: Index, to j: Index) -> Int {
+      var r = j._transcodedOffset - i._transcodedOffset
       UTF8._transcode(
         _core[i.encodedOffset..<j.encodedOffset], from: UTF16.self) {
         r += $0.count
@@ -678,7 +677,7 @@ extension String.UTF8View {
   @available(
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional index")
-  public func index(_ i: Index?, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index?, offsetBy n: Int) -> Index {
     return index(i!, offsetBy: n)
   }
   @_inlineable // FIXME(sil-serialize-all)
@@ -686,7 +685,7 @@ extension String.UTF8View {
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional indices")
   public func distance(
-    from i: Index?, to j: Index?) -> IndexDistance {
+    from i: Index?, to j: Index?) -> Int {
     return distance(from: i!, to: j!)
   }
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -96,7 +96,6 @@ extension String {
     }
 
     public typealias Index = String.Index
-    public typealias IndexDistance = Int
     
     /// Translates a `_core` index into a `UnicodeScalarIndex` using this view's
     /// `_coreOffset`.
@@ -528,14 +527,14 @@ extension String.UnicodeScalarView {
   @available(
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional index")
-  public func index(_ i: Index?,  offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index?,  offsetBy n: Int) -> Index {
     return index(i!, offsetBy: n)
   }
   @_inlineable // FIXME(sil-serialize-all)
   @available(
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional indices")
-  public func distance(from i: Index?, to j: Index?) -> IndexDistance {
+  public func distance(from i: Index?, to j: Index?) -> Int {
     return distance(from: i!, to: j!)
   }
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -90,7 +90,6 @@ extension String {
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct Substring : StringProtocol {
   public typealias Index = String.Index
-  public typealias IndexDistance = String.IndexDistance
   public typealias SubSequence = Substring
 
   @_versioned // FIXME(sil-serialize-all)
@@ -149,7 +148,7 @@ public struct Substring : StringProtocol {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     let result = _slice.index(i, offsetBy: n)
     // FIXME(strings): slice types currently lack necessary bound checks
     _precondition(
@@ -160,7 +159,7 @@ public struct Substring : StringProtocol {
 
   @_inlineable // FIXME(sil-serialize-all)
   public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     let result = _slice.index(i, offsetBy: n, limitedBy: limit)
     // FIXME(strings): slice types currently lack necessary bound checks
@@ -172,7 +171,7 @@ public struct Substring : StringProtocol {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func distance(from start: Index, to end: Index) -> IndexDistance {
+  public func distance(from start: Index, to end: Index) -> Int {
     return _slice.distance(from: start, to: end)
   }
 

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -130,18 +130,17 @@ extension _UIntBuffer : BidirectionalCollection {
 
 extension _UIntBuffer : RandomAccessCollection {
   public typealias Indices = DefaultRandomAccessIndices<_UIntBuffer>
-  public typealias IndexDistance = Int
   
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    let x = IndexDistance(i.bitOffset) &+ n &* Element.bitWidth
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    let x = Int(i.bitOffset) &+ n &* Element.bitWidth
     return Index(bitOffset: UInt8(truncatingIfNeeded: x))
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
-  public func distance(from i: Index, to j: Index) -> IndexDistance {
+  public func distance(from i: Index, to j: Index) -> Int {
     return (Int(j.bitOffset) &- Int(i.bitOffset)) / Element.bitWidth
   }
 }
@@ -232,6 +231,6 @@ extension _UIntBuffer : RangeReplaceableCollection {
     _storage |= replacement1._storage &<< (headCount &* w)
     _storage |= tailBits &<< ((tailOffset &+ growth) &* w)
     _bitCount = UInt8(
-      truncatingIfNeeded: IndexDistance(_bitCount) &+ growth &* w)
+      truncatingIfNeeded: Int(_bitCount) &+ growth &* w)
   }
 }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -65,7 +65,6 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   // struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 
   public typealias Index = Int
-  public typealias IndexDistance = Int
   public typealias Iterator = UnsafeBufferPointerIterator<Element>
 
   /// The index of the first element in a nonempty buffer.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -143,7 +143,6 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
   public typealias Element = UInt8
   public typealias Index = Int
-  public typealias IndexDistance = Int
   public typealias Indices = CountableRange<Int>
 
   /// Always zero, which is the index of the first byte in a nonempty buffer.

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -65,7 +65,6 @@ extension _ValidUTF8Buffer : Sequence {
 }
 
 extension _ValidUTF8Buffer : Collection {  
-  public typealias IndexDistance = Int
   
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Index : Comparable {
@@ -97,7 +96,7 @@ extension _ValidUTF8Buffer : Collection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public var count : IndexDistance {
+  public var count : Int {
     return Storage.bitWidth &>> 3 &- _biasedBits.leadingZeroBitCount &>> 3
   }
   
@@ -127,7 +126,7 @@ extension _ValidUTF8Buffer : RandomAccessCollection {
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
-  public func distance(from i: Index, to j: Index) -> IndexDistance {
+  public func distance(from i: Index, to j: Index) -> Int {
     _debugPrecondition(_isValid(i))
     _debugPrecondition(_isValid(j))
     return (
@@ -137,7 +136,7 @@ extension _ValidUTF8Buffer : RandomAccessCollection {
   
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     let startOffset = distance(from: startIndex, to: i)
     let newOffset = startOffset + n
     _debugPrecondition(newOffset >= 0)
@@ -153,12 +152,12 @@ extension _ValidUTF8Buffer : RangeReplaceableCollection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public var capacity: IndexDistance {
+  public var capacity: Int {
     return _ValidUTF8Buffer.capacity
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public static var capacity: IndexDistance {
+  public static var capacity: Int {
     return Storage.bitWidth / Element.bitWidth
   }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -161,7 +161,7 @@ func rdar20142523() {
 // <rdar://problem/21080030> Bad diagnostic for invalid method call in boolean expression: (_, ExpressibleByIntegerLiteral)' is not convertible to 'ExpressibleByIntegerLiteral
 func rdar21080030() {
   var s = "Hello"
-  if s.count() == 0 {} // expected-error{{cannot call value of non-function type 'String.IndexDistance' (aka 'Int')}}{{13-15=}}
+  if s.count() == 0 {} // expected-error{{cannot call value of non-function type 'Int'}}{{13-15=}}
 }
 
 // <rdar://problem/21248136> QoI: problem with return type inference mis-diagnosed as invalid arguments

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -231,7 +231,7 @@ extension MutableCollection where Self: RandomAccessCollection {
   @inline(__always)
   internal mutating func _rotateCycle(
     start: Index,
-    sourceOffsetForIndex: (Index) -> IndexDistance
+    sourceOffsetForIndex: (Index) -> Int
   ) {
     let tmp = self[start]
     var i = start
@@ -408,18 +408,17 @@ public struct ${Self}<C1 : ${Collection}, C2: ${Collection}>: ${Collection}
 %   end
 
 %   if Traversal is 'RandomAccess':
-  public func index(_ i: Index, offsetBy n: ${Self}.IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     if n == 0 { return i }
     return n > 0 ? _offsetForward(i, by: n) : _offsetBackward(i, by: -n)
   }
 
   internal func _offsetForward(
-    _ i: Index, by n: ${Self}.IndexDistance
+    _ i: Index, by n: Int
   ) -> Index {
     switch i._position {
     case let .first(i):
-      let d: ${Self}.IndexDistance = numericCast(
-        _base1.distance(from: i, to: _base1.endIndex))
+      let d: Int = _base1.distance(from: i, to: _base1.endIndex)
       if n < d {
         return ConcatenatedCollectionIndex(
           first: _base1.index(i, offsetBy: numericCast(n)))
@@ -434,15 +433,14 @@ public struct ${Self}<C1 : ${Collection}, C2: ${Collection}>: ${Collection}
   }
 
   internal func _offsetBackward(
-    _ i: Index, by n: ${Self}.IndexDistance
+    _ i: Index, by n: Int
   ) -> Index {
     switch i._position {
     case let .first(i):
       return ConcatenatedCollectionIndex(
         first: _base1.index(i, offsetBy: -numericCast(n)))
     case let .second(i):
-      let d: ${Self}.IndexDistance = numericCast(
-        _base2.distance(from: _base2.startIndex, to: i))
+      let d: Int = _base2.distance(from: _base2.startIndex, to: i)
       if n <= d {
         return ConcatenatedCollectionIndex(
           second: _base2.index(i, offsetBy: -numericCast(n)))
@@ -530,7 +528,7 @@ public struct ${Self}<
   }
 %   end
 
-  public func index(_ i: Index, offsetBy n: ${Self}.IndexDistance) -> Index {
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
     return RotatedCollectionIndex(
       _index: _concatenation.index(i._index, offsetBy: n))
   }
@@ -584,7 +582,7 @@ extension BidirectionalCollection
   }
 
   mutating func _stablePartition(
-    distance n: IndexDistance,
+    distance n: Int,
     choosingStartGroupBy p: (Element) -> Bool
   ) -> Index {
     assert(n >= 0)

--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -14,10 +14,10 @@
 
 //===--- Niceties ---------------------------------------------------------===//
 extension Collection {
-  func index(_ d: IndexDistance) -> Index {
+  func index(_ d: Int) -> Index {
     return index(startIndex, offsetBy: d)
   }
-  func offset(of i: Index) -> IndexDistance {
+  func offset(of i: Index) -> Int {
     return distance(from: startIndex, to: i)
   }
 }

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -158,13 +158,13 @@ extension Unicode.DefaultScalarView : BidirectionalCollection {
     
     switch parser.parseScalar(from: &more) {
     case .valid(let scalarContent):
-      let d: CodeUnits.IndexDistance = -numericCast(scalarContent.count)
+      let d: Int = -scalarContent.count
       return Index(
         codeUnitIndex: codeUnits.index(i.codeUnitIndex, offsetBy: d),
         scalar: Encoding.decode(scalarContent),
         stride: numericCast(scalarContent.count))
     case .error(let stride):
-      let d: CodeUnits.IndexDistance = -numericCast(stride)
+      let d: Int = -stride
       return Index(
         codeUnitIndex: codeUnits.index(i.codeUnitIndex, offsetBy: d) ,
         scalar: Unicode.Scalar(_unchecked: 0xfffd),

--- a/test/stdlib/DictionaryLiteral.swift
+++ b/test/stdlib/DictionaryLiteral.swift
@@ -34,7 +34,6 @@ func checkAssociatedTypes() {
     iteratorType: IndexingIterator<Subject>.self,
     subSequenceType: RandomAccessSlice<Subject>.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }
 

--- a/test/stdlib/IndexDistanceRemoval.swift
+++ b/test/stdlib/IndexDistanceRemoval.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Int64Distance<Element>: Collection {
+  let _storage: [Element]
+  
+  typealias Index = Int64
+  typealias IndexDistance = Int64
+  
+  var startIndex: Index { return Int64(_storage.startIndex) }
+  var endIndex: Index { return Int64(_storage.startIndex) }
+  func index(after i: Index) -> Index { return i + 1 }
+  
+  subscript(i: Index) -> Element { return _storage[Int(i)] }
+}
+
+let c = Int64Distance(_storage: [1,2,3])
+
+let i64: Int64 = 2
+_ = c.index(c.startIndex, offsetBy: i64) // expected-warning {{'index(_:offsetBy:)' is deprecated: all index distances are now of type Int}}
+
+let _: Int64 = c.distance(from: c.startIndex, to: c.endIndex) // expected-warning {{distance(from:to:)' is deprecated: all index distances are now of type Int}}
+

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -421,6 +421,5 @@ ${Suite}.test("${ArrayType}/AssociatedTypes") {
     iteratorType: IndexingIterator<Collection>.self,
     subSequenceType: CollectionSlice.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }

--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -1149,7 +1149,7 @@ func toIntRange<
   S : StringProtocol
 >(
   _ string: S, _ maybeRange: Range<String.Index>?
-) -> Range<Int>? where S.Index == String.Index, S.IndexDistance == Int {
+) -> Range<Int>? where S.Index == String.Index {
   guard let range = maybeRange else { return nil }
 
   return

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -17,7 +17,6 @@ struct MyString {
 extension MyString : BidirectionalCollection {
   typealias Iterator = String.Iterator
   typealias Index = String.Index
-  typealias IndexDistance = String.IndexDistance
   typealias SubSequence = MyString
   func makeIterator() -> Iterator { return base.makeIterator() }
   var startIndex: String.Index { return base.startIndex }
@@ -28,10 +27,10 @@ extension MyString : BidirectionalCollection {
   }
   func index(after i: Index) -> Index { return base.index(after: i) }
   func index(before i: Index) -> Index { return base.index(before: i) }
-  func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+  func index(_ i: Index, offsetBy n: Int) -> Index {
     return base.index(i, offsetBy: n)
   }
-  func distance(from i: Index, to j: Index) -> IndexDistance {
+  func distance(from i: Index, to j: Index) -> Int {
     return base.distance(from: i, to: j)
   }
 }

--- a/utils/sourcekit_fuzzer/sourcekit_fuzzer.swift
+++ b/utils/sourcekit_fuzzer/sourcekit_fuzzer.swift
@@ -55,7 +55,7 @@ extension MutableCollection {
     guard c > 1 else { return }
 
     for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
-      let d: IndexDistance = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
+      let d: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
       guard d != 0 else { continue }
       let i = index(firstUnshuffled, offsetBy: d)
       swapAt(firstUnshuffled, i)

--- a/validation-test/Sema/type_checker_crashers_fixed/sr1512.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr1512.swift
@@ -32,13 +32,13 @@ extension CollectionWrapper : Collection {
 
 	public var isEmpty: Bool { return collection.isEmpty }
 
-    public var count: C.IndexDistance { return collection.count }
+    public var count: Int { return collection.count }
 
     public var first: C.Iterator.Element? { return collection.first }
 
 	public func index(after idx: C.Index) -> C.Index { return collection.index(after: idx) }
 
-	public func index(_ idx: C.Index, offsetBy offset: C.IndexDistance, limitedBy limit: C.Index? = nil) -> C.Index {
+	public func index(_ idx: C.Index, offsetBy offset: Int, limitedBy limit: C.Index? = nil) -> C.Index {
 		return collection.index(idx, offsetBy: offset, limitedBy: limit)
 	}
 }

--- a/validation-test/compiler_crashers_2_fixed/0080-rdar30442622.swift
+++ b/validation-test/compiler_crashers_2_fixed/0080-rdar30442622.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -primary-file %s
 
 protocol AnyCodeUnits_ {
-  typealias IndexDistance = Int64
   typealias Index = Int64
   typealias Element = UInt32
   var startIndex: Index { get }

--- a/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
+++ b/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
@@ -134,16 +134,15 @@ extension _UIntBuffer : BidirectionalCollection {
 
 extension _UIntBuffer : RandomAccessCollection {
   public typealias Indices = DefaultRandomAccessIndices<_UIntBuffer>
-  public typealias IndexDistance = Int
   
   @inline(__always)
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    let x = IndexDistance(i.bitOffset) &+ n &* Element.bitWidth
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    let x = Int(i.bitOffset) &+ n &* Element.bitWidth
     return Index(bitOffset: UInt8(truncatingIfNeeded: x))
   }
 
   @inline(__always)
-  public func distance(from i: Index, to j: Index) -> IndexDistance {
+  public func distance(from i: Index, to j: Index) -> Int {
     return (Int(j.bitOffset) &- Int(i.bitOffset)) / Element.bitWidth
   }
 }
@@ -218,7 +217,7 @@ extension _UIntBuffer : RangeReplaceableCollection {
     _storage |= replacement1._storage &<< (headCount &* w)
     _storage |= tailBits &<< ((tailOffset &+ growth) &* w)
     _bitCount = UInt8(
-      truncatingIfNeeded: IndexDistance(_bitCount) &+ growth &* w)
+      truncatingIfNeeded: Int(_bitCount) &+ growth &* w)
   }
 }
 //===----------------------------------------------------------------------===//
@@ -451,13 +450,13 @@ extension Unicode.DefaultScalarView : BidirectionalCollection {
     
     switch d.parseOne(&more) {
     case .valid(let scalarContent):
-      let d: CodeUnits.IndexDistance = -numericCast(scalarContent.count)
+      let d: Int = -numericCast(scalarContent.count)
       return Index(
         codeUnitIndex: codeUnits.index(i.codeUnitIndex, offsetBy: d),
         scalar: Encoding.ReverseDecoder.decodeOne(scalarContent),
         stride: numericCast(scalarContent.count))
     case .invalid(let stride):
-      let d: CodeUnits.IndexDistance = -numericCast(stride)
+      let d: Int = -numericCast(stride)
       return Index(
         codeUnitIndex: codeUnits.index(i.codeUnitIndex, offsetBy: d) ,
         scalar: UnicodeScalar(_unchecked: 0xfffd),

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -849,7 +849,6 @@ CollectionTypeTests.test("AssociatedTypes/${Collection}") {
     iteratorType: IndexingIterator<C>.self,
     subSequenceType: ${Slice}<C>.self,
     indexType: FatalIndex.self,
-    indexDistanceType: Int.self,
     indicesType: ${Indices}<C>.self)
 }
 % end

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -162,7 +162,6 @@ CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer/AssociatedTypes") {
     iteratorType: IndexingIterator<Subject>.self,
     subSequenceType: MutableRandomAccessSlice<Subject>.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }
 

--- a/validation-test/stdlib/Data.swift
+++ b/validation-test/stdlib/Data.swift
@@ -38,7 +38,6 @@ DataTestSuite.test("associated types") {
     iteratorType: Data.Iterator.self,
     subSequenceType: Subject.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -64,7 +64,6 @@ DictionaryTestSuite.test("AssociatedTypes") {
     iteratorType: DictionaryIterator<MinimalHashableValue, OpaqueValue<Int>>.self,
     subSequenceType: Slice<Collection>.self,
     indexType: DictionaryIndex<MinimalHashableValue, OpaqueValue<Int>>.self,
-    indexDistanceType: Int.self,
     indicesType: DefaultIndices<Collection>.self)
 }
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -40,7 +40,6 @@ LazyTestSuite.test("Repeated/AssociatedTypes") {
     iteratorType: IndexingIterator<Subject>.self,
     subSequenceType: Slice<Subject>.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }
 
@@ -123,7 +122,6 @@ LazyTestSuite.test("CollectionOfOne/AssociatedTypes") {
     iteratorType: IteratorOverOne<OpaqueValue<Int>>.self,
     subSequenceType: Slice<Subject>.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }
 
@@ -247,7 +245,6 @@ LazyTestSuite.test("EmptyCollection/AssociatedTypes") {
     iteratorType: EmptyIterator<OpaqueValue<Int>>.self,
     subSequenceType: Subject.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 }
 
@@ -878,7 +875,6 @@ tests.test("LazyMapCollection/AssociatedTypes") {
     iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
     subSequenceType: LazyMapCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: Base.Indices.self)
 }
 
@@ -890,7 +886,6 @@ tests.test("LazyMapBidirectionalCollection/AssociatedTypes") {
     iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
     subSequenceType: LazyMapBidirectionalCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: Base.Indices.self)
 }
 
@@ -902,7 +897,6 @@ tests.test("LazyMapRandomAccessCollection/AssociatedTypes") {
     iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
     subSequenceType: LazyMapRandomAccessCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: Base.Indices.self)
 }
 
@@ -1168,7 +1162,6 @@ tests.test("LazyFilterCollection/AssociatedTypes") {
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
     subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
     indexType: LazyFilterIndex<Base>.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultIndices<Subject>.self)
 }
 
@@ -1180,7 +1173,6 @@ tests.test("LazyFilterBidirectionalCollection/AssociatedTypes") {
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
     subSequenceType: LazyFilterBidirectionalCollection<Base.SubSequence>.self,
     indexType: LazyFilterIndex<Base>.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
 }
 
@@ -1363,7 +1355,6 @@ tests.test("LazyPrefixWhileCollection/AssociatedTypes") {
     iteratorType: LazyPrefixWhileIterator<Base.Iterator>.self,
     subSequenceType: Slice<Subject>.self,
     indexType: LazyPrefixWhileIndex<Base>.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultIndices<Subject>.self)
 }
 
@@ -1376,7 +1367,6 @@ tests.test("LazyPrefixWhileBidirectionalCollection/AssociatedTypes") {
     // FIXME(ABI)#82 (Associated Types with where clauses): SubSequence should be `LazyFilterBidirectionalCollection<Base.Slice>`.
     subSequenceType: Slice<Subject>.self,
     indexType: LazyPrefixWhileIndex<Base>.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
 }
 
@@ -1423,7 +1413,6 @@ tests.test("LazyDropWhileCollection/AssociatedTypes") {
     iteratorType: LazyDropWhileIterator<Base.Iterator>.self,
     subSequenceType: Slice<Subject>.self,
     indexType: LazyDropWhileIndex<Base>.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultIndices<Subject>.self)
 }
 
@@ -1436,7 +1425,6 @@ tests.test("LazyDropWhileBidirectionalCollection/AssociatedTypes") {
     // FIXME(ABI)#83 (Associated Types with where clauses): SubSequence should be `LazyFilterBidirectionalCollection<Base.Slice>`.
     subSequenceType: Slice<Subject>.self,
     indexType: LazyDropWhileIndex<Base>.self,
-    indexDistanceType: Base.IndexDistance.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
 }
 

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -91,8 +91,7 @@ func test<
 where
 T.Iterator.Element == LifetimeTracked,
 T.Iterator.Element == T.Element,
-T.Index == Int,
-T.IndexDistance == Int {
+T.Index == Int {
   print("test: \(label)...", terminator: "")
 
   var x: T = [

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -760,7 +760,6 @@ CountableRangeTestSuite.test("AssociatedTypes") {
     iteratorType: IndexingIterator<Collection>.self,
     subSequenceType: Collection.self,
     indexType: MinimalStrideableValue.self,
-    indexDistanceType: MinimalStrideableValue.Stride.self,
     indicesType: Collection.self)
 }
 
@@ -771,7 +770,6 @@ CountableClosedRangeTestSuite.test("AssociatedTypes") {
     iteratorType: IndexingIterator<Collection>.self,
     subSequenceType: RandomAccessSlice<Collection>.self,
     indexType: ClosedRangeIndex<MinimalStrideableValue>.self,
-    indexDistanceType: MinimalStrideableValue.Stride.self,
     indicesType: DefaultRandomAccessIndices<Collection>.self)
 }
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -318,7 +318,6 @@ SetTestSuite.test("AssociatedTypes") {
     iteratorType: SetIterator<MinimalHashableValue>.self,
     subSequenceType: Slice<Collection>.self,
     indexType: SetIndex<MinimalHashableValue>.self,
-    indexDistanceType: Int.self,
     indicesType: DefaultIndices<Collection>.self)
 }
 

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -61,7 +61,6 @@ SliceTests.test("${Slice}/AssociatedTypes") {
       iteratorType: IndexingIterator<CollectionSlice>.self,
       subSequenceType: CollectionSlice.self,
       indexType: MinimalIndex.self,
-      indexDistanceType: Int.self,
       indicesType: Collection.Indices.self)
   }
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -66,7 +66,6 @@ StringTests.test("AssociatedTypes-UTF8View") {
     iteratorType: View.Iterator.self,
     subSequenceType: Substring.UTF8View.self,
     indexType: View.Index.self,
-    indexDistanceType: Int.self,
     indicesType: DefaultBidirectionalIndices<View>.self)
 }
 
@@ -77,7 +76,6 @@ StringTests.test("AssociatedTypes-UTF16View") {
     iteratorType: IndexingIterator<View>.self,
     subSequenceType: Substring.UTF16View.self,
     indexType: View.Index.self,
-    indexDistanceType: Int.self,
     indicesType: View.Indices.self)
 }
 
@@ -88,7 +86,6 @@ StringTests.test("AssociatedTypes-UnicodeScalarView") {
     iteratorType: View.Iterator.self,
     subSequenceType: Substring.UnicodeScalarView.self,
     indexType: View.Index.self,
-    indexDistanceType: Int.self,
     indicesType: DefaultBidirectionalIndices<View>.self)
 }
 
@@ -99,7 +96,6 @@ StringTests.test("AssociatedTypes-CharacterView") {
     iteratorType: IndexingIterator<View>.self,
     subSequenceType: View.self,
     indexType: View.Index.self,
-    indexDistanceType: Int.self,
     indicesType: DefaultBidirectionalIndices<View>.self)
 }
 

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -67,7 +67,6 @@ ${SelfName}TestSuite.test("AssociatedTypes") {
 %   end
     subSequenceType: ${'Mutable' if IsMutable else ''}RandomAccessSlice<${SelfType}>.self,
     indexType: Int.self,
-    indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 
   expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)


### PR DESCRIPTION
- **Explanation**: Eliminate the `IndexDistance` associated type, implementing [SE-191](https://github.com/apple/swift-evolution/blob/master/proposals/0191-eliminate-indexdistance.md).
- **Scope**: This touches a large number of types in the standard library, simplifying them to replace all occurrences of `IndexDistance` with `Int`. It also introduces some compatibility shims (an `IndexDistance` typealias equal to `Int`, and generic conversions for calls using non-`Int` index distances). 
- **Issue**: rdar://problem/35940300
- **Reviewed by**: @moiseev 
- **Risk**: Low; this is a pervasive change on all collections but the changes are fairly mechanical and easily reviewed. However, there are no known uses where `Int` is not already used, and the majority of changes are simplifications of the code to no longer need to perform casts between different distance types.
- **Testing**: The existing collection implementations in the standard library are extensively tested. Additionally this passes the compatibility suite, and also passes tests of other collections implemented in Foundation and SwiftPM.