### PR TITLE
[build-script] When skipping building LLVM, make sure to call intrins…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2002,7 +2002,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${SKIP_BUILD_LLVM}" ] ; then
                     # We can't skip the build completely because the standalone
                     # build of Swift depend on these.
-                    build_targets=(llvm-tblgen clang-headers)
+                    build_targets=(llvm-tblgen clang-headers intrinsics_gen)
                 fi
 
                 if [ "${HOST_LIBTOOL}" ] ; then


### PR DESCRIPTION
…ics_gen as well as clang-headers.

SILGen depends on headers generated by this build step.
