### PR TITLE
[swiftc (52 vs. 5619)] Add crasher in swift::namelookup::lookupInModule

### DIFF
--- a/validation-test/compiler_crashers/28865-void-lookupinmodule-llvm-smallset-swift-cantype-4u-anonymous-namespace-sortcanty.swift
+++ b/validation-test/compiler_crashers/28865-void-lookupinmodule-llvm-smallset-swift-cantype-4u-anonymous-namespace-sortcanty.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:a{}typealias a:A&


### PR DESCRIPTION
Add test case for crash triggered in `swift::namelookup::lookupInModule`.

Current number of unresolved compiler crashers: 52 (5619 resolved)

Stack trace:

```
0 0x0000000003f3abd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f3abd4)
1 0x0000000003f3af16 SignalHandler(int) (/path/to/swift/bin/swift+0x3f3af16)
2 0x00007f578bd5a390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000017262a7 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0x17262a7)
4 0x00000000013266d8 swift::TypeChecker::lookupUnqualifiedType(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x13266d8)
5 0x000000000137baa4 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137baa4)
6 0x0000000001375b6c resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1375b6c)
7 0x0000000001375544 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1375544)
8 0x00000000013762c1 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13762c1)
9 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
10 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
11 0x0000000001441ceb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x1441ceb)
12 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
13 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
14 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
15 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
16 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
17 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
18 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
19 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
20 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
21 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
22 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
23 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
24 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
25 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
26 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
27 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
28 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
29 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
30 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
31 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
32 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
33 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
34 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
35 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
36 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
37 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
38 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
39 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
40 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
41 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
42 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
43 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
44 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
45 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
46 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
47 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
48 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
49 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
50 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
51 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
52 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
53 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
54 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
55 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
56 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
57 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
58 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
59 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
60 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
61 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
62 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
63 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
64 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
65 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
66 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
67 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
68 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
69 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
70 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
71 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
72 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
73 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
74 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
75 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
76 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
77 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
78 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
79 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
80 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
81 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
82 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
83 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
84 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
85 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
86 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
87 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
88 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
89 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
90 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
91 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
92 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
93 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
94 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
95 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
96 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
97 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
98 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
99 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
100 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
101 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
102 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
103 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
104 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
105 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
106 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
107 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
108 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
109 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
110 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
111 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
112 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
113 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
114 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
115 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
116 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
117 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
118 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
119 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
120 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
121 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
122 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
123 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
124 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
125 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
126 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
127 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
128 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
129 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
130 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
131 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
132 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
133 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
134 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
135 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
136 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
137 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
138 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
139 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
140 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
141 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
142 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
143 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
144 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
145 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
146 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
147 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
148 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
149 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
150 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
151 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
152 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
153 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
154 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
155 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
156 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
157 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
158 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
159 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
160 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
161 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
162 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
163 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
164 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
165 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
166 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
167 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
168 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
169 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
170 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
171 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
172 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
173 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
174 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
175 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
176 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
177 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
178 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
179 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
180 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
181 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
182 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
183 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
184 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
185 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
186 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
187 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
188 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
189 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
190 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
191 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
192 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
193 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
194 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
195 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
196 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
197 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
198 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
199 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
200 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
201 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
202 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
203 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
204 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
205 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
206 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
207 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
208 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
209 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
210 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
211 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
212 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
213 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
214 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
215 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
216 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
217 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
218 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
219 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
220 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
221 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
222 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
223 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
224 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
225 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
226 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
227 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
228 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
229 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
230 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
231 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
232 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
233 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
234 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
235 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
236 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
237 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
238 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
239 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
240 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
241 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
242 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
243 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
244 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
245 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
246 0x000000000174766a swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x174766a)
247 0x0000000001377c2d (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1377c2d)
248 0x00000000013761cc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13761cc)
249 0x0000000001374a89 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1374a89)
250 0x00000000014427ed swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x14427ed)
251 0x000000000140ac26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140ac26)
252 0x000000000140aceb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x140aceb)
253 0x00000000012e6769 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x12e6769)
254 0x00000000016b4fb5 swift::ProtocolDecl::getInheritedProtocols() const (/path/to/swift/bin/swift+0x16b4fb5)
255 0x0000000001745e10 swift::ProtocolType::canonicalizeProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x1745e10)
```