### PR TITLE
 AST: Property requirements in @objc protocols should return `true` for `requiresForeignGetterAndSetter`.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4166,8 +4166,8 @@ bool VarDecl::isSelfParameter() const {
   return false;
 }
 
-/// Return true if this stored property needs to be accessed with getters and
-/// setters for Objective-C.
+/// Return true if this stored property has a getter and
+/// setter that are accessible from Objective-C.
 bool AbstractStorageDecl::hasForeignGetterAndSetter() const {
   if (auto override = getOverriddenDecl())
     return override->hasForeignGetterAndSetter();
@@ -4188,9 +4188,11 @@ bool AbstractStorageDecl::requiresForeignGetterAndSetter() const {
   // Imported accessors are foreign and only have objc entry points.
   if (hasClangNode())
     return true;
-  // Otherwise, we only dispatch by @objc if the declaration is dynamic or
-  // NSManaged.
-  return isDynamic() || getAttrs().hasAttribute<NSManagedAttr>();
+  // Otherwise, we only dispatch by @objc if the declaration is dynamic,
+  // NSManaged, or dispatched through an ObjC protocol.
+  return isDynamic()
+    || getAttrs().hasAttribute<NSManagedAttr>()
+    || (isa<ProtocolDecl>(getDeclContext()) && isProtocolRequirement());
 }
 
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4904,7 +4904,14 @@ namespace {
   };
   
   /// An adapter that turns a metadata layout class into a foreign metadata
-  /// layout class. Foreign metadata has an additional header that
+  /// layout class.
+  ///
+  /// Foreign metadata is generated for declarations that are
+  /// synthesized by the Clang importer from C declarations, meaning they don't
+  /// have a single Swift binary that is responsible for their emission.
+  /// In this case, we emit the record into every binary that needs it, with
+  /// a header with a unique identifier string that the runtime can use to pick
+  /// the first-used instance as the canonical instance for a process.
   template<typename Impl, typename Base>
   class ForeignMetadataBuilderBase : public Base {
     typedef Base super;

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -76,3 +76,15 @@ func nonobjcExtensionOfObjCClass() {
   _ = \NSObject.dynamic
 
 }
+
+@objc protocol ObjCProto {
+  var objcRequirement: Int { get set }
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}ProtocolRequirement
+func objcProtocolRequirement<T: ObjCProto>(_: T) {
+  // CHECK: keypath {{.*}} id #ObjCProto.objcRequirement!getter.1.foreign
+  _ = \T.objcRequirement
+  // CHECK: keypath {{.*}} id #ObjCProto.objcRequirement!getter.1.foreign
+  _ = \ObjCProto.objcRequirement
+}


### PR DESCRIPTION
We need to use ObjC dispatch to get to the witness of an ObjC protocol requirement. The wrong answer here was causing us to do the wrong thing when producing identifiers for key paths that refer to ObjC protocol requirements.
f7fc743

Fixes rdar://problem/36111009.