### PR TITLE
unittests: silence -Wqual-cast warnings

### DIFF
--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -912,7 +912,8 @@ static void witnessTableInstantiator(WitnessTable *instantiatedTable,
   // The last witness is computed dynamically at instantiation time.
   ((void **) instantiatedTable)[2] = (void *) 345;
 
-  auto conditionalTables = (WitnessTableSlice *)instantiationArgs;
+  auto conditionalTables =
+      reinterpret_cast<const WitnessTableSlice *>(instantiationArgs);
 
   EXPECT_EQ(conditionalTables->count, 1UL);
   EXPECT_EQ(conditionalTables->tables[0], (void *)678);
@@ -1036,14 +1037,21 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
-        EXPECT_EQ(((void **) instantiatedTable)[-2], (void *) 0);
-        EXPECT_EQ(((void **) instantiatedTable)[-1], (void *) 678);
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[-2],
+                  reinterpret_cast<void *>(0));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[-1],
+                  reinterpret_cast<void *>(678));
 
-        EXPECT_EQ(((void **) instantiatedTable)[0], (void *) 123);
-        EXPECT_EQ(((void **) instantiatedTable)[1], (void *) 234);
-        EXPECT_EQ(((void **) instantiatedTable)[2], (void *) 345);
-        EXPECT_EQ(((void **) instantiatedTable)[3], (void *) 456);
-        EXPECT_EQ(((void **) instantiatedTable)[4], (void *) 567);
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[0],
+                  reinterpret_cast<void *>(123));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[1],
+                  reinterpret_cast<void *>(234));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[2],
+                  reinterpret_cast<void *>(345));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[3],
+                  reinterpret_cast<void *>(456));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[4],
+                  reinterpret_cast<void *>(567));
 
         return instantiatedTable;
       });
@@ -1068,14 +1076,21 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
-        EXPECT_EQ(((void **) instantiatedTable)[-2], (void *) 0);
-        EXPECT_EQ(((void **) instantiatedTable)[-1], (void *) 678);
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[-2],
+                  reinterpret_cast<void *>(0));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[-1],
+                  reinterpret_cast<void *>(678));
 
-        EXPECT_EQ(((void **) instantiatedTable)[0], (void *) 123);
-        EXPECT_EQ(((void **) instantiatedTable)[1], (void *) 234);
-        EXPECT_EQ(((void **) instantiatedTable)[2], (void *) 345);
-        EXPECT_EQ(((void **) instantiatedTable)[3], (void *) 456);
-        EXPECT_EQ(((void **) instantiatedTable)[4], (void *) fakeDefaultWitness2);
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[0],
+                  reinterpret_cast<void *>(123));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[1],
+                  reinterpret_cast<void *>(234));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[2],
+                  reinterpret_cast<void *>(345));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[3],
+                  reinterpret_cast<void *>(456));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[4],
+                  reinterpret_cast<void *>(fakeDefaultWitness2));
 
         return instantiatedTable;
       });
@@ -1101,14 +1116,21 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
-        EXPECT_EQ(((void **) instantiatedTable)[-2], (void *) 0);
-        EXPECT_EQ(((void **) instantiatedTable)[-1], (void *) 678);
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[-2],
+                  reinterpret_cast<void *>(0));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[-1],
+                  reinterpret_cast<void *>(678));
 
-        EXPECT_EQ(((void **) instantiatedTable)[0], (void *) 123);
-        EXPECT_EQ(((void **) instantiatedTable)[1], (void *) 234);
-        EXPECT_EQ(((void **) instantiatedTable)[2], (void *) 345);
-        EXPECT_EQ(((void **) instantiatedTable)[3], (void *) fakeDefaultWitness1);
-        EXPECT_EQ(((void **) instantiatedTable)[4], (void *) fakeDefaultWitness2);
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[0],
+                  reinterpret_cast<void *>(123));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[1],
+                  reinterpret_cast<void *>(234));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[2],
+                  reinterpret_cast<void *>(345));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[3],
+                  reinterpret_cast<void *>(fakeDefaultWitness1));
+        EXPECT_EQ(reinterpret_cast<void * const *>(instantiatedTable)[4],
+                  reinterpret_cast<void *>(fakeDefaultWitness2));
 
         return instantiatedTable;
       });


### PR DESCRIPTION
Qualify the casts to ensure that we do not trigger `-Wqual-cast`
warnings from the compiler.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
