### PR TITLE
The callback to Builtin.once is a C function, not a Swift one

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1103,11 +1103,11 @@ static ValueDecl *getUnreachableOperation(ASTContext &Context,
 static ValueDecl *getOnceOperation(ASTContext &Context,
                                    Identifier Id,
                                    bool withContext) {
-  // (RawPointer, @convention(thin) ([Context]) -> ()[, Context]) -> ()
+  // (RawPointer, @convention(c) ([Context]) -> ()[, Context]) -> ()
   
   auto HandleTy = Context.TheRawPointerType;
   auto VoidTy = Context.TheEmptyTupleType;
-  auto Thin = FunctionType::ExtInfo(FunctionTypeRepresentation::Thin,
+  auto Thin = FunctionType::ExtInfo(FunctionTypeRepresentation::CFunctionPointer,
                                     /*throws*/ false);
   if (withContext) {
     auto ContextTy = Context.TheRawPointerType;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2006,6 +2006,10 @@ getForeignRepresentable(Type type, ForeignLanguage language,
              nullptr };
   }
 
+  // Give special dispensation to builtin types for testing purposes.
+  if (type->is<BuiltinType>())
+    return { ForeignRepresentableKind::Trivial, nullptr };
+
   auto nominal = type->getAnyNominal();
   if (!nominal) return failure();
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -386,7 +386,7 @@ func testCondFail(_ b: Bool, c: Bool) {
 // CHECK-objc:    [[IS_DONE:%.*]] = icmp eq [[WORD]] [[PRED]], -1
 // CHECK-objc:    call void @llvm.assume(i1 [[IS_DONE]])
 
-func testOnce(_ p: Builtin.RawPointer, f: @escaping @convention(thin) () -> ()) {
+func testOnce(_ p: Builtin.RawPointer, f: @escaping @convention(c) () -> ()) {
   Builtin.once(p, f)
 }
 
@@ -402,7 +402,7 @@ func testOnce(_ p: Builtin.RawPointer, f: @escaping @convention(thin) () -> ()) 
 // CHECK-objc:    [[PRED:%.*]] = load {{.*}} [[WORD]]* [[PRED_PTR]]
 // CHECK-objc:    [[IS_DONE:%.*]] = icmp eq [[WORD]] [[PRED]], -1
 // CHECK-objc:    call void @llvm.assume(i1 [[IS_DONE]])
-func testOnceWithContext(_ p: Builtin.RawPointer, f: @escaping @convention(thin) (Builtin.RawPointer) -> (), k: Builtin.RawPointer) {
+func testOnceWithContext(_ p: Builtin.RawPointer, f: @escaping @convention(c) (Builtin.RawPointer) -> (), k: Builtin.RawPointer) {
   Builtin.onceWithContext(p, f, k)
 }
 

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -909,3 +909,16 @@ func retain(ptr: Builtin.NativeObject) {
 func release(ptr: Builtin.NativeObject) {
   Builtin.release(ptr)
 }
+
+//===----------------------------------------------------------------------===//
+// Other Operations
+//===----------------------------------------------------------------------===//
+
+func once_helper() {}
+
+// CHECK-LABEL: sil hidden @_T08builtins4onceyBp7control_tF
+// CHECK:      [[T0:%.*]] = function_ref @_T08builtins11once_helperyyFTo : $@convention(c) () -> ()
+// CHECK-NEXT: builtin "once"(%0 : $Builtin.RawPointer, [[T0]] : $@convention(c) () -> ())
+func once(control: Builtin.RawPointer) {
+  Builtin.once(control, once_helper)
+}


### PR DESCRIPTION
If we want it to be a Swift function, we'll have to thunk in the
runtime when using a system implementaton like dispatch_once_f,
since the function pointer ABIs could be different, depending on
the target.  Dealing with that, or avoiding it on a per-target basis,
is more complexiity than a micro-optimization of the slow path of
this builtin could possibly be worth.