### PR TITLE
Teach the SILPrinter to be more resilient to null operands.

### DIFF
--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -29,7 +29,7 @@ class SILBasicBlock;
 class SILPrintContext {
 public:
   struct ID {
-    enum ID_Kind { SILBasicBlock, SILUndef, SSAValue } Kind;
+    enum ID_Kind { SILBasicBlock, SILUndef, SSAValue, Null } Kind;
     unsigned Number;
 
     // A stable ordering of ID objects.


### PR DESCRIPTION
Previously, when in the debugger and dumping out SIL code, the
printer would crash if it encountered a null operand.  If you
are dumping a basic block, this means that the dump stops at
that instruction instead of showing you the whole block.  Null
operands can happen when you call dropAllReferences() but have
yet to delete the instruction.

Now the printer is a bit more resilient.  We probably don't catch
all the cases, but we handle a lot of them, e.g.:

  %116 = apply <<NULL OPERAND>>(<<NULL OPERAND>>, <<NULL OPERAND>>) : <<NULL CALLEE>>
  debug_value <<NULL OPERAND>>, let, name "c", argno 1 // id: %120
  retain_value <<NULL OPERAND>>                   // id: %138

Since this is only relevant to invalid IR, this is just
a debugging aid, so no testcase.
