### PR TITLE
[stdlib]Add benchmark for strings with long shared prefixes

### DIFF
--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -63,6 +63,10 @@ public let StringComparison = [
     name: "StringComparison_zalgo",
     runFunction: run_StringComparison_zalgo,
     tags: [.validation, .api, .String]),    
+  BenchmarkInfo(
+    name: "StringComparison_longSharedPrefix",
+    runFunction: run_StringComparison_longSharedPrefix,
+    tags: [.validation, .api, .String]),    
 ]
     
   @inline(never)
@@ -181,6 +185,22 @@ public let StringComparison = [
   public func run_StringComparison_zalgo(_ N: Int) {
     var count = 0
     let workload = Workload.zalgo
+    let tripCount = workload.tripCount
+    let payload = workload.payload
+    for _ in 1...tripCount*N {
+      for s1 in payload {
+        for s2 in payload {
+          let cmp = s1 < s2
+          count += cmp ? 1 : 0
+        }
+      }
+    }
+  }
+    
+  @inline(never)
+  public func run_StringComparison_longSharedPrefix(_ N: Int) {
+    var count = 0
+    let workload = Workload.longSharedPrefix
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
@@ -387,6 +407,21 @@ struct Workload {
     xͣͤͥͦͧͨͩͪͫͬͭͮ
     """.lines(),
     scaleMultiplier: 0.25
+  )
+  
+  static let longSharedPrefix = Workload(
+    name: "LongSharedPrefix",
+    payload: """
+    http://www.dogbook.com/dog/239495828/friends/mutual/2939493815
+    http://www.dogbook.com/dog/239495828/friends/mutual/3910583739
+    http://www.dogbook.com/dog/239495828/friends/mutual/3910583739/shared
+    http://www.dogbook.com/dog/239495828/friends/mutual/3910583739/shared
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.🤔
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    🤔Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.🤔
+    """.lines()
   )
   
 }

--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -71,15 +71,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_ascii(_ N: Int) {
-    var count = 0
     let workload = Workload.ascii
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -87,15 +85,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_latin1(_ N: Int) {
-    var count = 0
     let workload = Workload.latin1
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -103,15 +99,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_fastPrenormal(_ N: Int) {
-    var count = 0
     let workload = Workload.fastPrenormal
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -119,15 +113,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_slowerPrenormal(_ N: Int) {
-    var count = 0
     let workload = Workload.slowerPrenormal
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -135,15 +127,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_nonBMPSlowestPrenormal(_ N: Int) {
-    var count = 0
     let workload = Workload.nonBMPSlowestPrenormal
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -151,15 +141,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_emoji(_ N: Int) {
-    var count = 0
     let workload = Workload.emoji
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -167,15 +155,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_abnormal(_ N: Int) {
-    var count = 0
     let workload = Workload.abnormal
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -183,15 +169,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_zalgo(_ N: Int) {
-    var count = 0
     let workload = Workload.zalgo
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }
@@ -199,15 +183,13 @@ public let StringComparison = [
     
   @inline(never)
   public func run_StringComparison_longSharedPrefix(_ N: Int) {
-    var count = 0
     let workload = Workload.longSharedPrefix
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -30,7 +30,7 @@ extension String {
   }
 }
 
-% Names = ["ascii", "latin1", "fastPrenormal", "slowerPrenormal", "nonBMPSlowestPrenormal", "emoji", "abnormal", "zalgo"]
+% Names = ["ascii", "latin1", "fastPrenormal", "slowerPrenormal", "nonBMPSlowestPrenormal", "emoji", "abnormal", "zalgo", "longSharedPrefix"]
 
 public let StringComparison = [
 % for Name in Names:
@@ -253,6 +253,21 @@ struct Workload {
     xͣͤͥͦͧͨͩͪͫͬͭͮ
     """.lines(),
     scaleMultiplier: 0.25
+  )
+  
+  static let longSharedPrefix = Workload(
+    name: "LongSharedPrefix",
+    payload: """
+    http://www.dogbook.com/dog/239495828/friends/mutual/2939493815
+    http://www.dogbook.com/dog/239495828/friends/mutual/3910583739
+    http://www.dogbook.com/dog/239495828/friends/mutual/3910583739/shared
+    http://www.dogbook.com/dog/239495828/friends/mutual/3910583739/shared
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.🤔
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    🤔Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.🤔
+    """.lines()
   )
   
 }

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -44,15 +44,13 @@ public let StringComparison = [
 % for Name in Names:
   @inline(never)
   public func run_StringComparison_${Name}(_ N: Int) {
-    var count = 0
     let workload = Workload.${Name}
     let tripCount = workload.tripCount
     let payload = workload.payload
     for _ in 1...tripCount*N {
       for s1 in payload {
         for s2 in payload {
-          let cmp = s1 < s2
-          count += cmp ? 1 : 0
+          blackHole(s1 < s2)
         }
       }
     }


### PR DESCRIPTION
As per Michael's suggestion in https://github.com/apple/swift/pull/13217, this is a benchmark that exercises the path for long, shared prefixes