### PR TITLE
[CMake] Add swift-syntax-generated-headers to tools targets dependencies

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Add generated libSyntax headers to global dependencies.
+list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
+
 add_swift_tool_subdirectory(driver)
 add_swift_tool_subdirectory(sil-opt)
 add_swift_tool_subdirectory(swift-ide-test)


### PR DESCRIPTION
Fixes https://ci.swift.org/job/swift-master-source-compat-suite/903/ failure
CC: @shahmishal 
