### PR TITLE
[swiftc (55 vs. 5619)] Add crasher in swift::Type

### DIFF
--- a/validation-test/compiler_crashers/28868-known-typebindings-end.swift
+++ b/validation-test/compiler_crashers/28868-known-typebindings-end.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct B{func a{a(Int?as?ManagedBuffer{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type`.

Current number of unresolved compiler crashers: 55 (5619 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `known != typeBindings.end()` added on 2017-01-19 by you in commit 8de0ca54 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 1807)`](https://github.com/apple/swift/blob/08c4f5106ba8f5ecfafa43de2b922a03dd6c9a2b/lib/Sema/ConstraintSystem.cpp#L1807):

```
Assertion `known != typeBindings.end()' failed.

When executing: auto swift::constraints::Solution::simplifyType(swift::Type)::(anonymous class)::operator()(swift::TypeVariableType *) const
```

Assertion context:

```c++
  // Map type variables to fixed types from bindings.
  return simplifyTypeImpl(
      getConstraintSystem(), type,
      [&](TypeVariableType *tvt) -> Type {
        auto known = typeBindings.find(tvt);
        assert(known != typeBindings.end());
        return known->second;
      });
}

size_t Solution::getTotalMemory() const {
```
Stack trace:

```
0 0x0000000003f3abd4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f3abd4)
1 0x0000000003f3af16 SignalHandler(int) (/path/to/swift/bin/swift+0x3f3af16)
2 0x00007f53ba016390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f53b853b428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f53b853d02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f53b8533bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f53b8533c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012c3523 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::Type simplifyTypeImpl<swift::constraints::Solution::simplifyType(swift::Type) const::$_7>(swift::constraints::ConstraintSystem&, swift::Type, swift::constraints::Solution::simplifyType(swift::Type) const::$_7)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x12c3523)
8 0x0000000001755dd6 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const::$_15>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x1755dd6)
9 0x000000000174f022 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x174f022)
10 0x000000000174f25e swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x174f25e)
11 0x000000000174f577 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x174f577)
12 0x0000000001743b07 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0x1743b07)
13 0x00000000012c08bf swift::constraints::Solution::simplifyType(swift::Type) const (/path/to/swift/bin/swift+0x12c08bf)
14 0x00000000012d7181 swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, swift::ConcreteDeclRef&, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0x12d7181)
15 0x00000000013cb9a8 (anonymous namespace)::FailureDiagnosis::diagnoseParameterErrors(swift::CalleeCandidateInfo&, swift::Expr*, swift::Expr*, llvm::ArrayRef<swift::Identifier>) (/path/to/swift/bin/swift+0x13cb9a8)
16 0x00000000013d1069 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x13d1069)
17 0x00000000013b8506 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13b8506)
18 0x00000000013b2282 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13b2282)
19 0x00000000013b82c6 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13b82c6)
20 0x00000000012d3008 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12d3008)
21 0x00000000012d6cf2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12d6cf2)
22 0x0000000001364886 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1364886)
23 0x0000000001363956 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0x1363956)
24 0x0000000001362bc1 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1362bc1)
25 0x0000000001362a75 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1362a75)
26 0x0000000001363632 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1363632)
27 0x0000000001384cee typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x1384cee)
28 0x0000000001385abd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1385abd)
29 0x00000000010911c4 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x10911c4)
30 0x000000000109016e swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x109016e)
31 0x000000000108fb1a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x108fb1a)
32 0x00000000004c88de performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4c88de)
33 0x00000000004c762a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4c762a)
34 0x000000000047ff84 main (/path/to/swift/bin/swift+0x47ff84)
35 0x00007f53b8526830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
36 0x000000000047d839 _start (/path/to/swift/bin/swift+0x47d839)
```