### PR TITLE
[4.1][Parse] Disable token receiver while parsing types in editor placeholder

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2237,6 +2237,13 @@ Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
 
       // Temporarily swap out the parser's current lexer with our new one.
       llvm::SaveAndRestore<Lexer *> T(L, &LocalLex);
+
+      // Don't feed to syntax token recorder.
+      ConsumeTokenReceiver DisabledRec;
+      llvm::SaveAndRestore<ConsumeTokenReceiver *> R(TokReceiver, &DisabledRec);
+      SyntaxParsingContext SContext(SyntaxContext);
+      SContext.disable();
+
       Tok.setKind(tok::unknown); // we might be at tok::eof now.
       consumeTokenWithoutFeedingReceiver();
       return parseType().getPtrOrNull();

--- a/validation-test/IDE/crashers_2_fixed/0017-editorplacehoder-at-eof.swift
+++ b/validation-test/IDE/crashers_2_fixed/0017-editorplacehoder-at-eof.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -structure -source-filename=%s
+// rdar://problem/36081659
+
+var str = <#T##String#>


### PR DESCRIPTION
**Explanation**: The parser has `TokReceiver` for recording consumed tokens used by SourceKit. When the parser parses types in editor placeholder (e.g. `<#T##String#>`), it should stop the recording so it doesn't record *extra* tokens following to the placeholder. Although those *extra* tokens were usually just ignored,  if the placeholder was at the end of the file, it used to cause a SourceKit crash.
**Scope**: Affects SourceKit for files which has placeholder at the end of it.
**Issue**: rdar://problem/36081659
**Risk**: Low, `TokReceiver` is disabled in normal compilation.
**Testing**: Added compiler regression test.