### PR TITLE
Batch mode for frontend subsystems 1/N

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -29,6 +29,7 @@
 #include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace llvm {
   class raw_ostream;
@@ -378,6 +379,18 @@ public:
     for (const DeclContext *CurContext = this; CurContext;
          CurContext = CurContext->getParent())
       if (CurContext == Other)
+        return true;
+    return false;
+  }
+
+  /// Return true if this is a child of any of the specified other decl
+  /// contexts.
+  bool isChildContextOf(llvm::SetVector<const DeclContext *>Others) const {
+    if (Others.count(this) != 0) return false;
+
+    for (const DeclContext *CurContext = this; CurContext;
+         CurContext = CurContext->getParent())
+      if (Others.count(CurContext) != 0)
         return true;
     return false;
   }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -39,6 +39,7 @@
 #include "swift/Serialization/Validation.h"
 #include "swift/Subsystems.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -336,14 +337,31 @@ class CompilerInstance {
   enum : unsigned { NO_SUCH_BUFFER = ~0U };
   unsigned MainBufferID = NO_SUCH_BUFFER;
 
-  /// PrimaryBufferID corresponds to PrimaryInput.
-  unsigned PrimaryBufferID = NO_SUCH_BUFFER;
-  bool isWholeModuleCompilation() { return PrimaryBufferID == NO_SUCH_BUFFER; }
+  /// Identifies the set of input buffers in the SourceManager that are
+  /// considered primaries.
+  llvm::SetVector<unsigned> PrimaryBufferIDs;
 
-  SourceFile *PrimarySourceFile = nullptr;
+  /// Identifies the set of SourceFiles that are considered primaries. An
+  /// invariant is that any SourceFile in this set with an associated
+  /// buffer will also have its buffer ID in PrimaryBufferIDs.
+  llvm::SetVector<SourceFile*> PrimarySourceFiles;
+
+  /// Return whether there is an entry in PrimaryInputs for buffer \BufID.
+  bool bufferIDIsAPrimaryInput(unsigned BufID) const {
+    return PrimaryBufferIDs.count(BufID) != 0;
+  }
+
+  /// Record in PrimaryBufferIDs the fact that \BufID is a primary.
+  /// If \BufID is already in the set, do nothing.
+  void notePrimaryInputBuffer(unsigned BufID);
+
+  /// Record in PrimarySourceFiles the fact that \SF is a primary, and
+  /// call notePrimaryInputBuffer on \SF's buffer (if it exists).
+  void notePrimarySourceFile(SourceFile *SF);
+
+  bool isWholeModuleCompilation() { return PrimaryBufferIDs.empty(); }
 
   void createSILModule();
-  void setPrimarySourceFile(SourceFile *SF);
 
 public:
   SourceManager &getSourceMgr() { return SourceMgr; }
@@ -371,7 +389,7 @@ public:
   }
 
   void setReferencedNameTracker(ReferencedNameTracker *tracker) {
-    assert(!PrimarySourceFile && "must be called before performSema()");
+    assert(PrimarySourceFiles.empty() && "must be called before performSema()");
     NameTracker = tracker;
   }
   ReferencedNameTracker *getReferencedNameTracker() {
@@ -414,8 +432,16 @@ public:
   }
 
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
-  /// \returns the primary SourceFile, or nullptr if there is no primary input
-  SourceFile *getPrimarySourceFile() { return PrimarySourceFile; }
+  /// \returns the primary SourceFile, or nullptr if there is no primary input;
+  /// if there are _multiple_ primary inputs, fails with an assertion.
+  SourceFile *getPrimarySourceFile() {
+    if (PrimarySourceFiles.empty()) {
+      return nullptr;
+    } else {
+      assert(PrimarySourceFiles.size() == 1);
+      return *PrimarySourceFiles.begin();
+    }
+  }
 
   /// \brief Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation);

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -443,6 +443,12 @@ public:
     }
   }
 
