### PR TITLE
[4.1] Revert "reflection: handle LMA != VMA for ELF"

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -63,13 +63,13 @@ public:
     return MangledTypeName;
   }
 
-  std::string getMangledTypeName(uintptr_t Offset) const {
-    return MangledTypeName.get() + Offset;
+  std::string getMangledTypeName() const {
+    return MangledTypeName.get();
   }
 
-  std::string getFieldName(uintptr_t Offset)  const {
+  std::string getFieldName()  const {
     if (FieldName)
-      return FieldName.get() + Offset;
+      return FieldName.get();
     return "";
   }
 
@@ -188,16 +188,16 @@ public:
     return MangledTypeName;
   }
 
-  std::string getMangledTypeName(uintptr_t Offset) const {
-    return MangledTypeName.get() + Offset;
+  std::string getMangledTypeName() const {
+    return MangledTypeName.get();
   }
 
   bool hasSuperclass() const {
     return Superclass;
   }
 
-  std::string getSuperclass(uintptr_t Offset) const {
-    return Superclass.get() + Offset;
+  std::string getSuperclass() const {
+    return Superclass.get();
   }
 };
 
@@ -241,12 +241,12 @@ class AssociatedTypeRecord {
   const RelativeDirectPointer<const char> SubstitutedTypeName;
 
 public:
-  std::string getName(uintptr_t Offset) const {
-    return Name.get() + Offset;
+  std::string getName() const {
+    return Name.get();
   }
 
-  std::string getMangledSubstitutedTypeName(uintptr_t Offset) const {
-    return SubstitutedTypeName.get() + Offset;
+  std::string getMangledSubstitutedTypeName() const {
+    return SubstitutedTypeName.get();
   }
 };
 
@@ -319,12 +319,12 @@ public:
     return const_iterator { End, End };
   }
 
-  std::string getMangledProtocolTypeName(uintptr_t Offset) const {
-    return ProtocolTypeName.get() + Offset;
+  std::string getMangledProtocolTypeName() const {
+    return ProtocolTypeName.get();
   }
 
-  std::string getMangledConformingTypeName(uintptr_t Offset) const {
-    return ConformingTypeName.get() + Offset;
+  std::string getMangledConformingTypeName() const {
+    return ConformingTypeName.get();
   }
 };
 
@@ -377,8 +377,8 @@ public:
     return TypeName;
   }
 
-  std::string getMangledTypeName(uintptr_t Offset) const {
-    return TypeName.get() + Offset;
+  std::string getMangledTypeName() const {
+    return TypeName.get();
   }
 };
 
@@ -424,8 +424,8 @@ public:
     return MangledTypeName;
   }
 
-  std::string getMangledTypeName(uintptr_t Offset) const {
-    return MangledTypeName.get() + Offset;
+  std::string getMangledTypeName() const {
+    return MangledTypeName.get();
   }
 };
 
@@ -470,16 +470,16 @@ public:
     return MangledTypeName;
   }
 
-  std::string getMangledTypeName(uintptr_t Offset) const {
-    return MangledTypeName.get() + Offset;
+  std::string getMangledTypeName() const {
+    return MangledTypeName.get();
   }
 
   bool hasMangledMetadataSource() const {
     return MangledMetadataSource;
   }
 
-  std::string getMangledMetadataSource(uintptr_t Offset) const {
-    return MangledMetadataSource.get() + Offset;
+  std::string getMangledMetadataSource() const {
+    return MangledMetadataSource.get();
   }
 };
 

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -147,7 +147,7 @@ public:
       if (CD == nullptr)
         return nullptr;
 
-      auto Info = getBuilder().getClosureContextInfo(*CD, 0);
+      auto Info = getBuilder().getClosureContextInfo(*CD);
 
       return getClosureContextInfo(ObjectAddress, Info);
     }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -73,36 +73,12 @@ using CaptureSection = ReflectionSection<CaptureDescriptorIterator>;
 using GenericSection = ReflectionSection<const void *>;
 
 struct ReflectionInfo {
-  struct {
-    FieldSection Metadata;
-    uintptr_t SectionOffset;
-  } Field;
-
-  struct {
-    AssociatedTypeSection Metadata;
-    uintptr_t SectionOffset;
-  } AssociatedType;
-
-  struct {
-    BuiltinTypeSection Metadata;
-    uintptr_t SectionOffset;
-  } Builtin;
-
-  struct {
-    CaptureSection Metadata;
-    uintptr_t SectionOffset;
-  } Capture;
-
-  struct {
-    GenericSection Metadata;
-    uintptr_t SectionOffset;
-  } TypeReference;
-
-  struct {
-    GenericSection Metadata;
-    uintptr_t SectionOffset;
-  } ReflectionString;
-
+  FieldSection fieldmd;
+  AssociatedTypeSection assocty;
+  BuiltinTypeSection builtin;
+  CaptureSection capture;
+  GenericSection typeref;
+  GenericSection reflstr;
   uintptr_t LocalStartAddress;
   uintptr_t RemoteStartAddress;
 };
@@ -346,12 +322,10 @@ public:
   lookupSuperclass(const TypeRef *TR);
 
   /// Load unsubstituted field types for a nominal type.
-  std::pair<const FieldDescriptor *, uintptr_t>
-  getFieldTypeInfo(const TypeRef *TR);
+  const FieldDescriptor *getFieldTypeInfo(const TypeRef *TR);
 
   /// Get the parsed and substituted field types for a nominal type.
-  bool getFieldTypeRefs(const TypeRef *TR,
-                        const std::pair<const FieldDescriptor *, uintptr_t> &FD,
+  bool getFieldTypeRefs(const TypeRef *TR, const FieldDescriptor *FD,
                         std::vector<FieldTypeInfo> &Fields);
 
   /// Get the primitive type lowering for a builtin type.
@@ -362,8 +336,7 @@ public:
   const CaptureDescriptor *getCaptureDescriptor(uintptr_t RemoteAddress);
 
   /// Get the unsubstituted capture types for a closure context.
-  ClosureContextInfo getClosureContextInfo(const CaptureDescriptor &CD,
-                                           uintptr_t Offset);
+  ClosureContextInfo getClosureContextInfo(const CaptureDescriptor &CD);
 
   ///
   /// Dumping typerefs, field declarations, associated types

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -35,35 +35,12 @@ typedef struct swift_reflection_section {
 /// \brief Represents the set of Swift reflection sections of an image.
 /// Not all sections may be present.
 typedef struct swift_reflection_info {
-  struct {
-    swift_reflection_section_t section;
-    uintptr_t offset;
-  } field;
-
-  struct {
-    swift_reflection_section_t section;
-    uintptr_t offset;
-  } associated_types;
-
-  struct {
-    swift_reflection_section_t section;
-    uintptr_t offset;
-  } builtin_types;
-
-  struct {
-    swift_reflection_section_t section;
-    uintptr_t offset;
-  } capture;
-
-  struct {
-    swift_reflection_section_t section;
-    uintptr_t offset;
-  } type_references;
-
-  struct {
-    swift_reflection_section_t section;
-    uintptr_t offset;
-  } reflection_strings;
+  swift_reflection_section_t fieldmd;
+  swift_reflection_section_t assocty;
+  swift_reflection_section_t builtin;
+  swift_reflection_section_t capture;
+  swift_reflection_section_t typeref;
+  swift_reflection_section_t reflstr;
 
   // Start address in local and remote address spaces.
   uintptr_t LocalStartAddress;

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -22,7 +22,6 @@
 #include "llvm/Object/MachO.h"
 #include "llvm/Object/MachOUniversal.h"
 #include "llvm/Object/ELF.h"
-#include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Support/CommandLine.h"
 
 #if defined(_WIN32)
@@ -94,26 +93,20 @@ static SectionRef getSectionRef(const ObjectFile *objectFile,
 }
 
 template <typename Section>
-static std::pair<Section, uintptr_t>
-findReflectionSection(const ObjectFile *objectFile,
-                      ArrayRef<StringRef> anySectionNames) {
+static Section findReflectionSection(const ObjectFile *objectFile,
+                                     ArrayRef<StringRef> anySectionNames) {
   auto sectionRef = getSectionRef(objectFile, anySectionNames);
 
   if (sectionRef.getObject() == nullptr)
-    return {{nullptr, nullptr}, 0};
+    return {nullptr, nullptr};
 
   StringRef sectionContents;
   sectionRef.getContents(sectionContents);
 
-  uintptr_t Offset = 0;
-  if (isa<ELFObjectFileBase>(sectionRef.getObject())) {
-    ELFSectionRef S{sectionRef};
-    Offset = sectionRef.getAddress() - S.getOffset();
-  }
-
-  return {{reinterpret_cast<const void *>(sectionContents.begin()),
-           reinterpret_cast<const void *>(sectionContents.end())},
-          Offset};
+  return {
+    reinterpret_cast<const void *>(sectionContents.begin()),
+    reinterpret_cast<const void *>(sectionContents.end())
+  };
 }
 
 static ReflectionInfo findReflectionInfo(const ObjectFile *objectFile) {
@@ -131,14 +124,14 @@ static ReflectionInfo findReflectionInfo(const ObjectFile *objectFile) {
       objectFile, {"__swift3_reflstr", ".swift3_reflstr", "swift3_reflstr"});
 
   return {
-      {fieldSection.first, fieldSection.second},
-      {associatedTypeSection.first, associatedTypeSection.second},
-      {builtinTypeSection.first, builtinTypeSection.second},
-      {captureSection.first, captureSection.second},
-      {typeRefSection.first, typeRefSection.second},
-      {reflectionStringsSection.first, reflectionStringsSection.second},
-      /*LocalStartAddress*/ 0,
-      /*RemoteStartAddress*/ 0,
+    fieldSection,
+    associatedTypeSection,
+    builtinTypeSection,
+    captureSection,
+    typeRefSection,
+    reflectionStringsSection,
+    /*LocalStartAddress*/ 0,
+    /*RemoteStartAddress*/ 0,
   };
 }
 

--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -301,12 +301,12 @@ PipeMemoryReader_receiveReflectionInfo(SwiftReflectionContextRef RC,
       errorAndExit("Couldn't read reflection information");
 
     swift_reflection_info_t Info = {
-      {makeLocalSection(Buffer, RemoteInfo.fieldmd, RemoteInfo), 0},
-      {makeLocalSection(Buffer, RemoteInfo.assocty, RemoteInfo), 0},
-      {makeLocalSection(Buffer, RemoteInfo.builtin, RemoteInfo), 0},
-      {makeLocalSection(Buffer, RemoteInfo.capture, RemoteInfo), 0},
-      {makeLocalSection(Buffer, RemoteInfo.typeref, RemoteInfo), 0},
-      {makeLocalSection(Buffer, RemoteInfo.reflstr, RemoteInfo), 0},
+      makeLocalSection(Buffer, RemoteInfo.fieldmd, RemoteInfo),
+      makeLocalSection(Buffer, RemoteInfo.assocty, RemoteInfo),
+      makeLocalSection(Buffer, RemoteInfo.builtin, RemoteInfo),
+      makeLocalSection(Buffer, RemoteInfo.capture, RemoteInfo),
+      makeLocalSection(Buffer, RemoteInfo.typeref, RemoteInfo),
+      makeLocalSection(Buffer, RemoteInfo.reflstr, RemoteInfo),
       /*LocalStartAddress*/ (uintptr_t) Buffer,
       /*RemoteStartAddress*/ RemoteInfo.StartAddress,
     };


### PR DESCRIPTION
*Consider* reverting #12758 due to some incompatibilities with Apple libraries shipped with High Sierra. Mostly just for PR testing at this point.