### PR TITLE
master-next: attempt to fix Linux bots

### DIFF
--- a/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
+++ b/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
@@ -187,7 +187,7 @@ getMemBufferFromRope(StringRef Filename, const RewriteRope &Rope) {
     Ptr += Text.size();
   }
 
-  return MemBuf;
+  return std::move(MemBuf);
 }
 
 ImmutableTextBufferRef EditableTextBuffer::getBufferForSnapshot(

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -156,11 +156,11 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   }
 
   const char *Position = InputFile->getBufferStart() + CodeCompletionOffset;
-  std::unique_ptr<llvm::MemoryBuffer> NewBuffer =
+  std::unique_ptr<llvm::WritableMemoryBuffer> NewBuffer =
       llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
                                               InputFile->getBufferSize() + 1,
                                               InputFile->getBufferIdentifier());
-  char *NewBuf = const_cast<char*>(NewBuffer->getBufferStart());
+  char *NewBuf = NewBuffer->getBufferStart();
   char *NewPos = std::copy(InputFile->getBufferStart(), Position, NewBuf);
   *NewPos = '\0';
   std::copy(Position, InputFile->getBufferEnd(), NewPos+1);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
@@ -71,10 +71,10 @@ unsigned CompactArrayBuilderImpl::getOffsetForString(StringRef Str) {
 
 std::unique_ptr<llvm::MemoryBuffer>
 CompactArrayBuilderImpl::createBuffer() const {
-  std::unique_ptr<llvm::MemoryBuffer> Buf;
+  std::unique_ptr<llvm::WritableMemoryBuffer> Buf;
   Buf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(sizeInBytes());
-  copyInto(const_cast<char *>(Buf->getBufferStart()), Buf->getBufferSize());
-  return Buf;
+  copyInto(Buf->getBufferStart(), Buf->getBufferSize());
+  return std::move(Buf);
 }
 
 void CompactArrayBuilderImpl::appendTo(SmallVectorImpl<char> &Buf) const {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
@@ -253,7 +253,7 @@ std::unique_ptr<llvm::MemoryBuffer> DocStructureArrayBuilder::createBuffer() {
       inheritedTypesBufferSize + attrsBufferSize + elementsBufferSize +
       structureArrayBufferSize + structureBufferSize + headerSize);
 
-  char *start = const_cast<char *>(result->getBufferStart());
+  char *start = result->getBufferStart();
   char *headerPtr = start;
   char *ptr = start + headerSize;
 
@@ -277,7 +277,7 @@ std::unique_ptr<llvm::MemoryBuffer> DocStructureArrayBuilder::createBuffer() {
   assert(headerPtr == start + (headerSize - sizeof(topOffset)));
   memcpy(headerPtr, &topOffset, sizeof(topOffset));
 
-  return result;
+  return std::move(result);
 }
 
 namespace {


### PR DESCRIPTION
After my PR 13591 to adjust for LLVM r321257, the Linux bots are failing with
errors about missing conversions. For some reason that I don't understand,
those errors do not reproduce when I build locally on macOS. I think this
change should fix them. I also cleaned up some const_casts that should now
be unnecessary when using WritableMemoryBuffer.