### PR TITLE
[Syntax] Support "conflict marker" and "carriage return" trivia

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -517,7 +517,7 @@ private:
 
   /// Try to lex conflict markers by checking for the presence of the start and
   /// end of the marker in diff3 or Perforce style respectively.
-  bool tryLexConflictMarker();
+  bool tryLexConflictMarker(bool EatNewline);
 };
   
 /// Given an ordered token \param Array , get the iterator pointing to the first

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -68,6 +68,7 @@ struct ObjectTraits<syntax::TriviaPiece> {
       case syntax::TriviaKind::VerticalTab:
       case syntax::TriviaKind::Formfeed:
       case syntax::TriviaKind::Newline:
+      case syntax::TriviaKind::CarriageReturn:
       case syntax::TriviaKind::Backtick:
         out.mapRequired("value", value.Count);
         break;
@@ -93,6 +94,7 @@ struct ScalarEnumerationTraits<syntax::TriviaKind> {
     out.enumCase(value, "VerticalTab", syntax::TriviaKind::VerticalTab);
     out.enumCase(value, "Formfeed", syntax::TriviaKind::Formfeed);
     out.enumCase(value, "Newline", syntax::TriviaKind::Newline);
+    out.enumCase(value, "CarriageReturn", syntax::TriviaKind::CarriageReturn);
     out.enumCase(value, "LineComment", syntax::TriviaKind::LineComment);
     out.enumCase(value, "BlockComment", syntax::TriviaKind::BlockComment);
     out.enumCase(value, "DocLineComment", syntax::TriviaKind::DocLineComment);

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -111,6 +111,9 @@ enum class TriviaKind {
   /// A newline '\n' character.
   Newline,
 
+  /// A newline '\r' character.
+  CarriageReturn,
+
   /// A developer line comment, starting with '//'
   LineComment,
 
@@ -175,10 +178,16 @@ public:
     return {TriviaKind::Formfeed, Count};
   }
 
-  /// Return a piece of trivia for some number of newline characters
+  /// Return a piece of trivia for some number of newline (LF) characters
   /// in a row.
   static TriviaPiece newlines(unsigned Count) {
     return {TriviaKind::Newline, Count};
+  }
+
+  /// Return a piece of trivia for some number of carriage-return (CR)
+  /// characters in a row.
+  static TriviaPiece carriageReturns(unsigned Count) {
+    return {TriviaKind::CarriageReturn, Count};
   }
 
   /// Return a piece of trivia for a single line of ('//') developer comment.
@@ -225,6 +234,7 @@ public:
       case TriviaKind::GarbageText:
         return Text.size();
       case TriviaKind::Newline:
+      case TriviaKind::CarriageReturn:
       case TriviaKind::Space:
       case TriviaKind::Backtick:
       case TriviaKind::Tab:
@@ -385,7 +395,7 @@ struct Trivia {
   }
 
   /// Return a collection of trivia of some number of newline characters
-  // in a row.
+  /// in a row.
   static Trivia newlines(unsigned Count) {
     if (Count == 0) {
       return {};
@@ -393,8 +403,17 @@ struct Trivia {
     return {{TriviaPiece::newlines(Count)}};
   }
 
+  /// Return a collection of trivia of some number of carriage-return characters
+  /// in a row.
+  static Trivia carriageReturns(unsigned Count) {
+    if (Count == 0) {
+      return {};
+    }
+    return {{TriviaPiece::carriageReturns(Count)}};
+  }
+
   /// Return a collection of trivia with a single line of ('//')
-  // developer comment.
+  /// developer comment.
   static Trivia lineComment(const OwnedString Text) {
     assert(Text.str().startswith("//"));
     return {{TriviaPiece::lineComment(Text)}};
@@ -414,7 +433,7 @@ struct Trivia {
   }
 
   /// Return a collection of trivia with a documentation block
-  // comment ('/** ... */')
+  /// comment ('/** ... */')
   static Trivia docBlockComment(const OwnedString Text) {
     assert(Text.str().startswith("/**"));
     assert(Text.str().endswith("*/"));

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -358,7 +358,7 @@ void Lexer::skipSlashSlashComment(bool EatNewline) {
 void Lexer::skipHashbang(bool EatNewline) {
   assert(CurPtr == ContentStart && CurPtr[0] == '#' && CurPtr[1] == '!' &&
          "Not a hashbang");
-  skipToEndOfLine(/*EatNewline=*/EatNewline);
+  skipToEndOfLine(EatNewline);
 }
 
 /// skipSlashStarComment - /**/ comments are skipped (treated as whitespace).
@@ -1813,7 +1813,7 @@ static const char *findConflictEnd(const char *CurPtr, const char *BufferEnd,
   return nullptr;
 }
 
-bool Lexer::tryLexConflictMarker() {
+bool Lexer::tryLexConflictMarker(bool EatNewline) {
   const char *Ptr = CurPtr - 1;
 
   // Only a conflict marker if it starts at the beginning of a line.
@@ -1834,7 +1834,7 @@ bool Lexer::tryLexConflictMarker() {
     
     // Skip ahead to the end of the marker.
     if (CurPtr != BufferEnd)
-      skipToEndOfLine(/*EatNewline=*/true);
+      skipToEndOfLine(EatNewline);
     
     return true;
   }
@@ -2223,12 +2223,12 @@ Restart:
   case '<':
     if (CurPtr[0] == '#')
       return tryLexEditorPlaceholder();
-    else if (CurPtr[0] == '<' && tryLexConflictMarker())
+    else if (CurPtr[0] == '<' && tryLexConflictMarker(/*EatNewline=*/true))
       goto Restart;
     return lexOperatorIdentifier();
 
   case '>':
-    if (CurPtr[0] == '>' && tryLexConflictMarker())
+    if (CurPtr[0] == '>' && tryLexConflictMarker(/*EatNewline=*/true))
       goto Restart;
     return lexOperatorIdentifier();
  
@@ -2371,6 +2371,15 @@ Restart:
       if (BufferID != SourceMgr.getHashbangBufferID())
         diagnose(TriviaStart, diag::lex_hashbang_not_allowed);
       skipHashbang(/*EatNewline=*/false);
+      size_t Length = CurPtr - TriviaStart;
+      Pieces.push_back(TriviaPiece::garbageText({TriviaStart, Length}));
+      goto Restart;
+    }
+    break;
+  case '<':
+  case '>':
+    if (tryLexConflictMarker(/*EatNewline=*/false)) {
+      // Conflict marker.
       size_t Length = CurPtr - TriviaStart;
       Pieces.push_back(TriviaPiece::garbageText({TriviaStart, Length}));
       goto Restart;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2318,10 +2318,11 @@ Restart:
       Pieces.push_back(TriviaPiece::spaces(Length));
       break;
     case '\n':
-    case '\r':
-      // FIXME: Distinguish CR and LF
       // FIXME: CR+LF shoud form one trivia piece
       Pieces.push_back(TriviaPiece::newlines(Length));
+      break;
+    case '\r':
+      Pieces.push_back(TriviaPiece::carriageReturns(Length));
       break;
     case '\t':
       Pieces.push_back(TriviaPiece::tabs(Length));

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2366,7 +2366,7 @@ Restart:
     }
     break;
   case '#':
-    if (TriviaStart == BufferStart && *CurPtr == '!') {
+    if (TriviaStart == ContentStart && *CurPtr == '!') {
       // Hashbang '#!/path/to/swift'.
       --CurPtr;
       if (BufferID != SourceMgr.getHashbangBufferID())

--- a/lib/Syntax/Trivia.cpp
+++ b/lib/Syntax/Trivia.cpp
@@ -55,6 +55,9 @@ void TriviaPiece::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   case TriviaKind::Newline:
     OS << "newline " << Count;
     break;
+  case TriviaKind::CarriageReturn:
+    OS << "carriage_return " << Count;
+    break;
   case TriviaKind::LineComment:
     OS << "line_comment" << Text.str();
     break;
@@ -97,6 +100,7 @@ void TriviaPiece::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
     Pos.addText(Text.str());
     break;
   case TriviaKind::Newline:
+  case TriviaKind::CarriageReturn:
     Pos.addNewlines(Count);
     break;
   case TriviaKind::Space:
@@ -125,6 +129,9 @@ void TriviaPiece::print(llvm::raw_ostream &OS) const {
     break;
   case TriviaKind::Newline:
     printRepeated(OS, '\n', Count);
+    break;
+  case TriviaKind::CarriageReturn:
+    printRepeated(OS, '\r', Count);
     break;
   case TriviaKind::LineComment:
   case TriviaKind::BlockComment:

--- a/unittests/Parse/CMakeLists.txt
+++ b/unittests/Parse/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_unittest(SwiftParseTests
   BuildConfigTests.cpp
   LexerTests.cpp
+  LexerTriviaTests.cpp
   TokenizerTests.cpp
 )
 

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -409,55 +409,6 @@ TEST_F(LexerTest, RestoreStopAtCodeCompletion) {
   ASSERT_EQ(tok::eof, Tok.getKind());
 }
 
-TEST_F(LexerTest, RestoreWithTrivia) {
-  using namespace swift::syntax;
-  StringRef SourceStr = "aaa \n bbb /*C*/ccc";
-
-  LangOptions LangOpts;
-  SourceManager SourceMgr;
-  unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
-
-  Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
-          TriviaRetentionMode::WithTrivia);
-
-  Token Tok;
-  Trivia LeadingTrivia, TrailingTrivia;
-
-  L.lex(Tok, LeadingTrivia, TrailingTrivia);
-  ASSERT_EQ(tok::identifier, Tok.getKind());
-  ASSERT_EQ("aaa", Tok.getText());
-  ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia, Trivia());
-  ASSERT_EQ(TrailingTrivia, (Trivia{{TriviaPiece::spaces(1)}}));
-
-  L.lex(Tok, LeadingTrivia, TrailingTrivia);
-  ASSERT_EQ(tok::identifier, Tok.getKind());
-  ASSERT_EQ("bbb", Tok.getText());
-  ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
-            (Trivia{{TriviaPiece::newlines(1), TriviaPiece::spaces(1)}}));
-  ASSERT_EQ(TrailingTrivia, (Trivia{{TriviaPiece::spaces(1)}}));
-
-  LexerState S = L.getStateForBeginningOfToken(Tok, LeadingTrivia);
-
-  L.lex(Tok, LeadingTrivia, TrailingTrivia);
-  ASSERT_EQ(tok::identifier, Tok.getKind());
-  ASSERT_EQ("ccc", Tok.getText());
-  ASSERT_FALSE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia, (Trivia{{TriviaPiece::blockComment("/*C*/")}}));
-  ASSERT_EQ(TrailingTrivia, Trivia());
-
-  L.restoreState(S);
-  L.lex(Tok, LeadingTrivia, TrailingTrivia);
-  ASSERT_EQ(tok::identifier, Tok.getKind());
-  ASSERT_EQ("bbb", Tok.getText());
-  ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
-            (Trivia{{TriviaPiece::newlines(1), TriviaPiece::spaces(1)}}));
-  ASSERT_EQ(TrailingTrivia, (Trivia{{TriviaPiece::spaces(1)}}));
-}
-
 TEST_F(LexerTest, getLocForStartOfToken) {
   const char *Source = "aaa \n \tbbb \"hello\" \"-\\(val)-\"";
 

--- a/unittests/Parse/LexerTriviaTests.cpp
+++ b/unittests/Parse/LexerTriviaTests.cpp
@@ -1,0 +1,61 @@
+#include "swift/Basic/LangOptions.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Parse/Lexer.h"
+#include "swift/Subsystems.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::syntax;
+using namespace llvm;
+
+class LexerTriviaTest : public ::testing::Test {};
+
+TEST_F(LexerTriviaTest, RestoreWithTrivia) {
+  using namespace swift::syntax;
+  StringRef SourceStr = "aaa \n bbb /*C*/ccc";
+
+  LangOptions LangOpts;
+  SourceManager SourceMgr;
+  unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
+
+  Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
+          CommentRetentionMode::AttachToNextToken,
+          TriviaRetentionMode::WithTrivia);
+
+  Token Tok;
+  Trivia LeadingTrivia, TrailingTrivia;
+
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::identifier, Tok.getKind());
+  ASSERT_EQ("aaa", Tok.getText());
+  ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, Trivia());
+  ASSERT_EQ(TrailingTrivia, (Trivia{{TriviaPiece::spaces(1)}}));
+
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::identifier, Tok.getKind());
+  ASSERT_EQ("bbb", Tok.getText());
+  ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia,
+            (Trivia{{TriviaPiece::newlines(1), TriviaPiece::spaces(1)}}));
+  ASSERT_EQ(TrailingTrivia, (Trivia{{TriviaPiece::spaces(1)}}));
+
+  LexerState S = L.getStateForBeginningOfToken(Tok, LeadingTrivia);
+
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::identifier, Tok.getKind());
+  ASSERT_EQ("ccc", Tok.getText());
+  ASSERT_FALSE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, (Trivia{{TriviaPiece::blockComment("/*C*/")}}));
+  ASSERT_EQ(TrailingTrivia, Trivia());
+
+  L.restoreState(S);
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::identifier, Tok.getKind());
+  ASSERT_EQ("bbb", Tok.getText());
+  ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia,
+            (Trivia{{TriviaPiece::newlines(1), TriviaPiece::spaces(1)}}));
+  ASSERT_EQ(TrailingTrivia, (Trivia{{TriviaPiece::spaces(1)}}));
+}

