### PR TITLE
IRGen: Fix mismatching sret attribute for indirect return values

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1281,8 +1281,10 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   assert(LastArgWritten == 1 && "emitting unnaturally to indirect result");
 
   Args[0] = result.getAddress();
+  SILFunctionConventions FnConv(CurCallee.getSubstFunctionType(),
+                                IGF.getSILModule());
   addIndirectResultAttributes(IGF.IGM, CurCallee.getMutableAttributes(),
-                              0, true);
+                              0, FnConv.getNumIndirectSILResults() <= 1);
 #ifndef NDEBUG
   LastArgWritten = 0; // appease an assert
 #endif

--- a/test/IRGen/indirect_return.swift
+++ b/test/IRGen/indirect_return.swift
@@ -9,3 +9,18 @@ func generic_get<T>(p: UnsafeMutablePointer<T>) -> T {
   // CHECK: call %swift.opaque* {{%.*}}(%swift.opaque* noalias %0, %swift.opaque* noalias [[T1]], %swift.type* %T)
   return p.pointee
 }
+
+
+protocol Number {}
+extension Int: Number {}
+
+// Make sure that the absence of the sret attribute matches.
+// CHECK: define hidden swiftcc void @_T015indirect_return3fooSS_S2SAA6Number_pAaC_ptyF(<{ %TSS, %TSS, %TSS }>* noalias nocapture
+func foo() -> (String, String, String, Number, Number) {
+    return ("1", "2", "3", 42, 7)
+}
+// CHECK-LABEL: define{{.*}}testCall
+func testCall() {
+// CHECK: call swiftcc void @_T015indirect_return3fooSS_S2SAA6Number_pAaC_ptyF(<{ %TSS, %TSS, %TSS }>* noalias nocapture %{{.*}}
+  print(foo())
+}

--- a/test/Interpreter/functions.swift
+++ b/test/Interpreter/functions.swift
@@ -42,3 +42,13 @@ func bar(_ c: C) { print("Right") }
 foo(D())
 // CHECK: Right
 bar(D())
+
+protocol Number {}
+extension Int: Number {}
+
+func foo() -> (String, String, String, Number, Number) {
+    return ("1", "2", "3", 42, 7)
+}
+
+// CHECK: ("1", "2", "3", 42, 7)
+print(foo())


### PR DESCRIPTION
We incorrectly lowered callsites when we had sil function return types
that involved both direct return types that we decide to lower
indirectly,  and indirect return types.

@convention(thin) () -> (@owned String, @owned String, @owned String, @out Any, @out Any)

(This should have been handled by the address lowering pass but isn't)

rdar://35874410