### PR TITLE
[Syntax] Fix and update 'Adding New Syntax Nodes' in README

### DIFF
--- a/lib/Syntax/README.md
+++ b/lib/Syntax/README.md
@@ -530,9 +530,6 @@ will be re-generated whenever any Python files are changed.
 ## Adding new Syntax Nodes
 
 Here's a handy checklist when implementing a production in the grammar.
-- Check that the corresponding `lib/AST` node has `SourceLocs` for all terms. If
-  it doesn't, [file a Swift bug][NewSwiftBug] and fix that first.
-  - **Add the `Syntax` bug label!**
 - Check if it's not already being worked on, and then
   [file a Swift bug][NewSwiftBug], noting which grammar productions
   are affected.
@@ -558,7 +555,7 @@ Here's a handy checklist when implementing a production in the grammar.
     - check for a zero-diff print with `-round-trip-parse`
 - Update `lib/Syntax/Status.md` if applicable.
 
-[NewSwiftBug]: https://bugs.swift.org/secure/CreateIssue!default.jspa)
+[NewSwiftBug]: (https://bugs.swift.org/secure/CreateIssue!default.jspa)
 
 ## Try libSyntax in Xcode
 

--- a/lib/Syntax/README.md
+++ b/lib/Syntax/README.md
@@ -531,8 +531,8 @@ will be re-generated whenever any Python files are changed.
 
 Here's a handy checklist when implementing a production in the grammar.
 - Check if it's not already being worked on, and then
-  [file a Swift bug][NewSwiftBug], noting which grammar productions
-  are affected.
+  [file a Swift bug](https://bugs.swift.org/secure/CreateIssue!default.jspa),
+  noting which grammar productions are affected.
   - **Add the `Syntax` bug label!**
 - Create the `${KIND}` entry in the appropriate Python file (Expr, Stmt,
   Pattern, etc.).
@@ -554,8 +554,6 @@ Here's a handy checklist when implementing a production in the grammar.
     - check for a zero-diff print with `-round-trip-lex`, and
     - check for a zero-diff print with `-round-trip-parse`
 - Update `lib/Syntax/Status.md` if applicable.
-
-[NewSwiftBug]: (https://bugs.swift.org/secure/CreateIssue!default.jspa)
 
 ## Try libSyntax in Xcode
 


### PR DESCRIPTION
This PR fixes the broken links in the Syntax README and removes unnecessary steps (no longer need to add SourceLocs in `lib/AST`).