### PR TITLE
[4.1] [Exclusivity] Look through block arguments to find noescape closures

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -957,9 +957,62 @@ static void checkForViolationWithCall(
   }
 }
 
+/// Given a block used as a noescape function argument, attempt to find
+/// the Swift closure that invoking the block will call.
+static SILValue findClosureStoredIntoBlock(SILValue V) {
+  auto FnType = V->getType().castTo<SILFunctionType>();
+  assert(FnType->getRepresentation() == SILFunctionTypeRepresentation::Block);
+
+  // Given a no escape block argument to a function,
+  // pattern match to find the noescape closure that invoking the block
+  // will call:
+  //     %noescape_closure = ...
+  //     %storage = alloc_stack
+  //     %storage_address = project_block_storage %storage
+  //     store %noescape_closure to [init] %storage_address
+  //     %block = init_block_storage_header %storage invoke %thunk
+  //     %arg = copy_block %block
+
+  InitBlockStorageHeaderInst *IBSHI = nullptr;
+
+  // Look through block copies to find the initialization of block storage.
+  while (true) {
+    if (auto *CBI = dyn_cast<CopyBlockInst>(V)) {
+      V = CBI->getOperand();
+      continue;
+    }
+
+    IBSHI = dyn_cast<InitBlockStorageHeaderInst>(V);
+    break;
+  }
+
+  if (!IBSHI)
+    return nullptr;
+
+  SILValue BlockStorage = IBSHI->getBlockStorage();
+  auto *PBSI = BlockStorage->getSingleUserOfType<ProjectBlockStorageInst>();
+  assert(PBSI && "Couldn't find block storage projection");
+
+  auto *SI = PBSI->getSingleUserOfType<StoreInst>();
+  assert(SI && "Couldn't find single store of function into block storage");
+
+  return SI->getSrc();
+}
+
 /// Look through a value passed as a function argument to determine whether
 /// it is a partial_apply.
 static PartialApplyInst *lookThroughForPartialApply(SILValue V) {
+  auto ArgumentFnType = V->getType().castTo<SILFunctionType>();
+  assert(ArgumentFnType->isNoEscape());
+
+  if (ArgumentFnType->getRepresentation() ==
+        SILFunctionTypeRepresentation::Block) {
+    V = findClosureStoredIntoBlock(V);
+
+    if (!V)
+      return nullptr;
+  }
+
   while (true) {
     if (auto CFI = dyn_cast<ConvertFunctionInst>(V)) {
       V = CFI->getOperand();
@@ -977,11 +1030,6 @@ static PartialApplyInst *lookThroughForPartialApply(SILValue V) {
 /// if any of the @inout_aliasable captures passed to those closures have
 /// in-progress accesses that would conflict with any access the summary
 /// says the closure would perform.
-//
-/// TODO: We currently fail to statically diagnose non-escaping closures pased
-/// via @block_storage convention. To enforce this case, we should statically
-/// recognize when the apply takes a block argument that has been initialized to
-/// a non-escaping closure.
 static void checkForViolationsInNoEscapeClosureArguments(
     const StorageMap &Accesses, ApplySite AS, AccessSummaryAnalysis *ASA,
     llvm::SmallVectorImpl<ConflictingAccess> &ConflictingAccesses,
@@ -1023,12 +1071,20 @@ static void checkForViolationsInNoEscapeClosureArguments(
     if (Callee->empty())
       continue;
 
+
+    // For source compatibility reasons, treat conflicts found by
+    // looking through noescape blocks as warnings. A future compiler
+    // will upgrade these to errors.
+    bool ArgumentIsBlock = (ArgumentFnType->getRepresentation() ==
+                            SILFunctionTypeRepresentation::Block);
+
     // Check the closure's captures, which are a suffix of the closure's
     // parameters.
     unsigned StartIndex =
         Callee->getArguments().size() - PAI->getNumArguments();
     checkForViolationWithCall(Accesses, Callee, StartIndex,
-                              PAI->getArguments(), ASA, DiagnoseAsWarning,
+                              PAI->getArguments(), ASA,
+                              DiagnoseAsWarning || ArgumentIsBlock,
                               ConflictingAccesses);
   }
 }

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -534,7 +534,9 @@ func doBlockInout(_: @convention(block) ()->(), _: inout Int) {}
 func readBlockWriteInout() {
   var x = 3
   // Around the call: [modify] [static]
-  // Inside closure: [modify] [static]
+  // Inside closure: [read] [static]
+  // expected-warning@+2{{overlapping accesses to 'x', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-note@+1{{conflicting access is here}}
   doBlockInout({ _ = x }, &x)
 }
 
@@ -558,6 +560,8 @@ func readBlockWriteInout() {
 func noEscapeBlock() {
   var x = 3
   doOne {
+    // expected-warning@+2{{overlapping accesses to 'x', but modification requires exclusive access; consider copying to a local variable}}
+    // expected-note@+1{{conflicting access is here}}
     doBlockInout({ _ = x }, &x)
   }
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -12,6 +12,7 @@ sil @makesInt : $@convention(thin) () -> Int
 sil @takesInoutAndNoEscapeClosure : $@convention(thin) (@inout Int, @noescape @owned @callee_owned () -> ()) -> ()
 sil @takesInoutAndNoEscapeClosureTakingArgument : $@convention(thin) (@inout Int, @noescape @owned @callee_owned (Int) -> ()) -> ()
 sil @takesInoutAndNoEscapeClosureWithGenericReturn : $@convention(thin) <T> (@inout Int, @owned @noescape @callee_owned (Int) -> @out T) -> ()
+sil @takesInoutAndNoEscapeBlockClosure : $@convention(thin) (@inout Int, @owned @convention(block) @noescape () -> ()) -> ()
 
 // CHECK-LABEL: sil hidden @twoLocalInoutsDisaliased
 sil hidden @twoLocalInoutsDisaliased : $@convention(thin) (Int) -> () {
@@ -553,7 +554,7 @@ bb0(%0 : $Storage, %1 : $Builtin.Word):
 
 sil hidden @closureThatModifiesCapture_1: $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
-  %1 = begin_access [modify] [unknown] %0 : $*Int // expected-note {{conflicting access is here}}
+  %1 = begin_access [modify] [unknown] %0 : $*Int // expected-note 2{{conflicting access is here}}
   end_access %1 : $*Int
   %2 = tuple ()
   return %2 : $()
@@ -656,6 +657,35 @@ bb0(%0 : $Int):
   %13 = tuple ()
   return %13 : $()
 }
+
+sil [reabstraction_thunk] @thunkForCalleeGuaranteed : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_guaranteed () -> ()) -> ()
+
+// CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeClosureWithBlockStorage
+sil hidden @inProgressConflictWithNoEscapeClosureWithBlockStorage : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesInoutAndNoEscapeBlockClosure : $@convention(thin) (@inout Int, @owned @convention(block) @noescape () -> ()) -> ()
+  %5 = function_ref @closureThatModifiesCapture_1 : $@convention(thin) (@inout_aliasable Int) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%3) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %conv = convert_function %6 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  %7 = alloc_stack $@block_storage @noescape @callee_guaranteed () -> ()
+  %8 = project_block_storage %7 : $*@block_storage @noescape @callee_guaranteed () -> ()
+  store %conv to [init] %8 : $*@noescape  @callee_guaranteed () -> ()
+  %10 = function_ref @thunkForCalleeGuaranteed : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_guaranteed () -> ()) -> ()
+  %11 = init_block_storage_header %7 : $*@block_storage @noescape @callee_guaranteed () -> (), invoke %10 : $@convention(c) (@inout_aliasable @block_storage @noescape @callee_guaranteed () -> ()) -> (), type $@convention(block) @noescape () -> ()
+  %12 = copy_block %11 : $@convention(block) @noescape () -> ()
+  %13 = begin_access [modify] [unknown] %3 : $*Int // expected-warning {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %14 = apply %4(%13, %12) : $@convention(thin) (@inout Int, @owned @convention(block) @noescape () -> ()) -> ()
+  end_access %13 : $*Int
+  destroy_addr %8 : $*@callee_guaranteed @noescape () -> ()
+  dealloc_stack %7 : $*@block_storage @callee_guaranteed @noescape () -> ()
+  destroy_value %2 : ${ var Int }
+  %ret = tuple ()
+  return %ret : $()
+}
+
 
 // Stored property relaxation.
 

--- a/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+class SomeClass {
+  @objc
+  func testCallNoEscapeBlockDirectly(_ c: @convention(block) () -> ()) {
+    c()
+  }
+}


### PR DESCRIPTION
…(#13497)

Update static enforcement to look through noescape blocks to find an underlying
noescape closure when a closure is converted to a block and passed as an
argument to a function. This fixes a false negative when the closure performs
an access that conflicts with an already in-progress access.

These new diagnostics are warnings for source compatibility but will
be upgraded to errors in the future.

rdar://problem/32912660
