### PR TITLE
WIP: Eliminate setBuffer (rebased)

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -83,7 +83,7 @@ public:
     for (InputFile input : other.getAllFiles())
       addInput(input);
   }
-  
+
   FrontendInputs &operator=(const FrontendInputs &other) {
     clearInputs();
     for (InputFile input : other.getAllFiles())
@@ -191,7 +191,7 @@ public:
   }
   void addPrimaryInputFile(StringRef file,
                            llvm::MemoryBuffer *buffer = nullptr) {
-    addInput(InputFile(file.str(), true, buffer));
+    addInput(InputFile(file, true, buffer));
   }
 
   void setBuffer(llvm::MemoryBuffer *buffer, unsigned index) {
@@ -203,6 +203,7 @@ public:
       PrimaryInputs.insert(std::make_pair(input.file(), AllFiles.size()));
     AllFiles.push_back(input);
   }
+  
   void clearInputs() {
     AllFiles.clear();
     PrimaryInputs.clear();

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -58,8 +58,6 @@ public:
     return Filename;
   }
 
-  void setBuffer(llvm::MemoryBuffer *buffer) { Buffer = buffer; }
-
   /// Return Swift-standard file name from a buffer name set by
   /// llvm::MemoryBuffer::getFileOrSTDIN, which uses "<stdin>" instead of "-".
   static StringRef convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
@@ -194,16 +192,12 @@ public:
     addInput(InputFile(file, true, buffer));
   }
 
-  void setBuffer(llvm::MemoryBuffer *buffer, unsigned index) {
-    AllFiles[index].setBuffer(buffer);
-  }
-
   void addInput(const InputFile &input) {
     if (!input.file().empty() && input.isPrimary())
       PrimaryInputs.insert(std::make_pair(input.file(), AllFiles.size()));
     AllFiles.push_back(input);
   }
