### PR TITLE
[Refactoring] Local rename in lazy block failing

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -319,6 +319,11 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
     }
   }
 
+  // FIXME: Even implicit Decls should have proper ranges if they include any
+  // non-implicit children (fix implicit Decls created for lazy vars).
+  if (D->isImplicit())
+    return !isDone();
+
   if (shouldSkip(D->getSourceRange()))
     return false;
   

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename-lazy.swift.expected
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename-lazy.swift.expected
@@ -1,0 +1,4 @@
+source.edit.kind.active:
+  7:11-7:16 source.refactoring.range.kind.basename
+source.edit.kind.active:
+  8:14-8:19 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
@@ -2,6 +2,12 @@ func foo() {
   var aa = 3
   aa = aa + 1
   _ = "before \(aa) after"
+  struct S {
+    lazy var lazyVal: Int = {
+      let myVal = 0
+      return myVal
+     }()
+  }
   return 1
 }
 
@@ -10,5 +16,7 @@ func foo() {
 // RUN: diff -u %S/local-rename.swift.expected %t.result/local-rename.swift.expected
 // RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=2:8 %s -- %s > %t.result/local-rename-ranges.swift.expected
 // RUN: diff -u %S/local-rename-ranges.swift.expected %t.result/local-rename-ranges.swift.expected
+// RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=7:11 %s -- %s > %t.result/local-rename-lazy.swift.expected
+// RUN: diff -u %S/local-rename-lazy.swift.expected %t.result/local-rename-lazy.swift.expected
 
 // REQUIRES-ANY: OS=macosx, OS=linux-gnu

--- a/test/refactoring/SyntacticRename/Outputs/variables/ivar-x.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/variables/ivar-x.swift.expected
@@ -31,3 +31,10 @@ if let i = opt, let /*var-j:def*/j = opt2 {
 var (a, /*pattern-b:def*/b) = (1, 2)
 print(a + /*pattern-b*/b)
 
+struct S {
+	lazy var lazyVal: Int = {
+		let /*lazy:def*/myVal = 0
+		return /*lazy:ref*/myVal
+	}()
+}
+

--- a/test/refactoring/SyntacticRename/Outputs/variables/lazy.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/variables/lazy.swift.expected
@@ -28,13 +28,13 @@ if let i = opt, let /*var-j:def*/j = opt2 {
 	print(i + /*var-j*/j)
 }
 
-var (a, /*pattern-b:def*/bee) = (1, 2)
-print(a + /*pattern-b*/bee)
+var (a, /*pattern-b:def*/b) = (1, 2)
+print(a + /*pattern-b*/b)
 
 struct S {
 	lazy var lazyVal: Int = {
-		let /*lazy:def*/myVal = 0
-		return /*lazy:ref*/myVal
+		let /*lazy:def*/myNewVal = 0
+		return /*lazy:ref*/myNewVal
 	}()
 }
 

--- a/test/refactoring/SyntacticRename/Outputs/variables/pattern-a.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/variables/pattern-a.swift.expected
@@ -31,3 +31,10 @@ if let i = opt, let /*var-j:def*/j = opt2 {
 var (a, /*pattern-b:def*/b) = (1, 2)
 print(a + /*pattern-b*/b)
 
+struct S {
+	lazy var lazyVal: Int = {
+		let /*lazy:def*/myVal = 0
+		return /*lazy:ref*/myVal
+	}()
+}
+

--- a/test/refactoring/SyntacticRename/Outputs/variables/var-j.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/variables/var-j.swift.expected
@@ -31,3 +31,10 @@ if let i = opt, let /*var-j:def*/jackalope = opt2 {
 var (a, /*pattern-b:def*/b) = (1, 2)
 print(a + /*pattern-b*/b)
 
+struct S {
+	lazy var lazyVal: Int = {
+		let /*lazy:def*/myVal = 0
+		return /*lazy:ref*/myVal
+	}()
+}
+

--- a/test/refactoring/SyntacticRename/Outputs/variables/var-y.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/variables/var-y.swift.expected
@@ -31,3 +31,10 @@ if let i = opt, let /*var-j:def*/j = opt2 {
 var (a, /*pattern-b:def*/b) = (1, 2)
 print(a + /*pattern-b*/b)
 
+struct S {
+	lazy var lazyVal: Int = {
+		let /*lazy:def*/myVal = 0
+		return /*lazy:ref*/myVal
+	}()
+}
+

--- a/test/refactoring/SyntacticRename/variables.swift
+++ b/test/refactoring/SyntacticRename/variables.swift
@@ -31,6 +31,13 @@ if let i = opt, let /*var-j:def*/j = opt2 {
 var (a, /*pattern-b:def*/b) = (1, 2)
 print(a + /*pattern-b*/b)
 
+struct S {
+	lazy var lazyVal: Int = {
+		let /*lazy:def*/myVal = 0
+		return /*lazy:ref*/myVal
+	}()
+}
+
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="var-y" -old-name "y" -new-name "yack" >> %t.result/variables_var-y.swift
 // RUN: diff -u %S/Outputs/variables/var-y.swift.expected %t.result/variables_var-y.swift
@@ -42,3 +49,5 @@ print(a + /*pattern-b*/b)
 // RUN: diff -u %S/Outputs/variables/var-j.swift.expected %t.result/variables_var-j.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="pattern-b" -old-name "b" -new-name "bee" >> %t.result/variables_pattern-b.swift
 // RUN: diff -u %S/Outputs/variables/pattern-b.swift.expected %t.result/variables_pattern-b.swift
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="lazy" -old-name "myVal" -new-name "myNewVal" >> %t.result/variables_lazy.swift
+// RUN: diff -u %S/Outputs/variables/lazy.swift.expected %t.result/variables_lazy.swift


### PR DESCRIPTION
<!-- What's in this pull request? -->
Some of the implicit decls generated for lazy var blocks report source ranges that don't enclose the source ranges of their children. For now, just always walk into implicit decls when looking for name locations.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/35255644.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->