### PR TITLE
[lib/Syntax] Rename another API, statments -> statements.

### DIFF
--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -170,7 +170,7 @@ STMT_NODES = [
     Node('CodeBlock', kind='Syntax',
          children=[
              Child('OpenBrace', kind='LeftBraceToken'),
-             Child('Statments', kind='StmtList'),
+             Child('Statements', kind='StmtList'),
              Child('CloseBrace', kind='RightBraceToken'),
          ]),
 


### PR DESCRIPTION
I think this is the corrected/intended name.
