### PR TITLE
[SourceKit] Add GenericTypeParam to structure (SR-5474)

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -96,6 +96,7 @@ enum class SyntaxStructureKind : uint8_t {
   TypeAlias,
   Subscript,
   AssociatedType,
+  GenericTypeParam,
 
   ForEachStatement,
   WhileStatement,

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -909,6 +909,22 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     SN.NameRange = CharSourceRange(AssociatedTypeD->getNameLoc(),
                                    AssociatedTypeD->getName().getLength());
     pushStructureNode(SN, AssociatedTypeD);
+  } else if (auto *GenericParamD = dyn_cast<GenericTypeParamDecl>(D)) {
+    SyntaxStructureNode SN;
+    setDecl(SN, D);
+    SN.Kind = SyntaxStructureKind::GenericTypeParam;
+    SN.Range = charSourceRangeFromSourceRange(SM,
+                                              GenericParamD->getSourceRange());
+    SN.NameRange = CharSourceRange(GenericParamD->getNameLoc(),
+                                   GenericParamD->getName().getLength());
+    for (const TypeLoc &TL : GenericParamD->getInherited()) {
+      CharSourceRange TR = charSourceRangeFromSourceRange(SM,
+                                                          TL.getSourceRange());
+      SN.InheritedTypeRanges.push_back(TR);
+      SN.Elements.emplace_back(SyntaxStructureElementKind::TypeRef, TR);
+    }
+
+    pushStructureNode(SN, GenericParamD);
   }
 
   return true;

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -217,7 +217,7 @@ class ReturnType {
   // CHECK: }</ifunc>
   
   func foo2<T>() -> T {}
-  // CHECK:  <ifunc>func <name>foo2<T>()</name> -> <type>T</type> {}</ifunc>
+  // CHECK:  <ifunc>func <name>foo2<<generic-param><name>T</name></generic-param>>()</name> -> <type>T</type> {}</ifunc>
   
   func foo3() -> () -> Int {}
   // CHECK:  <ifunc>func <name>foo3()</name> -> <type>() -> Int</type> {}</ifunc>
@@ -228,6 +228,15 @@ protocol FooProtocol {
   // CHECK:  <associatedtype>associatedtype <name>Bar</name></associatedtype>
   associatedtype Baz: Equatable
   // CHECK:  <associatedtype>associatedtype <name>Baz</name>: Equatable</associatedtype>
+}
+
+// CHECK: <struct>struct <name>Generic</name><<generic-param><name>T</name>: <inherited><elem-typeref>Comparable</elem-typeref></inherited></generic-param>, <generic-param><name>X</name></generic-param>> {
+// CHECK:   <subscript><name>subscript<<generic-param><name>U</name></generic-param>>(<param>generic: <type>U</type></param>)</name> -> <type>Int</type> { return 0 }</subscript>
+// CHECK:   <typealias>typealias <name>Foo</name><<generic-param><name>Y</name></generic-param>> = Bar<Y></typealias>
+// CHECK: }</struct>
+struct Generic<T: Comparable, X> {
+  subscript<U>(generic: U) -> Int { return 0 }
+  typealias Foo<Y> = Bar<Y>
 }
 
 a.b(c: d?.e?.f, g: h)

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -253,7 +253,25 @@
       key.nameoffset: 430,
       key.namelength: 6,
       key.bodyoffset: 446,
-      key.bodylength: 0
+      key.bodylength: 0,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T1",
+          key.offset: 437,
+          key.length: 2,
+          key.nameoffset: 437,
+          key.namelength: 2
+        },
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T2",
+          key.offset: 441,
+          key.length: 2,
+          key.nameoffset: 441,
+          key.namelength: 2
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.class,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1201,7 +1201,8 @@ public:
     UIdent AccessLevel;
     UIdent SetterAccessLevel;
     if (Node.Kind != SyntaxStructureKind::Parameter &&
-        Node.Kind != SyntaxStructureKind::LocalVariable) {
+        Node.Kind != SyntaxStructureKind::LocalVariable &&
+        Node.Kind != SyntaxStructureKind::GenericTypeParam) {
       if (auto *VD = dyn_cast_or_null<ValueDecl>(Node.Dcl)) {
         AccessLevel = getAccessLevelUID(inferAccessLevel(VD));
       } else if (auto *ED = dyn_cast_or_null<ExtensionDecl>(Node.Dcl)) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -395,6 +395,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclSubscript;
     case SyntaxStructureKind::AssociatedType:
       return KindDeclAssociatedType;
+    case SyntaxStructureKind::GenericTypeParam:
+      return KindDeclGenericTypeParam;
     case SyntaxStructureKind::Parameter:
       return KindDeclVarParam;
     case SyntaxStructureKind::ForEachStatement:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1091,6 +1091,7 @@ private:
       case SyntaxStructureKind::TypeAlias: return "typealias";
       case SyntaxStructureKind::Subscript: return "subscript";
       case SyntaxStructureKind::AssociatedType: return "associatedtype";
+      case SyntaxStructureKind::GenericTypeParam: return "generic-param";
       case SyntaxStructureKind::Parameter: return "param";
       case SyntaxStructureKind::ForEachStatement: return "foreach";
       case SyntaxStructureKind::WhileStatement: return "while";


### PR DESCRIPTION
Continued from #12093.

This adds `source.lang.swift.decl.generic_type_param` to the structure provided by SourceKit. It doesn't provide any information declared on the `where` clause currently.

For this snippet:

```swift
struct Foo<T: Equatable> {}
```

We'll now get this structure:

```
{
      key.kind: source.lang.swift.decl.struct,
      key.accessibility: source.lang.swift.accessibility.internal,
      key.name: "Foo",
      key.offset: 0,
      key.length: 27,
      key.nameoffset: 7,
      key.namelength: 3,
      key.bodyoffset: 26,
      key.bodylength: 0,
      key.substructure: [
        {
          key.kind: source.lang.swift.decl.generic_type_param,
          key.name: "T",
          key.offset: 11,
          key.length: 12,
          key.nameoffset: 11,
          key.namelength: 1,
          key.inheritedtypes: [
            {
              key.name: "Equatable"
            }
          ],
          key.elements: [
            {
              key.kind: source.lang.swift.structure.elem.typeref,
              key.offset: 14,
              key.length: 9
            }
          ]
        }
      ]
    }
```

Resolves [SR-5474](https://bugs.swift.org/browse/SR-5474).

// cc @nkcsgexi 