### PR TITLE
IRGen: Fix runtime crash with default implementation of protocol requirement with a generic class

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -323,18 +323,9 @@ void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
     // The Self type is abstract, so we can fulfill its metadata from
     // the Self metadata parameter.
     addSelfMetadataFulfillment(selfTy);
-  } else {
-    // If the Self type is concrete, we have a witness thunk with a
-    // fully substituted Self type. The witness table parameter is not
-    // used.
-    //
-    // FIXME: As above, we should fulfill the Self metadata and
-    // conformance from our two special paramaters here. However, the
-    // Self metadata will be inexact.
-    //
-    // For now, just fulfill the generic arguments of 'Self'.
-    considerType(selfTy, IsInexact, Sources.size() - 1, MetadataPath());
   }
+
+  considerType(selfTy, IsInexact, Sources.size() - 1, MetadataPath());
 
   // The witness table for the Self : P conformance can be
   // fulfilled from the Self witness table parameter.

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -110,7 +110,7 @@ class TPSReport<CoverSheet> : Strategy {
   func disrupt() -> GrowthHack
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(%swift.type* %CoverSheet, %T14witness_method9TPSReportC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(%T14witness_method9TPSReportC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type* %Self, i8** %SelfWitnessTable)
 
 sil @classArchetypeWitnessMethod : $@convention(witness_method: Strategy) <T><CoverSheet where T : TPSReport<CoverSheet>> (@in_guaranteed T) -> () {
 entry(%self : $*T):

--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -315,6 +315,8 @@ class SelfMetadataBase : SelfMetadataTest {}
 
 class SelfMetadataDerived : SelfMetadataBase {}
 
+class SelfMetadataGeneric<T> : SelfMetadataTest {}
+
 func testSelfMetadata<T : SelfMetadataTest>(_ x: T, _ t: T.T) -> [Any.Type] {
   return [x.staticTypeOfSelf(),
           x.staticTypeOfSelfTakesT(t),
@@ -347,6 +349,16 @@ ProtocolExtensionTestSuite.test("WitnessSelf") {
     expectTrue(SelfMetadataBase.self == result[1])
     expectTrue(SelfMetadataDerived.self == result[2])
     expectTrue(SelfMetadataDerived.self == result[3])
+  }
+
+  // Make sure the calling convention works out if 'Self' is a generic
+  // class too.
+  do {
+    let result = testSelfMetadata(SelfMetadataGeneric<Int>(), 0)
+    expectTrue(SelfMetadataGeneric<Int>.self == result[0])
+    expectTrue(SelfMetadataGeneric<Int>.self == result[1])
+    expectTrue(SelfMetadataGeneric<Int>.self == result[2])
+    expectTrue(SelfMetadataGeneric<Int>.self == result[3])
   }
 }
 


### PR DESCRIPTION
If the 'self' type is abstract, we still have to consider it as
a source of type metadata, because it might be a class-bound
generic parameter and the class might have generic parameters.

Fixes <rdar://problem/36093833>.