### PR TITLE
[Syntax] Parse: add support for TupleType and FunctionType

### DIFF
--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -38,13 +38,12 @@ class ${node.name}Builder {
 
 public:
 %     for child in node.children:
+  ${node.name}Builder &use${child.name}(${child.type_name} ${child.name});
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
 %         child_elt = child_node.collection_element_name
 %         child_elt_type = child_node.collection_element_type
   ${node.name}Builder &add${child_elt}(${child_elt_type} ${child_elt});
-%       else:
-  ${node.name}Builder &use${child.name}(${child.type_name} ${child.name});
 %       end
 %     end
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -843,6 +843,8 @@ static SyntaxKind getListElementKind(SyntaxKind ListKind) {
     return SyntaxKind::TupleElement;
   case SyntaxKind::FunctionParameterList:
     return SyntaxKind::FunctionParameter;
+  case SyntaxKind::TupleTypeElementList:
+    return SyntaxKind::TupleTypeElement;
   default:
     return SyntaxKind::Unknown;
   }
@@ -858,6 +860,7 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
   SyntaxKind ElementKind = getListElementKind(Kind);
 
   if (Tok.is(RightK)) {
+    ListContext.reset();
     RightLoc = consumeToken(RightK);
     return makeParserSuccess();
   }

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -28,6 +28,12 @@ using namespace swift::syntax;
 % for node in SYNTAX_NODES:
 %   if node.is_buildable():
 %     for child in node.children:
+${node.name}Builder &
+${node.name}Builder::use${child.name}(${child.type_name} ${child.name}) {
+  Layout[cursorIndex(${node.name}::Cursor::${child.name})] =
+    ${child.name}.getRaw();
+  return *this;
+}
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
 %         child_elt = child_node.collection_element_name
@@ -36,13 +42,6 @@ ${node.name}Builder &
 ${node.name}Builder::add${child_elt}(${child_elt_type} ${child_elt}) {
   auto &raw = Layout[cursorIndex(${node.name}::Cursor::${child.name})];
   raw = raw->append(${child_elt}.getRaw());
-  return *this;
-}
-%       else:
-${node.name}Builder &
-${node.name}Builder::use${child.name}(${child.type_name} ${child.name}) {
-  Layout[cursorIndex(${node.name}::Cursor::${child.name})] =
-    ${child.name}.getRaw();
   return *this;
 }
 %       end

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -215,6 +215,10 @@ SyntaxFactory::getUnknownKind(SyntaxKind Kind) {
 %     Result = 'SyntaxKind::UnknownDecl'
 %   elif node.syntax_kind.endswith('Token'):
 %     Result = 'SyntaxKind::UnknownToken'
+%   elif node.syntax_kind.endswith('Type'):
+%     Result = 'SyntaxKind::UnknownType'
+%   elif node.syntax_kind.endswith('Pattern'):
+%     Result = 'SyntaxKind::UnknownPattern'
 %   else:
 %     Result = 'SyntaxKind::Unknown'
 %   end
@@ -307,17 +311,20 @@ TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
                        makeRightParenToken({}, {}));
 }
 
-TupleTypeElementSyntax SyntaxFactory::makeTupleTypeElement(
-    llvm::Optional<TokenSyntax> Label,
-    llvm::Optional<TokenSyntax> Colon, TypeSyntax Type,
-    llvm::Optional<TokenSyntax> TrailingComma) {
-  auto annotation = makeTypeAnnotation(makeBlankAttributeList(), None, Type);
-  return makeTupleTypeElement(Label, Colon, annotation, TrailingComma);
+TupleTypeElementSyntax
+SyntaxFactory::makeTupleTypeElement(llvm::Optional<TokenSyntax> Label,
+                                    llvm::Optional<TokenSyntax> Colon,
+                                    TypeSyntax Type,
+                                    llvm::Optional<TokenSyntax> TrailingComma) {
+  return makeTupleTypeElement(None, Label, None, Colon, Type, None, None,
+                              TrailingComma);
 }
 
-TupleTypeElementSyntax SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
-    llvm::Optional<TokenSyntax> TrailingComma) {
-  return makeTupleTypeElement(None, None, Type, TrailingComma);
+TupleTypeElementSyntax
+SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
+                                    llvm::Optional<TokenSyntax> TrailingComma) {
+  return makeTupleTypeElement(None, None, None, None, Type, None, None,
+                              TrailingComma);
 }
 
 GenericParameterSyntax

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -60,11 +60,13 @@ class C {<FunctionDecl>
 }
 
 typealias A = <SimpleTypeIdentifier>Any</SimpleTypeIdentifier>
-typealias B = (<MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any</SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element</MemberTypeIdentifier>)
+typealias B = <TupleType>(<TupleTypeElement><MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any</SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element</MemberTypeIdentifier>, </TupleTypeElement><TupleTypeElement>x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TupleTypeElement>)</TupleType>
 typealias C = <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>
 typealias D = <DictionaryType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>]</DictionaryType>
 typealias E = <MetatypeType><OptionalType><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>?</OptionalType>.Protocol</MetatypeType>
