### PR TITLE
Mangle imported declarations using their C names

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -56,8 +56,20 @@ class IRGenOptions;
 class LazyResolver;
 class ModuleDecl;
 class NominalTypeDecl;
+class TypeDecl;
 class VisibleDeclConsumer;
 enum class SelectorSplitKind;
+
+/// Represents the different namespaces for types in C.
+///
+/// A simplified version of clang::Sema::LookupKind.
+enum class ClangTypeKind {
+  Typedef,
+  ObjCClass = Typedef,
+  /// Structs, enums, and unions.
+  Tag,
+  ObjCProtocol,
+};
 
 /// \brief Class that imports Clang modules into Swift, mapping directly
 /// from Clang ASTs over to Swift ASTs.
@@ -135,6 +147,14 @@ public:
   ///
   /// \param name The name we're searching for.
   void lookupValue(DeclName name, VisibleDeclConsumer &consumer);
+
+  /// Look up a type declaration by its Clang name.
+  ///
+  /// Note that this method does no filtering. If it finds the type in a loaded
+  /// module, it returns it. This is intended for use in reflection / debugging
+  /// contexts where access is not a problem.
+  void lookupTypeDecl(StringRef clangName, ClangTypeKind kind,
+                      llvm::function_ref<void(TypeDecl*)> receiver);
 
   /// Look for textually included declarations from the bridging header.
   ///

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -414,7 +414,7 @@ protected:
   NodePointer popModule();
   NodePointer popContext();
   NodePointer popTypeAndGetChild();
