### PR TITLE
Eliminate InputFile::setBuffer()

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -58,8 +58,6 @@ public:
     return Filename;
   }
 
-  void setBuffer(llvm::MemoryBuffer *buffer) { Buffer = buffer; }
-
   /// Return Swift-standard file name from a buffer name set by
   /// llvm::MemoryBuffer::getFileOrSTDIN, which uses "<stdin>" instead of "-".
   static StringRef convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
@@ -194,16 +192,12 @@ public:
     addInput(InputFile(file, true, buffer));
   }
 
-  void setBuffer(llvm::MemoryBuffer *buffer, unsigned index) {
-    AllFiles[index].setBuffer(buffer);
-  }
-
   void addInput(const InputFile &input) {
     if (!input.file().empty() && input.isPrimary())
       PrimaryInputs.insert(std::make_pair(input.file(), AllFiles.size()));
     AllFiles.push_back(input);
   }
-  
+
   void clearInputs() {
     AllFiles.clear();
     PrimaryInputs.clear();

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -98,7 +98,6 @@ bool FrontendInputs::verifyInputs(DiagnosticEngine &diags, bool treatAsSIL,
 
 bool FrontendInputs::areAllNonPrimariesSIB() const {
   for (const InputFile &input : getAllFiles()) {
-    assert(!input.file().empty() && "all files have (perhaps pseudo) names");
     if (input.isPrimary())
       continue;
     if (!llvm::sys::path::extension(input.file()).endswith(SIB_EXTENSION)) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -908,7 +908,7 @@ void ASTProducer::findSnapshotAndOpenFiles(
       }
     }
     if (FoundSnapshot)
-      break;
+      continue;
 
     auto Content = MgrImpl.getFileContent(File, IsPrimary, Error);
     if (!Content.Buffer) {


### PR DESCRIPTION
Change SwiftASTManager to create new InputFile's with the buffer set or not as needed.

<!-- What's in this pull request? -->


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->