### PR TITLE
[runtime/abi] Add tagged BridgeObject recognition to 32-bit.

### DIFF
--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -105,6 +105,7 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_X86_64_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedMask _swift_abi_ObjCReservedBitsMask
 
 #elif defined(__arm64__)
 
@@ -121,6 +122,7 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_ARM64_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_ARM64_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedMask _swift_abi_ObjCReservedBitsMask
 
 #elif defined(__powerpc64__)
 
@@ -132,6 +134,8 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedMask                                         \
+  SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAGGED_MASK
 
 #elif defined(__s390x__)
 
@@ -143,6 +147,8 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedMask                                         \
+  SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAGGED_MASK
 
 #else
 
@@ -164,6 +170,8 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedMask                                  \
+  SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAGGED_MASK
 #endif
 
 /// Corresponding namespaced decls
@@ -175,13 +183,10 @@ static const __swift_uintptr_t SwiftSpareBitsMask =
     _swift_abi_SwiftSpareBitsMask;
 static const __swift_uintptr_t ObjCReservedBitsMask =
     _swift_abi_ObjCReservedBitsMask;
+static const __swift_uintptr_t TaggedBridgeObjectMask =
+    _swift_BridgeObject_TaggedMask;
 static const unsigned ObjCReservedLowBits = _swift_abi_ObjCReservedLowBits;
 } // heap_object_abi
 #endif // __cplusplus
-
-/// BridgeObject masks
-
-#define _swift_BridgeObject_TaggedPointerBits _swift_abi_ObjCReservedBitsMask
-
 
 #endif // SWIFT_STDLIB_SHIMS_HEAPOBJECT_H

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -48,6 +48,9 @@
 /// By default we assume the ObjC runtime doesn't use tagged pointers.
 #define SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK 0
 
+/// The bitmask of a tagged pointer as used by BridgeObject.
+#define SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAGGED_MASK 0x1
+
 /// The number of low bits in an Objective-C object pointer that
 /// are reserved by the Objective-C runtime.
 #define SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS 0

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -364,7 +364,7 @@ internal func _class_getInstancePositiveExtentSize(_ theClass: AnyClass) -> Int 
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned
 internal var _objCTaggedPointerBits: UInt {
-  @inline(__always) get { return UInt(_swift_BridgeObject_TaggedPointerBits) }
+  @inline(__always) get { return UInt(_swift_BridgeObject_TaggedMask) }
 }
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -579,10 +579,20 @@ static void* toPlainObject_unTagged_bridgeObject(void *object) {
   return (void*)(uintptr_t(object) & ~unTaggedNonNativeBridgeObjectBits);
 }
 
+/// Is the given value a tagged bridge object?
+static bool isTaggedBridgeObject(void *object) {
+#if SWIFT_OBJC_INTEROP
+  return (((uintptr_t)object) & heap_object_abi::TaggedBridgeObjectMask);
+#else
+  assert(!(((uintptr_t)object) & heap_object_abi::TaggedBridgeObjectMask));
+  return false;
+#endif
+}
+
 void *swift::swift_bridgeObjectRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return object;
 #endif
 
@@ -604,7 +614,7 @@ SWIFT_RUNTIME_EXPORT
 void *swift::swift_nonatomic_bridgeObjectRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return object;
 #endif
 
@@ -626,7 +636,7 @@ SWIFT_RUNTIME_EXPORT
 void swift::swift_bridgeObjectRelease(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return;
 #endif
 
@@ -644,7 +654,7 @@ void swift::swift_bridgeObjectRelease(void *object)
 void swift::swift_nonatomic_bridgeObjectRelease(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return;
 #endif
 
@@ -662,7 +672,7 @@ void swift::swift_nonatomic_bridgeObjectRelease(void *object)
 void *swift::swift_bridgeObjectRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return object;
 #endif
 
@@ -686,7 +696,7 @@ void *swift::swift_bridgeObjectRetain_n(void *object, int n)
 void swift::swift_bridgeObjectRelease_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return;
 #endif
 
@@ -705,7 +715,7 @@ void swift::swift_bridgeObjectRelease_n(void *object, int n)
 void *swift::swift_nonatomic_bridgeObjectRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return object;
 #endif
 
@@ -729,7 +739,7 @@ void *swift::swift_nonatomic_bridgeObjectRetain_n(void *object, int n)
 void swift::swift_nonatomic_bridgeObjectRelease_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
-  if (isObjCTaggedPointer(object))
+  if (isTaggedBridgeObject(object))
     return;
 #endif
 


### PR DESCRIPTION
BridgeObject is useful as a builtin to distinguish objects from values
(i.e. does retain/release need to track lifetime) as well as expose an
additional bit to denote ObjC vs Swift tracking. It just so happens
that there are no tagged pointers on 32-bit, so BridgeObject didn't
historically provide a tagged pattern on 32-bit. This adds that
ability, as it will be useful for String in Swift 5 as well as any
other structures that need a built-in way of distinguishing values
from references as well as ObjC vs Swift management.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
