### PR TITLE
[4.1] [Type checker] Use the declared interface type of a type declaration.

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -204,8 +204,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
             ->getAsProtocolOrProtocolExtensionContext()) {
       // Fast path: if there are no type parameters in the concrete type, just
       // return it.
-      if (!concrete->getInterfaceType()->hasTypeParameter())
-        return concrete->getInterfaceType();
+      if (!concrete->getDeclaredInterfaceType()->hasTypeParameter())
+        return concrete->getDeclaredInterfaceType();
 
       tc.validateDecl(proto);
       auto subMap = SubstitutionMap::getProtocolSubstitutions(

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -278,3 +278,15 @@ extension P10 where A == X<Self.U> { }
 
 extension P10 where V == Int { } // expected-warning 3{{'V' is deprecated: just use Int, silly}}
 // expected-warning@-1{{neither type in same-type constraint ('P10.V' (aka 'Int') or 'Int') refers to a generic parameter or associated type}}
+
+// rdar://problem/36003312
+protocol P11 {
+  typealias A = Y11
+}
+
+struct X11<T: P11> { }
+struct Y11: P11 { }
+
+extension P11 {
+  func foo(_: X11<Self.A>) { }
+}

--- a/validation-test/compiler_crashers/28779-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers/28779-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 protocol P{func a:Self.a.a{}class a{class a


### PR DESCRIPTION
- **Explanation**: Fix a silly error where we were returning the interface type of a type rather than the *declared* interface type when referring to a type alias in a protocol.
- **Scope**: Affects users of `IndexDistance`, now that it is `Int`.
- **Issue**: rdar://problem/36003312
- **Reviewed by**: @jrose-apple  
- **Risk**: Very low. Fixes a bug in recently-added code.
- **Testing**: Added compiler regression tests.