### PR TITLE
[swiftc (58 vs. 5619)] Add crasher in swift::ArchetypeType::resolveNestedType

### DIFF
--- a/validation-test/compiler_crashers/28871-nested-second-nested-second-isequal-result-nested-second-haserror-result-haserro.swift
+++ b/validation-test/compiler_crashers/28871-nested-second-nested-second-isequal-result-nested-second-haserror-result-haserro.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a:A
+protocol A:a{typealias a:=a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeType::resolveNestedType`.

Current number of unresolved compiler crashers: 58 (5619 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!nested.second || nested.second->isEqual(result) || (nested.second->hasError() && result->hasError())` added on 2016-11-29 by you in commit 95f1aaf4 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 2748)`](https://github.com/apple/swift/blob/066762a77fc2f862b5b8f1af73d4843be8f4cad4/lib/AST/GenericSignatureBuilder.cpp#L2748):

```
Assertion `!nested.second || nested.second->isEqual(result) || (nested.second->hasError() && result->hasError())' failed.

When executing: void swift::ArchetypeType::resolveNestedType(std::pair<Identifier, Type> &) const
```

Assertion context:

```c++
                                  memberInterfaceType,
                                  ArchetypeResolutionKind::CompleteWellFormed);
  auto result = equivClass->getTypeInContext(builder, genericEnv);
  assert(!nested.second ||
         nested.second->isEqual(result) ||
         (nested.second->hasError() && result->hasError()));
  nested.second = result;
}

Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
                        ArrayRef<GenericTypeParamType *> genericParams) const {
```
Stack trace:

```
0 0x0000000003f3bfe4 PrintStackTraceSignalHandler(void*) (/path/to/swift/bin/swift+0x3f3bfe4)
1 0x0000000003f3c326 SignalHandler(int) (/path/to/swift/bin/swift+0x3f3c326)
2 0x00007fc48086d390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fc47ed92428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc47ed9402a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fc47ed8abd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fc47ed8ac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016eaaa0 swift::ArchetypeType::resolveNestedType(std::pair<swift::Identifier, swift::Type>&) const (/path/to/swift/bin/swift+0x16eaaa0)
8 0x000000000174cce4 swift::ArchetypeType::getNestedType(swift::Identifier) const (/path/to/swift/bin/swift+0x174cce4)
9 0x000000000174e2e9 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x174e2e9)
10 0x0000000001753f3f llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x1753f3f)
11 0x0000000001750432 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x1750432)
12 0x000000000174ed69 substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) (/path/to/swift/bin/swift+0x174ed69)
13 0x0000000001749bfb swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x1749bfb)
14 0x00000000013751b2 swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x13751b2)
15 0x0000000001374f03 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1374f03)
16 0x000000000137dff7 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137dff7)
17 0x000000000137cd5f resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137cd5f)
18 0x0000000001376d7c resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1376d7c)
19 0x0000000001376754 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1376754)
20 0x00000000013774d1 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13774d1)
21 0x00000000013773dc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13773dc)
22 0x0000000001375c99 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1375c99)
23 0x00000000012f19cb swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12f19cb)
24 0x000000000130165e (anonymous namespace)::DeclChecker::visitAssociatedTypeDecl(swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x130165e)
25 0x00000000012efb2a (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12efb2a)
26 0x00000000013032db (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x13032db)
27 0x00000000012efb5a (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12efb5a)
28 0x00000000012efa03 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12efa03)
29 0x0000000001386bd2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1386bd2)
30 0x0000000001092284 swift::CompilerInstance::parseAndTypeCheckMainFile(swift::PersistentParserState&, swift::DelayedParsingCallbacks*, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>) (/path/to/swift/bin/swift+0x1092284)
31 0x000000000109122e swift::CompilerInstance::parseAndCheckTypes(swift::CompilerInstance::ImplicitImports const&) (/path/to/swift/bin/swift+0x109122e)
32 0x0000000001090bda swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x1090bda)
33 0x00000000004c88de performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4c88de)
34 0x00000000004c762a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4c762a)
35 0x000000000047ff84 main (/path/to/swift/bin/swift+0x47ff84)
36 0x00007fc47ed7d830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
37 0x000000000047d839 _start (/path/to/swift/bin/swift+0x47d839)
```