+  /// Gets the set of primary input SourceFiles, which may be empty if
+  /// running in whole-module mode.
+  const llvm::SetVector<SourceFile*>& getPrimarySourceFiles() const {
+    return PrimarySourceFiles;
+  }
+
   /// \brief Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation);
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -235,12 +235,14 @@ namespace swift {
   performSILGeneration(ModuleDecl *M, SILOptions &options,
                        bool wholeModuleCompilation = false);
 
-  /// Turn a source file into SIL IR.
+  /// Turn a set of (source and/or serialized AST) files into SIL IR.
   ///
   /// If \p StartElem is provided, the module is assumed to be only part of the
-  /// SourceFile, and any optimizations should take that into account.
+  /// Files, and any optimizations should take that into account.
   std::unique_ptr<SILModule>
-  performSILGeneration(FileUnit &SF, SILOptions &options,
+  performSILGeneration(ModuleDecl *Module,
+                       SILOptions &options,
+                       ArrayRef<FileUnit*> Files,
                        Optional<unsigned> StartElem = None);
 
   /// Serializes a module and zero or more source files to the given output file.

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Mutex.h"
 
 #include <memory>
@@ -242,10 +243,10 @@ namespace swift {
   performSILGeneration(FileUnit &SF, SILOptions &options,
                        Optional<unsigned> StartElem = None);
 
-  using ModuleOrSourceFile = PointerUnion<ModuleDecl *, SourceFile *>;
-
-  /// Serializes a module or single source file to the given output file.
-  void serialize(ModuleOrSourceFile DC, const SerializationOptions &options,
+  /// Serializes a module and zero or more source files to the given output file.
+  void serialize(ModuleDecl *Module,
+                 const llvm::SetVector<SourceFile*> &SourceFiles,
+                 const SerializationOptions &options,
                  const SILModule *M = nullptr);
 
   /// Get the CPU and subtarget feature options to use when emitting code.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -61,14 +61,16 @@ void CompilerInstance::createSILModule() {
       Invocation.getFrontendOptions().Inputs.isWholeModule());
 }
 
-void CompilerInstance::setPrimarySourceFile(SourceFile *SF) {
-  assert(SF);
+void CompilerInstance::notePrimaryInputBuffer(unsigned BufID) {
+  PrimaryBufferIDs.insert(BufID);
+}
+
+void CompilerInstance::notePrimarySourceFile(SourceFile *SF) {
   assert(MainModule && "main module not created yet");
-  assert(!PrimarySourceFile && "already has a primary source file");
-  assert(PrimaryBufferID == NO_SUCH_BUFFER || !SF->getBufferID().hasValue() ||
-         SF->getBufferID().getValue() == PrimaryBufferID);
-  PrimarySourceFile = SF;
-  PrimarySourceFile->setReferencedNameTracker(NameTracker);
+  PrimarySourceFiles.insert(SF);
+  SF->setReferencedNameTracker(NameTracker);
+  if (SF->getBufferID().hasValue())
+    notePrimaryInputBuffer(SF->getBufferID().getValue());
 }
 
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
@@ -186,9 +188,9 @@ bool CompilerInstance::setUpInputs() {
 
   // Set the primary file to the code-completion point if one exists.
   if (codeCompletionBufferID.hasValue() &&
-      *codeCompletionBufferID != PrimaryBufferID) {
-    assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-    PrimaryBufferID = *codeCompletionBufferID;
+      !bufferIDIsAPrimaryInput(*codeCompletionBufferID)) {
+    assert(PrimaryBufferIDs.empty() && "re-setting PrimaryBufferID");
+    notePrimaryInputBuffer(*codeCompletionBufferID);
   }
 
   if (isInputSwift() && MainBufferID == NO_SUCH_BUFFER &&
@@ -214,8 +216,8 @@ bool CompilerInstance::setUpForInput(const InputFile &input) {
   }
 
   if (input.isPrimary()) {
-    assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-    PrimaryBufferID = *bufferID;
+    assert(PrimaryBufferIDs.empty() && "re-setting PrimaryBufferID");
+    notePrimaryInputBuffer(*bufferID);
   }
   return false;
 }
@@ -587,7 +589,7 @@ void CompilerInstance::parseLibraryFile(
   addAdditionalInitialImportsTo(NextInput, implicitImports);
 
   auto *DelayedCB = SecondaryDelayedCB;
-  if (BufferID == PrimaryBufferID) {
+  if (bufferIDIsAPrimaryInput(BufferID)) {
     DelayedCB = PrimaryDelayedCB;
   }
   if (isWholeModuleCompilation())
@@ -595,7 +597,7 @@ void CompilerInstance::parseLibraryFile(
 
   auto &Diags = NextInput->getASTContext().Diags;
   auto DidSuppressWarnings = Diags.getSuppressWarnings();
-  auto IsPrimary = isWholeModuleCompilation() || BufferID == PrimaryBufferID;
+  auto IsPrimary = isWholeModuleCompilation() || bufferIDIsAPrimaryInput(BufferID);
   Diags.setSuppressWarnings(DidSuppressWarnings || !IsPrimary);
 
   bool Done;
@@ -661,7 +663,7 @@ void CompilerInstance::parseAndTypeCheckMainFile(
   SharedTimer timer(
       "performSema-checkTypesWhileParsingMain-parseAndTypeCheckMainFile");
   bool mainIsPrimary =
-      (isWholeModuleCompilation() || MainBufferID == PrimaryBufferID);
+      (isWholeModuleCompilation() || bufferIDIsAPrimaryInput(MainBufferID));
 
   SourceFile &MainFile =
       MainModule->getMainSourceFile(Invocation.getSourceFileKind());
@@ -724,7 +726,9 @@ void CompilerInstance::forEachFileToTypeCheck(
   if (isWholeModuleCompilation()) {
     forEachSourceFileIn(MainModule, [&](SourceFile &SF) { fn(SF); });
   } else {
-    fn(*PrimarySourceFile);
+    for (auto *SF : PrimarySourceFiles) {
+      fn(*SF);
+    }
   }
 }
 
@@ -746,8 +750,9 @@ SourceFile *CompilerInstance::createSourceFileForMainModule(
       SourceFile(*mainModule, fileKind, bufferID, importKind, keepSyntaxInfo);
   MainModule->addFile(*inputFile);
 
-  if (bufferID && *bufferID == PrimaryBufferID)
-    setPrimarySourceFile(inputFile);
+  if (bufferID && bufferIDIsAPrimaryInput(*bufferID)) {
+    notePrimarySourceFile(inputFile);
+  }
 
   return inputFile;
 }
@@ -813,6 +818,7 @@ void CompilerInstance::freeContextAndSIL() {
   TheSILModule.reset();
   MainModule = nullptr;
   SML = nullptr;
-  PrimarySourceFile = nullptr;
+  PrimaryBufferIDs.clear();
+  PrimarySourceFiles.clear();
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -828,15 +828,15 @@ static bool performCompile(CompilerInstance &Instance,
     if (Invocation.getSILOptions().LinkMode == SILOptions::LinkAll)
       performSILLinking(SM.get(), true);
 
-    auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
 
-      serialize(DC, serializationOpts, SM.get());
+      serialize(Instance.getMainModule(),
+                Instance.getPrimarySourceFiles(),
+                serializationOpts, SM.get());
     }
     return Context.hadError();
   }
@@ -885,8 +885,6 @@ static bool performCompile(CompilerInstance &Instance,
 
   auto SerializeSILModuleAction = [&]() {
     if (!opts.ModuleOutputPath.empty() || !opts.ModuleDocOutputPath.empty()) {
-      auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile)
-                                  : Instance.getMainModule();
       if (!opts.ModuleOutputPath.empty()) {
         SerializationOptions serializationOpts;
         serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -908,7 +906,9 @@ static bool performCompile(CompilerInstance &Instance,
         serializationOpts.SerializeOptionsForDebugging =
             !moduleIsPublic || opts.AlwaysSerializeDebuggingOptions;
 
-        serialize(DC, serializationOpts, SM.get());
+        serialize(Instance.getMainModule(),
+                  Instance.getPrimarySourceFiles(),
+                  serializationOpts, SM.get());
       }
     }
   };
@@ -969,15 +969,15 @@ static bool performCompile(CompilerInstance &Instance,
   }
 
   if (Action == FrontendOptions::ActionType::EmitSIB) {
-    auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
 
-      serialize(DC, serializationOpts, SM.get());
+      serialize(Instance.getMainModule(),
+                Instance.getPrimarySourceFiles(),
+                serializationOpts, SM.get());
     }
     return Context.hadError();
   }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1314,7 +1314,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
 static bool isAvailableExternally(IRGenModule &IGM, const DeclContext *dc) {
   dc = dc->getModuleScopeContext();
   if (isa<ClangModuleUnit>(dc) ||
-      dc == IGM.getSILModule().getAssociatedContext())
+      IGM.getSILModule().getAssociatedContexts().count(dc) != 0)
     return false;
   return true;
 }

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -831,7 +831,9 @@ private:
     std::unique_ptr<SILModule> sil;
     
     if (!CI.getASTContext().hadError()) {
-      sil = performSILGeneration(REPLInputFile, CI.getSILOptions(),
+      sil = performSILGeneration(REPLInputFile.getParentModule(),
+                                 CI.getSILOptions(),
+                                 ArrayRef<FileUnit *>(&REPLInputFile),
                                  RC.CurIRGenElem);
       performSILLinking(sil.get());
       runSILDiagnosticPasses(*sil);

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -85,8 +85,10 @@ class SILModule::SerializationCallback : public SerializedSILLoader::Callback {
 };
 
 SILModule::SILModule(ModuleDecl *SwiftModule, SILOptions &Options,
-                     const DeclContext *associatedDC, bool wholeModule)
-    : TheSwiftModule(SwiftModule), AssociatedDeclContext(associatedDC),
+                     ArrayRef<DeclContext *> associatedDCs,
+                     bool wholeModule)
+  : TheSwiftModule(SwiftModule),
+      AssociatedDeclContexts(associatedDCs.begin(), associatedDCs.end()),
       Stage(SILStage::Raw), Callback(new SILModule::SerializationCallback()),
       wholeModule(wholeModule), Options(Options), serialized(false),
       SerializeSILAction(), Types(*this) {}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2559,7 +2559,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
 
   // Print the declarations and types from the origin module, unless we're not
   // in whole-module mode.
-  if (M && AssociatedDeclContext == M && PrintASTDecls) {
+  if (M && AssociatedDeclContexts.count(M) != 0 && PrintASTDecls) {
     PrintOptions Options = PrintOptions::printSIL();
     Options.TypeDefinitions = true;
     Options.VarInitializers = true;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4194,9 +4194,15 @@ static bool isVerbatimNullableTypeInC(SILModule &M, Type ty) {
   }
 
   // Other types like UnsafePointer can also be nullable.
-  const DeclContext *DC = M.getAssociatedContext();
-  if (!DC)
-    DC = M.getSwiftModule();
+
+  // NB: This used to try to restrict DC to M's AssociatedContext
+  // when there was only one of those, but it is now falling back
+  // to only using the module. I believe this is correct (nothing
+  // in the callees of isTriviallyRepresentableIn seems to use
+  // the DC for anything where it would make a difference) but
+  // please be skeptical and thorough when reviewing this!
+  const DeclContext *DC = M.getSwiftModule();
+
   ty = OptionalType::get(ty);
   return ty->isTriviallyRepresentableIn(ForeignLanguage::C, DC);
 }

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -231,7 +231,7 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
                                ClassHierarchyAnalysis::ClassList &Subs) {
   ClassMethodInst *CMI = cast<ClassMethodInst>(AI.getCallee());
   auto *Method = CMI->getMember().getFuncDecl();
-  const DeclContext *DC = AI.getModule().getAssociatedContext();
+  auto DCs = AI.getModule().getAssociatedContexts();
 
   if (CD->isFinal())
     return true;
@@ -244,11 +244,11 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
 
   // Without an associated context we cannot perform any
   // access-based optimizations.
-  if (!DC)
+  if (DCs.empty())
     return false;
 
   // Only handle classes defined within the SILModule's associated context.
-  if (!CD->isChildContextOf(DC))
+  if (!CD->isChildContextOf(DCs))
     return false;
 
   if (!CD->hasAccess())

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -90,11 +90,11 @@ static bool isEffectivelyFinalMethod(FullApplySite AI,
   if (CD && CD->isFinal())
     return true;
 
-  const DeclContext *DC = AI.getModule().getAssociatedContext();
+  auto DCs = AI.getModule().getAssociatedContexts();
 
   // Without an associated context we cannot perform any
   // access-based optimizations.
-  if (!DC)
+  if (DCs.empty())
     return false;
 
   auto *CMI = cast<MethodInst>(AI.getCallee());
@@ -152,18 +152,18 @@ static bool isEffectivelyFinalMethod(FullApplySite AI,
 ///   it is a whole-module compilation.
 static bool isKnownFinalClass(ClassDecl *CD, SILModule &M,
                               ClassHierarchyAnalysis *CHA) {
-  const DeclContext *DC = M.getAssociatedContext();
+  auto DCs = M.getAssociatedContexts();
 
   if (CD->isFinal())
     return true;
 
   // Without an associated context we cannot perform any
   // access-based optimizations.
-  if (!DC)
+  if (DCs.empty())
     return false;
 
   // Only handle classes defined within the SILModule's associated context.
-  if (!CD->isChildContextOf(DC))
+  if (!CD->isChildContextOf(DCs))
     return false;
 
   if (!CD->hasAccess())

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -3039,15 +3039,15 @@ bool swift::calleesAreStaticallyKnowable(SILModule &M, SILDeclRef Decl) {
   if (Decl.isForeign)
     return false;
 
-  const DeclContext *AssocDC = M.getAssociatedContext();
-  if (!AssocDC)
+  auto AssocDCs = M.getAssociatedContexts();
+  if (AssocDCs.empty())
     return false;
 
   auto *AFD = Decl.getAbstractFunctionDecl();
   assert(AFD && "Expected abstract function decl!");
 
   // Only handle members defined within the SILModule's associated context.
-  if (!AFD->isChildContextOf(AssocDC))
+  if (!AFD->isChildContextOf(AssocDCs))
     return false;
 
   if (AFD->isDynamic())

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -44,11 +44,11 @@ class Serializer {
   /// The module currently being serialized.
   const ModuleDecl *M = nullptr;
 
-  /// The SourceFile currently being serialized, if any.
+  /// The SourceFiles currently being serialized, if any.
   ///
-  /// If this is non-null, only decls actually from this SourceFile will be
+  /// If this is non-empty, only decls actually from this SourceFile will be
   /// serialized. Any other decls will be cross-referenced instead.
-  const SourceFile *SF = nullptr;
+  const llvm::SetVector<SourceFile*> &SFS;
 
 public:
   /// Stores a declaration or a type to be written to the AST file.
@@ -406,22 +406,27 @@ private:
   void writeSIL(const SILModule *M, bool serializeAllSIL);
 
   /// Top-level entry point for serializing a module.
-  void writeAST(ModuleOrSourceFile DC,
-                bool enableNestedTypeLookupTable);
+  void writeAST(bool enableNestedTypeLookupTable);
 
   void writeToStream(raw_ostream &os);
 
   template <size_t N>
-  Serializer(const unsigned char (&signature)[N], ModuleOrSourceFile DC);
+  Serializer(const unsigned char (&signature)[N],
+             ModuleDecl *Module,
+             const llvm::SetVector<SourceFile*> &SourceFiles);
 
 public:
   /// Serialize a module to the given stream.
-  static void writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
+  static void writeToStream(raw_ostream &os,
+                            ModuleDecl *Module,
+                            const llvm::SetVector<SourceFile*> &SourceFiles,
                             const SILModule *M,
                             const SerializationOptions &options);
 
   /// Serialize module documentation to the given stream.
-  static void writeDocToStream(raw_ostream &os, ModuleOrSourceFile DC,
+  static void writeDocToStream(raw_ostream &os,
+                               ModuleDecl *Module,
+                               const llvm::SetVector<SourceFile*> &SourceFiles,
                                StringRef GroupInfoPath, ASTContext &Ctx);
 
   /// Records the use of the given Type.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2339,18 +2339,19 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // Go through all SILVTables in SILMod and write them if we should
   // serialize everything.
   // FIXME: Resilience: could write out vtable for fragile classes.
-  const DeclContext *assocDC = SILMod->getAssociatedContext();
-  assert(assocDC && "cannot serialize SIL without an associated DeclContext");
+  auto assocDCs = SILMod->getAssociatedContexts();
+  assert(!assocDCs.empty() &&
+         "cannot serialize SIL without an associated DeclContext");
   for (const SILVTable &vt : SILMod->getVTables()) {
     if ((ShouldSerializeAll || vt.isSerialized()) &&
-        vt.getClass()->isChildContextOf(assocDC))
+        vt.getClass()->isChildContextOf(assocDCs))
       writeSILVTable(vt);
   }
 
   // Write out fragile WitnessTables.
   for (const SILWitnessTable &wt : SILMod->getWitnessTables()) {
     if ((ShouldSerializeAll || wt.isSerialized()) &&
-        wt.getConformance()->getDeclContext()->isChildContextOf(assocDC))
+        wt.getConformance()->getDeclContext()->isChildContextOf(assocDCs))
       writeSILWitnessTable(wt);
   }
 
@@ -2358,7 +2359,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   for (const SILDefaultWitnessTable &wt : SILMod->getDefaultWitnessTables()) {
     // FIXME: Don't need to serialize private and internal default witness
     // tables.
-    if (wt.getProtocol()->getDeclContext()->isChildContextOf(assocDC))
+    if (wt.getProtocol()->getDeclContext()->isChildContextOf(assocDCs))
       writeSILDefaultWitnessTable(wt);
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -879,7 +879,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
 
     if (auto SF = CompIns.getPrimarySourceFile()) {
       SILOptions SILOpts = Invocation.getSILOptions();
-      std::unique_ptr<SILModule> SILMod = performSILGeneration(*SF, SILOpts);
+      std::unique_ptr<SILModule> SILMod = performSILGeneration(
+        SF->getParentModule(), SILOpts, ArrayRef<FileUnit *>(SF));
       runSILDiagnosticPasses(*SILMod);
     }
   }

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -357,7 +357,8 @@ int main(int argc, char **argv) {
     serializationOpts.SerializeAllSIL = true;
     serializationOpts.IsSIB = true;
 
-    serialize(CI.getMainModule(), serializationOpts, CI.getSILModule());
+    serialize(CI.getMainModule(), CI.getPrimarySourceFiles(),
+              serializationOpts, CI.getSILModule());
   } else {
     const StringRef OutputFile =
         OutputFilename.size() ? StringRef(OutputFilename) : "-";

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -444,7 +444,8 @@ int main(int argc, char **argv) {
     serializationOpts.SerializeAllSIL = true;
     serializationOpts.IsSIB = true;
 
-    serialize(CI.getMainModule(), serializationOpts, CI.getSILModule());
+    serialize(CI.getMainModule(), CI.getPrimarySourceFiles(),
+              serializationOpts, CI.getSILModule());
   } else {
     const StringRef OutputFile = OutputFilename.size() ?
                                    StringRef(OutputFilename) : "-";


### PR DESCRIPTION
A bunch of work following @davidungar's work but further downstream in the compiler, altering the various subsystems called by FrontendTool (Sema/Serialization/SIL) to accept and work with multiple primary files. Theoretically NFC but see below.

You can't actually _use_ this without disabling a couple assertions upstream that the user only provided one primary, but that's an intentional part of @davidungar's plan :)

Passes swift tests but needs to be accompanied by a matching LLDB change.

There are a couple bits I'd like to see scrutinized in review here, each marked with a comment. The change to lib/SILGen/SILGenExpr.cpp is I _think_ NFC but I'm not 100% sure, and the FIXME-marked bit on line 793 of lib/FrontendTool/FrontendTool.cpp suggests we might have drifted to the point of having redundant logic that can be eliminated.