### PR TITLE
Lower the FunctionMergeThreshold from 30 to 15

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -75,7 +75,7 @@ static cl::opt<unsigned> FunctionMergeThreshold(
     "swiftmergefunc-threshold",
     cl::desc("Functions larger than the threshold are considered for merging."
              "'0' disables function merging at all."),
-    cl::init(30), cl::Hidden);
+    cl::init(15), cl::Hidden);
 
 namespace {
 


### PR DESCRIPTION
rdar://problem/35705596

This PR lowers the threshold in LLVM's Function Merge pass from 30 to 15.

This reduces the size of the Swift standard library by 2.1% and reduces the size of projects that make heavy use of classes containing a large number of properties by up to 24.87%