### PR TITLE
[4.1] DynamicCasts: Emit a direct copy if soure and target SIL types match

### DIFF
--- a/test/SILOptimizer/cast_foldings.sil
+++ b/test/SILOptimizer/cast_foldings.sil
@@ -139,3 +139,13 @@ bb0(%0 : $*AnyObject):
   return %r : $()
 }
 
+// CHECK-LABEL: sil @testIOU
+// CHECK: bb0(%0 : $*Optional<AnyObject>, %1 : $*Optional<AnyObject>):
+// CHECK:  [[TMP:%.*]] = load %1 : $*Optional<AnyObject>
+// CHECK:  store [[TMP]] to %0 : $*Optional<AnyObject>
+sil @testIOU : $@convention(thin) (@in Optional<AnyObject>) -> (@out Optional<AnyObject>) {
+bb0(%0 : $*Optional<AnyObject>, %1: $*Optional<AnyObject>):
+  unconditional_checked_cast_addr ImplicitlyUnwrappedOptional<AnyObject> in %1 : $*Optional<AnyObject> to Optional<AnyObject> in %0 : $*Optional<AnyObject>
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
DynamicCasts: Emit a direct copy if soure and target SIL types match

  unconditional_checked_cast_addr ImplicitlyUnwrappedOptional in %136 : *Optional to *Optional in %135

* Description: Casts involving IOUs crashed the compiler.

public class  Crasher {
  public func crash() -> Dictionary<String, AnyObject?> {
    let world = Dictionary<String, AnyObject!>()
    return world
  }
}

* Origin: We must have changed how we treat IOUs recently

* Scope: Target fix in the cast optimization

* Risk: Low. Targeted fix of code that without fix would have cause a compiler crash.

* Testing: A CI test was added.

rdar://35987160


