### PR TITLE
[Associated type inference] Allow `_Default_Foo` typealias guides for inference.

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1307,6 +1307,13 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         secondType = req.getSecondType();
       }
 
+      // Don't do further checking on error types.
+      if (firstType->hasError() || (secondType && secondType->hasError())) {
+        // Another requirement will fail later; just continue.
+        valid = false;
+        continue;
+      }
+
       bool requirementFailure = false;
       if (listener && !listener->shouldCheck(kind, firstType, secondType))
         continue;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -734,6 +734,14 @@ private:
   /// known to the compiler.
   Type computeDerivedTypeWitness(AssociatedTypeDecl *assocType);
 
+  /// Compute a type witness without using a specific potential witness,
+  /// e.g., using a fixed type (from a refined protocol), default type
+  /// on an associated type, or deriving the type.
+  ///
+  /// \param allowDerived Whether to allow "derived" type witnesses.
+  Type computeAbstractTypeWitness(AssociatedTypeDecl *assocType,
+                                  bool allowDerived);
+
   /// Substitute the current type witnesses into the given interface type.
   Type substCurrentTypeWitnesses(Type type);
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -737,6 +737,10 @@ private:
   /// Substitute the current type witnesses into the given interface type.
   Type substCurrentTypeWitnesses(Type type);
 
+  /// Retrieve substitution options with a tentative type witness
+  /// operation that queries the current set of type witnesses.
+  SubstOptions getSubstOptionsWithCurrentTypeWitnesses();
+
   /// Check whether the current set of type witnesses meets the
   /// requirements of the protocol.
   bool checkCurrentTypeWitnesses(

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -139,7 +139,7 @@ struct InferredTypeWitnessesSolution {
 #ifndef NDEBUG
   LLVM_ATTRIBUTE_USED
 #endif
-  void dump();
+  void dump() const;
 };
 
 class RequirementEnvironment;
@@ -707,6 +707,12 @@ private:
                    const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                    ValueDecl *req);
 
+  /// Infer associated type witnesses for the given associated type.
+  InferredAssociatedTypesByWitnesses inferTypeWitnessesViaAssociatedType(
+                   ConformanceChecker &checker,
+                   const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+                   AssociatedTypeDecl *assocType);
+
   /// Infer associated type witnesses for all relevant value requirements.
   ///
   /// \param assocTypes The set of associated types we're interested in.
@@ -733,7 +739,13 @@ private:
 
   /// Check whether the current set of type witnesses meets the
   /// requirements of the protocol.
-  bool checkCurrentTypeWitnesses();
+  bool checkCurrentTypeWitnesses(
+         const SmallVectorImpl<std::pair<ValueDecl *, ValueDecl *>>
+           &valueWitnesses);
+
+  /// Check the current type witnesses against the
+  /// requirements of the given constrained extension.
+  bool checkConstrainedExtension(ExtensionDecl *ext);
 
   /// Top-level operation to find solutions for the given unresolved
   /// associated types.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -571,12 +571,6 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
     if (!typeDecl || isa<AssociatedTypeDecl>(typeDecl))
       continue;
 
-    // With @_implements attributes.
-    auto implementsAttr = typeDecl->getAttrs().getAttribute<ImplementsAttr>();
-    if (!implementsAttr) continue;
-
-    // FIXME: Validate the @_implements attribute.
-
     // We only find these within a protocol extension.
     auto defaultProto = typeDecl->getDeclContext()
                           ->getAsProtocolOrProtocolExtensionContext();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -63,7 +63,7 @@ void InferredAssociatedTypesByWitness::dump(llvm::raw_ostream &out,
   out << ")";
 }
 
