### PR TITLE
[Syntax] Use SyntaxKind APIs for getUnknownKind()

### DIFF
--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -59,8 +59,6 @@ struct SyntaxFactory {
   /// between these two numbers is the number of optional children.
   static std::pair<unsigned, unsigned> countChildren(SyntaxKind Kind);
 
-  static SyntaxKind getUnknownKind(SyntaxKind Kind);
-
   static Syntax
   makeBlankCollectionSyntax(SyntaxKind Kind);
 

--- a/include/swift/Syntax/SyntaxKind.h.gyb
+++ b/include/swift/Syntax/SyntaxKind.h.gyb
@@ -63,6 +63,8 @@ bool isPatternKind(SyntaxKind Kind);
 bool isTokenKind(SyntaxKind Kind);
 
 bool isUnknownKind(SyntaxKind Kind);
+
+SyntaxKind getUnknownKind(SyntaxKind Kind);
 } // end namespace syntax
 
 namespace json {

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -203,32 +203,6 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
   }
 }
 
-SyntaxKind
-SyntaxFactory::getUnknownKind(SyntaxKind Kind) {
-  switch(Kind) {
-% for node in SYNTAX_NODES:
-%   if node.syntax_kind.endswith('Expr'):
-%     Result = 'SyntaxKind::UnknownExpr'
-%   elif node.syntax_kind.endswith('Stmt'):
-%     Result = 'SyntaxKind::UnknownStmt'
-%   elif node.syntax_kind.endswith('Decl'):
-%     Result = 'SyntaxKind::UnknownDecl'
-%   elif node.syntax_kind.endswith('Token'):
-%     Result = 'SyntaxKind::UnknownToken'
-%   elif node.syntax_kind.endswith('Type'):
-%     Result = 'SyntaxKind::UnknownType'
-%   elif node.syntax_kind.endswith('Pattern'):
-%     Result = 'SyntaxKind::UnknownPattern'
-%   else:
-%     Result = 'SyntaxKind::Unknown'
-%   end
-  case SyntaxKind::${node.syntax_kind}: return ${Result};
-% end
-  default:
-    return SyntaxKind::Unknown;
-  }
-}
-
 % for node in SYNTAX_NODES:
 %   if node.children:
 %     child_params = []

--- a/lib/Syntax/SyntaxKind.cpp.gyb
+++ b/lib/Syntax/SyntaxKind.cpp.gyb
@@ -84,5 +84,19 @@ bool isUnknownKind(SyntaxKind Kind) {
          Kind == SyntaxKind::UnknownType ||
          Kind == SyntaxKind::UnknownPattern;
 }
+
+SyntaxKind getUnknownKind(SyntaxKind Kind) {
+  if (isExprKind(Kind))
+    return SyntaxKind::UnknownExpr;
+  if (isStmtKind(Kind))
+    return SyntaxKind::UnknownStmt;
+  if (isDeclKind(Kind))
+    return SyntaxKind::UnknownDecl;
+  if (isTypeKind(Kind))
+    return SyntaxKind::UnknownType;
+  if (isPatternKind(Kind))
+    return SyntaxKind::UnknownPattern;
+  return SyntaxKind::Unknown;
+}
 } // end namespace syntax
 } // end namespace swift

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -47,7 +47,7 @@ static RC<RawSyntax> createSyntaxAs(SyntaxKind Kind,
     return Node->getRaw();
 
   // Fallback to unknown syntax for the category.
-  return makeUnknownSyntax(SyntaxFactory::getUnknownKind(Kind), Parts);
+  return makeUnknownSyntax(getUnknownKind(Kind), Parts);
 }
 
 } // End of anonymous namespace


### PR DESCRIPTION
Instead of name text based heuristics.
CC: @nkcsgexi 