### PR TITLE
[4.1] [ClangImporter] Handle subscript getters redeclared in subclasses

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6348,8 +6348,6 @@ SwiftDeclConverter::importSubscript(Decl *decl,
              ->getAsNominalTypeOrNominalTypeExtensionContext() ==
          setter->getDeclContext()
              ->getAsNominalTypeOrNominalTypeExtensionContext());
-    // TODO: Possible that getter and setter are different instantiations
-    // of the same objc generic type?
 
     // Whether we can update the types involved in the subscript
     // operation.
@@ -6404,8 +6402,16 @@ SwiftDeclConverter::importSubscript(Decl *decl,
     }
   }
 
-  // The context into which the subscript should go.
-  bool associateWithSetter = setter && !getterAndSetterInSameType;
+  // The context into which the subscript should go. We prefer wherever the
+  // getter is declared unless the two accessors are in different types and the
+  // one we started with is the setter. This happens when:
+  // - A read-only subscript is made read/write is a subclass.
+  // - A setter is redeclared in a subclass, but not the getter.
+  // And not when:
+  // - A getter is redeclared in a subclass, but not the setter.
+  // - The getter and setter are part of the same type.
+  // - There is no setter.
+  bool associateWithSetter = !getterAndSetterInSameType && setter == decl;
   DeclContext *dc =
       associateWithSetter ? setter->getDeclContext() : getter->getDeclContext();
 

--- a/test/ClangImporter/Inputs/custom-modules/ObjCSubscripts.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCSubscripts.h
@@ -29,3 +29,34 @@
 - (NSString *)objectForKeyedSubscript:(NSString *)subscript;
 - (void)setObject:(NSString *)object forKeyedSubscript:(NSString *)key;
 @end
+
+
+// rdar://problem/36033356 failed specifically when the base class was never
+// subscripted, so please don't mention this class in the .swift file.
+@interface KeySubscriptBase
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end
+
+@interface KeySubscriptOverrideGetter : KeySubscriptBase
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+@end
+
+@interface KeySubscriptOverrideSetter : KeySubscriptBase
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end
+
+// rdar://problem/36033356 failed specifically when the base class was never
+// subscripted, so please don't mention this class in the .swift file.
+@interface KeySubscriptReversedBase
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+@end
+
+@interface KeySubscriptReversedOverrideGetter : KeySubscriptReversedBase
+- (id)objectForKeyedSubscript:(NSString *)subscript;
+@end
+
+@interface KeySubscriptReversedOverrideSetter : KeySubscriptReversedBase
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+@end

--- a/test/ClangImporter/objc_subscript.swift
+++ b/test/ClangImporter/objc_subscript.swift
@@ -48,3 +48,24 @@ class ConformsToKeySubscriptProto2 : KeySubscriptProto2 {
     set { }
   }
 }
+
+func testOverridesWithoutBase(
+  o1: KeySubscriptOverrideGetter,
+  o2: KeySubscriptOverrideSetter,
+  o3: KeySubscriptReversedOverrideGetter,
+  o4: KeySubscriptReversedOverrideSetter
+) {
+  // rdar://problem/36033356 failed specifically when the base class was never
+  // subscripted, so please don't mention the base classes here.
+  _ = o1["abc"]
+  o1["abc"] = "xyz"
+
+  _ = o2["abc"]
+  o2["abc"] = "xyz"
+
+  _ = o3["abc"]
+  o3["abc"] = "xyz"
+
+  _ = o4["abc"]
+  o4["abc"] = "xyz"
+}


### PR DESCRIPTION
- **Explanation**: Swift accidentally assumed that whenever an Objective-C subscript getter method and setter method were declared in different places, the setter was always going to be in a subclass (turning a read-only subscript into a read/write one). That's not true if there are redeclarations involved. The fix is to check if the two methods are in different classes and prefer the accessor we started with.
- **Scope**: Affects how Objective-C subscripts are imported if the getter and setter are declared in different places.
- **Issue**: rdar://problem/36033356
- **Reviewed by**: @DougGregor
- **Risk**: Medium-low. This kind of change for Objective-C subscripts isn't super common.
- **Testing**: Added compiler regression tests, passed the source compatibility suite