### PR TITLE
[docs] Rename `isUniquelyReferencedNonObjC` to `isKnownUniquelyReferenced`

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -444,7 +444,7 @@ construct such a data structure:
       var value: T {
           get { return ref.val }
           set {
-            if (!isUniquelyReferencedNonObjC(&ref)) {
+            if (!isKnownUniquelyReferenced(&ref)) {
               ref = Ref(newValue)
               return
             }


### PR DESCRIPTION
Because it has been removed in [3.0](https://github.com/apple/swift/blob/master/CHANGELOG.md#swift-30) (as a part of [SE-0125](https://github.com/apple/swift-evolution/blob/master/proposals/0125-remove-nonobjectivecbase.md))