### PR TITLE
 [Type checker] Use the declared interface type of a type declaration.

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -907,7 +907,7 @@ static bool hasConformanceInSignature(ArrayRef<Requirement> requirements,
                                       Type subjectType,
                                       ProtocolDecl *proto) {
   // Make sure this requirement exists in the requirement signature.
-  for (const auto& req: requirements) {
+  for (const auto &req: requirements) {
     if (req.getKind() == RequirementKind::Conformance &&
         req.getFirstType()->isEqual(subjectType) &&
         req.getSecondType()->castTo<ProtocolType>()->getDecl()

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -204,8 +204,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
             ->getAsProtocolOrProtocolExtensionContext()) {
       // Fast path: if there are no type parameters in the concrete type, just
       // return it.
-      if (!concrete->getInterfaceType()->hasTypeParameter())
-        return concrete->getInterfaceType();
+      if (!concrete->getDeclaredInterfaceType()->hasTypeParameter())
+        return concrete->getDeclaredInterfaceType();
 
       tc.validateDecl(proto);
       auto subMap = SubstitutionMap::getProtocolSubstitutions(

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -278,3 +278,15 @@ extension P10 where A == X<Self.U> { }
 
 extension P10 where V == Int { } // expected-warning 3{{'V' is deprecated: just use Int, silly}}
 // expected-warning@-1{{neither type in same-type constraint ('P10.V' (aka 'Int') or 'Int') refers to a generic parameter  or associated type}}
+
+// rdar://problem/36003312
+protocol P11 {
+  typealias A = Y11
+}
+
+struct X11<T: P11> { }
+struct Y11: P11 { }
+
+extension P11 {
+  func foo(_: X11<Self.A>) { }
+}

--- a/validation-test/compiler_crashers/28779-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers/28779-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 protocol P{func a:Self.a.a{}class a{class a


### PR DESCRIPTION
Fix a silly error where we were returning the interface type of a type
declaration rather than the *declared* interface type, which meant we were
getting a metatype where we shouldn't.

Fixes rdar://problem/36003312.