### PR TITLE
libSyntax: allow children of syntax nodes to have multiple choices. rdar://35879331

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -104,10 +104,8 @@ using llvm::StringRef;
 #define syntax_assert_node_choice(Raw, CursorName)                             \
   ({                                                                           \
     auto Child = Raw->getChild(Cursor::CursorName);                            \
-    if (Child->isPresent()) {                                                  \
-      auto Node = make<Syntax>(Child);                                         \
-      assert(check##CursorName(Node));                                         \
-    }                                                                          \
+    auto Node = make<Syntax>(Child);                                           \
+    assert(check##CursorName(Node));                                           \
   })
 #else
 #define syntax_assert_node_choice(Raw, CursorName) ({});

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -100,6 +100,19 @@ using llvm::StringRef;
 #define syntax_assert_token_is(Tok, Kind, Text) ({});
 #endif
 
+#ifndef NDEBUG
+#define syntax_assert_node_choice(Raw, CursorName)                             \
+  ({                                                                           \
+    auto Child = Raw->getChild(Cursor::CursorName);                            \
+    if (Child->isPresent()) {                                                  \
+      auto Node = make<Syntax>(Child);                                         \
+      assert(check##CursorName(Node));                                         \
+    }                                                                          \
+  })
+#else
+#define syntax_assert_node_choice(Raw, CursorName) ({});
+#endif
+
 namespace swift {
 namespace syntax {
 

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -100,6 +100,7 @@ public:
 %   end
 % end
 
+bool checkAccessorListOrStmtList(const Syntax &S);
 }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3786,6 +3786,15 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
                              SourceLoc &LastValidLoc, SourceLoc StaticLoc,
                              SourceLoc VarLBLoc,
                              SmallVectorImpl<Decl *> &Decls) {
+  // If the body is completely empty, preserve it.  This is at best a getter with
+  // an implicit fallthrough off the end.
+  if (Tok.is(tok::r_brace)) {
+    // Give syntax node an empty statement list.
+    SyntaxParsingContext StmtListContext(SyntaxContext, SyntaxKind::StmtList);
+    diagnose(Tok, diag::computed_property_no_accessors);
+    return true;
+  }
+
   // Properties in protocols use sufficiently limited syntax that we have a
   // special parsing loop for them.  SIL mode uses the same syntax.
   if (Flags.contains(PD_InProtocol) || isInSILMode()) {
@@ -3859,21 +3868,11 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
       
       Decls.push_back(TheDecl);
     }
-
     return false;
   }
 
-
   // Otherwise, we have a normal var or subscript declaration, parse the full
   // complement of specifiers, along with their bodies.
-
-  // If the body is completely empty, preserve it.  This is at best a getter with
-  // an implicit fallthrough off the end.
-  if (Tok.is(tok::r_brace)) {
-    diagnose(Tok, diag::computed_property_no_accessors);
-    return true;
-  }
-
   bool IsFirstAccessor = true;
   while (Tok.isNot(tok::r_brace)) {
     if (Tok.is(tok::eof))

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -100,11 +100,6 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
   }
 }
 
-static bool checkAccessorListOrStmtList(const Syntax &S) {
-  return S.getKind() == SyntaxKind::AccessorList ||
-    S.getKind() == SyntaxKind::StmtList;
-}
-
 Optional<Syntax>
 SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
   switch(Kind) {

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -100,6 +100,11 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
   }
 }
 
+static bool checkAccessorListOrStmtList(const Syntax &S) {
+  return S.getKind() == SyntaxKind::AccessorList ||
+    S.getKind() == SyntaxKind::StmtList;
+}
+
 Optional<Syntax>
 SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
   switch(Kind) {
@@ -144,6 +149,12 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
                 return ${all_checks};
               }
               return false;
+            }
+        },
+%       elif child.node_choices:
+        {   ${option},
+            [] (const Syntax &S) {
+              return check${child.name}(S);
             }
         },
 %       else:

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -24,6 +24,12 @@
 using namespace swift;
 using namespace swift::syntax;
 
+
+bool swift::syntax::checkAccessorListOrStmtList(const Syntax &S) {
+  return S.getKind() == SyntaxKind::AccessorList ||
+    S.getKind() == SyntaxKind::StmtList;
+}
+
 % for node in SYNTAX_NODES:
 %   if node.requires_validation():
 void ${node.name}::validate() const {
@@ -41,8 +47,11 @@ void ${node.name}::validate() const {
 %         token_kind = child.main_token().kind
 %         choices = ", ".join("\"%s\"" % choice
 %                             for choice in child.text_choices)
-  syntax_assert_child_token_text(raw, ${child.name}, 
+  syntax_assert_child_token_text(raw, ${child.name},
                                  tok::${token_kind}, ${choices});
+%       end
+%       if child.node_choices:
+  syntax_assert_node_choice(raw, ${child.name});
 %       end
 %     end
 }

--- a/utils/gyb_syntax_support/Child.py
+++ b/utils/gyb_syntax_support/Child.py
@@ -8,8 +8,8 @@ class Child(object):
     A child of a node, that may be declared optional or a token with a
     restricted subset of acceptable kinds or texts.
     """
-    def __init__(self, name, kind, is_optional=False,
-                 token_choices=None, text_choices=None):
+    def __init__(self, name, kind, either_group=None, is_optional=False,
+                 token_choices=None, text_choices=None, node_choices=None):
         self.name = name
         self.swift_name = lowercase_first_word(name)
         self.syntax_kind = kind
@@ -38,6 +38,19 @@ class Child(object):
         # This will force validation logic to check the text passed into the
         # token against the choices.
         self.text_choices = text_choices or []
+
+        # A list of valid choices for a child
+        self.node_choices = node_choices or []
+
+        # Check the choices are either empty or multiple
+        assert len(self.node_choices) != 1
+
+        # Check node choices are well-formed
+        for choice in self.node_choices:
+            assert not choice.is_optional, \
+                "node choice %s cannot be optional" % choice.name
+            assert not choice.node_choices, \
+                "node choice %s cannot have further choices" % choice.name
 
     def is_token(self):
         """

--- a/utils/gyb_syntax_support/Child.py
+++ b/utils/gyb_syntax_support/Child.py
@@ -8,7 +8,7 @@ class Child(object):
     A child of a node, that may be declared optional or a token with a
     restricted subset of acceptable kinds or texts.
     """
-    def __init__(self, name, kind, either_group=None, is_optional=False,
+    def __init__(self, name, kind, is_optional=False,
                  token_choices=None, text_choices=None, node_choices=None):
         self.name = name
         self.swift_name = lowercase_first_word(name)

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -358,9 +358,10 @@ DECL_NODES = [
     Node('AccessorBlock', kind="Syntax",
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
-             # one of the following children should be required.
-             Child('Accessors', kind='AccessorList', is_optional=True),
-             Child('Statements', kind='StmtList', is_optional=True),
+             Child('AccessorListOrStmtList', kind='Syntax',
+                   node_choices=[
+                      Child('Accessors', kind='AccessorList'),
+                      Child('Statements', kind='StmtList')]),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 


### PR DESCRIPTION
Some structures of syntax nodes can have children choices, e.g. a
dictionary expression can either contain a single ':' token or a list of
key-value pairs.

This patch gives the existing code generation infrastructure a way to
specify such node choices. Node choices are specified under a child
declaration with two constraints: a choice cannot be declared as
optional, and a choice cannot have further recursive choices.

Since we don't have too many node structures with choices, part of the
SyntaxFactory code for these nodes is manually typed.

This patch also teaches AccessorBlock to use node choices.