### PR TITLE
In SILCodeMotion, be sure to invalidate global enum tag dataflow state when deleting instructions

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -68,7 +68,7 @@ public:
   /// Returns -1 if the block is not contained in a function.
   /// Warning: This function is slow. Therefore it should only be used for
   ///          debug output.
-  int getDebugID();
+  int getDebugID() const;
 
   SILFunction *getParent() { return Parent; }
   const SILFunction *getParent() const { return Parent; }

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -63,7 +63,7 @@ SILBasicBlock::~SILBasicBlock() {
   InstList.clearAndLeakNodesUnsafely();
 }
 
-int SILBasicBlock::getDebugID() {
+int SILBasicBlock::getDebugID() const {
   if (!getParent())
     return -1;
   int idx = 0;

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -118,6 +118,7 @@ using EnumBBCaseList =
 /// Class that performs enum tag state dataflow on the given BB.
 class BBEnumTagDataflowState
     : public SILInstructionVisitor<BBEnumTagDataflowState, bool> {
+  EnumCaseDataflowContext *Context;
   NullablePtr<SILBasicBlock> BB;
 
   using ValueToCaseSmallBlotMapVectorTy =
@@ -137,11 +138,7 @@ public:
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
                             "only for use within the debugger");
 
-  bool init(SILBasicBlock *NewBB) {
-    assert(NewBB && "NewBB should not be null");
-    BB = NewBB;
-    return true;
-  }
+  bool init(EnumCaseDataflowContext &Context, SILBasicBlock *NewBB);
 
   SILBasicBlock *getBB() { return BB.get(); }
 
@@ -200,7 +197,7 @@ public:
     BBToStateVec.resize(PO->size());
     unsigned RPOIdx = 0;
     for (SILBasicBlock *BB : PO->getReversePostOrder()) {
-      BBToStateVec[RPOIdx].init(BB);
+      BBToStateVec[RPOIdx].init(*this, BB);
       ++RPOIdx;
     }
   }
@@ -755,6 +752,14 @@ void BBEnumTagDataflowState::dump() const {
     llvm::dbgs() << "  End Case List.\n";
   }
 #endif
+}
+
+bool BBEnumTagDataflowState::init(EnumCaseDataflowContext &NewContext,
+                                  SILBasicBlock *NewBB) {
+  assert(NewBB && "NewBB should not be null");
+  Context = &NewContext;
+  BB = NewBB;
+  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -134,6 +134,9 @@ public:
   BBEnumTagDataflowState(const BBEnumTagDataflowState &Other) = default;
   ~BBEnumTagDataflowState() = default;
 
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "only for use within the debugger");
+
   bool init(SILBasicBlock *NewBB) {
     assert(NewBB && "NewBB should not be null");
     BB = NewBB;
@@ -731,6 +734,27 @@ bool BBEnumTagDataflowState::sinkIncrementsOutOfSwitchRegions(
   }
 
   return Changed;
+}
+
+void BBEnumTagDataflowState::dump() const {
+#ifndef NDEBUG
+  llvm::dbgs() << "Dumping state for BB" << BB.get()->getDebugID() << "\n";
+  // For each (EnumValue, [(BB, EnumTag)]) that we are tracking...
+  for (auto &P : EnumToEnumBBCaseListMap) {
+    if (!P.hasValue()) {
+      llvm::dbgs() << "  NULL enum value... skipping!\n";
+      continue;
+    }
+    llvm::dbgs() << "  Found value: " << P->first << "\n";
+    llvm::dbgs() << "  Case List:\n";
+    for (auto &P2 : P->second) {
+      llvm::dbgs() << "    BB" << P2.first->getDebugID() << ": ";
+      P2.second->dump(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    }
+    llvm::dbgs() << "  End Case List.\n";
+  }
+#endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -68,6 +68,8 @@ enum Optional<T> {
   case some(T)
 }
 
+class Klass {}
+
 sil @user : $@convention(thin) (Builtin.NativeObject) -> ()
 sil @user_int : $@convention(thin) (Int) -> ()
 sil @optional_user : $@convention(thin) (Optional<Builtin.Int32>) -> ()
@@ -1593,3 +1595,41 @@ bb3(%20 : $Int):                                  // Preds: bb1 bb2
   return %23 : $()                                // id: %25
 }
 
+// Make sure that we properly perform global blotting of values and do not crash
+// on this code. This will only fail reliably in ASAN builds of swift in such a
+// case.
+sil @test_global_blotting : $@convention(thin) () -> () {
+bbBegin:
+  %0a = enum $Optional<Klass>, #Optional.none!enumelt
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb8(%0a : $Optional<Klass>)
+
+bb2:
+  %0 = enum $Optional<Klass>, #Optional.none!enumelt
+  cond_br undef, bb7, bb3
+
+bb3:
+  cond_br undef, bb4, bb5
+
+bb4:
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  br bb9
+
+bb7:
+  br bb8(%0 : $Optional<Klass>)
+
+bb8(%result : $Optional<Klass>):
+  release_value %result : $Optional<Klass>
+  br bb9
+
+bb9:
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
Specifically what happens is shown by the following SIL example:

```
enum Optional<T> {
case none
case some(T)
}

class Klass {}

sil @foo : $@convention(thin) () -> () {
bbBegin:
  %0a = enum $Optional<Klass>, #Optional.none!enumelt
  cond_br undef, bb1, bb2

bb1:
  br bb8(%0a : $Optional<Klass>)

bb2:
  %0 = enum $Optional<Klass>, #Optional.none!enumelt
  cond_br undef, bb7, bb3

bb3:
  cond_br undef, bb4, bb5

bb4:
  br bb6

bb5:
  br bb6

bb6:
  br bb9

bb7:
  br bb8(%0 : $Optional<Klass>)

bb8(%result : $Optional<Klass>):
  release_value %result : $Optional<Klass>
  br bb9

bb9:
  %9999 = tuple()
  return %9999 : $()
}
```

The way the bug manifests is that:

1. We visit bbBegin, start tracking that enum (for the purpose of moving retains/releases out of switch regions where one of the switch branches has a non-payloaded enum).
2. When we visit bb8, we want to sink the creation of %result so we perform a release_value on a non-phi node value. But, we move %0a instead of %0 and delete %0.
3. When we hit bb9, we check our predecessor state to see if we are the end of a switch region. We are still tracking %0 and try to look up %0's RCIdentity... *boom* =><=.

The fix is to:

1. Add a layer of indirection so in our dataflow we do not refer directly to SILValues. Instead we use an index into a data store where the SILValues are actually stored.
2. If a different part of the pass eliminates an instruction, it blots out the SILValue results of that instruction in the list.
3. When the enum tag dataflow attempts to lookup a value for its ID, if the stored value was invalidated, it just skips it.

Some notes:

1. I ran into forward declaration issues, so I had to move the non-enum tag dataflow part beneath the enum tag dataflow part. I put that into the first commit to ease review.
2. I also found another instance of this in a different part of the pass. I fixed that as well.

rdar://36032876