### PR TITLE
Add new function (expectCrash) to StdlibUnittest

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -542,9 +542,9 @@ public func expectCrashLater() {
   _seenExpectCrash = true
 }
 
-public func expectCrash(_ disaster: () -> Void) {
+public func expectCrash(executing: () -> Void) {
   expectCrashLater()
-  disaster()
+  executing()
 }
 
 func _defaultTestSuiteFailedCallback() {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -542,6 +542,11 @@ public func expectCrashLater() {
   _seenExpectCrash = true
 }
 
+public func expectCrash(_ disaster: () -> Void) {
+  expectCrashLater()
+  disaster()
+}
+
 func _defaultTestSuiteFailedCallback() {
   abort()
 }

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -327,13 +327,11 @@ OptionalTests.test("Casting Optional") {
 
 OptionalTests.test("Casting Optional Traps") {
   let nx: C? = nil
-  expectCrashLater()
-  _blackHole(anyToAny(nx, Int.self))
+  expectCrash { _blackHole(anyToAny(nx, Int.self)) }
 }
 OptionalTests.test("Casting Optional Any Traps") {
   let nx: X? = X()
-  expectCrashLater()
-  _blackHole(anyToAny(nx as Any, Optional<Int>.self))
+  expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
 }
 
 class TestNoString {}
@@ -402,8 +400,7 @@ OptionalTests.test("unsafelyUnwrapped nil")
     reason: "assertions are disabled in Release and Unchecked mode"))
   .code {
   let empty: Int? = nil
-  expectCrashLater()
-  _blackHole(empty.unsafelyUnwrapped)
+  expectCrash { _blackHole(empty.unsafelyUnwrapped) }
 }
 
 runAllTests()


### PR DESCRIPTION
`expectCrash` makes testing easier and more expressive.