### PR TITLE
Make expectCrash(executing:_) safer

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -542,9 +542,11 @@ public func expectCrashLater() {
   _seenExpectCrash = true
 }
 
-public func expectCrash(executing: () -> Void) {
+public func expectCrash(executing: () -> Void) -> Never {
   expectCrashLater()
   executing()
+  expectUnreachable()
+  fatalError()
 }
 
 func _defaultTestSuiteFailedCallback() {


### PR DESCRIPTION
Check out https://github.com/apple/swift/pull/13411 for details