### PR TITLE
[Parse] Refactor Lexer's skipToEndOfline

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -491,7 +491,7 @@ private:
   void skipToEndOfLine(bool EatNewline);
 
   /// Skip to the end of the line of a // comment.
-  void skipSlashSlashComment();
+  void skipSlashSlashComment(bool EatNewline);
 
   /// Skip a #! hashbang line.
   void skipHashbang();

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -485,12 +485,10 @@ private:
 
   void formToken(tok Kind, const char *TokStart, bool MultilineString = false);
 
-  /// Advance to the end of the line but leave the current buffer pointer
-  /// at that newline character.
-  void skipUpToEndOfLine();
-
-  /// Advance past the next newline character.
-  void skipToEndOfLine();
+  /// Advance to the end of the line.
+  /// If EatNewLine is true, CurPtr will be at end of newline character.
+  /// Otherwise, CurPtr will be at newline character.
+  void skipToEndOfLine(bool EatNewline);
 
   /// Skip to the end of the line of a // comment.
   void skipSlashSlashComment();

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -494,7 +494,7 @@ private:
   void skipSlashSlashComment(bool EatNewline);
 
   /// Skip a #! hashbang line.
-  void skipHashbang();
+  void skipHashbang(bool EatNewline);
 
   void skipSlashStarComment();
   void lexHash();

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -350,9 +350,9 @@ void Lexer::skipToEndOfLine(bool EatNewline) {
   }
 }
 
-void Lexer::skipSlashSlashComment() {
+void Lexer::skipSlashSlashComment(bool EatNewline) {
   assert(CurPtr[-1] == '/' && CurPtr[0] == '/' && "Not a // comment");
-  skipToEndOfLine(/*EatNewline=*/true);
+  skipToEndOfLine(EatNewline);
 }
 
 void Lexer::skipHashbang() {
@@ -2183,7 +2183,7 @@ Restart:
       // Operator characters.
   case '/':
     if (CurPtr[0] == '/') {  // "//"
-      skipSlashSlashComment();
+      skipSlashSlashComment(/*EatNewline=*/true);
       SeenComment = true;
       if (isKeepingComments())
         return formToken(tok::comment, TokStart);
@@ -2346,11 +2346,7 @@ Restart:
       // '// ...' comment.
       SeenComment = true;
       bool isDocComment = CurPtr[1] == '/';
-      
-      // NOTE: Don't use skipSlashSlashComment() here
-      // because it consumes trailing newline.
-      skipToEndOfLine(/*EatNewline=*/false);
-      
+      skipSlashSlashComment(/*EatNewline=*/false);
       size_t Length = CurPtr - TriviaStart;
       Pieces.push_back(isDocComment
                            ? TriviaPiece::docLineComment({TriviaStart, Length})


### PR DESCRIPTION
`Lexer` has two similar methods which are `skipToEndOfLine` and `skipUpToEndOfLine`.

This PR unify them. 

The only difference in them are that 
it will stop at which before or after of newline found,
so add `EatNewline` parameter to function to control this.

And because of this behavior about newline,
`lexTrivia` does not reuse `skipSlashSlashComment` and `skipHashbang`.
So add `EatNewline` to them, use in common from `lexTrivia`

This PR includes my other PR #13483 