### PR TITLE
utils: add ConcurrenySal.h to the overlay

### DIFF
--- a/utils/WindowsSDKVFSOverlay.yaml.in
+++ b/utils/WindowsSDKVFSOverlay.yaml.in
@@ -2,6 +2,12 @@
 version: 0
 case-sensitive: false
 roots:
+  - name: "@VCToolsInstallDir@/include"
+    type: directory
+    contents:
+      - name: ConcurrencySal.h
+        type: file
+        external-contents: "@VCToolsInstallDir@/include/concurrencysal.h"
   - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared"
     type: directory
     contents:


### PR DESCRIPTION
ConcurrecySal.h is provided as concurrencysal.h in newer releases of
Visual Studio (e.g. 25547) which causes build issues on case sensitive
file systems.  Add it to the remapping.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
