### PR TITLE
[Clang importer] Lazily load all named members with a matching base name

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -213,7 +213,7 @@ public:
   /// Returns None if an error occurred \em or named member-lookup
   /// was otherwise unsupported in this implementation or Decl.
   virtual Optional<TinyPtrVector<ValueDecl *>>
-  loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
+  loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) = 0;
 
   /// Populates the given vector with all conformances for \p D.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -733,7 +733,7 @@ public:
 
   virtual
   Optional<TinyPtrVector<ValueDecl *>>
-  loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
+  loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;
 
   virtual void

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1249,7 +1249,8 @@ populateLookupTableEntryFromLazyIDCLoader(ASTContext &ctx,
   IDC->setLoadingLazyMembers(true);
   auto ci = ctx.getOrCreateLazyIterableContextData(IDC,
                                                    /*lazyLoader=*/nullptr);
-  if (auto res = ci->loader->loadNamedMembers(IDC, name, ci->memberData)) {
+  if (auto res = ci->loader->loadNamedMembers(IDC, name.getBaseName(),
+                                              ci->memberData)) {
     IDC->setLoadingLazyMembers(false);
     if (auto s = ctx.Stats) {
       ++s->getFrontendCounters().NamedLazyMemberLoadSuccessCount;
@@ -1363,6 +1364,11 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
   // not yet loaded all the members into the IDC list in the first place.
   bool useNamedLazyMemberLoading = (ctx.LangOpts.NamedLazyMemberLoading &&
                                     hasLazyMembers());
+
+  if (getBaseName().getIdentifier().str().equals("NotificationCenter") &&
+      name.getBaseName().getKind() == DeclBaseName::Kind::Normal &&
+      name.getBaseName().getIdentifier().str().equals("addObserver"))
+    fprintf(stderr, "---NotificatiobCenter.addObserver\n");
 
   // FIXME: At present, lazy member loading conflicts with a bunch of other code
   // that appears to special-case initializers (clang-imported initializer

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3292,7 +3292,7 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
 
 Optional<TinyPtrVector<ValueDecl *>>
 ClangImporter::Implementation::loadNamedMembers(
-    const IterableDeclContext *IDC, DeclName N, uint64_t contextData) {
+    const IterableDeclContext *IDC, DeclBaseName N, uint64_t contextData) {
 
   auto *D = IDC->getDecl();
   auto *DC = cast<DeclContext>(D);
@@ -3351,7 +3351,7 @@ ClangImporter::Implementation::loadNamedMembers(
   assert(isa<clang::ObjCContainerDecl>(CD));
 
   TinyPtrVector<ValueDecl *> Members;
-  for (auto entry : table->lookup(SerializedSwiftName(N.getBaseName()),
+  for (auto entry : table->lookup(SerializedSwiftName(N),
                                   effectiveClangContext)) {
     if (!entry.is<clang::NamedDecl *>()) continue;
     auto member = entry.get<clang::NamedDecl *>();
@@ -3365,7 +3365,7 @@ ClangImporter::Implementation::loadNamedMembers(
     for (auto *TD : tmp) {
       if (auto *V = dyn_cast<ValueDecl>(TD)) {
         // Skip ValueDecls if they import under different names.
-        if (V->getFullName().matchesRef(N)) {
+        if (V->getBaseName() == N) {
           Members.push_back(V);
         }
       }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1149,7 +1149,7 @@ public:
   loadAllMembers(Decl *D, uint64_t unused) override;
 
   virtual Optional<TinyPtrVector<ValueDecl *>>
-  loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
+  loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;
 
 private:

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1793,7 +1793,7 @@ void ModuleFile::loadObjCMethods(
 }
 
 Optional<TinyPtrVector<ValueDecl *>>
-ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
+ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                              uint64_t contextData) {
   PrettyStackTraceDecl trace("loading members for", IDC->getDecl());
 
@@ -1801,7 +1801,7 @@ ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclName N,
   assert(DeclMemberNames);
 
   TinyPtrVector<ValueDecl *> results;
-  auto i = DeclMemberNames->find(N.getBaseName());
+  auto i = DeclMemberNames->find(N);
   if (i == DeclMemberNames->end())
     return results;
 

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
@@ -97,3 +97,9 @@
 
 @interface DerivedFromMirroringDoer : MirroringDoer
 @end
+
+@interface SimilarlyNamedThings
+- (void)doSomething:(double)x;
+- (void)doSomething:(double)x celsius:(double)y;
+- (void)doSomething:(double)x fahrenheit:(double)y using:(void (^)(void))block;
+@end

--- a/test/NameBinding/named_lazy_member_loading_anyobject.swift
+++ b/test/NameBinding/named_lazy_member_loading_anyobject.swift
@@ -1,0 +1,15 @@
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+//
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers %s -verify
+
+import NamedLazyMembers
+
+func callViaAnyObject(ao: AnyObject, d: Double) {
+  ao.doSomething(d, celsius: d)
+}
+
+func callDirect(snt: SimilarlyNamedThings, d: Double) {
+  snt.doSomething(d, fahrenheit: d) {
+  }
+}


### PR DESCRIPTION
When loading the named members for a given name, we want to load all
of the members with that base name... not only the ones that match the
full name, because the lookup table is indexed by base name and
filtering too early drops candidates.

Fixes rdar://problem/36085994.
