### PR TITLE
hasValidLinkageForFragileRef: Add a test that checks if the containing module is serialized

### DIFF
--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -311,6 +311,13 @@ bool SILLinkerVisitor::process() {
   while (!Worklist.empty()) {
     auto *Fn = Worklist.pop_back_val();
 
+    if (Fn->getModule().isSerialized()) {
+      // If the containing module has been serialized,
+      // Remove The Serialized state (if any)
+      //  This allows for more optimizations
+      Fn->setSerialized(IsSerialized_t::IsNotSerialized);
+    }
+
     DEBUG(llvm::dbgs() << "Process imports in function: "
                        << Fn->getName() << "\n");
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -444,6 +444,11 @@ bool SILFunction::hasValidLinkageForFragileRef() const {
   if (hasValidLinkageForFragileInline())
     return true;
 
+  // If the containing module has been serialized
+  if (getModule().isSerialized()) {
+    return true;
+  }
+
   // Otherwise, only public functions can be referenced.
   return hasPublicVisibility(getLinkage());
 }

--- a/validation-test/compiler_crashers_2_fixed/0134-rdar35947198.swift
+++ b/validation-test/compiler_crashers_2_fixed/0134-rdar35947198.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend %s -emit-ir -o -
+
+public protocol NumProt: Prot {
+    func value() -> Double
+}
+
+extension Float: NumProt {
+    public func value() -> Double {
+        return Double(self)
+    }
+}
+
+public protocol Prot: CustomStringConvertible {
+    func getOp() -> Op
+}
+
+extension Prot {
+    public func getOp() -> Op {
+        return Op("\(self) ")
+    }
+}
+
+public protocol CompProt: Prot {}
+
+open class Op: CompProt {
+    fileprivate var valueText = ""
+    
+    open var description: String {
+        return "42"
+    }
+    
+    open func getOp() -> Op {
+        return self
+    }
+
+    public init(_ value: Double) {
+        self.valueText = "\(value)"
+    }
+
+    public init(_ operationString: String) {
+        self.valueText = operationString
+    }
+}


### PR DESCRIPTION
radar rdar://problem/35947198

Commit 53754a7a6944c587b2912a2c32fcda3c77c0b824 added a module pass that serializes the entire module.
Part of that pass is a method called removeSerializedFlagFromAllFunctions that removes the serialized flag from all functions within the module, which allows for more optimizations and for a better dead function elimination.
The problem is that this might break the Devirtualizer: If we run Devirtualization after “SerializeSILPass”, and we do LinkAll after Devirtualizing a function, SIL Verifier will fail: a public_external [serialized] function might be calling a [serialized] function for which we removed the [serialized] flag and added said flag to the module itself.
The verifier thinks that a function_ref inside fragile function is referencing private or hidden symbol. which is not the case.