### PR TITLE
[Doc] libSyntax: mark AttributedType as done.

### DIFF
--- a/lib/Syntax/Status.md
+++ b/lib/Syntax/Status.md
@@ -132,6 +132,4 @@
   * CompositionType
   * TupleType
   * FunctionType
-
-### In-progress:
   * AttributedType


### PR DESCRIPTION
cc @rintaro 