### PR TITLE
[Basic] NFC: Inline bitfield cleanup

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -236,6 +236,9 @@ bool conflicting(const OverloadSignature& sig1, const OverloadSignature& sig2);
 
 /// Decl - Base class for all declarations in Swift.
 class alignas(1 << DeclAlignInBits) Decl {
+protected:
+  union { uint64_t OpaqueBits;
+
   SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1+1+1,
     Kind : bitmax(NumDeclKindBits,8),
 
@@ -587,34 +590,6 @@ class alignas(1 << DeclAlignInBits) Decl {
     NumberOfVTableEntries : 2
   );
 
-protected:
-  union {
-    uint64_t OpaqueBits;
-    SWIFT_INLINE_BITS(Decl);
-    SWIFT_INLINE_BITS(PatternBindingDecl);
-    SWIFT_INLINE_BITS(EnumCaseDecl);
-    SWIFT_INLINE_BITS(ValueDecl);
-    SWIFT_INLINE_BITS(AbstractStorageDecl);
-    SWIFT_INLINE_BITS(AbstractFunctionDecl);
-    SWIFT_INLINE_BITS(VarDecl);
-    SWIFT_INLINE_BITS(ParamDecl);
-    SWIFT_INLINE_BITS(EnumElementDecl);
-    SWIFT_INLINE_BITS(FuncDecl);
-    SWIFT_INLINE_BITS(ConstructorDecl);
-    SWIFT_INLINE_BITS(TypeDecl);
-    SWIFT_INLINE_BITS(GenericTypeParamDecl);
-    SWIFT_INLINE_BITS(TypeAliasDecl);
-    SWIFT_INLINE_BITS(NominalTypeDecl);
-    SWIFT_INLINE_BITS(ProtocolDecl);
-    SWIFT_INLINE_BITS(ClassDecl);
-    SWIFT_INLINE_BITS(StructDecl);
-    SWIFT_INLINE_BITS(EnumDecl);
-    SWIFT_INLINE_BITS(AssociatedTypeDecl);
-    SWIFT_INLINE_BITS(PrecedenceGroupDecl);
-    SWIFT_INLINE_BITS(ImportDecl);
-    SWIFT_INLINE_BITS(ExtensionDecl);
-    SWIFT_INLINE_BITS(IfConfigDecl);
-    SWIFT_INLINE_BITS(MissingMemberDecl);
   } Bits;
 
   // Storage for the declaration attributes.

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -130,6 +130,9 @@ class alignas(8) Expr {
   Expr(const Expr&) = delete;
   void operator=(const Expr&) = delete;
 
+protected:
+  union { uint64_t OpaqueBits;
+
   SWIFT_INLINE_BITFIELD_BASE(Expr, bitmax(NumExprKindBits,8)+2+1,
     /// The subclass of Expr that this is.
     Kind : bitmax(NumExprKindBits,8),
@@ -363,41 +366,6 @@ class alignas(8) Expr {
     NumElements : 32
   );
 
-protected:
-  union {
-    SWIFT_INLINE_BITS(Expr);
-    SWIFT_INLINE_BITS(NumberLiteralExpr);
-    SWIFT_INLINE_BITS(StringLiteralExpr);
-    SWIFT_INLINE_BITS(DeclRefExpr);
-    SWIFT_INLINE_BITS(UnresolvedDeclRefExpr);
-    SWIFT_INLINE_BITS(TupleExpr);
-    SWIFT_INLINE_BITS(TupleElementExpr);
-    SWIFT_INLINE_BITS(MemberRefExpr);
-    SWIFT_INLINE_BITS(UnresolvedDotExpr);
-    SWIFT_INLINE_BITS(SubscriptExpr);
-    SWIFT_INLINE_BITS(DynamicSubscriptExpr);
-    SWIFT_INLINE_BITS(UnresolvedMemberExpr);
-    SWIFT_INLINE_BITS(OverloadSetRefExpr);
-    SWIFT_INLINE_BITS(BooleanLiteralExpr);
-    SWIFT_INLINE_BITS(MagicIdentifierLiteralExpr);
-    SWIFT_INLINE_BITS(ObjectLiteralExpr);
-    SWIFT_INLINE_BITS(AbstractClosureExpr);
-    SWIFT_INLINE_BITS(ClosureExpr);
-    SWIFT_INLINE_BITS(BindOptionalExpr);
-    SWIFT_INLINE_BITS(ApplyExpr);
-    SWIFT_INLINE_BITS(CallExpr);
-    SWIFT_INLINE_BITS(CheckedCastExpr);
-    SWIFT_INLINE_BITS(TupleShuffleExpr);
-    SWIFT_INLINE_BITS(InOutToPointerExpr);
-    SWIFT_INLINE_BITS(ArrayToPointerExpr);
-    SWIFT_INLINE_BITS(ObjCSelectorExpr);
-    SWIFT_INLINE_BITS(KeyPathExpr);
-    SWIFT_INLINE_BITS(ParenExpr);
-    SWIFT_INLINE_BITS(SequenceExpr);
-    SWIFT_INLINE_BITS(CollectionExpr);
-    SWIFT_INLINE_BITS(ErasureExpr);
-    SWIFT_INLINE_BITS(UnresolvedSpecializeExpr);
-    SWIFT_INLINE_BITS(CaptureListExpr);
   } Bits;
 
 private:
@@ -410,6 +378,7 @@ private:
  
 protected:
   Expr(ExprKind Kind, bool Implicit, Type Ty = Type()) : Ty(Ty) {
+    Bits.OpaqueBits = 0;
     Bits.Expr.Kind = unsigned(Kind);
     Bits.Expr.Implicit = Implicit;
     Bits.Expr.LValueAccessKind = 0;

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -49,6 +49,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, PatternKind kind);
   
 /// Pattern - Base class for all patterns in Swift.
 class alignas(8) Pattern {
+protected:
+  union { uint64_t OpaqueBits;
+
   SWIFT_INLINE_BITFIELD_BASE(Pattern, bitmax(NumPatternKindBits,8)+1+1,
     Kind : bitmax(NumPatternKindBits,8),
     isImplicit : 1,
@@ -64,12 +67,6 @@ class alignas(8) Pattern {
     IsPropagatedType : 1
   );
 
-protected:
-  union {
-    uint64_t OpaqueBits;
-    SWIFT_INLINE_BITS(Pattern);
-    SWIFT_INLINE_BITS(TuplePattern);
-    SWIFT_INLINE_BITS(TypedPattern);
   } Bits;
 
   Pattern(PatternKind kind) {

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -51,6 +51,9 @@ class alignas(8) Stmt {
   Stmt(const Stmt&) = delete;
   Stmt& operator=(const Stmt&) = delete;
 
+protected:
+  union { uint64_t OpaqueBits;
+
   SWIFT_INLINE_BITFIELD_BASE(Stmt, bitmax(NumStmtKindBits,8) + 1,
     /// Kind - The subclass of Stmt that this is.
     Kind : bitmax(NumStmtKindBits,8),
@@ -81,14 +84,6 @@ class alignas(8) Stmt {
     CaseCount : 32
   );
 
-protected:
-  union {
-    uint64_t OpaqueBits;
-    SWIFT_INLINE_BITS(Stmt);
-    SWIFT_INLINE_BITS(BraceStmt);
-    SWIFT_INLINE_BITS(DoCatchStmt);
-    SWIFT_INLINE_BITS(CaseStmt);
-    SWIFT_INLINE_BITS(SwitchStmt);
   } Bits;
 
   /// Return the given value for the 'implicit' flag if present, or if None,

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -49,6 +49,9 @@ class alignas(8) TypeRepr {
   TypeRepr(const TypeRepr&) = delete;
   void operator=(const TypeRepr&) = delete;
 
+protected:
+  union { uint64_t OpaqueBits;
+
   SWIFT_INLINE_BITFIELD_BASE(TypeRepr, bitmax(NumTypeReprKindBits,8)+1+1,
     /// The subclass of TypeRepr that this is.
     Kind : bitmax(NumTypeReprKindBits,8),
@@ -71,11 +74,6 @@ class alignas(8) TypeRepr {
     NumElements : 16
   );
 
-protected:
-  union {
-    uint64_t OpaqueBits;
-    SWIFT_INLINE_BITS(TypeRepr);
-    SWIFT_INLINE_BITS(TupleTypeRepr);
   } Bits;
 
   TypeRepr(TypeReprKind K) {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -259,14 +259,6 @@ class alignas(1 << TypeAlignInBits) TypeBase {
   /// form of a non-canonical type is requested.
   llvm::PointerUnion<TypeBase *, const ASTContext *> CanonicalType;
 
-  SWIFT_INLINE_BITFIELD_BASE(TypeBase, bitmax(NumTypeKindBits,8) +
-                             RecursiveTypeProperties::BitWidth,
-    /// Kind - The discriminator that indicates what subclass of type this is.
-    Kind : bitmax(NumTypeKindBits,8),
-
-    Properties : RecursiveTypeProperties::BitWidth
-  );
-
   /// Returns true if the given type is a sugared type.
   ///
   /// Only intended for use in compile-time assertions.
@@ -277,6 +269,18 @@ class alignas(1 << TypeAlignInBits) TypeBase {
   }
 
 protected:
+  enum { NumAFTExtInfoBits = 7 };
+  enum { NumSILExtInfoBits = 6 };
+  union { uint64_t OpaqueBits;
+
+  SWIFT_INLINE_BITFIELD_BASE(TypeBase, bitmax(NumTypeKindBits,8) +
+                             RecursiveTypeProperties::BitWidth,
+    /// Kind - The discriminator that indicates what subclass of type this is.
+    Kind : bitmax(NumTypeKindBits,8),
+
+    Properties : RecursiveTypeProperties::BitWidth
+  );
+
   SWIFT_INLINE_BITFIELD(ErrorType, TypeBase, 1,
     /// Whether there is an original type.
     HasOriginalType : 1
@@ -288,7 +292,6 @@ protected:
     Flags : NumFlagBits
   );
 
-  enum { NumAFTExtInfoBits = 7 };
   SWIFT_INLINE_BITFIELD_FULL(AnyFunctionType, TypeBase, NumAFTExtInfoBits+16,
     /// Extra information which affects how the function is called, like
     /// regparm and the calling convention.
@@ -318,7 +321,6 @@ protected:
     GraphIndex : 29
   );
 
-  enum { NumSILExtInfoBits = 6 };
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+3+1+2,
     ExtInfo : NumSILExtInfoBits,
     CalleeConvention : 3,
@@ -367,20 +369,6 @@ protected:
     GenericArgCount : 32
   );
 
-  union {
-    uint64_t OpaqueBits;
-    SWIFT_INLINE_BITS(TypeBase);
-    SWIFT_INLINE_BITS(ErrorType);
-    SWIFT_INLINE_BITS(ParenType);
-    SWIFT_INLINE_BITS(AnyFunctionType);
-    SWIFT_INLINE_BITS(TypeVariableType);
-    SWIFT_INLINE_BITS(ArchetypeType);
-    SWIFT_INLINE_BITS(SILFunctionType);
-    SWIFT_INLINE_BITS(SILBoxType);
-    SWIFT_INLINE_BITS(AnyMetatypeType);
-    SWIFT_INLINE_BITS(ProtocolCompositionType);
-    SWIFT_INLINE_BITS(TupleType);
-    SWIFT_INLINE_BITS(BoundGenericType);
   } Bits;
 
 protected:

--- a/include/swift/Basic/InlineBitfield.h
+++ b/include/swift/Basic/InlineBitfield.h
@@ -38,10 +38,10 @@ namespace swift {
   class T##Bitfield { \
     friend class T; \
     uint64_t __VA_ARGS__; \
-    uint64_t : 64 - (C); /* Pad and error if C > 64 */ \
-  }; \
+  } T; \
   LLVM_PACKED_END \
-  enum { Num##T##Bits = (C) }
+  enum { Num##T##Bits = (C) }; \
+  static_assert(sizeof(T##Bitfield) <= 8, "Bitfield overflow")
 
 /// Define an bitfield for type 'T' with parent class 'U' and 'C' bits used.
 #define SWIFT_INLINE_BITFIELD(T, U, C, ...) \
@@ -49,10 +49,10 @@ namespace swift {
   class T##Bitfield { \
     friend class T; \
     uint64_t : Num##U##Bits, __VA_ARGS__; \
-    uint64_t : 64 - (Num##U##Bits + (C)); /* Pad and error if C > 64 */ \
-  }; \
+  } T; \
   LLVM_PACKED_END \
-  enum { Num##T##Bits = Num##U##Bits + (C) }
+  enum { Num##T##Bits = Num##U##Bits + (C) }; \
+  static_assert(sizeof(T##Bitfield) <= 8, "Bitfield overflow")
 
 /// Define a full bitfield for type 'T' that uses all of the remaining bits in
 /// the inline bitfield.
@@ -72,15 +72,13 @@ namespace swift {
     friend class T; \
     enum { NumPadBits = 64 - (Num##U##Bits + (C)) }; \
     uint64_t : Num##U##Bits, __VA_ARGS__; \
-  }; \
+  } T; \
   LLVM_PACKED_END \
   static_assert(sizeof(T##Bitfield) <= 8, "Bitfield overflow")
 
 /// Define an empty bitfield for type 'T'.
 #define SWIFT_INLINE_BITFIELD_EMPTY(T, U) \
   enum { Num##T##Bits = Num##U##Bits }
-
-#define SWIFT_INLINE_BITS(T) T##Bitfield T
 
 // XXX/HACK: templated max() doesn't seem to work in a bitfield size context.
 constexpr unsigned bitmax(unsigned a, unsigned b) {

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -98,7 +98,10 @@ public:
   enum { NumLoadOwnershipQualifierBits = 2 };
   enum { NumSILAccessKindBits = 2 };
   enum { NumSILAccessEnforcementBits = 2 };
+
 protected:
+  union { uint64_t OpaqueBits;
+
   SWIFT_INLINE_BITFIELD_BASE(SILNode, bitmax(NumSILNodeKindBits,8)+1+1,
     Kind : bitmax(NumSILNodeKindBits,8),
     StorageLoc : 1,
@@ -123,10 +126,11 @@ protected:
   SWIFT_INLINE_BITFIELD_EMPTY(SILInstruction, SILNode);
 
   // Special handling for UnaryInstructionWithTypeDependentOperandsBase
-  SWIFT_INLINE_BITFIELD(IBWTO, SILNode, 32,
+  SWIFT_INLINE_BITFIELD(IBWTO, SILNode, 64-NumSILNodeBits,
     // DO NOT allocate bits at the front!
-    // IBWTO is a template, and must allocate bits from back to front and
-    // update IBWTO_BITFIELD().
+    // IBWTO is a template, and templates must allocate bits from back to front
+    // so that "normal" subclassing can allocate bits from front to back.
+    // If you update this, then you must update the IBWTO_BITFIELD macros.
 
     /*pad*/ : 32-NumSILNodeBits,
 
@@ -138,9 +142,14 @@ protected:
   );
 
 #define IBWTO_BITFIELD(T, U, C, ...) \
-  SWIFT_INLINE_BITFIELD_FULL(T, U, (C)+32, __VA_ARGS__)
+  SWIFT_INLINE_BITFIELD(T, U, (C), __VA_ARGS__, : 32)
+#define IBWTO_BITFIELD_EMPTY(T, U) \
+  SWIFT_INLINE_BITFIELD_EMPTY(T, U)
+
 #define UIWTDOB_BITFIELD(T, U, C, ...) \
   IBWTO_BITFIELD(T, U, (C), __VA_ARGS__)
+#define UIWTDOB_BITFIELD_EMPTY(T, U) \
+  IBWTO_BITFIELD_EMPTY(T, U)
 
   SWIFT_INLINE_BITFIELD_EMPTY(SingleValueInstruction, SILInstruction);
   SWIFT_INLINE_BITFIELD_EMPTY(DeallocationInst, SILInstruction);
@@ -148,10 +157,10 @@ protected:
   SWIFT_INLINE_BITFIELD_EMPTY(AllocationInst, SingleValueInstruction);
 
   // Ensure that StructInst bitfield does not overflow.
-  IBWTO_BITFIELD(StructInst, SingleValueInstruction, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(StructInst, SingleValueInstruction);
 
   // Ensure that TupleInst bitfield does not overflow.
-  IBWTO_BITFIELD(TupleInst, SingleValueInstruction, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(TupleInst, SingleValueInstruction);
 
   IBWTO_BITFIELD(BuiltinInst, SingleValueInstruction,
                              32-NumSingleValueInstructionBits,
@@ -194,9 +203,9 @@ protected:
   );
 
   // Ensure that AllocBoxInst bitfield does not overflow.
-  IBWTO_BITFIELD(AllocBoxInst, AllocationInst, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(AllocBoxInst, AllocationInst);
   // Ensure that AllocExistentialBoxInst bitfield does not overflow.
-  IBWTO_BITFIELD(AllocExistentialBoxInst, AllocationInst, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(AllocExistentialBoxInst, AllocationInst);
   SWIFT_INLINE_BITFIELD_FULL(AllocStackInst, AllocationInst,
                              64-NumAllocationInstBits,
     NumOperands : 32-NumAllocationInstBits,
@@ -209,7 +218,7 @@ protected:
   );
   static_assert(32-1-1-NumAllocationInstBits >= 16, "Reconsider bitfield use?");
 
-  UIWTDOB_BITFIELD(AllocValueBufferInst, AllocationInst, 0, : NumPadBits);
+  UIWTDOB_BITFIELD_EMPTY(AllocValueBufferInst, AllocationInst);
 
   // TODO: Sort the following in SILNodes.def order
 
@@ -222,13 +231,13 @@ protected:
   );
 
   // Ensure that BindMemoryInst bitfield does not overflow.
-  IBWTO_BITFIELD(BindMemoryInst, NonValueInstruction, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(BindMemoryInst, NonValueInstruction);
 
   // Ensure that MarkFunctionEscapeInst bitfield does not overflow.
-  IBWTO_BITFIELD(MarkFunctionEscapeInst, NonValueInstruction, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(MarkFunctionEscapeInst, NonValueInstruction);
 
   // Ensure that MetatypeInst bitfield does not overflow.
-  IBWTO_BITFIELD(MetatypeInst, SingleValueInstruction, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(MetatypeInst, SingleValueInstruction);
 
   SWIFT_INLINE_BITFIELD(CopyAddrInst, NonValueInstruction, 1+1,
     /// IsTakeOfSrc - True if ownership will be taken from the value at the
@@ -287,8 +296,8 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(MethodInst, SingleValueInstruction);
   // Ensure that WitnessMethodInst bitfield does not overflow.
-  IBWTO_BITFIELD(WitnessMethodInst, MethodInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(ObjCMethodInst, MethodInst, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(WitnessMethodInst, MethodInst);
+  UIWTDOB_BITFIELD_EMPTY(ObjCMethodInst, MethodInst);
 
   SWIFT_INLINE_BITFIELD_EMPTY(ConversionInst, SingleValueInstruction);
   SWIFT_INLINE_BITFIELD(PointerToAddressInst, ConversionInst, 1+1,
@@ -296,29 +305,29 @@ protected:
     IsInvariant : 1
   );
 
-  UIWTDOB_BITFIELD(ConvertFunctionInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(PointerToThinFunctionInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UnconditionalCheckedCastInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UpcastInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UncheckedRefCastInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UncheckedAddrCastInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UncheckedTrivialBitCastInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UncheckedBitwiseCastInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(ThinToThickFunctionInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(UnconditionalCheckedCastValueInst, ConversionInst, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(InitExistentialAddrInst, SingleValueInstruction, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(InitExistentialValueInst, SingleValueInstruction, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(InitExistentialRefInst, SingleValueInstruction, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(InitExistentialMetatypeInst, SingleValueInstruction, 0, : NumPadBits);
+  UIWTDOB_BITFIELD_EMPTY(ConvertFunctionInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(PointerToThinFunctionInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UnconditionalCheckedCastInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UpcastInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UncheckedRefCastInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UncheckedAddrCastInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UncheckedTrivialBitCastInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UncheckedBitwiseCastInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(ThinToThickFunctionInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(UnconditionalCheckedCastValueInst, ConversionInst);
+  UIWTDOB_BITFIELD_EMPTY(InitExistentialAddrInst, SingleValueInstruction);
+  UIWTDOB_BITFIELD_EMPTY(InitExistentialValueInst, SingleValueInstruction);
+  UIWTDOB_BITFIELD_EMPTY(InitExistentialRefInst, SingleValueInstruction);
+  UIWTDOB_BITFIELD_EMPTY(InitExistentialMetatypeInst, SingleValueInstruction);
 
   SWIFT_INLINE_BITFIELD_EMPTY(TermInst, SILInstruction);
-  UIWTDOB_BITFIELD(CheckedCastBranchInst, SingleValueInstruction, 0, : NumPadBits);
-  UIWTDOB_BITFIELD(CheckedCastValueBranchInst, SingleValueInstruction, 0, : NumPadBits);
+  UIWTDOB_BITFIELD_EMPTY(CheckedCastBranchInst, SingleValueInstruction);
+  UIWTDOB_BITFIELD_EMPTY(CheckedCastValueBranchInst, SingleValueInstruction);
 
   // Ensure that BranchInst bitfield does not overflow.
-  IBWTO_BITFIELD(BranchInst, TermInst, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(BranchInst, TermInst);
   // Ensure that YieldInst bitfield does not overflow.
-  IBWTO_BITFIELD(YieldInst, TermInst, 0, : NumPadBits);
+  IBWTO_BITFIELD_EMPTY(YieldInst, TermInst);
   IBWTO_BITFIELD(CondBranchInst, TermInst, 32-NumTermInstBits,
     NumTrueArgs : 32-NumTermInstBits
   );
@@ -331,68 +340,14 @@ protected:
     NumCases : 32
   );
 
+  } Bits;
+
   enum class SILNodeStorageLocation : uint8_t { Value, Instruction };
 
   enum class IsRepresentative : bool {
     No = false,
     Yes = true,
   };
-
-  union {
-    uint64_t OpaqueBits;
-    SWIFT_INLINE_BITS(SILNode);
-    SWIFT_INLINE_BITS(SILArgument);
-    SWIFT_INLINE_BITS(MultipleValueInstructionResult);
-    SWIFT_INLINE_BITS(IBWTO);
-    SWIFT_INLINE_BITS(AllocStackInst);
-    SWIFT_INLINE_BITS(AllocRefInstBase);
-    SWIFT_INLINE_BITS(AllocValueBufferInst);
-    SWIFT_INLINE_BITS(ConvertFunctionInst);
-    SWIFT_INLINE_BITS(PointerToThinFunctionInst);
-    SWIFT_INLINE_BITS(UpcastInst);
-    SWIFT_INLINE_BITS(UncheckedRefCastInst);
-    SWIFT_INLINE_BITS(UncheckedAddrCastInst);
-    SWIFT_INLINE_BITS(UncheckedTrivialBitCastInst);
-    SWIFT_INLINE_BITS(UncheckedBitwiseCastInst);
-    SWIFT_INLINE_BITS(ThinToThickFunctionInst);
-    SWIFT_INLINE_BITS(UnconditionalCheckedCastInst);
-    SWIFT_INLINE_BITS(UnconditionalCheckedCastValueInst);
-    SWIFT_INLINE_BITS(ObjCMethodInst);
-    SWIFT_INLINE_BITS(InitExistentialAddrInst);
-    SWIFT_INLINE_BITS(InitExistentialValueInst);
-    SWIFT_INLINE_BITS(InitExistentialRefInst);
-    SWIFT_INLINE_BITS(InitExistentialMetatypeInst);
-    SWIFT_INLINE_BITS(CheckedCastBranchInst);
-    SWIFT_INLINE_BITS(CheckedCastValueBranchInst);
-    SWIFT_INLINE_BITS(UncheckedOwnershipConversionInst);
-    SWIFT_INLINE_BITS(RefCountingInst);
-    SWIFT_INLINE_BITS(StoreReferenceInstBaseT);
-    SWIFT_INLINE_BITS(LoadReferenceInstBaseT);
-    SWIFT_INLINE_BITS(StrongPinInst);
-    SWIFT_INLINE_BITS(CopyAddrInst);
-    SWIFT_INLINE_BITS(StoreInst);
-    SWIFT_INLINE_BITS(LoadInst);
-    SWIFT_INLINE_BITS(IntegerLiteralInst);
-    SWIFT_INLINE_BITS(FloatLiteralInst);
-    SWIFT_INLINE_BITS(DeallocRefInst);
-    SWIFT_INLINE_BITS(WitnessMethodInst);
-    SWIFT_INLINE_BITS(TupleExtractInst);
-    SWIFT_INLINE_BITS(TupleElementAddrInst);
-    SWIFT_INLINE_BITS(SwitchValueInst);
-    SWIFT_INLINE_BITS(SwitchEnumInstBase);
-    SWIFT_INLINE_BITS(PointerToAddressInst);
-    SWIFT_INLINE_BITS(BeginAccessInst);
-    SWIFT_INLINE_BITS(EndAccessInst);
-    SWIFT_INLINE_BITS(MetatypeInst);
-    SWIFT_INLINE_BITS(BuiltinInst);
-    SWIFT_INLINE_BITS(StringLiteralInst);
-    SWIFT_INLINE_BITS(ConstStringLiteralInst);
-    SWIFT_INLINE_BITS(StructInst);
-    SWIFT_INLINE_BITS(TupleInst);
-    SWIFT_INLINE_BITS(ObjectInst);
-    SWIFT_INLINE_BITS(CondBranchInst);
-    SWIFT_INLINE_BITS(SelectEnumInstBase);
-  } Bits;
 
 private:
 


### PR DESCRIPTION
1) Remove SWIFT_INLINE_BITS boilerplate. Now that we're not using anonymous/transparent unions, we don't need the SWIFT_BITFIELD_BITS macro.
2) Refine the the bitfield size check to better support templated bitfields.
3) Refine the SIL templated bitfields to not be prematurely "full".