-typealias F = <MetatypeType><ImplicitlyUnwrappedOptionalType><ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>!</ImplicitlyUnwrappedOptionalType>.Type</MetatypeType><StructDecl>
+typealias F = <MetatypeType><ImplicitlyUnwrappedOptionalType><ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>!</ImplicitlyUnwrappedOptionalType>.Type</MetatypeType>
+typealias G = <FunctionType>(<TupleTypeElement>a x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement>_ y: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>... <Initializer>= <IntegerLiteralExpr>1</IntegerLiteralExpr></Initializer></TupleTypeElement>) -> <FunctionType>() -> <TupleType>()</TupleType></FunctionType></FunctionType>
+typealias H = <TupleType>()</TupleType><StructDecl>
 
 struct foo <MemberDeclBlock>{<StructDecl>
   struct foo <MemberDeclBlock>{<StructDecl>

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -65,8 +65,8 @@ typealias C = <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</Arr
 typealias D = <DictionaryType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>]</DictionaryType>
 typealias E = <MetatypeType><OptionalType><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>?</OptionalType>.Protocol</MetatypeType>
 typealias F = <MetatypeType><ImplicitlyUnwrappedOptionalType><ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>!</ImplicitlyUnwrappedOptionalType>.Type</MetatypeType>
-typealias G = <FunctionType>(<TupleTypeElement>a x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement>_ y: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>... <Initializer>= <IntegerLiteralExpr>1</IntegerLiteralExpr></Initializer></TupleTypeElement>) -> <FunctionType>() -> <TupleType>()</TupleType></FunctionType></FunctionType>
-typealias H = <TupleType>()</TupleType><StructDecl>
+typealias G = <FunctionType>(<TupleTypeElement>a x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement>_ y: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>... <Initializer>= <IntegerLiteralExpr>1</IntegerLiteralExpr></Initializer></TupleTypeElement>) throw -> <FunctionType>() -> <TupleType>()</TupleType></FunctionType></FunctionType>
+typealias H = <FunctionType>() rethrows -> <TupleType>()</TupleType></FunctionType><StructDecl>
 
 struct foo <MemberDeclBlock>{<StructDecl>
   struct foo <MemberDeclBlock>{<StructDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -65,8 +65,8 @@ typealias C = [Int]
 typealias D = [Int: String]
 typealias E = Int?.Protocol
 typealias F = [Int]!.Type
-typealias G = (a x: Int, _ y: Int ... = 1) -> () -> ()
-typealias H = ()
+typealias G = (a x: Int, _ y: Int ... = 1) throw -> () -> ()
+typealias H = () rethrows -> ()
 
 struct foo {
   struct foo {

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -60,11 +60,13 @@ class C {
 }
 
 typealias A = Any
-typealias B = (Array<Array<Any>>.Element)
+typealias B = (Array<Array<Any>>.Element, x: Int)
 typealias C = [Int]
 typealias D = [Int: String]
 typealias E = Int?.Protocol
 typealias F = [Int]!.Type
+typealias G = (a x: Int, _ y: Int ... = 1) -> () -> ()
+typealias H = ()
 
 struct foo {
   struct foo {

--- a/tools/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -120,21 +120,18 @@ public enum SyntaxFactory {
                          rightParen: makeRightParenToken())
   }
 
-  public static func makeTupleTypeElement(label: TokenSyntax?,
+  public static func makeTupleTypeElement(name: TokenSyntax?,
     colon: TokenSyntax?, type: TypeSyntax,
-    comma: TokenSyntax?) -> TupleTypeElementSyntax {
-    let annotation = makeTypeAnnotation(attributes: makeBlankAttributeList(),
-                                        inOutKeyword: nil,
-                                        type: type)
-    return makeTupleTypeElement(label: label, colon: colon, 
-                                typeAnnotation: annotation,
-                                comma: comma)
+    trailingComma: TokenSyntax?) -> TupleTypeElementSyntax {
+    return makeTupleTypeElement(inOut: nil, name: name, secondName: nil,
+                                colon: colon, type: type, ellipsis: nil,
+                                initializer: nil, trailingComma: trailingComma)
   }
 
   public static func makeTupleTypeElement(type: TypeSyntax,
-    comma: TokenSyntax?) -> TupleTypeElementSyntax  {
-    return makeTupleTypeElement(label: nil, colon: nil, 
-                                type: type, comma: comma)
+    trailingComma: TokenSyntax?) -> TupleTypeElementSyntax  {
+    return makeTupleTypeElement(name: nil, colon: nil, 
+                                type: type, trailingComma: trailingComma)
   }
 
   public static func makeGenericParameter(name: TokenSyntax,

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -79,26 +79,43 @@ TYPE_NODES = [
              Child('ExclamationMark', kind='ExclamationMarkToken'),
          ]),
 
-    # throwing-specifier -> 'throws' | 'rethrows'
-    # function-type -> attribute-list '(' function-type-argument-list ')'
-    #   throwing-specifier? '->'? type?
-    Node('FunctionType', kind='Type',
+    Node('Initializer', kind='Syntax',
          children=[
-             Child('TypeAttributes', kind='AttributeList'),
-             Child('LeftParen', kind='LeftParenToken'),
-             Child('ArgumentList', kind='FunctionTypeArgumentList'),
-             Child('RightParen', kind='RightParenToken'),
-             Child('ThrowsOrRethrowsKeyword', kind='Token',
+             Child('Equal', kind='EqualToken'),
+             Child('Value', kind='Expr'),
+         ]),
+
+    # tuple-type-element -> identifier? ':'? type-annotation ','?
+    Node('TupleTypeElement', kind='Syntax',
+         children=[
+             Child('InOut', kind='InOutToken',
+                   is_optional=True),
+             Child('Name', kind='Token',
                    is_optional=True,
                    token_choices=[
-                       'ThrowsToken',
-                       'RethrowsToken',
+                       'IdentifierToken',
+                       'WildcardToken'
                    ]),
-             Child('Arrow', kind='ArrowToken',
+             Child('SecondName', kind='Token',
+                   is_optional=True,
+                   token_choices=[
+                       'IdentifierToken',
+                       'WildcardToken'
+                   ]),
+             Child('Colon', kind='ColonToken',
                    is_optional=True),
-             Child('ReturnType', kind='Type',
+             Child('Type', kind='Type'),
+             Child('Ellipsis', kind='Token',
+                   is_optional=True),
+             Child('Initializer', kind='Initializer',
+                   is_optional=True),
+             Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),
+
+    # tuple-type-element-list -> tuple-type-element tuple-type-element-list?
+    Node('TupleTypeElementList', kind='SyntaxCollection',
+         element='TupleTypeElement'),
 
     # tuple-type -> '(' tuple-type-element-list ')'
     Node('TupleType', kind='Type',
@@ -108,16 +125,22 @@ TYPE_NODES = [
              Child('RightParen', kind='RightParenToken'),
          ]),
 
-    # tuple-type-element -> identifier? ':'? type-annotation ','?
-    Node('TupleTypeElement', kind='Syntax',
+    # throwing-specifier -> 'throws' | 'rethrows'
+    # function-type -> attribute-list '(' function-type-argument-list ')'
+    #   throwing-specifier? '->'? type?
+    Node('FunctionType', kind='Type',
          children=[
-             Child('Label', kind='IdentifierToken',
-                   is_optional=True),
-             Child('Colon', kind='ColonToken',
-                   is_optional=True),
-             Child('TypeAnnotation', kind='TypeAnnotation'),
-             Child('Comma', kind='CommaToken',
-                   is_optional=True),
+             Child('LeftParen', kind='LeftParenToken'),
+             Child('Arguments', kind='TupleTypeElementList'),
+             Child('RightParen', kind='RightParenToken'),
+             Child('ThrowsOrRethrowsKeyword', kind='Token',
+                   is_optional=True,
+                   token_choices=[
+                       'ThrowsToken',
+                       'RethrowsToken',
+                   ]),
+             Child('Arrow', kind='ArrowToken'),
+             Child('ReturnType', kind='Type'),
          ]),
 
     # type-annotation -> attribute-list 'inout'? type
@@ -133,10 +156,6 @@ TYPE_NODES = [
     #   protocol-composition-element-list?
     Node('ProtocolCompositionElementList', kind='SyntaxCollection',
          element='ProtocolCompositionElement'),
-
-    # tuple-type-element-list -> tuple-type-element tuple-type-element-list?
-    Node('TupleTypeElementList', kind='SyntaxCollection',
-         element='TupleTypeElement'),
 
     # protocol-composition-element -> type-identifier '&'
     Node('ProtocolCompositionElement', kind='Syntax',
@@ -167,26 +186,6 @@ TYPE_NODES = [
              Child('Arguments', kind='GenericArgumentList'),
              Child('RightAngleBracket', kind='RightAngleToken'),
          ]),
-
-    # function-type-argument -> identifier? identifier? ':'
-    #   type-annotation ','?
-    Node('FunctionTypeArgument', kind='Syntax',
-         children=[
-             Child('ExternalName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LocalName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('Colon', kind='ColonToken',
-                   is_optional=True),
-             Child('TypeAnnotation', kind='TypeAnnotation'),
-             Child('TrailingComma', kind='CommaToken',
-                   is_optional=True),
-         ]),
-
-    # function-type-argument-list -> function-type-argument
-    #   function-type-argument-list?
-    Node('FunctionTypeArgumentList', kind='SyntaxCollection',
-         element='FunctionTypeArgument'),
 
     # protocol-composition-type -> protocol-composition-elements
     Node('ProtocolCompositionType', kind='Type',


### PR DESCRIPTION
For now, using `SyntaxParsingContext`.
CC: @nkcsgexi 