### PR TITLE
[Parse] Slightly refactor TypleTypeRepr element parsing

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -594,7 +594,6 @@ struct TupleTypeReprElement {
   SourceLoc SecondNameLoc;
   SourceLoc UnderscoreLoc;
   SourceLoc ColonLoc;
-  SourceLoc InOutLoc;
   TypeRepr *Type;
   SourceLoc TrailingCommaLoc;
 

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -188,3 +188,7 @@ func sr5505(arg: Int) -> String {
   return "hello"
 }
 var _: sr5505 = sr5505 // expected-error {{use of undeclared type 'sr5505'}}
+
+typealias A = (inout Int ..., Int ... = [42, 12]) -> Void // expected-error {{'inout' must not be used on variadic parameters}}
+                                                          // expected-error@-1 {{only a single element can be variadic}} {{35-39=}}
+                                                          // expected-error@-2 {{default argument not permitted in a tuple type}} {{39-49=}}


### PR DESCRIPTION
As a groundwork for libSyntax parsing.

* Instead of consuming `inout` unconditionally, use backtracking to determine it's obsolete usage of `inout` position.
* parse `...` before `= <initializer>` because `(Int... = [1])` is more
  likely than `(Int = 1 ...)`. This improves diagnostics.
* Remove unused `InOutLoc` field from `TupleTypeReprElement`