### PR TITLE
[Parse] Disable token receiver while parsing types in editor placeholder

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2245,6 +2245,13 @@ Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
 
       // Temporarily swap out the parser's current lexer with our new one.
       llvm::SaveAndRestore<Lexer *> T(L, &LocalLex);
+
+      // Don't feed to syntax token recorder.
+      ConsumeTokenReceiver DisabledRec;
+      llvm::SaveAndRestore<ConsumeTokenReceiver *> R(TokReceiver, &DisabledRec);
+      SyntaxParsingContext SContext(SyntaxContext);
+      SContext.disable();
+
       Tok.setKind(tok::unknown); // we might be at tok::eof now.
       consumeTokenWithoutFeedingReceiver();
       return parseType().getPtrOrNull();

--- a/validation-test/IDE/crashers_2_fixed/0017-editorplacehoder-at-eof.swift
+++ b/validation-test/IDE/crashers_2_fixed/0017-editorplacehoder-at-eof.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -structure -source-filename=%s
+// rdar://problem/36081659
+
+var str = <#T##String#>


### PR DESCRIPTION
Otherwise, for `<#T##Type#>`, `TokReceiver` records `{'<#T##Type#>', 'Type'}`.
That used to cause a SourceKit crash if an editor placeholder was at the end of file.
rdar://problem/36081659