### PR TITLE
[4.1] [Serialization] Deserialize type witnesses before value witnesses.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 390; // Last change: remove 'volatile' bit from witness_method
+const uint16_t VERSION_MINOR = 391; // Last change: normal protocol conformance
 
 using DeclIDField = BCFixed<31>;
 
@@ -1215,11 +1215,11 @@ namespace decls_block {
     NORMAL_PROTOCOL_CONFORMANCE,
     DeclIDField, // the protocol
     DeclContextIDField, // the decl that provided this conformance
-    BCVBR<5>, // value mapping count
     BCVBR<5>, // type mapping count
+    BCVBR<5>, // value mapping count
     BCVBR<5>, // requirement signature conformance count
     BCArray<DeclIDField>
-    // The array contains archetype-value pairs, then type declarations.
+    // The array contains type witnesses, then value witnesses.
     // Requirement signature conformances follow, then the substitution records
     // for the associated types.
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1492,6 +1492,17 @@ void Serializer::writeNormalConformance(
   unsigned numValueWitnesses = 0;
   unsigned numTypeWitnesses = 0;
 
+  conformance->forEachTypeWitness(/*resolver=*/nullptr,
+                                  [&](AssociatedTypeDecl *assocType,
+                                      Type type, TypeDecl *typeDecl) {
+    data.push_back(addDeclRef(assocType));
+    data.push_back(addTypeRef(type));
+    data.push_back(addDeclRef(typeDecl, /*forceSerialization*/false,
+                              /*allowTypeAliasXRef*/true));
+    ++numTypeWitnesses;
+    return false;
+  });
+
   conformance->forEachValueWitness(nullptr,
     [&](ValueDecl *req, Witness witness) {
       ++numValueWitnesses;
@@ -1519,17 +1530,6 @@ void Serializer::writeNormalConformance(
       data.push_back(witness.getSubstitutions().size());
   });
 
-  conformance->forEachTypeWitness(/*resolver=*/nullptr,
-                                  [&](AssociatedTypeDecl *assocType,
-                                      Type type, TypeDecl *typeDecl) {
-    data.push_back(addDeclRef(assocType));
-    data.push_back(addTypeRef(type));
-    data.push_back(addDeclRef(typeDecl, /*forceSerialization*/false,
-                              /*allowTypeAliasXRef*/true));
-    ++numTypeWitnesses;
-    return false;
-  });
-
   unsigned numSignatureConformances =
       conformance->getSignatureConformances().size();
 
@@ -1538,8 +1538,8 @@ void Serializer::writeNormalConformance(
   auto ownerID = addDeclContextRef(conformance->getDeclContext());
   NormalProtocolConformanceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                               addDeclRef(protocol), ownerID,
-                                              numValueWitnesses,
                                               numTypeWitnesses,
+                                              numValueWitnesses,
                                               numSignatureConformances,
                                               data);
 


### PR DESCRIPTION
The deserialization of the type witnesses for a normal protocol conformance
is crucial to the usability of said conformance. Deserializing the
value witnesses first can fail if they somehow rely on the type
witnesses (e.g., through a recursive conformance).

As a stop-gap, deserialize and record type witnesses *first*, then
deserialize value witnesses afterward. A longer-term solution would
make deserialization of the normal protocol conformance far more
lazy.

Fixes SR-6522 / rdar://problem/35830641, a merge-modules crasher in a
nontrivial project.
