### PR TITLE
NFC: Add predicates to SILOptions & do renaming in TBD generation.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -161,6 +161,10 @@ public:
   bool shouldOptimize() const {
     return OptMode > OptimizationMode::NoOptimization;
   }
+
+  bool hasMultipleIRGenThreads() const { return NumThreads > 1; }
+  bool shouldPerformIRGenerationInParallel() const { return NumThreads != 0; }
+  bool hasMultipleIGMs() const { return hasMultipleIRGenThreads(); }
 };
 
 } // end namespace swift

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -37,12 +37,29 @@ bool useDllStorage(const llvm::Triple &triple);
 
 class UniversalLinkageInfo {
 public:
-  bool IsELFObject, UseDLLStorage, HasMultipleIGMs, IsWholeModule;
+  bool IsELFObject;
+  bool UseDLLStorage;
+
+  /// True iff are multiple llvm modules.
+  bool HasMultipleIGMs;
+
+  bool IsWholeModule;
 
   UniversalLinkageInfo(IRGenModule &IGM);
 
   UniversalLinkageInfo(const llvm::Triple &triple, bool hasMultipleIGMs,
                        bool isWholeModule);
+
+  /// In case of multiple llvm modules (in multi-threaded compilation) all
+  /// private decls must be visible from other files.
+  bool shouldAllPrivateDeclsBeVisibleFromOtherFiles() const {
+    return HasMultipleIGMs;
+  }
+  /// In case of multipe llvm modules, private lazy protocol
+  /// witness table accessors could be emitted by two different IGMs during
+  /// IRGen into different object files and the linker would complain about
+  /// duplicate symbols.
+  bool needLinkerToMergeDuplicateSymbols() const { return HasMultipleIGMs; }
 };
 
 /// Selector for type metadata symbol kinds.

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -24,12 +24,11 @@ class FileUnit;
 class ModuleDecl;
 
 void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,
-                            bool hasMultipleIRGenThreads);
+                            bool hasMultipleIGMs);
 void enumeratePublicSymbols(ModuleDecl *module, llvm::StringSet<> &symbols,
-                            bool hasMultipleIRGenThreads);
+                            bool hasMultipleIGMs);
 
