### PR TITLE
Suggest @objc for overrides of declarations from/in extensions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1795,10 +1795,13 @@ NOTE(overridden_near_match_here,none,
      "potential overridden %0 %1 here",
       (DescriptiveDeclKind, DeclName))
 ERROR(override_decl_extension,none,
-      "overriding declarations %select{in extensions|from extensions}0 "
-      "is not supported", (bool))
+      "overriding %select{|non-@objc }0declarations "
+      "%select{in extensions|from extensions}0 is not supported", (bool, bool))
 NOTE(overridden_here,none,
      "overridden declaration is here", ())
+NOTE(overridden_here_can_be_objc,none,
+     "add '@objc' to make this declaration overridable", ())
+
 ERROR(override_objc_type_mismatch_method,none,
       "overriding method with selector %0 has incompatible type %1",
       (ObjCSelector, Type))

--- a/include/swift/AST/RequirementEnvironment.h
+++ b/include/swift/AST/RequirementEnvironment.h
@@ -1,4 +1,4 @@
-//===--- RequirementEnvironment.h - Swift Language Type ASTs ----*- C++ -*-===//
+//===--- RequirementEnvironment.h - Requirement Environments ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -1,4 +1,4 @@
-//===--- RequirementEnvironment.cpp - ASTContext Implementation -----------===//
+//===--- RequirementEnvironment.cpp - Requirement Environments ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6689,9 +6689,18 @@ public:
     if ((base->getDeclContext()->isExtensionContext() ||
          override->getDeclContext()->isExtensionContext()) &&
         !base->isObjC() && !isKnownObjC) {
-      TC.diagnose(override, diag::override_decl_extension,
-                  !override->getDeclContext()->isExtensionContext());
-      TC.diagnose(base, diag::overridden_here);
+      bool baseCanBeObjC = TC.canBeRepresentedInObjC(base);
+      TC.diagnose(override, diag::override_decl_extension, baseCanBeObjC,
+                  !base->getDeclContext()->isExtensionContext());
+      if (baseCanBeObjC) {
+        SourceLoc insertionLoc =
+          override->getAttributeInsertionLoc(/*forModifier=*/false);
+        TC.diagnose(base, diag::overridden_here_can_be_objc)
+          .fixItInsert(insertionLoc, "@objc ");
+      } else {
+        TC.diagnose(base, diag::overridden_here);
+      }
+
       return true;
     }
     

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3959,6 +3959,26 @@ bool TypeChecker::isRepresentableInObjC(const SubscriptDecl *SD,
   return Result;
 }
 
+bool TypeChecker::canBeRepresentedInObjC(const ValueDecl *decl) {
+  if (!Context.LangOpts.EnableObjCInterop)
+    return false;
+
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    Optional<ForeignErrorConvention> errorConvention;
+    return isRepresentableInObjC(func, ObjCReason::MemberOfObjCMembersClass,
+                                 errorConvention);
+  }
+
+  if (auto var = dyn_cast<VarDecl>(decl))
+    return isRepresentableInObjC(var, ObjCReason::MemberOfObjCMembersClass);
+
+  if (auto subscript = dyn_cast<SubscriptDecl>(decl))
+    return isRepresentableInObjC(subscript,
+                                 ObjCReason::MemberOfObjCMembersClass);
+
+  return false;
+}
+
 void TypeChecker::diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
                                                      Type T,
                                                      SourceRange TypeRange) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2279,6 +2279,8 @@ public:
   bool isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason);
   bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
 
+  bool canBeRepresentedInObjC(const ValueDecl *decl);
+
   void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
                                           Type T, SourceRange TypeRange);
 

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -67,7 +67,7 @@ class A {
     set { }
   }
 
