### PR TITLE
Move the fast path of TypeBase::getCanonicalType into the header

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -408,10 +408,20 @@ public:
   /// hasCanonicalTypeComputed - Return true if we've already computed a
   /// canonical version of this type.
   bool hasCanonicalTypeComputed() const { return !CanonicalType.isNull(); }
-  
+
+private:
+  void computeCanonicalType();
+
+public:
   /// getCanonicalType - Return the canonical version of this type, which has
   /// sugar from all levels stripped off.
-  CanType getCanonicalType();
+  CanType getCanonicalType() {
+    if (isCanonical())
+      return CanType(this);
+    if (!hasCanonicalTypeComputed())
+      computeCanonicalType();
+    return CanType(CanonicalType.get<TypeBase*>());
+  }
 
   /// getCanonicalType - Stronger canonicalization which folds away equivalent
   /// associated types, or type parameters that have been made concrete.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1045,17 +1045,9 @@ getCanonicalInputType(AnyFunctionType *funcType,
   return inputType;
 }
 
-/// getCanonicalType - Return the canonical version of this type, which has
-/// sugar from all levels stripped off.
-CanType TypeBase::getCanonicalType() {
-  // If the type is itself canonical, return it.
-  if (isCanonical())
-    return CanType(this);
-  // If the canonical type was already computed, just return what we have.
-  if (TypeBase *CT = CanonicalType.get<TypeBase*>())
-    return CanType(CT);
+void TypeBase::computeCanonicalType() {
+  assert(!hasCanonicalTypeComputed() && "called unnecessarily");
 
-  // Otherwise, compute and cache it.
   TypeBase *Result = nullptr;
   switch (getKind()) {
 #define ALWAYS_CANONICAL_TYPE(id, parent) case TypeKind::id:
@@ -1227,12 +1219,10 @@ CanType TypeBase::getCanonicalType() {
     break;
   }
   }
-    
-  
+
   // Cache the canonical type for future queries.
   assert(Result && "Case not implemented!");
   CanonicalType = Result;
-  return CanType(Result);
 }
 
 CanType TypeBase::getCanonicalType(GenericSignature *sig) {


### PR DESCRIPTION
I'm not sure how much benefit there'll be to inlining this, but a side benefit is that crashes in optimized builds of the compiler are much more likely to distinguish between "bug in getCanonicalType" (which almost never happens) and "bug in the function calling getCanonicalType".