### PR TITLE
[WIP] SILGen: Don't inject "willThrow" hooks before rethrow propagation branches.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1427,9 +1427,6 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
     SILValue error = errorBB->createPHIArgument(fnConv.getSILErrorType(),
                                                 ValueOwnershipKind::Owned);
 
-    B.createBuiltin(loc, SGM.getASTContext().getIdentifier("willThrow"),
-                    SGM.Types.getEmptyTupleType(), {}, {error});
-
     Cleanups.emitCleanupsForReturn(CleanupLocation::get(loc));
     B.createThrow(loc, error);
   }

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -171,12 +171,6 @@ emitApplyWithRethrow(SILBuilder &Builder,
     SILValue Error = ErrorBB->createPHIArgument(fnConv.getSILErrorType(),
                                                 ValueOwnershipKind::Owned);
 
-    Builder.createBuiltin(Loc,
-                          Builder.getASTContext().getIdentifier("willThrow"),
-                          Builder.getModule().Types.getEmptyTupleType(),
-                          SubstitutionList(),
-                          {Error});
-
     EmitCleanup(Builder, Loc);
     addThrowValue(ErrorBB, Error);
   }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -188,7 +188,6 @@ class HasThrowingInit {
 // CHECK:    bb1([[SELF:%.*]] : @owned $HasThrowingInit):
 // CHECK-NEXT: return [[SELF]]
 // CHECK:    bb2([[ERROR:%.*]] : @owned $Error):
-// CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: throw [[ERROR]]
 
 // CHECK-LABEL: sil hidden @_T06errors15HasThrowingInit{{.*}} : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error) {
@@ -238,7 +237,6 @@ protocol Doomed {
 // CHECK:      [[T0:%.*]] = tuple ()
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
-// CHECK:      builtin "willThrow"([[T0]] : $Error)
 // CHECK:      throw [[T0]] : $Error
 struct DoomedStruct : Doomed {
   func check() throws {}
@@ -253,7 +251,6 @@ struct DoomedStruct : Doomed {
 // CHECK:      end_borrow [[BORROWED_SELF]] from %0
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
-// CHECK:      builtin "willThrow"([[T0]] : $Error)
 // CHECK:      end_borrow [[BORROWED_SELF]] from %0
 // CHECK:      throw [[T0]] : $Error
 class DoomedClass : Doomed {
@@ -294,7 +291,6 @@ func testThunk(_ fn: () throws -> Int) throws -> Int {
 // CHECK:   [[T0:%.*]] = tuple ()
 // CHECK:   return [[T0]]
 // CHECK: bb2([[T0:%.*]] : @owned $Error):
-// CHECK:   builtin "willThrow"([[T0]] : $Error)
 // CHECK:   throw [[T0]] : $Error
 
 func createInt(_ fn: () -> Int) throws {}

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -57,7 +57,6 @@ extension Hive {
   // CHECK:   return [[HIVE]]
   //
   // CHECK: [[ERROR_BB]]([[ERROR:%.*]] : @owned $Error):
-  // CHECK:   builtin "willThrow"([[ERROR]] : $Error)
   // CHECK:   throw [[ERROR]]
   // CHECK: } // end sil function '_T0So4HiveC17objc_factory_initEABSo3BeeC15otherFlakyQueen_tKcfC'
   convenience init(otherFlakyQueen other: Bee) throws {

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -228,7 +228,6 @@ bb2:
 // CHECK:   try_apply %{{.*}}(%{{.*}}, %{{.*}}) : $@convention(thin) (Int, Int) -> (Int, @error Error), normal bb8, error bb7
 
 // CHECK: bb7(%{{.*}} : $Error):
-// CHECK:   %{{.*}} = builtin "willThrow"(%{{.*}} : $Error) : $()
 // CHECK:   br bb3(%{{.*}} : $Error)
 
 // CHECK: bb8(%{{.*}} : $Int):


### PR DESCRIPTION
The hook is intended to be used by debuggers to catch the point a `throw` happened in user source. It's unnecessary and undesirable to hook in places where an already-thrown error is just being implicitly propagated.