-void InferredTypeWitnessesSolution::dump() {
+void InferredTypeWitnessesSolution::dump() const {
   llvm::errs() << "Type Witnesses:\n";
   for (auto &typeWitness : TypeWitnesses) {
     llvm::errs() << "  " << typeWitness.first->getName() << " := ";
@@ -394,9 +394,21 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     if (!req)
       continue;
 
-    // We only look at value witnesses.
-    if (isa<AssociatedTypeDecl>(req))
+    // Infer type witnesses for associated types.
+    if (auto assocType = dyn_cast<AssociatedTypeDecl>(req)) {
+      // If this is not one of the associated types we are trying to infer,
+      // just continue.
+      if (assocTypes.count(assocType) == 0)
+        continue;
+
+      auto reqInferred = inferTypeWitnessesViaAssociatedType(checker,
+                                                             assocTypes,
+                                                             assocType);
+      if (!reqInferred.empty())
+        result.push_back({req, std::move(reqInferred)});
+
       continue;
+    }
 
     // Skip operator requirements, because they match globally and
     // therefore tend to cause deduction mismatches.
@@ -429,7 +441,8 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
 
     // Infer associated types from the potential value witnesses for
     // this requirement.
-    auto reqInferred = inferTypeWitnessesViaValueWitnesses(checker, assocTypes, req);
+    auto reqInferred =
+      inferTypeWitnessesViaValueWitnesses(checker, assocTypes, req);
     if (reqInferred.empty())
       continue;
 
@@ -524,6 +537,69 @@ static Type removeSelfParam(ValueDecl *value, Type type) {
   }
 
   return type;
+}
+
+InferredAssociatedTypesByWitnesses
+AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
+                   ConformanceChecker &checker,
+                   const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+                   AssociatedTypeDecl *assocType) {
+  auto &tc = checker.TC;
+
+  // Form the default name _Default_Foo.
+  Identifier defaultName;
+  {
+    SmallString<32> defaultNameStr;
+    {
+      llvm::raw_svector_ostream out(defaultNameStr);
+      out << "_Default_";
+      out << assocType->getName().str();
+    }
+
+    defaultName = tc.Context.getIdentifier(defaultNameStr);
+  }
+
+  // Look for types with the given default name that have appropriate
+  // @_implements attributes.
+  InferredAssociatedTypesByWitnesses result;
+  auto lookupOptions = defaultMemberTypeLookupOptions;
+  lookupOptions -= NameLookupFlags::PerformConformanceCheck;
+  for (auto candidate : tc.lookupMember(dc, adoptee, defaultName,
+                                        lookupOptions)) {
+    // We want type declarations.
+    auto typeDecl = dyn_cast<TypeDecl>(candidate.getValueDecl());
+    if (!typeDecl || isa<AssociatedTypeDecl>(typeDecl))
+      continue;
+
+    // With @_implements attributes.
+    auto implementsAttr = typeDecl->getAttrs().getAttribute<ImplementsAttr>();
+    if (!implementsAttr) continue;
+
+    // FIXME: Validate the @_implements attribute.
+
+    // We only find these within a protocol extension.
+    auto defaultProto = typeDecl->getDeclContext()
+                          ->getAsProtocolOrProtocolExtensionContext();
+    if (!defaultProto)
+      continue;
+
+    // Determine the witness type.
+    Type witnessType = getWitnessTypeForMatching(tc, conformance, typeDecl);
+    if (!witnessType) continue;
+
+    if (auto witnessMetaType = witnessType->getAs<AnyMetatypeType>())
+      witnessType = witnessMetaType->getInstanceType();
+    else
+      continue;
+
+    // Add this result.
+    InferredAssociatedTypesByWitness inferred;
+    inferred.Witness = typeDecl;
+    inferred.Inferred.push_back({assocType, witnessType});
+    result.push_back(std::move(inferred));
+  }
+
+  return result;
 }
 
 /// Attempt to resolve a type witness via a specific value witness.
@@ -898,7 +974,9 @@ static void sanitizeProtocolRequirements(
   }
 }
 
