### PR TITLE
[Exclusivity] Additional tests for static and dynamic exclusivity.

### DIFF
--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -104,66 +104,6 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
   globalX = X() // no-trap
 }
 
-// FIXME: This should be covered by static diagnostics.
-// Once this radar is fixed, confirm that a it is covered by a static diagnostic
-// (-verify) test in exclusivity_static_diagnostics.sil.
-// <rdar://problem/32061282> Enforce exclusive access in noescape closures.
-//
-//ExclusiveAccessTestSuite.test("ClosureCaptureModifyModify")
-//.skip(.custom(
-//    { _isFastAssertConfiguration() },
-//    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("Previous access (a modification) started at")
-//  .crashOutputMatches("Current access (a modification) started at")
-//  .code
-//{
-//  var x = X()
-//  modifyAndPerform(&x) {
-//    expectCrashLater()
-//    x.i = 12
-//  }
-//}
-
-// FIXME: This should be covered by static diagnostics.
-// Once this radar is fixed, confirm that a it is covered by a static diagnostic
-// (-verify) test in exclusivity_static_diagnostics.sil.
-// <rdar://problem/32061282> Enforce exclusive access in noescape closures.
-//
-//ExclusiveAccessTestSuite.test("ClosureCaptureReadModify")
-//.skip(.custom(
-//    { _isFastAssertConfiguration() },
-//    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("Previous access (a read) started at")
-//  .crashOutputMatches("Current access (a modification) started at")
-//  .code
-//{
-//  var x = X()
-//  modifyAndPerform(&x) {
-//    expectCrashLater()
-//    _blackHole(x.i)
-//  }
-//}
-
-// FIXME: This should be covered by static diagnostics.
-// Once this radar is fixed, confirm that a it is covered by a static diagnostic
-// (-verify) test in exclusivity_static_diagnostics.sil.
-// <rdar://problem/32061282> Enforce exclusive access in noescape closures.
-//
-//ExclusiveAccessTestSuite.test("ClosureCaptureModifyRead")
-//.skip(.custom(
-//    { _isFastAssertConfiguration() },
-//    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("Previous access (a modification) started at")
-//  .crashOutputMatches("Current access (a read) started at")
-//  .code
-//{
-//  var x = X()
-//  readAndPerform(&x) {
-//    expectCrashLater()
-//    x.i = 12
-//  }
-//}
-
 ExclusiveAccessTestSuite.test("ClosureCaptureReadRead") {
   var x = X()
   readAndPerform(&x) {
@@ -300,5 +240,28 @@ ExclusiveAccessTestSuite.test("InoutWriteEscapeWrite")
   expectCrashLater()
   doOne { modifyAndPerform(&x, closure: c) }
 }
+
+class ClassWithStoredProperty {
+  var f = 7
+}
+
+// FIXME: This should trap with a modify/modify violation at run time.
+ExclusiveAccessTestSuite.test("KeyPathClassStoredProp")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+//  .crashOutputMatches("Previous access (a modification) started at")
+//  .crashOutputMatches("Current access (a modification) started at")
+  .code
+{
+  let getF = \ClassWithStoredProperty.f
+  let c = ClassWithStoredProperty()
+
+//  expectCrashLater()
+  modifyAndPerform(&c[keyPath: getF]) {
+    c[keyPath: getF] = 12
+  }
+}
+
 
 runAllTests()


### PR DESCRIPTION
Add more exclusivity tests. This includes a test for a known false
negative involving keypaths for class properties.