-  func overriddenInExtension() {} // expected-note {{overridden declaration is here}}
+  func overriddenInExtension() {} // expected-note {{overri}}
 }
 
 class B : A {
@@ -140,7 +140,7 @@ class B : A {
 }
 
 extension B {
-  override func overriddenInExtension() {} // expected-error{{overriding declarations in extensions is not supported}}
+  override func overriddenInExtension() {} // expected-error{{overri}}
 }
 
 struct S {

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 //
 // REQUIRES: objc_interop
 
@@ -8,11 +8,19 @@ class MixedKeywordsAndAttributes { // expected-note{{in declaration of 'MixedKey
 }
 
 @objc class ObjCClass {}
+struct SwiftStruct { }
 
 class A {
   @objc subscript (a: ObjCClass) -> ObjCClass { // expected-note{{overridden declaration here has type '(ObjCClass) -> ObjCClass'}}
     get { return ObjCClass() }
   }
+
+  func bar() { } // expected-note{{add '@objc' to make this declaration overridable}}{{3-3=@objc }}
+}
+
+extension A {
+  func foo() { } // expected-note{{add '@objc' to make this declaration overridable}}{{3-3=@objc }}
+  func wibble(_: SwiftStruct) { } // expected-note{{overridden declaration is here}}
 }
 
 class B : A {
@@ -20,4 +28,12 @@ class B : A {
   @objc subscript (a: ObjCClass) -> AnyObject { // expected-error{{overriding keyed subscript with incompatible type '(ObjCClass) -> AnyObject'}}
     get { return self }
   }
+
+  override func foo() { } // expected-error{{overriding non-@objc declarations from extensions is not supported}}
+
+  override func wibble(_: SwiftStruct) { } // expected-error{{overriding declarations in extensions is not supported}}
+}
+
+extension B {
+  override func bar() { } // expected-error{{overriding non-@objc declarations from extensions is not supported}}
 }

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -67,7 +67,7 @@ class A {
     set { }
   }
 
-  func overriddenInExtension() {} // expected-note {{overridden declaration is here}}
+  func overriddenInExtension() {} // expected-note {{overr}}
 }
 
 class B : A {
@@ -140,7 +140,7 @@ class B : A {
 }
 
 extension B {
-  override func overriddenInExtension() {} // expected-error{{overriding declarations in extensions is not supported}}
+  override func overriddenInExtension() {} // expected-error{{overr}}
 }
 
 struct S {

--- a/test/decl/class/classes.swift
+++ b/test/decl/class/classes.swift
@@ -6,7 +6,7 @@ class B : A {
   func g() -> (B, B) { return (B(), B()) } // expected-error {{declaration 'g()' cannot override more than one superclass declaration}}
   override func h() -> (A, B) { return (B(), B()) } // expected-note {{'h()' previously overridden here}}
   override func h() -> (B, A) { return (B(), B()) } // expected-error {{'h()' has already been overridden}}
-  func i() {} // expected-error {{overriding declarations from extensions is not supported}}
+  func i() {} // expected-error {{overri}}
   override func j() -> Int { return 0 }
   func j() -> Float { return 0.0 }
   func k() -> Float { return 0.0 }
@@ -39,7 +39,7 @@ class A {
   }
 }
 extension A {
-  func i() {} // expected-note{{overridden declaration is here}}
+  func i() {} // expected-note{{overri}}
 }
 func f() {
   let x = B()

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -61,21 +61,21 @@ extension E {
 }
 
 class C {
-  static func f1() {} // expected-note 3{{overridden declaration is here}}
+  static func f1() {} // expected-note 3{{overri}}
   class func f2() {}
   class func f3() {}
-  class func f4() {} // expected-note {{overridden declaration is here}}
-  class func f5() {} // expected-note {{overridden declaration is here}}
+  class func f4() {} // expected-note {{overri}}
+  class func f5() {} // expected-note {{overri}}
   static final func f6() {} // expected-error {{static declarations are already final}} {{10-16=}}
-  final class func f7() {} // expected-note 3{{overridden declaration is here}}
+  final class func f7() {} // expected-note 3{{overri}}
 }
 
 extension C {
   static func ef1() {}
-  class func ef2() {} // expected-note {{overridden declaration is here}}
-  class func ef3() {} // expected-note {{overridden declaration is here}}
-  class func ef4() {} // expected-note {{overridden declaration is here}}
-  class func ef5() {} // expected-note {{overridden declaration is here}}
+  class func ef2() {} // expected-note {{overri}}
+  class func ef3() {} // expected-note {{overri}}
+  class func ef4() {} // expected-note {{overri}}
+  class func ef5() {} // expected-note {{overri}}
 }
 
 class C_Derived : C {
@@ -83,8 +83,8 @@ class C_Derived : C {
   override class func f2() {}
   class override func f3() {}
 
-  override class func ef2() {} // expected-error {{overriding declarations from extensions is not supported}}
-  class override func ef3() {} // expected-error {{overriding declarations from extensions is not supported}}
+  override class func ef2() {} // expected-error {{not supported}}
+  class override func ef3() {} // expected-error {{not supported}}
   override static func f7() {} // expected-error {{static method overrides a 'final' class method}}
 }
 
@@ -98,11 +98,11 @@ class C_Derived3 : C {
 }
 
 extension C_Derived {
-  override class func f4() {} // expected-error {{overriding declarations in extensions is not supported}}
-  class override func f5() {} // expected-error {{overriding declarations in extensions is not supported}}
+  override class func f4() {} // expected-error {{not supported}}
+  class override func f5() {} // expected-error {{not supported}}
 
-  override class func ef4() {} // expected-error {{overriding declarations in extensions is not supported}}
-  class override func ef5() {} // expected-error {{overriding declarations in extensions is not supported}}
+  override class func ef4() {} // expected-error {{not supported}}
+  class override func ef5() {} // expected-error {{not supported}}
 }
 
 protocol P {

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -4,22 +4,22 @@
 @objc class ObjCClassB : ObjCClassA {}
 
 class A { 
-  func f1() { } // expected-note{{overridden declaration is here}}
-  func f2() -> A { } // expected-note{{overridden declaration is here}}
+  func f1() { } // expected-note{{overri}}
+  func f2() -> A { } // expected-note{{overri}}
 
-  @objc func f3() { } // expected-note{{overridden declaration is here}}
-  @objc func f4() -> ObjCClassA { } // expected-note{{overridden declaration is here}}
-  @objc var v1: Int { return 0 } // expected-note{{overridden declaration is here}}
-  @objc var v2: Int { return 0 } // expected-note{{overridden declaration is here}}
-  @objc var v3: Int = 0 // expected-note{{overridden declaration is here}}
+  @objc func f3() { } // expected-note{{overri}}
+  @objc func f4() -> ObjCClassA { } // expected-note{{overri}}
+  @objc var v1: Int { return 0 } // expected-note{{overri}}
+  @objc var v2: Int { return 0 } // expected-note{{overri}}
+  @objc var v3: Int = 0 // expected-note{{overri}}
 
   dynamic func f3D() { } // expected-error{{'dynamic' instance method 'f3D()' must also be '@objc'}}{{3-3=@objc }}
   dynamic func f4D() -> ObjCClassA { } // expected-error{{'dynamic' instance method 'f4D()' must also be '@objc'}}{{3-3=@objc }}
 }
 
 extension A {
-  func f5() { } // expected-note{{overridden declaration is here}}
-  func f6() -> A { } // expected-note{{overridden declaration is here}}
+  func f5() { } // expected-note{{overri}}
+  func f6() -> A { } // expected-note{{overri}}
 
   @objc func f7() { }
   @objc func f8() -> ObjCClassA { }
@@ -28,8 +28,8 @@ extension A {
 class B : A { }
 
 extension B { 
-  func f1() { }  // expected-error{{overriding declarations in extensions is not supported}}
-  func f2() -> B { } // expected-error{{overriding declarations in extensions is not supported}}
+  func f1() { }  // expected-error{{overri}}
+  func f2() -> B { } // expected-error{{overri}}
 
   override func f3() { } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
   override func f4() -> ObjCClassB { } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
@@ -46,7 +46,7 @@ extension B {
   override func f3D() { }
   override func f4D() -> ObjCClassB { }
 
-  func f5() { }  // expected-error{{overriding declarations in extensions is not supported}}
+  func f5() { }  // expected-error{{overridi}}
   func f6() -> A { }  // expected-error{{overriding declarations in extensions is not supported}}
 
   @objc override func f7() { }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1121,7 +1121,7 @@ class OwnershipBadSub : OwnershipBase {
 
 // <rdar://problem/17391625> Swift Compiler Crashes when Declaring a Variable and didSet in an Extension
 class rdar17391625 {
-  var prop = 42  // expected-note {{overridden declaration is here}}
+  var prop = 42  // expected-note {{overri}}
 }
 
 extension rdar17391625 {
@@ -1137,7 +1137,7 @@ class rdar17391625derived :  rdar17391625 {
 
 extension rdar17391625derived {
   // Not a stored property, computed because it is an override.
-  override var prop: Int { // expected-error {{overriding declarations in extensions is not supported}}
+  override var prop: Int { // expected-error {{overri}}
   didSet {
   }
   }


### PR DESCRIPTION
The Swift class model does not support overriding declarations where either
the overridden declaration or the overriding declaration are in an extension.
However, the Objective-C class model does, so marking the declaration as
@objc (when possible) will work around the limitation.

Customize the "cannot override declaration in extension" diagnostic to
suggest adding @objc to the overridden declaration in cases where
@objc is permitted. Fixes SR-6512 / rdar://problem/35787914.