### PR TITLE
Compute the BuiltinInfo for a builtin call to IRGenSIL; NFC.

### DIFF
--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -99,7 +99,8 @@ ValueDecl *getBuiltinValueDecl(ASTContext &Context, Identifier Name);
 StringRef getBuiltinName(BuiltinValueKind ID);
   
 /// \brief The information identifying the builtin - its kind and types.
-struct BuiltinInfo {
+class BuiltinInfo {
+public:
   BuiltinValueKind ID;
   SmallVector<Type, 4> Types;
   bool isReadNone() const;

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -116,13 +116,10 @@ getLoweredTypeAndTypeInfo(IRGenModule &IGM, Type unloweredType) {
 }
 
 /// emitBuiltinCall - Emit a call to a builtin function.
-void irgen::emitBuiltinCall(IRGenFunction &IGF, Identifier FnId,
-                            SILType resultType,
+void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
+                            Identifier FnId, SILType resultType,
                             Explosion &args, Explosion &out,
                             SubstitutionList substitutions) {
-  // Decompose the function's name into a builtin name and type list.
-  const BuiltinInfo &Builtin = IGF.getSILModule().getBuiltinInfo(FnId);
-
   if (Builtin.ID == BuiltinValueKind::UnsafeGuaranteedEnd) {
     // Just consume the incoming argument.
     assert(args.size() == 1 && "Expecting one incoming argument");

--- a/lib/IRGen/GenBuiltin.h
+++ b/lib/IRGen/GenBuiltin.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
+  class BuiltinInfo;
   class Identifier;
   class SILType;
 
@@ -30,8 +31,8 @@ namespace irgen {
   class IRGenFunction;
 
   /// Emit a call to a builtin function.
-  void emitBuiltinCall(IRGenFunction &IGF, Identifier FnId,
-                       SILType resultType,
+  void emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &builtin,
+                       Identifier fnId, SILType resultType,
                        Explosion &args, Explosion &result,
                        SubstitutionList substitutions);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2106,16 +2106,21 @@ static CallEmission getCallEmissionForLoweredValue(IRGenSILFunction &IGF,
 }
 
 void IRGenSILFunction::visitBuiltinInst(swift::BuiltinInst *i) {
+  const BuiltinInfo &builtin = getSILModule().getBuiltinInfo(i->getName());
+
   auto argValues = i->getArguments();
   Explosion args;
-  for (auto argValue : argValues) {
+
+  for (auto idx : indices(argValues)) {
+    auto argValue = argValues[idx];
+
     // Builtin arguments should never be substituted, so use the value's type
     // as the parameter type.
     emitApplyArgument(*this, argValue, argValue->getType(), args);
   }
   
   Explosion result;
-  emitBuiltinCall(*this, i->getName(), i->getType(),
+  emitBuiltinCall(*this, builtin, i->getName(), i->getType(),
                   args, result, i->getSubstitutions());
   
   setLoweredExplosion(i, result);


### PR DESCRIPTION
The intention here is to make it easier to do specialized lowering for specific builtin arguments.