--- a/unittests/Parse/LexerTriviaTests.cpp
+++ b/unittests/Parse/LexerTriviaTests.cpp
@@ -123,3 +123,39 @@ TEST_F(LexerTriviaTest, TriviaConflictMarker) {
                                     TriviaPiece::garbageText(expectedTrivia),
                                     TriviaPiece::newlines(1)}}));
 }
+
+TEST_F(LexerTriviaTest, TriviaCarriageReturn) {
+  using namespace swift::syntax;
+  StringRef SourceStr = "aaa\r\rbbb\r";
+
+  LangOptions LangOpts;
+  SourceManager SourceMgr;
+  unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
+
+  Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
+          CommentRetentionMode::AttachToNextToken,
+          TriviaRetentionMode::WithTrivia);
+
+  Token Tok;
+  Trivia LeadingTrivia, TrailingTrivia;
+
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::identifier, Tok.getKind());
+  ASSERT_EQ("aaa", Tok.getText());
+  ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, Trivia());
+  ASSERT_EQ(TrailingTrivia, Trivia());
+
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::identifier, Tok.getKind());
+  ASSERT_EQ("bbb", Tok.getText());
+  ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, (Trivia{{TriviaPiece::carriageReturns(2)}}));
+  ASSERT_EQ(TrailingTrivia, Trivia());
+
+  L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  ASSERT_EQ(tok::eof, Tok.getKind());
+  ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, (Trivia{{TriviaPiece::carriageReturns(1)}}));
+  ASSERT_EQ(TrailingTrivia, Trivia());
+}


### PR DESCRIPTION
* To distinguish `\r` from `\n`, added `CarriageReturn` trivia.
* Support lexing VCS conflict markers as `GarbargeText` trivia.