### PR TITLE
[4.1] [GSB] Canonicalize conformance access paths on-the-fly.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -936,9 +936,11 @@ private:
   /// Whether there is a trailing written requirement location.
   const bool hasTrailingWrittenRequirementLoc;
 
+public:
   /// Whether a protocol requirement came from the requirement signature.
   const bool usesRequirementSignature;
 
+private:
   /// The actual storage, described by \c storageKind.
   union {
     /// The type to which a requirement applies.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -939,7 +939,8 @@ static bool hasNonCanonicalSelfProtocolRequirement(
     }
 
     // Check whether the given requirement is in the requirement signature.
-    if (!hasConformanceInSignature(inProto->getRequirementSignature(),
+    if (!source->usesRequirementSignature &&
+        !hasConformanceInSignature(inProto->getRequirementSignature(),
                                    source->getStoredType(), conformingProto))
       return true;
 

--- a/test/IRGen/conformance_access_path.swift
+++ b/test/IRGen/conformance_access_path.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir > %t.ll
+// RUN: %FileCheck %s < %t.ll
+
+
+// SR-6200: canonicalizing a conformance access path that was built
+// without the requirement signature.
+public struct Valid<V> {}
+
+extension Valid where V: ValidationSuite {}
+
+public protocol Validatable {}
+
+extension Validatable {
+    public func tested() {}
+
+    // CHECK-LABEL: define{{.*}}_T023conformance_access_path11ValidatablePAAE6testedyqd__m2by_t9InputTypeQyd__RszAA15ValidationSuiteRd__lF
+    public func tested<S: ValidationSuite>(by suite: S.Type) where S.InputType == Self {
+      // CHECK:   [[S_AS_VALIDATION_SUITE:%[0-9]+]] = load i8*, i8** %S.ValidationSuite
+      // CHECK-NEXT:   [[S_VALIDATOR_BASE:%.*]] = bitcast i8* [[S_AS_VALIDATION_SUITE]] to i8**
+      // CHECK-NEXT: [[S_VALIDATABLE_ADDR:%[0-9]+]] = getelementptr inbounds i8*, i8** [[S_VALIDATOR_BASE]], i32 1
+      // CHECK-NEXT: [[S_VALIDATABLE_FN_RAW:%[0-9]+]] = load i8*, i8** [[S_VALIDATABLE_ADDR]]
+      // CHECK-NEXT: [[S_VALIDATABLE_FN:%[0-9]+]] = bitcast i8* [[S_VALIDATABLE_FN_RAW]] to i8** (%swift.type*, %swift.type*, i8**)*
+      // CHECK-NEXT: call i8** [[S_VALIDATABLE_FN]](%swift.type* %Self, %swift.type* %S, i8** %S.Validator)
+      tested()
+    }
+}
+
+public protocol Validator {
+    associatedtype InputType: Validatable
+}
+
+public protocol ValidationSuite: Validator {
+    associatedtype InputType: Validatable
+}


### PR DESCRIPTION
* Explanation: Eliminates a crash during IRGen when dealing with redundant associated type conformances in certain multi-file scenarios and with some declaration ordering.
* Scope of Issue: Only affects cases where associated types are given redundant conformance requirements in a protocol, and only under certain perturbations of the source. Affected some versions of the Vapor project.
* Risk: Low; it's a proper fix for a previously-broken code path.
* Reviewed By: @slavapestov 
* Testing: Existing automated test suite, new tests, source compatibility suite
* Directions for QA: N/A
* SR / Radar: [SR-6200](https://bugs.swift.org/browse/SR-6200) / rdar://problem/35113583