### PR TITLE
Clean up the IRGen APIs around dynamic allocas

### DIFF
--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -120,6 +120,11 @@ public:
   StackAddress(Address address, llvm::Value *SP)
       : Addr(address), StackPtrResetLocation(SP) {}
 
+  /// Return a StackAddress with the address changed in some superficial way.
+  StackAddress withAddress(Address addr) const {
+    return StackAddress(addr, StackPtrResetLocation);
+  }
+
   llvm::Value *getAddressPointer() const { return Addr.getAddress(); }
   Alignment getAlignment() const { return Addr.getAlignment(); }
   Address getAddress() const { return Addr; }

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_IRGEN_CALLEMISSION_H
 #define SWIFT_IRGEN_CALLEMISSION_H
 
+#include "Address.h"
 #include "Callee.h"
 
 namespace llvm {
@@ -26,7 +27,6 @@ namespace llvm {
 namespace swift {
 namespace irgen {
 
-class Address;
 class Explosion;
 class LoadableTypeInfo;
 struct WitnessMetadata;
@@ -36,9 +36,17 @@ class CallEmission {
 public:
   IRGenFunction &IGF;
 
+  struct TypedTemporary {
+    StackAddress Temp;
+    SILType Type;
+  };
+
 private:
   /// The builtin/special arguments to pass to the call.
   SmallVector<llvm::Value*, 8> Args;
+
+  /// Temporaries required by the call.
+  SmallVector<TypedTemporary, 4> Temporaries;
 
   /// The function we're going to call.
   Callee CurCallee;

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -76,7 +76,7 @@ public:
     return (isFixedSize(expansion) && StorageSize.isZero());
   }
 
-  StackAddress allocateStack(IRGenFunction &IGF, SILType T, bool isEntryBlock,
+  StackAddress allocateStack(IRGenFunction &IGF, SILType T,
                              const llvm::Twine &name) const override;
   void deallocateStack(IRGenFunction &IGF, StackAddress addr, SILType T) const override;
   void destroyStack(IRGenFunction &IGF, StackAddress addr, SILType T,

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -813,7 +813,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     } else if (origNativeSchema.requiresIndirect()) {
       assert(!nativeResultSchema.requiresIndirect());
       auto stackAddr = outResultTI.allocateStack(
-          subIGF, outConv.getSILResultType(), false, "return.temp");
+          subIGF, outConv.getSILResultType(), "return.temp");
       resultValueAddr = stackAddr.getAddress();
       auto resultAddr = subIGF.Builder.CreateBitCast(
           resultValueAddr,
@@ -1097,7 +1097,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
         // The +1 argument is passed indirectly, so we need to copy into a
         // temporary.
         needsAllocas = true;
-        auto stackAddr = fieldTI.allocateStack(subIGF, fieldTy, false, "arg.temp");
+        auto stackAddr = fieldTI.allocateStack(subIGF, fieldTy, "arg.temp");
         auto addressPointer = stackAddr.getAddress().getAddress();
         fieldTI.initializeWithCopy(subIGF, stackAddr.getAddress(), fieldAddr,
                                    fieldTy, false);

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -57,7 +57,6 @@ void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
 }
 
 StackAddress FixedTypeInfo::allocateStack(IRGenFunction &IGF, SILType T,
-                                          bool isEntryBlock,
                                           const Twine &name) const {
   // If the type is known to be empty, don't actually allocate anything.
   if (isKnownEmpty(ResilienceExpansion::Maximal)) {

--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -29,7 +29,6 @@ namespace irgen {
   class IRGenFunction;
   class IRGenModule;
   enum class ValueWitness : unsigned;
-  class StackAddress;
   class WitnessIndex;
 
   /// Return the size of a fixed buffer.
@@ -234,21 +233,6 @@ namespace irgen {
   /// Emit a load of the 'extraInhabitantCount' value witness.
   /// The type must be dynamically known to have extra inhabitant witnesses.
   llvm::Value *emitLoadOfExtraInhabitantCount(IRGenFunction &IGF, SILType T);
-
-  /// Emit a dynamic alloca call to allocate enough memory to hold an object of
-  /// type 'T' and an optional llvm.stackrestore point if 'isInEntryBlock' is
-  /// false.
-  struct DynamicAlloca {
-    llvm::Value *Alloca;
-    llvm::Value *SavedSP;
-    DynamicAlloca(llvm::Value *A, llvm::Value *SP) : Alloca(A), SavedSP(SP) {}
-  };
-  DynamicAlloca emitDynamicAlloca(IRGenFunction &IGF, SILType T,
-                                  bool isInEntryBlock);
-
-  /// Deallocate dynamic alloca's memory if the stack address has an SP restore
-  /// point associated with it.
-  void emitDeallocateDynamicAlloca(IRGenFunction &IGF, StackAddress address);
 
   /// Returns the IsInline flag and the loaded flags value.
   std::pair<llvm::Value *, llvm::Value *>

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -127,10 +127,16 @@ public:
   }
 
   Address createAlloca(llvm::Type *ty, Alignment align,
-                       const llvm::Twine &name);
-  Address createAlloca(llvm::Type *ty, llvm::Value *ArraySize, Alignment align,
-                       const llvm::Twine &name);
+                       const llvm::Twine &name = "");
+  Address createAlloca(llvm::Type *ty, llvm::Value *arraySize, Alignment align,
+                       const llvm::Twine &name = "");
   Address createFixedSizeBufferAlloca(const llvm::Twine &name);
+
+  StackAddress emitDynamicAlloca(SILType type, const llvm::Twine &name = "");
+  StackAddress emitDynamicAlloca(llvm::Type *eltTy, llvm::Value *arraySize,
+                                 Alignment align,
+                                 const llvm::Twine &name = "");
+  void emitDeallocateDynamicAlloca(StackAddress address);
 
   llvm::BasicBlock *createBasicBlock(const llvm::Twine &Name);
   const TypeInfo &getTypeInfoForUnlowered(Type subst);

--- a/lib/IRGen/NativeConventionSchema.h
+++ b/lib/IRGen/NativeConventionSchema.h
@@ -26,13 +26,14 @@
 namespace swift {
 namespace irgen {
 
+using SwiftAggLowering = clang::CodeGen::swiftcall::SwiftAggLowering;
+
 class NativeConventionSchema {
-  clang::CodeGen::swiftcall::SwiftAggLowering Lowering;
+  SwiftAggLowering Lowering;
   bool RequiresIndirect;
 
 public:
-  using EnumerationCallback =
-      clang::CodeGen::swiftcall::SwiftAggLowering::EnumerationCallback;
+  using EnumerationCallback = SwiftAggLowering::EnumerationCallback;
 
   NativeConventionSchema(IRGenModule &IGM, const TypeInfo *TI, bool isResult);
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -261,7 +261,6 @@ public:
 
   /// Allocate a variable of this type on the stack.
   virtual StackAddress allocateStack(IRGenFunction &IGF, SILType T,
-                                     bool isInEntryBlock,
                                      const llvm::Twine &name) const = 0;
 
   /// Deallocate a variable of this type.

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -203,8 +203,8 @@ class Foo {
   // x86_64-macosx:      call void @llvm.lifetime.start
   // x86_64-macosx:      store i32 {{.*}}
   // x86_64-macosx:      store i32 {{.*}}
-  // x86_64-macosx:      getelementptr inbounds { i64 }, { i64 }
-  // x86_64-macosx:      load i64, i64* %12, align 8
+  // x86_64-macosx:      [[T0:%.*]] = getelementptr inbounds { i64 }, { i64 }
+  // x86_64-macosx:      load i64, i64* [[T0]], align 8
   // x86_64-macosx:      bitcast
   // x86_64-macosx:      call void @llvm.lifetime.end
   // x86_64-macosx:      ret i64


### PR DESCRIPTION
Clean up the internal APIs around dynamic allocas to structurally
discourage accidental use of them.  Relatedly, fix several bugs
where we were accidentally using dynamic allocas.