### PR TITLE
[Syntax] Add CRLF support to libSyntax

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -126,13 +126,13 @@ class Lexer {
   ///
   /// This is only preserved if this Lexer was constructed with
   /// `TriviaRetentionMode::WithTrivia`.
-  syntax::TriviaList LeadingTrivia;
+  syntax::Trivia LeadingTrivia;
 
   /// The current trailing trivia for the next token.
   ///
   /// This is only preserved if this Lexer was constructed with
   /// `TriviaRetentionMode::WithTrivia`.
-  syntax::TriviaList TrailingTrivia;
+  syntax::Trivia TrailingTrivia;
   
   Lexer(const Lexer&) = delete;
   void operator=(const Lexer&) = delete;
@@ -255,7 +255,7 @@ public:
       TokStart = Tok.getLoc();
     auto S = getStateForBeginningOfTokenLoc(TokStart);
     if (TriviaRetention == TriviaRetentionMode::WithTrivia)
-      S.LeadingTrivia = LeadingTrivia.Pieces;
+      S.LeadingTrivia = LeadingTrivia;
     return S;
   }
 
@@ -503,7 +503,7 @@ private:
   void lexOperatorIdentifier();
   void lexHexNumber();
   void lexNumber();
-  void lexTrivia(syntax::TriviaList &T, bool IsForTrailingTrivia);
+  void lexTrivia(syntax::Trivia &T, bool IsForTrailingTrivia);
   static unsigned lexUnicodeEscape(const char *&CurPtr, Lexer *Diags);
 
   unsigned lexCharacter(const char *&CurPtr,

--- a/include/swift/Parse/LexerState.h
+++ b/include/swift/Parse/LexerState.h
@@ -39,7 +39,7 @@ public:
 private:
   explicit LexerState(SourceLoc Loc) : Loc(Loc) {}
   SourceLoc Loc;
-  llvm::Optional<syntax::TriviaList> LeadingTrivia;
+  llvm::Optional<syntax::Trivia> LeadingTrivia;
   friend class Lexer;
 };
 

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -69,6 +69,7 @@ struct ObjectTraits<syntax::TriviaPiece> {
       case syntax::TriviaKind::Formfeed:
       case syntax::TriviaKind::Newline:
       case syntax::TriviaKind::CarriageReturn:
+      case syntax::TriviaKind::CarriageReturnLineFeed:
       case syntax::TriviaKind::Backtick:
         out.mapRequired("value", value.Count);
         break;
@@ -95,6 +96,7 @@ struct ScalarEnumerationTraits<syntax::TriviaKind> {
     out.enumCase(value, "Formfeed", syntax::TriviaKind::Formfeed);
     out.enumCase(value, "Newline", syntax::TriviaKind::Newline);
     out.enumCase(value, "CarriageReturn", syntax::TriviaKind::CarriageReturn);
+    out.enumCase(value, "CarriageReturnLineFeed", syntax::TriviaKind::CarriageReturnLineFeed);
     out.enumCase(value, "LineComment", syntax::TriviaKind::LineComment);
     out.enumCase(value, "BlockComment", syntax::TriviaKind::BlockComment);
     out.enumCase(value, "DocLineComment", syntax::TriviaKind::DocLineComment);

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -113,6 +113,9 @@ enum class TriviaKind {
 
   /// A newline '\r' character.
   CarriageReturn,
+  
+  /// A newline consists of contiguous '\r' and '\n' characters.
+  CarriageReturnLineFeed,
 
   /// A developer line comment, starting with '//'
   LineComment,
@@ -189,6 +192,12 @@ public:
   static TriviaPiece carriageReturns(unsigned Count) {
     return {TriviaKind::CarriageReturn, Count};
   }
+  
+  /// Return a piece of trivia for some number of two bytes sequence
+  /// consists of CR and LF in a row.
+  static TriviaPiece carriageReturnLineFeeds(unsigned Count) {
+    return {TriviaKind::CarriageReturnLineFeed, Count};
+  }
 
   /// Return a piece of trivia for a single line of ('//') developer comment.
   static TriviaPiece lineComment(const OwnedString Text) {
@@ -241,6 +250,8 @@ public:
       case TriviaKind::VerticalTab:
       case TriviaKind::Formfeed:
         return Count;
+      case TriviaKind::CarriageReturnLineFeed:
+        return Count * 2;
     }
   }
 
@@ -418,6 +429,15 @@ struct Trivia {
       return {};
     }
     return {{TriviaPiece::carriageReturns(Count)}};
+  }
+  
+  /// Return a collection of trivia of some number of two bytes sequence
+  /// consists of CR and LF in a row.
+  static Trivia carriageReturnLineFeeds(unsigned Count) {
+    if (Count == 0) {
+      return {};
+    }
+    return {{TriviaPiece::carriageReturnLineFeeds(Count)}};
   }
 
   /// Return a collection of trivia with a single line of ('//')

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -245,6 +245,10 @@ public:
   }
 
   void accumulateAbsolutePosition(AbsolutePosition &Pos) const;
