### PR TITLE
Reapply "IRGen: The partial application forwarder needs to cast { swi…

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -973,6 +973,8 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
           ti.isSingleSwiftRetainablePointer(ResilienceExpansion::Maximal))
         ref = subIGF.coerceValue(rawData, ti.getStorageType(),
                                  subIGF.IGM.DataLayout);
+      else
+        ref = subIGF.Builder.CreateBitCast(rawData, ti.getStorageType());
       param.add(ref);
       bindPolymorphicParameter(subIGF, origType, substType, param, paramI);
       (void)param.claimAll();

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -969,7 +969,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       Explosion param;
       auto ref = rawData;
       // We can get a '{ swift.refcounted* }' type for AnyObject on linux.
-      if (!ref->getType()->isPointerTy() &&
+      if (!ti.getStorageType()->isPointerTy() &&
           ti.isSingleSwiftRetainablePointer(ResilienceExpansion::Maximal))
         ref = subIGF.coerceValue(rawData, ti.getStorageType(),
                                  subIGF.IGM.DataLayout);

--- a/test/IRGen/objc_partial_apply_forwarder.swift
+++ b/test/IRGen/objc_partial_apply_forwarder.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+public class Foo<T> {
+}
+
+public func use(_: Any) {}
+
+// Don't crash trying to generate IR.
+// CHECK:  define{{.*}}swiftcc void @_T028objc_partial_apply_forwarder13createClosureyAA3FooCyxGcyXl1a_xm1ttlF5localL_yAE1x_tlFTA
+public func createClosure<T>(a: AnyObject, t: T.Type) -> (Foo<T>) -> () {
+  func local(x: Foo<T>) {
+    use(a)
+    use(x)
+  }
+  return local
+}
+
+// Don't crash.
+public final class K<Error: Swift.Error> {
+  func act(error: Error) {}
+}
+
+public struct A<Error: Swift.Error>{
+  private let action: (K<Error>) -> Void
+
+  public init(_ action: @escaping (K<Error>) -> Void) {
+    self.action = action
+  }
+
+  public init(error: Error) {
+    self.init { actor in
+      actor.act(error: error)
+    }
+  }
+}


### PR DESCRIPTION
…ft.refcounted* } to swift.refcounted* for AnyObject types on linux"

With fix and test case for failed case.

This reverts commit d14cd40916efe5c447e6b957d8ebeb8b03c4ab90.

SR-6547
rdar://problem/35911150