-  
+
   void clearInputs() {
     AllFiles.clear();
     PrimaryInputs.clear();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -237,7 +237,9 @@ Optional<unsigned> CompilerInstance::getRecordedBufferID(const InputFile &input,
     return None;
   }
 
-  if (serialization::isSerializedAST(buffers.first.get()->getBuffer())) {
+  // FIXME: The fact that this test happens twice, for some cases,
+  // suggests that setupInputs could use another round of refactoring.
+  if (serialization::isSerializedAST(buffers.first->getBuffer())) {
     PartialModules.push_back(
         {std::move(buffers.first), std::move(buffers.second)});
     return None;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -232,7 +232,7 @@ Optional<unsigned> CompilerInstance::getRecordedBufferID(const InputFile &input,
             std::unique_ptr<llvm::MemoryBuffer>>
       buffers = getInputBufferAndModuleDocBufferIfPresent(input);
 
-  if (!buffers.first.get()) {
+  if (!buffers.first) {
     failed = true;
     return None;
   }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -97,12 +97,10 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
 
   assert(Lexer::isIdentifier(Invocation.getModuleName()));
 
-  const Optional<unsigned> codeCompletionBufferID = setUpCodeCompletionBuffer();
-
   if (isInSILMode())
     Invocation.getLangOptions().EnableAccessControl = false;
 
-  return setUpInputs(codeCompletionBufferID);
+  return setUpInputs();
 }
 
 void CompilerInstance::setUpLLVMArguments() {
@@ -176,7 +174,11 @@ Optional<unsigned> CompilerInstance::setUpCodeCompletionBuffer() {
   return codeCompletionBufferID;
 }
 
-bool CompilerInstance::setUpInputs(Optional<unsigned> codeCompletionBufferID) {
+bool CompilerInstance::setUpInputs() {
+  // Adds to InputSourceCodeBufferIDs, so may need to happen before the
+  // per-input setup.
+  const Optional<unsigned> codeCompletionBufferID = setUpCodeCompletionBuffer();
+
   for (const InputFile &input :
        Invocation.getFrontendOptions().Inputs.getAllFiles())
     if (setUpForInput(input))
@@ -190,107 +192,111 @@ bool CompilerInstance::setUpInputs(Optional<unsigned> codeCompletionBufferID) {
   }
 
   if (isInputSwift() && MainBufferID == NO_SUCH_BUFFER &&
-      InputSourceCodeBufferIDs.size() == 1) {
+      InputSourceCodeBufferIDs.size() == 1)
     MainBufferID = InputSourceCodeBufferIDs.front();
-  }
 
   return false;
 }
 
 bool CompilerInstance::setUpForInput(const InputFile &input) {
-  if (llvm::MemoryBuffer *inputBuffer = input.buffer()) {
-    setUpForBuffer(inputBuffer, input.isPrimary());
-    return false;
-  }
-  return setUpForFile(input.file(), input.isPrimary());
-}
-void CompilerInstance::setUpForBuffer(llvm::MemoryBuffer *buffer,
-                                      bool isPrimary) {
-  auto copy = llvm::MemoryBuffer::getMemBufferCopy(
-      buffer->getBuffer(), buffer->getBufferIdentifier());
-  if (serialization::isSerializedAST(copy->getBuffer())) {
-    PartialModules.push_back({std::move(copy), nullptr});
-  } else {
-    unsigned bufferID = SourceMgr.addNewSourceBuffer(std::move(copy));
-    InputSourceCodeBufferIDs.push_back(bufferID);
-
-    if (isInSILMode()) {
-      assert(MainBufferID == NO_SUCH_BUFFER && "re-setting MainBufferID");
-      MainBufferID = bufferID;
-    }
-
-    if (isPrimary) {
-      assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-      PrimaryBufferID = bufferID;
-    }
-  }
-}
-
-bool CompilerInstance::setUpForFile(StringRef fileName, bool isPrimary) {
-  if (fileName.empty())
-    return false;
-  // FIXME: Working with filenames is fragile, maybe use the real path
-  // or have some kind of FileManager.
-  using namespace llvm::sys::path;
-  if (Optional<unsigned> existingBufferID =
-          SourceMgr.getIDForBufferIdentifier(fileName)) {
-    if (isInSILMode() ||
-        (isInputSwift() && filename(fileName) == "main.swift")) {
-      assert(MainBufferID == NO_SUCH_BUFFER && "re-setting MainBufferID");
-      MainBufferID = existingBufferID.getValue();
-    }
-
-    if (isPrimary) {
-      assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-      PrimaryBufferID = existingBufferID.getValue();
-    }
-
-    return false; // replaced by a memory buffer.
-  }
-
-  // Open the input file.
-  using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
-  FileOrError inputFileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(fileName);
-  if (!inputFileOrErr) {
-    Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file, fileName,
-                         inputFileOrErr.getError().message());
+  bool failed = false;
+  Optional<unsigned> bufferID = getRecordedBufferID(input, failed);
+  if (failed)
     return true;
+  if (!bufferID)
+    return false;
+
+  if (isInSILMode() ||
+      (input.buffer() == nullptr && isInputSwift() &&
+       llvm::sys::path::filename(input.file()) == "main.swift")) {
+    assert(MainBufferID == NO_SUCH_BUFFER && "re-setting MainBufferID");
+    MainBufferID = *bufferID;
   }
 
-  if (serialization::isSerializedAST(inputFileOrErr.get()->getBuffer())) {
-    llvm::SmallString<128> ModuleDocFilePath(fileName);
-    llvm::sys::path::replace_extension(ModuleDocFilePath,
-                                       SERIALIZED_MODULE_DOC_EXTENSION);
-    FileOrError moduleDocOrErr =
-        llvm::MemoryBuffer::getFileOrSTDIN(ModuleDocFilePath.str());
-    if (!moduleDocOrErr &&
-        moduleDocOrErr.getError() != std::errc::no_such_file_or_directory) {
-      Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file, fileName,
-                           moduleDocOrErr.getError().message());
-      return true;
-    }
-    PartialModules.push_back(
-        {std::move(inputFileOrErr.get()),
-         moduleDocOrErr ? std::move(moduleDocOrErr.get()) : nullptr});
-    return false;
+  if (input.isPrimary()) {
+    assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
+    PrimaryBufferID = *bufferID;
   }
+  return false;
+}
+
+Optional<unsigned> CompilerInstance::getRecordedBufferID(const InputFile &input,
+                                                         bool &failed) {
+  if (!input.buffer()) {
+    if (Optional<unsigned> existingBufferID =
+            SourceMgr.getIDForBufferIdentifier(input.file())) {
+      return existingBufferID;
+    }
+  }
+  std::pair<std::unique_ptr<llvm::MemoryBuffer>,
+            std::unique_ptr<llvm::MemoryBuffer>>
+      buffers = getInputBufferAndModuleDocBufferIfPresent(input);
+
+  if (!buffers.first.get()) {
+    failed = true;
+    return None;
+  }
+
+  if (serialization::isSerializedAST(buffers.first.get()->getBuffer())) {
+    PartialModules.push_back(
+        {std::move(buffers.first), std::move(buffers.second)});
+    return None;
+  }
+  assert(buffers.second.get() == nullptr);
   // Transfer ownership of the MemoryBuffer to the SourceMgr.
-  unsigned bufferID =
-      SourceMgr.addNewSourceBuffer(std::move(inputFileOrErr.get()));
+  unsigned bufferID = SourceMgr.addNewSourceBuffer(std::move(buffers.first));
 
   InputSourceCodeBufferIDs.push_back(bufferID);
+  return bufferID;
+}
 
-  if (isInSILMode() || (isInputSwift() && filename(fileName) == "main.swift")) {
-    assert(MainBufferID == NO_SUCH_BUFFER && "re-setting MainBufferID");
-    MainBufferID = bufferID;
+std::pair<std::unique_ptr<llvm::MemoryBuffer>,
+          std::unique_ptr<llvm::MemoryBuffer>>
+CompilerInstance::getInputBufferAndModuleDocBufferIfPresent(
+    const InputFile &input) {
+  if (auto b = input.buffer()) {
+    return std::make_pair(llvm::MemoryBuffer::getMemBufferCopy(
+                              b->getBuffer(), b->getBufferIdentifier()),
+                          nullptr);
   }
-
-  if (isPrimary) {
-    assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-    PrimaryBufferID = bufferID;
+  // FIXME: Working with filenames is fragile, maybe use the real path
+  // or have some kind of FileManager.
+  using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
+  FileOrError inputFileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(input.file());
+  if (!inputFileOrErr) {
+    Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file, input.file(),
+                         inputFileOrErr.getError().message());
+    return std::make_pair(nullptr, nullptr);
   }
+  if (!serialization::isSerializedAST((*inputFileOrErr)->getBuffer()))
+    return std::make_pair(std::move(*inputFileOrErr), nullptr);
 
-  return false;
+  if (Optional<std::unique_ptr<llvm::MemoryBuffer>> moduleDocBuffer =
+          openModuleDoc(input)) {
+    return std::make_pair(std::move(*inputFileOrErr),
+                          std::move(*moduleDocBuffer));
+  }
+  return std::make_pair(nullptr, nullptr);
+}
+
+Optional<std::unique_ptr<llvm::MemoryBuffer>>
+CompilerInstance::openModuleDoc(const InputFile &input) {
+  llvm::SmallString<128> moduleDocFilePath(input.file());
+  llvm::sys::path::replace_extension(moduleDocFilePath,
+                                     SERIALIZED_MODULE_DOC_EXTENSION);
+  using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
+  FileOrError moduleDocFileOrErr =
+      llvm::MemoryBuffer::getFileOrSTDIN(moduleDocFilePath);
+  if (moduleDocFileOrErr)
+    return std::move(*moduleDocFileOrErr);
+
+  if (moduleDocFileOrErr.getError() == std::errc::no_such_file_or_directory)
+    return std::unique_ptr<llvm::MemoryBuffer>();
+
+  Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
+                       moduleDocFilePath,
+                       moduleDocFileOrErr.getError().message());
+  return None;
 }
 
 ModuleDecl *CompilerInstance::getMainModule() {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -98,7 +98,6 @@ bool FrontendInputs::verifyInputs(DiagnosticEngine &diags, bool treatAsSIL,
 
 bool FrontendInputs::areAllNonPrimariesSIB() const {
   for (const InputFile &input : getAllFiles()) {
-    assert(!input.file().empty() && "all files have (perhaps pseudo) names");
     if (input.isPrimary())
       continue;
     if (!llvm::sys::path::extension(input.file()).endswith(SIB_EXTENSION)) {

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -439,6 +439,5 @@ const MigratorOptions &Migrator::getMigratorOptions() const {
 const StringRef Migrator::getInputFilename() const {
   auto &PrimaryInput = StartInvocation.getFrontendOptions()
                            .Inputs.getRequiredUniquePrimaryInput();
-  assert(!PrimaryInput.file().empty());
   return PrimaryInput.file();
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Changes ASTManager to create input files with buffer set as appropriate instead of setting after creation.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
