### PR TITLE
IRGen: The partial application forwarder needs to cast { swift.refcounted* } to swift.refcounted* for AnyObject types on linux

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -967,7 +967,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       auto paramInfo = substType->getParameters()[paramI];
       auto &ti = IGM.getTypeInfoForLowered(paramInfo.getType());
       Explosion param;
-      param.add(subIGF.Builder.CreateBitCast(rawData, ti.getStorageType()));
+      param.add(subIGF.coerceValue(rawData, ti.getStorageType(), subIGF.IGM.DataLayout));
       bindPolymorphicParameter(subIGF, origType, substType, param, paramI);
       (void)param.claimAll();
     }

--- a/test/IRGen/objc_partial_apply_forwarder.swift
+++ b/test/IRGen/objc_partial_apply_forwarder.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+public class Foo<T> {
+}
+
+public func use(_: Any) {}
+
+// Don't crash trying to generate IR.
+// CHECK:  define{{.*}}swiftcc void @_T028objc_partial_apply_forwarder13createClosureyAA3FooCyxGcyXl1a_xm1ttlF5localL_yAE1x_tlFTA
+public func createClosure<T>(a: AnyObject, t: T.Type) -> (Foo<T>) -> () {
+  func local(x: Foo<T>) {
+    use(a)
+    use(x)
+  }
+  return local
+}
+


### PR DESCRIPTION
SR-6547