### PR TITLE
NFC SIL cleanups

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -52,6 +52,11 @@ public:
   /// Does instruction A properly dominate instruction B?
   bool properlyDominates(SILInstruction *a, SILInstruction *b);
 
+  /// Does instruction A dominate instruction B?
+  bool dominates(SILInstruction *a, SILInstruction *b) {
+    return a == b || properlyDominates(a, b);
+  }
+
   /// Does value A properly dominate instruction B?
   bool properlyDominates(SILValue a, SILInstruction *b);
 
@@ -74,6 +79,7 @@ public:
   }
 
   using DominatorTreeBase::properlyDominates;
+  using DominatorTreeBase::dominates;
 
   bool isValid(SILFunction *F) const {
     return getNode(&F->front()) != nullptr;

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -417,8 +417,9 @@ void SILBuilder::addOpenedArchetypeOperands(SILInstruction *I) {
 
   while (I && I->getNumOperands() == 1 &&
          I->getNumTypeDependentOperands() == 0) {
-    // All the open instructions are single-value instructions.
-    auto SVI = dyn_cast<SingleValueInstruction>(I->getOperand(0));
+    // All the open instructions are single-value instructions.  Operands may
+    // be null when code is being transformed.
+    auto SVI = dyn_cast_or_null<SingleValueInstruction>(I->getOperand(0));
     // Within SimplifyCFG this function may be called for an instruction
     // within unreachable code. And within an unreachable block it can happen
     // that defs do not dominate uses (because there is no dominance defined).


### PR DESCRIPTION
- Add a DominanceInfo::dominates helper functions that takes two instructions,
  as analogues to the properlyDominates ones.
- Further generalize some SILBuilder code to be more defensive in the face
  of incorrect or partially constructed SIL instructions.

These are cleanups, NFC.