-void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
-                  bool hasMultipleIRGenThreads,
+void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os, bool hasMultipleIGMs,
                   llvm::StringRef installName);
 
 } // end namespace swift

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -757,12 +757,11 @@ static bool performCompile(CompilerInstance &Instance,
 
   const auto &SILOpts = Invocation.getSILOptions();
   if (!opts.TBDPath.empty()) {
-    auto hasMultipleIRGenThreads = SILOpts.NumThreads > 1;
     auto installName = opts.TBDInstallName.empty()
                            ? "lib" + Invocation.getModuleName().str() + ".dylib"
                            : opts.TBDInstallName;
 
-    if (writeTBD(Instance.getMainModule(), hasMultipleIRGenThreads,
+    if (writeTBD(Instance.getMainModule(), SILOpts.hasMultipleIGMs(),
                  opts.TBDPath, installName))
       return true;
   }
@@ -1082,14 +1081,13 @@ static bool performCompile(CompilerInstance &Instance,
       break;
 
     const auto &SILOpts = Invocation.getSILOptions();
-    auto hasMultipleIRGenThreads = SILOpts.NumThreads > 1;
+    const auto hasMultipleIGMs = SILOpts.hasMultipleIGMs();
     bool error;
     if (PrimarySourceFile)
-      error = validateTBD(PrimarySourceFile, *IRModule, hasMultipleIRGenThreads,
+      error = validateTBD(PrimarySourceFile, *IRModule, hasMultipleIGMs,
                           allSymbols);
     else
-      error = validateTBD(Instance.getMainModule(), *IRModule,
-                          hasMultipleIRGenThreads,
+      error = validateTBD(Instance.getMainModule(), *IRModule, hasMultipleIGMs,
                           allSymbols);
     if (error)
       return true;

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -38,9 +38,8 @@ static std::vector<StringRef> sortSymbols(llvm::StringSet<> &symbols) {
   return sorted;
 }
 
-bool swift::writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
-                     StringRef OutputFilename,
-                     StringRef installName) {
+bool swift::writeTBD(ModuleDecl *M, bool hasMultipleIGMs,
+                     StringRef OutputFilename, StringRef installName) {
   std::error_code EC;
   llvm::raw_fd_ostream OS(OutputFilename, EC, llvm::sys::fs::F_None);
   if (EC) {
@@ -49,7 +48,7 @@ bool swift::writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
     return true;
   }
 
-  writeTBDFile(M, OS, hasMultipleIRGenThreads, installName);
+  writeTBDFile(M, OS, hasMultipleIGMs, installName);
 
   return false;
 }
@@ -118,20 +117,18 @@ static bool validateSymbolSet(DiagnosticEngine &diags,
 }
 
 bool swift::validateTBD(ModuleDecl *M, llvm::Module &IRModule,
-                        bool hasMultipleIRGenThreads,
-                        bool diagnoseExtraSymbolsInTBD) {
+                        bool hasMultipleIGMs, bool diagnoseExtraSymbolsInTBD) {
   llvm::StringSet<> symbols;
-  enumeratePublicSymbols(M, symbols, hasMultipleIRGenThreads);
+  enumeratePublicSymbols(M, symbols, hasMultipleIGMs);
 
   return validateSymbolSet(M->getASTContext().Diags, symbols, IRModule,
                            diagnoseExtraSymbolsInTBD);
 }
 
 bool swift::validateTBD(FileUnit *file, llvm::Module &IRModule,
-                        bool hasMultipleIRGenThreads,
-                        bool diagnoseExtraSymbolsInTBD) {
+                        bool hasMultipleIGMs, bool diagnoseExtraSymbolsInTBD) {
   llvm::StringSet<> symbols;
-  enumeratePublicSymbols(file, symbols, hasMultipleIRGenThreads);
+  enumeratePublicSymbols(file, symbols, hasMultipleIGMs);
 
   return validateSymbolSet(file->getParentModule()->getASTContext().Diags,
                            symbols, IRModule, diagnoseExtraSymbolsInTBD);

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -24,15 +24,12 @@ class ModuleDecl;
 class FileUnit;
 class FrontendOptions;
 
-bool writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
-              llvm::StringRef OutputFilename,
-              llvm::StringRef installName);
+bool writeTBD(ModuleDecl *M, bool hasMultipleIGMs,
+              llvm::StringRef OutputFilename, llvm::StringRef installName);
 bool inputFileKindCanHaveTBDValidated(InputFileKind kind);
-bool validateTBD(ModuleDecl *M, llvm::Module &IRModule,
-                 bool hasMultipleIRGenThreads,
+bool validateTBD(ModuleDecl *M, llvm::Module &IRModule, bool hasMultipleIGMs,
                  bool diagnoseExtraSymbolsInTBD);
-bool validateTBD(FileUnit *M, llvm::Module &IRModule,
-                 bool hasMultipleIRGenThreads,
+bool validateTBD(FileUnit *M, llvm::Module &IRModule, bool hasMultipleIGMs,
                  bool diagnoseExtraSymbolsInTBD);
 }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1066,10 +1066,10 @@ performIRGeneration(IRGenOptions &Opts, swift::ModuleDecl *M,
                     std::unique_ptr<SILModule> SILMod,
                     StringRef ModuleName, llvm::LLVMContext &LLVMContext,
                     llvm::GlobalVariable **outModuleHash) {
-  int numThreads = SILMod->getOptions().NumThreads;
-  if (numThreads != 0) {
-    ::performParallelIRGeneration(Opts, M, std::move(SILMod),
-                                  ModuleName, numThreads);
+  if (SILMod->getOptions().shouldPerformIRGenerationInParallel()) {
+    auto NumThreads = SILMod->getOptions().NumThreads;
+    ::performParallelIRGeneration(Opts, M, std::move(SILMod), ModuleName,
+                                  NumThreads);
     // TODO: Parallel LLVM compilation cannot be used if a (single) module is
     // needed as return value.
     return nullptr;

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -327,12 +327,12 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
 
 static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
                                            StringSet &symbols,
-                                           bool hasMultipleIRGenThreads,
+                                           bool hasMultipleIGMs,
                                            llvm::raw_ostream *os,
                                            StringRef installName) {
   auto isWholeModule = singleFile == nullptr;
   const auto &target = M->getASTContext().LangOpts.Target;
-  UniversalLinkageInfo linkInfo(target, hasMultipleIRGenThreads, isWholeModule);
+  UniversalLinkageInfo linkInfo(target, hasMultipleIGMs, isWholeModule);
 
   TBDGenVisitor visitor(symbols, target, linkInfo, M, installName);
 
@@ -369,20 +369,18 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
 }
 
 void swift::enumeratePublicSymbols(FileUnit *file, StringSet &symbols,
-                                   bool hasMultipleIRGenThreads) {
-  enumeratePublicSymbolsAndWrite(
-      file->getParentModule(), file, symbols, hasMultipleIRGenThreads,
-      nullptr, StringRef());
+                                   bool hasMultipleIGMs) {
+  enumeratePublicSymbolsAndWrite(file->getParentModule(), file, symbols,
+                                 hasMultipleIGMs, nullptr, StringRef());
 }
 void swift::enumeratePublicSymbols(ModuleDecl *M, StringSet &symbols,
-                                   bool hasMultipleIRGenThreads) {
-  enumeratePublicSymbolsAndWrite(M, nullptr, symbols, hasMultipleIRGenThreads,
-                                 nullptr, StringRef());
+                                   bool hasMultipleIGMs) {
+  enumeratePublicSymbolsAndWrite(M, nullptr, symbols, hasMultipleIGMs, nullptr,
+                                 StringRef());
 }
 void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
-                         bool hasMultipleIRGenThreads,
-                         StringRef installName) {
+                         bool hasMultipleIGMs, StringRef installName) {
   StringSet symbols;
-  enumeratePublicSymbolsAndWrite(M, nullptr, symbols, hasMultipleIRGenThreads,
-                                 &os, installName);
+  enumeratePublicSymbolsAndWrite(M, nullptr, symbols, hasMultipleIGMs, &os,
+                                 installName);
 }


### PR DESCRIPTION
Add hasMultipleGMs predicate to SILOptions.
Rename parameters to TBD file handling to better reflect abstraction boundary.

<!-- What's in this pull request? -->
NFC: preparation for batch mode.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
