### PR TITLE
[Conformance checking] Don't suppress substitution failures during checking

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -387,6 +387,11 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements() {
 
 void NormalProtocolConformance::setSignatureConformances(
                                ArrayRef<ProtocolConformanceRef> conformances) {
+  if (conformances.empty()) {
+    SignatureConformances = { };
+    return;
+  }
+
   auto &ctx = getProtocol()->getASTContext();
   SignatureConformances = ctx.AllocateCopy(conformances);
 
@@ -458,11 +463,6 @@ NormalProtocolConformance::populateSignatureConformances() {
         requirementSignature(other.requirementSignature),
         buffer(other.buffer) {
       other.owning = false;
-    }
-
-    ~Writer() {
-      assert((!owning || self->isInvalid() || requirementSignature.empty()) &&
-             "signature conformances were not fully populated");
     }
 
     void operator()(ProtocolConformanceRef conformance){

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -636,12 +636,18 @@ public:
 
   /// Check all of the protocols requirements are actually satisfied by a
   /// the chosen type witnesses.
-  void ensureRequirementsAreSatisfied();
+  ///
+  /// \param failUnsubstituted Whether to fail when the requirements of the
+  /// protocol could not be substituted (e.g., due to missing information).
+  /// When true, emits a diagnostic in such cases; when false, enqueues the
+  /// conformance for later checking.
+  void ensureRequirementsAreSatisfied(bool failUnsubstituted);
 
   /// Check the entire protocol conformance, ensuring that all
   /// witnesses are resolved and emitting any diagnostics.
   void checkConformance(MissingWitnessDiagnosisKind Kind);
 };
+
 /// Captures the state needed to infer associated types.
 class AssociatedTypeInference {
   /// The type checker we'll need to validate declarations etc.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1648,7 +1648,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
   SWIFT_DEFER {
     // Resolution attempts to have the witnesses be correct by construction, but
     // this isn't guaranteed, so let's double check.
-    ensureRequirementsAreSatisfied();
+    ensureRequirementsAreSatisfied(/*failUnsubstituted=*/false);
   };
 
   // Attempt to infer associated type witnesses.
@@ -1657,10 +1657,10 @@ void ConformanceChecker::resolveTypeWitnesses() {
     for (const auto &inferredWitness : *inferred) {
       recordTypeWitness(inferredWitness.first, inferredWitness.second,
                         /*typeDecl=*/nullptr,
-      /*performRedeclarationCheck=*/true);
+                        /*performRedeclarationCheck=*/true);
     }
 
-    ensureRequirementsAreSatisfied();
+    ensureRequirementsAreSatisfied(/*failUnsubstituted=*/false);
     return;
   }
 
@@ -1676,11 +1676,6 @@ void ConformanceChecker::resolveTypeWitnesses() {
 
     recordTypeWitness(assocType, ErrorType::get(TC.Context), nullptr, true);
   }
-
-  return;
-
-  // Multiple solutions. Diagnose the ambiguity.
-
 }
 
 void ConformanceChecker::resolveSingleTypeWitness(

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -471,6 +471,14 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
       TC.finalizeDecl(decl);
     }
 
+    // Ensure that the requirements of the given conformance are
+    // fully checked.
+    for (unsigned i = 0; i != TC.PartiallyCheckedConformances.size(); ++i) {
+      auto conformance = TC.PartiallyCheckedConformances[i];
+      TC.checkConformanceRequirements(conformance);
+    }
+    TC.PartiallyCheckedConformances.clear();
+
     // Complete any conformances that we used.
     for (unsigned i = 0; i != TC.UsedConformances.size(); ++i) {
       auto conformance = TC.UsedConformances[i];
@@ -483,7 +491,8 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
            currentExternalDef < TC.Context.ExternalDefinitions.size() ||
            !TC.DeclsToFinalize.empty() ||
            !TC.DelayedRequirementSignatures.empty() ||
-           !TC.UsedConformances.empty());
+           !TC.UsedConformances.empty() ||
+           !TC.PartiallyCheckedConformances.empty());
 
   // FIXME: Horrible hack. Store this somewhere more appropriate.
   TC.Context.LastCheckedExternalDefinition = currentExternalDef;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -712,6 +712,11 @@ public:
   /// completed before type checking is considered complete.
   llvm::SetVector<NormalProtocolConformance *> UsedConformances;
 
+  /// The list of protocol conformances whose requirements could not be
+  /// fully checked and, therefore, should be checked again at the top
+  /// level.
+  llvm::SetVector<NormalProtocolConformance *> PartiallyCheckedConformances;
+
   /// The list of declarations that we've done at least partial validation
   /// of during type-checking, but which will need to be finalized before
   /// we can hand them off to SILGen etc.
@@ -2027,6 +2032,9 @@ public:
 
   /// Completely check the given conformance.
   void checkConformance(NormalProtocolConformance *conformance);
+
+  /// Check the requirement signature of the given conformance.
+  void checkConformanceRequirements(NormalProtocolConformance *conformance);
 
   /// Check all of the conformances in the given context.
   void checkConformancesInContext(DeclContext *dc,

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -321,7 +321,7 @@ func foo() {
 
 infix operator +&
 func +&<R, S>(lhs: inout R, rhs: S) where R : RangeReplaceableCollection, S : Sequence, R.Element == S.Element {}
-// expected-note@-1 {{candidate requires that the types 'String' and 'String.Element' (aka 'Character') be equivalent (requirement specified as 'R.Element' == 'S.Element' [with R = [String], S = String])}}
+// expected-note@-1 {{candidate requires that the types 'String' and 'Character' be equivalent (requirement specified as 'R.Element' == 'S.Element' [with R = [String], S = String])}}
 
 func rdar33477726_1() {
   var arr: [String] = []
@@ -330,13 +330,13 @@ func rdar33477726_1() {
 }
 
 func rdar33477726_2<R, S>(_: R, _: S) where R: Sequence, S == R.Element {}
-// expected-note@-1 {{candidate requires that the types 'Int' and 'String.Element' (aka 'Character') be equivalent (requirement specified as 'S' == 'R.Element' [with R = String, S = Int])}}
+// expected-note@-1 {{candidate requires that the types 'Int' and 'Character' be equivalent (requirement specified as 'S' == 'R.Element' [with R = String, S = Int])}}
 rdar33477726_2("answer", 42)
 // expected-error@-1 {{cannot invoke 'rdar33477726_2(_:_:)' with an argument list of type '(String, Int)'}}
 
 prefix operator +-
 prefix func +-<T>(_: T) where T: Sequence, T.Element == Int {}
-// expected-note@-1 {{candidate requires that the types 'String.Element' (aka 'Character') and 'Int' be equivalent (requirement specified as 'T.Element' == 'Int' [with T = String])}}
+// expected-note@-1 {{candidate requires that the types 'Character' and 'Int' be equivalent (requirement specified as 'T.Element' == 'Int' [with T = String])}}
 
 +-"hello"
 // expected-error@-1 {{unary operator '+-(_:)' cannot be applied to an operand of type 'String'}}

--- a/validation-test/compiler_crashers_2_fixed/0135-rdar26140749.swift
+++ b/validation-test/compiler_crashers_2_fixed/0135-rdar26140749.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+protocol ProtocolWithCount: Collection {
+    var count : UInt64 { get }
+}
+
+class ClassWithoutCount : ProtocolWithCount {
+//    var count: UInt64 = 0
+    var startIndex: UInt64 { get { return 0 }}
+    var endIndex: UInt64 { get { return 0 }}
+    subscript(i:UInt64) -> Int64 { get {return 0}}
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0136-rdar35082483.swift
+++ b/validation-test/compiler_crashers_2_fixed/0136-rdar35082483.swift
@@ -1,0 +1,20 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct S : Sequence {
+  struct Iterator : IteratorProtocol {
+    mutating func next() -> Int? {
+      fatalError()
+    }
+  }
+
+  func makeIterator() -> Iterator {
+    fatalError()
+  }
+}
+
+extension S : Collection {
+  typealias Index = Int
+
+  var startIndex: Int { return 0 }
+  var endIndex: Int { return 1 }
+}

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -7,8 +7,7 @@ import StdlibCollectionUnittest
 // Check that Collection.SubSequence is constrained to Collection.
 //
 
-// expected-error@+2 {{type 'CollectionWithBadSubSequence' does not conform to protocol 'Collection'}}
-// expected-error@+1 {{type 'CollectionWithBadSubSequence' does not conform to protocol 'Sequence'}}
+// expected-error@+1 {{type 'CollectionWithBadSubSequence' does not conform to protocol 'Collection'}}
 struct CollectionWithBadSubSequence : Collection {
   var startIndex: MinimalIndex {
     fatalError("unreachable")
@@ -22,7 +21,6 @@ struct CollectionWithBadSubSequence : Collection {
     fatalError("unreachable")
   }
 
-  // expected-note@+2 {{possibly intended match}}
   // expected-note@+1 {{possibly intended match}}
   typealias SubSequence = OpaqueValue<Int8>
 }


### PR DESCRIPTION
When checking whether a particular protocol conformance satisfies all of
the protocol's requirements, we were suppressing substitution failures.
In some cases, this would mean that we marked a conformance "invalid"
without ever emitting a diagnostic, which would lead to downstream crashes.

Instead, treat substitution failures somewhat more lazily. If we encounter
one while performing the checking, put the conformance into a "delayed" list
rather than failing immediately. Teach the top-level type checking
loop to re-check these conformances, emitting a diagnostic if they
fail the second time around.

Fixes rdar://problem/35082483 and likely other issues that slipped
through the type checker or blew up in unpredictable ways.