### PR TITLE
Support opt-viewer when benchmarking in stand-alone mode

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -217,6 +217,20 @@ option(SWIFT_BENCHMARK_GENERATE_OPT_VIEW
   "Produce optimization view for benchmarks"
   FALSE)
 
+set(SWIFT_BENCHMARK_OPT_VIEWER "" CACHE FILEPATH
+  "Path to opt-viewer")
+
+if(SWIFT_BENCHMARK_OPT_VIEWER)
+  # If the path to the opt-viewer was specified manually and we have no access
+  # to the LLVM tree, assume we have the modules for the opt-viewer installed.
+  if(SWIFT_BENCHMARK_BUILT_STANDALONE)
+    set(LLVM_HAVE_OPT_VIEWER_MODULES 1)
+  endif()
+else()
+  set (SWIFT_BENCHMARK_OPT_VIEWER
+    "${LLVM_BUILD_MAIN_SRC_DIR}/tools/opt-viewer/opt-viewer.py")
+endif()
+
 # Options for other configurations
 set(BENCHOPTS_MULTITHREADED
     "-whole-module-optimization" "-num-threads" "4")

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -99,11 +99,10 @@ endfunction()
 function(add_opt_view opt_view_main_dir, module_name, opt_view_dir_out)
   set(opt_view_dir "${opt_view_main_dir}/${module_name}")
   set(opt_record "${objdir}/${module_name}.opt.yaml")
-  set(opt_viewer "${LLVM_BUILD_MAIN_SRC_DIR}/tools/opt-viewer/opt-viewer.py")
   add_custom_command(
     OUTPUT ${opt_view_dir}
     DEPENDS "${objfile}"
-    COMMAND ${opt_viewer} ${opt_record} "-o" ${opt_view_dir})
+    COMMAND ${SWIFT_BENCHMARK_OPT_VIEWER} ${opt_record} "-o" ${opt_view_dir})
   set(${opt_view_dir_out} ${opt_view_dir} PARENT_SCOPE)
 endfunction()
 
@@ -214,9 +213,6 @@ function (swift_benchmark_compile_archopts)
 
   set(opt_view_main_dir)
   if(SWIFT_BENCHMARK_GENERATE_OPT_VIEW AND LLVM_HAVE_OPT_VIEWER_MODULES)
-    precondition(SWIFT_BENCHMARK_BUILT_STANDALONE NEGATE
-      "Opt-viewer is not supported when running the benchmarks outside the Swift tree")
-
     if(NOT ${optflag} STREQUAL "Onone" AND "${bench_flags}" MATCHES "-whole-module.*")
       list(APPEND common_options "-save-optimization-record")
       set(opt_view_main_dir "${objdir}/opt-view")


### PR DESCRIPTION
Tested locally with both stand-alone and in-tree benchmarking.
