### PR TITLE
libSyntax: create syntax nodes for variable declarations.

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -777,6 +777,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
   
   // Now parse an optional type annotation.
   if (Tok.is(tok::colon)) {
+    SyntaxParsingContext TypeAnnoCtx(SyntaxContext, SyntaxKind::TypeAnnotation);
     SourceLoc colonLoc = consumeToken(tok::colon);
     
     if (result.isNull())  // Recover by creating AnyPattern.
@@ -841,6 +842,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
 ///   pattern ::= 'let' pattern
 ///
 ParserResult<Pattern> Parser::parsePattern() {
+  SyntaxParsingContext PatternCtx(SyntaxContext, SyntaxContextKind::Pattern);
   switch (Tok.getKind()) {
   case tok::l_paren:
     return parsePatternTuple();
@@ -849,6 +851,7 @@ ParserResult<Pattern> Parser::parsePattern() {
     return makeParserResult(new (Context) AnyPattern(consumeToken(tok::kw__)));
     
   case tok::identifier: {
+    PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
     Identifier name;
     SourceLoc loc = consumeIdentifier(&name);
     bool isLet = (InVarOrLetPattern != IVOLP_InVar);

--- a/lib/Syntax/Status.md
+++ b/lib/Syntax/Status.md
@@ -68,10 +68,10 @@
   * ImportDecl
   * TypeAliasDecl
   * IfConfigDecl
-
-### In-progress (UnknownDecl):
   * PatternBindingDecl
   * VarDecl
+
+### In-progress (UnknownDecl):
   * ExtensionDecl (SR-6572)
 
 ### Not-started (UnknownDecl):
@@ -118,7 +118,6 @@
   * AnyPattern
   * TypedPattern
   * VarPattern
-
 
 ## TypeRepr
 ### Done:

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -41,7 +41,7 @@ bool SyntaxData::isExpr() const {
 }
 
 bool SyntaxData::isPattern() const {
-  return false; // FIXME: Raw->isPattern();
+  return Raw->isPattern();
 }
 
 bool SyntaxData::isUnknown() const {

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -116,8 +116,22 @@
                               "kind": "DeclList",
                               "layout": [
                                 {
-                                  "kind": "UnknownDecl",
+                                  "kind": "VariableDecl",
                                   "layout": [
+                                    {
+                                      "kind": "AttributeList",
+                                      "layout": [
+
+                                      ],
+                                      "presence": "Missing"
+                                    },
+                                    {
+                                      "kind": "ModifierList",
+                                      "layout": [
+
+                                      ],
+                                      "presence": "Missing"
+                                    },
                                     {
                                       "tokenKind": {
                                         "kind": "kw_let"
@@ -141,58 +155,108 @@
                                       "presence": "Present"
                                     },
                                     {
-                                      "tokenKind": {
-                                        "kind": "identifier",
-                                        "text": "bar"
-                                      },
-                                      "leadingTrivia": [
-
-                                      ],
-                                      "trailingTrivia": [
-                                        {
-                                          "kind": "Space",
-                                          "value": 1
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    },
-                                    {
-                                      "tokenKind": {
-                                        "kind": "colon"
-                                      },
-                                      "leadingTrivia": [
-
-                                      ],
-                                      "trailingTrivia": [
-                                        {
-                                          "kind": "Space",
-                                          "value": 1
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    },
-                                    {
-                                      "kind": "SimpleTypeIdentifier",
+                                      "kind": "PatternBindingList",
                                       "layout": [
                                         {
-                                          "tokenKind": {
-                                            "kind": "identifier",
-                                            "text": "Int"
-                                          },
-                                          "leadingTrivia": [
+                                          "kind": "PatternBinding",
+                                          "layout": [
+                                            {
+                                              "kind": "IdentifierPattern",
+                                              "layout": [
+                                                {
+                                                  "tokenKind": {
+                                                    "kind": "identifier",
+                                                    "text": "bar"
+                                                  },
+                                                  "leadingTrivia": [
 
-                                          ],
-                                          "trailingTrivia": [
+                                                  ],
+                                                  "trailingTrivia": [
+                                                    {
+                                                      "kind": "Space",
+                                                      "value": 1
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
+                                                }
+                                              ],
+                                              "presence": "Present"
+                                            },
+                                            {
+                                              "kind": "TypeAnnotation",
+                                              "layout": [
+                                                {
+                                                  "tokenKind": {
+                                                    "kind": "colon"
+                                                  },
+                                                  "leadingTrivia": [
 
+                                                  ],
+                                                  "trailingTrivia": [
+                                                    {
+                                                      "kind": "Space",
+                                                      "value": 1
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
+                                                },
+                                                {
+                                                  "kind": "SimpleTypeIdentifier",
+                                                  "layout": [
+                                                    {
+                                                      "tokenKind": {
+                                                        "kind": "identifier",
+                                                        "text": "Int"
+                                                      },
+                                                      "leadingTrivia": [
+
+                                                      ],
+                                                      "trailingTrivia": [
+
+                                                      ],
+                                                      "presence": "Present"
+                                                    },
+                                                    {
+                                                      "kind": "GenericArgumentClause",
+                                                      "layout": [
+
+                                                      ],
+                                                      "presence": "Missing"
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
+                                                }
+                                              ],
+                                              "presence": "Present"
+                                            },
+                                            {
+                                              "kind": "InitializerClause",
+                                              "layout": [
+
+                                              ],
+                                              "presence": "Missing"
+                                            },
+                                            {
+                                              "kind": "AccessorBlock",
+                                              "layout": [
+
+                                              ],
+                                              "presence": "Missing"
+                                            },
+                                            {
+                                              "tokenKind": {
+                                                "kind": "comma"
+                                              },
+                                              "leadingTrivia": [
+
+                                              ],
+                                              "trailingTrivia": [
+
+                                              ],
+                                              "presence": "Missing"
+                                            }
                                           ],
                                           "presence": "Present"
-                                        },
-                                        {
-                                          "kind": "GenericArgumentClause",
-                                          "layout": [
-
-                                          ],
-                                          "presence": "Missing"
                                         }
                                       ],
                                       "presence": "Present"
@@ -201,8 +265,22 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "kind": "UnknownDecl",
+                                  "kind": "VariableDecl",
                                   "layout": [
+                                    {
+                                      "kind": "AttributeList",
+                                      "layout": [
+
+                                      ],
+                                      "presence": "Missing"
+                                    },
+                                    {
+                                      "kind": "ModifierList",
+                                      "layout": [
+
+                                      ],
+                                      "presence": "Missing"
+                                    },
                                     {
                                       "tokenKind": {
                                         "kind": "kw_let"
@@ -226,86 +304,76 @@
                                       "presence": "Present"
                                     },
                                     {
-                                      "tokenKind": {
-                                        "kind": "identifier",
-                                        "text": "baz"
-                                      },
-                                      "leadingTrivia": [
-
-                                      ],
-                                      "trailingTrivia": [
-                                        {
-                                          "kind": "Space",
-                                          "value": 1
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    },
-                                    {
-                                      "tokenKind": {
-                                        "kind": "colon"
-                                      },
-                                      "leadingTrivia": [
-
-                                      ],
-                                      "trailingTrivia": [
-                                        {
-                                          "kind": "Space",
-                                          "value": 1
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    },
-                                    {
-                                      "kind": "SimpleTypeIdentifier",
+                                      "kind": "PatternBindingList",
                                       "layout": [
                                         {
-                                          "tokenKind": {
-                                            "kind": "identifier",
-                                            "text": "Array"
-                                          },
-                                          "leadingTrivia": [
-
-                                          ],
-                                          "trailingTrivia": [
-                                            {
-                                              "kind": "Space",
-                                              "value": 1
-                                            }
-                                          ],
-                                          "presence": "Present"
-                                        },
-                                        {
-                                          "kind": "GenericArgumentClause",
+                                          "kind": "PatternBinding",
                                           "layout": [
                                             {
-                                              "tokenKind": {
-                                                "kind": "l_angle"
-                                              },
-                                              "leadingTrivia": [
-
-                                              ],
-                                              "trailingTrivia": [
+                                              "kind": "IdentifierPattern",
+                                              "layout": [
                                                 {
-                                                  "kind": "Space",
-                                                  "value": 1
+                                                  "tokenKind": {
+                                                    "kind": "identifier",
+                                                    "text": "baz"
+                                                  },
+                                                  "leadingTrivia": [
+
+                                                  ],
+                                                  "trailingTrivia": [
+                                                    {
+                                                      "kind": "Space",
+                                                      "value": 1
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
                                                 }
                                               ],
                                               "presence": "Present"
                                             },
                                             {
-                                              "kind": "GenericArgumentList",
+                                              "kind": "TypeAnnotation",
                                               "layout": [
                                                 {
-                                                  "kind": "GenericArgument",
+                                                  "tokenKind": {
+                                                    "kind": "colon"
+                                                  },
+                                                  "leadingTrivia": [
+
+                                                  ],
+                                                  "trailingTrivia": [
+                                                    {
+                                                      "kind": "Space",
+                                                      "value": 1
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
+                                                },
+                                                {
+                                                  "kind": "SimpleTypeIdentifier",
                                                   "layout": [
                                                     {
-                                                      "kind": "SimpleTypeIdentifier",
+                                                      "tokenKind": {
+                                                        "kind": "identifier",
+                                                        "text": "Array"
+                                                      },
+                                                      "leadingTrivia": [
+
+                                                      ],
+                                                      "trailingTrivia": [
+                                                        {
+                                                          "kind": "Space",
+                                                          "value": 1
+                                                        }
+                                                      ],
+                                                      "presence": "Present"
+                                                    },
+                                                    {
+                                                      "kind": "GenericArgumentClause",
                                                       "layout": [
                                                         {
                                                           "tokenKind": {
-                                                            "kind": "identifier",
-                                                            "text": "Int"
+                                                            "kind": "l_angle"
                                                           },
                                                           "leadingTrivia": [
 
@@ -319,26 +387,72 @@
                                                           "presence": "Present"
                                                         },
                                                         {
-                                                          "kind": "GenericArgumentClause",
+                                                          "kind": "GenericArgumentList",
                                                           "layout": [
+                                                            {
+                                                              "kind": "GenericArgument",
+                                                              "layout": [
+                                                                {
+                                                                  "kind": "SimpleTypeIdentifier",
+                                                                  "layout": [
+                                                                    {
+                                                                      "tokenKind": {
+                                                                        "kind": "identifier",
+                                                                        "text": "Int"
+                                                                      },
+                                                                      "leadingTrivia": [
+
+                                                                      ],
+                                                                      "trailingTrivia": [
+                                                                        {
+                                                                          "kind": "Space",
+                                                                          "value": 1
+                                                                        }
+                                                                      ],
+                                                                      "presence": "Present"
+                                                                    },
+                                                                    {
+                                                                      "kind": "GenericArgumentClause",
+                                                                      "layout": [
+
+                                                                      ],
+                                                                      "presence": "Missing"
+                                                                    }
+                                                                  ],
+                                                                  "presence": "Present"
+                                                                },
+                                                                {
+                                                                  "tokenKind": {
+                                                                    "kind": "comma"
+                                                                  },
+                                                                  "leadingTrivia": [
+
+                                                                  ],
+                                                                  "trailingTrivia": [
+
+                                                                  ],
+                                                                  "presence": "Missing"
+                                                                }
+                                                              ],
+                                                              "presence": "Present"
+                                                            }
+                                                          ],
+                                                          "presence": "Present"
+                                                        },
+                                                        {
+                                                          "tokenKind": {
+                                                            "kind": "r_angle"
+                                                          },
+                                                          "leadingTrivia": [
 
                                                           ],
-                                                          "presence": "Missing"
+                                                          "trailingTrivia": [
+
+                                                          ],
+                                                          "presence": "Present"
                                                         }
                                                       ],
                                                       "presence": "Present"
-                                                    },
-                                                    {
-                                                      "tokenKind": {
-                                                        "kind": "comma"
-                                                      },
-                                                      "leadingTrivia": [
-
-                                                      ],
-                                                      "trailingTrivia": [
-
-                                                      ],
-                                                      "presence": "Missing"
                                                     }
                                                   ],
                                                   "presence": "Present"
@@ -347,8 +461,22 @@
                                               "presence": "Present"
                                             },
                                             {
+                                              "kind": "InitializerClause",
+                                              "layout": [
+
+                                              ],
+                                              "presence": "Missing"
+                                            },
+                                            {
+                                              "kind": "AccessorBlock",
+                                              "layout": [
+
+                                              ],
+                                              "presence": "Missing"
+                                            },
+                                            {
                                               "tokenKind": {
-                                                "kind": "r_angle"
+                                                "kind": "comma"
                                               },
                                               "leadingTrivia": [
 
@@ -356,7 +484,7 @@
                                               "trailingTrivia": [
 
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Missing"
                                             }
                                           ],
                                           "presence": "Present"

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -16,15 +16,15 @@ class C <MemberDeclBlock>{<FunctionDecl>
   func bar2<FunctionSignature><ParameterClause>(<FunctionParameter>a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>b: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>c:<SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock></FunctionDecl><FunctionDecl>
   func bar3<FunctionSignature><ParameterClause>(<FunctionParameter>a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock></FunctionDecl><FunctionDecl>
   func bar4<FunctionSignature><ParameterClause>(<FunctionParameter>_ a: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock></FunctionDecl><FunctionDecl>
-  func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{
-    var a = <StringLiteralExpr>/*comment*/"ab\(x)c"</StringLiteralExpr>/*comment*/
-    var b = <PrefixOperatorExpr>/*comment*/+<IntegerLiteralExpr>2</IntegerLiteralExpr></PrefixOperatorExpr><IdentifierExpr>/*comment*/
+  func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<VariableDecl>
+    var <PatternBinding><IdentifierPattern>a </IdentifierPattern><InitializerClause>= <StringLiteralExpr>/*comment*/"ab\(x)c"</StringLiteralExpr></InitializerClause></PatternBinding></VariableDecl><VariableDecl>/*comment*/
+    var <PatternBinding><IdentifierPattern>b </IdentifierPattern><InitializerClause>= <PrefixOperatorExpr>/*comment*/+<IntegerLiteralExpr>2</IntegerLiteralExpr></PrefixOperatorExpr></InitializerClause></PatternBinding></VariableDecl><IdentifierExpr>/*comment*/
     bar</IdentifierExpr>(<FunctionCallArgument><IntegerLiteralExpr>1</IntegerLiteralExpr></FunctionCallArgument>)<IdentifierExpr>
     bar</IdentifierExpr>(<FunctionCallArgument><PrefixOperatorExpr>+<IntegerLiteralExpr>10</IntegerLiteralExpr></PrefixOperatorExpr></FunctionCallArgument>)<IdentifierExpr>
     bar</IdentifierExpr>(<FunctionCallArgument><PrefixOperatorExpr>-<IntegerLiteralExpr>10</IntegerLiteralExpr></PrefixOperatorExpr></FunctionCallArgument>)<IdentifierExpr>
     bar1</IdentifierExpr>(<FunctionCallArgument><PrefixOperatorExpr>-<FloatLiteralExpr>1.1</FloatLiteralExpr></PrefixOperatorExpr></FunctionCallArgument>)<IdentifierExpr>
-    bar1</IdentifierExpr>(<FunctionCallArgument><FloatLiteralExpr>1.1</FloatLiteralExpr></FunctionCallArgument>)
-    var f = <PrefixOperatorExpr>/*comments*/+<FloatLiteralExpr>0.1</FloatLiteralExpr></PrefixOperatorExpr><IdentifierExpr>/*comments*/
+    bar1</IdentifierExpr>(<FunctionCallArgument><FloatLiteralExpr>1.1</FloatLiteralExpr></FunctionCallArgument>)<VariableDecl>
+    var <PatternBinding><IdentifierPattern>f </IdentifierPattern><InitializerClause>= <PrefixOperatorExpr>/*comments*/+<FloatLiteralExpr>0.1</FloatLiteralExpr></PrefixOperatorExpr></InitializerClause></PatternBinding></VariableDecl><IdentifierExpr>/*comments*/
     foo</IdentifierExpr>()
   }</CodeBlock></FunctionDecl><FunctionDecl>
 
@@ -87,12 +87,12 @@ typealias K <TypeInitializerClause>= <FunctionType>(<TupleTypeElement><Attribute
 @objc </Attribute><DeclModifier>private </DeclModifier>typealias T<GenericParameterClause><<GenericParameter>a,</GenericParameter><GenericParameter>b</GenericParameter>> </GenericParameterClause><TypeInitializerClause>= <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TypeInitializerClause></TypealiasDecl><TypealiasDecl><Attribute>
 @objc </Attribute><DeclModifier>private </DeclModifier>typealias T<GenericParameterClause><<GenericParameter>a,</GenericParameter><GenericParameter>b</GenericParameter>></GenericParameterClause></TypealiasDecl><ClassDecl>
 
-class Foo <MemberDeclBlock>{
-  let bar: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>
+class Foo <MemberDeclBlock>{<VariableDecl>
+  let <PatternBinding><IdentifierPattern>bar</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl>
 }</MemberDeclBlock></ClassDecl><ClassDecl>
 
-class Bar<TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Foo </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{
-  var foo: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier>= <IntegerLiteralExpr>42</IntegerLiteralExpr>
+class Bar<TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Foo </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{<VariableDecl>
+  var <PatternBinding><IdentifierPattern>foo</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><InitializerClause>= <IntegerLiteralExpr>42</IntegerLiteralExpr></InitializerClause></PatternBinding></VariableDecl>
 }</MemberDeclBlock></ClassDecl><ClassDecl>
 
 class C<GenericParameterClause><<GenericParameter>A, </GenericParameter><GenericParameter>B</GenericParameter>> </GenericParameterClause><GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>: <SimpleTypeIdentifier>Foo</SimpleTypeIdentifier>, </ConformanceRequirement><SameTypeRequirement><SimpleTypeIdentifier>B </SimpleTypeIdentifier>== <SimpleTypeIdentifier>Bar </SimpleTypeIdentifier></SameTypeRequirement></GenericWhereClause><MemberDeclBlock>{}</MemberDeclBlock></ClassDecl><ClassDecl><Attribute>
@@ -194,19 +194,25 @@ func closure<FunctionSignature><ParameterClause>() </ParameterClause></FunctionS
 #else</ElseDirectiveClause>
 #endif</IfConfigDecl><ClassDecl>
 
-class C <MemberDeclBlock>{
-  var a: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><AccessorBlock>{<AccessorDecl><Attribute>
+class C <MemberDeclBlock>{<VariableDecl>
+  var <PatternBinding><IdentifierPattern>a</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{<AccessorDecl><Attribute>
     @objc </Attribute><DeclModifier>mutating </DeclModifier>set<AccessorParameter>(value) </AccessorParameter><CodeBlock>{}</CodeBlock></AccessorDecl><AccessorDecl><DeclModifier>
     mutating </DeclModifier>get <CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>3 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock></AccessorDecl><AccessorDecl><Attribute>
     @objc </Attribute>didSet <CodeBlock>{}</CodeBlock></AccessorDecl><AccessorDecl>
     willSet<AccessorParameter>(newValue)</AccessorParameter><CodeBlock>{ }</CodeBlock></AccessorDecl>
-  }</AccessorBlock>
-  var a : <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><AccessorBlock>{<ReturnStmt>
+  }</AccessorBlock></PatternBinding></VariableDecl><VariableDecl>
+  var <PatternBinding><IdentifierPattern>a </IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{<ReturnStmt>
     return <IntegerLiteralExpr>3</IntegerLiteralExpr></ReturnStmt>
-  }</AccessorBlock>
+  }</AccessorBlock></PatternBinding></VariableDecl>
 }</MemberDeclBlock></ClassDecl><ProtocolDecl>
 
-protocol P <MemberDeclBlock>{
-  var a: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><AccessorBlock>{ <AccessorDecl>get </AccessorDecl><AccessorDecl>set </AccessorDecl>}</AccessorBlock>
-  var a: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><AccessorBlock>{}</AccessorBlock>
-}</MemberDeclBlock></ProtocolDecl>
+protocol P <MemberDeclBlock>{<VariableDecl>
+  var <PatternBinding><IdentifierPattern>a</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{ <AccessorDecl>get </AccessorDecl><AccessorDecl>set </AccessorDecl>}</AccessorBlock></PatternBinding></VariableDecl><VariableDecl>
+  var <PatternBinding><IdentifierPattern>a</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{}</AccessorBlock></PatternBinding></VariableDecl>
+}</MemberDeclBlock></ProtocolDecl><ClassDecl>
+
+class C <MemberDeclBlock>{<VariableDecl><Attribute>
+  @objc</Attribute><DeclModifier>
+  static </DeclModifier><DeclModifier>private </DeclModifier>var <PatternBinding><IdentifierPattern>a</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><InitializerClause>= <IntegerLiteralExpr>3 </IntegerLiteralExpr></InitializerClause><AccessorBlock>{ <ReturnStmt>return <IntegerLiteralExpr>3 </IntegerLiteralExpr></ReturnStmt>}</AccessorBlock>, </PatternBinding><PatternBinding><IdentifierPattern>b</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TypeAnnotation>, </PatternBinding><PatternBinding><IdentifierPattern>c </IdentifierPattern><InitializerClause>= <IntegerLiteralExpr>4</IntegerLiteralExpr></InitializerClause>, </PatternBinding><PatternBinding><IdentifierPattern>d </IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{ <AccessorDecl>get <CodeBlock>{} </CodeBlock></AccessorDecl><AccessorDecl>get <CodeBlock>{}</CodeBlock></AccessorDecl>}</AccessorBlock>, </PatternBinding><PatternBinding>(<IdentifierPattern>a</IdentifierPattern>, <IdentifierPattern>b</IdentifierPattern>)<TypeAnnotation>: <TupleType>(<TupleTypeElement><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement><SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TupleTypeElement>)</TupleType></TypeAnnotation></PatternBinding></VariableDecl><VariableDecl>
+  let <PatternBinding>(<IdentifierPattern>a</IdentifierPattern>, <IdentifierPattern>b</IdentifierPattern>) <InitializerClause>= <TupleExpr>(<TupleElement><IntegerLiteralExpr>1</IntegerLiteralExpr>,</TupleElement><TupleElement><IntegerLiteralExpr>2</IntegerLiteralExpr></TupleElement>)</TupleExpr></InitializerClause>, </PatternBinding><PatternBinding>_ <InitializerClause>= <IntegerLiteralExpr>4 </IntegerLiteralExpr></InitializerClause><AccessorBlock>{}</AccessorBlock></PatternBinding></VariableDecl>
+}</MemberDeclBlock></ClassDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -210,3 +210,9 @@ protocol P {
   var a: Int { get set }
   var a: Int {}
 }
+
+class C {
+  @objc
+  static private var a: Int = 3 { return 3 }, b: Int, c = 4, d : Int { get {} get {}}, (a, b): (Int, Int)
+  let (a, b) = (1,2), _ = 4 {}
+}

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -363,4 +363,28 @@ DECL_NODES = [
              Child('Statements', kind='StmtList', is_optional=True),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
+
+    # Pattern: Type = Value { get {} },
+    Node('PatternBinding', kind="Syntax",
+         children=[
+             Child('Pattern', kind='Pattern'),
+             Child('TypeAnnotation', kind='TypeAnnotation', is_optional=True),
+             Child('Initializer', kind='InitializerClause', is_optional=True),
+             Child('Accesor', kind='AccessorBlock', is_optional=True),
+             Child('TrailingComma', kind='CommaToken', is_optional=True),
+         ]),
+
+    Node('PatternBindingList', kind="SyntaxCollection",
+         element='PatternBinding'),
+
+    Node('VariableDecl', kind='Decl',
+         children=[
+             Child('Attributes', kind='AttributeList', is_optional=True),
+             Child('Modifiers', kind='ModifierList', is_optional=True),
+             Child('LetOrVarKeyword', kind='Token',
+                   token_choices=[
+                       'LetToken', 'VarToken',
+                   ]),
+             Child('Bindings', kind='PatternBindingList'),
+         ]),
 ]

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -35,12 +35,10 @@ PATTERN_NODES = [
              Child('QuestionMark', kind='PostfixQuestionMarkToken'),
          ]),
 
-    # identifier-pattern -> identifier type-annotation?
+    # identifier-pattern -> identifier
     Node('IdentifierPattern', kind='Pattern',
          children=[
-             Child('Identifier', kind='IdentifierToken'),
-             Child('TypeAnnotation', kind='TypeAnnotation',
-                   is_optional=True),
+             Child('Identifier', kind='IdentifierToken')
          ]),
 
     # as-pattern -> pattern 'as' type


### PR DESCRIPTION
Variable declarations are declarations led by either 'var' or 'let'. It
can contain multiple pattern bindings as children.

For patterns, this patch only creates syntax nodes for simple identifier
patterns, e.g. 'a = 3'. The rest of the pattern kinds are still left
unknown (UnknownPattern).
