### PR TITLE
[4.1] Stricter enforcement of the "large space" heuristic

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -244,7 +244,7 @@ WARNING(unreachable_code_after_stmt,none,
         "code after '%select{return|break|continue|throw}0' will never "
         "be executed", (unsigned))
 WARNING(unreachable_case,none,
-        "%select{case|default}0 will never be executed", (bool))
+        "case will never be executed", ())
 WARNING(switch_on_a_constant,none,
         "switch condition evaluates to a constant", ())
 NOTE(unreachable_code_note,none, "will never be executed", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3860,6 +3860,11 @@ WARNING(redundant_particular_literal_case,none,
 NOTE(redundant_particular_literal_case_here,none,
      "first occurrence of identical literal pattern is here", ())
 
+ERROR(cannot_prove_exhaustive_switch,none,
+      "analysis of uncovered switch statement is too complex to perform in a "
+      "reasonable amount of time; "
+      "insert a 'default' clause to cover this switch statement", ())
+
 // HACK: Downgrades the above to warnings if any of the cases is marked
 // @_downgrade_exhaustivity_check.
 WARNING(non_exhaustive_switch_warn_swift3,none, "switch must be exhaustive", ())

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1031,7 +1031,8 @@ void PatternMatchEmission::emitDispatch(ClauseMatrix &clauses, ArgArray args,
         } else {
           Loc = clauses[firstRow].getCasePattern()->getStartLoc();
         }
-        SGF.SGM.diagnose(Loc, diag::unreachable_case, isDefault);
+        if (!isDefault)
+          SGF.SGM.diagnose(Loc, diag::unreachable_case);
       }
     }
   }

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -106,7 +106,7 @@ func testUnreachableCase5(a : Tree) {
   switch a {
   case _:
     break
-  default:  // expected-warning {{default will never be executed}}
+  default:  
     return
   }
 }

--- a/test/SILOptimizer/unreachable_code.swift
+++ b/test/SILOptimizer/unreachable_code.swift
@@ -208,7 +208,7 @@ class r20097963MyClass {
       str = "A"
     case .B:
       str = "B"
-    default:    // expected-warning {{default will never be executed}}
+    default: 
       str = "unknown"  // Should not be rejected.
     }
     return str

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -559,6 +559,28 @@ func infinitelySized() -> Bool {
   }
 }
 
+// SR-6316: Size heuristic is insufficient to catch space covering when the
+// covered space size is greater than or equal to the master space size.
+func largeSpaceMatch(_ x: Bool) {
+  switch (x, (x, x, x, x), (x, x, x, x)) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add a default clause?}}
+  case (true, (_, _, _, _), (_, true, true, _)):
+    break
+  case (true, (_, _, _, _), (_, _, false, _)):
+    break
+  case (_, (_, true, true, _), (_, _, false, _)):
+    break
+  case (_, (_, _, false, _), (_, true, true, _)):
+    break
+  case (_, (_, true, true, _), (_, true, true, _)):
+    break
+  case (_, (_, _, false, _), (_, _, false, _)):
+    break
+  case (_, (false, false, false, false), (_, _, _, _)):
+    break
+  }
+}
+
 func diagnoseDuplicateLiterals() {
   let str = "def"
   let int = 2

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -444,7 +444,7 @@ enum ContainsOverlyLargeEnum {
 }
 
 func quiteBigEnough() -> Bool {
-  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{analysis of uncovered switch statement is too complex to perform in a reasonable amount of time}}
   // expected-note@-1 {{do you want to add a default clause?}}
   case (.case0, .case0): return true
   case (.case1, .case1): return true
@@ -460,8 +460,7 @@ func quiteBigEnough() -> Bool {
   case (.case11, .case11): return true
   }
 
-  // No diagnostic
-  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{analysis of uncovered switch statement is too complex to perform in a reasonable amount of time}}
   // expected-note@-1 {{do you want to add a default clause?}}
   case (.case0, _): return true
   case (.case1, _): return true
@@ -477,8 +476,9 @@ func quiteBigEnough() -> Bool {
   }
 
 
-  // No diagnostic
+  // expected-error@+1 {{analysis of uncovered switch statement is too complex to perform in a reasonable amount of time}}
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  // expected-note@-1 {{do you want to add a default clause?}}
   case (.case0, _): return true
   case (.case1, _): return true
   case (.case2, _): return true
@@ -493,8 +493,9 @@ func quiteBigEnough() -> Bool {
   case (.case11, _): return true
   }
 
-  // No diagnostic
+  // expected-error@+1 {{analysis of uncovered switch statement is too complex to perform in a reasonable amount of time}}
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  // expected-note@-1 {{do you want to add a default clause?}}
   case (_, .case0): return true
   case (_, .case1): return true
   case (_, .case2): return true
@@ -509,13 +510,14 @@ func quiteBigEnough() -> Bool {
   case (_, .case11): return true
   }
 
-  // No diagnostic
+  // No diagnostic 
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
   case (_, _): return true
   }
 
-  // No diagnostic
+  // expected-error@+1 {{analysis of uncovered switch statement is too complex to perform in a reasonable amount of time}} 
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  // expected-note@-1 {{do you want to add a default clause?}}
   case (.case0, .case0): return true
   case (.case1, .case1): return true
   case (.case2, .case2): return true
@@ -523,7 +525,7 @@ func quiteBigEnough() -> Bool {
   case _: return true
   }
   
-  // No diagnostic
+  // No diagnostic 
   switch ContainsOverlyLargeEnum.one(.case0) {
   case .one: return true
   case .two: return true
@@ -562,7 +564,7 @@ func infinitelySized() -> Bool {
 // SR-6316: Size heuristic is insufficient to catch space covering when the
 // covered space size is greater than or equal to the master space size.
 func largeSpaceMatch(_ x: Bool) {
-  switch (x, (x, x, x, x), (x, x, x, x)) { // expected-error {{switch must be exhaustive}}
+  switch (x, (x, x, x, x), (x, x, x, x)) { // expected-error {{analysis of uncovered switch statement is too complex to perform in a reasonable amount of time}}
   // expected-note@-1 {{do you want to add a default clause?}}
   case (true, (_, _, _, _), (_, true, true, _)):
     break


### PR DESCRIPTION
- **Explanation**: Pairs with #12818 on master.  

The Space Engine includes a heuristic that attempted a combinatorics-
based check to see if a pattern covered an insufficient amount of cases.
In straight-line switches this avoided computing a subspace match that
would have been quite expensive computationally. However, when
expressive patterns (like tuple patterns) are used, it can fool the
check because the covered space is much larger than the actual size of
the space due to pattern overlap that counting like this simply can't detect.

Instead weaken the heuristic to diagnose large spaces as "uncheckable" and suggest a default clause. This requires disabling SILGen's warning for unreachable default clauses which is itself incomplete.

- **Scope**: Affects users that write complex switch statements with (large) tuple types.
- **Issue**: (Needs radar post-nomination: see rdar://problem/35389001 and [SR-6316](https://bugs.swift.org/browse/SR-6316))
- **Reviewed by**: @jckarter 
- **Risk**: Low. Improves on a broken heuristic and does some diagnostics QoI work too.
- **Testing**: Added compiler regression tests.