### PR TITLE
Re-enable SwiftSyntax tests

### DIFF
--- a/test/SwiftSyntax/DiagnosticTest.swift
+++ b/test/SwiftSyntax/DiagnosticTest.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
-// REQUIRES: sdk_overlay
+// REQUIRES: objc_interop
 
 import Foundation
 import StdlibUnittest
@@ -55,3 +55,5 @@ Diagnostics.test("DiagnosticEmission") {
   guard let fixIt = note.fixIts.first else { return }
   expectEqual(fixIt.text, " != 0")
 }
+
+runAllTests()

--- a/test/SwiftSyntax/LazyCaching.swift
+++ b/test/SwiftSyntax/LazyCaching.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
-// REQUIRES: sdk_overlay
+// REQUIRES: objc_interop
 
 import StdlibUnittest
 import Foundation

--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
-// REQUIRES: sdk_overlay
+// REQUIRES: objc_interop
 
 import Foundation
 import StdlibUnittest

--- a/test/SwiftSyntax/SyntaxChildren.swift
+++ b/test/SwiftSyntax/SyntaxChildren.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
-// REQUIRES: sdk_overlay
+// REQUIRES: objc_interop
 
 import Foundation
 import StdlibUnittest

--- a/tools/SwiftSyntax/Diagnostic.swift
+++ b/tools/SwiftSyntax/Diagnostic.swift
@@ -107,7 +107,7 @@ public enum FixIt: Codable {
 
   /// The source range associated with a FixIt. If this is an insertion,
   /// it is a range with the same start and end location.
-  var range: SourceRange {
+  public var range: SourceRange {
     switch self {
     case .remove(let range), .replace(let range, _): return range
     case .insert(let loc, _): return SourceRange(start: loc, end: loc)
@@ -116,7 +116,7 @@ public enum FixIt: Codable {
 
   /// The text associated with this FixIt. If this is a removal, the text is
   /// the empty string.
-  var text: String {
+  public var text: String {
     switch self {
     case .remove(_): return ""
     case .insert(_, let text), .replace(_, let text): return text


### PR DESCRIPTION
Re-enables the SwiftSyntax tests by guarding them on `objc_interop` vs. `sdk_overlay`, given that `sdk_overlay` is only set when the stdlib is not being built.