### PR TITLE
[Parse] Lexer build backtick trivia around espaced identifier token

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -484,6 +484,7 @@ private:
   }
 
   void formToken(tok Kind, const char *TokStart, bool MultilineString = false);
+  void formEscapedIdentifierToken(const char *TokStart);
 
   /// Advance to the end of the line.
   /// If EatNewLine is true, CurPtr will be at end of newline character.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -286,10 +286,6 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts,
   Trivia LeadingTrivia, TrailingTrivia;
   do {
     L.lex(Tok, LeadingTrivia, TrailingTrivia);
-    if (Tok.isEscapedIdentifier()) {
-      LeadingTrivia.push_back(TriviaPiece::backtick());
-      TrailingTrivia.push_front(TriviaPiece::backtick());
-    }
     auto ThisToken = RawTokenSyntax::make(Tok.getKind(), Tok.getText(),
                                       SourcePresence::Present, LeadingTrivia,
                                       TrailingTrivia);

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -77,10 +77,6 @@ void SyntaxParsingContext::addToken(Token &Tok, Trivia &LeadingTrivia,
   if (!Enabled)
     return;
 
-  if (Tok.isEscapedIdentifier()) {
-    LeadingTrivia.push_back(TriviaPiece::backtick());
-    TrailingTrivia.push_front(TriviaPiece::backtick());
-  }
   addRawSyntax(RawTokenSyntax::make(Tok.getKind(), Tok.getText(),
                                     SourcePresence::Present, LeadingTrivia,
                                     TrailingTrivia));

--- a/test/Syntax/tokens_escaped_identifier.swift
+++ b/test/Syntax/tokens_escaped_identifier.swift
@@ -1,0 +1,21 @@
+// RUN: %swift-syntax-test -input-source-filename %s -dump-full-tokens | %FileCheck %s
+let /*leading trivia*/ `if` = 3
+print(/*leading trivia*/ `if` )
+
+// CHECK-LABEL: 2:25
+// CHECK-NEXT:(token identifier
+// CHECK-NEXT: (trivia block_comment/*leading trivia*/)
+// CHECK-NEXT: (trivia space 1)
+// CHECK-NEXT: (trivia backtick 1)
+// CHECK-NEXT: (text="if")
+// CHECK-NEXT: (trivia backtick 1)
+// CHECK-NEXT: (trivia space 1))
+
+// CHECK-LABEL: 3:27
+// CHECK-NEXT:(token identifier
+// CHECK-NEXT: (trivia block_comment/*leading trivia*/)
+// CHECK-NEXT: (trivia space 1)
+// CHECK-NEXT: (trivia backtick 1)
+// CHECK-NEXT: (text="if")
+// CHECK-NEXT: (trivia backtick 1)
+// CHECK-NEXT: (trivia space 1))


### PR DESCRIPTION
There was a logic that build backtick trivia before and after of escaped identifier token at two places.
First is at `swift::tokenizeWithTrivia` in `Parser.cpp`.
Second is at `SyntaxParsingContext::addToken` in `SyntaxParsingContext.cpp`.

This PR moves this logic into Lexer and makes them common.

First commit is adding of testcase for existing.
To check first case, it runs `swift-syntax-test -dump-full-tokens`.
To check second case, it runs `swift-syntax-test -serialize-raw-tree`.

Second commit is actual patch.