### PR TITLE
Remove TypeChecker::forceExternalDeclMembers() and friends

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -453,11 +453,7 @@ class alignas(1 << DeclAlignInBits) Decl {
     unsigned IsCompatibilityAlias : 1;
   BITFIELD_END;
 
-  BITFIELD_START(NominalTypeDecl, GenericTypeDecl, 4);
-    /// Whether or not the nominal type decl has delayed protocol or member
-    /// declarations.
-    unsigned HasDelayedMembers : 1;
-
+  BITFIELD_START(NominalTypeDecl, GenericTypeDecl, 3);
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     unsigned AddedImplicitInitializers : 1;
@@ -2802,7 +2798,6 @@ protected:
     IterableDeclContext(IterableDeclContextKind::NominalTypeDecl)
   {
     setGenericParams(GenericParams);
-    NominalTypeDeclBits.HasDelayedMembers = false;
     NominalTypeDeclBits.AddedImplicitInitializers = false;
     ExtensionGeneration = 0;
     NominalTypeDeclBits.HasLazyConformances = false;
@@ -2831,17 +2826,6 @@ public:
   /// \brief Does this declaration expose a fixed layout to the given
   /// module?
   bool hasFixedLayout(ModuleDecl *M, ResilienceExpansion expansion) const;
-
-  /// \brief Returns true if this decl contains delayed value or protocol
-  /// declarations.
-  bool hasDelayedMembers() const {
-    return NominalTypeDeclBits.HasDelayedMembers;
-  }
-  
-  /// \brief Mark this declaration as having delayed members or not.
-  void setHasDelayedMembers(bool hasDelayedMembers = true) {
-    NominalTypeDeclBits.HasDelayedMembers = hasDelayedMembers;
-  }
 
   /// Determine whether we have already attempted to add any
   /// implicitly-defined initializers to this declaration.

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -96,10 +96,6 @@ public:
   /// Resolve an implicitly-generated member with the given name.
   virtual void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) = 0;
 
-  /// Resolve any implicitly-generated members and conformances for generated
-  /// external decls.
-  virtual void resolveExternalDeclImplicitMembers(NominalTypeDecl *nominal) = 0;
-
   /// Determine whether the given (potentially constrained) protocol extension
   /// is usable for the given type.
   virtual bool isProtocolExtensionUsable(DeclContext *dc, Type type,
@@ -167,10 +163,6 @@ public:
 
   void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) override {
     Principal.resolveImplicitMember(nominal, member);
-  }
-
-  void resolveExternalDeclImplicitMembers(NominalTypeDecl *nominal) override {
-    Principal.resolveExternalDeclImplicitMembers(nominal);
   }
 
   bool isProtocolExtensionUsable(DeclContext *dc, Type type,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1384,8 +1384,6 @@ static void makeStructRawValued(
   var->addTrivialAccessors(varGetter, nullptr, nullptr);
   assert(var->hasStorage());
 
-  structDecl->setHasDelayedMembers();
-
   // Create constructors to initialize that value from a value of the
   // underlying type.
   if (options.contains(MakeStructRawValuedFlags::MakeUnlabeledValueInit))
@@ -1537,7 +1535,6 @@ static void makeStructRawValuedWithBridge(
         Impl, structDecl, computedVar, storedVar,
         /*wantLabel*/ false, wantBody);
 
-  structDecl->setHasDelayedMembers();
   if (unlabeledCtor)
     structDecl->addMember(unlabeledCtor);
   structDecl->addMember(init);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7472,25 +7472,15 @@ void ClangImporter::Implementation::finishedImportingEntity() {
 }
 
 void ClangImporter::Implementation::finishPendingActions() {
-  while (true) {
-    // The odd shape of this loop comes from previously having more than one
-    // possible kind of pending action. It's left this way to make it easy to
-    // add another one back in an `else if` clause.
-    if (!RegisteredExternalDecls.empty()) {
-      if (hasFinishedTypeChecking()) {
-        RegisteredExternalDecls.clear();
-      } else {
-        Decl *D = RegisteredExternalDecls.pop_back_val();
-        SwiftContext.addExternalDecl(D);
-        if (auto typeResolver = getTypeResolver())
-          if (auto *nominal = dyn_cast<NominalTypeDecl>(D))
-            if (!nominal->hasDelayedMembers())
-              typeResolver->resolveExternalDeclImplicitMembers(nominal);
-      }
-    } else {
-      break;
-    }
+  if (RegisteredExternalDecls.empty())
+    return;
+
+  if (!hasFinishedTypeChecking()) {
+    for (auto *D : RegisteredExternalDecls)
+      SwiftContext.addExternalDecl(D);
   }
+
+  RegisteredExternalDecls.clear();
 }
 
 /// Look up associated type requirements in the conforming type.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3121,17 +3121,14 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // the candidate should be favored.
     if (isa<ConstructorDecl>(decl) && favoredType &&
         result.FavoredChoice == ~0U) {
+      auto *ctor = cast<ConstructorDecl>(decl);
+
       // Only try and favor monomorphic initializers.
-      if (auto fnTypeWithSelf = decl->getInterfaceType()
-                                                     ->getAs<FunctionType>()) {
-        if (auto fnType = fnTypeWithSelf->getResult()->getAs<FunctionType>()) {
-          auto argType = fnType->getInput()->getWithoutParens();
-          argType = decl->getInnermostDeclContext()
-                                                  ->mapTypeIntoContext(argType);
-          if (argType->isEqual(favoredType))
-            if (!decl->getAttrs().isUnavailable(getASTContext()))
-              result.FavoredChoice = result.ViableCandidates.size();
-        }
+      if (!ctor->isGenericContext()) {
+        auto argType = ctor->getArgumentInterfaceType();
+        if (argType->isEqual(favoredType))
+          if (!decl->getAttrs().isUnavailable(getASTContext()))
+            result.FavoredChoice = result.ViableCandidates.size();
       }
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3180,13 +3180,6 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         }
       }
     }
-    
-    // If the result's type contains delayed members, we need to force them now.
-    if (auto NT = dyn_cast<NominalType>(decl->getInterfaceType().getPointer())){
-      if (auto *NTD = dyn_cast<NominalTypeDecl>(NT->getDecl())) {
-        TC.forceExternalDeclMembers(NTD);
-      }
-    }
 
     // Otherwise, we're good, add the candidate to the list.
     result.addViable(candidate);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -234,14 +234,6 @@ TypeChecker::getDynamicBridgedThroughObjCClass(DeclContext *dc,
   return Context.getBridgedToObjC(dc, valueType);
 }
 
-void TypeChecker::forceExternalDeclMembers(NominalTypeDecl *nominalDecl) {
-  // Force any delayed members added to the nominal type declaration.
-  if (nominalDecl->hasDelayedMembers()) {
-    this->handleExternalDecl(nominalDecl);
-    nominalDecl->setHasDelayedMembers(false);
-  }
-}
-
 Type TypeChecker::resolveTypeInContext(
        TypeDecl *typeDecl,
        DeclContext *foundDC,
@@ -265,7 +257,6 @@ Type TypeChecker::resolveTypeInContext(
   if (auto nominalType = dyn_cast<NominalTypeDecl>(typeDecl)) {
     if (!isa<ProtocolDecl>(nominalType) &&
         (!nominalType->getGenericParams() || !isSpecialized)) {
-      forceExternalDeclMembers(nominalType);
       for (auto parentDC = fromDC;
            !parentDC->isModuleScopeContext();
            parentDC = parentDC->getParent()) {
@@ -1150,11 +1141,6 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
   for (const auto entry : globals) {
     auto *foundDC = entry.getDeclContext();
     auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
-
-    // If necessary, add delayed members to the declaration.
-    if (auto nomDecl = dyn_cast<NominalTypeDecl>(typeDecl)) {
-      TC.forceExternalDeclMembers(nomDecl);
-    }
 
     Type type = resolveTypeDecl(TC, typeDecl, comp->getIdLoc(),
                                 foundDC, DC,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1335,11 +1335,6 @@ public:
     synthesizeMemberForLookup(nominal, member);
   }
 
-  virtual void
-  resolveExternalDeclImplicitMembers(NominalTypeDecl *nominal) override {
-    handleExternalDecl(nominal);
-  }
-
   /// Infer default value witnesses for all requirements in the given protocol.
   void inferDefaultWitnesses(ProtocolDecl *proto);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1086,10 +1086,6 @@ public:
   /// translation unit has been processed.
   void finalizeDecl(ValueDecl *D);
 
-  /// \brief Force all members of an external decl, and also add its
-  /// conformances.
-  void forceExternalDeclMembers(NominalTypeDecl *NTD);
-
   /// Resolve a reference to the given type declaration within a particular
   /// context.
   ///

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -95,14 +95,14 @@ public func testTopLevel() {
 // CHECK: %objc_class** @"OBJC_CLASS_REF_$_PrivFooSub"
 // CHECK: }
 
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGs5Int32V2___tcfcTO
-// CHECK: @"\01L_selector(init:)"
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGs5Int32V9__twoArgs_AE5othertcfcTO
-// CHECK: @"\01L_selector(initWithTwoArgs:other:)"
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGs5Int32V8__oneArg_tcfcTO
-// CHECK: @"\01L_selector(initWithOneArg:)"
 // CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGyt8__noArgs_tcfcTO
 // CHECK: @"\01L_selector(initWithNoArgs)"
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGs5Int32V8__oneArg_tcfcTO
+// CHECK: @"\01L_selector(initWithOneArg:)"
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGs5Int32V9__twoArgs_AE5othertcfcTO
+// CHECK: @"\01L_selector(initWithTwoArgs:other:)"
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @_T0So3BarCSQyABGs5Int32V2___tcfcTO
+// CHECK: @"\01L_selector(init:)"
 
 _ = __PrivAnonymousA
 _ = __E0PrivA

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -125,6 +125,11 @@ func configureWithoutOptions() {
   _ = GenericClass<NSObject>(options: nil)
 }
 
+// This gets emitted down here for some reason
+
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So12GenericClassCSQyAByxGGSayxG13arrayOfThings_tcfcTO
+// CHECK:         objc_method {{%.*}} : $GenericClass<T>, #GenericClass.init!initializer.1.foreign {{.*}}, $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject> (NSArray, @owned GenericClass<τ_0_0>) -> @owned Optional<GenericClass<τ_0_0>>
+
 // foreign to native thunk for init(options:), uses GenericOption : Hashable
 // conformance
 
@@ -132,11 +137,6 @@ func configureWithoutOptions() {
 // CHECK: [[FN:%.*]] = function_ref @_T0s10DictionaryV10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: apply [[FN]]<GenericOption, Any>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: return
-
-// This gets emitted down here for some reason
-
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So12GenericClassCSQyAByxGGSayxG13arrayOfThings_tcfcTO
-// CHECK:         objc_method {{%.*}} : $GenericClass<T>, #GenericClass.init!initializer.1.foreign {{.*}}, $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject> (NSArray, @owned GenericClass<τ_0_0>) -> @owned Optional<GenericClass<τ_0_0>>
 
 // Make sure we emitted the witness table for the above conformance
 


### PR DESCRIPTION
I was working on a fix for rdar://35945827 and came across a potential simplification but it needs some testing.