### PR TITLE
[Syntax] Use initializer clause syntax node for function parameter

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -66,6 +66,8 @@ static ParserStatus parseDefaultArgument(Parser &P,
                                    unsigned argIndex,
                                    Expr *&init,
                                  Parser::ParameterContextKind paramContext) {
+  SyntaxParsingContext DefaultArgContext(P.SyntaxContext,
+                                         SyntaxKind::InitializerClause);
   SourceLoc equalLoc = P.consumeToken(tok::equal);
 
   // Enter a fresh default-argument context with a meaningless parent.
@@ -1143,5 +1145,4 @@ bool Parser::canParseTypedPattern() {
     return canParseType();
   return true;
 }
-
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -948,7 +948,8 @@ ParserResult<TupleTypeRepr> Parser::parseTypeTupleBody() {
     // Parse '= expr' here so we can complain about it directly, rather
     // than dying when we see it.
     if (Tok.is(tok::equal)) {
-      SyntaxParsingContext InitContext(SyntaxContext, SyntaxKind::Initializer);
+      SyntaxParsingContext InitContext(SyntaxContext,
+                                       SyntaxKind::InitializerClause);
       SourceLoc equalLoc = consumeToken(tok::equal);
       auto init = parseExpr(diag::expected_init_value);
       auto inFlight = diagnose(equalLoc, diag::tuple_type_init);

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -65,7 +65,7 @@ typealias C = <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</Arr
 typealias D = <DictionaryType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>]</DictionaryType>
 typealias E = <MetatypeType><OptionalType><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>?</OptionalType>.Protocol</MetatypeType>
 typealias F = <MetatypeType><ImplicitlyUnwrappedOptionalType><ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>!</ImplicitlyUnwrappedOptionalType>.Type</MetatypeType>
-typealias G = <FunctionType>(<TupleTypeElement>a x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement>_ y: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>... <Initializer>= <IntegerLiteralExpr>1</IntegerLiteralExpr></Initializer></TupleTypeElement>) throw -> <FunctionType>() -> <TupleType>()</TupleType></FunctionType></FunctionType>
+typealias G = <FunctionType>(<TupleTypeElement>a x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement>_ y: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>... <InitializerClause>= <IntegerLiteralExpr>1</IntegerLiteralExpr></InitializerClause></TupleTypeElement>) throw -> <FunctionType>() -> <TupleType>()</TupleType></FunctionType></FunctionType>
 typealias H = <FunctionType>() rethrows -> <TupleType>()</TupleType></FunctionType><StructDecl>
 
 struct foo <MemberDeclBlock>{<StructDecl>
@@ -97,10 +97,10 @@ private </DeclModifier>struct S<GenericParameterClause><<GenericParameter>A, </G
 protocol P<TypeInheritanceClause>: <InheritedType>class </InheritedType></TypeInheritanceClause><MemberDeclBlock>{}</MemberDeclBlock></ProtocolDecl><FunctionDecl>
 
 func foo<FunctionSignature><ParameterClause>(<FunctionParameter>_ _: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>,</FunctionParameter><FunctionParameter>
-         a b: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>= <SequenceExpr><IntegerLiteralExpr>3 </IntegerLiteralExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><IntegerLiteralExpr>2</IntegerLiteralExpr></SequenceExpr>,</FunctionParameter><FunctionParameter>
-         _ c: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>= <IntegerLiteralExpr>2</IntegerLiteralExpr>,</FunctionParameter><FunctionParameter>
-         d _: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>= <SequenceExpr><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>2</IntegerLiteralExpr>: <IntegerLiteralExpr>3</IntegerLiteralExpr></TernaryExpr></SequenceExpr>,</FunctionParameter><FunctionParameter><Attribute>
-         @objc </Attribute>e: <SimpleTypeIdentifier>X </SimpleTypeIdentifier>= <BooleanLiteralExpr>true</BooleanLiteralExpr>,</FunctionParameter><FunctionParameter>
+         a b: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><InitializerClause>= <SequenceExpr><IntegerLiteralExpr>3 </IntegerLiteralExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><IntegerLiteralExpr>2</IntegerLiteralExpr></SequenceExpr></InitializerClause>,</FunctionParameter><FunctionParameter>
+         _ c: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><InitializerClause>= <IntegerLiteralExpr>2</IntegerLiteralExpr></InitializerClause>,</FunctionParameter><FunctionParameter>
+         d _: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><InitializerClause>= <SequenceExpr><TernaryExpr><BooleanLiteralExpr>true </BooleanLiteralExpr>? <IntegerLiteralExpr>2</IntegerLiteralExpr>: <IntegerLiteralExpr>3</IntegerLiteralExpr></TernaryExpr></SequenceExpr></InitializerClause>,</FunctionParameter><FunctionParameter><Attribute>
+         @objc </Attribute>e: <SimpleTypeIdentifier>X </SimpleTypeIdentifier><InitializerClause>= <BooleanLiteralExpr>true</BooleanLiteralExpr></InitializerClause>,</FunctionParameter><FunctionParameter>
          f: inout <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>,</FunctionParameter><FunctionParameter>
          g: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>...</FunctionParameter>) </ParameterClause>throws <ReturnClause>-> <DictionaryType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>] </DictionaryType></ReturnClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><FunctionDecl>
 

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -217,11 +217,12 @@ FunctionParameterSyntax getCannedFunctionParameter() {
   auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
   auto One = SyntaxFactory::makePrefixOperatorExpr(Sign,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
+  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
   auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
 
-  return SyntaxFactory::makeFunctionParameter(None, ExternalName, LocalName, Colon,
-                                              Int, NoEllipsis, Equal,
-                                              One, Comma);
+  return SyntaxFactory::makeFunctionParameter(None, ExternalName, LocalName,
+                                              Colon, Int, NoEllipsis,
+                                              DefaultArg, Comma);
 }
 
 TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
@@ -254,11 +255,12 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
   auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
   auto One = SyntaxFactory::makePrefixOperatorExpr(Sign,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
+  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
   auto Comma = SyntaxFactory::makeCommaToken({}, {});
 
-  auto Param = SyntaxFactory::makeFunctionParameter(None, ExternalName, LocalName,
-                                                    Colon, Int,
-                                                    NoEllipsis, Equal, One,
+  auto Param = SyntaxFactory::makeFunctionParameter(None, ExternalName,
+                                                    LocalName, Colon, Int,
+                                                    NoEllipsis, DefaultArg,
                                                     Comma);
 
   ASSERT_EQ(ExternalName.getRaw(), Param.getFirstName().getRaw());
@@ -269,10 +271,10 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
   auto GottenType2 = Param.getTypeAnnotation();
   ASSERT_TRUE(GottenType.hasSameIdentityAs(GottenType2));
 
-  ASSERT_EQ(Equal.getRaw(), Param.getDefaultEquals()->getRaw());
+  ASSERT_EQ(DefaultArg.getRaw(), Param.getDefaultArgument()->getRaw());
 
-  auto GottenDefaultValue = Param.getDefaultValue().getValue();
-  auto GottenDefaultValue2 = Param.getDefaultValue().getValue();
+  auto GottenDefaultValue = Param.getDefaultArgument()->getValue();
+  auto GottenDefaultValue2 = Param.getDefaultArgument()->getValue();
   ASSERT_TRUE(GottenDefaultValue.hasSameIdentityAs(GottenDefaultValue2));
 
   ASSERT_EQ(Comma.getRaw(), Param.getTrailingComma()->getRaw());
@@ -280,10 +282,10 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
   // Test that llvm::None is returned for non-token missing children:
   auto Decimated = Param
     .withTypeAnnotation(llvm::None)
-    .withDefaultValue(llvm::None);
+    .withDefaultArgument(llvm::None);
 
   ASSERT_TRUE(Decimated.getTypeAnnotation().isMissing());
-  ASSERT_FALSE(Decimated.getDefaultValue().hasValue());
+  ASSERT_FALSE(Decimated.getDefaultArgument().hasValue());
 }
 
 TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
@@ -300,6 +302,7 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
   auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
   auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
+  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
   auto Comma = SyntaxFactory::makeCommaToken({}, {});
 
   {
@@ -310,8 +313,7 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
       .withSecondName(LocalName)
       .withColon(Colon)
       .withTypeAnnotation(Int)
-      .withDefaultEquals(Equal)
-      .withDefaultValue(One)
+      .withDefaultArgument(DefaultArg)
       .withTrailingComma(Comma)
       .print(OS);
     ASSERT_EQ(OS.str().str(), "for integer : Int = 1,");
@@ -321,9 +323,9 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     getCannedFunctionParameter()
       .withTypeAnnotation(llvm::None)
-      .withDefaultValue(llvm::None)
+      .withDefaultArgument(llvm::None)
       .print(OS);
-    ASSERT_EQ(OS.str().str(), "with radius: = , ");
+    ASSERT_EQ(OS.str().str(), "with radius: , ");
   }
 }
 

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -167,6 +167,13 @@ DECL_NODES = [
              Child('Body', kind='StmtList')
          ]),
 
+    # initializer -> '=' expr
+    Node('InitializerClause', kind='Syntax',
+         children=[
+             Child('Equal', kind='EqualToken'),
+             Child('Value', kind='Expr'),
+         ]),
+
     # parameter ->
     # external-parameter-name? local-parameter-name ':'
     #   type '...'? '='? expression? ','?
@@ -191,9 +198,7 @@ DECL_NODES = [
              Child('TypeAnnotation', kind='Type'),
              Child('Ellipsis', kind='Token',
                    is_optional=True),
-             Child('DefaultEquals', kind='EqualToken',
-                   is_optional=True),
-             Child('DefaultValue', kind='Expr',
+             Child('DefaultArgument', kind='InitializerClause',
                    is_optional=True),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -79,12 +79,6 @@ TYPE_NODES = [
              Child('ExclamationMark', kind='ExclamationMarkToken'),
          ]),
 
-    Node('Initializer', kind='Syntax',
-         children=[
-             Child('Equal', kind='EqualToken'),
-             Child('Value', kind='Expr'),
-         ]),
-
     # tuple-type-element -> identifier? ':'? type-annotation ','?
     Node('TupleTypeElement', kind='Syntax',
          children=[
@@ -107,7 +101,7 @@ TYPE_NODES = [
              Child('Type', kind='Type'),
              Child('Ellipsis', kind='Token',
                    is_optional=True),
-             Child('Initializer', kind='Initializer',
+             Child('Initializer', kind='InitializerClause',
                    is_optional=True),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),


### PR DESCRIPTION
Also, renamed to `InitializerClause` from `Initializer` so that we don't confuse with `InitializerDecl`.