### PR TITLE
[WIP] [CSSolver] Don't skip generic choices if operator used non-default literal

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1787,9 +1787,11 @@ static bool shouldSkipDisjunctionChoice(ConstraintSystem &cs,
     auto &score = bestNonGenericScore->Data;
     // Let's skip generic overload choices only in case if
     // non-generic score indicates that there were no forced
-    // unwrappings of optional(s) and no unavailable overload
-    // choices present in the solution.
-    if (score[SK_ForceUnchecked] == 0 && score[SK_Unavailable] == 0)
+    // unwrappings of optional(s), no unavailable overload
+    // choices present in the solution and there were no
+    // non-default literals used.
+    if (score[SK_ForceUnchecked] == 0 && score[SK_Unavailable] == 0 &&
+        score[SK_NonDefaultLiteral] == 0)
       return true;
   }
 
@@ -1943,11 +1945,12 @@ bool ConstraintSystem::solveSimplified(
       auto *lastChoice = lastSolvedChoice->first.getConstraint();
       auto &score = lastSolvedChoice->second;
       bool hasUnavailableOverloads = score.Data[SK_Unavailable] > 0;
+      bool hasNonDefaultLiterals = score.Data[SK_NonDefaultLiteral] > 0;
 
       // Attempt to short-circuit disjunction only if
       // score indicates that there are no unavailable
       // overload choices present in the solution.
-      if (!hasUnavailableOverloads &&
+      if (!hasUnavailableOverloads && !hasNonDefaultLiterals &&
           shortCircuitDisjunctionAt(&currentChoice, lastChoice,
                                     getASTContext()))
         break;


### PR DESCRIPTION
Currently we are going to skip generic choices if we don't have any
unavailable choices or force casts, but we need to include non-default
literals as well, because that gives pretty good signal that concrete
type overloads might not be the best option.

Resolves: rdar://problem/36113283

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
