### PR TITLE
Remove a wrong assert in the specializer and enable old Collection index functions in stdlib

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -245,9 +245,6 @@ static bool growingSubstitutions(SubstitutionList Subs1,
   for (unsigned idx = 0, e = Subs1.size(); idx < e; ++idx) {
     auto Type1 = Subs1[idx].getReplacement()->getCanonicalType();
     auto Type2 = Subs2[idx].getReplacement()->getCanonicalType();
-    // Replacement types should be concrete.
-    assert(!Type1->hasArchetype());
-    assert(!Type2->hasArchetype());
     // If types are the same, the substitution type does not grow.
     if (TypeCmp.isEqual(Type2, Type1))
       continue;

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1706,7 +1706,6 @@ extension Collection {
   public func index<T: BinaryInteger>(_ i: Index, offsetBy n: T) -> Index {
     return index(i, offsetBy: Int(n))
   }
-  /* FIXME: crashes the compiler
   @available(*, deprecated, message: "all index distances are now of type Int")
   public func formIndex<T: BinaryInteger>(_ i: Index, offsetBy n: T) {
     return formIndex(i, offsetBy: Int(n))
@@ -1715,7 +1714,6 @@ extension Collection {
   public func index<T: BinaryInteger>(_ i: Index, offsetBy n: T, limitedBy limit: Index) -> Index {
     return index(i, offsetBy: Int(n), limitedBy: limit)
   }
-  */
   @available(*, deprecated, message: "all index distances are now of type Int")
   public func formIndex<T: BinaryInteger>(_ i: inout Index, offsetBy n: T, limitedBy limit: Index) -> Bool {
     return formIndex(&i, offsetBy: Int(n), limitedBy: limit)


### PR DESCRIPTION
In case of partial specialization, the replacement type of a substitution can be generic.
I couldn't find a small unit test for this bug fix. But it is tested by compiling the stdlib with the change in Collection.swift.

This change also enables the temporarily disabled deprecated Collection index functions, which are needed for source compatibility.

rdar://problem/36033852