### PR TITLE
Fix the IR attributes of swift_getObjectType.

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1049,14 +1049,10 @@ FUNCTION(LookUpClass, objc_lookUpClass, C_CC,
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getObjectType(id object);
-//
-// Since this is intended to look through dynamic subclasses, it's
-// invariant across reasonable isa-rewriting schemes and therefore can
-// be readnone.
 FUNCTION(GetObjectType, swift_getObjectType, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
          ARGS(ObjCPtrTy),
-         ATTRS(NoUnwind, ReadNone))
+         ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_getDynamicType(opaque_t *obj, Metadata *self);
 FUNCTION(GetDynamicType, swift_getDynamicType, DefaultCC,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4230,7 +4230,7 @@ llvm::Value *irgen::emitDynamicTypeOfOpaqueHeapObject(IRGenFunction &IGF,
                                          object,
                                          object->getName() + ".Type");
   metadata->setDoesNotThrow();
-  metadata->setDoesNotAccessMemory();
+  metadata->setOnlyReadsMemory();
   return metadata;
 }
 

--- a/test/IRGen/object_type.swift
+++ b/test/IRGen/object_type.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-build-swift -O %s -emit-ir | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+// Check if the runtime function swift_getObjectType is not readnone and
+// therefore not re-scheduled with release-calls, which would lead to a crash
+// in this example.
+
+public protocol Proto: class {
+   static func printit()
+}
+
+public final class ConformingClass : Proto {
+   public static func printit() { print("okay") }
+}
+
+public final class Creator {
+   @inline(never)
+   public init() {}
+
+   @inline(never)
+   public func createIt() -> Proto {
+      return ConformingClass ()
+   }
+}
+
+func work() {
+  let myProtocolType: Proto.Type = type(of: Creator().createIt())
+  myProtocolType.printit()
+}
+
+// CHECK-IR: call {{.*}} @swift_getObjectType({{.*}}) #[[M:[0-9]]]
+// CHECK-IR: declare {{.*}} @swift_getObjectType{{.*}} #[[M]]
+// CHECK-IR: attributes #[[M]] = { nounwind readonly }
+
+// CHECK: okay
+work()


### PR DESCRIPTION
It's not readnone, because it reads the metatype from an object.
Readnone would let the llvm ARC optimizer reschedule the call with a release-call for the object.

fixes SR-6560.
rdar://problem/35998785