### PR TITLE
libSyntax: teach the generic factory method for syntax nodes creation  to check text-choices of a token child.

### DIFF
--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -130,6 +130,22 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
               return false;
             }
         },
+%       elif child.text_choices:
+        {   ${option},
+            [](const Syntax &S) {
+              // check ${child.name}.
+              if (auto Tok = S.getAs<TokenSyntax>()) {
+                auto Text = Tok->getText();
+%           tok_checks = []
+%           for choice in child.text_choices:
+%             tok_checks.append("Text == \"%s\"" % choice)
+%           end
+%           all_checks = ' || '.join(tok_checks)
+                return ${all_checks};
+              }
+              return false;
+            }
+        },
 %       else:
         {   ${option},
             [](const Syntax &S) {


### PR DESCRIPTION
This allows us to reject the creation of a syntax node if one of its token
syntax children doesn't follow the required textual choices, e.g.
modifiers.
