### PR TITLE
Fixes for uses of noescape functions.

### DIFF
--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -42,3 +42,25 @@ func bar(_: () throws -> ()) {}
 func bar_empty() {}
 
 bar(bar_empty)
+
+func consumeNoEscape(_ f: (Int) -> Int) {}
+func consumeEscaping(_ f: @escaping (Int) -> Int) {}
+func takesAny(_ f: Any)  {}
+
+func twoFns(_ f: (Int) -> Int, _ g: @escaping (Int) -> Int) {
+  // expected-note@-1 {{parameter 'f' is implicitly non-escaping}}
+  takesAny(f) // expected-error {{argument type '(Int) -> Int' does not conform to expected type 'Any'}}
+  takesAny(g)
+  var h = g
+  h = f // expected-error {{assigning non-escaping parameter 'f' to an @escaping closure}}
+}
+
+takesAny(consumeNoEscape)
+takesAny(consumeEscaping)
+
+var noEscapeParam: ((Int) -> Int) -> () = consumeNoEscape
+var escapingParam: (@escaping (Int) -> Int) -> () = consumeEscaping
+noEscapeParam = escapingParam // expected-error {{cannot assign value of type '(@escaping (Int) -> Int) -> ()' to type '((Int) -> Int) -> ()}}
+
+escapingParam = takesAny
+noEscapeParam = takesAny // expected-error {{cannot assign value of type '(Any) -> ()' to type '((Int) -> Int) -> ()'}}

--- a/test/Constraints/suspicious_bit_casts.swift
+++ b/test/Constraints/suspicious_bit_casts.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
 func escapeByBitCast(f: () -> ()) -> () -> () {
-  // expected-warning@+1{{'unsafeBitCast' from non-escaping function type '() -> ()' to escaping function type '() -> ()' is undefined; use 'withoutActuallyEscaping' to temporarily escape a function}}
   return unsafeBitCast(f, to: (() -> ()).self)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
 }
 
 func changeFnRep(f: @escaping () -> ()) -> @convention(block) () -> () {

--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -84,6 +84,7 @@ def derive_name((type, val)):
 
 for name, type, val in map(derive_name, type_initializer_map):
   generic = (type in ['T', 'U'])
+  function = "->" in type
 }%                                  
 %  if generic:
 public class ContextA_${name}<T, U : Proto> {
@@ -329,7 +330,9 @@ public func arg_${name}(_ v: ${type}) {
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_artificial
 %  end
+%  if not function:
   use(v)
+%  end
 }
 
 public func arg_inout_${name}(_ v: inout ${type}) {

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -339,21 +339,20 @@ func convUpcastMetatype(_ c4: @escaping (Parent.Type, Trivial?) -> Child.Type,
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   [[REABSTRACT_THUNK:%.*]] = function_ref @$SypS2iIegyd_Iegio_S2iIgyd_ypIegyr_TR
+// CHECK:   [[REABSTRACT_THUNK:%.*]] = function_ref @$SypS2iIegyd_Iegio_S2iIegyd_ypIegxr_TR
 // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[ARG_COPY]])
 // CHECK:   destroy_value [[PA]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '$S19function_conversion19convFuncExistentialyyS2icypcF'
 func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
-  let _: ((Int) -> Int) -> Any = f1
+  let _: (@escaping (Int) -> Int) -> Any = f1
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$SypS2iIegyd_Iegio_S2iIgyd_ypIegyr_TR : $@convention(thin) (@noescape @callee_guaranteed (Int) -> Int, @guaranteed @callee_guaranteed (@in Any) -> @owned @callee_guaranteed (Int) -> Int) -> @out Any
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$SypS2iIegyd_Iegio_S2iIegyd_ypIegxr_TR : $@convention(thin) (@owned @callee_guaranteed (Int) -> Int, @guaranteed @callee_guaranteed (@in Any) -> @owned @callee_guaranteed (Int) -> Int) -> @out Any {
 // CHECK:         alloc_stack $Any
-// CHECK:         function_ref @$SS2iIgyd_S2iIegir_TR
+// CHECK:         function_ref @$SS2iIegyd_S2iIegir_TR
 // CHECK-NEXT:    partial_apply
-// CHECK-NEXT:    convert_escape_to_noescape
 // CHECK-NEXT:    init_existential_addr %3 : $*Any, $(Int) -> Int
 // CHECK-NEXT:    store
 // CHECK-NEXT:    apply

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -10,6 +10,13 @@ func doesEscape(_ fn : @escaping () -> Int) {}
 func takesGenericClosure<T>(_ a : Int, _ fn : @noescape () -> T) {} // expected-warning{{@noescape is the default and is deprecated}} {{47-57=}}
 
 
+var globalAny: Any = 0
+
+func assignToGlobal<T>(_ t: T) {
+  // expected-note@-1 {{in call to function 'assignToGlobal'}}
+  globalAny = t
+}
+
 func takesArray(_ fns: [() -> Int]) {
   doesEscape(fns[0]) // Okay - array-of-function parameters are escaping
 }
@@ -26,8 +33,6 @@ func takesNoEscapeClosure(_ fn : () -> Int) {
   // expected-note@-5{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   // expected-note@-6{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   // expected-note@-7{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
-  // expected-note@-8{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
-  // expected-note@-9{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   takesNoEscapeClosure { 4 }  // ok
 
   _ = fn()  // ok
@@ -51,12 +56,15 @@ func takesNoEscapeClosure(_ fn : () -> Int) {
   takesGenericClosure(4, fn)       // ok
   takesGenericClosure(4) { fn() }  // ok.
 
-  _ = [fn] // expected-error {{non-escaping parameter 'fn' may only be called}}
+  _ = [fn] // expected-error {{type of expression is ambiguous without more context}}
   _ = [doesEscape(fn)] // expected-error {{'(() -> Int) -> ()' is not convertible to '(@escaping () -> Int) -> ()'}}
-  _ = [1 : fn] // expected-error {{non-escaping parameter 'fn' may only be called}}
+  _ = [1 : fn] // expected-error {{type of expression is ambiguous without more context}}
   _ = [1 : doesEscape(fn)] // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
   _ = "\(doesEscape(fn))" // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
   _ = "\(takesArray([fn]))" // expected-error {{using non-escaping parameter 'fn' in a context expecting an @escaping closure}}
+
+  // FIXME: Generate a more specific error about the non-escaping parameter 'fn'
+  assignToGlobal(fn) // expected-error {{generic parameter 'T' could not be inferred}}
 }
 
 class SomeClass {


### PR DESCRIPTION
Disallow noescape functions from being captured in collections or
passed as arguments in generic positions.

Fixes rdar://problem/24097075.
