### PR TITLE
[build-script] I am finding that I also need clang-tablegen-targets a…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2002,7 +2002,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${SKIP_BUILD_LLVM}" ] ; then
                     # We can't skip the build completely because the standalone
                     # build of Swift depend on these.
-                    build_targets=(llvm-tblgen clang-headers intrinsics_gen)
+                    build_targets=(llvm-tblgen clang-headers intrinsics_gen clang-tablegen-targets)
                 fi
 
                 if [ "${HOST_LIBTOOL}" ] ; then


### PR DESCRIPTION
…s well to get --xcode --skip-build-llvm to work.
