### PR TITLE
Fix default witness checking [4.1]

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -184,10 +184,6 @@ namespace swift {
                            unsigned WarnLongExpressionTypeChecking = 0,
                            unsigned ExpressionTimeoutThreshold = 0);
 
-  /// Once type checking is complete, this walks protocol requirements
-  /// to resolve default witnesses.
-  void finishTypeCheckingFile(SourceFile &SF);
-
   /// Now that we have type-checked an entire module, perform any type
   /// checking that requires the full module, e.g., Objective-C method
   /// override checking.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -648,7 +648,6 @@ void CompilerInstance::finishTypeChecking(
       performWholeModuleTypeChecking(SF);
     });
   }
-  forEachFileToTypeCheck([&](SourceFile &SF) { finishTypeCheckingFile(SF); });
 }
 
 void CompilerInstance::performParseOnly(bool EvaluateConditionals) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -827,7 +827,8 @@ public:
 
     // Build a default witness table if this is a protocol.
     if (auto protocol = dyn_cast<ProtocolDecl>(theType)) {
-      if (!protocol->isObjC())
+      if (!protocol->isObjC() &&
+          !protocol->hasFixedLayout())
         SGM.emitDefaultWitnessTable(protocol);
       return;
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3969,6 +3969,10 @@ public:
       if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
         TC.checkDeclCircularity(nominal);
       }
+      if (auto protocol = dyn_cast<ProtocolDecl>(decl)) {
+        if (!protocol->hasFixedLayout())
+          TC.inferDefaultWitnesses(protocol);
+      }
     }
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -672,16 +672,6 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   }
 }
 
-void swift::finishTypeCheckingFile(SourceFile &SF) {
-  auto &Ctx = SF.getASTContext();
-  TypeChecker TC(Ctx);
-
-  for (auto D : SF.Decls)
-    if (auto PD = dyn_cast<ProtocolDecl>(D))
-      if (!PD->hasFixedLayout())
-        TC.inferDefaultWitnesses(PD);
-}
-
 void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   SharedTimer("performWholeModuleTypeChecking");
   auto &Ctx = SF.getASTContext();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -678,7 +678,8 @@ void swift::finishTypeCheckingFile(SourceFile &SF) {
 
   for (auto D : SF.Decls)
     if (auto PD = dyn_cast<ProtocolDecl>(D))
-      TC.inferDefaultWitnesses(PD);
+      if (!PD->hasFixedLayout())
+        TC.inferDefaultWitnesses(PD);
 }
 
 void swift::performWholeModuleTypeChecking(SourceFile &SF) {

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -254,19 +254,6 @@ func inoutResilientProtocol(_ x: inout OtherConformingType) {
   inoutFunc(&OtherConformingType.staticPropertyInExtension)
 }
 
-// Protocol is not public -- make sure default witnesses have the right linkage
-protocol InternalProtocol {
-  func noDefaultF()
-  func defaultG()
-}
-
-extension InternalProtocol {
-
-  // CHECK-LABEL: sil private [transparent] [thunk] @_T019protocol_resilience16InternalProtocolP8defaultGyyF
-  // CHECK: return
-  func defaultG() {}
-}
-
 // CHECK-LABEL: sil_default_witness_table P {
 // CHECK-NEXT: }
 
@@ -327,9 +314,4 @@ extension InternalProtocol {
 // CHECK-NEXT:   method #ReabstractSelfRefined.callback!getter.1: {{.*}} : @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcvg
 // CHECK-NEXT:   method #ReabstractSelfRefined.callback!setter.1: {{.*}} : @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcvs
 // CHECK-NEXT:   method #ReabstractSelfRefined.callback!materializeForSet.1: {{.*}} : @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcvm
-// CHECK-NEXT: }
-
-// CHECK-LABEL: sil_default_witness_table hidden InternalProtocol {
-// CHECK-NEXT:   no_default
-// CHECK-NEXT:   method #InternalProtocol.defaultG!1: {{.*}} : @_T019protocol_resilience16InternalProtocolP8defaultGyyF
 // CHECK-NEXT: }

--- a/test/SILGen/witness_accessibility.swift
+++ b/test/SILGen/witness_accessibility.swift
@@ -20,9 +20,9 @@ extension R {
 
 public struct S : R {}
 
-// CHECK-LABEL: sil private @_T021witness_accessibility1R{{.*}}AE18privateRequirementyyF
 // CHECK-LABEL: sil private @_T021witness_accessibility1R{{.*}}E17publicRequirementyyF
 // CHECK-LABEL: sil private @_T021witness_accessibility1R{{.*}}E19internalRequirementyyF
+// CHECK-LABEL: sil private @_T021witness_accessibility1R{{.*}}AE18privateRequirementyyF
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T021witness_accessibility1SVAA1R{{.*}}dELLP18privateRequirementyyFTW
 // CHECK-LABEL: sil private [transparent] [thunk] @_T021witness_accessibility1SVAA1QA2aDP19internalRequirementyyFTW

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -216,15 +216,3 @@ internal func donotEliminate() {
 
 // CHECK-TESTING-LABEL: sil_witness_table [serialized] Adopt: Prot
 // CHECK-TESTING: DeadWitness{{.*}}: @{{.*}}DeadWitness
-
-// CHECK-LABEL: sil_default_witness_table hidden Prot
-// CHECK:  no_default
-// CHECK:  no_default
-// CHECK:  method #Prot.aliveDefaultWitness!1: {{.*}} : @{{.*}}aliveDefaultWitness
-// CHECK:  no_default
-
-// CHECK-TESTING-LABEL: sil_default_witness_table Prot
-// CHECK-TESTING:  no_default
-// CHECK-TESTING:  no_default
-// CHECK-TESTING:  method #Prot.aliveDefaultWitness!1: {{.*}} : @{{.*}}aliveDefaultWitness
-// CHECK-TESTING:  method #Prot.DeadDefaultWitness!1: {{.*}} : @{{.*}}DeadDefaultWitness

--- a/test/multifile/Inputs/default-witness.swift
+++ b/test/multifile/Inputs/default-witness.swift
@@ -1,0 +1,9 @@
+public protocol Node: Source { }
+
+public protocol Source {
+    associatedtype Output
+}
+
+public final class GraphNode<U>: Node {
+    public typealias Output = U
+}

--- a/test/multifile/default-witness.swift
+++ b/test/multifile/default-witness.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck %S/Inputs/default-witness.swift -primary-file %s -enable-resilience
+
+public protocol GraphType {
+    func insert<U>(_: GraphNode<U>, _: GraphNode<U>)
+}
+
+public extension GraphType {
+    func insert<N: Node>(_: N, _: GraphNode<N.Output>) {}
+}
+


### PR DESCRIPTION
* Description: Fixes a type checker bug where SILGen would try to use an incomplete conformance due to a subtle phase ordering issue. Since the problem was with default witness tables and those are not used unless building a resilient module, go further and don't emit them at all unless resilience is enabled.

* Scope of the issue: Reported by a user on Twitter who was hitting this with a real project.

* Risk: Low, we're basically just disabling a code path for normal users.

* Origination: Probably the specific crash was introduced in 4.0 when conformance access paths came along. Default witness tables have been broken in this way since first added in 3.0 or 3.1.

* Tested: New test case added.

* Radar: <rdar://problem/35949729> 

* Reviewed by: @jckarter  