### PR TITLE
LoadableByAddress: take the function type's generic environment when converting BB args

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -637,6 +637,12 @@ static bool shouldConvertBBArg(SILArgument *arg, irgen::IRGenModule &Mod) {
   if (!genEnv && loweredTy->isPolymorphic()) {
     genEnv = getGenericEnvironment(F->getModule(), loweredTy);
   }
+  CanType currCanType = storageType.getSwiftRValueType();
+  if (auto funcType = dyn_cast<SILFunctionType>(currCanType)) {
+    if (funcType->isPolymorphic()) {
+      genEnv = getGenericEnvironment(F->getModule(), funcType);
+    }
+  }
   SILType newSILType = getNewSILType(genEnv, storageType, Mod);
   // We (currently) only care about function signatures
   if (!isLargeLoadableType(genEnv, storageType, Mod) &&


### PR DESCRIPTION
radar rdar://problem/36179840

Fixes a crash in the large loadable types IR Gen module pass.

Note: creating a small / understandable / meaningful test case is a bit tricky. I will do so in a follow-up commit. I just want to get this in before we freeze the 4.1 branch.