### PR TITLE
[ClangImporter] Put subscripts in the same DC as the found accessor

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/ObjCSubscripts.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCSubscripts.h
@@ -29,3 +29,34 @@
 - (NSString *)objectForKeyedSubscript:(NSString *)subscript;
 - (void)setObject:(NSString *)object forKeyedSubscript:(NSString *)key;
 @end
+
+
+// rdar://problem/36033356 failed specifically when the base class was never
+// subscripted, so please don't mention this class in the .swift file.
+@interface KeySubscriptBase
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end
+
+@interface KeySubscriptOverrideGetter : KeySubscriptBase
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+@end
+
+@interface KeySubscriptOverrideSetter : KeySubscriptBase
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end
+
+// rdar://problem/36033356 failed specifically when the base class was never
+// subscripted, so please don't mention this class in the .swift file.
+@interface KeySubscriptReversedBase
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+@end
+
+@interface KeySubscriptReversedOverrideGetter : KeySubscriptReversedBase
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+@end
+
+@interface KeySubscriptReversedOverrideSetter : KeySubscriptReversedBase
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end

--- a/test/ClangImporter/objc_subscript.swift
+++ b/test/ClangImporter/objc_subscript.swift
@@ -48,3 +48,24 @@ class ConformsToKeySubscriptProto2 : KeySubscriptProto2 {
     set { }
   }
 }
+
+func testOverridesWithoutBase(
+  o1: KeySubscriptOverrideGetter,
+  o2: KeySubscriptOverrideSetter,
+  o3: KeySubscriptReversedOverrideGetter,
+  o4: KeySubscriptReversedOverrideSetter
+) {
+  // rdar://problem/36033356 failed specifically when the base class was never
+  // subscripted, so please don't mention the base classes here.
+  _ = o1["abc"]
+  o1["abc"] = "xyz"
+
+  _ = o2["abc"]
+  o2["abc"] = "xyz"
+
+  _ = o3["abc"]
+  o3["abc"] = "xyz"
+
+  _ = o4["abc"]
+  o4["abc"] = "xyz"
+}


### PR DESCRIPTION
Objective-C subscripts don't have special declarations like properties; they're just specially-named methods (or method pairs), and we have to make an independent SubscriptDecl in Swift. Previously, we tried to always put that SubscriptDecl in the same context as the setter, but that doesn't make sense if the setter was actually inherited from a superclass! ~Give up on a consistent "always with the setter" or "always with the getter" rule, which doesn't really affect anything in practice, and instead just use the context we know we can trust: the one containing the declaration we started with, whether getter or setter.~

This all started because when an Objective-C subclass wants to make a subscript settable, they just add the appropriately-named setter method. Swift handled this by detecting when the getter and setter weren't declared in the same type, and assuming this meant it was a subclass adding a setter. Unfortunately, the same condition *also* picked up the case where the getter (and only the getter) is *redeclared* in a subclass (perhaps to add an attribute), and the new subscript was getting added to the base class instead of the subclass.

The fix relies on the fact that the original decl we provide is what we use to look up the other accessor. If the getter and setter are in different types, whichever one we started with must be the more-derived one. So the final change is just "did we start with the setter?" rather than "is there a setter at all?".

I'm not sure why this is only just now causing problems, given that we seem to have been getting this wrong for years, but it definitely *was* wrong and now it's not. ~Unfortunately, it's been this way so long I can't trace back to a reason *why* it was this way.~ All the tests still pass.

rdar://problem/36033356