### PR TITLE
[4.1] [DO NOT MERGE] Revert "[XCTest overlay] Remove extraneous XCAssert(Not)Equal overloads."

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -304,6 +304,207 @@ public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws 
   }
 }
 
+// FIXME(ABI): once <rdar://problem/17144340> is implemented, this could be 
+// changed to take two T rather than two T? since Optional<Equatable>: Equatable
+public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    let assertionType = _XCTAssertionType.equal
+
+    // evaluate each expression exactly once
+    // FIXME: remove optionality once this is generic over Equatable T
+    var expressionValue1Optional: T?
+    var expressionValue2Optional: T?
+
+    let result = _XCTRunThrowableBlock {
+        expressionValue1Optional = try expression1()
+        expressionValue2Optional = try expression2()
+    }
+
+    switch result {
+    case .success:
+        if expressionValue1Optional != expressionValue2Optional {
+            // TODO: @auto_string expression1
+            // TODO: @auto_string expression2
+
+            // once this function is generic over T, it will only print these
+            // values as optional when they are...
+            let expressionValueStr1 = String(describing: expressionValue1Optional)
+            let expressionValueStr2 = String(describing: expressionValue2Optional)
+
+            // FIXME: this file seems to use `as NSString` unnecessarily a lot,
+            // unless I'm missing something.
+            _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+        }
+
+    case .failedWithError(let error):
+        _XCTRegisterFailure(false, "XCTAssertEqual failed: threw error \"\(error)\"", message, file, line)
+
+    case .failedWithException(_, _, let reason):
+        _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+
+    case .failedWithUnknownException:
+        _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+    }
+}
+
+// FIXME(ABI): Due to <rdar://problem/17144340> we need overrides of 
+// XCTAssertEqual for:
+//  ContiguousArray<T>
+//  ArraySlice<T>
+//  Array<T>
+//  Dictionary<T, U>
+
+public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> ArraySlice<T>, _ expression2: @autoclosure () throws -> ArraySlice<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.equal
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: ArraySlice<T>?
+  var expressionValue2Optional: ArraySlice<T>?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: ArraySlice<T> = expressionValue1Optional!
+    let expressionValue2: ArraySlice<T> = expressionValue2Optional!
+    
+    if expressionValue1 != expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> ContiguousArray<T>, _ expression2: @autoclosure () throws -> ContiguousArray<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.equal
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: ContiguousArray<T>?
+  var expressionValue2Optional: ContiguousArray<T>?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: ContiguousArray<T> = expressionValue1Optional!
+    let expressionValue2: ContiguousArray<T> = expressionValue2Optional!
+    
+    if expressionValue1 != expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> [T], _ expression2: @autoclosure () throws -> [T], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.equal
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: [T]?
+  var expressionValue2Optional: [T]?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: [T] = expressionValue1Optional!
+    let expressionValue2: [T] = expressionValue2Optional!
+    
+    if expressionValue1 != expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertEqual<T, U : Equatable>(_ expression1: @autoclosure () throws -> [T: U], _ expression2: @autoclosure () throws -> [T: U], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.equal
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: [T: U]?
+  var expressionValue2Optional: [T: U]?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: [T: U] = expressionValue1Optional!
+    let expressionValue2: [T: U] = expressionValue2Optional!
+    
+    if expressionValue1 != expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
 public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
   let assertionType = _XCTAssertionType.notEqual
   
@@ -321,6 +522,199 @@ public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () thro
     let expressionValue1: T = expressionValue1Optional!
     let expressionValue2: T = expressionValue2Optional!
 
+    if expressionValue1 == expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertNotEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    let assertionType = _XCTAssertionType.notEqual
+
+    // evaluate each expression exactly once
+    var expressionValue1Optional: T?
+    var expressionValue2Optional: T?
+
+    let result = _XCTRunThrowableBlock {
+        expressionValue1Optional = try expression1()
+        expressionValue2Optional = try expression2()
+    }
+
+    switch result {
+    case .success:
+        if expressionValue1Optional == expressionValue2Optional {
+            // TODO: @auto_string expression1
+            // TODO: @auto_string expression2
+
+            let expressionValueStr1 = String(describing: expressionValue1Optional)
+            let expressionValueStr2 = String(describing: expressionValue2Optional)
+
+            _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+        }
+
+    case .failedWithError(let error):
+        _XCTRegisterFailure(false, "XCTAssertNotEqual failed: threw error \"\(error)\"", message, file, line)
+
+    case .failedWithException(_, _, let reason):
+        _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+
+    case .failedWithUnknownException:
+        _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+    }
+}
+
+// FIXME: Due to <rdar://problem/16768059> we need overrides of XCTAssertNotEqual for:
+//  ContiguousArray<T>
+//  ArraySlice<T>
+//  Array<T>
+//  Dictionary<T, U>
+
+public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> ContiguousArray<T>, _ expression2: @autoclosure () throws -> ContiguousArray<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.notEqual
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: ContiguousArray<T>?
+  var expressionValue2Optional: ContiguousArray<T>?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: ContiguousArray<T> = expressionValue1Optional!
+    let expressionValue2: ContiguousArray<T> = expressionValue2Optional!
+    
+    if expressionValue1 == expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertNotEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> ArraySlice<T>, _ expression2: @autoclosure () throws -> ArraySlice<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.notEqual
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: ArraySlice<T>?
+  var expressionValue2Optional: ArraySlice<T>?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: ArraySlice<T> = expressionValue1Optional!
+    let expressionValue2: ArraySlice<T> = expressionValue2Optional!
+    
+    if expressionValue1 == expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertNotEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> [T], _ expression2: @autoclosure () throws -> [T], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.notEqual
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: [T]?
+  var expressionValue2Optional: [T]?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: [T] = expressionValue1Optional!
+    let expressionValue2: [T] = expressionValue2Optional!
+    
+    if expressionValue1 == expressionValue2 {
+      // TODO: @auto_string expression1
+      // TODO: @auto_string expression2
+      
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
+      
+      _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+    }
+    
+  case .failedWithError(let error):
+    _XCTRegisterFailure(false, "XCTAssertNotEqual failed: threw error \"\(error)\"", message, file, line)
+    
+  case .failedWithException(_, _, let reason):
+    _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+    
+  case .failedWithUnknownException:
+    _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+  }
+}
+
+public func XCTAssertNotEqual<T, U : Equatable>(_ expression1: @autoclosure () throws -> [T: U], _ expression2: @autoclosure () throws -> [T: U], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  let assertionType = _XCTAssertionType.notEqual
+  
+  // evaluate each expression exactly once
+  var expressionValue1Optional: [T: U]?
+  var expressionValue2Optional: [T: U]?
+  
+  let result = _XCTRunThrowableBlock {
+    expressionValue1Optional = try expression1()
+    expressionValue2Optional = try expression2()
+  }
+  
+  switch result {
+  case .success:
+    let expressionValue1: [T: U] = expressionValue1Optional!
+    let expressionValue2: [T: U] = expressionValue2Optional!
+    
     if expressionValue1 == expressionValue2 {
       // TODO: @auto_string expression1
       // TODO: @auto_string expression2


### PR DESCRIPTION
This reverts commit 208b2c180c00d633ae780c4252e04dd0be909405, i.e., it reinstates the `XCTAssert(Not)Equal` overloads made obsolete by conditional conformances. Fixes rdar://problem/35831575.