-  NodePointer popTypeAndGetNominal();
+  NodePointer popTypeAndGetAnyGeneric();
   NodePointer demangleBuiltinType();
   NodePointer demangleAnyGenericType(Node::Kind kind);
   NodePointer demangleExtensionContext();

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -106,7 +106,9 @@ class TypeDecoder {
       return decodeMangledType(Node->getChild(0));
     case NodeKind::Class:
     case NodeKind::Enum:
-    case NodeKind::Structure: {
+    case NodeKind::Structure:
+    case NodeKind::TypeAlias: // This can show up for imported Clang decls.
+    {
       BuiltNominalTypeDecl typeDecl = BuiltNominalTypeDecl();
       BuiltType parent = BuiltType();
       if (!decodeMangledNominalType(Node, typeDecl, parent))

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -226,6 +226,7 @@ public:
   bool isEnum() const;
   bool isClass() const;
   bool isProtocol() const;
+  bool isAlias() const;
 
   bool isErrorProtocol() const {
     return MangledName == "s5ErrorP";

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -39,9 +39,9 @@ namespace swift {
   static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] = "__lldb_expr_";
 
   /// The name of the fake module used to hold imported Objective-C things.
-  static const char MANGLING_MODULE_OBJC[] = "__ObjC";
-  /// The name of the fake module used to hold imported C things.
-  static const char MANGLING_MODULE_C[] = "__C";
+  static const char MANGLING_MODULE_OBJC[] = "__C";
+  /// The name of the fake module used to hold synthesized ClangImporter things.
+  static const char MANGLING_MODULE_CLANG_IMPORTER[] = "__C_Synthesized";
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1442,7 +1442,8 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
       // Note: This includes enums, but that's okay. A Clang enum is not always
       // imported as a Swift enum.
       appendOperator("V");
-    } else if (isa<clang::TypedefNameDecl>(clangDecl)) {
+    } else if (isa<clang::TypedefNameDecl>(clangDecl) ||
+               isa<clang::ObjCCompatibleAliasDecl>(clangDecl)) {
       appendOperator("a");
     } else {
       llvm_unreachable("unknown imported Clang type");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1171,34 +1171,25 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
 /// Mangle the context of the given declaration as a <context.
 /// This is the top-level entrypoint for mangling <context>.
 void ASTMangler::appendContextOf(const ValueDecl *decl) {
-  auto clangDecl = decl->getClangDecl();
-
-  // Declarations provided provided by a C module have a special context
-  // mangling.
+  // Declarations provided by a C module have a special context mangling.
   //   known-context ::= 'So'
-  if (isa<ClassDecl>(decl) && clangDecl) {
-    assert(isa<clang::ObjCInterfaceDecl>(clangDecl) ||
-           isa<clang::TypedefDecl>(clangDecl));
-    return appendOperator("So");
-  }
-
-  if (isa<ProtocolDecl>(decl) && clangDecl) {
-    assert(isa<clang::ObjCProtocolDecl>(clangDecl));
-    return appendOperator("So");
-  }
-
+  //
   // Also handle top-level imported declarations that don't have corresponding
   // Clang decls. Check getKind() directly to avoid a layering dependency.
   //   known-context ::= 'SC'
   if (auto file = dyn_cast<FileUnit>(decl->getDeclContext())) {
     if (file->getKind() == FileUnitKind::ClangModule) {
-      // FIXME: Import-as-member Clang decls should appear under 'So' as well,
-      // rather than under their current parent.
-      if (clangDecl)
+      if (decl->getClangDecl())
         return appendOperator("So");
       return appendOperator("SC");
     }
   }
+
+  // Nested types imported from C should also get use the special "So" context.
+  if (isa<TypeDecl>(decl))
+    if (auto *clangDecl = decl->getClangDecl())
+      if (clangDecl->getDeclContext()->isTranslationUnit())
+        return appendOperator("So");
 
   // Just mangle the decl's DC.
   appendContext(decl->getDeclContext());
@@ -1406,7 +1397,11 @@ void ASTMangler::appendModule(const ModuleDecl *module) {
 /// Mangle the name of a protocol as a substitution candidate.
 void ASTMangler::appendProtocolName(const ProtocolDecl *protocol) {
   appendContextOf(protocol);
-  appendDeclName(protocol);
+  auto *clangDecl = protocol->getClangDecl();
+  if (auto *clangProto = cast_or_null<clang::ObjCProtocolDecl>(clangDecl))
+    appendIdentifier(clangProto->getName());
+  else
+    appendDeclName(protocol);
 }
 
 void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
@@ -1430,28 +1425,53 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
     return;
 
   appendContextOf(decl);
-  appendDeclName(decl);
 
-  switch (decl->getKind()) {
-  default:
-    llvm_unreachable("not a nominal type");
+  // Always use Clang names for imported Clang declarations.
+  auto *clangDecl = dyn_cast_or_null<clang::NamedDecl>(decl->getClangDecl());
+  if (clangDecl && !clangDecl->getName().empty()) {
+    appendIdentifier(clangDecl->getName());
+    // The important distinctions to maintain here are Objective-C's various
+    // namespaces: protocols, tags (struct/enum/union), and unqualified names.
+    // We continue to mangle "class" the standard Swift way because it feels
+    // weird to call that an alias, but they're really in the same namespace.
+    if (isa<clang::ObjCInterfaceDecl>(clangDecl)) {
+      appendOperator("C");
+    } else if (isa<clang::ObjCProtocolDecl>(clangDecl)) {
+      appendOperator("P");
+    } else if (isa<clang::TagDecl>(clangDecl)) {
+      // Note: This includes enums, but that's okay. A Clang enum is not always
+      // imported as a Swift enum.
+      appendOperator("V");
+    } else if (isa<clang::TypedefNameDecl>(clangDecl)) {
+      appendOperator("a");
+    } else {
+      llvm_unreachable("unknown imported Clang type");
+    }
+  } else {
+    appendDeclName(decl);
 
-  case DeclKind::TypeAlias:
-    appendOperator("a");
-    break;
-  case DeclKind::Protocol:
-    appendOperator("P");
-    break;
-  case DeclKind::Class:
-    appendOperator("C");
-    break;
-  case DeclKind::Enum:
-    appendOperator("O");
-    break;
-  case DeclKind::Struct:
-    appendOperator("V");
-    break;
+    switch (decl->getKind()) {
+    default:
+      llvm_unreachable("not a nominal type");
+
+    case DeclKind::TypeAlias:
+      appendOperator("a");
+      break;
+    case DeclKind::Protocol:
+      appendOperator("P");
+      break;
+    case DeclKind::Class:
+      appendOperator("C");
+      break;
+    case DeclKind::Enum:
+      appendOperator("O");
+      break;
+    case DeclKind::Struct:
+      appendOperator("V");
+      break;
+    }
   }
+
   addSubstitution(key.getPointer());
 }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1173,7 +1173,7 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
 void ASTMangler::appendContextOf(const ValueDecl *decl) {
   auto clangDecl = decl->getClangDecl();
 
-  // Classes and protocols implemented in Objective-C have a special context
+  // Declarations provided provided by a C module have a special context
   // mangling.
   //   known-context ::= 'So'
   if (isa<ClassDecl>(decl) && clangDecl) {
@@ -1187,12 +1187,17 @@ void ASTMangler::appendContextOf(const ValueDecl *decl) {
     return appendOperator("So");
   }
 
-  // Declarations provided by a C module have a special context mangling.
+  // Also handle top-level imported declarations that don't have corresponding
+  // Clang decls. Check getKind() directly to avoid a layering dependency.
   //   known-context ::= 'SC'
-  // Do a dance to avoid a layering dependency.
   if (auto file = dyn_cast<FileUnit>(decl->getDeclContext())) {
-    if (file->getKind() == FileUnitKind::ClangModule)
+    if (file->getKind() == FileUnitKind::ClangModule) {
+      // FIXME: Import-as-member Clang decls should appear under 'So' as well,
+      // rather than under their current parent.
+      if (clangDecl)
+        return appendOperator("So");
       return appendOperator("SC");
+    }
   }
 
   // Just mangle the decl's DC.
@@ -1392,7 +1397,7 @@ void ASTMangler::appendModule(const ModuleDecl *module) {
   StringRef ModName = module->getName().str();
   if (ModName == MANGLING_MODULE_OBJC)
     return appendOperator("So");
-  if (ModName == MANGLING_MODULE_C)
+  if (ModName == MANGLING_MODULE_CLANG_IMPORTER)
     return appendOperator("SC");
 
   appendIdentifier(ModName);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2297,6 +2297,42 @@ void ClangImporter::lookupValue(DeclName name, VisibleDeclConsumer &consumer){
     });
 }
 
+void
+ClangImporter::lookupTypeDecl(StringRef rawName, ClangTypeKind kind,
+                              llvm::function_ref<void(TypeDecl*)> receiver) {
+  clang::DeclarationName clangName(
+      &Impl.Instance->getASTContext().Idents.get(rawName));
+
+  clang::Sema::LookupNameKind lookupKind;
+  switch (kind) {
+  case ClangTypeKind::Typedef:
+    lookupKind = clang::Sema::LookupOrdinaryName;
+    break;
+  case ClangTypeKind::Tag:
+    lookupKind = clang::Sema::LookupTagName;
+    break;
+  case ClangTypeKind::ObjCProtocol:
+    lookupKind = clang::Sema::LookupObjCProtocolName;
+    break;
+  }
+
+  // Perform name lookup into the global scope.
+  auto &sema = Impl.Instance->getSema();
+  clang::LookupResult lookupResult(sema, clangName, clang::SourceLocation(),
+                                   lookupKind);
+  if (sema.LookupName(lookupResult, /*Scope=*/nullptr)) {
+    for (auto clangDecl : lookupResult) {
+      if (!isa<clang::TypeDecl>(clangDecl) &&
+          !isa<clang::ObjCContainerDecl>(clangDecl)) {
+        continue;
+      }
+      auto *imported = Impl.importDecl(clangDecl, Impl.CurrentVersion);
+      if (auto *importedType = dyn_cast_or_null<TypeDecl>(imported))
+        receiver(importedType);
+    }
+  }
+}
+
 void ClangModuleUnit::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
                                          VisibleDeclConsumer &consumer,
                                          NLKind lookupKind) const {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2323,7 +2323,8 @@ ClangImporter::lookupTypeDecl(StringRef rawName, ClangTypeKind kind,
   if (sema.LookupName(lookupResult, /*Scope=*/nullptr)) {
     for (auto clangDecl : lookupResult) {
       if (!isa<clang::TypeDecl>(clangDecl) &&
-          !isa<clang::ObjCContainerDecl>(clangDecl)) {
+          !isa<clang::ObjCContainerDecl>(clangDecl) &&
+          !isa<clang::ObjCCompatibleAliasDecl>(clangDecl)) {
         continue;
       }
       auto *imported = Impl.importDecl(clangDecl, Impl.CurrentVersion);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -56,12 +56,13 @@ static bool isContext(Node::Kind kind) {
   }
 }
 
-static bool isNominal(Node::Kind kind) {
+static bool isAnyGeneric(Node::Kind kind) {
   switch (kind) {
     case Node::Kind::Structure:
     case Node::Kind::Class:
     case Node::Kind::Enum:
     case Node::Kind::Protocol:
+    case Node::Kind::TypeAlias:
       return true;
     default:
       return false;
@@ -765,9 +766,9 @@ NodePointer Demangler::popTypeAndGetChild() {
   return Ty->getFirstChild();
 }
 
-NodePointer Demangler::popTypeAndGetNominal() {
+NodePointer Demangler::popTypeAndGetAnyGeneric() {
   NodePointer Child = popTypeAndGetChild();
-  if (Child && isNominal(Child->getKind()))
+  if (Child && isAnyGeneric(Child->getKind()))
     return Child;
   return nullptr;
 }
@@ -855,7 +856,7 @@ NodePointer Demangler::demangleAnyGenericType(Node::Kind kind) {
 NodePointer Demangler::demangleExtensionContext() {
   NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
   NodePointer Module = popModule();
-  NodePointer Type = popTypeAndGetNominal();
+  NodePointer Type = popTypeAndGetAnyGeneric();
   NodePointer Ext = createWithChildren(Node::Kind::Extension, Module, Type);
   if (GenSig)
     Ext = addChild(Ext, GenSig);
@@ -1063,7 +1064,7 @@ NodePointer Demangler::demangleBoundGenericType() {
     if (!popNode(Node::Kind::FirstElementMarker))
       return nullptr;
   }
-  NodePointer Nominal = popTypeAndGetNominal();
+  NodePointer Nominal = popTypeAndGetAnyGeneric();
   NodePointer NTy = createType(demangleBoundGenericArgs(Nominal, TypeListList, 0));
   addSubstitution(NTy);
   return NTy;
@@ -1261,7 +1262,7 @@ NodePointer Demangler::demangleMetatype() {
                              popProtocolConformance());
     case 'C': {
       NodePointer Ty = popNode(Node::Kind::Type);
-      if (!Ty || !isNominal(Ty->getChild(0)->getKind()))
+      if (!Ty || !isAnyGeneric(Ty->getChild(0)->getKind()))
         return nullptr;
       return createWithChild(Node::Kind::ReflectionMetadataSuperclassDescriptor,
                              Ty->getChild(0));

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -583,7 +583,7 @@ NodePointer Demangler::demangleStandardSubstitution() {
     case 'o':
       return createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     case 'C':
-      return createNode(Node::Kind::Module, MANGLING_MODULE_C);
+      return createNode(Node::Kind::Module, MANGLING_MODULE_CLANG_IMPORTER);
     case 'g': {
       NodePointer OptionalTy =
         createType(createWithChildren(Node::Kind::BoundGenericEnum,

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -858,7 +858,8 @@ private:
     if (Mangled.nextIf('o'))
       return Factory.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     if (Mangled.nextIf('C'))
-      return Factory.createNode(Node::Kind::Module, MANGLING_MODULE_C);
+      return Factory.createNode(Node::Kind::Module,
+                                MANGLING_MODULE_CLANG_IMPORTER);
     if (Mangled.nextIf('a'))
       return createSwiftType(Node::Kind::Structure, "Array");
     if (Mangled.nextIf('b'))

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -427,7 +427,7 @@ bool Remangler::mangleStandardSubstitution(Node *node) {
     case Node::Kind::Module:
       SUCCESS_IF_TEXT_IS(STDLIB_NAME, "s");
       SUCCESS_IF_TEXT_IS(MANGLING_MODULE_OBJC, "So");
-      SUCCESS_IF_TEXT_IS(MANGLING_MODULE_C, "SC");
+      SUCCESS_IF_TEXT_IS(MANGLING_MODULE_CLANG_IMPORTER, "SC");
       break;
     case Node::Kind::Structure:
       if (isInSwiftModule(node)) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1338,7 +1338,7 @@ void Remangler::mangleModule(Node *node) {
     Buffer << 's';
   } else if (node->getText() == MANGLING_MODULE_OBJC) {
     Buffer << "So";
-  } else if (node->getText() == MANGLING_MODULE_C) {
+  } else if (node->getText() == MANGLING_MODULE_CLANG_IMPORTER) {
     Buffer << "SC";
   } else {
     mangleIdentifier(node);

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -109,7 +109,7 @@ public:
     assert(!module_name.empty());
     static ConstString g_ObjectiveCModule(MANGLING_MODULE_OBJC);
     static ConstString g_BuiltinModule("Builtin");
-    static ConstString g_CModule(MANGLING_MODULE_C);
+    static ConstString g_CModule(MANGLING_MODULE_CLANG_IMPORTER);
     if (allow_crawler) {
       if (module_name == g_ObjectiveCModule || module_name == g_CModule)
         return DeclsLookupSource(&ast, module_name);

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/Remote/MetadataReader.h"
+#include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
@@ -564,7 +565,8 @@ bool RemoteASTTypeBuilder::isForeignModule(const Demangle::NodePointer &node) {
   if (node->getKind() != Demangle::Node::Kind::Module)
     return false;
 
-  return (node->getText() == "__ObjC");
+  return (node->getText() == MANGLING_MODULE_OBJC ||
+          node->getText() == MANGLING_MODULE_CLANG_IMPORTER);
 }
 
 DeclContext *

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -78,6 +78,8 @@ public:
       printHeader("protocol");
       mangledName = Demangle::dropSwiftManglingPrefix(mangledName);
     }
+    else if (N->isAlias())
+      printHeader("alias");
     else
       printHeader("nominal");
     auto demangled = Demangle::demangleTypeAsString(mangledName);
@@ -462,6 +464,17 @@ bool isProtocol(Demangle::NodePointer Node) {
       return false;
   }
 }
+
+bool isAlias(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+    case Demangle::Node::Kind::Type:
+      return isAlias(Node->getChild(0));
+    case Demangle::Node::Kind::TypeAlias:
+      return true;
+    default:
+      return false;
+  }
+}
 } // end anonymous namespace
 
 bool NominalTypeTrait::isStruct() const {
@@ -470,13 +483,11 @@ bool NominalTypeTrait::isStruct() const {
   return ::isStruct(Demangled);
 }
 
-
 bool NominalTypeTrait::isEnum() const {
   Demangle::Demangler Dem;
   Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
   return ::isEnum(Demangled);
 }
-
 
 bool NominalTypeTrait::isClass() const {
   Demangle::Demangler Dem;
@@ -489,6 +500,12 @@ bool NominalTypeTrait::isProtocol() const {
   StringRef adjustedMangledName = Demangle::dropSwiftManglingPrefix(MangledName);
   Demangle::NodePointer Demangled = Dem.demangleType(adjustedMangledName);
   return ::isProtocol(Demangled);
+}
+
+bool NominalTypeTrait::isAlias() const {
+  Demangle::Demangler Dem;
+  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
+  return ::isAlias(Demangled);
 }
 
 /// Visitor class to set the WasAbstract flag of any MetatypeTypeRefs

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -190,9 +190,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     auto objcWrapper = static_cast<const ObjCClassWrapperMetadata *>(type);
     const char *className = class_getName(objcWrapper->getObjCClassObject());
     
-    // ObjC classes mangle as being in the magic "__ObjC" module.
-    auto module = Dem.createNode(Node::Kind::Module, "__ObjC");
-    
+    auto module = Dem.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     auto node = Dem.createNode(Node::Kind::Class);
     node->addChild(module, Dem);
     node->addChild(Dem.createNode(Node::Kind::Identifier,

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -229,7 +229,7 @@ static const WitnessTable *getNSErrorConformanceToError() {
   // Swift source.
 
   auto TheWitnessTable = SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT,
-               MANGLE_AS_STRING(MANGLE_SYM(So7CFErrorCs5Error10FoundationWP))));
+      MANGLE_AS_STRING(MANGLE_SYM(So10CFErrorRefas5Error10FoundationWP))));
   assert(TheWitnessTable &&
          "Foundation overlay not loaded, or 'CFError : Error' conformance "
          "not available");

--- a/test/APINotes/versioned-test-mangling.swift
+++ b/test/APINotes/versioned-test-mangling.swift
@@ -1,15 +1,14 @@
 // RUN: %empty-directory(%t)
 
-// Use fake mangled names here with the name of the imported module.
-// swift-ide-test isn't testing the full demangling algorithm.
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 3 -find-mangled '$SSo11SomeCStructV' | %FileCheck -check-prefix=CHECK-TOP-ALIAS-3 %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 4 -find-mangled '$SSo11SomeCStructV' | %FileCheck -check-prefix=CHECK-TOP-ALIAS-4 %s
 
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 3 -find-mangled '$SSo16ImportantCStructa' | %FileCheck -check-prefix=CHECK-TOP-ALIAS %s
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 4 -find-mangled '$SSo16ImportantCStructa' | %FileCheck -check-prefix=CHECK-TOP-ALIAS %s
-
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 3 -find-mangled '$SSo13InnerInSwift4a' | %FileCheck -check-prefix=CHECK-NESTED-ALIAS %s
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 4 -find-mangled '$SSo13InnerInSwift4a' | %FileCheck -check-prefix=CHECK-NESTED-ALIAS %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 3 -find-mangled '$SSo13InnerInSwift4V' | %FileCheck -check-prefix=CHECK-NESTED-ALIAS-3 %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 4 -find-mangled '$SSo13InnerInSwift4V' | %FileCheck -check-prefix=CHECK-NESTED-ALIAS-4 %s
 
 import APINotesFrameworkTest
 
-// CHECK-TOP-ALIAS: typealias ImportantCStruct = VeryImportantCStruct
-// CHECK-NESTED-ALIAS: typealias InnerInSwift4 = Outer.Inner
+// CHECK-TOP-ALIAS-3: typealias ImportantCStruct = VeryImportantCStruct
+// CHECK-TOP-ALIAS-4: struct VeryImportantCStruct {
+// CHECK-NESTED-ALIAS-3: typealias InnerInSwift4 = Outer.Inner
+// CHECK-NESTED-ALIAS-4: struct Inner {

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -251,14 +251,14 @@ func testRenamedOptionyEnum() {
 #if !swift(>=4)
 
 func useSwift3Name(_: ImportantCStruct) {}
-// CHECK-SILGEN-3: sil hidden @$S9versioned13useSwift3NameyySo20VeryImportantCStructVF
+// CHECK-SILGEN-3: sil hidden @$S9versioned13useSwift3NameyySo11SomeCStructVF
 
 func useNewlyNested(_: InnerInSwift4) {}
-// CHECK-SILGEN-3: sil hidden @$S9versioned14useNewlyNestedyySo5OuterV5InnerVF
+// CHECK-SILGEN-3: sil hidden @$S9versioned14useNewlyNestedyySo13InnerInSwift4VF
 #endif
 
 func useSwift4Name(_: VeryImportantCStruct) {}
-// CHECK-SILGEN: sil hidden @$S9versioned13useSwift4NameyySo20VeryImportantCStructVF
+// CHECK-SILGEN: sil hidden @$S9versioned13useSwift4NameyySo11SomeCStructVF
 
 
 

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -251,14 +251,14 @@ func testRenamedOptionyEnum() {
 #if !swift(>=4)
 
 func useSwift3Name(_: ImportantCStruct) {}
-// CHECK-SILGEN-3: sil hidden @$S9versioned13useSwift3NameyySC20VeryImportantCStructVF
+// CHECK-SILGEN-3: sil hidden @$S9versioned13useSwift3NameyySo20VeryImportantCStructVF
 
 func useNewlyNested(_: InnerInSwift4) {}
-// CHECK-SILGEN-3: sil hidden @$S9versioned14useNewlyNestedyySC5OuterV5InnerVF
+// CHECK-SILGEN-3: sil hidden @$S9versioned14useNewlyNestedyySo5OuterV5InnerVF
 #endif
 
 func useSwift4Name(_: VeryImportantCStruct) {}
-// CHECK-SILGEN: sil hidden @$S9versioned13useSwift4NameyySC20VeryImportantCStructVF
+// CHECK-SILGEN: sil hidden @$S9versioned13useSwift4NameyySo20VeryImportantCStructVF
 
 
 

--- a/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
@@ -62,4 +62,6 @@
 
 int global_int SWIFT_NAME(GlobalInt);
 
+@compatibility_alias SwiftNameAlias SwiftNameTest;
+
 #pragma clang assume_nonnull end

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -91,7 +91,7 @@ public func testTopLevel() {
 #endif
 }
 
-// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo12__PrivFooSubCMa{{.*}} {
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo10PrivFooSubCMa{{.*}} {
 // CHECK: %objc_class** @"OBJC_CLASS_REF_$_PrivFooSub"
 // CHECK: }
 

--- a/test/ClangImporter/ctypes_ir.swift
+++ b/test/ClangImporter/ctypes_ir.swift
@@ -27,7 +27,7 @@ func testStructWithFlexibleArray(_ s : StructWithFlexibleArray) {
 }
 
 // Make sure flexible array struct member isn't represented in IR function signature as i0 (or at all). rdar://problem/18510461
-// CHECK-LABEL: define hidden swiftcc void @"$S9ctypes_ir27testStructWithFlexibleArrayyySC0defG0VF"(i32)
+// CHECK-LABEL: define hidden swiftcc void @"$S9ctypes_ir27testStructWithFlexibleArrayyySo0defG0VF"(i32)
 
 typealias EightUp = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)
 

--- a/test/ClangImporter/ctypes_ir.swift
+++ b/test/ClangImporter/ctypes_ir.swift
@@ -27,7 +27,7 @@ func testStructWithFlexibleArray(_ s : StructWithFlexibleArray) {
 }
 
 // Make sure flexible array struct member isn't represented in IR function signature as i0 (or at all). rdar://problem/18510461
-// CHECK-LABEL: define hidden swiftcc void @"$S9ctypes_ir27testStructWithFlexibleArrayyySo0defG0VF"(i32)
+// CHECK-LABEL: define hidden swiftcc void @"$S9ctypes_ir27testStructWithFlexibleArrayyySo0defG0aF"(i32)
 
 typealias EightUp = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)
 

--- a/test/ClangImporter/enum.swift
+++ b/test/ClangImporter/enum.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck %s
 // -- Check that we can successfully round-trip.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -D IRGEN -emit-ir %s >/dev/null
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -D IRGEN -emit-ir -primary-file %s | %FileCheck -check-prefix=CHECK-IR %s
 
 // REQUIRES: objc_interop
 
@@ -227,3 +227,6 @@ let _: UnknownOptionsThanksToAPINotes = .first // expected-error {{has no member
 #endif
 let _ = UnknownEnumThanksToAPINotesFirst
 let _ = UnknownOptionsThanksToAPINotesFirst
+
+// CHECK-IR: $S4enum12testMangling2e12e22e3ySo9EnumByTagV_So0gH7TypedefaSo0gH4BothVtF
+func testMangling(e1: EnumByTag, e2: EnumByTypedef, e3: EnumByBoth) {}

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -emit-ir -g -o - -primary-file %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
@@ -329,10 +329,20 @@ func customFactoryMethodsInherited() {
 // CHECK: load i8*, i8** @"\01L_selector(err7:callback:)"
 // CHECK: }
 
+
+// CHECK-LABEL: define hidden swiftcc void @"$S7objc_ir30testCompatibilityAliasMangling3objySo13SwiftNameTestC_tF"
+func testCompatibilityAliasMangling(obj: SwiftNameAlias) {
+  // CHECK: call void @llvm.dbg.declare(metadata %TSo13SwiftNameTestC** {{%.+}}, metadata ![[SWIFT_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
+}
+
+
 // CHECK: linkonce_odr hidden {{.*}} @"$SSo1BC3intSQyABGs5Int32V_tcfcTO"
 // CHECK: load i8*, i8** @"\01L_selector(initWithInt:)"
 // CHECK: call [[OPAQUE:%.*]]* bitcast (void ()* @objc_msgSend
 
 
 // CHECK: attributes [[NOUNWIND]] = { nounwind }
+
+// CHECK: ![[SWIFT_NAME_ALIAS_VAR]] = !DILocalVariable(name: "obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])
+// CHECK: ![[SWIFT_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$SSo14SwiftNameAliasaD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, baseType: !{{[0-9]+}})
 

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -303,3 +303,5 @@ _T0iW ---> _T0iW
 _S$iW ---> _S$iW
 _T0s5print_9separator10terminatoryypfC ---> _T0s5print_9separator10terminatoryypfC
 _S$s5print_9separator10terminatoryypfC ---> _S$s5print_9separator10terminatoryypfC
+_T0So13GenericOptionas8HashableSCsACP9hashValueSivgTW ---> {T:} protocol witness for Swift.Hashable.hashValue.getter : Swift.Int in conformance __C.GenericOption : Swift.Hashable in __C_Synthesized
+_T0So11CrappyColorVs16RawRepresentableSCMA --> reflection metadata associated type descriptor __C.CrappyColor : Swift.RawRepresentable in __C_Synthesized

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -26,7 +26,7 @@ _TtGSqSS_ ---> Swift.String?
 _TtGSQSS_ ---> Swift.String!
 _TtGVs10DictionarySSSi_ ---> [Swift.String : Swift.Int]
 _TtVs7CString ---> Swift.CString
-_TtCSo8NSObject ---> __ObjC.NSObject
+_TtCSo8NSObject ---> __C.NSObject
 _TtO6Monads6Either ---> Monads.Either
 _TtbSiSu ---> @convention(block) (Swift.Int) -> Swift.UInt
 _TtcSiSu ---> @convention(c) (Swift.Int) -> Swift.UInt
@@ -79,15 +79,15 @@ _TF3foog3barSi ---> foo.bar.getter : Swift.Int
 _TF3foos3barSi ---> foo.bar.setter : Swift.Int
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
 _TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 __$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-__$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+__$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 $S3foo3barC3bas3zimyAaEC_tFTo ---> {T:$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-$SSC3fooyS2d_SdtFTO ---> {T:$SSC3fooyS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+$SSC3fooyS2d_SdtFTO ---> {T:$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
 _TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim
@@ -125,7 +125,7 @@ _TWGC3foo3barS_8barrableS_ ---> generic protocol witness table for foo.bar : foo
 _TWIC3foo3barS_8barrableS_ ---> {C} instantiation function for generic protocol witness table for foo.bar : foo.barrable in foo
 _TWtC3foo3barS_8barrableS_4fred ---> {C} associated type metadata accessor for fred in foo.bar : foo.barrable in foo
 _TWTC3foo3barS_8barrableS_4fredS_6thomas ---> {C} associated type witness table accessor for fred : foo.thomas in foo.bar : foo.barrable in foo
-_TFSCg5greenVSC5Color ---> __C.green.getter : __C.Color
+_TFSCg5greenVSC5Color ---> __C_Synthesized.green.getter : __C_Synthesized.Color
 _TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> ()
 _TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> ()
 _TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A?
@@ -175,8 +175,8 @@ _TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2
 _TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0"
 _TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_"
 _TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String]
-_TFCSo1AE ---> __ObjC.A.__ivar_destroyer
-_TFCSo1Ae ---> __ObjC.A.__ivar_initializer
+_TFCSo1AE ---> __C.A.__ivar_destroyer
+_TFCSo1Ae ---> __C.A.__ivar_initializer
 _TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
 _T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
 _TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self
@@ -267,8 +267,8 @@ _$S8mangling14varargsVsArray3arr1nySaySiGd_SStF ---> mangling.varargsVsArray(arr
 _$S8mangling14varargsVsArray3arrySid_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
 _$S8mangling14varargsVsArray3arrySaySiGd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
 _T0s13_UnicodeViewsVss22RandomAccessCollectionRzs0A8EncodingR_11SubSequence_5IndexQZAFRtzsAcERpzAE_AEQZAIRSs15UnsignedInteger8Iterator_7ElementRPzAE_AlMQZANRS13EncodedScalar_AlMQY_AORSr0_lE13CharacterViewVyxq__G ---> (extension in Swift):Swift._UnicodeViews<A, B><A, B where A: Swift.RandomAccessCollection, B: Swift.UnicodeEncoding, A.Index == A.SubSequence.Index, A.SubSequence: Swift.RandomAccessCollection, A.SubSequence == A.SubSequence.SubSequence, A.Iterator.Element: Swift.UnsignedInteger, A.Iterator.Element == A.SubSequence.Iterator.Element, A.SubSequence.Iterator.Element == B.EncodedScalar.Iterator.Element>.CharacterView
-_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __ObjC.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__ObjC.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__ObjC.UnitAngle>.Orientation) -> Swift.Bool
-_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __ObjC.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__ObjC.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__ObjC.UnitAngle>.Orientation) -> Swift.Bool
+_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
+_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
 _T04main1_yyF ---> main._() -> ()
 _T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
 _$S4test6testitySiyt_tF ---> test.testit(()) -> Swift.Int
@@ -285,12 +285,12 @@ _$S4main4TestC1xACSi_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int)
 _T0SqWy.17 ---> outlined copy of Swift.Optional with unmangled suffix ".17"
 _T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.Int]
 _T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int]
-_T0So11UITextFieldC4textSSSgvgToTepb_ ---> outlined bridged method (pb) of @objc __ObjC.UITextField.text.getter : Swift.String?
-_T0So11UITextFieldC4textSSSgvgToTeab_ ---> outlined bridged method (ab) of @objc __ObjC.UITextField.text.getter : Swift.String?
-_T0So5GizmoC11doSomethingSQyypGSQySaySSGGFToTembnn_ ---> outlined bridged method (mbnn) of @objc __ObjC.Gizmo.doSomething([Swift.String]!) -> Any!
-_T0So5GizmoC12modifyStringSQySSGAD_Si10withNumberSQyypG0D6FoobartFToTembnnnb_ ---> outlined bridged method (mbnnnb) of @objc __ObjC.Gizmo.modifyString(_: Swift.String!, withNumber: Swift.Int, withFoobar: Any!) -> Swift.String!
-_$SSo5GizmoC11doSomethingySQyypGSQySaySSGGFToTembnn_ ---> outlined bridged method (mbnn) of @objc __ObjC.Gizmo.doSomething([Swift.String]!) -> Any!
-_$SSo5GizmoC12modifyString_10withNumber0D6FoobarSQySSGAF_SiSQyypGtFToTembnnnb_ ---> outlined bridged method (mbnnnb) of @objc __ObjC.Gizmo.modifyString(_: Swift.String!, withNumber: Swift.Int, withFoobar: Any!) -> Swift.String!
+_T0So11UITextFieldC4textSSSgvgToTepb_ ---> outlined bridged method (pb) of @objc __C.UITextField.text.getter : Swift.String?
+_T0So11UITextFieldC4textSSSgvgToTeab_ ---> outlined bridged method (ab) of @objc __C.UITextField.text.getter : Swift.String?
+_T0So5GizmoC11doSomethingSQyypGSQySaySSGGFToTembnn_ ---> outlined bridged method (mbnn) of @objc __C.Gizmo.doSomething([Swift.String]!) -> Any!
+_T0So5GizmoC12modifyStringSQySSGAD_Si10withNumberSQyypG0D6FoobartFToTembnnnb_ ---> outlined bridged method (mbnnnb) of @objc __C.Gizmo.modifyString(_: Swift.String!, withNumber: Swift.Int, withFoobar: Any!) -> Swift.String!
+_$SSo5GizmoC11doSomethingySQyypGSQySaySSGGFToTembnn_ ---> outlined bridged method (mbnn) of @objc __C.Gizmo.doSomething([Swift.String]!) -> Any!
+_$SSo5GizmoC12modifyString_10withNumber0D6FoobarSQySSGAF_SiSQyypGtFToTembnnnb_ ---> outlined bridged method (mbnnnb) of @objc __C.Gizmo.modifyString(_: Swift.String!, withNumber: Swift.Int, withFoobar: Any!) -> Swift.String!
 _T04test1SVyxGAA1RA2A1ZRzAA1Y2ZZRpzl1A_AhaGPWT ---> {C} associated type witness table accessor for A.ZZ : test.Y in <A where A: test.Z, A.ZZ: test.Y> test.S<A> : test.R in test
 _T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69)
 _T0D ---> _T0D

--- a/test/IDE/Inputs/reconstruct_type_helper.h
+++ b/test/IDE/Inputs/reconstruct_type_helper.h
@@ -8,6 +8,18 @@ enum TagTypedefCollision {
   TagTypedefCollisionX
 } __attribute__((swift_name("TTCollisionTag")));
 
+
+enum EnumByTag {
+  EnumByTagX
+};
+typedef enum {
+  EnumByTypedefX
+} EnumByTypedef;
+typedef enum EnumByBoth {
+  EnumByBothX
+} EnumByBoth;
+
+
 #if __OBJC__
 #include "swift_name_objc.h"
 

--- a/test/IDE/Inputs/reconstruct_type_helper.h
+++ b/test/IDE/Inputs/reconstruct_type_helper.h
@@ -1,0 +1,17 @@
+#include "swift_name.h"
+
+typedef int Unwrapped;
+typedef int Wrapped __attribute__((swift_wrapper(struct)));
+
+typedef int TagTypedefCollision __attribute__((swift_name("TTCollisionTypedef")));
+enum TagTypedefCollision {
+  TagTypedefCollisionX
+} __attribute__((swift_name("TTCollisionTag")));
+
+#if __OBJC__
+#include "swift_name_objc.h"
+
+@compatibility_alias SomeClassAlias SNSomeClass;
+
+#endif // __OBJC__
+

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -5,9 +5,9 @@
 #endif
 
 #ifndef SWIFT_ENUM
-#  define SWIFT_ENUM(_type, _name)    \
-  enum _name : _type _name;           \
-  enum __attribute__((enum_extensibility(open))) SWIFT_ENUM_EXTRA _name : _type
+#  define SWIFT_ENUM(_name)    \
+  enum _name _name;            \
+  enum __attribute__((enum_extensibility(open))) SWIFT_ENUM_EXTRA _name
 #endif
 
 // Renaming global variables.
@@ -27,7 +27,7 @@ struct SNSomeStruct SNMakeSomeStructForX(double X) SWIFT_NAME(makeSomeStruct(x:)
 typedef int SNIntegerType SWIFT_NAME(MyInt);
 
 // Renaming enumerations.
-SWIFT_ENUM(unsigned char, SNColorChoice) {
+SWIFT_ENUM(SNColorChoice) {
   SNColorRed SWIFT_NAME(Rouge),
   SNColorGreen,
   SNColorBlue

--- a/test/IDE/reconstruct_type_from_mangled_name_import.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name_import.swift
@@ -7,7 +7,10 @@ func test(
   d: SNColorChoice,
   e: Unwrapped,
   f: TTCollisionTypedef,
-  g: TTCollisionTag
+  g: TTCollisionTag,
+  h: EnumByTag,
+  i: EnumByTypedef,
+  j: EnumByBoth
 ) {
   // CHECK: type: Wrapped	for 'a' mangled=$SSo7WrappedaD
   _ = a
@@ -23,6 +26,12 @@ func test(
   _ = f
   // CHECK: type: TTCollisionTag	for 'g' mangled=$SSo19TagTypedefCollisionVD
   _ = g
+  // CHECK: type: EnumByTag	for 'h' mangled=$SSo9EnumByTagVD
+  _ = h
+  // CHECK: type: EnumByTypedef	for 'i' mangled=$SSo13EnumByTypedefaD
+  _ = i
+  // CHECK: type: EnumByBoth	for 'j' mangled=$SSo10EnumByBothVD
+  _ = j
 }
 
 #if _runtime(_ObjC)

--- a/test/IDE/reconstruct_type_from_mangled_name_import.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name_import.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-ide-test -reconstruct-type -source-filename %s -import-objc-header %S/Inputs/reconstruct_type_helper.h | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-runtime %s
+
+func test(
+  a: Wrapped,
+  b: SomeStruct,
+  c: MyInt,
+  d: SNColorChoice,
+  e: Unwrapped,
+  f: TTCollisionTypedef,
+  g: TTCollisionTag
+) {
+  // CHECK: type: Wrapped	for 'a' mangled=$SSo7WrappedaD
+  _ = a
+  // CHECK: type: SomeStruct	for 'b' mangled=$SSo12SNSomeStructVD
+  _ = b
+  // CHECK: type: MyInt	for 'c' mangled=$SSo13SNIntegerTypeaD
+  _ = c
+  // CHECK: type: SNColorChoice	for 'd' mangled=$SSo13SNColorChoiceVD
+  _ = d
+  // CHECK: type: Unwrapped	for 'e' mangled=$SSo9UnwrappedaD
+  _ = e
+  // CHECK: type: TTCollisionTypedef	for 'f' mangled=$SSo19TagTypedefCollisionaD
+  _ = f
+  // CHECK: type: TTCollisionTag	for 'g' mangled=$SSo19TagTypedefCollisionVD
+  _ = g
+}
+
+#if _runtime(_ObjC)
+func testObjC(
+  a: SomeClass,
+  b: SomeProtocol,
+  c: SNCollision,
+  d: SNCollisionProtocol,
+  e: CFTypeRef,
+  f: CCItem,
+  g: SomeClassAlias
+) {
+  // CHECK-objc: type: SomeClass	for 'a' mangled=$SSo11SNSomeClassCD
+  _ = a
+  // CHECK-objc: type: SomeProtocol	for 'b' mangled=$SSo14SNSomeProtocol_pD
+  _ = b
+  // CHECK-objc: type: SNCollision	for 'c' mangled=$SSo11SNCollisionCD
+  _ = c
+  // CHECK-objc: type: SNCollisionProtocol	for 'd' mangled=$SSo11SNCollision_pD
+  _ = d
+  // CHECK-objc: type: CFTypeRef	for 'e' mangled=$SSo9CFTypeRefaD
+  _ = e
+  // CHECK-objc: type: CCItem	for 'f' mangled=$SSo9CCItemRefaD
+  _ = f
+  // CHECK-objc: type: SomeClassAlias	for 'g' mangled=$SSo14SomeClassAliasaD
+  _ = g
+}
+#endif // _ObjC

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -22,20 +22,20 @@ class Foo {
   // x86_64-macosx: define hidden { <2 x float>, <2 x float> } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*) unnamed_addr {{.*}} {
   // x86_64-ios: define hidden swiftcc { i64, i64 } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
   // x86_64-ios: define hidden { <2 x float>, <2 x float> } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*) unnamed_addr {{.*}} {
-  // i386-ios: define hidden swiftcc void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%TSC6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
-  // i386-ios: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // i386-ios: define hidden swiftcc void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%TSo6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
+  // i386-ios: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // armv7-ios: define hidden swiftcc { float, float, float, float } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
-  // armv7-ios: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // armv7-ios: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // armv7s-ios: define hidden swiftcc { float, float, float, float } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
-  // armv7s-ios: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // armv7s-ios: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // arm64-ios: define hidden swiftcc { i64, i64 } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
   // arm64-ios: define hidden [[ARM64_MYRECT]] @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*) unnamed_addr {{.*}} {
   // x86_64-tvos: define hidden swiftcc { i64, i64 } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
   // x86_64-tvos: define hidden { <2 x float>, <2 x float> } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*) unnamed_addr {{.*}} {
   // arm64-tvos: define hidden swiftcc { i64, i64 }  @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
   // arm64-tvos: define hidden [[ARM64_MYRECT]] @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*) unnamed_addr {{.*}} {
-  // i386-watchos: define hidden swiftcc void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%TSC6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
-  // i386-watchos: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // i386-watchos: define hidden swiftcc void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%TSo6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
+  // i386-watchos: define hidden void @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // armv7k-watchos: define hidden swiftcc { float, float, float, float } @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
   // armv7k-watchos: define hidden [[ARMV7K_MYRECT]] @"$S8abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*) unnamed_addr {{.*}} {
   dynamic func bar() -> MyRect {
@@ -44,7 +44,7 @@ class Foo {
 
 
   // x86_64-macosx: define hidden swiftcc double @"$S8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(double, double, double, double, %T8abitypes3FooC* swiftself) {{.*}} {
-  // x86_64-macosx: define hidden double @"$S8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*, %TSC6CGRectV* byval align 8) unnamed_addr {{.*}} {
+  // x86_64-macosx: define hidden double @"$S8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*, %TSo6CGRectV* byval align 8) unnamed_addr {{.*}} {
   // armv7-ios: define hidden swiftcc double @"$S8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(float, float, float, float, %T8abitypes3FooC* swiftself) {{.*}} {
   // armv7-ios: define hidden double @"$S8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*, [4 x i32]) unnamed_addr {{.*}} {
   // armv7s-ios: define hidden swiftcc double @"$S8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(float, float, float, float, %T8abitypes3FooC* swiftself) {{.*}} {
@@ -107,7 +107,7 @@ class Foo {
   }
 
   // Ensure that MyRect is passed as an indirect-byval on x86_64 because we run out of registers for direct arguments
-  // x86_64-macosx: define hidden float @"$S8abitypes3FooC25getXFromRectIndirectByVal{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*, float, float, float, float, float, float, float, %TSC6MyRectV* byval align 8) unnamed_addr {{.*}} {
+  // x86_64-macosx: define hidden float @"$S8abitypes3FooC25getXFromRectIndirectByVal{{[_0-9a-zA-Z]*}}FTo"(i8*, i8*, float, float, float, float, float, float, float, %TSo6MyRectV* byval align 8) unnamed_addr {{.*}} {
   dynamic func getXFromRectIndirectByVal(_: Float, second _: Float, 
                                        third _: Float, fourth _: Float,
                                        fifth _: Float, sixth _: Float,
@@ -168,7 +168,7 @@ class Foo {
   }
 
   // x86_64-macosx: define hidden swiftcc { double, double, double } @"$S8abitypes3FooC3baz{{[_0-9a-zA-Z]*}}F"(%T8abitypes3FooC* swiftself) {{.*}} {
-  // x86_64-macosx: define hidden void @"$S8abitypes3FooC3baz{{[_0-9a-zA-Z]*}}FTo"(%TSC4TrioV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // x86_64-macosx: define hidden void @"$S8abitypes3FooC3baz{{[_0-9a-zA-Z]*}}FTo"(%TSo4TrioV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   dynamic func baz() -> Trio {
     return Trio(i: 1.0, j: 2.0, k: 3.0)
   }
@@ -176,7 +176,7 @@ class Foo {
   // x86_64-macosx:      define hidden swiftcc double @"$S8abitypes3FooC4bazc{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC*, %T8abitypes3FooC* swiftself) {{.*}} {
   // x86_64-macosx:      load i8*, i8** @"\01L_selector(newTrio)", align 8
   // x86_64-macosx:      [[CAST:%[0-9]+]] = bitcast {{%.*}}* %0
-  // x86_64-macosx:      call void bitcast (void ()* @objc_msgSend_stret to void (%TSC4TrioV*, [[OPAQUE:.*]]*, i8*)*)
+  // x86_64-macosx:      call void bitcast (void ()* @objc_msgSend_stret to void (%TSo4TrioV*, [[OPAQUE:.*]]*, i8*)*)
   func bazc(_ p: StructReturns) -> Double {
     return p.newTrio().j
   }
@@ -509,10 +509,10 @@ class Foo {
   }
 
   // arm64-ios: define hidden swiftcc { i64, i64, i64, i64 } @"$S8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC*, i64, i64, i64, i64, %T8abitypes3FooC* swiftself) {{.*}} {
-  // arm64-ios: define hidden void @"$S8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSC9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSC9BigStructV*) unnamed_addr {{.*}} {
+  // arm64-ios: define hidden void @"$S8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSo9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSo9BigStructV*) unnamed_addr {{.*}} {
   //
   // arm64-tvos: define hidden swiftcc { i64, i64, i64, i64 } @"$S8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC*, i64, i64, i64, i64, %T8abitypes3FooC* swiftself) {{.*}} {
-  // arm64-tvos: define hidden void @"$S8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSC9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSC9BigStructV*) unnamed_addr {{.*}} {
+  // arm64-tvos: define hidden void @"$S8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSo9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSo9BigStructV*) unnamed_addr {{.*}} {
   dynamic func callJustReturn(_ r: StructReturns, with v: BigStruct) -> BigStruct {
     return r.justReturn(v)
   }
@@ -529,11 +529,11 @@ class Foo {
 // armv7k-watchos: define internal %struct.One @makeOne(float %f, float %s)
 
 // rdar://17631440 - Expand direct arguments that are coerced to aggregates.
-// x86_64-macosx: define{{( protected)?}} swiftcc float @"$S8abitypes13testInlineAggySfSC6MyRectVF"(i64, i64) {{.*}} {
-// x86_64-macosx: [[COERCED:%.*]] = alloca %TSC6MyRectV, align 8
+// x86_64-macosx: define{{( protected)?}} swiftcc float @"$S8abitypes13testInlineAggySfSo6MyRectVF"(i64, i64) {{.*}} {
+// x86_64-macosx: [[COERCED:%.*]] = alloca %TSo6MyRectV, align 8
 // x86_64-macosx: store i64 %
 // x86_64-macosx: store i64 %
-// x86_64-macosx: [[CAST:%.*]] = bitcast %TSC6MyRectV* [[COERCED]] to { <2 x float>, <2 x float> }*
+// x86_64-macosx: [[CAST:%.*]] = bitcast %TSo6MyRectV* [[COERCED]] to { <2 x float>, <2 x float> }*
 // x86_64-macosx: [[T0:%.*]] = getelementptr inbounds { <2 x float>, <2 x float> }, { <2 x float>, <2 x float> }* [[CAST]], i32 0, i32 0
 // x86_64-macosx: [[FIRST_HALF:%.*]] = load <2 x float>, <2 x float>* [[T0]], align 8
 // x86_64-macosx: [[T0:%.*]] = getelementptr inbounds { <2 x float>, <2 x float> }, { <2 x float>, <2 x float> }* [[CAST]], i32 0, i32 1
@@ -547,8 +547,8 @@ public func testInlineAgg(_ rect: MyRect) -> Float {
 // We need to allocate enough memory on the stack to hold the argument value we load.
 // arm64-ios: define swiftcc void @"$S8abitypes14testBOOLStructyyF"()
 // arm64-ios:  [[COERCED:%.*]] = alloca i64
-// arm64-ios:  [[STRUCTPTR:%.*]] = bitcast i64* [[COERCED]] to %TSC14FiveByteStructV
-// arm64-ios:  [[PTR0:%.*]] = getelementptr inbounds %TSC14FiveByteStructV, %TSC14FiveByteStructV* [[STRUCTPTR]], {{i.*}} 0, {{i.*}} 0
+// arm64-ios:  [[STRUCTPTR:%.*]] = bitcast i64* [[COERCED]] to %TSo14FiveByteStructV
+// arm64-ios:  [[PTR0:%.*]] = getelementptr inbounds %TSo14FiveByteStructV, %TSo14FiveByteStructV* [[STRUCTPTR]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  [[PTR1:%.*]] = getelementptr inbounds %T10ObjectiveC8ObjCBoolV, %T10ObjectiveC8ObjCBoolV* [[PTR0]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  [[PTR2:%.*]] = getelementptr inbounds %TSb, %TSb* [[PTR1]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  store i1 false, i1* [[PTR2]], align 8

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -40,7 +40,7 @@ public struct BigBigStruct {
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @testBitfieldInBlock
-// CHECK:         call void {{%.*}}(%TSC11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSC11BitfieldOneV* byval align 8 {{%.*}})
+// CHECK:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne
@@ -48,7 +48,7 @@ entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @testTupleExtract
-// CHECK:         call void {{%.*}}(%TSC11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSC11BitfieldOneV* byval align 8 {{%.*}})
+// CHECK:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testTupleExtract : $@convention(thin) (@owned (BitfieldOne, @convention(block) (BitfieldOne) -> BitfieldOne), BitfieldOne) -> BitfieldOne  {
 entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x : $BitfieldOne):
   %a = tuple_extract %b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), 1

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -20,8 +20,8 @@ func test_indirect_by_val_alignment() {
 }
 
 // x86_64-LABEL: define hidden swiftcc void  @"$S11c_functions30test_indirect_by_val_alignmentyyF"()
-// x86_64: %indirect-temporary = alloca %TSC7a_thingV, align [[ALIGN:[0-9]+]]
-// x86_64: [[CAST:%.*]] = bitcast %TSC7a_thingV* %indirect-temporary to %struct.a_thing*
+// x86_64: %indirect-temporary = alloca %TSo7a_thingV, align [[ALIGN:[0-9]+]]
+// x86_64: [[CAST:%.*]] = bitcast %TSo7a_thingV* %indirect-temporary to %struct.a_thing*
 // x86_64: call void @log_a_thing(%struct.a_thing* byval align [[ALIGN]] [[CAST]])
 // x86_64: define internal void @log_a_thing(%struct.a_thing* byval align [[ALIGN]]
 

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -20,8 +20,8 @@ func test_indirect_by_val_alignment() {
 }
 
 // x86_64-LABEL: define hidden swiftcc void  @"$S11c_functions30test_indirect_by_val_alignmentyyF"()
-// x86_64: %indirect-temporary = alloca %TSo7a_thingV, align [[ALIGN:[0-9]+]]
-// x86_64: [[CAST:%.*]] = bitcast %TSo7a_thingV* %indirect-temporary to %struct.a_thing*
+// x86_64: %indirect-temporary = alloca %TSo7a_thinga, align [[ALIGN:[0-9]+]]
+// x86_64: [[CAST:%.*]] = bitcast %TSo7a_thinga* %indirect-temporary to %struct.a_thing*
 // x86_64: call void @log_a_thing(%struct.a_thing* byval align [[ALIGN]] [[CAST]])
 // x86_64: define internal void @log_a_thing(%struct.a_thing* byval align [[ALIGN]]
 

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -7,13 +7,13 @@ import Swift
 
 // TODO: Provide tests for other architectures
 
-// CHECK-x86_64: %TSC11BitfieldOneV = type <{ %Ts6UInt32V, %TSC6NestedV, [4 x i8], [4 x i8], %TSf, [1 x i8], [7 x i8], %Ts6UInt64V, %Ts6UInt32V, [4 x i8] }>
-// CHECK-x86_64: %TSC6NestedV = type <{ %TSf, [3 x i8], [1 x i8] }>
+// CHECK-x86_64: %TSo11BitfieldOneV = type <{ %Ts6UInt32V, %TSo6NestedV, [4 x i8], [4 x i8], %TSf, [1 x i8], [7 x i8], %Ts6UInt64V, %Ts6UInt32V, [4 x i8] }>
+// CHECK-x86_64: %TSo6NestedV = type <{ %TSf, [3 x i8], [1 x i8] }>
 
-// CHECK-x86_64: %TSC26BitfieldSeparatorReferenceV = type [[BITFIELD_SEP_TYPE:<{ %Ts5UInt8V, \[3 x i8\], %Ts5UInt8V }>]]
-// CHECK-x86_64: %TSC25BitfieldSeparatorSameNameV = type [[BITFIELD_SEP_TYPE]]
-// CHECK-x86_64: %TSC36BitfieldSeparatorDifferentNameStructV = type [[BITFIELD_SEP_TYPE]]
-// CHECK-x86_64: %TSC21BitfieldSeparatorAnonV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo26BitfieldSeparatorReferenceV = type [[BITFIELD_SEP_TYPE:<{ %Ts5UInt8V, \[3 x i8\], %Ts5UInt8V }>]]
+// CHECK-x86_64: %TSo25BitfieldSeparatorSameNameV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo36BitfieldSeparatorDifferentNameStructV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo21BitfieldSeparatorAnonV = type [[BITFIELD_SEP_TYPE]]
 
 sil public_external @createBitfieldOne : $@convention(c) () -> BitfieldOne
 sil public_external @consumeBitfieldOne : $@convention(c) (BitfieldOne) -> ()
@@ -28,68 +28,68 @@ bb0:
   return %r : $()
 }
 // CHECK-x86_64: define{{( protected)?}} swiftcc void @test0()
-// CHECK-x86_64:   [[RESULT:%.*]] = alloca %TSC11BitfieldOneV, align 8
-// CHECK-x86_64:   [[ARG:%.*]] = alloca %TSC11BitfieldOneV, align 8
+// CHECK-x86_64:   [[RESULT:%.*]] = alloca %TSo11BitfieldOneV, align 8
+// CHECK-x86_64:   [[ARG:%.*]] = alloca %TSo11BitfieldOneV, align 8
 //   Make the first call and pull all the values out of the indirect result.
-// CHECK-x86_64:   call void @createBitfieldOne(%TSC11BitfieldOneV* noalias nocapture sret [[RESULT]])
-// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 0
+// CHECK-x86_64:   call void @createBitfieldOne(%TSo11BitfieldOneV* noalias nocapture sret [[RESULT]])
+// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_A_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_A]], i32 0, i32 0
 // CHECK-x86_64:   [[A:%.*]] = load i32, i32* [[ADDR_A_V]], align 8
-// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 1
-// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 0
+// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_B_X_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_B_X]], i32 0, i32 0
 // CHECK-x86_64:   [[B_X:%.*]] = load float, float* [[ADDR_B_X_V]], align 4
-// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 1
 // CHECK-x86_64:   [[ADDR_B_YZ_1:%.*]] = bitcast [3 x i8]* [[ADDR_B_YZ]] to i24*
 // CHECK-x86_64:   [[B_YZ:%.*]] = load i24, i24* [[ADDR_B_YZ_1]], align 4
-// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 2
+// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 2
 // CHECK-x86_64:   [[ADDR_CDE_1:%.*]] = bitcast [4 x i8]* [[ADDR_CDE]] to i32*
 // CHECK-x86_64:   [[CDE:%.*]] = load i32, i32* [[ADDR_CDE_1]], align 4
-// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 3
+// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 3
 // CHECK-x86_64:   [[ADDR_FGH_1:%.*]] = bitcast [4 x i8]* [[ADDR_FGH]] to i32*
 // CHECK-x86_64:   [[FGH:%.*]] = load i32, i32* [[ADDR_FGH_1]], align 8
-// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 4
+// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 4
 // CHECK-x86_64:   [[ADDR_I_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_I]], i32 0, i32 0
 // CHECK-x86_64:   [[I:%.*]] = load float, float* [[ADDR_I_V]], align 4
-// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 5
+// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 5
 // CHECK-x86_64:   [[ADDR_JK_1:%.*]] = bitcast [1 x i8]* [[ADDR_JK]] to i8*
 // CHECK-x86_64:   [[JK:%.*]] = load i8, i8* [[ADDR_JK_1]], align 8
-// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 7
+// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 7
 // CHECK-x86_64:   [[ADDR_L_V:%.*]] = getelementptr inbounds %Ts6UInt64V, %Ts6UInt64V* [[ADDR_L]], i32 0, i32 0
 // CHECK-x86_64:   [[L:%.*]] = load i64, i64* [[ADDR_L_V]], align 8
-// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 8
+// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 8
 // CHECK-x86_64:   [[ADDR_M_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_M]], i32 0, i32 0
 // CHECK-x86_64:   [[M:%.*]] = load i32, i32* [[ADDR_M_V]], align 8
 //   Put all of the values into the indirect argument and make the second call.
-// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 0
+// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_A_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_A]], i32 0, i32 0
 // CHECK-x86_64:   store i32 [[A]], i32* [[ADDR_A_V]], align 8
-// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 1
-// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 0
+// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_B_X_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_B_X]], i32 0, i32 0
 // CHECK-x86_64:   store float [[B_X]], float* [[ADDR_B_X_V]], align 4
-// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 1
 // CHECK-x86_64:   [[ADDR_B_YZ_1:%.*]] = bitcast [3 x i8]* [[ADDR_B_YZ]] to i24*
 // CHECK-x86_64:   store i24 [[B_YZ]], i24* [[ADDR_B_YZ_1]], align 4
-// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 2
+// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 2
 // CHECK-x86_64:   [[ADDR_CDE_1:%.*]] = bitcast [4 x i8]* [[ADDR_CDE]] to i32*
 // CHECK-x86_64:   store i32 [[CDE]], i32* [[ADDR_CDE_1]], align 4
-// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 3
+// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 3
 // CHECK-x86_64:   [[ADDR_FGH_1:%.*]] = bitcast [4 x i8]* [[ADDR_FGH]] to i32*
 // CHECK-x86_64:   store i32 [[FGH]], i32* [[ADDR_FGH_1]], align 8
-// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 4
+// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 4
 // CHECK-x86_64:   [[ADDR_I_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_I]], i32 0, i32 0
 // CHECK-x86_64:   store float [[I]], float* [[ADDR_I_V]], align 4
-// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 5
+// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 5
 // CHECK-x86_64:   [[ADDR_JK_1:%.*]] = bitcast [1 x i8]* [[ADDR_JK]] to i8*
 // CHECK-x86_64:   store i8 [[JK]], i8* [[ADDR_JK_1]], align 8
-// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 7
+// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 7
 // CHECK-x86_64:   [[ADDR_L_V:%.*]] = getelementptr inbounds %Ts6UInt64V, %Ts6UInt64V* [[ADDR_L]], i32 0, i32 0
 // CHECK-x86_64:   store i64 [[L]], i64* [[ADDR_L_V]], align 8
-// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 8
+// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 8
 // CHECK-x86_64:   [[ADDR_M_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_M]], i32 0, i32 0
 // CHECK-x86_64:   store i32 [[M]], i32* [[ADDR_M_V]], align 8
-// CHECK-x86_64:   call void @consumeBitfieldOne(%TSC11BitfieldOneV* byval align 8 [[ARG]])
+// CHECK-x86_64:   call void @consumeBitfieldOne(%TSo11BitfieldOneV* byval align 8 [[ARG]])
 // CHECK-x86_64:   ret void
 
 
@@ -320,7 +320,7 @@ entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
 }
 
 // CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testBitfieldInBlock
-// CHECK-x86_64:         call void {{%.*}}(%TSC11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSC11BitfieldOneV* byval align 8 {{%.*}})
+// CHECK-x86_64:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -13,7 +13,7 @@ import Swift
 // CHECK-x86_64: %TSo26BitfieldSeparatorReferenceV = type [[BITFIELD_SEP_TYPE:<{ %Ts5UInt8V, \[3 x i8\], %Ts5UInt8V }>]]
 // CHECK-x86_64: %TSo25BitfieldSeparatorSameNameV = type [[BITFIELD_SEP_TYPE]]
 // CHECK-x86_64: %TSo36BitfieldSeparatorDifferentNameStructV = type [[BITFIELD_SEP_TYPE]]
-// CHECK-x86_64: %TSo21BitfieldSeparatorAnonV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo21BitfieldSeparatorAnona = type [[BITFIELD_SEP_TYPE]]
 
 sil public_external @createBitfieldOne : $@convention(c) () -> BitfieldOne
 sil public_external @consumeBitfieldOne : $@convention(c) (BitfieldOne) -> ()

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -4,35 +4,35 @@
 // REQUIRES: objc_interop
 
 // CHECK: [[TYPE:%swift.type]] = type
-// CHECK: [[REFRIGERATOR:%TSo14CCRefrigeratorC]] = type
-// CHECK: [[MUTABLE_REFRIGERATOR:%TSo21CCMutableRefrigeratorC]] = type
+// CHECK: [[REFRIGERATOR:%TSo17CCRefrigeratorRefa]] = type
+// CHECK: [[MUTABLE_REFRIGERATOR:%TSo24CCMutableRefrigeratorRefa]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 
-// CHECK: [[REFRIGERATOR_NAME:@.*]] = private constant [20 x i8] c"So14CCRefrigeratorC\00"
+// CHECK: [[REFRIGERATOR_NAME:@.*]] = private constant [23 x i8] c"So17CCRefrigeratorRefa\00"
 
-// CHECK-32: @"$SSo14CCRefrigeratorCN" = linkonce_odr hidden global <{ {{.*}} }> <{
+// CHECK-32: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
 // CHECK-32-SAME: [[REFRIGERATOR_NAME]] to i32
 // CHECK-32-SAME: i32 0,
-// CHECK-32-SAME: i8** @"$SBOWV", i32 16, {{.*}}"$SSo14CCRefrigeratorCMn", [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK-32-SAME: i8** @"$SBOWV", i32 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
-// CHECK-64: @"$SSo14CCRefrigeratorCN" = linkonce_odr hidden global <{ {{.*}} }> <{
+// CHECK-64: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
 // CHECK-64-SAME: i32 0,
 // CHECK-64-SAME: i32 trunc {{.*}} [[REFRIGERATOR_NAME]] to i64
 // CHECK-64-SAME: i64 0,
-// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo14CCRefrigeratorCMn", [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
-// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [27 x i8] c"So21CCMutableRefrigeratorC\00"
+// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [30 x i8] c"So24CCMutableRefrigeratorRefa\00"
 
-// CHECK-64: @"$SSo21CCMutableRefrigeratorCMn" = linkonce_odr hidden constant
+// CHECK-64: @"$SSo24CCMutableRefrigeratorRefaMn" = linkonce_odr hidden constant
 // CHECK-64-SAME: [[MUTABLE_REFRIGERATOR_NAME]]
 // CHECK-64-SAME: @get_field_types_CCMutableRefrigerator
 // CHECK-64-SAME: i16 1, i16 2, i32 0 }>
 
-// CHECK-64: @"$SSo21CCMutableRefrigeratorCN" = linkonce_odr hidden global <{ {{.*}} }> <{
+// CHECK-64: @"$SSo24CCMutableRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
 // CHECK-64-SAME: @initialize_metadata_CCMutableRefrigerator
 // CHECK-64-SAME: i32 trunc {{.*}} [[MUTABLE_REFRIGERATOR_NAME]] to i64
 // CHECK-64-SAME: i64 1,
-// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo21CCMutableRefrigeratorCMn", [[TYPE]]* bitcast{{.*}}@"$SSo14CCRefrigeratorCN{{.*}} to %swift.type*), i8* null, i8* null, i8* null }>
+// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo24CCMutableRefrigeratorRefaMn", [[TYPE]]* bitcast{{.*}}@"$SSo17CCRefrigeratorRefaN{{.*}} to %swift.type*), i8* null, i8* null, i8* null }>
 
 sil_stage canonical
 
@@ -52,16 +52,16 @@ bb0(%0 : $CCRefrigerator, %1: $CCMutableRefrigerator):
 
 // CHECK:    define{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*, [[MUTABLE_REFRIGERATOR]]*) {{.*}} {
 // CHECK:      [[T0:%.*]] = bitcast [[REFRIGERATOR]]* %0 to [[OBJC]]*
-// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @"$SSo14CCRefrigeratorCMa"()
+// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @"$SSo17CCRefrigeratorRefaMa"()
 // CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T1]])
 // CHECK:      [[T0:%.*]] = bitcast [[MUTABLE_REFRIGERATOR]]* %1 to [[OBJC]]*
-// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @"$SSo21CCMutableRefrigeratorCMa"()
+// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @"$SSo24CCMutableRefrigeratorRefaMa"()
 // CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T1]])
 // CHECK-NEXT: ret void
 
-// CHECK:    define linkonce_odr hidden [[TYPE]]* @"$SSo14CCRefrigeratorCMa"()
-// CHECK-32:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo14CCRefrigeratorCN" to i8*), i32 12) to [[TYPE]]*))
-// CHECK-64:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo14CCRefrigeratorCN" to i8*), i64 24) to [[TYPE]]*))
+// CHECK:    define linkonce_odr hidden [[TYPE]]* @"$SSo17CCRefrigeratorRefaMa"()
+// CHECK-32:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo17CCRefrigeratorRefaN" to i8*), i32 12) to [[TYPE]]*))
+// CHECK-64:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo17CCRefrigeratorRefaN" to i8*), i64 24) to [[TYPE]]*))
 
 // CHECK:    define private void @initialize_metadata_CCMutableRefrigerator(%swift.type*)
 // CHECK-64:   [[T0:%.*]] = bitcast %swift.type* %0 to i8**

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -3,12 +3,12 @@
 sil_stage canonical
 import c_layout
 
-// CHECK-LABEL: @"$SSC14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden global
+// CHECK-LABEL: @"$SSo14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden global
 // CHECK-SAME:  [[INT:i[0-9]+]] sub ([[INT]] ptrtoint
 // CHECK-SAME:  [[INT]] 0,
-// CHECK-SAME:  @"$SSC14HasNestedUnionV18__Unnamed_struct_sVWV"
+// CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVWV"
 // CHECK-SAME:  [[INT]] 1,
-// CHECK-SAME:  @"$SSC14HasNestedUnionV18__Unnamed_struct_sVMn"
+// CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVMn"
 // CHECK-SAME:  [[INT]] 0,
 // CHECK-SAME:  [[INT]] 4 }
 

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -9,11 +9,11 @@ import Newtype
 // REQUIRES: objc_interop
 
 // Witness table for synthesized ClosedEnums : _ObjectiveCBridgeable.
-// CHECK: @"$SSC10ClosedEnumVs21_ObjectiveCBridgeable7NewtypeWP" = linkonce_odr
+// CHECK: @"$SSo10ClosedEnumVs21_ObjectiveCBridgeable7NewtypeWP" = linkonce_odr
 
-// CHECK-LABEL: define swiftcc %TSo8NSStringC* @"$S7newtype14getErrorDomainSC0cD0VyF"()
+// CHECK-LABEL: define swiftcc %TSo8NSStringC* @"$S7newtype14getErrorDomainSo0cD0VyF"()
 public func getErrorDomain() -> ErrorDomain {
-  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSC11ErrorDomainV, %TSC11ErrorDomainV* {{.*}}@SNTErrOne
+  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSo11ErrorDomainV, %TSo11ErrorDomainV* {{.*}}@SNTErrOne
   return .one
 }
 
@@ -39,7 +39,7 @@ public func getGlobalNotification(_ x: Int) -> String {
 // CHECK: ret
 }
 
-// CHECK-LABEL: $S7newtype17getCFNewTypeValue6useVarSC0cD0VSb_tF
+// CHECK-LABEL: $S7newtype17getCFNewTypeValue6useVarSo0cD0VSb_tF
 public func getCFNewTypeValue(useVar: Bool) -> CFNewType {
   if (useVar) {
     return CFNewType.MyCFNewTypeValue
@@ -132,26 +132,26 @@ public func anchor() -> Bool {
 }
 
 class ObjCTest {
-  // CHECK-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySC11ErrorDomainVSgAGFTo"
+  // CHECK-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGFTo"
   // CHECK: [[CASTED:%.+]] = ptrtoint %0* %2 to i{{32|64}}
-  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @"$S7newtype8ObjCTestC19optionalPassThroughySC11ErrorDomainVSgAGF"(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @"$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGF"(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[RESULT]] to %0*
   // CHECK: ret %0* [[OPAQUE_RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySC11ErrorDomainVSgAGFTo"
+  // OPT-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGFTo"
   // OPT: ret %0* %2
   // OPT: {{^}$}}
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }
 
-  // CHECK-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySC5MyIntVAFFTo"
-  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @"$S7newtype8ObjCTestC18integerPassThroughySC5MyIntVAFF"(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFFTo"
+  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFF"(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: ret i32 [[RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySC5MyIntVAFFTo"
+  // OPT-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFFTo"
   // OPT: ret i32 %2
   // OPT: {{^}$}}
   @objc func integerPassThrough(_ num: MyInt) -> MyInt {

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -9,7 +9,7 @@ import Newtype
 // REQUIRES: objc_interop
 
 // Witness table for synthesized ClosedEnums : _ObjectiveCBridgeable.
-// CHECK: @"$SSo13SNTClosedEnumas21_ObjectiveCBridgeable7NewtypeWP" = linkonce_odr
+// CHECK: @"$SSo13SNTClosedEnumas21_ObjectiveCBridgeableSCWP" = linkonce_odr
 
 // CHECK-LABEL: define swiftcc %TSo8NSStringC* @"$S7newtype14getErrorDomainSo08SNTErrorD0ayF"()
 public func getErrorDomain() -> ErrorDomain {

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -9,15 +9,15 @@ import Newtype
 // REQUIRES: objc_interop
 
 // Witness table for synthesized ClosedEnums : _ObjectiveCBridgeable.
-// CHECK: @"$SSo10ClosedEnumVs21_ObjectiveCBridgeable7NewtypeWP" = linkonce_odr
+// CHECK: @"$SSo13SNTClosedEnumas21_ObjectiveCBridgeable7NewtypeWP" = linkonce_odr
 
-// CHECK-LABEL: define swiftcc %TSo8NSStringC* @"$S7newtype14getErrorDomainSo0cD0VyF"()
+// CHECK-LABEL: define swiftcc %TSo8NSStringC* @"$S7newtype14getErrorDomainSo08SNTErrorD0ayF"()
 public func getErrorDomain() -> ErrorDomain {
-  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSo11ErrorDomainV, %TSo11ErrorDomainV* {{.*}}@SNTErrOne
+  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSo14SNTErrorDomaina, %TSo14SNTErrorDomaina* {{.*}}@SNTErrOne
   return .one
 }
 
-// CHECK-LABEL: $S7newtype6getFooSo14NSNotificationC4NameVyF
+// CHECK-LABEL: $S7newtype6getFooSo18NSNotificationNameayF
 public func getFoo() -> NSNotification.Name {
   return NSNotification.Name.Foo
   // CHECK: load {{.*}} @FooNotification
@@ -39,7 +39,7 @@ public func getGlobalNotification(_ x: Int) -> String {
 // CHECK: ret
 }
 
-// CHECK-LABEL: $S7newtype17getCFNewTypeValue6useVarSo0cD0VSb_tF
+// CHECK-LABEL: $S7newtype17getCFNewTypeValue6useVarSo0cD0aSb_tF
 public func getCFNewTypeValue(useVar: Bool) -> CFNewType {
   if (useVar) {
     return CFNewType.MyCFNewTypeValue
@@ -51,7 +51,7 @@ public func getCFNewTypeValue(useVar: Bool) -> CFNewType {
   // CHECK: ret
 }
 
-// CHECK-LABEL: $S7newtype21getUnmanagedCFNewType6useVars0C0VySo8CFStringCGSb_tF
+// CHECK-LABEL: $S7newtype21getUnmanagedCFNewType6useVars0C0VySo11CFStringRefaGSb_tF
 public func getUnmanagedCFNewType(useVar: Bool) -> Unmanaged<CFString> {
   if (useVar) {
     return CFNewType.MyCFNewTypeValueUnaudited
@@ -132,26 +132,26 @@ public func anchor() -> Bool {
 }
 
 class ObjCTest {
-  // CHECK-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGFTo"
+  // CHECK-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo"
   // CHECK: [[CASTED:%.+]] = ptrtoint %0* %2 to i{{32|64}}
-  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @"$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGF"(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @"$S7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGF"(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[RESULT]] to %0*
   // CHECK: ret %0* [[OPAQUE_RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGFTo"
+  // OPT-LABEL: define hidden %0* @"$S7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo"
   // OPT: ret %0* %2
   // OPT: {{^}$}}
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }
 
-  // CHECK-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFFTo"
-  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFF"(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntaAFFTo"
+  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntaAFF"(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: ret i32 [[RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFFTo"
+  // OPT-LABEL: define hidden i32 @"$S7newtype8ObjCTestC18integerPassThroughySo5MyIntaAFFTo"
   // OPT: ret i32 %2
   // OPT: {{^}$}}
   @objc func integerPassThrough(_ num: MyInt) -> MyInt {

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -15,14 +15,14 @@ import gizmo
 // CHECK: [[OBJC:%objc_object]] = type
 // CHECK: [[ID:%T4objc2idV]] = type <{ %AnyObject }>
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type
-// CHECK: [[RECT:%TSC4RectV]] = type
+// CHECK: [[RECT:%TSo4RectV]] = type
 // CHECK: [[FLOAT:%TSf]] = type
 
 // CHECK: @"\01L_selector_data(bar)" = private global [4 x i8] c"bar\00", section "__TEXT,__objc_methname,cstring_literals", align 1
 // CHECK: @"\01L_selector(bar)" = private externally_initialized global i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(bar)", i64 0, i64 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip", align 8
 
-// CHECK: @"$SSC4RectVMn" = linkonce_odr hidden constant
-// CHECK: @"$SSC4RectVN" = linkonce_odr hidden global
+// CHECK: @"$SSo4RectVMn" = linkonce_odr hidden constant
+// CHECK: @"$SSo4RectVN" = linkonce_odr hidden global
 
 // CHECK: @"\01L_selector_data(acquiesce)"
 // CHECK-NOT: @"\01L_selector_data(disharmonize)"
@@ -124,8 +124,8 @@ func test10(_ g: Gizmo, r: Rect) {
 // Force the emission of the Rect metadata.
 func test11_helper<T>(_ t: T) {}
 // NSRect's metadata needs to be uniqued at runtime using getForeignTypeMetadata.
-// CHECK-LABEL: define hidden swiftcc void @"$S4objc6test11yySC4RectVF"
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSC4RectVN"
+// CHECK-LABEL: define hidden swiftcc void @"$S4objc6test11yySo4RectVF"
+// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSo4RectVN"
 func test11(_ r: Rect) { test11_helper(r) }
 
 class WeakObjC {

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -10,9 +10,9 @@
 // CHECK: [[FOO:%T17objc_class_export3FooC]] = type <{ [[REF]], %TSi }>
 // CHECK: [[INT:%TSi]] = type <{ i64 }>
 // CHECK: [[DOUBLE:%TSd]] = type <{ double }>
-// CHECK: [[NSRECT:%TSC6NSRectV]] = type <{ %TSC7NSPointV, %TSC6NSSizeV }>
-// CHECK: [[NSPOINT:%TSC7NSPointV]] = type <{ %TSd, %TSd }>
-// CHECK: [[NSSIZE:%TSC6NSSizeV]] = type <{ %TSd, %TSd }>
+// CHECK: [[NSRECT:%TSo6NSRectV]] = type <{ %TSo7NSPointV, %TSo6NSSizeV }>
+// CHECK: [[NSPOINT:%TSo7NSPointV]] = type <{ %TSd, %TSd }>
+// CHECK: [[NSSIZE:%TSo6NSSizeV]] = type <{ %TSd, %TSd }>
 // CHECK: [[OBJC:%objc_object]] = type opaque
 
 // CHECK: @"OBJC_METACLASS_$__TtC17objc_class_export3Foo" = hidden global %objc_class {
@@ -58,7 +58,7 @@
 // CHECK:   %swift.opaque* null,
 // CHECK:   i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC17objc_class_export3Foo to i64), i64 1),
 // CHECK:   [[FOO]]* (%swift.type*)* @"$S17objc_class_export3FooC6createACyFZ",
-// CHECK:   void (double, double, double, double, [[FOO]]*)* @"$S17objc_class_export3FooC10drawInRect5dirtyySC6NSRectV_tF"
+// CHECK:   void (double, double, double, double, [[FOO]]*)* @"$S17objc_class_export3FooC10drawInRect5dirtyySo6NSRectV_tF"
 // CHECK: }>, section "__DATA,__objc_data, regular"
 // -- TODO: The OBJC_CLASS symbol should reflect the qualified runtime name of
 //    Foo.
@@ -82,25 +82,25 @@ struct BigStructWithNativeObjects {
 
   @objc func drawInRect(dirty dirty: NSRect) {
   }
-  // CHECK: define internal void @"$S17objc_class_export3FooC10drawInRect5dirtyySC6NSRectV_tFTo"([[OPAQUE:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
+  // CHECK: define internal void @"$S17objc_class_export3FooC10drawInRect5dirtyySo6NSRectV_tFTo"([[OPAQUE:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
   // CHECK:   [[CAST:%[a-zA-Z0-9]+]] = bitcast [[OPAQUE]]* %0 to [[FOO]]*
-  // CHECK:   call swiftcc void @"$S17objc_class_export3FooC10drawInRect5dirtyySC6NSRectV_tF"(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
+  // CHECK:   call swiftcc void @"$S17objc_class_export3FooC10drawInRect5dirtyySo6NSRectV_tF"(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
   // CHECK: }
 
   @objc func bounds() -> NSRect {
     return NSRect(origin: NSPoint(x: 0, y: 0), 
                   size: NSSize(width: 0, height: 0))
   }
-  // CHECK: define internal void @"$S17objc_class_export3FooC6boundsSC6NSRectVyFTo"([[NSRECT]]* noalias nocapture sret, [[OPAQUE4:%.*]]*, i8*) unnamed_addr {{.*}} {
+  // CHECK: define internal void @"$S17objc_class_export3FooC6boundsSo6NSRectVyFTo"([[NSRECT]]* noalias nocapture sret, [[OPAQUE4:%.*]]*, i8*) unnamed_addr {{.*}} {
   // CHECK:   [[CAST:%[a-zA-Z0-9]+]] = bitcast [[OPAQUE4]]* %1 to [[FOO]]*
-  // CHECK:   call swiftcc { double, double, double, double } @"$S17objc_class_export3FooC6boundsSC6NSRectVyF"([[FOO]]* swiftself [[CAST]])
+  // CHECK:   call swiftcc { double, double, double, double } @"$S17objc_class_export3FooC6boundsSo6NSRectVyF"([[FOO]]* swiftself [[CAST]])
 
   @objc func convertRectToBacking(r r: NSRect) -> NSRect {
     return r
   }
-  // CHECK: define internal void @"$S17objc_class_export3FooC20convertRectToBacking1rSC6NSRectVAG_tFTo"([[NSRECT]]* noalias nocapture sret, [[OPAQUE5:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
+  // CHECK: define internal void @"$S17objc_class_export3FooC20convertRectToBacking1rSo6NSRectVAG_tFTo"([[NSRECT]]* noalias nocapture sret, [[OPAQUE5:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
   // CHECK:   [[CAST:%[a-zA-Z0-9]+]] = bitcast [[OPAQUE5]]* %1 to [[FOO]]*
-  // CHECK:   call swiftcc { double, double, double, double } @"$S17objc_class_export3FooC20convertRectToBacking1rSC6NSRectVAG_tF"(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
+  // CHECK:   call swiftcc { double, double, double, double } @"$S17objc_class_export3FooC20convertRectToBacking1rSo6NSRectVAG_tF"(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
 
   func doStuffToSwiftSlice(f f: [Int]) {
   }

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -71,7 +71,7 @@ entry(%0: $Subclass):
   unreachable
 }
 
-sil @$S27objc_generic_class_metadata8SubclassC7optionsSQyACGs10DictionaryVySC13GenericOptionVypGSg_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
+sil @$S27objc_generic_class_metadata8SubclassC7optionsSQyACGs10DictionaryVySo13GenericOptionVypGSg_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
 entry(%0: $Subclass, %1: $NSDictionary):
   unreachable
 }

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -71,7 +71,7 @@ entry(%0: $Subclass):
   unreachable
 }
 
-sil @$S27objc_generic_class_metadata8SubclassC7optionsSQyACGs10DictionaryVySo13GenericOptionVypGSg_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
+sil @$S27objc_generic_class_metadata8SubclassC7optionsSQyACGs10DictionaryVySo13GenericOptionaypGSg_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
 entry(%0: $Subclass, %1: $NSDictionary):
   unreachable
 }

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -8,71 +8,71 @@
 import Foundation
 import gizmo
 
-// CHECK: @"$SSo16NSRuncingOptionsOWV" = linkonce_odr hidden constant
-// CHECK: @"$SSo16NSRuncingOptionsOMn" = linkonce_odr hidden constant
-// CHECK: @"$SSo16NSRuncingOptionsON" = linkonce_odr hidden global
-// CHECK: @"$SSo28NeverActuallyMentionedByNameOs9Equatable5gizmoWP" = linkonce_odr hidden constant
+// CHECK: @"$SSo16NSRuncingOptionsVWV" = linkonce_odr hidden constant
+// CHECK: @"$SSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
+// CHECK: @"$SSo16NSRuncingOptionsVN" = linkonce_odr hidden global
+// CHECK: @"$SSo28NeverActuallyMentionedByNameVs9Equatable5gizmoWP" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( protected)?}} i32 @main
-// CHECK:         call %swift.type* @"$SSo16NSRuncingOptionsOMa"()
+// CHECK:         call %swift.type* @"$SSo16NSRuncingOptionsVMa"()
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsVyF"()
 // CHECK:   ret i16 123
 func imported_enum_inject_a() -> NSRuncingOptions {
   return .mince
 }
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_bSo16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_bSo16NSRuncingOptionsVyF"()
 // CHECK:   ret i16 4567
 func imported_enum_inject_b() -> NSRuncingOptions {
   return .quinceSliced
 }
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_cSo16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_cSo16NSRuncingOptionsVyF"()
 // CHECK:   ret i16 5678
 func imported_enum_inject_c() -> NSRuncingOptions {
   return .quinceJulienned
 }
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_dSo16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_dSo16NSRuncingOptionsVyF"()
 // CHECK:   ret i16 6789
 func imported_enum_inject_d() -> NSRuncingOptions {
   return .quinceDiced
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_aSo16NSRadixedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_aSo16NSRadixedOptionsVyF"() {{.*}} {
 // -- octal 0755
 // CHECK:   ret i32 493
 func imported_enum_inject_radixed_a() -> NSRadixedOptions {
   return .octal
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_bSo16NSRadixedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_bSo16NSRadixedOptionsVyF"() {{.*}} {
 // -- hex 0xFFFF
 // CHECK:   ret i32 65535
 func imported_enum_inject_radixed_b() -> NSRadixedOptions {
   return .hex
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_aSo17NSNegativeOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_aSo17NSNegativeOptionsVyF"() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_a() -> NSNegativeOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_bSo17NSNegativeOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_bSo17NSNegativeOptionsVyF"() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_b() -> NSNegativeOptions {
   return .bar
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_aSo25NSNegativeUnsignedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_aSo25NSNegativeUnsignedOptionsVyF"() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_unsigned_a() -> NSNegativeUnsignedOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_bSo25NSNegativeUnsignedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_bSo25NSNegativeUnsignedOptionsVyF"() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_unsigned_b() -> NSNegativeUnsignedOptions {
   return .bar
@@ -85,8 +85,8 @@ func test_enum_without_name_Equatable(_ obj: TestThatEnumType) -> Bool {
 func use_metadata<T>(_ t:T){}
 use_metadata(NSRuncingOptions.mince)
 
-// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo16NSRuncingOptionsOMa"()
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSo16NSRuncingOptionsON" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo16NSRuncingOptionsVMa"()
+// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSo16NSRuncingOptionsVN" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 @objc enum ExportedToObjC: Int {
   case Foo = -1, Bar, Bas

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -11,7 +11,7 @@ import gizmo
 // CHECK: @"$SSo16NSRuncingOptionsVWV" = linkonce_odr hidden constant
 // CHECK: @"$SSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
 // CHECK: @"$SSo16NSRuncingOptionsVN" = linkonce_odr hidden global
-// CHECK: @"$SSo28NeverActuallyMentionedByNameVs9Equatable5gizmoWP" = linkonce_odr hidden constant
+// CHECK: @"$SSo28NeverActuallyMentionedByNameVs9EquatableSCWP" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( protected)?}} i32 @main
 // CHECK:         call %swift.type* @"$SSo16NSRuncingOptionsVMa"()

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -8,71 +8,71 @@
 import Foundation
 import gizmo
 
-// CHECK: @"$SSC16NSRuncingOptionsOWV" = linkonce_odr hidden constant
-// CHECK: @"$SSC16NSRuncingOptionsOMn" = linkonce_odr hidden constant
-// CHECK: @"$SSC16NSRuncingOptionsON" = linkonce_odr hidden global
-// CHECK: @"$SSC28NeverActuallyMentionedByNameOs9Equatable5gizmoWP" = linkonce_odr hidden constant
+// CHECK: @"$SSo16NSRuncingOptionsOWV" = linkonce_odr hidden constant
+// CHECK: @"$SSo16NSRuncingOptionsOMn" = linkonce_odr hidden constant
+// CHECK: @"$SSo16NSRuncingOptionsON" = linkonce_odr hidden global
+// CHECK: @"$SSo28NeverActuallyMentionedByNameOs9Equatable5gizmoWP" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( protected)?}} i32 @main
-// CHECK:         call %swift.type* @"$SSC16NSRuncingOptionsOMa"()
+// CHECK:         call %swift.type* @"$SSo16NSRuncingOptionsOMa"()
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_aSC16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsOyF"()
 // CHECK:   ret i16 123
 func imported_enum_inject_a() -> NSRuncingOptions {
   return .mince
 }
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_bSC16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_bSo16NSRuncingOptionsOyF"()
 // CHECK:   ret i16 4567
 func imported_enum_inject_b() -> NSRuncingOptions {
   return .quinceSliced
 }
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_cSC16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_cSo16NSRuncingOptionsOyF"()
 // CHECK:   ret i16 5678
 func imported_enum_inject_c() -> NSRuncingOptions {
   return .quinceJulienned
 }
 
-// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_dSC16NSRuncingOptionsOyF"()
+// CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_dSo16NSRuncingOptionsOyF"()
 // CHECK:   ret i16 6789
 func imported_enum_inject_d() -> NSRuncingOptions {
   return .quinceDiced
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_aSC16NSRadixedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_aSo16NSRadixedOptionsOyF"() {{.*}} {
 // -- octal 0755
 // CHECK:   ret i32 493
 func imported_enum_inject_radixed_a() -> NSRadixedOptions {
   return .octal
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_bSC16NSRadixedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C17_inject_radixed_bSo16NSRadixedOptionsOyF"() {{.*}} {
 // -- hex 0xFFFF
 // CHECK:   ret i32 65535
 func imported_enum_inject_radixed_b() -> NSRadixedOptions {
   return .hex
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_aSC17NSNegativeOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_aSo17NSNegativeOptionsOyF"() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_a() -> NSNegativeOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_bSC17NSNegativeOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C18_inject_negative_bSo17NSNegativeOptionsOyF"() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_b() -> NSNegativeOptions {
   return .bar
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_aSC25NSNegativeUnsignedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_aSo25NSNegativeUnsignedOptionsOyF"() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_unsigned_a() -> NSNegativeUnsignedOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_bSC25NSNegativeUnsignedOptionsOyF"() {{.*}} {
+// CHECK: define hidden swiftcc i32 @"$S12objc_ns_enum09imported_C27_inject_negative_unsigned_bSo25NSNegativeUnsignedOptionsOyF"() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_unsigned_b() -> NSNegativeUnsignedOptions {
   return .bar
@@ -85,8 +85,8 @@ func test_enum_without_name_Equatable(_ obj: TestThatEnumType) -> Bool {
 func use_metadata<T>(_ t:T){}
 use_metadata(NSRuncingOptions.mince)
 
-// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSC16NSRuncingOptionsOMa"()
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSC16NSRuncingOptionsON" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo16NSRuncingOptionsOMa"()
+// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSo16NSRuncingOptionsON" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 @objc enum ExportedToObjC: Int {
   case Foo = -1, Bar, Bas

--- a/test/IRGen/objc_shared_imported_decl.sil
+++ b/test/IRGen/objc_shared_imported_decl.sil
@@ -13,6 +13,6 @@ sil public @use_witness : $@convention(thin) () -> () {
 }
 
 // We used to emit linkonce_odr llvm linkage for this declaration.
-sil_witness_table shared SomeOptions : Equatable module __ObjC
+sil_witness_table shared SomeOptions : Equatable module __C_Synthesized
 
-// CHECK: @"$SSo11SomeOptionsVs9Equatable6__ObjCWP" = external hidden global
+// CHECK: @"$SSo11SomeOptionsVs9EquatableSCWP" = external hidden global

--- a/test/IRGen/objc_shared_imported_decl.sil
+++ b/test/IRGen/objc_shared_imported_decl.sil
@@ -15,4 +15,4 @@ sil public @use_witness : $@convention(thin) () -> () {
 // We used to emit linkonce_odr llvm linkage for this declaration.
 sil_witness_table shared SomeOptions : Equatable module __ObjC
 
-// CHECK: @"$SSC11SomeOptionsVs9EquatableSoWP" = external hidden global
+// CHECK: @"$SSo11SomeOptionsVs9Equatable6__ObjCWP" = external hidden global

--- a/test/IRGen/objc_structs.swift
+++ b/test/IRGen/objc_structs.swift
@@ -9,7 +9,7 @@ import Foundation
 import gizmo
 
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type opaque
-// CHECK: [[NSRECT:%TSC6NSRectV]] = type <{ [[NSPOINT:%TSC7NSPointV]], [[NSSIZE:%TSC6NSSizeV]] }>
+// CHECK: [[NSRECT:%TSo6NSRectV]] = type <{ [[NSPOINT:%TSo7NSPointV]], [[NSSIZE:%TSo6NSSizeV]] }>
 // CHECK: [[NSPOINT]] = type <{ [[DOUBLE:%TSd]], [[DOUBLE]] }>
 // CHECK: [[DOUBLE]] = type <{ double }>
 // CHECK: [[NSSIZE]] = type <{ [[DOUBLE]], [[DOUBLE]] }>
@@ -61,7 +61,7 @@ func convertRectFromBase(_ v: NSView, r: NSRect) -> NSRect {
 }
 // CHECK: }
 
-// CHECK: define hidden swiftcc { {{.*}}*, {{.*}}*, {{.*}}*, {{.*}}* } @"$S12objc_structs20useStructOfNSStringsySC0deF0VADF"({{.*}}*, {{.*}}*, {{.*}}*, {{.*}}*)
+// CHECK: define hidden swiftcc { {{.*}}*, {{.*}}*, {{.*}}*, {{.*}}* } @"$S12objc_structs20useStructOfNSStringsySo0deF0VADF"({{.*}}*, {{.*}}*, {{.*}}*, {{.*}}*)
 // CHECK:   call void @useStructOfNSStringsInObjC(%struct.StructOfNSStrings* noalias nocapture sret {{%.*}}, %struct.StructOfNSStrings* byval align 8 {{%.*}})
 func useStructOfNSStrings(_ s: StructOfNSStrings) -> StructOfNSStrings {
   return useStructOfNSStringsInObjC(s)

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -14,7 +14,7 @@ import gizmo
 // CHECK: [[SUPER:%objc_super]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type
-// CHECK: [[NSRECT:%TSC6NSRectV]] = type
+// CHECK: [[NSRECT:%TSo6NSRectV]] = type
 
 class Hoozit : Gizmo {
   // CHECK: define hidden swiftcc void @"$S10objc_super6HoozitC4frobyyF"([[HOOZIT]]* swiftself) {{.*}} {
@@ -37,7 +37,7 @@ class Hoozit : Gizmo {
   }
   // CHECK: }
 
-  // CHECK: define hidden swiftcc { double, double, double, double } @"$S10objc_super6HoozitC5frameSC6NSRectVyF"(%T10objc_super6HoozitC* swiftself) {{.*}} {
+  // CHECK: define hidden swiftcc { double, double, double, double } @"$S10objc_super6HoozitC5frameSo6NSRectVyF"(%T10objc_super6HoozitC* swiftself) {{.*}} {
   override func frame() -> NSRect {
     // CHECK: [[T0:%.*]] = call [[TYPE]]* @"$S10objc_super6HoozitCMa"()
     // CHECK: [[T1:%.*]] = bitcast [[TYPE]]* [[T0]] to [[CLASS]]*

--- a/test/IRGen/objc_types_as_member.sil
+++ b/test/IRGen/objc_types_as_member.sil
@@ -8,7 +8,7 @@ import gizmo
 
 sil @use_metatype : $@convention(thin) <T> (@thin T.Type) -> ()
 
-// CHECK-LABEL: define swiftcc void @test(%TSo9InnerTypeC* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define swiftcc void @test(%TSo014OuterTypeInnerB0C* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK:   [[TMP:%.*]] = call %swift.type* @"$SSo9OuterTypeCMa"()
 // CHECK:   call swiftcc void @use_metatype(%swift.type* [[TMP]])
 // CHECK:   ret void

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -37,7 +37,7 @@ bb0(%0 : $Int, %1 : $ObjCClass):
   %v = tuple()
   return %v : $()
 }
-sil @$S18partial_apply_objc9ObjCClassC7method21rySC6NSRectV_tFTo : $@convention(objc_method) (NSRect, ObjCClass) -> () {
+sil @$S18partial_apply_objc9ObjCClassC7method21rySo6NSRectV_tFTo : $@convention(objc_method) (NSRect, ObjCClass) -> () {
 bb0(%0 : $NSRect, %1 : $ObjCClass):
   %v = tuple()
   return %v : $()
@@ -124,9 +124,9 @@ entry(%c : $ObjCClass):
 // CHECK:  ret { i8*, %swift.refcounted* } [[CLOSURE]]
 // CHECK:}
 // CHECK: define internal swiftcc void [[OBJC_PARTIAL_APPLY_STUB2]](double, double, double, double, %swift.refcounted*
-// CHECK:  [[TMP:%.*]] = alloca %TSC6NSRectV
-// CHECK:  [[ORIGIN:%.*]] = getelementptr inbounds %TSC6NSRectV, %TSC6NSRectV* [[TMP]]
-// CHECK:  [[ORIGINX:%.*]] = getelementptr inbounds %TSC7NSPointV, %TSC7NSPointV* [[ORIGIN]]
+// CHECK:  [[TMP:%.*]] = alloca %TSo6NSRectV
+// CHECK:  [[ORIGIN:%.*]] = getelementptr inbounds %TSo6NSRectV, %TSo6NSRectV* [[TMP]]
+// CHECK:  [[ORIGINX:%.*]] = getelementptr inbounds %TSo7NSPointV, %TSo7NSPointV* [[ORIGIN]]
 // CHECK:  [[ORIGINXVAL:%*]] = getelementptr inbounds %TSd, %TSd* [[ORIGINX]]
 // CHECK:  store double %0, double* [[ORIGINXVAL]]
 sil @objc_partial_apply_indirect_sil_argument : $@convention(thin) ObjCClass -> @callee_owned NSRect -> () {
@@ -201,7 +201,7 @@ entry(%c : $Gizmo):
 
 // CHECK: define internal swiftcc void @"$STa.17"(i64, i64, i64, %swift.refcounted* swiftself)
 // CHECK: [[TMPCOERCE:%.*]] = alloca { i64, i64, i64 }
-// CHECK: [[INDIRECTTEMP:%.*]] = alloca %TSC3FobV
+// CHECK: [[INDIRECTTEMP:%.*]] = alloca %TSo3FobV
 // CHECK: [[ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[TMPCOERCE]], i32 0, i32 0
 // CHECK:  store i64 %0, i64* [[ADDR]]
 // CHECK:  [[ADDR:%.]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[TMPCOERCE]], i32 0, i32 1

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -18,9 +18,9 @@ public protocol Runcible {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE:%swift.protocol\* @"\$S33protocol_conformance_records_objc8RuncibleMp"]]
 // -- nominal type descriptor
-// CHECK:           @"$SSC6NSRectVMn"
+// CHECK:           @"$SSo6NSRectVMn"
 // -- witness table
-// CHECK:           @"$SSC6NSRectV33protocol_conformance_records_objc8RuncibleACWP"
+// CHECK:           @"$SSo6NSRectV33protocol_conformance_records_objc8RuncibleACWP"
 // -- reserved
 // CHECK:           i32 0
 // CHECK:         },

--- a/test/IRGen/reflection_metadata_imported.swift
+++ b/test/IRGen/reflection_metadata_imported.swift
@@ -5,9 +5,9 @@ import c_layout
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
 
 // CHECK-DAG: @"$S28reflection_metadata_imported15HasImportedTypeVMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$SSC1AVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @"$SSC11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @"$SSC11CrappyColorVs16RawRepresentable8c_layoutMA" = linkonce_odr hidden constant {{.*}}swift3_assocty
+// CHECK-DAG: @"$SSo1AVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
+// CHECK-DAG: @"$SSo11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
+// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentable8c_layoutMA" = linkonce_odr hidden constant {{.*}}swift3_assocty
 
 struct HasImportedType {
   let a: A

--- a/test/IRGen/reflection_metadata_imported.swift
+++ b/test/IRGen/reflection_metadata_imported.swift
@@ -7,7 +7,7 @@ import c_layout
 // CHECK-DAG: @"$S28reflection_metadata_imported15HasImportedTypeVMF" = internal constant {{.*}}swift3_fieldmd
 // CHECK-DAG: @"$SSo1AVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
 // CHECK-DAG: @"$SSo11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentable8c_layoutMA" = linkonce_odr hidden constant {{.*}}swift3_assocty
+// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentableSCMA" = linkonce_odr hidden constant {{.*}}swift3_assocty
 
 struct HasImportedType {
   let a: A

--- a/test/IRGen/unexploded-calls.swift
+++ b/test/IRGen/unexploded-calls.swift
@@ -17,17 +17,17 @@ public func g(_ s : S) {
   return f(s)
 }
 
-// CHECK: define {{.*}}swiftcc void @"$Ss1gyySC1SVF"(float, float) {{.*}}{
+// CHECK: define {{.*}}swiftcc void @"$Ss1gyySo1SVF"(float, float) {{.*}}{
 // CHECK: entry:
-// CHECK:   [[ALLOCA:%[-._0-9a-zA-Z]+]] = alloca %TSC1SV, align 4
-// CHECK:   %2 = bitcast %TSC1SV* [[ALLOCA]] to i8*
-// CHECK:   [[ALLOCA]].f = getelementptr inbounds %TSC1SV, %TSC1SV* [[ALLOCA]], i32 0, i32 0
+// CHECK:   [[ALLOCA:%[-._0-9a-zA-Z]+]] = alloca %TSo1SV, align 4
+// CHECK:   %2 = bitcast %TSo1SV* [[ALLOCA]] to i8*
+// CHECK:   [[ALLOCA]].f = getelementptr inbounds %TSo1SV, %TSo1SV* [[ALLOCA]], i32 0, i32 0
 // CHECK:   [[ALLOCA]].f._value = getelementptr inbounds %TSf, %TSf* [[ALLOCA]].f, i32 0, i32 0
 // CHECK:   store float %0, float* [[ALLOCA]].f._value, align 4
-// CHECK:   [[ALLOCA]].g = getelementptr inbounds %TSC1SV, %TSC1SV* [[ALLOCA]], i32 0, i32 1
+// CHECK:   [[ALLOCA]].g = getelementptr inbounds %TSo1SV, %TSo1SV* [[ALLOCA]], i32 0, i32 1
 // CHECK:   [[ALLOCA]].g._value = getelementptr inbounds %TSf, %TSf* [[ALLOCA]].g, i32 0, i32 0
 // CHECK:   store float %1, float* [[ALLOCA]].g._value, align 4
-// CHECK:   %3 = bitcast %TSC1SV* [[ALLOCA]] to %struct.S*
+// CHECK:   %3 = bitcast %TSo1SV* [[ALLOCA]] to %struct.S*
 // CHECK:   %4 = load %struct.S, %struct.S* %3, align 4
 // CHECK:   call void @f(%struct.S %4)
 // CHECK: }

--- a/test/Inputs/clang-importer-sdk/usr/include/enums_using_attributes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/enums_using_attributes.h
@@ -16,3 +16,13 @@ typedef CF_OPTIONS(int, CFOptionsWithAttr) {
 typedef CF_OPTIONS(int, UnknownOptionsThanksToAPINotes) {
   UnknownOptionsThanksToAPINotesFirst = 1,
 };
+
+enum EnumByTag {
+  EnumByTagX
+};
+typedef enum {
+  EnumByTypedefX
+} EnumByTypedef;
+typedef enum EnumByBoth {
+  EnumByBothX
+} EnumByBoth;

--- a/test/Interpreter/SDK/check_class_for_archiving_log.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving_log.swift
@@ -131,7 +131,7 @@ checkArchiving(ArchivedTwiceGeneric<Int>.self)
 mark() // CHECK-NEXT: --[[@LINE]]--
 
 checkArchiving(ArchivedTwiceGeneric<NSObject>.self)
-// CHECK-NEXT: Attempting to archive generic Swift class '_Test.ArchivedTwiceGeneric<__ObjC.NSObject>' with mangled runtime name '_TtGC5_Test20ArchivedTwiceGenericCSo8NSObject_'
+// CHECK-NEXT: Attempting to archive generic Swift class '_Test.ArchivedTwiceGeneric<__C.NSObject>' with mangled runtime name '_TtGC5_Test20ArchivedTwiceGenericCSo8NSObject_'
 // CHECK-NEXT: NSKeyedUnarchiver.setClass(_:forClassName:)
 // CHECK-SAME: _TtGC5_Test20ArchivedTwiceGenericCSo8NSObject_
 // CHECK-NEXT: NSKeyedArchiver.setClassName(_:for:)

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -16,8 +16,8 @@
 // CHECK: nsString: __C.NSString
 // CHECK: (class __C.NSString)
 
-// CHECK: cfString: __C.CFString
-// CHECK: (class __C.CFString)
+// CHECK: cfString: __C.CFStringRef
+// CHECK: (alias __C.CFStringRef)
 
 // CHECK: aBlock: @convention(block) () -> ()
 // CHECK: (function convention=block
@@ -27,9 +27,9 @@
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
 // CHECK:   (class __C.NSString))
 
-// CHECK: occfs: TypesToReflect.GenericOC<__C.CFString>
+// CHECK: occfs: TypesToReflect.GenericOC<__C.CFStringRef>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __C.CFString))
+// CHECK:   (alias __C.CFStringRef))
 
 // CHECK: TypesToReflect.GenericOC
 // CHECK: ------------------------
@@ -48,7 +48,7 @@
 // CHECK: TypesToReflect.OP
 // CHECK: -----------------
 
-// CHECK: __C.Bundle
+// CHECK: __C.NSBundle
 // CHECK: ----------
 // CHECK: __C.NSURL
 // CHECK: ---------
@@ -77,7 +77,7 @@
 // CHECK-NEXT: ====================
 
 // CHECK:      - Capture types:
-// CHECK-NEXT: (class __C.Bundle)
+// CHECK-NEXT: (class __C.NSBundle)
 // CHECK-NEXT: (protocol_composition
 // CHECK-NEXT:   (protocol __C.NSCoding))
 // CHECK-NEXT: - Metadata sources:

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -10,34 +10,34 @@
 // CHECK: =======
 // CHECK: TypesToReflect.OC
 // CHECK: -----------------
-// CHECK: nsObject: __ObjC.NSObject
-// CHECK: (class __ObjC.NSObject)
+// CHECK: nsObject: __C.NSObject
+// CHECK: (class __C.NSObject)
 
-// CHECK: nsString: __ObjC.NSString
-// CHECK: (class __ObjC.NSString)
+// CHECK: nsString: __C.NSString
+// CHECK: (class __C.NSString)
 
-// CHECK: cfString: __ObjC.CFString
-// CHECK: (class __ObjC.CFString)
+// CHECK: cfString: __C.CFString
+// CHECK: (class __C.CFString)
 
 // CHECK: aBlock: @convention(block) () -> ()
 // CHECK: (function convention=block
 // CHECK:   (tuple))
 
-// CHECK: ocnss: TypesToReflect.GenericOC<__ObjC.NSString>
+// CHECK: ocnss: TypesToReflect.GenericOC<__C.NSString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __ObjC.NSString))
+// CHECK:   (class __C.NSString))
 
-// CHECK: occfs: TypesToReflect.GenericOC<__ObjC.CFString>
+// CHECK: occfs: TypesToReflect.GenericOC<__C.CFString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __ObjC.CFString))
+// CHECK:   (class __C.CFString))
 
 // CHECK: TypesToReflect.GenericOC
 // CHECK: ------------------------
 
 // CHECK: TypesToReflect.HasObjCClasses
 // CHECK: -----------------------------
-// CHECK: url: __ObjC.NSURL
-// CHECK: (class __ObjC.NSURL)
+// CHECK: url: __C.NSURL
+// CHECK: (class __C.NSURL)
 
 // CHECK: integer: Swift.Int
 // CHECK: (struct Swift.Int)
@@ -48,12 +48,12 @@
 // CHECK: TypesToReflect.OP
 // CHECK: -----------------
 
-// CHECK: __ObjC.Bundle
-// CHECK: ---------------
-// CHECK: __ObjC.NSURL
+// CHECK: __C.Bundle
+// CHECK: ----------
+// CHECK: __C.NSURL
+// CHECK: ---------
+// CHECK: __C.NSCoding
 // CHECK: ------------
-// CHECK: __ObjC.NSCoding
-// CHECK: ---------------
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
@@ -77,7 +77,7 @@
 // CHECK-NEXT: ====================
 
 // CHECK:      - Capture types:
-// CHECK-NEXT: (class __ObjC.Bundle)
+// CHECK-NEXT: (class __C.Bundle)
 // CHECK-NEXT: (protocol_composition
-// CHECK-NEXT:   (protocol __ObjC.NSCoding))
+// CHECK-NEXT:   (protocol __C.NSCoding))
 // CHECK-NEXT: - Metadata sources:

--- a/test/RemoteAST/Inputs/custom-modules/ErrorEnums.h
+++ b/test/RemoteAST/Inputs/custom-modules/ErrorEnums.h
@@ -1,0 +1,26 @@
+@import Foundation;
+
+NSString * const MyErrorDomain;
+typedef NS_ENUM(int, MyError) {
+  MyErrorGood,
+  MyErrorBad,
+} __attribute__((ns_error_domain(MyErrorDomain)));
+
+NSString * const MyRenamedErrorDomain;
+typedef NS_ENUM(int, MyRenamedError) {
+  MyRenamedErrorGood,
+  MyRenamedErrorBad,
+} __attribute__((ns_error_domain(MyRenamedErrorDomain))) __attribute__((swift_name("RenamedError")));
+
+
+struct Wrapper {
+  int unrelatedValue;
+};
+
+// Not actually an error enum, since those can't be import-as-member'd right 
+// now, but it can still hang with us.
+typedef NS_ENUM(int, MyMemberEnum) {
+  MyMemberEnumA,
+  MyMemberEnumB,
+} __attribute__((swift_name("Wrapper.MemberEnum")));
+

--- a/test/RemoteAST/Inputs/custom-modules/ErrorEnums.h
+++ b/test/RemoteAST/Inputs/custom-modules/ErrorEnums.h
@@ -24,3 +24,5 @@ typedef NS_ENUM(int, MyMemberEnum) {
   MyMemberEnumB,
 } __attribute__((swift_name("Wrapper.MemberEnum")));
 
+
+typedef int WrapperByAttribute __attribute__((swift_wrapper(struct)));

--- a/test/RemoteAST/Inputs/custom-modules/module.modulemap
+++ b/test/RemoteAST/Inputs/custom-modules/module.modulemap
@@ -1,0 +1,1 @@
+module ErrorEnums { header "ErrorEnums.h" }

--- a/test/RemoteAST/foreign_types.swift
+++ b/test/RemoteAST/foreign_types.swift
@@ -1,12 +1,29 @@
-// RUN: %target-swift-remoteast-test -sdk %S/../IRGen/Inputs %s | %FileCheck %s
+// RUN: %target-swift-remoteast-test-with-sdk -I %S/../ClangImporter/Inputs/custom-modules -I %S/Inputs/custom-modules %s | %FileCheck %s
 
 // REQUIRES: swift-remoteast-test
 // REQUIRES: objc_interop
 
+import Foundation
 import CoreCooling
+import ErrorEnums
 
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
 printType(CCRefrigerator.self)
 // CHECK: found type: CCRefrigerator
+
+printType(MyError.self)
+// CHECK: found type: MyError{{$}}
+
+printType(MyError.Code.self)
+// CHECK: found type: MyError.Code{{$}}
+
+printType(RenamedError.self)
+// CHECK: found type: RenamedError{{$}}
+
+printType(RenamedError.Code.self)
+// CHECK: found type: RenamedError.Code{{$}}
+
+printType(Wrapper.MemberEnum.self)
+// CHECK: found type: Wrapper.MemberEnum{{$}}

--- a/test/RemoteAST/foreign_types.swift
+++ b/test/RemoteAST/foreign_types.swift
@@ -27,3 +27,6 @@ printType(RenamedError.Code.self)
 
 printType(Wrapper.MemberEnum.self)
 // CHECK: found type: Wrapper.MemberEnum{{$}}
+
+printType(WrapperByAttribute.self)
+// CHECK: found type: WrapperByAttribute{{$}}

--- a/test/SILGen/Inputs/usr/include/Gizmo.h
+++ b/test/SILGen/Inputs/usr/include/Gizmo.h
@@ -5,6 +5,10 @@
 - (void) anse;
 @end
 
+__attribute__((swift_name("BetterAnsing")))
+@protocol NSBetterAnsing <NSAnsing>
+@end
+
 @interface NSObject (NSAnsing)
 @property Class<NSAnsing> qualifiedClassProp;
 @end

--- a/test/SILGen/c_materializeForSet_linkage.swift
+++ b/test/SILGen/c_materializeForSet_linkage.swift
@@ -16,8 +16,8 @@ extension NSReferencePoint: Pointable {}
 // Make sure synthesized materializeForSet and its callbacks have shared linkage
 // for properties imported from Clang
 
-// CHECK-LABEL: sil shared [transparent] [serializable] @$SSC7NSPointV1xSfvm
-// CHECK-LABEL: sil shared [transparent] [serializable] @$SSC7NSPointV1ySfvm
+// CHECK-LABEL: sil shared [transparent] [serializable] @$SSo7NSPointV1xSfvm
+// CHECK-LABEL: sil shared [transparent] [serializable] @$SSo7NSPointV1ySfvm
 
 // CHECK-LABEL: sil shared [serializable] @$SSo16NSReferencePointC1xSfvmytfU_
 // CHECK-LABEL: sil shared [serializable] @$SSo16NSReferencePointC1xSfvm

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -65,10 +65,10 @@ protocol Impedance {
 
 extension CCImpedance: Impedance {}
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$SSC11CCImpedanceV2cf9ImpedanceA2cDP4real9ComponentQzvgTW
-// CHECK-LABEL: sil shared [transparent] [serializable] @$SSC11CCImpedanceV4realSdvg
-// CHECK-LABEL: sil private [transparent] [thunk] @$SSC11CCImpedanceV2cf9ImpedanceA2cDP4imag9ComponentQzvgTW
-// CHECK-LABEL: sil shared [transparent] [serializable] @$SSC11CCImpedanceV4imagSdvg
+// CHECK-LABEL: sil private [transparent] [thunk] @$SSo11CCImpedanceV2cf9ImpedanceA2cDP4real9ComponentQzvgTW
+// CHECK-LABEL: sil shared [transparent] [serializable] @$SSo11CCImpedanceV4realSdvg
+// CHECK-LABEL: sil private [transparent] [thunk] @$SSo11CCImpedanceV2cf9ImpedanceA2cDP4imag9ComponentQzvgTW
+// CHECK-LABEL: sil shared [transparent] [serializable] @$SSo11CCImpedanceV4imagSdvg
 
 class MyMagnetism : CCMagnetismModel {
   // CHECK-LABEL: sil hidden [thunk] @$S2cf11MyMagnetismC15getRefrigerator{{[_0-9a-zA-Z]*}}FTo : $@convention(objc_method) (MyMagnetism) -> @autoreleased CCRefrigerator

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -39,7 +39,7 @@ public func foo(_ x: Double) {
   z = makeMetatype().init(value: x)
 
   // CHECK: [[SELF_META:%.*]] = metatype $@thin Struct1.Type
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSC7Struct1V5valueABSd_tcfCTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V5valueABSd_tcfCTcTO
   // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
   // CHECK: [[A_COPY:%.*]] = copy_value [[BORROWED_A]]
@@ -68,7 +68,7 @@ public func foo(_ x: Double) {
 
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
-  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@\$SSC7Struct1V9translate7radiansABSd_tFTcTO]]
+  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@\$SSo7Struct1V9translate7radiansABSd_tFTcTO]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
@@ -105,7 +105,7 @@ public func foo(_ x: Double) {
 
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSC7Struct1V5scaleyABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V5scaleyABSdFTcTO
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
   // CHECK: [[F_COPY:%.*]] = copy_value [[BORROWED_F]]
@@ -115,7 +115,7 @@ public func foo(_ x: Double) {
   // CHECK: destroy_value [[F_COPY]]
   // CHECK: end_borrow [[BORROWED_F]] from [[F]]
   z = f(x)
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSC7Struct1V5scaleyABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V5scaleyABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
   let g = Struct1.scale
   // CHECK:  [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
@@ -161,7 +161,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]()
   var y = Struct1.staticMethod()
   // CHECK: [[SELF:%.*]] = metatype
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSC7Struct1V12staticMethods5Int32VyFZTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V12staticMethods5Int32VyFZTcTO
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
   // CHECK: [[BORROWED_I:%.*]] = begin_borrow [[I]]
   // CHECK: [[I_COPY:%.*]] = copy_value [[BORROWED_I]]
@@ -238,37 +238,37 @@ public func foo(_ x: Double) {
 }
 // CHECK: } // end sil function '$S10cf_members3foo{{[_0-9a-zA-Z]*}}F'
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSC7Struct1V5valueABSd_tcfCTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V5valueABSd_tcfCTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1CreateSimple
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSC7Struct1V9translate7radiansABSd_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V9translate7radiansABSd_tFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         store [[SELF]] to [trivial] [[TMP:%.*]] :
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Rotate
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[TMP]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSC7Struct1V5scaleyABSdFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V5scaleyABSdFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Scale
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[SELF]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSC7Struct1V12staticMethods5Int32VyFZTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V12staticMethods5Int32VyFZTO
 // CHECK:       bb0([[SELF:%.*]] : @trivial $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1StaticMethod
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]()
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSC7Struct1V13selfComesLast1xySd_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V13selfComesLast1xySd_tFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesLast
 // CHECK:         apply [[CFUNC]]([[X]], [[SELF]])
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSC7Struct1V14selfComesThird1a1b1xys5Int32V_SfSdtFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V14selfComesThird1a1b1xys5Int32V_SfSdtFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Int32, [[Y:%.*]] : @trivial $Float, [[Z:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesThird
 // CHECK:         apply [[CFUNC]]([[X]], [[Y]], [[SELF]], [[Z]])

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -39,7 +39,7 @@ public func foo(_ x: Double) {
   z = makeMetatype().init(value: x)
 
   // CHECK: [[SELF_META:%.*]] = metatype $@thin Struct1.Type
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V5valueABSd_tcfCTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo10IAMStruct1V5valueABSd_tcfCTcTO
   // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
   // CHECK: [[A_COPY:%.*]] = copy_value [[BORROWED_A]]
@@ -68,7 +68,7 @@ public func foo(_ x: Double) {
 
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
-  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@\$SSo7Struct1V9translate7radiansABSd_tFTcTO]]
+  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@\$SSo10IAMStruct1V9translate7radiansABSd_tFTcTO]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
@@ -105,7 +105,7 @@ public func foo(_ x: Double) {
 
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V5scaleyABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo10IAMStruct1V5scaleyABSdFTcTO
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
   // CHECK: [[F_COPY:%.*]] = copy_value [[BORROWED_F]]
@@ -115,7 +115,7 @@ public func foo(_ x: Double) {
   // CHECK: destroy_value [[F_COPY]]
   // CHECK: end_borrow [[BORROWED_F]] from [[F]]
   z = f(x)
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V5scaleyABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo10IAMStruct1V5scaleyABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
   let g = Struct1.scale
   // CHECK:  [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
@@ -161,7 +161,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]()
   var y = Struct1.staticMethod()
   // CHECK: [[SELF:%.*]] = metatype
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSo7Struct1V12staticMethods5Int32VyFZTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo10IAMStruct1V12staticMethods5Int32VyFZTcTO
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
   // CHECK: [[BORROWED_I:%.*]] = begin_borrow [[I]]
   // CHECK: [[I_COPY:%.*]] = copy_value [[BORROWED_I]]
@@ -238,37 +238,37 @@ public func foo(_ x: Double) {
 }
 // CHECK: } // end sil function '$S10cf_members3foo{{[_0-9a-zA-Z]*}}F'
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V5valueABSd_tcfCTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo10IAMStruct1V5valueABSd_tcfCTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1CreateSimple
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V9translate7radiansABSd_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo10IAMStruct1V9translate7radiansABSd_tFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         store [[SELF]] to [trivial] [[TMP:%.*]] :
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Rotate
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[TMP]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V5scaleyABSdFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo10IAMStruct1V5scaleyABSdFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Scale
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[SELF]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V12staticMethods5Int32VyFZTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo10IAMStruct1V12staticMethods5Int32VyFZTO
 // CHECK:       bb0([[SELF:%.*]] : @trivial $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1StaticMethod
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]()
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V13selfComesLast1xySd_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo10IAMStruct1V13selfComesLast1xySd_tFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesLast
 // CHECK:         apply [[CFUNC]]([[X]], [[SELF]])
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo7Struct1V14selfComesThird1a1b1xys5Int32V_SfSdtFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo10IAMStruct1V14selfComesThird1a1b1xys5Int32V_SfSdtFTO
 // CHECK:       bb0([[X:%.*]] : @trivial $Int32, [[Y:%.*]] : @trivial $Float, [[Z:%.*]] : @trivial $Double, [[SELF:%.*]] : @trivial $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesThird
 // CHECK:         apply [[CFUNC]]([[X]], [[Y]], [[SELF]], [[Z]])

--- a/test/SILGen/external_definitions.swift
+++ b/test/SILGen/external_definitions.swift
@@ -19,7 +19,7 @@ hasNoPrototype()
 // CHECK:   [[NSANSE_RESULT:%.*]] = apply [[NSANSE]]([[ANSIBLE]])
 // CHECK:   destroy_value [[ANSIBLE]] : $Optional<Ansible>
 // -- Referencing unapplied C function goes through a thunk
-// CHECK:   [[NSANSE:%.*]] = function_ref @$SSC6NSAnseySQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible>
+// CHECK:   [[NSANSE:%.*]] = function_ref @$SSo6NSAnseySQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible>
 // -- Referencing unprototyped C function passes no parameters
 // CHECK:   [[NOPROTO:%.*]] = function_ref @hasNoPrototype : $@convention(c) () -> ()
 // CHECK:   apply [[NOPROTO]]()
@@ -31,7 +31,7 @@ hasNoPrototype()
 // CHECK-LABEL: sil shared [serializable] @$SSo7AnsibleC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@in Optional<Any>, @thick Ansible.Type) -> @owned Optional<Ansible>
 
 // -- Native Swift thunk for NSAnse
-// CHECK: sil shared [serialized] [thunk] @$SSC6NSAnseySQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible> {
+// CHECK: sil shared [serialized] [thunk] @$SSo6NSAnseySQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible> {
 // CHECK: bb0(%0 : @owned $Optional<Ansible>):
 // CHECK:   %1 = function_ref @NSAnse : $@convention(c) (Optional<Ansible>) -> @autoreleased Optional<Ansible>
 // CHECK:   %2 = apply %1(%0) : $@convention(c) (Optional<Ansible>) -> @autoreleased Optional<Ansible>

--- a/test/SILGen/import_as_member.swift
+++ b/test/SILGen/import_as_member.swift
@@ -54,7 +54,7 @@ public func useClass(d: Double, opts: SomeClass.Options) {
 }
 
 extension SomeClass {
-  // CHECK-LABEL: sil hidden @$SSo9SomeClassC16import_as_memberE6doubleABSd_tcfc
+  // CHECK-LABEL: sil hidden @$SSo12IAMSomeClassC16import_as_memberE6doubleABSd_tcfc
   // CHECK: bb0([[DOUBLE:%[0-9]+]] : $Double
   // CHECK-NOT: value_metatype
   // CHECK: [[FNREF:%[0-9]+]] = function_ref @MakeIAMSomeClass

--- a/test/SILGen/imported_struct_array_field.swift
+++ b/test/SILGen/imported_struct_array_field.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -import-objc-header %S/Inputs/array_typedef.h %s | %FileCheck %s
 
-// CHECK-LABEL: sil shared [transparent] [serializable] @$SSC4NameV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (UInt8, UInt8, UInt8, UInt8, @thin Name.Type) -> Name
+// CHECK-LABEL: sil shared [transparent] [serializable] @$SSo4NameV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (UInt8, UInt8, UInt8, UInt8, @thin Name.Type) -> Name
 func useImportedArrayTypedefInit() -> Name {
   return Name(name: (0, 0, 0, 0))
 }

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -83,7 +83,7 @@ func uses_objc_class_and_protocol(o: NSObject, p: NSAnsing) {}
 // Clang-imported structs get mangled using their Clang module name.
 // FIXME: Temporarily mangles everything into the virtual module __C__
 // <rdar://problem/14221244>
-// CHECK-LABEL: sil hidden @$S8mangling17uses_clang_struct1rySC6NSRectV_tF
+// CHECK-LABEL: sil hidden @$S8mangling17uses_clang_struct1rySo6NSRectV_tF
 func uses_clang_struct(r: NSRect) {}
 
 // CHECK-LABEL: sil hidden @$S8mangling14uses_optionals1xs7UnicodeO6ScalarVSgSiSg_tF

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -77,8 +77,8 @@ func single_protocol_composition(x: protocol<Foo>) {} // expected-warning {{'pro
 
 // Clang-imported classes and protocols get mangled into a magic 'So' context
 // to make collisions into link errors. <rdar://problem/14221244>
-// CHECK-LABEL: sil hidden @$S8mangling28uses_objc_class_and_protocol1o1pySo8NSObjectC_So8NSAnsing_ptF
-func uses_objc_class_and_protocol(o: NSObject, p: NSAnsing) {}
+// CHECK-LABEL: sil hidden @$S8mangling28uses_objc_class_and_protocol1o1p2p2ySo8NSObjectC_So8NSAnsing_pSo14NSBetterAnsing_ptF
+func uses_objc_class_and_protocol(o: NSObject, p: NSAnsing, p2: BetterAnsing) {}
 
 // Clang-imported structs get mangled using their Clang module name.
 // FIXME: Temporarily mangles everything into the virtual module __C__

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -15,7 +15,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
   return ErrorDomain(rawValue: str)
 }
 
-// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @$SSo11ErrorDomainV8rawValueABSS_tcfC
+// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @$SSo14SNTErrorDomaina8rawValueABSS_tcfC
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
@@ -35,7 +35,7 @@ func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue
 }
 
-// CHECK-RAW-LABEL: sil shared [serializable] @$SSo11ErrorDomainV8rawValueSSvg
+// CHECK-RAW-LABEL: sil shared [serializable] @$SSo14SNTErrorDomaina8rawValueSSvg
 // CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
 // CHECK-RAW: [[STORED_VALUE:%[0-9]+]] = struct_extract [[SELF]] : $ErrorDomain, #ErrorDomain._rawValue
 // CHECK-RAW: [[STORED_VALUE_COPY:%.*]] = copy_value [[STORED_VALUE]]
@@ -46,21 +46,21 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: return [[STRING_RESULT]]
 
 class ObjCTest {
-  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
-  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
+  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
+  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }  
 
-  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
-  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
+  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC18integerPassThroughySo5MyIntaAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
+  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC18integerPassThroughySo5MyIntaAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
   @objc func integerPassThrough(_ ed: MyInt) -> MyInt {
     return ed
   }  
 }
 
 // These use a bridging conversion with a specialization of a generic witness.
-// CHECK-RAW-LABEL: sil hidden @$S7newtype15bridgeToNewtypeSo8MyStringVyF
+// CHECK-RAW-LABEL: sil hidden @$S7newtype15bridgeToNewtypeSo8MyStringayF
 func bridgeToNewtype() -> MyString {
 // CHECK-RAW: [[STRING:%.*]] = apply
 // CHECK-RAW: [[TO_NS:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
@@ -73,7 +73,7 @@ func bridgeToNewtype() -> MyString {
   return "foo" as NSString as MyString
 }
 
-// CHECK-RAW-LABEL: sil hidden @$S7newtype17bridgeFromNewtype6stringSSSo8MyStringV_tF
+// CHECK-RAW-LABEL: sil hidden @$S7newtype17bridgeFromNewtype6stringSSSo8MyStringa_tF
 func bridgeFromNewtype(string: MyString) -> String {
 // CHECK-RAW: [[FROM_MY:%.*]] = function_ref @$Ss20_SwiftNewtypeWrapperPss21_ObjectiveCBridgeable8RawValueRpzrlE09_bridgeToD1CAD_01_D5CTypeQZyF : $@convention(method) <τ_0_0 where τ_0_0 : _SwiftNewtypeWrapper, τ_0_0.RawValue : _ObjectiveCBridgeable> (@in_guaranteed τ_0_0) -> @owned τ_0_0.RawValue._ObjectiveCType
 // CHECK-RAW: [[NS:%.*]] = apply [[FROM_MY]]<MyString, String>(

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -15,7 +15,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
   return ErrorDomain(rawValue: str)
 }
 
-// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @$SSC11ErrorDomainV8rawValueABSS_tcfC
+// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @$SSo11ErrorDomainV8rawValueABSS_tcfC
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
@@ -35,7 +35,7 @@ func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue
 }
 
-// CHECK-RAW-LABEL: sil shared [serializable] @$SSC11ErrorDomainV8rawValueSSvg
+// CHECK-RAW-LABEL: sil shared [serializable] @$SSo11ErrorDomainV8rawValueSSvg
 // CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
 // CHECK-RAW: [[STORED_VALUE:%[0-9]+]] = struct_extract [[SELF]] : $ErrorDomain, #ErrorDomain._rawValue
 // CHECK-RAW: [[STORED_VALUE_COPY:%.*]] = copy_value [[STORED_VALUE]]
@@ -46,21 +46,21 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: return [[STRING_RESULT]]
 
 class ObjCTest {
-  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC19optionalPassThroughySC11ErrorDomainVSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
-  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC19optionalPassThroughySC11ErrorDomainVSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
+  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
+  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC19optionalPassThroughySo11ErrorDomainVSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }  
 
-  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC18integerPassThroughySC5MyIntVAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
-  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC18integerPassThroughySC5MyIntVAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
+  // CHECK-RAW-LABEL: sil hidden @$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
+  // CHECK-RAW: sil hidden [thunk] @$S7newtype8ObjCTestC18integerPassThroughySo5MyIntVAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
   @objc func integerPassThrough(_ ed: MyInt) -> MyInt {
     return ed
   }  
 }
 
 // These use a bridging conversion with a specialization of a generic witness.
-// CHECK-RAW-LABEL: sil hidden @$S7newtype15bridgeToNewtypeSC8MyStringVyF
+// CHECK-RAW-LABEL: sil hidden @$S7newtype15bridgeToNewtypeSo8MyStringVyF
 func bridgeToNewtype() -> MyString {
 // CHECK-RAW: [[STRING:%.*]] = apply
 // CHECK-RAW: [[TO_NS:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
@@ -73,7 +73,7 @@ func bridgeToNewtype() -> MyString {
   return "foo" as NSString as MyString
 }
 
-// CHECK-RAW-LABEL: sil hidden @$S7newtype17bridgeFromNewtype6stringSSSC8MyStringV_tF
+// CHECK-RAW-LABEL: sil hidden @$S7newtype17bridgeFromNewtype6stringSSSo8MyStringV_tF
 func bridgeFromNewtype(string: MyString) -> String {
 // CHECK-RAW: [[FROM_MY:%.*]] = function_ref @$Ss20_SwiftNewtypeWrapperPss21_ObjectiveCBridgeable8RawValueRpzrlE09_bridgeToD1CAD_01_D5CTypeQZyF : $@convention(method) <τ_0_0 where τ_0_0 : _SwiftNewtypeWrapper, τ_0_0.RawValue : _ObjectiveCBridgeable> (@in_guaranteed τ_0_0) -> @owned τ_0_0.RawValue._ObjectiveCType
 // CHECK-RAW: [[NS:%.*]] = apply [[FROM_MY]]<MyString, String>(

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -515,7 +515,7 @@ func applyStringBlock(_ f: @convention(block) (String) -> String, x: String) -> 
 
 // CHECK-LABEL: sil hidden @$S13objc_bridging15bridgeCFunction{{.*}}F
 func bridgeCFunction() -> (String?) -> (String?) {
-  // CHECK: [[THUNK:%.*]] = function_ref @$SSC18NSStringFromStringySQySSGABFTO : $@convention(thin) (@owned Optional<String>) -> @owned Optional<String>
+  // CHECK: [[THUNK:%.*]] = function_ref @$SSo18NSStringFromStringySQySSGABFTO : $@convention(thin) (@owned Optional<String>) -> @owned Optional<String>
   // CHECK: [[THICK:%.*]] = thin_to_thick_function [[THUNK]]
   // CHECK: return [[THICK]]
   return NSStringFromString

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -754,5 +754,5 @@ func bridgeOptionalFunctionToAnyObject(fn: (() -> ())?) -> AnyObject {
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$SSo13GenericOptionVs8Hashable13objc_genericssACP9hashValueSivgTW
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$SSo13GenericOptionas8Hashable13objc_genericssACP9hashValueSivgTW
 // CHECK-NEXT: }

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -754,5 +754,5 @@ func bridgeOptionalFunctionToAnyObject(fn: (() -> ())?) -> AnyObject {
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$SSo13GenericOptionas8Hashable13objc_genericssACP9hashValueSivgTW
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$SSo13GenericOptionas8HashableSCsACP9hashValueSivgTW
 // CHECK-NEXT: }

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -754,5 +754,5 @@ func bridgeOptionalFunctionToAnyObject(fn: (() -> ())?) -> AnyObject {
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$SSC13GenericOptionVs8Hashable13objc_genericssACP9hashValueSivgTW
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$SSo13GenericOptionVs8Hashable13objc_genericssACP9hashValueSivgTW
 // CHECK-NEXT: }

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -7,15 +7,15 @@
 import gizmo
 
 
-// CHECK-DAG: sil shared [serializable] @$SSC16NSRuncingOptionsO{{[_0-9a-zA-Z]*}}fC
-// CHECK-DAG: sil shared [serializable] @$SSC16NSRuncingOptionsO8rawValueSivg
-// CHECK-DAG: sil shared [serializable] @$SSC16NSRuncingOptionsO9hashValueSivg
+// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsO{{[_0-9a-zA-Z]*}}fC
+// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsO8rawValueSivg
+// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsO9hashValueSivg
 
 // Non-payload enum ctors don't need to be instantiated at all.
-// NEGATIVE-NOT: sil shared [transparent] @$SSC16NSRuncingOptionsO5MinceAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @$SSC16NSRuncingOptionsO12QuinceSlicedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @$SSC16NSRuncingOptionsO15QuinceJuliennedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @$SSC16NSRuncingOptionsO11QuinceDicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO5MinceAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO12QuinceSlicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO15QuinceJuliennedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO11QuinceDicedAbBmF
 
 var runcing: NSRuncingOptions = .mince
 
@@ -45,7 +45,7 @@ _ = NSFungingMask.toTheMax
 // CHECK-DAG: sil_witness_table shared [serialized] NSRuncingOptions: Hashable module gizmo
 // CHECK-DAG: sil_witness_table shared [serialized] NSFungingMask: RawRepresentable module gizmo
 
-// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @$SSC16NSRuncingOptionsOs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
+// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @$SSo16NSRuncingOptionsOs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
 
 // Extension conformances get linkage according to the protocol's accessibility, as normal.
 // CHECK-DAG: sil_witness_table hidden NSRuncingOptions: Bub module objc_enum

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -45,7 +45,7 @@ _ = NSFungingMask.toTheMax
 // CHECK-DAG: sil_witness_table shared [serialized] NSRuncingOptions: Hashable module gizmo
 // CHECK-DAG: sil_witness_table shared [serialized] NSFungingMask: RawRepresentable module gizmo
 
-// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @$SSo16NSRuncingOptionsVs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
+// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @$SSo16NSRuncingOptionsVs16RawRepresentableSCsACP{{[_0-9a-zA-Z]*}}fCTW
 
 // Extension conformances get linkage according to the protocol's accessibility, as normal.
 // CHECK-DAG: sil_witness_table hidden NSRuncingOptions: Bub module objc_enum

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -7,15 +7,15 @@
 import gizmo
 
 
-// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsO{{[_0-9a-zA-Z]*}}fC
-// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsO8rawValueSivg
-// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsO9hashValueSivg
+// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsV{{[_0-9a-zA-Z]*}}fC
+// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsV8rawValueSivg
+// CHECK-DAG: sil shared [serializable] @$SSo16NSRuncingOptionsV9hashValueSivg
 
 // Non-payload enum ctors don't need to be instantiated at all.
-// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO5MinceAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO12QuinceSlicedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO15QuinceJuliennedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsO11QuinceDicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsV5MinceAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsV12QuinceSlicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsV15QuinceJuliennedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @$SSo16NSRuncingOptionsV11QuinceDicedAbBmF
 
 var runcing: NSRuncingOptions = .mince
 
@@ -45,7 +45,7 @@ _ = NSFungingMask.toTheMax
 // CHECK-DAG: sil_witness_table shared [serialized] NSRuncingOptions: Hashable module gizmo
 // CHECK-DAG: sil_witness_table shared [serialized] NSFungingMask: RawRepresentable module gizmo
 
-// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @$SSo16NSRuncingOptionsOs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
+// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @$SSo16NSRuncingOptionsVs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
 
 // Extension conformances get linkage according to the protocol's accessibility, as normal.
 // CHECK-DAG: sil_witness_table hidden NSRuncingOptions: Bub module objc_enum

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -66,12 +66,12 @@ extension Hive {
 }
 
 extension SomeClass {
-  // CHECK-LABEL: sil hidden @$SSo9SomeClassC17objc_factory_initE6doubleABSd_tcfc : $@convention(method) (Double, @owned SomeClass) -> @owned SomeClass {
+  // CHECK-LABEL: sil hidden @$SSo12IAMSomeClassC17objc_factory_initE6doubleABSd_tcfc : $@convention(method) (Double, @owned SomeClass) -> @owned SomeClass {
   // CHECK: bb0([[DOUBLE:%.*]] : @trivial $Double,
   // CHECK-NOT: value_metatype
   // CHECK: [[FNREF:%[0-9]+]] = function_ref @MakeIAMSomeClass
   // CHECK: apply [[FNREF]]([[DOUBLE]])
-  // CHECK: } // end sil function '$SSo9SomeClassC17objc_factory_initE6doubleABSd_tcfc'
+  // CHECK: } // end sil function '$SSo12IAMSomeClassC17objc_factory_initE6doubleABSd_tcfc'
   convenience init(double: Double) {
     self.init(value: double)
   }

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -141,5 +141,5 @@ func configureWithoutOptions() {
 // Make sure we emitted the witness table for the above conformance
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
-// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @$SSo13GenericOptionas8Hashable13objc_genericssACP9hashValueSivgTW
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @$SSo13GenericOptionas8HashableSCsACP9hashValueSivgTW
 // CHECK: }

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -133,7 +133,7 @@ func configureWithoutOptions() {
 // foreign to native thunk for init(options:), uses GenericOption : Hashable
 // conformance
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo12GenericClassC7optionsSQyAByxGGs10DictionaryVySC0A6OptionVypGSg_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo12GenericClassC7optionsSQyAByxGGs10DictionaryVySo0A6OptionVypGSg_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
 // CHECK: [[FN:%.*]] = function_ref @$Ss10DictionaryV10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: apply [[FN]]<GenericOption, Any>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: return
@@ -141,5 +141,5 @@ func configureWithoutOptions() {
 // Make sure we emitted the witness table for the above conformance
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
-// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @$SSC13GenericOptionVs8Hashable13objc_genericssACP9hashValueSivgTW
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @$SSo13GenericOptionVs8Hashable13objc_genericssACP9hashValueSivgTW
 // CHECK: }

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -133,7 +133,7 @@ func configureWithoutOptions() {
 // foreign to native thunk for init(options:), uses GenericOption : Hashable
 // conformance
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo12GenericClassC7optionsSQyAByxGGs10DictionaryVySo0A6OptionVypGSg_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo12GenericClassC7optionsSQyAByxGGs10DictionaryVySo0A6OptionaypGSg_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
 // CHECK: [[FN:%.*]] = function_ref @$Ss10DictionaryV10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: apply [[FN]]<GenericOption, Any>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: return
@@ -141,5 +141,5 @@ func configureWithoutOptions() {
 // Make sure we emitted the witness table for the above conformance
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
-// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @$SSo13GenericOptionVs8Hashable13objc_genericssACP9hashValueSivgTW
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @$SSo13GenericOptionas8Hashable13objc_genericssACP9hashValueSivgTW
 // CHECK: }

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -779,22 +779,22 @@ print("Swift to NS sets: End")
 
 // Check optimizations of casts from String to CFString
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding29testForcedCastSwiftToCFStringSo0I0CyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding29testForcedCastSwiftToCFStringSo0I3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSString to $CFString
-// CHECK: end{{.*}}$S21bridged_casts_folding29testForcedCastSwiftToCFStringSo0I0CyF
+// CHECK: end{{.*}}$S21bridged_casts_folding29testForcedCastSwiftToCFStringSo0I3RefayF
 @inline(never)
 public func testForcedCastSwiftToCFString() -> CFString {
   let o: CFString = forcedCast(swiftString)
   return o
 }
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding27testCondCastSwiftToCFStringSo0I0CSgyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding27testCondCastSwiftToCFStringSo0I3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSString to $CFString
-// CHECK: end{{.*}}$S21bridged_casts_folding27testCondCastSwiftToCFStringSo0I0CSgyF
+// CHECK: end{{.*}}$S21bridged_casts_folding27testCondCastSwiftToCFStringSo0I3RefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFString() -> CFString? {
   let o: CFString? = condCast(swiftString)
@@ -803,22 +803,22 @@ public func testCondCastSwiftToCFString() -> CFString? {
 
 // Check optimizations of casts from Int to CFNumber
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J0CyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSNumber to $CFNumber
-// CHECK: end{{.*}}$S21bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J0CyF
+// CHECK: end{{.*}}$S21bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J3RefayF
 @inline(never)
 public func testForcedCastSwiftIntToCFNumber() -> CFNumber {
   let o: CFNumber = forcedCast(swiftIntNumber)
   return o
 }
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J0CSgyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSNumber to $CFNumber
-// CHECK: end{{.*}}$S21bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J0CSgyF
+// CHECK: end{{.*}}$S21bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J3RefaSgyF
 @inline(never)
 public func testCondCastSwiftIntToCFNumber() -> CFNumber? {
   let o: CFNumber? = condCast(swiftIntNumber)
@@ -827,22 +827,22 @@ public func testCondCastSwiftIntToCFNumber() -> CFNumber? {
 
 // Check optimization of casts from Swift Array to CFArray
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I0CyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSArray to $CFArray
-// CHECK: end{{.*}}$S21bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I0CyF
+// CHECK: end{{.*}}$S21bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I3RefayF
 @inline(never)
 public func testForcedCastSwiftToCFArrayInt() -> CFArray {
   let arr: CFArray = forcedCast(arrInt)
   return arr
 }
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I0CSgyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSArray to $CFArray
-// CHECK: end{{.*}}$S21bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I0CSgyF
+// CHECK: end{{.*}}$S21bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I3RefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFArrayInt() -> CFArray? {
   let arrOpt: CFArray? = condCast(arrInt)
@@ -851,22 +851,22 @@ public func testCondCastSwiftToCFArrayInt() -> CFArray? {
 
 // Check optimization of casts from Swift Dict to CFDictionary
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding30testForcedCastSwiftToCFDictIntSo12CFDictionaryCyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding30testForcedCastSwiftToCFDictIntSo15CFDictionaryRefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSDictionary to $CFDictionary
-// CHECK: end{{.*}}$S21bridged_casts_folding30testForcedCastSwiftToCFDictIntSo12CFDictionaryCyF
+// CHECK: end{{.*}}$S21bridged_casts_folding30testForcedCastSwiftToCFDictIntSo15CFDictionaryRefayF
 @inline(never)
 public func testForcedCastSwiftToCFDictInt() -> CFDictionary {
   let dict: CFDictionary = forcedCast(dictInt)
   return dict
 }
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding28testCondCastSwiftToCFDictIntSo12CFDictionaryCSgyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding28testCondCastSwiftToCFDictIntSo15CFDictionaryRefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSDictionary to $CFDictionary
-// CHECK: end{{.*}}$S21bridged_casts_folding28testCondCastSwiftToCFDictIntSo12CFDictionaryCSgyF
+// CHECK: end{{.*}}$S21bridged_casts_folding28testCondCastSwiftToCFDictIntSo15CFDictionaryRefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFDictInt() -> CFDictionary? {
   let dictOpt: CFDictionary? = condCast(dictInt)
@@ -875,22 +875,22 @@ public func testCondCastSwiftToCFDictInt() -> CFDictionary? {
 
 // Check optimization of casts from Swift Set to CFSet
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I0CyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSSet to $CFSet
-// CHECK: end{{.*}}$S21bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I0CyF
+// CHECK: end{{.*}}$S21bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I3RefayF
 @inline(never)
 public func testForcedCastSwiftToCFSetInt() -> CFSet {
   let set: CFSet = forcedCast(setInt)
   return set
 }
 
-// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I0CSgyF
+// CHECK-LABEL: sil [noinline] @$S21bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSSet to $CFSet
-// CHECK: end{{.*}}$S21bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I0CSgyF
+// CHECK: end{{.*}}$S21bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I3RefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFSetInt() -> CFSet? {
   let setOpt: CFSet? = condCast(setInt)

--- a/test/SILOptimizer/predictable_memopt_unreferenceable_storage.swift
+++ b/test/SILOptimizer/predictable_memopt_unreferenceable_storage.swift
@@ -14,7 +14,7 @@ struct T {
         self.s = s
     }
 }
-// CHECK-LABEL: sil hidden @$S42predictable_memopt_unreferenceable_storage1TV1v1sACSC19StructWithBitfieldsV_AA1SVtcfC
+// CHECK-LABEL: sil hidden @$S42predictable_memopt_unreferenceable_storage1TV1v1sACSo19StructWithBitfieldsV_AA1SVtcfC
 // CHECK:       bb0(%0 : $StructWithBitfields, %1 : $S, %2 : $@thin T.Type):
 // CHECK:         [[RESULT:%.*]] = struct $T (%0 : $StructWithBitfields, %1 : $S)
 // CHECK:         return [[RESULT]]

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -14,7 +14,7 @@
 import Foundation
 import UsesImportedEnums
 
-// CHECK-LABEL: sil hidden @$S4main4test1eSbSo13NSRuncingModeO_tF
+// CHECK-LABEL: sil hidden @$S4main4test1eSbSo13NSRuncingModeV_tF
 func test(e: NSRuncingMode) -> Bool {
   // CHECK-NOT: return
   // CHECK: $Ss2eeoiySbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -14,7 +14,7 @@
 import Foundation
 import UsesImportedEnums
 
-// CHECK-LABEL: sil hidden @$S4main4test1eSbSC13NSRuncingModeO_tF
+// CHECK-LABEL: sil hidden @$S4main4test1eSbSo13NSRuncingModeO_tF
 func test(e: NSRuncingMode) -> Bool {
   // CHECK-NOT: return
   // CHECK: $Ss2eeoiySbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -5632,7 +5632,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:So17FooStructTypedef2VABycfc",
+        key.usr: "s:So17FooStructTypedef2aABycfc",
         key.offset: 3187,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -5640,7 +5640,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:So17FooStructTypedef2V1x1yABs5Int32V_Sdtcfc",
+        key.usr: "s:So17FooStructTypedef2a1x1yABs5Int32V_Sdtcfc",
         key.offset: 3199,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -1236,7 +1236,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "Element",
-    key.usr: "s:SC17FooRuncingOptionsV7Elementa",
+    key.usr: "s:So17FooRuncingOptionsV7Elementa",
     key.offset: 1458,
     key.length: 7
   },
@@ -4554,7 +4554,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC8FooEnum1VyABs6UInt32Vcfc",
+        key.usr: "s:So8FooEnum1VyABs6UInt32Vcfc",
         key.offset: 89,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -4571,7 +4571,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC8FooEnum1V8rawValueABs6UInt32V_tcfc",
+        key.usr: "s:So8FooEnum1V8rawValueABs6UInt32V_tcfc",
         key.offset: 119,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -4595,7 +4595,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC8FooEnum1V8rawValues6UInt32Vvp",
+        key.usr: "s:So8FooEnum1V8rawValues6UInt32Vvp",
         key.offset: 156,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
@@ -4655,7 +4655,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC8FooEnum2VyABs6UInt32Vcfc",
+        key.usr: "s:So8FooEnum2VyABs6UInt32Vcfc",
         key.offset: 327,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -4672,7 +4672,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC8FooEnum2V8rawValueABs6UInt32V_tcfc",
+        key.usr: "s:So8FooEnum2V8rawValueABs6UInt32V_tcfc",
         key.offset: 357,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -4696,7 +4696,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC8FooEnum2V8rawValues6UInt32Vvp",
+        key.usr: "s:So8FooEnum2V8rawValues6UInt32Vvp",
         key.offset: 394,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
@@ -4763,7 +4763,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC8FooEnum3VyABs6UInt32Vcfc",
+        key.usr: "s:So8FooEnum3VyABs6UInt32Vcfc",
         key.offset: 597,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -4780,7 +4780,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC8FooEnum3V8rawValueABs6UInt32V_tcfc",
+        key.usr: "s:So8FooEnum3V8rawValueABs6UInt32V_tcfc",
         key.offset: 627,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -4804,7 +4804,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC8FooEnum3V8rawValues6UInt32Vvp",
+        key.usr: "s:So8FooEnum3V8rawValues6UInt32Vvp",
         key.offset: 664,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
@@ -4940,7 +4940,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC17FooRuncingOptionsV8rawValueABSi_tcfc",
+        key.usr: "s:So17FooRuncingOptionsV8rawValueABSi_tcfc",
         key.offset: 1055,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5061,7 +5061,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.doc.full_as_xml: "<Function><Name>init(_:)</Name><USR>s:s10SetAlgebraPsEyxqd__cs8SequenceRd__7ElementQyd__ADRtzlufc</USR><Declaration>convenience init&lt;S&gt;(_ sequence: S) where S : Sequence, Self.Element == S.Element</Declaration><CommentParts><Abstract><Para>Creates a new set from a finite sequence of items.</Para></Abstract><Parameters><Parameter><Name>sequence</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The elements to use as members of the new set.</Para></Discussion></Parameter></Parameters><Discussion><Para>Use this initializer to create a new set from an existing sequence, like an array or a range:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let validIndices = Set(0..<7).subtracting([2, 4, 5])]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(validIndices)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[6, 0, 1, 3]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
         key.offset: 1385,
         key.length: 93,
-        key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>&lt;S&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>sequence</decl.var.parameter.name>: <decl.var.parameter.type>S</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>S : <ref.protocol usr=\"s:s8SequenceP\">Sequence</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>.<ref.typealias usr=\"s:SC17FooRuncingOptionsV7Elementa\">Element</ref.typealias> == S.Element</decl.generic_type_requirement></decl.function.constructor>",
+        key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>&lt;S&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>sequence</decl.var.parameter.name>: <decl.var.parameter.type>S</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>S : <ref.protocol usr=\"s:s8SequenceP\">Sequence</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>.<ref.typealias usr=\"s:So17FooRuncingOptionsV7Elementa\">Element</ref.typealias> == S.Element</decl.generic_type_requirement></decl.function.constructor>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -5493,7 +5493,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC10FooStruct1VABycfc",
+        key.usr: "s:So10FooStruct1VABycfc",
         key.offset: 2864,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -5501,7 +5501,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:SC10FooStruct1V1x1yABs5Int32V_Sdtcfc",
+        key.usr: "s:So10FooStruct1V1x1yABs5Int32V_Sdtcfc",
         key.offset: 2876,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5566,7 +5566,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC10FooStruct2VABycfc",
+        key.usr: "s:So10FooStruct2VABycfc",
         key.offset: 3033,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -5574,7 +5574,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:SC10FooStruct2V1x1yABs5Int32V_Sdtcfc",
+        key.usr: "s:So10FooStruct2V1x1yABs5Int32V_Sdtcfc",
         key.offset: 3045,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5632,7 +5632,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC17FooStructTypedef2VABycfc",
+        key.usr: "s:So17FooStructTypedef2VABycfc",
         key.offset: 3187,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -5640,7 +5640,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:SC17FooStructTypedef2V1x1yABs5Int32V_Sdtcfc",
+        key.usr: "s:So17FooStructTypedef2V1x1yABs5Int32V_Sdtcfc",
         key.offset: 3199,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -6429,7 +6429,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC15_InternalStructVABycfc",
+        key.usr: "s:So15_InternalStructVABycfc",
         key.offset: 5777,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -6437,7 +6437,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
-        key.usr: "s:SC15_InternalStructV1xABs5Int32V_tcfc",
+        key.usr: "s:So15_InternalStructV1xABs5Int32V_tcfc",
         key.offset: 5789,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -7063,7 +7063,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC11FooSubEnum1VyABs6UInt32Vcfc",
+        key.usr: "s:So11FooSubEnum1VyABs6UInt32Vcfc",
         key.offset: 7464,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -7080,7 +7080,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
+        key.usr: "s:So11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
         key.offset: 7494,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -7104,7 +7104,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC11FooSubEnum1V8rawValues6UInt32Vvp",
+        key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vvp",
         key.offset: 7531,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -28,5 +28,5 @@
 
 // CHECK:             key.kind: source.lang.swift.decl.var.static,
 // CHECK-NEXT:        key.name: "errFirst",
-// CHECK-NEXT:        key.usr: "s:SC7MyErrorV8errFirstAB4CodeOvpZ",
+// CHECK-NEXT:        key.usr: "s:SC7MyErrorV8errFirstSo0aB4CodeVvpZ",
 // CHECK-NEXT:        This is first error.

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -63,7 +63,7 @@ print("ObjC quick look objects:")
 // CHECK-LABEL: ObjC enums:
 print("ObjC enums:")
 
-// CHECK-NEXT: We cannot reflect ComparisonResult yet
+// CHECK-NEXT: We cannot reflect NSComparisonResult yet
 print("We cannot reflect \(ComparisonResult.orderedAscending) yet")
 
 // Don't crash when introspecting framework types such as NSURL.

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -361,7 +361,7 @@ Runtime.test("Generic class ObjC runtime names") {
   expectEqual("_TtGC1a12GenericClassMPS_9ProtocolAS_9ProtocolB__",
               NSStringFromClass(GenericClass<(ProtocolB & ProtocolA).Protocol>.self))
 
-  expectEqual("_TtGC1a12GenericClassCSo7CFArray_",
+  expectEqual("_TtGC1a12GenericClassaSo10CFArrayRef_",
               NSStringFromClass(GenericClass<CFArray>.self))
   expectEqual("_TtGC1a12GenericClassVSo7Decimal_",
               NSStringFromClass(GenericClass<Decimal>.self))
@@ -761,8 +761,8 @@ Reflection.test("Unmanaged/not-nil") {
   dump(optionalURL, to: &output)
 
   let expected =
-    "▿ Optional(Swift.Unmanaged<__C.CFURL>(_value: http://llvm.org/))\n" +
-    "  ▿ some: Swift.Unmanaged<__C.CFURL>\n" +
+    "▿ Optional(Swift.Unmanaged<__C.CFURLRef>(_value: http://llvm.org/))\n" +
+    "  ▿ some: Swift.Unmanaged<__C.CFURLRef>\n" +
     "    - _value: http://llvm.org/ #0\n" +
     "      - super: NSObject\n"
 

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -363,7 +363,7 @@ Runtime.test("Generic class ObjC runtime names") {
 
   expectEqual("_TtGC1a12GenericClassaSo10CFArrayRef_",
               NSStringFromClass(GenericClass<CFArray>.self))
-  expectEqual("_TtGC1a12GenericClassVSo7Decimal_",
+  expectEqual("_TtGC1a12GenericClassaSo9NSDecimal_",
               NSStringFromClass(GenericClass<Decimal>.self))
   expectEqual("_TtGC1a12GenericClassCSo8NSObject_",
               NSStringFromClass(GenericClass<NSObject>.self))

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -363,7 +363,7 @@ Runtime.test("Generic class ObjC runtime names") {
 
   expectEqual("_TtGC1a12GenericClassCSo7CFArray_",
               NSStringFromClass(GenericClass<CFArray>.self))
-  expectEqual("_TtGC1a12GenericClassVSC7Decimal_",
+  expectEqual("_TtGC1a12GenericClassVSo7Decimal_",
               NSStringFromClass(GenericClass<Decimal>.self))
   expectEqual("_TtGC1a12GenericClassCSo8NSObject_",
               NSStringFromClass(GenericClass<NSObject>.self))
@@ -761,8 +761,8 @@ Reflection.test("Unmanaged/not-nil") {
   dump(optionalURL, to: &output)
 
   let expected =
-    "▿ Optional(Swift.Unmanaged<__ObjC.CFURL>(_value: http://llvm.org/))\n" +
-    "  ▿ some: Swift.Unmanaged<__ObjC.CFURL>\n" +
+    "▿ Optional(Swift.Unmanaged<__C.CFURL>(_value: http://llvm.org/))\n" +
+    "  ▿ some: Swift.Unmanaged<__C.CFURL>\n" +
     "    - _value: http://llvm.org/ #0\n" +
     "      - super: NSObject\n"
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2617,7 +2617,8 @@ private:
     } else {
       Stream << "FAILURE";
     }
-    Stream << "\tfor '" << range.str() << "' mangled=" << mangledName << "\n";
+    Stream << "\tfor '" << range.str() << "' mangled=" << mangledName << " "
+           << Error << "\n";
   }
 
   void tryDemangleDecl(ValueDecl *VD, CharSourceRange range, bool isRef) {
@@ -2642,7 +2643,8 @@ private:
     } else {
       Stream << "FAILURE";
     }
-    Stream << "\tfor '" << range.str() << "' usr=" << USR << "\n";
+    Stream << "\tfor '" << range.str() << "' usr=" << USR << " " << error
+           << "\n";
   }
 };
 


### PR DESCRIPTION
Reviving #8871 for Swift 5. Using C names for imported declarations makes them consistent no matter what shenanigans are pulled by the importer, particularly NS_ENUM vs. NS_OPTIONS and NS_SWIFT_NAME. (Up until now we've just been using the Swift 4 name to mangle everything, which *sorta* works but doesn't scale.)

Still to improve:

- [x] The 'NSErrorDomain' API note nearly works with this, but the synthesized error struct is still mangled as a Swift declaration, which means it's not rename-stable. Fortunately, these are rare to appear at API boundaries. *Now handled in #13841.*

- [ ] For NS_STRING_ENUM: when this is applied, a typedef is imported as a unique struct, but without it it's just a typealias for the underlying type. I don't know if there's a good answer for this; we might just have to stick with Swift 3/4's "ignore an API that doesn't match up" practice. *Yep, I think that's the best we can do.*

- [x] Synthesized conformances have a module mangled into the witness table symbol. This isn't critical because that symbol is linkonce_odr, but we should still clean it up.

~This probably still needs more tests, especially around "type reconstruction" (going from mangled names back to AST types, as used by LLDB and SourceKit).~

rdar://problem/24688918
  