+  
+  /// Try to compose this and Next to one TriviaPiece.
+  /// It returns true if it is succeeded.
+  bool trySquash(const TriviaPiece &Next);
 
   /// Print a debug representation of this trivia piece to the provided output
   /// stream and indentation level.
@@ -336,6 +340,10 @@ struct Trivia {
       Len += P.getTextLength();
     return Len;
   }
+  
+  /// Append Next TriviaPiece or compose last TriviaPiece and
+  /// Next TriviaPiece to one last TriviaPiece if it can.
+  void appendOrSquash(const TriviaPiece &Next);
 
   /// Dump a debug representation of this Trivia collection to standard error.
   void dump() const;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2298,24 +2298,20 @@ Restart:
   // TODO: Handle invalid UTF8 sequence which is skipped in lexImpl().
   switch (*CurPtr++) {
   case '\n':
+    if (IsForTrailingTrivia)
+      break;
+    NextToken.setAtStartOfLine(true);
+    Pieces.appendOrSquash(TriviaPiece::newlines(1));
+    break;
   case '\r':
     if (IsForTrailingTrivia)
       break;
     NextToken.setAtStartOfLine(true);
-    switch (CurPtr[-1]) {
-    case '\n':
-      Pieces.appendOrSquash(TriviaPiece::newlines(1));
-      break;
-    case '\r':
-      if (CurPtr[0] == '\n') {
-        Pieces.appendOrSquash(TriviaPiece::carriageReturnLineFeeds(1));
-        CurPtr++;
-      } else {
-        Pieces.appendOrSquash(TriviaPiece::carriageReturns(1));
-      }
-      break;
-    default:
-      llvm_unreachable("unexcepted char here");
+    if (CurPtr[0] == '\n') {
+      Pieces.appendOrSquash(TriviaPiece::carriageReturnLineFeeds(1));
+      ++CurPtr;
+    } else {
+      Pieces.appendOrSquash(TriviaPiece::carriageReturns(1));
     }
     goto Restart;
   case ' ':

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2304,11 +2304,15 @@ Restart:
     NextToken.setAtStartOfLine(true);
     switch (CurPtr[-1]) {
     case '\n':
-      // FIXME: CR+LF shoud form one trivia piece
       Pieces.appendOrSquash(TriviaPiece::newlines(1));
       break;
     case '\r':
-      Pieces.appendOrSquash(TriviaPiece::carriageReturns(1));
+      if (CurPtr[0] == '\n') {
+        Pieces.appendOrSquash(TriviaPiece::carriageReturnLineFeeds(1));
+        CurPtr++;
+      } else {
+        Pieces.appendOrSquash(TriviaPiece::carriageReturns(1));
+      }
       break;
     default:
       llvm_unreachable("unexcepted char here");

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2119,6 +2119,8 @@ Restart:
 
   case '\n':
   case '\r':
+    assert(TriviaRetention != TriviaRetentionMode::WithTrivia &&
+           "newlines should be eaten by lexTrivia as LeadingTrivia");
     NextToken.setAtStartOfLine(true);
     goto Restart;  // Skip whitespace.
 
@@ -2302,7 +2304,7 @@ Restart:
       break;
     NextToken.setAtStartOfLine(true);
     Pieces.appendOrSquash(TriviaPiece::newlines(1));
-    break;
+    goto Restart;
   case '\r':
     if (IsForTrailingTrivia)
       break;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2302,42 +2302,30 @@ Restart:
     if (IsForTrailingTrivia)
       break;
     NextToken.setAtStartOfLine(true);
-    LLVM_FALLTHROUGH;
-  case ' ':
-  case '\t':
-  case '\v':
-  case '\f': {
-    auto Char = CurPtr[-1];
-    // Consume consective same characters.
-    while (*CurPtr == Char)
-      ++CurPtr;
-
-    auto Length = CurPtr - TriviaStart;
-    switch (Char) {
-    case ' ':
-      Pieces.push_back(TriviaPiece::spaces(Length));
-      break;
+    switch (CurPtr[-1]) {
     case '\n':
       // FIXME: CR+LF shoud form one trivia piece
-      Pieces.push_back(TriviaPiece::newlines(Length));
+      Pieces.appendOrSquash(TriviaPiece::newlines(1));
       break;
     case '\r':
-      Pieces.push_back(TriviaPiece::carriageReturns(Length));
-      break;
-    case '\t':
-      Pieces.push_back(TriviaPiece::tabs(Length));
-      break;
-    case '\v':
-      Pieces.push_back(TriviaPiece::verticalTabs(Length));
-      break;
-    case '\f':
-      Pieces.push_back(TriviaPiece::formfeeds(Length));
+      Pieces.appendOrSquash(TriviaPiece::carriageReturns(1));
       break;
     default:
-      llvm_unreachable("Invalid character for whitespace trivia");
+      llvm_unreachable("unexcepted char here");
     }
     goto Restart;
-  }
+  case ' ':
+    Pieces.appendOrSquash(TriviaPiece::spaces(1));
+    goto Restart;
+  case '\t':
+    Pieces.appendOrSquash(TriviaPiece::tabs(1));
+    goto Restart;
+  case '\v':
+    Pieces.appendOrSquash(TriviaPiece::verticalTabs(1));
+    goto Restart;
+  case '\f':
+    Pieces.appendOrSquash(TriviaPiece::formfeeds(1));
+    goto Restart;
   case '/':
     if (IsForTrailingTrivia || isKeepingComments()) {
       // Don't lex comments as trailing trivias (for now).

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2287,7 +2287,7 @@ Token Lexer::getTokenAtLocation(const SourceManager &SM, SourceLoc Loc) {
   return L.peekNextToken();
 }
 
-void Lexer::lexTrivia(syntax::TriviaList &Pieces, bool IsForTrailingTrivia) {
+void Lexer::lexTrivia(syntax::Trivia &Pieces, bool IsForTrailingTrivia) {
   if (TriviaRetention == TriviaRetentionMode::WithoutTrivia)
     return;
 

--- a/lib/Syntax/Trivia.cpp
+++ b/lib/Syntax/Trivia.cpp
@@ -104,8 +104,10 @@ void TriviaPiece::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
     break;
   case TriviaKind::Newline:
   case TriviaKind::CarriageReturn:
+    Pos.addNewlines(Count, 1);
+    break;
   case TriviaKind::CarriageReturnLineFeed:
-    Pos.addNewlines(Count);
+    Pos.addNewlines(Count, 2);
     break;
   case TriviaKind::Space:
   case TriviaKind::Backtick:

--- a/lib/Syntax/Trivia.cpp
+++ b/lib/Syntax/Trivia.cpp
@@ -58,6 +58,9 @@ void TriviaPiece::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   case TriviaKind::CarriageReturn:
     OS << "carriage_return " << Count;
     break;
+  case TriviaKind::CarriageReturnLineFeed:
+    OS << "carriage_return_line_feed " << Count;
+    break;
   case TriviaKind::LineComment:
     OS << "line_comment" << Text.str();
     break;
@@ -101,6 +104,7 @@ void TriviaPiece::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
     break;
   case TriviaKind::Newline:
   case TriviaKind::CarriageReturn:
+  case TriviaKind::CarriageReturnLineFeed:
     Pos.addNewlines(Count);
     break;
   case TriviaKind::Space:
@@ -123,6 +127,7 @@ bool TriviaPiece::trySquash(const TriviaPiece &Next) {
     case TriviaKind::Formfeed:
     case TriviaKind::Newline:
     case TriviaKind::CarriageReturn:
+    case TriviaKind::CarriageReturnLineFeed:
       Count += Next.Count;
       return true;
     case TriviaKind::LineComment:
@@ -154,6 +159,11 @@ void TriviaPiece::print(llvm::raw_ostream &OS) const {
     break;
   case TriviaKind::CarriageReturn:
     printRepeated(OS, '\r', Count);
+    break;
+  case TriviaKind::CarriageReturnLineFeed:
+    for (unsigned i = 0; i < Count; i++) {
+      OS << "\r\n";
+    }
     break;
   case TriviaKind::LineComment:
   case TriviaKind::BlockComment:

--- a/unittests/Syntax/RawSyntaxTests.cpp
+++ b/unittests/Syntax/RawSyntaxTests.cpp
@@ -1,5 +1,6 @@
 #include "swift/Parse/Token.h"
 #include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/RawTokenSyntax.h"
 #include "swift/Syntax/SyntaxFactory.h"
 #include "llvm/ADT/SmallString.h"
 #include "gtest/gtest.h"
@@ -8,3 +9,33 @@ using namespace swift;
 using namespace swift::syntax;
 
 // TODO
+
+TEST(RawSyntaxTests, accumulateAbsolutePosition1) {
+  auto Token = RawTokenSyntax::make(tok::identifier,
+                                    OwnedString("aaa"),
+                                    SourcePresence::Present,
+                                    Trivia {{
+                                      TriviaPiece::newlines(2),
+                                      TriviaPiece::carriageReturns(2),
+                                      TriviaPiece::carriageReturnLineFeeds(2) }},
+                                    Trivia {{  }});
+  AbsolutePosition Pos;
+  Token->accumulateAbsolutePosition(Pos);
+  ASSERT_EQ(7u, Pos.getLine());
+  ASSERT_EQ(4u, Pos.getColumn());
+  ASSERT_EQ(11u, Pos.getOffset());
+}
+
+TEST(RawSyntaxTests, accumulateAbsolutePosition2) {
+  auto Token = RawTokenSyntax::make(tok::identifier,
+                                    OwnedString("aaa"),
+                                    SourcePresence::Present,
+                                    Trivia {{
+                                      TriviaPiece::blockComment("/* \n\r\r\n */") }},
+                                    Trivia {{  }});
+  AbsolutePosition Pos;
+  Token->accumulateAbsolutePosition(Pos);
+  ASSERT_EQ(4u, Pos.getLine());
+  ASSERT_EQ(7u, Pos.getColumn());
+  ASSERT_EQ(13u, Pos.getOffset());
+}


### PR DESCRIPTION
This PR add CRLF support to libSyntax.
CRLF is added as new Trivia which is `TriviaKind::CarriageReturnLineFeed`.

To write simply parse logic in Lexer,
I added `trySquash` method to `TriviaPiece`,
`appendOrSquash` method to `Trivia`.

This is process that compose TriviaKind which keeps length by Count
such like Newline or CarriageReturnLineFeed to one TriviaKind and increase Count.

Then, I changed type of `LeadingTrivia` and `TrailingTrivia` in Lexer from
`TriviaList` to `Trivia`.