### PR TITLE
[WIP] [IDE] Toy with reimplementing synthesized extension checking.

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -45,12 +45,6 @@ namespace swift {
   /// \returns true on convertible, false on not.
   bool isConvertibleTo(Type T1, Type T2, DeclContext &DC);
 
-  bool isEqual(Type T1, Type T2, DeclContext &DC);
-
-  bool canPossiblyEqual(Type T1, Type T2, DeclContext &DC);
-
-  bool canPossiblyConvertTo(Type T1, Type T2, DeclContext &DC);
-
   void collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
                         llvm::SmallDenseMap<ValueDecl*, ValueDecl*> &DefaultMap);
 
@@ -84,8 +78,12 @@ namespace swift {
   /// \brief Given a type and an extension to the original type decl of that type,
   /// decide if the extension has been applied, i.e. if the requirements of the
   /// extension have been fulfilled.
+  /// \param openTypeParameters Whether to "open" type parameters into type
+  /// variables, allowing those type variables to be free.
+  ///
   /// \returns True on applied, false on not applied.
-  bool isExtensionApplied(DeclContext &DC, Type Ty, const ExtensionDecl *ED);
+  bool isExtensionApplied(DeclContext &DC, Type Ty, const ExtensionDecl *ED,
+                          bool openTypeParameters);
 
 /// The kind of type checking to perform for code completion.
   enum class CompletionTypeCheckKind {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -907,7 +907,7 @@ static bool hasConformanceInSignature(ArrayRef<Requirement> requirements,
                                       Type subjectType,
                                       ProtocolDecl *proto) {
   // Make sure this requirement exists in the requirement signature.
-  for (const auto& req: requirements) {
+  for (const auto &req: requirements) {
     if (req.getKind() == RequirementKind::Conformance &&
         req.getFirstType()->isEqual(subjectType) &&
         req.getSecondType()->castTo<ProtocolType>()->getDecl()

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -193,7 +193,7 @@ static void doGlobalExtensionLookup(Type BaseType,
   // Look in each extension of this type.
   for (auto extension : nominal->getExtensions()) {
     if (!isExtensionApplied(*const_cast<DeclContext*>(CurrDC), BaseType,
-                            extension))
+                            extension, /*openTypeParameters=*/false))
       continue;
 
     bool validatedExtension = false;


### PR DESCRIPTION
[IDE] Toy with reimplementing synthesized extension checking.  …
The isApplicable() operation for extensions re-implements the idea of
checking whether a particular extension is valid for a given
type. Replace its implementation with one based on
swift::isExtensionApplied(), generalizing the latter to support this
use case.