### PR TITLE
[swift-4.1-branch][stdlib] Utilize conditional conformances for lazy collections

### DIFF
--- a/benchmark/single-source/LazyFilter.swift
+++ b/benchmark/single-source/LazyFilter.swift
@@ -47,7 +47,7 @@ public func run_LazilyFilteredArrays(_ N: Int) {
   CheckResults(res == 123)
 }
 
-fileprivate var multiplesOfThree: LazyFilterBidirectionalCollection<Array<Int>>?
+fileprivate var multiplesOfThree: LazyFilterCollection<Array<Int>>?
 
 fileprivate func setup_LazilyFilteredArrayContains() {
   multiplesOfThree = Array(1..<5_000).lazy.filter { $0 % 3 == 0 }

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -1584,11 +1584,6 @@ extension TestSuite {
       .forEach(in: distanceFromToTests) {
       test in
       let c = toCollection(0..<20)
-      let backwards = (test.startOffset > test.endOffset)
-      if backwards && !collectionIsBidirectional {
-        expectCrashLater()
-      }
-
       let d = c.distance(
         from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
       expectEqual(

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -658,8 +658,6 @@ public struct ${Self}<T> : ${SelfProtocols} {
   public func distance(from start: ${Index}, to end: ${Index})
     -> Int {
 %     if Traversal == 'Forward':
-    _precondition(start <= end,
-      "Only BidirectionalCollections can have end come before start")
 %     end
     // FIXME: swift-3-indexing-model: perform a range check properly.
     if start != endIndex {

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SWIFTLIB_ESSENTIAL
   Equatable.swift
   ErrorType.swift
   Existential.swift
-  Filter.swift.gyb
+  Filter.swift
   FixedArray.swift.gyb
   FlatMap.swift
   Flatten.swift.gyb

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -83,7 +83,7 @@ set(SWIFTLIB_ESSENTIAL
   LazySequence.swift
   LifetimeManager.swift
   ManagedBuffer.swift
-  Map.swift.gyb
+  Map.swift
   MemoryLayout.swift
   UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
   Mirrors.swift.gyb

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -701,16 +701,11 @@ public protocol Collection: Sequence where SubSequence: Collection {
 
   /// Returns the distance between two indices.
   ///
-  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
-  /// `start` must be less than or equal to `end`.
-  ///
   /// - Parameters:
   ///   - start: A valid index of the collection.
   ///   - end: Another valid index of the collection. If `end` is equal to
   ///     `start`, the result is zero.
-  /// - Returns: The distance between `start` and `end`. The result can be
-  ///   negative only if the collection conforms to the
-  ///   `BidirectionalCollection` protocol.
+  /// - Returns: The distance between `start` and `end`.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
@@ -962,30 +957,34 @@ extension Collection {
 
   /// Returns the distance between two indices.
   ///
-  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
-  /// `start` must be less than or equal to `end`.
-  ///
   /// - Parameters:
   ///   - start: A valid index of the collection.
   ///   - end: Another valid index of the collection. If `end` is equal to
   ///     `start`, the result is zero.
-  /// - Returns: The distance between `start` and `end`. The result can be
-  ///   negative only if the collection conforms to the
-  ///   `BidirectionalCollection` protocol.
+  /// - Returns: The distance between `start` and `end`.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
   @_inlineable
   public func distance(from start: Index, to end: Index) -> Int {
-    _precondition(start <= end,
-      "Only BidirectionalCollections can have end come before start")
-
-    var start = start
+    var _start: Index
+    let _end: Index
+    let step: Int
+    if start > end {
+      _start = end
+      _end = start
+      step = -1
+    }
+    else {
+      _start = start
+      _end = end
+      step = 1
+    }
     var count = 0
-    while start != end {
-      count = count + 1
-      formIndex(after: &start)
+    while _start != _end {
+      count += step
+      formIndex(after: &_start)
     }
     return count
   }

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -126,17 +126,11 @@ public typealias LazyFilterIndex<Base : Collection> = Base.Index
 ///   general operations on `LazyFilterCollection` instances may not have the
 ///   documented complexity.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct LazyFilterCollection<
-  Base : Collection
-> : LazyCollectionProtocol, Collection {
-
-  /// A type that represents a valid position in the collection.
-  ///
-  /// Valid indices consist of the position of every element and a
-  /// "past the end" position that's not valid for use as a subscript.
-  public typealias Index = Base.Index
-  public typealias Element = Base.Element
-
+public struct LazyFilterCollection<Base : Collection> {
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _base: Base
+  @_versioned // FIXME(sil-serialize-all)
+  internal let _predicate: (Base.Element) -> Bool
 
   /// Creates an instance containing the elements of `base` that
   /// satisfy `isIncluded`.
@@ -148,6 +142,38 @@ public struct LazyFilterCollection<
   ) {
     self._base = _base
     self._predicate = isIncluded
+  }
+}
+
+extension LazyFilterCollection : Sequence {
+  public typealias SubSequence = LazyFilterCollection<Base.SubSequence>
+  public typealias Element = Base.Element
+
+  // Any estimate of the number of elements that pass `_predicate` requires
+  // iterating the collection and evaluating each element, which can be costly,
+  // is unexpected, and usually doesn't pay for itself in saving time through
+  // preventing intermediate reallocations. (SR-4164)
+  @_inlineable // FIXME(sil-serialize-all)
+  public var underestimatedCount: Int { return 0 }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _copyToContiguousArray()
+    -> ContiguousArray<Base.Iterator.Element> {
+
+    // The default implementation of `_copyToContiguousArray` queries the
+    // `count` property, which evaluates `_predicate` for every element --
+    // see the note above `underestimatedCount`. Here we treat `self` as a
+    // sequence and only rely on underestimated count.
+    return _copySequenceToContiguousArray(self)
+  }
+
+  /// Returns an iterator over the elements of this sequence.
+  ///
+  /// - Complexity: O(1).
+  @_inlineable // FIXME(sil-serialize-all)
+  public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
+    return LazyFilterIterator(
+      _base: _base.makeIterator(), _predicate)
   }
 
   @_inlineable
@@ -162,6 +188,14 @@ public struct LazyFilterCollection<
     }
     return nil
   }
+}
+
+extension LazyFilterCollection : LazyCollectionProtocol, Collection {
+  /// A type that represents a valid position in the collection.
+  ///
+  /// Valid indices consist of the position of every element and a
+  /// "past the end" position that's not valid for use as a subscript.
+  public typealias Index = Base.Index
 
   /// The position of the first element in a non-empty collection.
   ///
@@ -207,6 +241,83 @@ public struct LazyFilterCollection<
     i = index
   }
 
+  @_inlineable // FIXME(sil-serialize-all)
+  // FIXME(conditional-conformances): this is a copy of a default
+  // implementation. Can be removed once teh default one allows negative
+  // results to be returned.
+  public func distance(from start: Index, to end: Index) -> Int {
+    var _start: Index
+    let _end: Index
+    let step: Int
+    if start > end {
+      _start = end
+      _end = start
+      step = -1
+    }
+    else {
+      _start = start
+      _end = end
+      step = 1
+    }
+    var count = 0
+    while _start != _end {
+      count += step
+      formIndex(after: &_start)
+    }
+    return count
+  }
+
+  @inline(__always)
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal func _advanceIndex(_ i: inout Index, step: Int) {
+      repeat {
+        _base.formIndex(&i, offsetBy: step)
+      } while i != _base.endIndex && !_predicate(_base[i])
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    var i = i
+    let step = n.signum()
+    for _ in 0 ..< abs(numericCast(n)) {
+      _advanceIndex(&i, step: step)
+    }
+    return i
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func formIndex(_ i: inout Index, offsetBy n: Int) {
+    i = index(i, offsetBy: n)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func index(
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
+  ) -> Index? {
+    var i = i
+    let step = n.signum()
+    for _ in 0 ..< abs(numericCast(n)) {
+      if i == limit {
+        return nil
+      }
+      _advanceIndex(&i, step: step)
+    }
+    return i
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func formIndex(
+    _ i: inout Index, offsetBy n: Int, limitedBy limit: Index
+  ) -> Bool {
+    if let advancedIndex = index(i, offsetBy: n, limitedBy: limit) {
+      i = advancedIndex
+      return true
+    }
+    i = limit
+    return false
+  }
+
   /// Accesses the element at `position`.
   ///
   /// - Precondition: `position` is a valid position in `self` and
@@ -216,44 +327,10 @@ public struct LazyFilterCollection<
     return _base[position]
   }
 
-  public typealias SubSequence = LazyFilterCollection<Base.SubSequence>
-
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(bounds: Range<Index>) -> SubSequence {
     return SubSequence(_base: _base[bounds], _predicate)
   }
-
-  // Any estimate of the number of elements that pass `_predicate` requires
-  // iterating the collection and evaluating each element, which can be costly,
-  // is unexpected, and usually doesn't pay for itself in saving time through
-  // preventing intermediate reallocations. (SR-4164)
-  @_inlineable // FIXME(sil-serialize-all)
-  public var underestimatedCount: Int { return 0 }
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public func _copyToContiguousArray()
-    -> ContiguousArray<Base.Iterator.Element> {
-
-    // The default implementation of `_copyToContiguousArray` queries the
-    // `count` property, which evaluates `_predicate` for every element --
-    // see the note above `underestimatedCount`. Here we treat `self` as a
-    // sequence and only rely on underestimated count.
-    return _copySequenceToContiguousArray(self)
-  }
-
-  /// Returns an iterator over the elements of this sequence.
-  ///
-  /// - Complexity: O(1).
-  @_inlineable // FIXME(sil-serialize-all)
-  public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
-    return LazyFilterIterator(
-      _base: _base.makeIterator(), _predicate)
-  }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _base: Base
-  @_versioned // FIXME(sil-serialize-all)
-  internal let _predicate: (Base.Element) -> Bool
 }
 
 extension LazyFilterCollection : BidirectionalCollection

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -95,8 +95,7 @@ extension LazyCollectionProtocol {
 extension LazyCollectionProtocol
   where
   Self : BidirectionalCollection,
-  Elements : BidirectionalCollection
-{
+  Elements : BidirectionalCollection {
   /// Returns the concatenated results of mapping the given transformation over
   /// this collection.
   ///
@@ -111,7 +110,7 @@ extension LazyCollectionProtocol
     _ transform: @escaping (Elements.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenBidirectionalCollection<
-      LazyMapBidirectionalCollection<Elements, SegmentOfResult>>> {
+      LazyMapCollection<Elements, SegmentOfResult>>> {
     return self.map(transform).joined()
   }
   
@@ -128,9 +127,9 @@ extension LazyCollectionProtocol
   @_inlineable // FIXME(sil-serialize-all)
   public func flatMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?
-  ) -> LazyMapBidirectionalCollection<
+  ) -> LazyMapCollection<
     LazyFilterCollection<
-      LazyMapBidirectionalCollection<Elements, ElementOfResult?>>,
+      LazyMapCollection<Elements, ElementOfResult?>>,
     ElementOfResult
   > {
     return self.map(transform).filter { $0 != nil }.map { $0! }

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -129,7 +129,7 @@ extension LazyCollectionProtocol
   public func flatMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?
   ) -> LazyMapBidirectionalCollection<
-    LazyFilterBidirectionalCollection<
+    LazyFilterCollection<
       LazyMapBidirectionalCollection<Elements, ElementOfResult?>>,
     ElementOfResult
   > {

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -38,18 +38,13 @@ extension LazyCollectionProtocol where Elements == Self {
   public var elements: Self { return self }
 }
 
-% for Traversal in TRAVERSALS:
-%   TraversalCollection = collectionForTraversal(Traversal)
-%   Self = 'Lazy' + TraversalCollection
-%   Slice = TraversalCollection.replace('Collection', 'Slice')
-
 /// A collection containing the same elements as a `Base` collection,
 /// but on which some operations such as `map` and `filter` are
 /// implemented lazily.
 ///
 /// - See also: `LazySequenceProtocol`, `LazyCollection`
 @_fixed_layout
-public struct ${Self}<Base : ${TraversalCollection}> : LazyCollectionProtocol {
+public struct LazyCollection<Base : Collection> : LazyCollectionProtocol {
 
   /// The type of the underlying collection.
   public typealias Elements = Base
@@ -78,7 +73,7 @@ public struct ${Self}<Base : ${TraversalCollection}> : LazyCollectionProtocol {
 
 /// Forward implementations to the base collection, to pick up any
 /// optimizations it might implement.
-extension ${Self} : Sequence {
+extension LazyCollection : Sequence {
   
   public typealias Iterator = Base.Iterator
 
@@ -118,7 +113,7 @@ extension ${Self} : Sequence {
   }
 }
 
-extension ${Self} : ${TraversalCollection} {
+extension LazyCollection : Collection {
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
@@ -162,7 +157,7 @@ extension ${Self} : ${TraversalCollection} {
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public subscript(bounds: Range<Index>) -> Slice<${Self}<Base>> {
+  public subscript(bounds: Range<Index>) -> Slice<LazyCollection<Base>> {
     return Slice(base: self, bounds: bounds)
   }
 
@@ -226,8 +221,10 @@ extension ${Self} : ${TraversalCollection} {
     return _base.distance(from:start, to: end)
   }
 
-%   if Traversal != 'Forward':
+}
 
+extension LazyCollection : BidirectionalCollection
+  where Base : BidirectionalCollection {
   @_inlineable
   public func index(before i: Base.Index) -> Base.Index {
     return _base.index(before: i)
@@ -237,11 +234,13 @@ extension ${Self} : ${TraversalCollection} {
   public var last: Base.Element? {
     return _base.last
   }
-%   end
 }
 
+extension LazyCollection : RandomAccessCollection
+  where Base : RandomAccessCollection {}
+
 /// Augment `self` with lazy methods such as `map`, `filter`, etc.
-extension ${TraversalCollection} {
+extension Collection {
   /// A view onto this collection that provides lazy implementations of
   /// normally eager operations, such as `map` and `filter`.
   ///
@@ -249,11 +248,13 @@ extension ${TraversalCollection} {
   /// intermediate operations from allocating storage, or when you only
   /// need a part of the final collection to avoid unnecessary computation.
   @_inlineable
-  public var lazy: ${Self}<Self> {
-    return ${Self}(_base: self)
+  public var lazy: LazyCollection<Self> {
+    return LazyCollection(_base: self)
   }
 }
 
+% for Traversal in TRAVERSALS:
+%   TraversalCollection = collectionForTraversal(Traversal)
 // Without this specific overload the non-re-wrapping extension on
 // LazyCollectionProtocol (below) is not selected for some reason.
 extension ${TraversalCollection} where Self : LazyCollectionProtocol {
@@ -263,12 +264,15 @@ extension ${TraversalCollection} where Self : LazyCollectionProtocol {
     return self
   }
 }
-
 % end
 
 extension Slice: LazySequenceProtocol where Base: LazySequenceProtocol { }
 extension Slice: LazyCollectionProtocol where Base: LazyCollectionProtocol { }
 
+@available(*, deprecated, renamed: "LazyCollection")
+public typealias LazyBidirectionalCollection<T> = LazyCollection<T> where T : BidirectionalCollection
+@available(*, deprecated, renamed: "LazyCollection")
+public typealias LazyRandomAccessCollection<T> = LazyCollection<T> where T : RandomAccessCollection
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -45,7 +45,8 @@ public struct LazyMapIterator<
   }
 }
 
-/// A `Sequence` whose elements consist of those in a `Base` /// `Sequence` passed through a transform function returning `Element`.
+/// A `Sequence` whose elements consist of those in a `Base`
+/// `Sequence` passed through a transform function returning `Element`.
 /// These elements are computed lazily, each time they're read, by
 /// calling the transform function on a base element.
 @_fixed_layout

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -1,4 +1,4 @@
-//===--- Map.swift.gyb - Lazily map over a Sequence -----------*- swift -*-===//
+//===--- Map.swift - Lazily map over a Sequence ---------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -9,13 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
-%{
-from gyb_stdlib_support import (
-    TRAVERSALS,
-    collectionForTraversal
-)
-}%
 
 /// The `IteratorProtocol` used by `MapSequence` and `MapCollection`.
 /// Produces each element by passing the output of the `Base`
@@ -52,8 +45,7 @@ public struct LazyMapIterator<
   }
 }
 
-/// A `Sequence` whose elements consist of those in a `Base`
-/// `Sequence` passed through a transform function returning `Element`.
+/// A `Sequence` whose elements consist of those in a `Base` /// `Sequence` passed through a transform function returning `Element`.
 /// These elements are computed lazily, each time they're read, by
 /// calling the transform function on a base element.
 @_fixed_layout
@@ -96,22 +88,14 @@ public struct LazyMapSequence<Base : Sequence, Element>
 
 //===--- Collections ------------------------------------------------------===//
 
-// FIXME(ABI)#45 (Conditional Conformance): `LazyMap*Collection` types should be
-// collapsed into one `LazyMapCollection` using conditional conformances.
-// Maybe even combined with `LazyMapSequence`.
-// rdar://problem/17144340
-
-% for Traversal in TRAVERSALS:
-%   Self = "LazyMap" + collectionForTraversal(Traversal)
-
 /// A `Collection` whose elements consist of those in a `Base`
 /// `Collection` passed through a transform function returning `Element`.
 /// These elements are computed lazily, each time they're read, by
 /// calling the transform function on a base element.
 @_fixed_layout
-public struct ${Self}<
-  Base : ${collectionForTraversal(Traversal)}, Element
-> : LazyCollectionProtocol, ${collectionForTraversal(Traversal)} {
+public struct LazyMapCollection<
+  Base : Collection, Element
+> : LazyCollectionProtocol, Collection {
 
   // FIXME(compiler limitation): should be inferable.
   public typealias Index = Base.Index
@@ -129,16 +113,6 @@ public struct ${Self}<
     _base.formIndex(after: &i)
   }
 
-%   if Traversal in ['Bidirectional', 'RandomAccess']:
-  @_inlineable
-  public func index(before i: Index) -> Index { return _base.index(before: i) }
-
-  @_inlineable
-  public func formIndex(before i: inout Index) {
-    _base.formIndex(before: &i)
-  }
-%   end
-
   /// Accesses the element at `position`.
   ///
   /// - Precondition: `position` is a valid position in `self` and
@@ -148,7 +122,7 @@ public struct ${Self}<
     return _transform(_base[position])
   }
 
-  public typealias SubSequence = ${Self}<Base.SubSequence, Element>
+  public typealias SubSequence = LazyMapCollection<Base.SubSequence, Element>
 
   @_inlineable
   public subscript(bounds: Range<Base.Index>) -> SubSequence {
@@ -182,11 +156,6 @@ public struct ${Self}<
 
   @_inlineable
   public var first: Element? { return _base.first.map(_transform) }
-
-%   if Traversal in ['Bidirectional', 'RandomAccess']:
-  @_inlineable
-  public var last: Element? { return _base.last.map(_transform) }
-%   end
 
   @_inlineable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -233,7 +202,24 @@ public struct ${Self}<
   internal let _transform: (Base.Element) -> Element
 }
 
-% end
+extension LazyMapCollection : BidirectionalCollection
+  where Base : BidirectionalCollection {
+
+  @_inlineable
+  public func index(before i: Index) -> Index { return _base.index(before: i) }
+
+  @_inlineable
+  public func formIndex(before i: inout Index) {
+    _base.formIndex(before: &i)
+  }
+
+  @_inlineable
+  public var last: Element? { return _base.last.map(_transform) }
+}
+
+extension LazyMapCollection : RandomAccessCollection
+  where Base : RandomAccessCollection {}
+
 
 //===--- Support for s.lazy -----------------------------------------------===//
 
@@ -249,29 +235,17 @@ extension LazySequenceProtocol {
   }
 }
 
-% for Traversal in TRAVERSALS:
-
-extension LazyCollectionProtocol
-%   if Traversal != 'Forward':
-  where
-  Self : ${collectionForTraversal(Traversal)},
-  Elements : ${collectionForTraversal(Traversal)}
-%   end
-{
+extension LazyCollectionProtocol {
   /// Returns a `LazyMapCollection` over this `Collection`.  The elements of
   /// the result are computed lazily, each time they are read, by
   /// calling `transform` function on a base element.
   @_inlineable
   public func map<U>(
     _ transform: @escaping (Elements.Element) -> U
-  ) -> LazyMap${collectionForTraversal(Traversal)}<Self.Elements, U> {
-    return LazyMap${collectionForTraversal(Traversal)}(
-      _base: self.elements,
-      transform: transform)
+  ) -> LazyMapCollection<Self.Elements, U> {
+    return LazyMapCollection(_base: self.elements, transform: transform)
   }
 }
-
-% end
 
 extension LazyMapCollection {
   // This overload is needed to re-enable Swift 3 source compatibility related
@@ -289,6 +263,7 @@ extension LazyMapCollection {
   }
 }
 
-// ${'Local Variables'}:
-// eval: (read-only-mode 1)
-// End:
+@available(*, deprecated, renamed: "LazyMapCollection")
+public typealias LazyMapBidirectionalCollection<T, E> = LazyMapCollection<T, E> where T : BidirectionalCollection
+@available(*, deprecated, renamed: "LazyMapCollection")
+public typealias LazyMapRandomAccessCollection<T, E> = LazyMapCollection<T, E> where T : RandomAccessCollection

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -312,7 +312,7 @@ extension LazyCollectionProtocol
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public func reversed() -> LazyBidirectionalCollection<
+  public func reversed() -> LazyCollection<
     ReversedCollection<Elements>
   > {
     return ReversedCollection(_base: elements).lazy

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -312,7 +312,7 @@ extension LazyCollectionProtocol
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public func reversed() -> LazyCollection<
+  public func reversed() -> LazyBidirectionalCollection<
     ReversedCollection<Elements>
   > {
     return ReversedCollection(_base: elements).lazy

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -312,25 +312,7 @@ extension LazyCollectionProtocol
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public func reversed() -> LazyBidirectionalCollection<
-    ReversedCollection<Elements>
-  > {
-    return ReversedCollection(_base: elements).lazy
-  }
-}
-
-extension LazyCollectionProtocol
-  where
-  Self : RandomAccessCollection,
-  Elements : RandomAccessCollection {
-
-  /// Returns the elements of the collection in reverse order.
-  ///
-  /// - Complexity: O(1)
-  @_inlineable
-  public func reversed() -> LazyRandomAccessCollection<
-    ReversedCollection<Elements>
-  > {
+  public func reversed() -> LazyCollection<ReversedCollection<Elements>> {
     return ReversedCollection(_base: elements).lazy
   }
 }

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -15,12 +15,12 @@ variations = [('', 'Sequence'), ('', 'Collection'), ('Bidirectional', 'Collectio
 // Test collections using value types as elements.
 % for (traversal, kind) in variations:
 CollectionTests.add${traversal}${kind}Tests(
-  make${kind}: { (elements: [OpaqueValue<Int>]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<OpaqueValue<Int>>> in
+  make${kind}: { (elements: [OpaqueValue<Int>]) -> LazyFilter${kind}<Minimal${traversal}${kind}<OpaqueValue<Int>>> in
     Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
   },
   wrapValue: identity,
   extractValue: identity,
-  make${kind}OfEquatable: { (elements: [MinimalEquatableValue]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<MinimalEquatableValue>> in
+  make${kind}OfEquatable: { (elements: [MinimalEquatableValue]) -> LazyFilter${kind}<Minimal${traversal}${kind}<MinimalEquatableValue>> in
     Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
   },
   wrapValueIntoEquatable: identityEq,
@@ -31,7 +31,7 @@ CollectionTests.add${traversal}${kind}Tests(
 // Test collections using reference types as elements.
 % for (traversal, kind) in variations:
 CollectionTests.add${traversal}${kind}Tests(
-  make${kind}: { (elements: [LifetimeTracked]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
+  make${kind}: { (elements: [LifetimeTracked]) -> LazyFilter${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
     // FIXME: create a better sequence and filter
     Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
   },
@@ -41,7 +41,7 @@ CollectionTests.add${traversal}${kind}Tests(
   extractValue: { (element: LifetimeTracked) in
     OpaqueValue(element.value, identity: element.identity)
   },
-  make${kind}OfEquatable: { (elements: [LifetimeTracked]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
+  make${kind}OfEquatable: { (elements: [LifetimeTracked]) -> LazyFilter${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
     // FIXME: create a better sequence and filter
     Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
   },

--- a/validation-test/stdlib/Collection/LazyMapBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/LazyMapBidirectionalCollection.swift
@@ -15,12 +15,12 @@ var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.
 CollectionTests.addBidirectionalCollectionTests(
-  makeCollection: { (elements: [OpaqueValue<Int>]) -> LazyMapBidirectionalCollection<MinimalBidirectionalCollection<OpaqueValue<Int>>, OpaqueValue<Int>> in
+  makeCollection: { (elements: [OpaqueValue<Int>]) -> LazyMapCollection<MinimalBidirectionalCollection<OpaqueValue<Int>>, OpaqueValue<Int>> in
     MinimalBidirectionalCollection(elements: elements).lazy.map(identity)
   },
   wrapValue: identity,
   extractValue: identity,
-  makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) -> LazyMapBidirectionalCollection<MinimalBidirectionalCollection<MinimalEquatableValue>, MinimalEquatableValue> in
+  makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) -> LazyMapCollection<MinimalBidirectionalCollection<MinimalEquatableValue>, MinimalEquatableValue> in
     MinimalBidirectionalCollection(elements: elements).lazy.map(identityEq)
   },
   wrapValueIntoEquatable: identityEq,
@@ -29,7 +29,7 @@ CollectionTests.addBidirectionalCollectionTests(
 
 // Test collections using reference types as elements.
 CollectionTests.addBidirectionalCollectionTests(
-  makeCollection: { (elements: [LifetimeTracked]) -> LazyMapBidirectionalCollection<MinimalBidirectionalCollection<LifetimeTracked>, LifetimeTracked> in
+  makeCollection: { (elements: [LifetimeTracked]) -> LazyMapCollection<MinimalBidirectionalCollection<LifetimeTracked>, LifetimeTracked> in
     MinimalBidirectionalCollection(elements: elements).lazy.map { $0 }
   },
   wrapValue: { (element: OpaqueValue<Int>) in
@@ -38,7 +38,7 @@ CollectionTests.addBidirectionalCollectionTests(
   extractValue: { (element: LifetimeTracked) in
     OpaqueValue(element.value, identity: element.identity)
   },
-  makeCollectionOfEquatable: { (elements: [LifetimeTracked]) -> LazyMapBidirectionalCollection<MinimalBidirectionalCollection<LifetimeTracked>, LifetimeTracked> in
+  makeCollectionOfEquatable: { (elements: [LifetimeTracked]) -> LazyMapCollection<MinimalBidirectionalCollection<LifetimeTracked>, LifetimeTracked> in
     MinimalBidirectionalCollection(elements: elements).lazy.map { $0 }
   },
   wrapValueIntoEquatable: { (element: MinimalEquatableValue) in

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -507,7 +507,7 @@ LazyTestSuite.test("MapCollection<${TraversalCollection}>/underestimatedCount") 
     OpaqueValue(Int32(input.value))
   }
   expectType(
-    LazyMap${TraversalCollection}<
+    LazyMapCollection<
       Minimal${TraversalCollection}<OpaqueValue<Int>>, OpaqueValue<Int32>
     >.self,
     &lazyMap)
@@ -810,7 +810,7 @@ tests.test("LazyMap${TraversalCollection}/Collection") {
   expectEqual(0, calls)
 
   expectType(
-    LazyMap${TraversalCollection}<
+    LazyMapCollection<
       Minimal${TraversalCollection}<OpaqueValue<Int>>,
       OpaqueValue<Double>>.self,
     &mapped)
@@ -926,7 +926,7 @@ tests.test("lazy.mapped/TypeInference") {
     var mapped = MinimalBidirectionalCollection(elements: baseArray)
       .lazy.map { _ in OpaqueValue<Int8>(0) }
     expectType(
-      LazyMapBidirectionalCollection<
+      LazyMapCollection<
         MinimalBidirectionalCollection<OpaqueValue<Int>>,
         OpaqueValue<Int8>
       >.self,
@@ -960,14 +960,14 @@ tests.test("ReversedCollection") {
   }
 
   checkBidirectionalCollection(
-    "raboof".characters,
-    "foobar".characters.reversed())
+    "raboof",
+    "foobar".reversed())
 
   // Check that the reverse collection is still eager
   do {
     var calls = 0
-    _ = "foobar".characters.reversed().map { _ in calls += 1 }
-    expectEqual("foobar".characters.count, calls)
+    _ = "foobar".reversed().map { _ in calls += 1 }
+    expectEqual("foobar".count, calls)
   }
 }
 
@@ -1002,12 +1002,8 @@ tests.test("ReversedCollection/Lazy") {
   }
 
   do {
-    typealias Expected = LazyBidirectionalCollection<
-      ReversedCollection<String.CharacterView>
-    >
-
-    let base = "foobar".characters.lazy.map { $0 }
-    typealias Base = LazyMapCollection<String.CharacterView, Character>
+    let base = "foobar".lazy.map { $0 }
+    typealias Base = LazyMapCollection<String, Character>
     ExpectType<Base>.test(base)
 
     typealias LazyReversedBase = LazyBidirectionalCollection<
@@ -1019,7 +1015,7 @@ tests.test("ReversedCollection/Lazy") {
     var calls = 0
     let reversedAndMapped = reversed.map { (x) -> Character in calls += 1; return x }
     expectEqual(0, calls)
-    checkBidirectionalCollection("raboof".characters, reversedAndMapped)
+    checkBidirectionalCollection("raboof", reversedAndMapped)
     expectNotEqual(0, calls)
   }
 }
@@ -1160,7 +1156,7 @@ tests.test("LazyFilterCollection/AssociatedTypes") {
     collectionType: Subject.self,
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
     subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
-    indexType: LazyFilterIndex<Base>.self,
+    indexType: Base.Index.self,
     indicesType: DefaultIndices<Subject>.self)
 }
 
@@ -1171,7 +1167,7 @@ tests.test("LazyFilterBidirectionalCollection/AssociatedTypes") {
     collectionType: Subject.self,
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
     subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
-    indexType: LazyFilterIndex<Base>.self,
+    indexType: Base.Index.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
 }
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -1167,11 +1167,11 @@ tests.test("LazyFilterCollection/AssociatedTypes") {
 
 tests.test("LazyFilterBidirectionalCollection/AssociatedTypes") {
   typealias Base = MinimalBidirectionalCollection<OpaqueValue<Int>>
-  typealias Subject = LazyFilterBidirectionalCollection<Base>
+  typealias Subject = LazyFilterCollection<Base>
   expectBidirectionalCollectionAssociatedTypes(
     collectionType: Subject.self,
     iteratorType: LazyFilterIterator<Base.Iterator>.self,
-    subSequenceType: LazyFilterBidirectionalCollection<Base.SubSequence>.self,
+    subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
     indexType: LazyFilterIndex<Base>.self,
     indicesType: DefaultBidirectionalIndices<Subject>.self)
 }
@@ -1196,7 +1196,7 @@ tests.test("lazy.filter/TypeInference") {
     var filtered = MinimalBidirectionalCollection(elements: baseArray)
       .lazy.filter { _ in true }
     expectType(
-      LazyFilterBidirectionalCollection<
+      LazyFilterCollection<
         MinimalBidirectionalCollection<OpaqueValue<Int>>
       >.self,
       &filtered)
@@ -1205,7 +1205,7 @@ tests.test("lazy.filter/TypeInference") {
     var filtered = MinimalRandomAccessCollection(elements: baseArray)
       .lazy.filter { _ in true }
     expectType(
-      LazyFilterBidirectionalCollection<
+      LazyFilterCollection<
         MinimalRandomAccessCollection<OpaqueValue<Int>>
       >.self,
       &filtered)

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -988,8 +988,7 @@ tests.test("ReversedCollection/Lazy") {
     typealias Base = LazyMapCollection<[Int], Int>
     ExpectType<Base>.test(base)
 
-    typealias LazyReversedBase = LazyRandomAccessCollection<
-      ReversedCollection<Base>>
+    typealias LazyReversedBase = LazyCollection<ReversedCollection<Base>>
 
     let reversed = base.reversed()
     ExpectType<LazyReversedBase>.test(reversed)
@@ -1006,8 +1005,7 @@ tests.test("ReversedCollection/Lazy") {
     typealias Base = LazyMapCollection<String, Character>
     ExpectType<Base>.test(base)
 
-    typealias LazyReversedBase = LazyBidirectionalCollection<
-      ReversedCollection<Base>>
+    typealias LazyReversedBase = LazyCollection<ReversedCollection<Base>>
 
     let reversed = base.reversed()
     ExpectType<LazyReversedBase>.test(reversed)

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -880,22 +880,22 @@ tests.test("LazyMapCollection/AssociatedTypes") {
 
 tests.test("LazyMapBidirectionalCollection/AssociatedTypes") {
   typealias Base = MinimalBidirectionalCollection<OpaqueValue<Int>>
-  typealias Subject = LazyMapBidirectionalCollection<Base, OpaqueValue<Int32>>
+  typealias Subject = LazyMapCollection<Base, OpaqueValue<Int32>>
   expectBidirectionalCollectionAssociatedTypes(
     collectionType: Subject.self,
     iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
-    subSequenceType: LazyMapBidirectionalCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
+    subSequenceType: LazyMapCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
     indicesType: Base.Indices.self)
 }
 
 tests.test("LazyMapRandomAccessCollection/AssociatedTypes") {
   typealias Base = MinimalRandomAccessCollection<OpaqueValue<Int>>
-  typealias Subject = LazyMapRandomAccessCollection<Base, OpaqueValue<Int32>>
+  typealias Subject = LazyMapCollection<Base, OpaqueValue<Int32>>
   expectRandomAccessCollectionAssociatedTypes(
     collectionType: Subject.self,
     iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
-    subSequenceType: LazyMapRandomAccessCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
+    subSequenceType: LazyMapCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
     indicesType: Base.Indices.self)
 }
@@ -936,7 +936,7 @@ tests.test("lazy.mapped/TypeInference") {
     var mapped = MinimalRandomAccessCollection(elements: baseArray)
       .lazy.map { _ in OpaqueValue<Int8>(0) }
     expectType(
-      LazyMapRandomAccessCollection<
+      LazyMapCollection<
         MinimalRandomAccessCollection<OpaqueValue<Int>>,
         OpaqueValue<Int8>
       >.self,
@@ -985,7 +985,7 @@ tests.test("ReversedCollection/Lazy") {
 
     let base = Array(stride(from: 11, through: 0, by: -1)).lazy.map { $0 }
 
-    typealias Base = LazyMapRandomAccessCollection<[Int], Int>
+    typealias Base = LazyMapCollection<[Int], Int>
     ExpectType<Base>.test(base)
 
     typealias LazyReversedBase = LazyRandomAccessCollection<
@@ -1007,8 +1007,7 @@ tests.test("ReversedCollection/Lazy") {
     >
 
     let base = "foobar".characters.lazy.map { $0 }
-    typealias Base = LazyMapBidirectionalCollection<
-      String.CharacterView, Character>
+    typealias Base = LazyMapCollection<String.CharacterView, Character>
     ExpectType<Base>.test(base)
 
     typealias LazyReversedBase = LazyBidirectionalCollection<

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -784,7 +784,7 @@ MiscTestSuite.test("map()") {
 
 MiscTestSuite.test("reversed()") {
   var result = (0..<10).lazy.reversed()
-  typealias Expected = LazyRandomAccessCollection<
+  typealias Expected = LazyCollection<
     ReversedRandomAccessCollection<CountableRange<Int>>>
     expectType(Expected.self, &result)
   expectEqualSequence(


### PR DESCRIPTION
* Explanation: Utilize conditional conformances to simplify
LazyFilter/LazyMap/Lazy Collection hierarchies.
* Scope of Issue: Reduces the API surface (fewer types) of the standard
library, which results in simpler user code.
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Existing automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/35944334>