### PR TITLE
WIP IRGen: preserve calling convention when importing functions

### DIFF
--- a/test/IRGen/Inputs/usr/include/SRoA.h
+++ b/test/IRGen/Inputs/usr/include/SRoA.h
@@ -6,3 +6,6 @@ typedef struct S {
 
 void f(S);
 
+float frand(void);
+float add(float f, float g) { return f + g; }
+

--- a/test/IRGen/calling-convention.swift
+++ b/test/IRGen/calling-convention.swift
@@ -1,0 +1,21 @@
+// RUN: %swift -target thumbv7-unknown-windows-msvc -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
+// RUN: %swift -target thumbv7-unknown-linux-gnueabihf -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
+// RUN: %swift -target thumbv7-unknown-linux-gnueabi -Xcc -mfloat-abi=hard -parse-stdlib -parse-as-library -I %S/Inputs/usr/include -module-name Swift -S -emit-ir -o - %s | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=ARM
+
+struct Float {
+  let _value: Builtin.FPIEEE32
+}
+
+typealias CFloat = Float
+typealias Void = ()
+
+import SRoA
+
+func f() -> Float {
+  return add(frand(), frand())
+}
+
+// CHECK: call arm_aapcs_vfpcc float @add
+


### PR DESCRIPTION
We do not currently preserve the calling convention when importing a
foreign function.  This is problematic as a call made with a mismatched
calling convention is UB.  The optimizer in LLVM then is permitted to
optimize that UB into a call elision.  For platforms where the default
calling convention is non-C (e.g. Linux ARMHF/Windows ARM default to ARM
AAPCS VFP CC rather than C) this will result in invalid function calls
outside of swift.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
