### PR TITLE
libSyntax: generate condition checking code for node choices instead of hard-coding them. NFC

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -100,17 +100,6 @@ using llvm::StringRef;
 #define syntax_assert_token_is(Tok, Kind, Text) ({});
 #endif
 
-#ifndef NDEBUG
-#define syntax_assert_node_choice(Raw, CursorName, NodeName)                   \
-  ({                                                                           \
-    auto Child = Raw->getChild(Cursor::CursorName);                            \
-    auto Node = make<Syntax>(Child);                                           \
-    assert(check##CursorName##In##NodeName(Node));                             \
-  })
-#else
-#define syntax_assert_node_choice(Raw, CursorName, NodeName) ({});
-#endif
-
 namespace swift {
 namespace syntax {
 

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -99,10 +99,6 @@ public:
 
 %   end
 % end
-
-bool checkAccessorListOrStmtListInAccessorBlock(const Syntax &S);
-bool checkInputInClosureSignature(const Syntax &S);
-bool checkContentInDictionaryExpr(const Syntax &S);
 }
 }
 

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -110,56 +110,13 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
     static std::pair<bool, std::function<bool(const Syntax&)>>
       ChildrenConditions[${child_count}] = {
 %    for child in node.children:
+%       check = check_child_condition(child)
 %       if child.is_optional:
 %         option = "true"
 %       else:
 %         option = "false"
-%       if child.token_choices:
-        {   ${option},
-            [](const Syntax &S) {
-              // check ${child.name}.
-              if (auto Tok = S.getAs<TokenSyntax>()) {
-                auto Kind = Tok->getTokenKind();
-%           tok_checks = []
-%           for choice in child.token_choices:
-%             tok_checks.append("Kind == tok::%s" % choice.kind)
-%           end
-%           all_checks = ' || '.join(tok_checks)
-                return ${all_checks};
-              }
-              return false;
-            }
-        },
-%       elif child.text_choices:
-        {   ${option},
-            [](const Syntax &S) {
-              // check ${child.name}.
-              if (auto Tok = S.getAs<TokenSyntax>()) {
-                auto Text = Tok->getText();
-%           tok_checks = []
-%           for choice in child.text_choices:
-%             tok_checks.append("Text == \"%s\"" % choice)
-%           end
-%           all_checks = ' || '.join(tok_checks)
-                return ${all_checks};
-              }
-              return false;
-            }
-        },
-%       elif child.node_choices:
-        {   ${option},
-            [] (const Syntax &S) {
-              return check${child.name}In${node.syntax_kind}(S);
-            }
-        },
-%       else:
-        {   ${option},
-            [](const Syntax &S) {
-              // check ${child.name}.
-              return S.getAs<${child.type_name}>().hasValue();
-            }
-        },
 %       end
+        {   ${option}, ${check} },
 %    end
     };
     Optional<Syntax> Parameters[${child_count}];

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -24,25 +24,6 @@
 using namespace swift;
 using namespace swift::syntax;
 
-
-bool swift::syntax::
-checkAccessorListOrStmtListInAccessorBlock(const Syntax &S) {
-  return S.getKind() == SyntaxKind::AccessorList ||
-    S.getKind() == SyntaxKind::StmtList;
-}
-
-bool swift::syntax::checkInputInClosureSignature(const Syntax &S) {
-  return S.getKind() == SyntaxKind::ClosureParamList ||
-    S.getKind() == SyntaxKind::ParameterClause;
-}
-
-bool swift::syntax::checkContentInDictionaryExpr(const Syntax &S) {
-  if (auto Tok = S.getAs<TokenSyntax>()) {
-    return Tok->getTokenKind() == tok::colon;
-  }
-  return S.getKind() == SyntaxKind::DictionaryElementList;
-}
-
 % for node in SYNTAX_NODES:
 %   if node.requires_validation():
 void ${node.name}::validate() const {
@@ -64,7 +45,13 @@ void ${node.name}::validate() const {
                                  tok::${token_kind}, ${choices});
 %       end
 %       if child.node_choices:
-  syntax_assert_node_choice(raw, ${child.name}, ${node.syntax_kind});
+#ifndef NDEBUG
+        {
+          auto child = make<Syntax>(raw->getChild(Cursor::${child.name}));
+%         content = check_child_condition(child) + '(child)'
+          assert(${content});
+        }
+#endif
 %       end
 %     end
 }

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -33,6 +33,49 @@ def make_missing_child(child):
         return 'RawSyntax::missing(SyntaxKind::%s)' % missing_kind
 
 
+def check_child_condition(child):
+    """
+    Generates a C++ closure to check whether a given syntax node S can satisfy
+    the requirements of child.
+    """
+    result = '[](const Syntax &S) {\n'
+    result += '  // check %s\n' % child.name
+    if child.token_choices:
+        # Check token kind choices are met.
+        result += 'if (auto Tok = S.getAs<TokenSyntax>()) {\n'
+        result += '  auto Kind = Tok->getTokenKind();\n'
+        tok_checks = []
+        for choice in child.token_choices:
+            tok_checks.append("Kind == tok::%s" % choice.kind)
+        all_checks = ' || '.join(tok_checks)
+        result += '  return %s;\n' % all_checks
+        result += '}\n'
+        result += 'return false;\n'
+    elif child.text_choices:
+        # Check token text choices are met.
+        result += 'if (auto Tok = S.getAs<TokenSyntax>()) {\n'
+        result += '  auto Text = Tok->getText();\n'
+        tok_checks = []
+        for choice in child.text_choices:
+            tok_checks.append("Text == \"%s\"" % choice)
+        all_checks = ' || '.join(tok_checks)
+        result += '  return %s;\n' % all_checks
+        result += '}\n'
+        result += 'return false;\n'
+    elif child.node_choices:
+        # Recursively, check one of the node choices' conditions are met.
+        node_checks = []
+        for choice in child.node_choices:
+            node_checks.append(check_child_condition(choice) + '(S)')
+        all_checks = ' || '.join(node_checks)
+        result += 'return %s;\n' % all_checks
+    else:
+        # For remaining children, simply check the syntax kind.
+        result += 'return S.getAs<%s>().hasValue();\n' % child.type_name
+    result += '}'
+    return result
+
+
 def make_missing_swift_child(child):
     """
     Generates a Swift call to make the raw syntax for a given Child object.


### PR DESCRIPTION
This patch adds a python function to syntax node gyb support called
"check_child_condition". Given a child's definition, this function
generate a C++ closure to check whether a given syntax node can satisfy
the condition of the child node. This function recursively generates code
for node choices too, therefore we don't need to hard code the
condition checking for node choices.