### PR TITLE
Serialization: Fix crash when deserializing store_unowned SIL instruction [4.1]

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1558,7 +1558,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   case SILInstructionKind::StoreUnownedInst: {
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory);
-    auto refType = addrType.castTo<WeakStorageType>();
+    auto refType = addrType.castTo<UnownedStorageType>();
     auto ValType = SILType::getPrimitiveObjectType(refType.getReferentType());
     bool isInit = (Attr > 0);
     ResultVal = Builder.createStoreUnowned(Loc,

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1183,7 +1183,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultVal = Builder.createPartialApply(
         Loc, FnVal, Substitutions, Args,
-        closureTy.getAs<SILFunctionType>()->getCalleeConvention());
+        closureTy.castTo<SILFunctionType>()->getCalleeConvention());
     break;
   }
   case SILInstructionKind::BuiltinInst: {
@@ -1317,7 +1317,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   }
   case SILInstructionKind::IntegerLiteralInst: {
     auto Ty = MF->getType(TyID);
-    auto intTy = Ty->getAs<BuiltinIntegerType>();
+    auto intTy = Ty->castTo<BuiltinIntegerType>();
     Identifier StringVal = MF->getIdentifier(ValID);
     // Build APInt from string.
     APInt value(intTy->getGreatestWidth(), StringVal.str(), 10);
@@ -1328,7 +1328,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   }
   case SILInstructionKind::FloatLiteralInst: {
     auto Ty = MF->getType(TyID);
-    auto floatTy = Ty->getAs<BuiltinFloatType>();
+    auto floatTy = Ty->castTo<BuiltinFloatType>();
     Identifier StringVal = MF->getIdentifier(ValID);
     // Build APInt from string.
     APInt bits(floatTy->getBitWidth(), StringVal.str(), 16);
@@ -1558,7 +1558,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   case SILInstructionKind::StoreUnownedInst: {
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory);
-    auto refType = addrType.getAs<WeakStorageType>();
+    auto refType = addrType.castTo<WeakStorageType>();
     auto ValType = SILType::getPrimitiveObjectType(refType.getReferentType());
     bool isInit = (Attr > 0);
     ResultVal = Builder.createStoreUnowned(Loc,
@@ -1570,7 +1570,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   case SILInstructionKind::StoreWeakInst: {
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory);
-    auto refType = addrType.getAs<WeakStorageType>();
+    auto refType = addrType.castTo<WeakStorageType>();
     auto ValType = SILType::getPrimitiveObjectType(refType.getReferentType());
     bool isInit = (Attr > 0);
     ResultVal = Builder.createStoreWeak(Loc,
@@ -1652,7 +1652,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     // Use OneTypeOneOperand layout where the field number is stored in TypeID.
     auto Ty2 = MF->getType(TyID2);
     SILType ST = getSILType(Ty2, (SILValueCategory)TyCategory2);
-    TupleType *TT = ST.getAs<TupleType>();
+    TupleType *TT = ST.castTo<TupleType>();
 
     auto ResultTy = TT->getElement(TyID).getType();
     switch (OpCode) {
@@ -1675,7 +1675,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     // Format: a type followed by a list of values. A value is expressed by
     // 2 IDs: ValueID, ValueResultNumber.
     auto Ty = MF->getType(TyID);
-    TupleType *TT = Ty->getAs<TupleType>();
+    TupleType *TT = Ty->castTo<TupleType>();
     assert(TT && "Type of a TupleInst should be TupleType");
     SmallVector<SILValue, 4> OpList;
     for (unsigned I = 0, E = ListOfValues.size(); I < E; I++) {

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -1253,6 +1253,31 @@ sil [serialized] [thunk] @a_regular_thunk : $@convention(thin) () -> () {
   return %1 : $()
 }
 
+public class WeakUnownedTest {
+  @sil_stored public unowned var unownedVal: @sil_unowned AnyObject { get set }
+  @sil_stored public weak var weakVal: @sil_weak AnyObject? { get set }
+  public init(protoVal: AnyObject)
+  deinit
+}
+
+// CHECK-LABEL: sil public_external [serialized] @weak_unowned : $@convention(thin) (@owned WeakUnownedTest, @owned AnyObject) -> ()
+sil [serialized] @weak_unowned : $@convention(thin) (@owned WeakUnownedTest, @owned AnyObject) -> () {
+bb0(%0 : $WeakUnownedTest, %1 : $AnyObject):
+  %2 = ref_element_addr %0 : $WeakUnownedTest, #WeakUnownedTest.unownedVal
+  // CHECK: store_unowned
+  store_unowned %1 to %2 : $*@sil_unowned AnyObject
+
+  %3 = enum $Optional<AnyObject>, #Optional.some!enumelt.1, %1 : $AnyObject
+  %4 = ref_element_addr %0 : $WeakUnownedTest, #WeakUnownedTest.weakVal
+  // CHECK: store_weak
+  store_weak %3 to %4 : $*@sil_weak AnyObject?
+
+  %r = tuple ()
+
+  // CHECK: return
+  return %r : $()
+}
+
 public class Foo {
   subscript (x: Int, y: Int) -> Int32 { get set }
   var x: Int
@@ -1467,6 +1492,7 @@ bb0:
   %150 = function_ref @bridge_object : $@convention(thin) (@owned Class1, Builtin.Word) -> ()
   %151 = function_ref @a_reabstraction_thunk: $@convention(thin) () -> ()
   %152 = function_ref @a_regular_thunk: $@convention(thin) () -> ()
+  %153 = function_ref @weak_unowned: $@convention(thin) (@owned WeakUnownedTest, @owned AnyObject) -> ()
 
   %r = tuple ()
   return %r : $()


### PR DESCRIPTION
* Description: We would crash in deserialization when deserializing the store_unowned instruction.

* Scope of the issue: Now that we preserve SIL when merging modules, there are more ways to trigger this in normal code, but in Swift 4.0 you could hit this by an `@inline(__always)` function that assigned to an unowned property.

* Origination: Bug was present in the original implementation of "new" unowned properties that was added to Swift 3.0.

* Risk: Very low, it's a trivial fix.

* Tested: New test case added.

* Radar: <rdar://problem/35980211>.

* Reviewed by: @jckarter