### PR TITLE
[Parse] Small cleanups in parseBraceItems()

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -710,11 +710,6 @@ public:
   /// Options that control the parsing of declarations.
   typedef OptionSet<ParseDeclFlags> ParseDeclOptions;
 
-  /// Skips the current token if it is '}', and emits a diagnostic.
-  ///
-  /// \returns true if any tokens were skipped.
-  bool skipExtraTopLevelRBraces();
-
   void delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
                                      ParseDeclOptions Flags);
   void consumeDecl(ParserPosition BeginParserPosition, ParseDeclOptions Flags,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -196,8 +196,6 @@ bool Parser::parseTopLevel() {
   // Parse the body of the file.
   SmallVector<ASTNode, 128> Items;
 
-  skipExtraTopLevelRBraces();
-
   // If we are in SIL mode, and if the first token is the start of a sil
   // declaration, parse that one SIL function and return to the top level.  This
   // allows type declarations and other things to be parsed, name bound, and
@@ -279,19 +277,6 @@ bool Parser::parseTopLevel() {
 
   return FoundTopLevelCodeToExecute;
 }
-
-bool Parser::skipExtraTopLevelRBraces() {
-  if (!Tok.is(tok::r_brace))
-    return false;
-  while (Tok.is(tok::r_brace)) {
-    diagnose(Tok, diag::extra_rbrace)
-        .fixItRemove(Tok.getLoc());
-    consumeToken();
-  }
-  return true;
-}
-
-
 
 static Optional<StringRef>
 getStringLiteralIfNotInterpolated(Parser &P, SourceLoc Loc, const Token &Tok,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -245,7 +245,6 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
   }
 
   ParserStatus BraceItemsStatus;
-  SmallVector<Decl*, 8> TmpDecls;
 
   bool PreviousHadSemi = true;
   while ((Kind == BraceItemListKind::TopLevelLibrary ||
@@ -292,9 +291,40 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
     // Parse the decl, stmt, or expression.
     PreviousHadSemi = false;
-    if (isStartOfDecl()
-        && Tok.isNot(
-            tok::pound_if, tok::pound_sourceLocation, tok::pound_line)) {
+    if (Tok.is(tok::pound_if)) {
+      auto IfConfigResult = parseIfConfig(
+        [&](SmallVectorImpl<ASTNode> &Elements, bool IsActive) {
+          parseBraceItems(Elements, Kind, IsActive
+                            ? BraceItemListKind::ActiveConditionalBlock
+                            : BraceItemListKind::InactiveConditionalBlock);
+        });
+      if (auto ICD = IfConfigResult.getPtrOrNull()) {
+        Result = ICD;
+        // Add the #if block itself
+        Entries.push_back(ICD);
+
+        for (auto &Entry : ICD->getActiveClauseElements()) {
+          if (Entry.is<Decl *>() && isa<IfConfigDecl>(Entry.get<Decl *>()))
+            // Don't hoist nested '#if'.
+            continue;
+          Entries.push_back(Entry);
+          if (Entry.is<Decl *>())
+            Entry.get<Decl *>()->setEscapedFromIfConfig(true);
+        }
+      } else {
+        NeedParseErrorRecovery = true;
+        continue;
+      }
+    } else if (Tok.is(tok::pound_line)) {
+      ParserStatus Status = parseLineDirective(true);
+      BraceItemsStatus |= Status;
+      NeedParseErrorRecovery = Status.isError();
+    } else if (Tok.is(tok::pound_sourceLocation)) {
+      ParserStatus Status = parseLineDirective(false);
+      BraceItemsStatus |= Status;
+      NeedParseErrorRecovery = Status.isError();
+    } else if (isStartOfDecl()) {
+      SmallVector<Decl*, 8> TmpDecls;
       ParserResult<Decl> DeclResult = 
           parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
                     [&](Decl *D) {TmpDecls.push_back(D);});
@@ -307,51 +337,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
         }
       }
       Result = DeclResult.getPtrOrNull();
-
-      for (Decl *D : TmpDecls)
-        Entries.push_back(D);
-      TmpDecls.clear();
-    } else if (Tok.is(tok::pound_if)) {
-      auto IfConfigResult = parseIfConfig(
-        [&](SmallVectorImpl<ASTNode> &Elements, bool IsActive) {
-          parseBraceItems(Elements, Kind, IsActive
-                            ? BraceItemListKind::ActiveConditionalBlock
-                            : BraceItemListKind::InactiveConditionalBlock);
-        });
-      
-      if (IfConfigResult.isParseError()) {
-        NeedParseErrorRecovery = true;
-        continue;
-      }
-      
-      Result = IfConfigResult.get();
-      
-      if (!Result) {
-        NeedParseErrorRecovery = true;
-        continue;
-      }
-
-      // Add the #if block itself
-      Entries.push_back(Result);
-
-      IfConfigDecl *ICD = cast<IfConfigDecl>(Result.get<Decl*>());
-      for (auto &Entry : ICD->getActiveClauseElements()) {
-        if (Entry.is<Decl*>() && isa<IfConfigDecl>(Entry.get<Decl*>()))
-          // Don't hoist nested '#if'.
-          continue;
-        Entries.push_back(Entry);
-        if (Entry.is<Decl*>()) {
-          Entry.get<Decl*>()->setEscapedFromIfConfig(true);
-        }
-      }
-    } else if (Tok.is(tok::pound_line)) {
-      ParserStatus Status = parseLineDirective(true);
-      BraceItemsStatus |= Status;
-      NeedParseErrorRecovery = Status.isError();
-    } else if (Tok.is(tok::pound_sourceLocation)) {
-      ParserStatus Status = parseLineDirective(false);
-      BraceItemsStatus |= Status;
-      NeedParseErrorRecovery = Status.isError();
+      Entries.append(TmpDecls.begin(), TmpDecls.end());
     } else if (IsTopLevel) {
       // If this is a statement or expression at the top level of the module,
       // Parse it as a child of a TopLevelCodeDecl.

--- a/test/Parse/ConditionalCompilation/pound-if-top-level-3.swift
+++ b/test/Parse/ConditionalCompilation/pound-if-top-level-3.swift
@@ -2,5 +2,6 @@
 
 #if arch(x86_64)
 // expected-error@+2{{expected '{' in protocol type}}
-// expected-error@+1{{expected #else or #endif at end of conditional compilation block}}
+// expected-error@+1{{extraneous '}' at top level}}
 public protocol CS}
+// expected-error@+1{{expected #else or #endif at end of conditional compilation block}}


### PR DESCRIPTION
* Reorder `if ... else if` branches to simplify conditions.
* Use `SmallVectorImpl::append()` instead of `for { push_back() }`
* Inline `skipExtraTopLevelRBraces()`.  Removed it from `parseTopLevel()`. There's no particular reason to diagnose it in `parseTopLevel()`.