-bool AssociatedTypeInference::checkCurrentTypeWitnesses() {
+bool AssociatedTypeInference::checkCurrentTypeWitnesses(
+       const SmallVectorImpl<std::pair<ValueDecl *, ValueDecl *>>
+         &valueWitnesses) {
   // Fold the dependent member types within this type.
   for (auto assocType : proto->getAssociatedTypeMembers()) {
     if (conformance->hasTypeWitness(assocType))
@@ -959,10 +1037,62 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses() {
 
   case RequirementCheckResult::Success:
   case RequirementCheckResult::SubstitutionFailure:
-    return false;
+    break;
+  }
+
+  // Check for extra requirements in the constrained extensions that supply
+  // defaults.
+  SmallPtrSet<ExtensionDecl *, 4> checkedExtensions;
+  for (const auto &valueWitness : valueWitnesses) {
+    // We only perform this additional checking for default associated types.
+    if (!isa<TypeDecl>(valueWitness.first)) continue;
+
+    auto witness = valueWitness.second;
+    if (!witness) continue;
+
+    auto ext = dyn_cast<ExtensionDecl>(witness->getDeclContext());
+    if (!ext) continue;
+
+    if (!ext->isConstrainedExtension()) continue;
+    if (!checkedExtensions.insert(ext).second) continue;
+
+    if (checkConstrainedExtension(ext)) return true;
   }
 
   return false;
+}
+
+bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
+  auto typeInContext = dc->mapTypeIntoContext(adoptee);
+  auto subs = typeInContext->getContextSubstitutions(ext);
+
+  SubstOptions options(None);
+  options.getTentativeTypeWitness =
+    [&](const NormalProtocolConformance *conformance,
+        AssociatedTypeDecl *assocType) -> TypeBase * {
+      if (conformance != this->conformance) return nullptr;
+
+      auto type = typeWitnesses.begin(assocType)->first;
+      return type->mapTypeOutOfContext().getPointer();
+    };
+
+  switch (tc.checkGenericArguments(
+                       dc, SourceLoc(), SourceLoc(), adoptee,
+                       ext->getGenericSignature()->getGenericParams(),
+                       ext->getGenericSignature()->getRequirements(),
+                       QueryTypeSubstitutionMap{subs},
+                       LookUpConformanceInModule(ext->getModuleContext()),
+                                   nullptr, ConformanceCheckFlags::InExpression,
+                                   nullptr,
+                                   options)) {
+  case RequirementCheckResult::Success:
+  case RequirementCheckResult::SubstitutionFailure:
+    return false;
+
+  case RequirementCheckResult::Failure:
+  case RequirementCheckResult::UnsatisfiedDependency:
+    return true;
+  }
 }
 
 void AssociatedTypeInference::findSolutions(
@@ -1066,7 +1196,7 @@ void AssociatedTypeInference::findSolutionsRec(
     }
 
     /// Check the current set of type witnesses.
-    bool invalid = checkCurrentTypeWitnesses();
+    bool invalid = checkCurrentTypeWitnesses(valueWitnesses);
 
     // Determine whether there is already a solution with the same
     // bindings.
@@ -1109,17 +1239,50 @@ void AssociatedTypeInference::findSolutionsRec(
   // looking for solutions involving each one.
   const auto &inferredReq = inferred[reqDepth];
   for (const auto &witnessReq : inferredReq.second) {
+    llvm::SaveAndRestore<unsigned> savedNumTypeWitnesses(numTypeWitnesses);
+
+    // If we inferred a type witness via a default, try both with and without
+    // the default.
+    if (isa<TypeDecl>(inferredReq.first)) {
+      // Recurse without considering this type.
+      valueWitnesses.push_back({inferredReq.first, nullptr});
+      findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
+                       valueWitnesses, numTypeWitnesses,
+                       numValueWitnessesInProtocolExtensions, reqDepth + 1);
+      valueWitnesses.pop_back();
+
+      ++numTypeWitnesses;
+      for (const auto &typeWitness : witnessReq.Inferred) {
+        auto known = typeWitnesses.begin(typeWitness.first);
+        if (known != typeWitnesses.end()) continue;
+
+        // Enter a new scope for the type witnesses hash table.
+        TypeWitnessesScope typeWitnessesScope(typeWitnesses);
+        typeWitnesses.insert(typeWitness.first, {typeWitness.second, reqDepth});
+
+        valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
+        findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
+                         valueWitnesses, numTypeWitnesses,
+                         numValueWitnessesInProtocolExtensions, reqDepth + 1);
+        valueWitnesses.pop_back();
+      }
+
+      continue;
+    }
+
     // Enter a new scope for the type witnesses hash table.
     TypeWitnessesScope typeWitnessesScope(typeWitnesses);
-    llvm::SaveAndRestore<unsigned> savedNumTypeWitnesses(numTypeWitnesses);
 
     // Record this value witness, popping it when we exit the current scope.
     valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
-    if (witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
+    if (!isa<TypeDecl>(inferredReq.first) &&
+        witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
       ++numValueWitnessesInProtocolExtensions;
     SWIFT_DEFER {
-      if (witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
+      if (!isa<TypeDecl>(inferredReq.first) &&
+          witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
         --numValueWitnessesInProtocolExtensions;
+
       valueWitnesses.pop_back();
     };
 
@@ -1130,7 +1293,11 @@ void AssociatedTypeInference::findSolutionsRec(
       // conflicts, there is no solution.
       auto known = typeWitnesses.begin(typeWitness.first);
       if (known != typeWitnesses.end()) {
-        // If witnesses for two difference requirements inferred the same
+        // Don't overwrite a defaulted associated type witness.
+        if (isa<TypeDecl>(valueWitnesses[known->second].second))
+          continue;
+
+        // If witnesses for two different requirements inferred the same
         // type, we're okay.
         if (known->first->isEqual(typeWitness.second))
           continue;
@@ -1191,6 +1358,22 @@ compareDeclsForInference(TypeChecker &TC, DeclContext *DC,
   // exclusive associated type constraints, and compareDeclarations will
   // consider these unordered since neither extension's generic signature
   // is a superset of the other.
+
+  // If one of the declarations is null, it implies that we're working with
+  // a skipped associated type default. Prefer that default to something
+  // that came from a protocol extension.
+  if (!decl1 || !decl2) {
+    if (!decl1 &&
+        decl2 && decl2->getDeclContext()->getAsProtocolExtensionContext())
+      return Comparison::Worse;
+
+    if (!decl2 &&
+        decl1 && decl1->getDeclContext()->getAsProtocolExtensionContext())
+      return Comparison::Better;
+
+    return Comparison::Unordered;
+  }
+
 
   // If the witnesses come from the same decl context, score normally.
   auto dc1 = decl1->getDeclContext();

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -166,6 +166,13 @@ extension RandomAccessCollection {
   }
 }
 
+// Provides an alternative default associated type witness for Indices
+// for random access collections with strideable indices.
+extension RandomAccessCollection where Index : Strideable, Index.Stride == Int {
+  @_implements(Collection, Indices)
+  public typealias _Default_Indices = CountableRange<Index>
+}
+
 extension RandomAccessCollection
 where Index : Strideable, 
       Index.Stride == Int,

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -612,6 +612,13 @@ public protocol Sequence {
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index)
 }
 
+// Provides a default associated type witness for Iterator when the
+// Self type is both a Sequence and an Iterator.
+extension Sequence where Self: IteratorProtocol {
+  // @_implements(Sequence, Iterator)
+  public typealias _Default_Iterator = Self
+}
+
 /// A default makeIterator() function for `IteratorProtocol` instances that
 /// are declared to conform to `Sequence`
 extension Sequence where Self.Iterator == Self {
@@ -621,7 +628,6 @@ extension Sequence where Self.Iterator == Self {
     return self
   }
 }
-
 
 /// A sequence that lazily consumes and drops `n` elements from an underlying
 /// `Base` iterator before possibly returning the first available element.

--- a/test/decl/protocol/req/associated_type_typealias_implements.swift
+++ b/test/decl/protocol/req/associated_type_typealias_implements.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P { }
+
+protocol Q {
+  associatedtype T
+  associatedtype U // expected-note 2{{protocol requires nested type 'U'; do you want to add it?}}
+}
+
+protocol R: Q {
+}
+
+struct XT: P { }
+struct XTWithoutP { }
+
+struct XU { }
+
+extension R where T: P {
+  @_implements(Q, U)
+  typealias _Default_U = XU
+}
+
+struct Y1: R {
+  typealias T = XT
+  // okay: infers U = XU
+}
+
+struct Y2: R { // expected-error{{type 'Y2' does not conform to protocol 'Q'}}
+  typealias T = XTWithoutP
+
+  // FIXME: More detail from diagnostic.
+  // error: T: P fails
+}
+
+struct Y3: Q { // expected-error{{type 'Y3' does not conform to protocol 'Q'}}
+  typealias T = XT
+  // FIXME: More detail from diagnostic.
+}

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -853,4 +853,28 @@ CollectionTypeTests.test("AssociatedTypes/${Collection}") {
 % end
 
 
+struct RACollectionWithIntIndex<T> {
+  var contents: [T]
+}
+
+extension RACollectionWithIntIndex: RandomAccessCollection {
+  var startIndex: Int { return contents.startIndex }
+  var endIndex: Int { return contents.endIndex }
+  subscript(index: Int) -> T {
+    get { return contents[index] }
+    set { }
+  }
+}
+
+CollectionTypeTests.test("AssociatedTypes/RACollectionWithIntIndex") {
+  typealias C = RACollectionWithIntIndex<Void>
+  expectCollectionAssociatedTypes(
+    collectionType: C.self,
+    iteratorType: IndexingIterator<C>.self,
+    subSequenceType: Slice<C>.self,
+    indexType: Int.self,
+    indicesType: CountableRange<Int>.self)
+}
+
+
 runAllTests()


### PR DESCRIPTION
Introduce an ugly hack where a typealias in a protocol extension that has the name `_Default_Foo` can be found by associated type inference for an associated type named `Foo`, respecting the constrains of the protocol extension in which that typealias resides.

Use this new machinery to define a conditional default type witness for the collection `Indices` associated type, so `Indices` becomes `CountableRange<Index>` when the `Index` type is
`Strideable` with `Int` as its `Stride` type.

This fixes the major regression with associated type inference for “minimal” random access collection types with `Int` index types, which has come up in a number of places.

Fixes rdar://problem/35035322 / [SR-6620](https://bugs.swift.org/browse/SR-6620)