### PR TITLE
[WIP] [Name lookup] Resolve unqualified associated type references via the resolver

### DIFF
--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -225,3 +225,15 @@ class G<T> : sr6097_b where T : AnyObject {
 }
 
 
+// rdar://problem/35756206
+protocol P11 {
+  associatedtype T
+}
+
+protocol P12 {
+  associatedtype T
+}
+
+extension P11 where Self: P12 {
+  func foo() -> T? { return nil }
+}


### PR DESCRIPTION
When resolving a qualified reference to an associated type, we use the
generic resolver (correctly). Do the same for unqualified references to
associated types.

Fixes rdar://problem/35756206.
