### PR TITLE
[swiftc (53 vs. 5619)] Add crasher in swift::CanType

### DIFF
--- a/validation-test/compiler_crashers/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[.a
+[Int?as?Int
+nil?


### PR DESCRIPTION
Add test case for crash triggered in `swift::CanType`.

Current number of unresolved compiler crashers: 53 (5619 resolved)

Stack trace:

```
0 0x0000000003f3abd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f3abd4)
1 0x0000000003f3af16 SignalHandler(int) (/path/to/swift/bin/swift+0x3f3af16)
2 0x00007f9e01f28390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f9e0044d428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9e0044f02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003ececfd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3ececfd)
6 0x00000000017566ca swift::CanType swift::CanTypeVisitor<TypeJoin, swift::CanType>::visit<>(swift::CanType) (/path/to/swift/bin/swift+0x17566ca)
7 0x0000000001756220 TypeJoin::join(swift::CanType, swift::CanType) (/path/to/swift/bin/swift+0x1756220)
8 0x00000000017564d1 TypeJoin::visitBoundGenericEnumType(swift::CanType) (/path/to/swift/bin/swift+0x17564d1)
9 0x000000000175668e swift::CanType swift::CanTypeVisitor<TypeJoin, swift::CanType>::visit<>(swift::CanType) (/path/to/swift/bin/swift+0x175668e)
10 0x0000000001756220 TypeJoin::join(swift::CanType, swift::CanType) (/path/to/swift/bin/swift+0x1756220)
11 0x00000000013aed42 swift::constraints::ConstraintSystem::PotentialBindings::addPotentialBinding(swift::constraints::ConstraintSystem::PotentialBinding, bool) (/path/to/swift/bin/swift+0x13aed42)
12 0x00000000013ac9e0 swift::constraints::ConstraintSystem::getPotentialBindings(swift::TypeVariableType*) (/path/to/swift/bin/swift+0x13ac9e0)
13 0x00000000013ac45b swift::constraints::ConstraintSystem::determineBestBindings() (/path/to/swift/bin/swift+0x13ac45b)
14 0x000000000129e3c5 swift::constraints::ConstraintSystem::solveSimplified(swift::constraints::Constraint*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129e3c5)
15 0x000000000129a88c swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a88c)
16 0x000000000129a0fd swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a0fd)
17 0x000000000129e433 swift::constraints::ConstraintSystem::solveSimplified(swift::constraints::Constraint*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129e433)
18 0x000000000129a88c swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a88c)
19 0x000000000129a0fd swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a0fd)
20 0x000000000129e433 swift::constraints::ConstraintSystem::solveSimplified(swift::constraints::Constraint*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129e433)
21 0x000000000129a88c swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a88c)
22 0x000000000129a0fd swift::constraints::ConstraintSystem::tryTypeVariableBindings(unsigned int, swift::TypeVariableType*, llvm::ArrayRef<swift::constraints::ConstraintSystem::PotentialBinding>, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a0fd)
23 0x000000000129e433 swift::constraints::ConstraintSystem::solveSimplified(swift::constraints::Constraint*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129e433)
24 0x000000000129a88c swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x129a88c)
25 0x00000000013b7354 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13b7354)
26 0x00000000012d3008 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12d3008)
27 0x00000000012d6cf2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12d6cf2)
28 0x00000000013bc007 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x13bc007)
29 0x00000000013c757c (anonymous namespace)::FailureDiagnosis::typeCheckArbitrarySubExprIndependently(swift::Expr*, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0x13c757c)
30 0x00000000013b340b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13b340b)
31 0x00000000013b82c6 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13b82c6)
32 0x00000000012d3008 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12d3008)
33 0x00000000012d6cf2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12d6cf2)
34 0x0000000001364886 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1364886)
35 0x0000000001364086 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1364086)
36 0x0000000001385a2d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1385a2d)
37 0x00000000010911c4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x10911c4)
38 0x000000000109016e swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x109016e)
39 0x000000000108fb1a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x108fb1a)
40 0x00000000004c88de performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4c88de)
41 0x00000000004c762a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4c762a)
42 0x000000000047ff84 main (/path/to/swift/bin/swift+0x47ff84)
43 0x00007f9e00438830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
44 0x000000000047d839 _start (/path/to/swift/bin/swift+0x47d839)
```