### PR TITLE
[IRGen] Work around assertion in handling of keypaths into @objc protocols.

### DIFF
--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -227,7 +227,12 @@ public:
       if (witness.matchesFunction(function))
         return getNonBaseWitnessIndex(&witness);
     }
-    llvm_unreachable("didn't find entry for function");
+
+    // FIXME: This should be an "unreachable", but Swift < 4.1 had an
+    // existing bug here that depends on (effectively) getting this
+    // result in non-Asserts builds. Emulate that behavior for now,
+    // but only on the Swift 4.1 branch.
+    return WitnessIndex(0, false);
   }
 
   /// Return the witness index for the type metadata access function

--- a/validation-test/compiler_crashers_2_fixed/0135-rdar36111009.swift
+++ b/validation-test/compiler_crashers_2_fixed/0135-rdar36111009.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o /dev/null
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol P {
+    var property: Int64 { get }
+}
+
+class PUser<T: P> where T: NSObject {
+  init(t: T, updating progress: Progress) {
+    _ = t.observe(\.property) { t, _ in
+      let _ = t.property
+    }
+  }
+}


### PR DESCRIPTION
While we await for a proper fix for rdar://problem/36111009, disable
the assertion triggered by that test case and make the result
deterministically produce what a non-Asserts build
will... usually... produce.
