### PR TITLE
Zero-initialize uninitialized variables at -Onone.

### DIFF
--- a/test/DebugInfo/uninitialized.swift
+++ b/test/DebugInfo/uninitialized.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+class MyClass {}
+
+// CHECK: define {{.*}} @_T013uninitialized1fyyF
+public func f() {
+  var object: MyClass
+  // CHECK: %[[OBJ:.*]] = alloca %[[T:.*]]*, align
+  // CHECK: call void @llvm.dbg.declare(metadata %[[T]]** %[[OBJ]],
+  // CHECK: %[[BC:.*]] = bitcast %[[T]]** %[[OBJ]] to %swift.opaque**, !dbg
+  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC]], align {{.*}}, !dbg
+}


### PR DESCRIPTION
This un-breaks the LLDB testsuite.

To make it unambiguous whether a `var` binding has been initialized,
zero-initialize the first pointer-sized field. LLDB uses this to
recognize to detect uninitizialized variables. This can be removed once
swiftc switches to @llvm.dbg.addr() intrinsics. This dead store will get
optimized away when optimizations are enabled.

<rdar://problem/36156857>

(cherry picked from commit fdc9489d251684e2cbd819e615e3258609248094)
