### PR TITLE
[Stdlib] Fix requirements on FlattenCollectionIndex.

### DIFF
--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -566,7 +566,7 @@ extension LazyCollectionProtocol
 }
 
 // @available(*, deprecated, renamed: "FlattenCollection.Index")
-public typealias FlattenCollectionIndex<T> = FlattenCollection<T>.Index where T : BidirectionalCollection, T.Element : BidirectionalCollection
+public typealias FlattenCollectionIndex<T> = FlattenCollection<T>.Index where T : Collection, T.Element : Collection
 @available(*, deprecated, renamed: "FlattenCollection.Index")
 public typealias FlattenBidirectionalCollectionIndex<T> = FlattenCollection<T>.Index where T : BidirectionalCollection, T.Element : BidirectionalCollection
 @available(*, deprecated, renamed: "FlattenCollection")

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -1291,6 +1291,11 @@ do {
   }
 }
 
+struct TryFlattenIndex<C: Collection> where C.Element: Collection {
+  typealias FlattenedIndex = FlattenCollectionIndex<C>
+}
+
+
 //===--- LazyPrefixWhile --------------------------------------------------===//
 
 let prefixDropWhileTests: [(data: [Int], value: Int, pivot: Int)] = [


### PR DESCRIPTION
`FlattenCollectionIndex` recently became a typealias, but overstated its
requirements.
