### PR TITLE
Sema: Fix keypaths vs. lazy member validation

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -920,12 +920,7 @@ namespace {
           memberLocator, substitutions);
       auto memberRef = ConcreteDeclRef(context, member, substitutions);
 
-      // Class members might be virtually dispatched, so we need to know
-      // the full layout of the class.
-      if (auto *classDecl = dyn_cast<ClassDecl>(member->getDeclContext()))
-        tc.requestNominalLayout(classDecl);
-      if (auto *protocolDecl = dyn_cast<ProtocolDecl>(member->getDeclContext()))
-        tc.requestNominalLayout(protocolDecl);
+      cs.TC.requestMemberLayout(member);
 
       auto refTy = solution.simplifyType(openedFullType);
 
@@ -4125,8 +4120,11 @@ namespace {
             resolvedComponents.push_back(
                  KeyPathExpr::Component::forOptionalForce(baseTy, SourceLoc()));
           }
-          
+
+          cs.TC.requestMemberLayout(property);
+
           auto dc = property->getInnermostDeclContext();
+
           SmallVector<Substitution, 4> subs;
           if (auto sig = dc->getGenericSignatureOfContext()) {
             // Compute substitutions to refer to the member.
@@ -4170,7 +4168,9 @@ namespace {
             resolvedComponents.push_back(
                  KeyPathExpr::Component::forOptionalForce(baseTy, SourceLoc()));
           }
-          
+
+          cs.TC.requestMemberLayout(subscript);
+
           auto dc = subscript->getInnermostDeclContext();
           SmallVector<Substitution, 4> subs;
           SubstitutionMap subMap;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7918,6 +7918,14 @@ static bool shouldValidateMemberDuringFinalization(NominalTypeDecl *nominal,
   return false;
 }
 
+void TypeChecker::requestMemberLayout(ValueDecl *member) {
+  auto *dc = member->getDeclContext();
+  if (auto *classDecl = dyn_cast<ClassDecl>(dc))
+    requestNominalLayout(classDecl);
+  if (auto *protocolDecl = dyn_cast<ProtocolDecl>(dc))
+    requestNominalLayout(protocolDecl);
+}
+
 void TypeChecker::requestNominalLayout(NominalTypeDecl *nominalDecl) {
   if (nominalDecl->hasValidatedLayout())
     return;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1073,6 +1073,11 @@ public:
   /// properly extends the nominal type it names.
   void validateExtension(ExtensionDecl *ext);
 
+  /// Request that type containing the given member needs to have all
+  /// members validated after everythign in the translation unit has
+  /// been processed.
+  void requestMemberLayout(ValueDecl *member);
+
   /// Request that the given class needs to have all members validated
   /// after everything in the translation unit has been processed.
   void requestNominalLayout(NominalTypeDecl *nominalDecl);

--- a/test/multifile/Inputs/keypath.swift
+++ b/test/multifile/Inputs/keypath.swift
@@ -1,0 +1,20 @@
+final class C<T> {
+  var a = 0
+  var b = 0
+
+  subscript(x: Int) -> Int { return x }
+}
+
+class D<T> {
+  var a = 0
+  var b = 0
+
+  subscript(x: Int) -> Int { return x }
+}
+
+protocol P {
+  var a: Int { get set }
+  var b: Int { get set }
+
+  subscript(x: Int) -> Int { get set }
+}

--- a/test/multifile/keypath.swift
+++ b/test/multifile/keypath.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/keypath.swift -primary-file %s
+
+func f<T>(_: T) {
+  _ = \C<T>.b
+  _ = \C<T>[0]
+
+  _ = \D<T>.b
+  _ = \D<T>[0]
+
+  _ = \P.b
+
+  // FIXME: crashes
+  // _ = \P[0]
+}


### PR DESCRIPTION
Constructing a keypath expression that references a class member
needs to validate all other members of the class (or a protocol,
but I couldn't reproduce a crash with that case -- added a test
anyway).

Fixes <rdar://problem/36083061>.