### PR TITLE
[Parse] Improve Lexer's UTF-8 BOM handling

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -86,6 +86,9 @@ class Lexer {
   /// produce a code completion token.
   const char *CodeCompletionPtr = nullptr;
 
+  /// Points to BufferStart or past the end of UTF-8 BOM sequence if it exists.
+  const char *ContentStart;
+
   /// Pointer to the next not consumed character.
   const char *CurPtr;
 


### PR DESCRIPTION
Current `Lexer` has a function to skip UTF-8 BOM.
But its behavior has some bugs.

- It skips shebang at the beginning of file, but does not with BOM.
- A token should be prefix operator at the beginning of file, but is become infix operator with BOM.
- It skips conflict marker, but does not with BOM.
- A token at the beginning of file should be `isAtStartOfLine`, but is not with BOM.

All these bugs are come from implementation of `Lexer` that `BufferStart` is regarded as the beginning of source code even if BOM was skipped.
In text file with BOM, the end of BOM should be regarded as the beginnig of text content.

This PR fix these issues.

A design is shown below.

In text file, the beginning of text content is ordinary the beginning of file.
But if there is a BOM, the end of BOM is.

So to represent the beginning of text content, `ContentStart` field is added to `Lexer`.

## note

Two bugs about BOM + shebang are at skipping logic in libParse and libSyntax(`Lexer::lexTrivia`) both.
This PR only fix and add testcase for libParse.

I think that libSyntax should not skip BOM and should keep it as LeadingTrivia.
But to implement this idea needs more changes,
So I plan to submit it as another PR in future.

---

Reported issues is not found in bugs.swift.org.
