### PR TITLE
master-next: Update to match LLVM r321411

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1211,7 +1211,7 @@ bool IndexSwiftASTWalker::indexComment(const Decl *D) {
     IndexSymbol Info;
     Info.decl = nullptr;
     Info.symInfo = SymbolInfo{ SymbolKind::CommentTag, SymbolSubKind::None,
-      SymbolPropertySet(), SymbolLanguage::Swift };
+      SymbolLanguage::Swift, SymbolPropertySet() };
     Info.roles |= (unsigned)SymbolRole::Definition;
     Info.name = StringRef();
     SmallString<128> storage;

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -138,7 +138,7 @@ static SymbolKind getVarSymbolKind(const VarDecl *VD) {
 
 SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
   SymbolInfo info{ SymbolKind::Unknown, SymbolSubKind::None,
-                   SymbolPropertySet(), SymbolLanguage::Swift };
+                   SymbolLanguage::Swift, SymbolPropertySet() };
   switch (D->getKind()) {
     case DeclKind::Enum:             info.Kind = SymbolKind::Enum; break;
     case DeclKind::Struct:           info.Kind = SymbolKind::Struct; break;


### PR DESCRIPTION
The SymbolPropertySet subfield of the SymbolInfo struct was moved to the
end.