### PR TITLE
master-next: use WritableMemoryBuffer::getNewUninitMemBuffer

### DIFF
--- a/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
+++ b/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
@@ -177,7 +177,8 @@ getMemBufferFromRope(StringRef Filename, const RewriteRope &Rope) {
     Length += I.piece().size();
   }
 
-  auto MemBuf = llvm::MemoryBuffer::getNewUninitMemBuffer(Length, Filename);
+  auto MemBuf =
+    llvm::WritableMemoryBuffer::getNewUninitMemBuffer(Length, Filename);
   char *Ptr = (char*)MemBuf->getBufferStart();
   for (RewriteRope::iterator I = Rope.begin(), E = Rope.end(); I != E;
        I.MoveToNextPiece()) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -157,7 +157,8 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
 
   const char *Position = InputFile->getBufferStart() + CodeCompletionOffset;
   std::unique_ptr<llvm::MemoryBuffer> NewBuffer =
-      llvm::MemoryBuffer::getNewUninitMemBuffer(InputFile->getBufferSize() + 1,
+      llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
+                                              InputFile->getBufferSize() + 1,
                                               InputFile->getBufferIdentifier());
   char *NewBuf = const_cast<char*>(NewBuffer->getBufferStart());
   char *NewPos = std::copy(InputFile->getBufferStart(), Position, NewBuf);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
@@ -72,7 +72,7 @@ unsigned CompactArrayBuilderImpl::getOffsetForString(StringRef Str) {
 std::unique_ptr<llvm::MemoryBuffer>
 CompactArrayBuilderImpl::createBuffer() const {
   std::unique_ptr<llvm::MemoryBuffer> Buf;
-  Buf = llvm::MemoryBuffer::getNewUninitMemBuffer(sizeInBytes());
+  Buf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(sizeInBytes());
   copyInto(const_cast<char *>(Buf->getBufferStart()), Buf->getBufferSize());
   return Buf;
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
@@ -249,7 +249,7 @@ std::unique_ptr<llvm::MemoryBuffer> DocStructureArrayBuilder::createBuffer() {
   // * offset of top structure array (relative to structure array section) (1)
   size_t headerSize = sizeof(uint64_t) * 6;
 
-  auto result = llvm::MemoryBuffer::getNewUninitMemBuffer(
+  auto result = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
       inheritedTypesBufferSize + attrsBufferSize + elementsBufferSize +
       structureArrayBufferSize + structureBufferSize + headerSize);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -245,7 +245,7 @@ void ResponseBuilder::Dictionary::setCustomBuffer(
       CustomBufferKind Kind, std::unique_ptr<llvm::MemoryBuffer> MemBuf) {
 
   std::unique_ptr<llvm::MemoryBuffer> CustomBuf;
-  CustomBuf = llvm::MemoryBuffer::getNewUninitMemBuffer(
+  CustomBuf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
       sizeof(uint64_t) + MemBuf->getBufferSize());
   char *BufPtr = (char*)CustomBuf->getBufferStart();
   *reinterpret_cast<uint64_t*>(BufPtr) = (uint64_t)Kind;


### PR DESCRIPTION
llvm r321257 removed MemoryBuffer::getNewUninitMemBuffer. Change to use
WritableMemoryBuffer::getNewUninitMemBuffer instead.