### PR TITLE
[Sema] Translate names in unused result warnings of implicit functions

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1201,6 +1201,18 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     
     // Otherwise, produce a generic diagnostic.
     if (callee) {
+      auto &ctx = callee->getASTContext();
+      if (callee->isImplicit()) {
+        // Translate calls to implicit functions to their user-facing names
+        if (callee->getBaseName() == ctx.Id_derived_enum_equals ||
+            callee->getBaseName() == ctx.Id_derived_struct_equals) {
+          diagnose(fn->getLoc(), diag::expression_unused_result_operator,
+                   ctx.Id_EqualsOperator)
+            .highlight(SR1).highlight(SR2);
+          return;
+        }
+      }
+
       auto diagID = diag::expression_unused_result_call;
       if (callee->getFullName().isOperator())
         diagID = diag::expression_unused_result_operator;

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -9,6 +9,8 @@ enum Foo {
 if Foo.A == .B { }
 var aHash: Int = Foo.A.hashValue
 
+Foo.A == Foo.B // expected-warning {{result of operator '==' is unused}}
+
 enum Generic<T> {
   case A, B
 

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -10,6 +10,8 @@ struct Point: Hashable {
 if Point(x: 1, y: 2) == Point(x: 2, y: 1) { }
 var pointHash: Int = Point(x: 3, y: 5).hashValue
 
+Point(x: 1, y: 2) == Point(x: 2, y: 1) // expected-warning {{result of operator '==' is unused}}
+
 struct Pair<T: Hashable>: Hashable {
   let first: T
   let second: T


### PR DESCRIPTION
## Problem

Currently, an unused call to synthesized `==` of enums and structs warns about an unused call to the functions `__derived_enum_equals` and `__derived_struct_equals`.

## Solution

This PR adds a special case to translate these calls back to the call to the operator `==`.

## Example
```swift
enum Bar {
  case A, B
}

// Before
Bar.A == .B // Result of call to '__derived_enum_equals' is unused

// Now
Bar.A == .B // Result of call to operator '==' is unused
```

I just found this bug and it is not tracked by an SR yet.