### PR TITLE
[stdlib] Nest Iterator and Index types for various stdlib types

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -78,7 +78,7 @@ set(SWIFTLIB_ESSENTIAL
   Integers.swift.gyb
   Join.swift
   KeyPath.swift
-  LazyCollection.swift.gyb
+  LazyCollection.swift
   LazySequence.swift
   LifetimeManager.swift
   ManagedBuffer.swift

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -17,24 +17,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An iterator that never produces an element.
-@_fixed_layout // FIXME(sil-serialize-all)
-public struct EmptyIterator<Element> {
-  // no properties
-  
-  /// Creates an instance.
-  @_inlineable // FIXME(sil-serialize-all)
-  public init() {}
-}
-
-extension EmptyIterator: IteratorProtocol, Sequence {
-  /// Returns `nil`, indicating that there are no more elements.
-  @_inlineable // FIXME(sil-serialize-all)
-  public mutating func next() -> Element? {
-    return nil
-  }
-}
-
 /// A collection whose element type is `Element` but that is always empty.
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct EmptyCollection<Element> {
@@ -43,6 +25,34 @@ public struct EmptyCollection<Element> {
   /// Creates an instance.
   @_inlineable // FIXME(sil-serialize-all)
   public init() {}
+}
+
+extension EmptyCollection {
+  /// An iterator that never produces an element.
+  @_fixed_layout // FIXME(sil-serialize-all)
+  public struct Iterator {
+    // no properties
+  
+    /// Creates an instance.
+    @_inlineable // FIXME(sil-serialize-all)
+    public init() {}
+  }  
+}
+
+extension EmptyCollection.Iterator: IteratorProtocol, Sequence {
+  /// Returns `nil`, indicating that there are no more elements.
+  @_inlineable // FIXME(sil-serialize-all)
+  public mutating func next() -> Element? {
+    return nil
+  }
+}
+
+extension EmptyCollection: Sequence {
+  /// Returns an empty iterator.
+  @_inlineable // FIXME(sil-serialize-all)
+  public func makeIterator() -> Iterator {
+    return Iterator()
+  }
 }
 
 extension EmptyCollection: RandomAccessCollection, MutableCollection {
@@ -84,12 +94,6 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
     _preconditionFailure("EmptyCollection can't advance indices")
   }
 
-  /// Returns an empty iterator.
-  @_inlineable // FIXME(sil-serialize-all)
-  public func makeIterator() -> EmptyIterator<Element> {
-    return EmptyIterator()
-  }
-
   /// Accesses the element at the given position.
   ///
   /// Must never be called, since this collection is always empty.
@@ -104,7 +108,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public subscript(bounds: Range<Index>) -> EmptyCollection<Element> {
+  public subscript(bounds: Range<Index>) -> SubSequence {
     get {
       _debugPrecondition(bounds.lowerBound == 0 && bounds.upperBound == 0,
         "Index out of range")
@@ -171,3 +175,6 @@ extension EmptyCollection : Equatable {
     return true
   }
 }
+
+// @available(*, deprecated, renamed: "EmptyCollection.Iterator")
+public typealias EmptyIterator<T> = EmptyCollection<T>.Iterator

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -10,15 +10,62 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An iterator over the elements traversed by some base iterator that also
-/// satisfy a given predicate.
+
+/// A sequence whose elements consist of the elements of some base
+/// sequence that also satisfy a given predicate.
 ///
-/// - Note: This is the associated `Iterator` of `LazyFilterSequence`
-/// and `LazyFilterCollection`.
+/// - Note: `s.lazy.filter { ... }`, for an arbitrary sequence `s`,
+///   is a `LazyFilterSequence`.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct LazyFilterIterator<
-  Base : IteratorProtocol
-> : IteratorProtocol, Sequence {
+public struct LazyFilterSequence<Base: Sequence> {
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _base: Base
+
+  /// The predicate used to determine which elements produced by
+  /// `base` are also produced by `self`.
+  @_versioned // FIXME(sil-serialize-all)
+  internal let _predicate: (Base.Element) -> Bool
+
+  /// Creates an instance consisting of the elements `x` of `base` for
+  /// which `isIncluded(x) == true`.
+  @_inlineable // FIXME(sil-serialize-all)
+  public // @testable
+  init(_base base: Base, _ isIncluded: @escaping (Base.Element) -> Bool) {
+    self._base = base
+    self._predicate = isIncluded
+  }
+}
+
+extension LazyFilterSequence {
+  /// An iterator over the elements traversed by some base iterator that also
+  /// satisfy a given predicate.
+  ///
+  /// - Note: This is the associated `Iterator` of `LazyFilterSequence`
+  /// and `LazyFilterCollection`.
+  @_fixed_layout // FIXME(sil-serialize-all)
+  public struct Iterator {
+    /// The underlying iterator whose elements are being filtered.
+    public var base: Base.Iterator { return _base }
+
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _base: Base.Iterator
+    @_versioned // FIXME(sil-serialize-all)
+    internal let _predicate: (Base.Element) -> Bool
+
+    /// Creates an instance that produces the elements `x` of `base`
+    /// for which `isIncluded(x) == true`.
+    @_inlineable // FIXME(sil-serialize-all)
+    @_versioned // FIXME(sil-serialize-all)
+    internal init(_base: Base.Iterator, _ isIncluded: @escaping (Base.Element) -> Bool) {
+      self._base = _base
+      self._predicate = isIncluded
+    }
+  }
+}
+
+extension LazyFilterSequence.Iterator: IteratorProtocol, Sequence {
+  public typealias Element = Base.Element
+  
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -27,7 +74,7 @@ public struct LazyFilterIterator<
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
   @_inlineable // FIXME(sil-serialize-all)
-  public mutating func next() -> Base.Element? {
+  public mutating func next() -> Element? {
     while let n = _base.next() {
       if _predicate(n) {
         return n
@@ -35,86 +82,24 @@ public struct LazyFilterIterator<
     }
     return nil
   }
-
-  /// Creates an instance that produces the elements `x` of `base`
-  /// for which `isIncluded(x) == true`.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_versioned // FIXME(sil-serialize-all)
-  internal init(
-    _base: Base,
-    _ isIncluded: @escaping (Base.Element) -> Bool
-  ) {
-    self._base = _base
-    self._predicate = isIncluded
-  }
-
-  /// The underlying iterator whose elements are being filtered.
-  public var base: Base { return _base }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _base: Base
-
-  /// The predicate used to determine which elements produced by
-  /// `base` are also produced by `self`.
-  @_versioned // FIXME(sil-serialize-all)
-  internal let _predicate: (Base.Element) -> Bool
 }
 
-/// A sequence whose elements consist of the elements of some base
-/// sequence that also satisfy a given predicate.
-///
-/// - Note: `s.lazy.filter { ... }`, for an arbitrary sequence `s`,
-///   is a `LazyFilterSequence`.
-@_fixed_layout // FIXME(sil-serialize-all)
-public struct LazyFilterSequence<Base : Sequence>
-  : LazySequenceProtocol {
-
+extension LazyFilterSequence: LazySequenceProtocol {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
   @_inlineable // FIXME(sil-serialize-all)
-  public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
-    return LazyFilterIterator(
-      _base: base.makeIterator(), _include)
+  public func makeIterator() -> Iterator {
+    return Iterator(_base: _base.makeIterator(), _predicate)
   }
 
   @_inlineable
-  public func _customContainsEquatableElement(
-    _ element: Element
-  ) -> Bool? {
-    if !_include(element) {
-      return false
-    }
-    if let baseContains = base._customContainsEquatableElement(element) {
-      return baseContains
-    }
-    return nil
+  public func _customContainsEquatableElement(_ element: Element) -> Bool? {
+    // optimization to check the element first matches the predicate
+    guard _predicate(element) else { return false }
+    return _base._customContainsEquatableElement(element)
   }
-
-  /// Creates an instance consisting of the elements `x` of `base` for
-  /// which `isIncluded(x) == true`.
-  @_inlineable // FIXME(sil-serialize-all)
-  public // @testable
-  init(
-    _base base: Base,
-    _ isIncluded: @escaping (Base.Element) -> Bool
-  ) {
-    self.base = base
-    self._include = isIncluded
-  }
-
-  /// The underlying sequence whose elements are being filtered
-  public let base: Base
-
-  /// The predicate used to determine which elements of `base` are
-  /// also elements of `self`.
-  @_versioned // FIXME(sil-serialize-all)
-  internal let _include: (Base.Element) -> Bool
 }
-
-/// The `Index` used for subscripting a `LazyFilterCollection`.
-@available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use Base.Index")
-public typealias LazyFilterIndex<Base : Collection> = Base.Index
 
 /// A lazy `Collection` wrapper that includes the elements of an
 /// underlying collection that satisfy a predicate.
@@ -136,18 +121,16 @@ public struct LazyFilterCollection<Base : Collection> {
   /// satisfy `isIncluded`.
   @_inlineable // FIXME(sil-serialize-all)
   public // @testable
-  init(
-    _base: Base,
-    _ isIncluded: @escaping (Base.Element) -> Bool
-  ) {
+  init(_base: Base, _ isIncluded: @escaping (Base.Element) -> Bool) {
     self._base = _base
     self._predicate = isIncluded
   }
 }
 
-extension LazyFilterCollection : Sequence {
-  public typealias SubSequence = LazyFilterCollection<Base.SubSequence>
+extension LazyFilterCollection : LazySequenceProtocol {
   public typealias Element = Base.Element
+  public typealias Iterator = LazyFilterSequence<Base>.Iterator
+  public typealias SubSequence = LazyFilterCollection<Base.SubSequence>
 
   // Any estimate of the number of elements that pass `_predicate` requires
   // iterating the collection and evaluating each element, which can be costly,
@@ -157,8 +140,7 @@ extension LazyFilterCollection : Sequence {
   public var underestimatedCount: Int { return 0 }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func _copyToContiguousArray()
-    -> ContiguousArray<Base.Iterator.Element> {
+  public func _copyToContiguousArray() -> ContiguousArray<Base.Element> {
 
     // The default implementation of `_copyToContiguousArray` queries the
     // `count` property, which evaluates `_predicate` for every element --
@@ -171,26 +153,18 @@ extension LazyFilterCollection : Sequence {
   ///
   /// - Complexity: O(1).
   @_inlineable // FIXME(sil-serialize-all)
-  public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
-    return LazyFilterIterator(
-      _base: _base.makeIterator(), _predicate)
+  public func makeIterator() -> Iterator {
+    return Iterator(_base: _base.makeIterator(), _predicate)
   }
 
   @_inlineable
-  public func _customContainsEquatableElement(
-    _ element: Element
-  ) -> Bool? {
-    if !_predicate(element) {
-      return false
-    }
-    if let baseContains = _base._customContainsEquatableElement(element) {
-      return baseContains
-    }
-    return nil
+  public func _customContainsEquatableElement(_ element: Element) -> Bool? {
+    guard _predicate(element) else { return false }
+    return _base._customContainsEquatableElement(element)
   }
 }
 
-extension LazyFilterCollection : LazyCollectionProtocol, Collection {
+extension LazyFilterCollection : LazyCollectionProtocol {
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
@@ -347,7 +321,7 @@ extension LazyFilterCollection : LazyCollectionProtocol, Collection {
   /// - Precondition: `position` is a valid position in `self` and
   /// `position != endIndex`.
   @_inlineable // FIXME(sil-serialize-all)
-  public subscript(position: Index) -> Base.Element {
+  public subscript(position: Index) -> Element {
     return _base[position]
   }
 
@@ -409,5 +383,10 @@ extension LazyCollectionProtocol {
   }
 }
 
+// @available(*, deprecated, renamed: "LazyFilterSequence.Iterator")
+public typealias LazyFilterIterator<T: Sequence> = LazyFilterSequence<T>.Iterator
+// @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use Base.Index")
+public typealias LazyFilterIndex<Base: Collection> = Base.Index
 @available(*, deprecated, renamed: "LazyFilterCollection")
 public typealias LazyFilterBidirectionalCollection<T> = LazyFilterCollection<T> where T : BidirectionalCollection
+

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -10,19 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_versioned // FIXME(sil-serialize-all)
-internal enum _JoinIteratorState {
-  case start
-  case generatingElements
-  case generatingSeparator
-  case end
-}
-
-/// An iterator that presents the elements of the sequences traversed
-/// by a base iterator, concatenated using a given separator.
+/// A sequence that presents the elements of a base sequence of sequences
+/// concatenated using a given separator.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
-  where Base.Element : Sequence {
+public struct JoinedSequence<Base : Sequence> where Base.Element : Sequence {
+
+  public typealias Element = Base.Element.Element
+  
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _base: Base
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _separator: ContiguousArray<Element>
 
   /// Creates an iterator that presents the elements of the sequences
   /// traversed by `base`, concatenated using `separator`.
@@ -30,17 +28,58 @@ public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
   /// - Complexity: O(`separator.count`).
   @_inlineable // FIXME(sil-serialize-all)
   public init<Separator : Sequence>(base: Base, separator: Separator)
-    where Separator.Element == Base.Element.Element {
+    where Separator.Element == Element {
     self._base = base
-    self._separatorData = ContiguousArray(separator)
+    self._separator = ContiguousArray(separator)
   }
+}
+
+extension JoinedSequence {
+  /// An iterator that presents the elements of the sequences traversed
+  /// by a base iterator, concatenated using a given separator.
+  @_fixed_layout // FIXME(sil-serialize-all)
+  public struct Iterator {
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _base: Base.Iterator
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _inner: Base.Element.Iterator?
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _separatorData: ContiguousArray<Element>
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _separator: ContiguousArray<Element>.Iterator?
+    
+    @_versioned // FIXME(sil-serialize-all)
+    internal enum JoinIteratorState {
+      case start
+      case generatingElements
+      case generatingSeparator
+      case end
+    }
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _state: JoinIteratorState = .start
+
+    /// Creates a sequence that presents the elements of `base` sequences
+    /// concatenated using `separator`.
+    ///
+    /// - Complexity: O(`separator.count`).
+    @_inlineable // FIXME(sil-serialize-all)
+    public init<Separator: Sequence>(base: Base.Iterator, separator: Separator)
+      where Separator.Element == Element {
+      self._base = base
+      self._separatorData = ContiguousArray(separator)
+    }
+  }  
+}
+
+extension JoinedSequence.Iterator: IteratorProtocol {
+  public typealias Element = Base.Element.Element
 
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   @_inlineable // FIXME(sil-serialize-all)
-  public mutating func next() -> Base.Element.Element? {
+  public mutating func next() -> Element? {
     while true {
       switch _state {
       case .start:
@@ -76,54 +115,22 @@ public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
 
       case .end:
         return nil
-
       }
     }
   }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _base: Base
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _inner: Base.Element.Iterator?
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _separatorData: ContiguousArray<Base.Element.Element>
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _separator:
-    ContiguousArray<Base.Element.Element>.Iterator?
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _state: _JoinIteratorState = .start
 }
 
-/// A sequence that presents the elements of a base sequence of sequences
-/// concatenated using a given separator.
-@_fixed_layout // FIXME(sil-serialize-all)
-public struct JoinedSequence<Base : Sequence> : Sequence
-  where Base.Element : Sequence {
-
-  /// Creates a sequence that presents the elements of `base` sequences
-  /// concatenated using `separator`.
-  ///
-  /// - Complexity: O(`separator.count`).
-  @_inlineable // FIXME(sil-serialize-all)
-  public init<Separator : Sequence>(base: Base, separator: Separator)
-    where Separator.Element == Base.Element.Element {
-    self._base = base
-    self._separator = ContiguousArray(separator)
-  }
-
+extension JoinedSequence: Sequence {
   /// Return an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
   @_inlineable // FIXME(sil-serialize-all)
-  public func makeIterator() -> JoinedIterator<Base.Iterator> {
-    return JoinedIterator(
-      base: _base.makeIterator(),
-      separator: _separator)
+  public func makeIterator() -> Iterator {
+    return Iterator(base: _base.makeIterator(), separator: _separator)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func _copyToContiguousArray()
-    -> ContiguousArray<Base.Element.Element> {
+  public func _copyToContiguousArray() -> ContiguousArray<Element> {
     var result = ContiguousArray<Element>()
     let separatorSize: Int = numericCast(_separator.count)
 
@@ -158,14 +165,8 @@ public struct JoinedSequence<Base : Sequence> : Sequence
 
     return result
   }
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _base: Base
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _separator:
-    ContiguousArray<Base.Element.Element>
 }
-
+  
 extension Sequence where Element : Sequence {
   /// Returns the concatenated elements of this sequence of sequences,
   /// inserting the given separator between each element.
@@ -189,3 +190,6 @@ extension Sequence where Element : Sequence {
     return JoinedSequence(base: self, separator: separator)
   }
 }
+
+// @available(*, deprecated, renamed: "JoinedSequence.Iterator")
+public typealias JoinedIterator<T: Sequence> = JoinedSequence<T>.Iterator where T.Element: Sequence

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -1,4 +1,4 @@
-//===--- LazyCollection.swift.gyb -----------------------------*- swift -*-===//
+//===--- LazyCollection.swift ---------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -32,6 +32,14 @@ extension LazyCollectionProtocol {
   @_inlineable // FIXME(sil-serialize-all)
   public var lazy: LazyCollection<Elements> {
     return elements.lazy
+  }
+}
+
+extension LazyCollectionProtocol where Elements: LazyCollectionProtocol {
+  // Lazy things are already lazy
+  @_inlineable // FIXME(sil-serialize-all)
+  public var lazy: Elements {
+    return elements
   }
 }
 

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-% from gyb_stdlib_support import TRAVERSALS, collectionForTraversal
-
 /// A collection on which normally-eager operations such as `map` and
 /// `filter` are implemented lazily.
 ///
@@ -21,8 +19,7 @@
 /// To add new lazy collection operations, extend this protocol with
 /// methods that return lazy wrappers that are themselves
 /// `LazyCollectionProtocol`s.
-public protocol LazyCollectionProtocol
-  : Collection, LazySequenceProtocol {
+public protocol LazyCollectionProtocol: Collection, LazySequenceProtocol {
   /// A `Collection` that can contain the same elements as this one,
   /// possibly with a simpler type.
   ///
@@ -30,12 +27,12 @@ public protocol LazyCollectionProtocol
   associatedtype Elements : Collection = Self
 }
 
-/// When there's no special associated `Elements` type, the `elements`
-/// property is provided.
-extension LazyCollectionProtocol where Elements == Self {
-  /// Identical to `self`.
+extension LazyCollectionProtocol {
+  // Lazy things are already lazy
   @_inlineable // FIXME(sil-serialize-all)
-  public var elements: Self { return self }
+  public var lazy: LazyCollection<Elements> {
+    return elements.lazy
+  }
 }
 
 /// A collection containing the same elements as a `Base` collection,
@@ -44,21 +41,7 @@ extension LazyCollectionProtocol where Elements == Self {
 ///
 /// - See also: `LazySequenceProtocol`, `LazyCollection`
 @_fixed_layout
-public struct LazyCollection<Base : Collection> : LazyCollectionProtocol {
-
-  /// The type of the underlying collection.
-  public typealias Elements = Base
-
-  /// The underlying collection.
-  @_inlineable
-  public var elements: Elements { return _base }
-
-  /// A type that represents a valid position in the collection.
-  ///
-  /// Valid indices consist of the position of every element and a
-  /// "past the end" position that's not valid for use as a subscript.
-  public typealias Index = Base.Index
-
+public struct LazyCollection<Base : Collection> {
   /// Creates an instance with `base` as its underlying Collection
   /// instance.
   @_inlineable
@@ -69,12 +52,20 @@ public struct LazyCollection<Base : Collection> : LazyCollectionProtocol {
 
   @_versioned
   internal var _base: Base
+} 
+
+extension LazyCollection: LazyCollectionProtocol {
+  /// The type of the underlying collection.
+  public typealias Elements = Base
+
+  /// The underlying collection.
+  @_inlineable
+  public var elements: Elements { return _base }
 }
 
 /// Forward implementations to the base collection, to pick up any
 /// optimizations it might implement.
 extension LazyCollection : Sequence {
-  
   public typealias Iterator = Base.Iterator
 
   /// Returns an iterator over the elements of this sequence.
@@ -114,13 +105,19 @@ extension LazyCollection : Sequence {
 }
 
 extension LazyCollection : Collection {
+  /// A type that represents a valid position in the collection.
+  ///
+  /// Valid indices consist of the position of every element and a
+  /// "past the end" position that's not valid for use as a subscript.
+  public typealias Element = Base.Element
+  public typealias Index = Base.Index
+  public typealias Indices = Base.Indices
+
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
   @_inlineable
-  public var startIndex: Base.Index {
-    return _base.startIndex
-  }
+  public var startIndex: Index { return _base.startIndex }
 
   /// The collection's "past the end" position---that is, the position one
   /// greater than the last valid subscript argument.
@@ -128,18 +125,14 @@ extension LazyCollection : Collection {
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
   @_inlineable
-  public var endIndex: Base.Index {
-    return _base.endIndex
-  }
+  public var endIndex: Index { return _base.endIndex }
 
   @_inlineable
-  public var indices: Base.Indices {
-    return _base.indices
-  }
+  public var indices: Indices { return _base.indices }
 
   // TODO: swift-3-indexing-model - add docs
   @_inlineable
-  public func index(after i: Base.Index) -> Base.Index {
+  public func index(after i: Index) -> Index {
     return _base.index(after: i)
   }
 
@@ -148,17 +141,8 @@ extension LazyCollection : Collection {
   /// - Precondition: `position` is a valid position in `self` and
   ///   `position != endIndex`.
   @_inlineable
-  public subscript(position: Base.Index) -> Base.Element {
+  public subscript(position: Index) -> Element {
     return _base[position]
-  }
-
-  /// Returns a collection representing a contiguous sub-range of
-  /// `self`'s elements.
-  ///
-  /// - Complexity: O(1)
-  @_inlineable
-  public subscript(bounds: Range<Index>) -> Slice<LazyCollection<Base>> {
-    return Slice(base: self, bounds: bounds)
   }
 
   /// A Boolean value indicating whether the collection is empty.
@@ -190,14 +174,14 @@ extension LazyCollection : Collection {
   /// - Complexity: O(*n*)
   @_inlineable
   public func _customIndexOfEquatableElement(
-    _ element: Base.Iterator.Element
+    _ element: Element
   ) -> Index?? {
     return _base._customIndexOfEquatableElement(element)
   }
 
   /// Returns the first element of `self`, or `nil` if `self` is empty.
   @_inlineable
-  public var first: Base.Element? {
+  public var first: Element? {
     return _base.first
   }
 
@@ -226,12 +210,12 @@ extension LazyCollection : Collection {
 extension LazyCollection : BidirectionalCollection
   where Base : BidirectionalCollection {
   @_inlineable
-  public func index(before i: Base.Index) -> Base.Index {
+  public func index(before i: Index) -> Index {
     return _base.index(before: i)
   }
 
   @_inlineable
-  public var last: Base.Element? {
+  public var last: Element? {
     return _base.last
   }
 }
@@ -253,26 +237,12 @@ extension Collection {
   }
 }
 
-% for Traversal in TRAVERSALS:
-%   TraversalCollection = collectionForTraversal(Traversal)
-// Without this specific overload the non-re-wrapping extension on
-// LazyCollectionProtocol (below) is not selected for some reason.
-extension ${TraversalCollection} where Self : LazyCollectionProtocol {
-  /// Identical to `self`.
-  @_inlineable
-  public var lazy: Self { // Don't re-wrap already-lazy collections
-    return self
-  }
-}
-% end
-
 extension Slice: LazySequenceProtocol where Base: LazySequenceProtocol { }
 extension Slice: LazyCollectionProtocol where Base: LazyCollectionProtocol { }
+extension ReversedCollection: LazySequenceProtocol where Base: LazySequenceProtocol { }
+extension ReversedCollection: LazyCollectionProtocol where Base: LazyCollectionProtocol { }
 
 @available(*, deprecated, renamed: "LazyCollection")
 public typealias LazyBidirectionalCollection<T> = LazyCollection<T> where T : BidirectionalCollection
 @available(*, deprecated, renamed: "LazyCollection")
 public typealias LazyRandomAccessCollection<T> = LazyCollection<T> where T : RandomAccessCollection
-// ${'Local Variables'}:
-// eval: (read-only-mode 1)
-// End:

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -10,13 +10,54 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The `IteratorProtocol` used by `MapSequence` and `MapCollection`.
-/// Produces each element by passing the output of the `Base`
-/// `IteratorProtocol` through a transform function returning `Element`.
+/// A `Sequence` whose elements consist of those in a `Base`
+/// `Sequence` passed through a transform function returning `Element`.
+/// These elements are computed lazily, each time they're read, by
+/// calling the transform function on a base element.
 @_fixed_layout
-public struct LazyMapIterator<
-  Base : IteratorProtocol, Element
-> : IteratorProtocol, Sequence {
+public struct LazyMapSequence<Base : Sequence, Element> {
+
+  public typealias Elements = LazyMapSequence
+
+  @_versioned
+  internal var _base: Base
+  @_versioned
+  internal let _transform: (Base.Element) -> Element
+
+  /// Creates an instance with elements `transform(x)` for each element
+  /// `x` of base.
+  @_inlineable
+  @_versioned
+  internal init(_base: Base, transform: @escaping (Base.Element) -> Element) {
+    self._base = _base
+    self._transform = transform
+  }
+}
+
+extension LazyMapSequence {
+  @_fixed_layout
+  public struct Iterator {
+    @_versioned
+    internal var _base: Base.Iterator
+    @_versioned
+    internal let _transform: (Base.Element) -> Element
+
+    @_inlineable
+    public var base: Base.Iterator { return _base }
+
+    @_inlineable
+    @_versioned
+    internal init(
+      _base: Base.Iterator, 
+      _transform: @escaping (Base.Element) -> Element
+    ) {
+      self._base = _base
+      self._transform = _transform
+    }
+  }
+}
+
+extension LazyMapSequence.Iterator: IteratorProtocol, Sequence {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///
@@ -28,39 +69,15 @@ public struct LazyMapIterator<
   public mutating func next() -> Element? {
     return _base.next().map(_transform)
   }
-
-  @_inlineable
-  public var base: Base { return _base }
-
-  @_versioned
-  internal var _base: Base
-  @_versioned
-  internal let _transform: (Base.Element) -> Element
-
-  @_inlineable
-  @_versioned
-  internal init(_base: Base, _transform: @escaping (Base.Element) -> Element) {
-    self._base = _base
-    self._transform = _transform
-  }
 }
 
-/// A `Sequence` whose elements consist of those in a `Base`
-/// `Sequence` passed through a transform function returning `Element`.
-/// These elements are computed lazily, each time they're read, by
-/// calling the transform function on a base element.
-@_fixed_layout
-public struct LazyMapSequence<Base : Sequence, Element>
-  : LazySequenceProtocol {
-
-  public typealias Elements = LazyMapSequence
-
+extension LazyMapSequence: LazySequenceProtocol {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
   @_inlineable
-  public func makeIterator() -> LazyMapIterator<Base.Iterator, Element> {
-    return LazyMapIterator(_base: _base.makeIterator(), _transform: _transform)
+  public func makeIterator() -> Iterator {
+    return Iterator(_base: _base.makeIterator(), _transform: _transform)
   }
 
   /// Returns a value less than or equal to the number of elements in
@@ -71,35 +88,50 @@ public struct LazyMapSequence<Base : Sequence, Element>
   public var underestimatedCount: Int {
     return _base.underestimatedCount
   }
-
-  /// Creates an instance with elements `transform(x)` for each element
-  /// `x` of base.
-  @_inlineable
-  @_versioned
-  internal init(_base: Base, transform: @escaping (Base.Element) -> Element) {
-    self._base = _base
-    self._transform = transform
-  }
-
-  @_versioned
-  internal var _base: Base
-  @_versioned
-  internal let _transform: (Base.Element) -> Element
 }
-
-//===--- Collections ------------------------------------------------------===//
 
 /// A `Collection` whose elements consist of those in a `Base`
 /// `Collection` passed through a transform function returning `Element`.
 /// These elements are computed lazily, each time they're read, by
 /// calling the transform function on a base element.
 @_fixed_layout
-public struct LazyMapCollection<
-  Base : Collection, Element
-> : LazyCollectionProtocol, Collection {
+public struct LazyMapCollection<Base: Collection, Element> {
+  @_versioned
+  internal var _base: Base
+  @_versioned
+  internal let _transform: (Base.Element) -> Element
 
-  // FIXME(compiler limitation): should be inferable.
+  /// Create an instance with elements `transform(x)` for each element
+  /// `x` of base.
+  @_inlineable
+  @_versioned
+  internal init(_base: Base, transform: @escaping (Base.Element) -> Element) {
+    self._base = _base
+    self._transform = transform
+  }  
+}
+
+extension LazyMapCollection: Sequence {
+  public typealias Iterator = LazyMapSequence<Base,Element>.Iterator
+
+  /// Returns an iterator over the elements of this sequence.
+  ///
+  /// - Complexity: O(1).
+  @_inlineable
+  public func makeIterator() -> Iterator {
+    return Iterator(_base: _base.makeIterator(), _transform: _transform)
+  }
+
+  @_inlineable
+  public var underestimatedCount: Int {
+    return _base.underestimatedCount
+  }
+}
+
+extension LazyMapCollection: LazyCollectionProtocol {
   public typealias Index = Base.Index
+  public typealias Indices = Base.Indices
+  public typealias SubSequence = LazyMapCollection<Base.SubSequence, Element>
 
   @_inlineable
   public var startIndex: Base.Index { return _base.startIndex }
@@ -108,11 +140,8 @@ public struct LazyMapCollection<
 
   @_inlineable
   public func index(after i: Index) -> Index { return _base.index(after: i) }
-
   @_inlineable
-  public func formIndex(after i: inout Index) {
-    _base.formIndex(after: &i)
-  }
+  public func formIndex(after i: inout Index) { _base.formIndex(after: &i) }
 
   /// Accesses the element at `position`.
   ///
@@ -123,14 +152,10 @@ public struct LazyMapCollection<
     return _transform(_base[position])
   }
 
-  public typealias SubSequence = LazyMapCollection<Base.SubSequence, Element>
-
   @_inlineable
   public subscript(bounds: Range<Base.Index>) -> SubSequence {
     return SubSequence(_base: _base[bounds], transform: _transform)
   }
-
-  public typealias Indices = Base.Indices
 
   @_inlineable
   public var indices: Indices {
@@ -174,33 +199,6 @@ public struct LazyMapCollection<
   public func distance(from start: Index, to end: Index) -> Int {
     return _base.distance(from: start, to: end)
   }
-
-  /// Returns an iterator over the elements of this sequence.
-  ///
-  /// - Complexity: O(1).
-  @_inlineable
-  public func makeIterator() -> LazyMapIterator<Base.Iterator, Element> {
-    return LazyMapIterator(_base: _base.makeIterator(), _transform: _transform)
-  }
-
-  @_inlineable
-  public var underestimatedCount: Int {
-    return _base.underestimatedCount
-  }
-
-  /// Create an instance with elements `transform(x)` for each element
-  /// `x` of base.
-  @_inlineable
-  @_versioned
-  internal init(_base: Base, transform: @escaping (Base.Element) -> Element) {
-    self._base = _base
-    self._transform = transform
-  }
-
-  @_versioned
-  internal var _base: Base
-  @_versioned
-  internal let _transform: (Base.Element) -> Element
 }
 
 extension LazyMapCollection : BidirectionalCollection
@@ -219,8 +217,7 @@ extension LazyMapCollection : BidirectionalCollection
 }
 
 extension LazyMapCollection : RandomAccessCollection
-  where Base : RandomAccessCollection {}
-
+  where Base : RandomAccessCollection { }
 
 //===--- Support for s.lazy -----------------------------------------------===//
 
@@ -264,6 +261,8 @@ extension LazyMapCollection {
   }
 }
 
+// @available(*, deprecated, renamed: "LazyMapSequence.Iterator")
+public typealias LazyMapIterator<T, E> = LazyMapSequence<T, E>.Iterator where T: Sequence
 @available(*, deprecated, renamed: "LazyMapCollection")
 public typealias LazyMapBidirectionalCollection<T, E> = LazyMapCollection<T, E> where T : BidirectionalCollection
 @available(*, deprecated, renamed: "LazyMapCollection")

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -257,9 +257,9 @@ extension String {
       @_versioned // FIXME(sil-serialize-all)
       internal let _ascii: Bool
       @_versioned // FIXME(sil-serialize-all)
-      internal var _asciiBase: UnsafeBufferPointerIterator<UInt8>!
+      internal var _asciiBase: UnsafeBufferPointer<UInt8>.Iterator!
       @_versioned // FIXME(sil-serialize-all)
-      internal var _base: UnsafeBufferPointerIterator<UInt16>!
+      internal var _base: UnsafeBufferPointer<UInt16>.Iterator!
       @_versioned // FIXME(sil-serialize-all)
       internal var _iterator: IndexingIterator<_StringCore>
     }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -10,34 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An iterator for the elements in the buffer referenced by an
-/// `UnsafeBufferPointer` or `UnsafeMutableBufferPointer` instance.
-@_fixed_layout
-public struct UnsafeBufferPointerIterator<Element>
-  : IteratorProtocol, Sequence {
-
-  /// Advances to the next element and returns it, or `nil` if no next element
-  /// exists.
-  ///
-  /// Once `nil` has been returned, all subsequent calls return `nil`.
-  @_inlineable
-  public mutating func next() -> Element? {
-    if _position == _end { return nil }
-
-    let result = _position!.pointee
-    _position! += 1
-    return result
-  }
-
-  @_versioned
-  internal var _position, _end: UnsafePointer<Element>?
-
-  @_inlineable
-  public init(_position: UnsafePointer<Element>?, _end: UnsafePointer<Element>?) {
-      self._position = _position
-      self._end = _end
-  }
-}
 
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
@@ -57,24 +29,89 @@ public struct UnsafeBufferPointerIterator<Element>
 /// instances stored in the underlying memory. However, initializing another
 /// collection with an `${Self}` instance copies the instances out of the
 /// referenced memory and into the new collection.
+// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
+// to avoid a hang in Foundation, which has the following setup:
+// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 @_fixed_layout
-public struct Unsafe${Mutable}BufferPointer<Element>
-  : ${Mutable}Collection, RandomAccessCollection {
-  // FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
-  // to avoid a hang in Foundation, which has the following setup:
-  // struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
+public struct Unsafe${Mutable}BufferPointer<Element> {
+  @_versioned
+  let _position, _end: Unsafe${Mutable}Pointer<Element>?
+}
 
+%if not mutable:
+extension UnsafeBufferPointer {
+  /// An iterator for the elements in the buffer referenced by an
+  /// `UnsafeBufferPointer` or `UnsafeMutableBufferPointer` instance.
+  @_fixed_layout
+  public struct Iterator {
+    @_versioned
+    internal var _position, _end: UnsafePointer<Element>?
+
+    @_inlineable
+    public init(_position: UnsafePointer<Element>?, _end: UnsafePointer<Element>?) {
+        self._position = _position
+        self._end = _end
+    }
+  }
+}
+
+extension UnsafeBufferPointer.Iterator: IteratorProtocol {
+  /// Advances to the next element and returns it, or `nil` if no next element
+  /// exists.
+  ///
+  /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @_inlineable
+  public mutating func next() -> Element? {
+    if _position == _end { return nil }
+
+    let result = _position!.pointee
+    _position! += 1
+    return result
+  }
+}
+%else:
+extension UnsafeMutableBufferPointer {
+  public typealias Iterator = UnsafeBufferPointer<Element>.Iterator
+}
+%end
+
+extension Unsafe${Mutable}BufferPointer: Sequence {
+  /// Returns an iterator over the elements of this buffer.
+  ///
+  /// - Returns: An iterator over the elements of this buffer.
+  @_inlineable
+  public func makeIterator() -> Iterator {
+    return Iterator(_position: _position, _end: _end)
+  }
+
+  /// Initializes the memory at `destination.baseAddress` with elements of `self`,
+  /// stopping when either `self` or `destination` is exhausted.
+  ///
+  /// - Returns: an iterator over any remaining elements of `self` and the
+  ///   number of elements initialized.
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _copyContents(
+    initializing destination: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
+    guard !isEmpty && !destination.isEmpty else { return (makeIterator(), 0) }
+    let s = self.baseAddress._unsafelyUnwrappedUnchecked
+    let d = destination.baseAddress._unsafelyUnwrappedUnchecked
+    let n = Swift.min(destination.count, self.count)
+    d.initialize(from: s, count: n)
+    return (Iterator(_position: s + n, _end: _end), n)
+  }
+}
+
+extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessCollection {
   public typealias Index = Int
-  public typealias Iterator = UnsafeBufferPointerIterator<Element>
+  public typealias Indices = CountableRange<Int>
 
   /// The index of the first element in a nonempty buffer.
   ///
   /// The `startIndex` property of an `Unsafe${Mutable}BufferPointer` instance
   /// is always zero.
   @_inlineable
-  public var startIndex: Int {
-    return 0
-  }
+  public var startIndex: Int { return 0 }
 
   /// The "past the end" position---that is, the position one greater than the
   /// last valid subscript argument.
@@ -82,9 +119,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   /// The `endIndex` property of an `Unsafe${Mutable}BufferPointer` instance is
   /// always identical to `count`.
   @_inlineable
-  public var endIndex: Int {
-    return count
-  }
+  public var endIndex: Int { return count }
 
   @_inlineable
   public func index(after i: Int) -> Int {
@@ -137,9 +172,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   }
 
   @_inlineable
-  public func index(
-    _ i: Int, offsetBy n: Int, limitedBy limit: Int
-  ) -> Int? {
+  public func index(_ i: Int, offsetBy n: Int, limitedBy limit: Int) -> Int? {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
@@ -172,28 +205,22 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     // NOTE: This method is a no-op for performance reasons.
   }
 
-  public typealias Indices = CountableRange<Int>
-
   @_inlineable
   public var indices: Indices {
     return startIndex..<endIndex
   }
 
-  /// Initializes the memory at `destination.baseAddress` with elements of `self`,
-  /// stopping when either `self` or `destination` is exhausted.
+  /// The number of elements in the buffer.
   ///
-  /// - Returns: an iterator over any remaining elements of `self` and the
-  ///   number of elements initialized.
-  @_inlineable // FIXME(sil-serialize-all)
-  public func _copyContents(
-    initializing destination: UnsafeMutableBufferPointer<Element>
-  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
-    guard !isEmpty && !destination.isEmpty else { return (makeIterator(), 0) }
-    let s = self.baseAddress._unsafelyUnwrappedUnchecked
-    let d = destination.baseAddress._unsafelyUnwrappedUnchecked
-    let n = Swift.min(destination.count, self.count)
-    d.initialize(from: s, count: n)
-    return (Iterator(_position: s + n, _end: _end), n)
+  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
+  /// a buffer can have a `count` of zero even with a non-`nil` base address.
+  @_inlineable
+  public var count: Int {
+    guard let start = _position, let end = _end else {
+      return 0
+    }
+    
+    return end - start
   }
 
   /// Accesses the element at the specified position.
@@ -267,7 +294,9 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     }
 %  end
   }
+}
 
+extension Unsafe${Mutable}BufferPointer {
   /// Creates a new buffer pointer over the specified number of contiguous
   /// instances beginning at the given pointer.
   ///
@@ -378,22 +407,12 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///
   /// - Parameter slice: The buffer slice to rebase.
   @_inlineable
-  public init(
-    rebasing slice:
-    Slice<UnsafeMutableBufferPointer<Element>>
-  ) {
-    self.init(start: slice.base.baseAddress! + slice.startIndex,
+  public init(rebasing slice: Slice<UnsafeMutableBufferPointer<Element>>) {
+    self.init(
+      start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)
   }
 
-  /// Returns an iterator over the elements of this buffer.
-  ///
-  /// - Returns: An iterator over the elements of this buffer.
-  @_inlineable
-  public func makeIterator() -> UnsafeBufferPointerIterator<Element> {
-    return UnsafeBufferPointerIterator(_position: _position, _end: _end)
-  }
-  
   /// Deallocates the memory block previously allocated at this buffer pointer’s 
   /// base address. 
   ///
@@ -539,22 +558,6 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   public var baseAddress: Unsafe${Mutable}Pointer<Element>? {
     return _position
   }
-
-  /// The number of elements in the buffer.
-  ///
-  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
-  /// a buffer can have a `count` of zero even with a non-`nil` base address.
-  @_inlineable
-  public var count: Int {
-    guard let start = _position, let end = _end else {
-      return 0
-    }
-    
-    return end - start
-  }
-
-  @_versioned
-  let _position, _end: Unsafe${Mutable}Pointer<Element>?
 }
 
 extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
@@ -595,6 +598,9 @@ extension UnsafeMutableBufferPointer {
     return source._copyContents(initializing: self)
   }
 }
+
+@available(*, deprecated, renamed: "UnsafeBufferPointer.Iterator")
+public typealias UnsafeBufferPointerIterator<T> = UnsafeBufferPointer<T>.Iterator
 
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -98,28 +98,11 @@ public struct Unsafe${Mutable}RawBufferPointer {
   internal let _position, _end: Unsafe${Mutable}RawPointer?
 }
 
-extension Unsafe${Mutable}RawBufferPointer: Sequence {
-  public typealias SubSequence = Slice<${Self}>
-
+%if not mutable:
+extension UnsafeRawBufferPointer {
   /// An iterator over the bytes viewed by a raw buffer pointer.
   @_fixed_layout
-  public struct Iterator : IteratorProtocol, Sequence {
-    /// Advances to the next byte and returns it, or `nil` if no next byte
-    /// exists.
-    ///
-    /// Once `nil` has been returned, all subsequent calls return `nil`.
-    ///
-    /// - Returns: The next sequential byte in the raw buffer if another byte
-    ///   exists; otherwise, `nil`.
-    @_inlineable
-    public mutating func next() -> UInt8? {
-      if _position == _end { return nil }
-
-      let result = _position!.load(as: UInt8.self)
-      _position! += 1
-      return result
-    }
-
+  public struct Iterator {
     @_versioned
     internal var _position, _end: UnsafeRawPointer?
 
@@ -130,6 +113,33 @@ extension Unsafe${Mutable}RawBufferPointer: Sequence {
       self._end = _end
     }
   }
+}
+
+extension UnsafeRawBufferPointer.Iterator: IteratorProtocol, Sequence {
+  /// Advances to the next byte and returns it, or `nil` if no next byte
+  /// exists.
+  ///
+  /// Once `nil` has been returned, all subsequent calls return `nil`.
+  ///
+  /// - Returns: The next sequential byte in the raw buffer if another byte
+  ///   exists; otherwise, `nil`.
+  @_inlineable
+  public mutating func next() -> UInt8? {
+    if _position == _end { return nil }
+
+    let result = _position!.load(as: UInt8.self)
+    _position! += 1
+    return result
+  }
+}
+%else:
+extension UnsafeMutableRawBufferPointer {
+  public typealias Iterator = UnsafeRawBufferPointer.Iterator
+}
+%end
+
+extension Unsafe${Mutable}RawBufferPointer: Sequence {
+  public typealias SubSequence = Slice<${Self}>
 
   /// Returns an iterator over the bytes of this sequence.
   @_inlineable
@@ -666,8 +676,8 @@ extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
 
 extension ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
-  @available(*, unavailable, message:
-    "use 'Unsafe${Mutable}RawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
+  @available(*, unavailable, 
+    message: "use 'Unsafe${Mutable}RawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
   public subscript(bounds: Range<Int>) -> ${Self} {
     get { return ${Self}(start: nil, count: 0) }
 %  if mutable:
@@ -676,8 +686,8 @@ extension ${Self} {
   }
 
 %  if mutable:
-  @available(*, unavailable, message:
-    "use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
+  @available(*, unavailable, 
+    message: "use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
   public subscript(bounds: Range<Int>) -> UnsafeRawBufferPointer {
     get { return UnsafeRawBufferPointer(start: nil, count: 0) }
     nonmutating set {}
@@ -740,3 +750,9 @@ public func withUnsafeBytes<T, Result>(
     try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
 }
+
+// @available(*, deprecated, renamed: "UnsafeRawBufferPointer.Iterator")
+public typealias UnsafeRawBufferPointerIterator<T> = UnsafeBufferPointer<T>.Iterator
+
+// @available(*, deprecated, renamed: "UnsafeRawBufferPointer.Iterator")
+public typealias UnsafeMutableRawBufferPointerIterator<T> = UnsafeBufferPointer<T>.Iterator

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -48,54 +48,6 @@ public func zip<Sequence1, Sequence2>(
   return Zip2Sequence(_sequence1: sequence1, _sequence2: sequence2)
 }
 
-/// An iterator for `Zip2Sequence`.
-@_fixed_layout // FIXME(sil-serialize-all)
-public struct Zip2Iterator<Iterator1: IteratorProtocol, Iterator2: IteratorProtocol> {
-  /// The type of element returned by `next()`.
-  public typealias Element = (Iterator1.Element, Iterator2.Element)
-
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _baseStream1: Iterator1
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _baseStream2: Iterator2
-  @_versioned // FIXME(sil-serialize-all)
-  internal var _reachedEnd: Bool = false
-
-  /// Creates an instance around a pair of underlying iterators.
-  @_inlineable // FIXME(sil-serialize-all)
-  @_versioned // FIXME(sil-serialize-all)
-  internal init(_ iterator1: Iterator1, _ iterator2: Iterator2) {
-    (_baseStream1, _baseStream2) = (iterator1, iterator2)
-  }
-}
-
-extension Zip2Iterator: IteratorProtocol {
-  /// Advances to the next element and returns it, or `nil` if no next element
-  /// exists.
-  ///
-  /// Once `nil` has been returned, all subsequent calls return `nil`.
-  @_inlineable // FIXME(sil-serialize-all)
-  public mutating func next() -> Element? {
-    // The next() function needs to track if it has reached the end.  If we
-    // didn't, and the first sequence is longer than the second, then when we
-    // have already exhausted the second sequence, on every subsequent call to
-    // next() we would consume and discard one additional element from the
-    // first sequence, even though next() had already returned nil.
-
-    if _reachedEnd {
-      return nil
-    }
-
-    guard let element1 = _baseStream1.next(),
-          let element2 = _baseStream2.next() else {
-      _reachedEnd = true
-      return nil
-    }
-
-    return (element1, element2)
-  }
-}
-
 /// A sequence of pairs built out of two underlying sequences.
 ///
 /// In a `Zip2Sequence` instance, the elements of the *i*th pair are the *i*th
@@ -136,10 +88,61 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
   }
 }
 
+extension Zip2Sequence {
+  /// An iterator for `Zip2Sequence`.
+  @_fixed_layout // FIXME(sil-serialize-all)
+  public struct Iterator {
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _baseStream1: Sequence1.Iterator
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _baseStream2: Sequence2.Iterator
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _reachedEnd: Bool = false
+
+    /// Creates an instance around a pair of underlying iterators.
+    @_inlineable // FIXME(sil-serialize-all)
+    @_versioned // FIXME(sil-serialize-all)
+    internal init(
+    _ iterator1: Sequence1.Iterator, 
+    _ iterator2: Sequence2.Iterator
+    ) {
+      (_baseStream1, _baseStream2) = (iterator1, iterator2)
+    }
+  }
+}
+
+extension Zip2Sequence.Iterator: IteratorProtocol {
+  /// The type of element returned by `next()`.
+  public typealias Element = (Sequence1.Element, Sequence2.Element)
+
+  /// Advances to the next element and returns it, or `nil` if no next element
+  /// exists.
+  ///
+  /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @_inlineable // FIXME(sil-serialize-all)
+  public mutating func next() -> Element? {
+    // The next() function needs to track if it has reached the end.  If we
+    // didn't, and the first sequence is longer than the second, then when we
+    // have already exhausted the second sequence, on every subsequent call to
+    // next() we would consume and discard one additional element from the
+    // first sequence, even though next() had already returned nil.
+
+    if _reachedEnd {
+      return nil
+    }
+
+    guard let element1 = _baseStream1.next(),
+          let element2 = _baseStream2.next() else {
+      _reachedEnd = true
+      return nil
+    }
+
+    return (element1, element2)
+  }
+}
+
 extension Zip2Sequence: Sequence {
-  /// A type whose instances can produce the elements of this
-  /// sequence, in order.
-  public typealias Iterator = Zip2Iterator<Sequence1.Iterator, Sequence2.Iterator>
+  public typealias Element = (Sequence1.Element, Sequence2.Element)
 
   /// Returns an iterator over the elements of this sequence.
   @_inlineable // FIXME(sil-serialize-all)
@@ -149,3 +152,6 @@ extension Zip2Sequence: Sequence {
       _sequence2.makeIterator())
   }
 }
+
+// @available(*, deprecated, renamed: "Zip2Sequence.Iterator")
+public typealias Zip2Iterator<T, U> = Zip2Sequence<T, U>.Iterator where T: Sequence, U: Sequence

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -15,7 +15,7 @@ public class BridgedClassSub : BridgedClass { }
 
 // Attempt to bridge to a type from another module. We only allow this for a
 // few specific types, like String.
-extension LazyFilterIterator : _ObjectiveCBridgeable { // expected-error{{conformance of 'LazyFilterIterator' to '_ObjectiveCBridgeable' can only be written in module 'Swift'}}
+extension LazyFilterSequence.Iterator : _ObjectiveCBridgeable { // expected-error{{conformance of 'Iterator' to '_ObjectiveCBridgeable' can only be written in module 'Swift'}}
   public typealias _ObjectiveCType = BridgedClassSub
 
   public func _bridgeToObjectiveC() -> _ObjectiveCType {
@@ -24,19 +24,19 @@ extension LazyFilterIterator : _ObjectiveCBridgeable { // expected-error{{confor
 
   public static func _forceBridgeFromObjectiveC(
     _ source: _ObjectiveCType,
-    result: inout LazyFilterIterator?
+    result: inout LazyFilterSequence.Iterator?
   ) { }
 
   public static func _conditionallyBridgeFromObjectiveC(
     _ source: _ObjectiveCType,
-    result: inout LazyFilterIterator?
+    result: inout LazyFilterSequence.Iterator?
   ) -> Bool {
     return true
   }
 
   public static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
-      -> LazyFilterIterator {
-    let result: LazyFilterIterator?
+      -> LazyFilterSequence.Iterator {
+    let result: LazyFilterSequence.Iterator?
     return result!
   }
 }

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -425,7 +425,7 @@ struct Sentinel2 {}
 // CHECK-DAG: - !private ["4main26OtherFileSecretTypeWrapperV0dE0V", "constant"]
 // CHECK-DAG: - !private ["4main25OtherFileProtoImplementorV", "deinit"]
 // CHECK-DAG: - !private ["4main26OtherFileProtoImplementor2V", "deinit"]
-// CHECK-DAG: - !private ["s13EmptyIteratorV", "init"]
+// CHECK-DAG: - !private ["s15EmptyCollectionV8IteratorV", "init"]
 // CHECK-DAG: - ["4main13OtherFileEnumO", "Value"]
 // CHECK-DAG: - !private ["4main20OtherFileEnumWrapperV", "Enum"]
 
@@ -451,7 +451,6 @@ struct Sentinel2 {}
 // CHECK: - "Sb"
 // CHECK: - "4main18ClassFromOtherFileC"
 // CHECK: - "s10ComparableP"
-// CHECK: - !private "s13EmptyIteratorV"
 // CHECK: - "s25ExpressibleByFloatLiteralP"
 // CHECK: - !private "s33ExpressibleByUnicodeScalarLiteralP"
 // CHECK: - !private "4main18OtherFileOuterTypeV05InnerE0V"

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -153,8 +153,7 @@ extension Unicode.DefaultScalarView : BidirectionalCollection {
   public func index(before i: Index) -> Index {
     var parser = Encoding.ReverseParser()
     
-    var more = _ReverseIndexingIterator(
-      _elements: codeUnits, _position: i.codeUnitIndex)
+    var more = codeUnits[..<i.codeUnitIndex].reversed().makeIterator()
     
     switch parser.parseScalar(from: &more) {
     case .valid(let scalarContent):

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -72,9 +72,9 @@ tests.test("AnyIterator") {
 
     // This is a really complicated type of no interest to our
     // clients.
-    let iterator: LazyMapIterator<
-        IndexingIterator<CountableRange<Int>>, OpaqueValue<Int>
-      > = lazyStrings.makeIterator()
+    let iterator: LazyMapSequence<
+      CountableRange<Int>, OpaqueValue<Int>
+    >.Iterator = lazyStrings.makeIterator()
     return AnyIterator(iterator)
   }
   expectEqual([0, 1, 2, 3, 4], Array(digits()).map { $0.value })
@@ -258,7 +258,7 @@ tests.test("${TestedType}: dispatch to wrapped, CollectionLog") {
 %   end
 
   do {
-    var startIndex = c.startIndex
+    let startIndex = c.startIndex
     var badBounds = c.index(c.startIndex, offsetBy: 3)..<c.endIndex
 
     Log.subscriptIndex.expectIncrement(Base.self) {

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -437,7 +437,7 @@ LazyTestSuite.test("LazySequence<${TraversalCollection}>/underestimatedCount") {
     underestimatedCount: .value(42))
   var lazySeq = s.lazy
   expectType(
-    Lazy${TraversalCollection}<
+    LazyCollection<
       Minimal${TraversalCollection}<OpaqueValue<Int>>
     >.self,
     &lazySeq)
@@ -555,7 +555,7 @@ LazyTestSuite.test("Lazy${TraversalCollection}.reversed") {
     underestimatedCount: .value(42))
   var reversed = base.lazy.reversed()
   expectType(
-    Lazy${TraversalCollection}<
+    LazyCollection<
       ${ReversedType}<Minimal${TraversalCollection}<OpaqueValue<Int>>>
     >.self, &reversed)
 
@@ -564,7 +564,7 @@ LazyTestSuite.test("Lazy${TraversalCollection}.reversed") {
 
   var reversedTwice = reversed.reversed()
   expectType(
-    Lazy${TraversalCollection}<
+    LazyCollection<
       ${ReversedType}<${ReversedType}<
         Minimal${TraversalCollection}<OpaqueValue<Int>>
       >>>.self, &reversedTwice)
@@ -594,7 +594,7 @@ extension ReversedCollection where Base : TestProtocol1 {
 //===----------------------------------------------------------------------===//
 
 // Check that the generic parameter is called 'Base'.
-extension ReversedIndex where Base : TestProtocol1 {
+extension ReversedCollection.Index where Base : TestProtocol1 {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
@@ -617,7 +617,7 @@ extension ReversedCollection
 //===----------------------------------------------------------------------===//
 
 // Check that the generic parameter is called 'Base'.
-extension ReversedIndex
+extension ReversedCollection.Index
     where Base : TestProtocol1, Base : RandomAccessCollection {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")
@@ -699,13 +699,13 @@ tests.test("Lazy${TraversalCollection}/Collection") {
   let base = Minimal${TraversalCollection}(elements: expected)
   var actual = base.lazy
 
-  expectType(Lazy${TraversalCollection}<
+  expectType(LazyCollection<
     Minimal${TraversalCollection}<OpaqueValue<Int>>
   >.self, &actual)
 
   // Asking for .lazy again doesn't re-wrap the type
   var again = actual.lazy
-  expectType(Lazy${TraversalCollection}<
+  expectType(LazyCollection<
     Minimal${TraversalCollection}<OpaqueValue<Int>>
   >.self, &again)
 
@@ -863,7 +863,7 @@ tests.test("LazyMapSequence/AssociatedTypes") {
   typealias Subject = LazyMapSequence<Base, OpaqueValue<Int32>>
   expectSequenceAssociatedTypes(
     sequenceType: Subject.self,
-    iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
+    iteratorType: LazyMapSequence<Base, OpaqueValue<Int32>>.Iterator.self,
     subSequenceType: AnySequence<OpaqueValue<Int32>>.self)
 }
 
@@ -872,7 +872,7 @@ tests.test("LazyMapCollection/AssociatedTypes") {
   typealias Subject = LazyMapCollection<Base, OpaqueValue<Int32>>
   expectCollectionAssociatedTypes(
     collectionType: Subject.self,
-    iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
+    iteratorType: LazyMapCollection<Base, OpaqueValue<Int32>>.Iterator.self,
     subSequenceType: LazyMapCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
     indicesType: Base.Indices.self)
@@ -883,7 +883,7 @@ tests.test("LazyMapBidirectionalCollection/AssociatedTypes") {
   typealias Subject = LazyMapCollection<Base, OpaqueValue<Int32>>
   expectBidirectionalCollectionAssociatedTypes(
     collectionType: Subject.self,
-    iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
+    iteratorType: LazyMapCollection<Base, OpaqueValue<Int32>>.Iterator.self,
     subSequenceType: LazyMapCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
     indicesType: Base.Indices.self)
@@ -894,7 +894,7 @@ tests.test("LazyMapRandomAccessCollection/AssociatedTypes") {
   typealias Subject = LazyMapCollection<Base, OpaqueValue<Int32>>
   expectRandomAccessCollectionAssociatedTypes(
     collectionType: Subject.self,
-    iteratorType: LazyMapIterator<Base.Iterator, OpaqueValue<Int32>>.self,
+    iteratorType: LazyMapCollection<Base, OpaqueValue<Int32>>.Iterator.self,
     subSequenceType: LazyMapCollection<Base.SubSequence, OpaqueValue<Int32>>.self,
     indexType: Base.Index.self,
     indicesType: Base.Indices.self)
@@ -1022,7 +1022,7 @@ tests.test("ReversedCollection/Lazy") {
 // the first selects even numbers and the second selects odd numbers,
 // both from an underlying sequence of whole numbers.
 func checkFilterIteratorBase<  S : Sequence, I>(_ s1: S, _ s2: S)
-where S.Iterator == LazyFilterIterator<I>, I.Element == OpaqueValue<Int> {
+where S.Iterator == LazyFilterSequence<I>.Iterator, I.Element == OpaqueValue<Int> {
   var iter1 = s1.makeIterator()
   expectEqual(0, iter1.next()!.value)
   expectEqual(2, iter1.next()!.value)
@@ -1143,7 +1143,7 @@ tests.test("LazyFilterSequence/AssociatedTypes") {
   typealias Subject = LazyFilterSequence<Base>
   expectSequenceAssociatedTypes(
     sequenceType: Subject.self,
-    iteratorType: LazyFilterIterator<Base.Iterator>.self,
+    iteratorType: LazyFilterSequence<Base>.Iterator.self,
     subSequenceType: AnySequence<OpaqueValue<Int>>.self)
 }
 
@@ -1152,7 +1152,7 @@ tests.test("LazyFilterCollection/AssociatedTypes") {
   typealias Subject = LazyFilterCollection<Base>
   expectCollectionAssociatedTypes(
     collectionType: Subject.self,
-    iteratorType: LazyFilterIterator<Base.Iterator>.self,
+    iteratorType: LazyFilterCollection<Base>.Iterator.self,
     subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
     indexType: Base.Index.self,
     indicesType: DefaultIndices<Subject>.self)
@@ -1163,10 +1163,10 @@ tests.test("LazyFilterBidirectionalCollection/AssociatedTypes") {
   typealias Subject = LazyFilterCollection<Base>
   expectBidirectionalCollectionAssociatedTypes(
     collectionType: Subject.self,
-    iteratorType: LazyFilterIterator<Base.Iterator>.self,
+    iteratorType: LazyFilterCollection<Base>.Iterator.self,
     subSequenceType: LazyFilterCollection<Base.SubSequence>.self,
     indexType: Base.Index.self,
-    indicesType: DefaultBidirectionalIndices<Subject>.self)
+    indicesType: DefaultIndices<Subject>.self)
 }
 
 tests.test("lazy.filter/TypeInference") {
@@ -1360,7 +1360,7 @@ tests.test("LazyPrefixWhileBidirectionalCollection/AssociatedTypes") {
     // FIXME(ABI)#82 (Associated Types with where clauses): SubSequence should be `LazyFilterBidirectionalCollection<Base.Slice>`.
     subSequenceType: Slice<Subject>.self,
     indexType: LazyPrefixWhileIndex<Base>.self,
-    indicesType: DefaultBidirectionalIndices<Subject>.self)
+    indicesType: DefaultIndices<Subject>.self)
 }
 
 //===--- LazyDropWhile ----------------------------------------------------===//
@@ -1418,7 +1418,7 @@ tests.test("LazyDropWhileBidirectionalCollection/AssociatedTypes") {
     // FIXME(ABI)#83 (Associated Types with where clauses): SubSequence should be `LazyFilterBidirectionalCollection<Base.Slice>`.
     subSequenceType: Slice<Subject>.self,
     indexType: LazyDropWhileIndex<Base>.self,
-    indicesType: DefaultBidirectionalIndices<Subject>.self)
+    indicesType: DefaultIndices<Subject>.self)
 }
 
 runAllTests()

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -1022,8 +1022,8 @@ SequenceTypeTests.test("Sequence/split/dispatch") {
 //===----------------------------------------------------------------------===//
 
 // Check generic parameter names.
-extension Zip2Iterator
-  where Iterator1 : TestProtocol1, Iterator2 : TestProtocol1 {
+extension Zip2Sequence.Iterator
+  where Sequence1 : TestProtocol1, Sequence2 : TestProtocol1 {
 
   var _generator1IsTestProtocol1: Bool {
     fatalError("not implemented")


### PR DESCRIPTION
Nests various custom iterators and indexes for stdlib types inside their used types. This has been possible for a while now that we have nested generics, and cleans up the namespace.

Should be a non-functional-change for now with type aliases for the old names which aren't yet deprecated (deprecation/removal of type aliases is not ABI impacting so can be done at any time).

Ignoring `Range` and `String` types for now since they're in flux.