### PR TITLE
[stdlib] Match memory layout of DoubleWidth to base integer types

### DIFF
--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -18,9 +18,14 @@ public struct DoubleWidth<Base : FixedWidthInteger> : _ExpressibleByBuiltinInteg
   public typealias High = Base
   public typealias Low = Base.Magnitude
 
+#if _endian(big)
   @_versioned // FIXME(sil-serialize-all)
-  internal var _storage: (high: Base, low: Base.Magnitude)
-  
+  internal var _storage: (high: High, low: Low)
+#else
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _storage: (low: Low, high: High)
+#endif
+
   @_inlineable // FIXME(sil-serialize-all)
   public var high: High {
     return _storage.high
@@ -34,7 +39,11 @@ public struct DoubleWidth<Base : FixedWidthInteger> : _ExpressibleByBuiltinInteg
   @_inlineable // FIXME(sil-serialize-all)
   public // @testable
   init(_ _value: (High, Low)) {
+#if _endian(big)
     self._storage = (high: _value.0, low: _value.1)
+#else
+    self._storage = (low: _value.1, high: _value.0)
+#endif
   }
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -187,8 +196,8 @@ extension DoubleWidth: FixedWidthInteger {
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Words : Collection {
     public enum _IndexValue {
-      case low(Base.Magnitude.Words.Index)
-      case high(Base.Words.Index)
+      case low(Low.Words.Index)
+      case high(High.Words.Index)
     }
     
     @_fixed_layout // FIXME(sil-serialize-all)
@@ -218,8 +227,8 @@ extension DoubleWidth: FixedWidthInteger {
       }
     }
 
-    public var _high: Base.Words
-    public var _low: Base.Magnitude.Words
+    public var _high: High.Words
+    public var _low: Low.Words
 
     @_inlineable // FIXME(sil-serialize-all)
     public init(_ value: DoubleWidth<Base>) {


### PR DESCRIPTION
Although `DoubleWidth` types do have a notional bit pattern that "works fine," the current implementation always stores the high half first in memory regardless of the endianness of the system. As a consequence, the actual bits of two equivalent values, one of type `DoubleWidth<Int32>` and the other of type `Int64`, would not be the same on little-endian systems.

Certainly, Swift makes no guarantees as to the memory layout of any particular user-defined structure. However, various APIs permit users to rely on the memory layout of "trivial" types, among which the built-in numeric types figure prominently. It stands to reason, therefore, that a mismatch between the layout of `DoubleWidth` and base integer types could become a very subtle source of bugs for some users.

This PR mitigates this issue by using storage that respects the endianness of the system. This has no implications for ordinary use of `DoubleWidth` as no public API is changed. What's more, no internal implementation changes are required, either.

(That said, in a few instances, I have modified the code to use the public type aliases `High` and `Low` to improve reading clarity, and I have future-proofed the public initializer implementation so as not to rely on the apparently unpopular feature that permits assigning a value of type `(high: U, low: T)` to a variable of type `(low: T, high: U)`.)