### PR TITLE
[test] Revert use of expectCrash(executing:) in the optional test

### DIFF
--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -400,7 +400,8 @@ OptionalTests.test("unsafelyUnwrapped nil")
     reason: "assertions are disabled in Release and Unchecked mode"))
   .code {
   let empty: Int? = nil
-  expectCrash { _blackHole(empty.unsafelyUnwrapped) }
+  expectCrashLater()
+  _blackHole(empty.unsafelyUnwrapped)
 }
 
 runAllTests()


### PR DESCRIPTION
The test is conditionally XFAILed for the release configuration only,
but using `expectCrash(executing:)` make it fail even in release mode,
but for a wrong reason (`expectUnreachable()` is unconditional).