### PR TITLE
[Syntax] Serialize text of contextual_keyword tokens

### DIFF
--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -142,6 +142,7 @@ struct ObjectTraits<TokenDescription> {
   static void mapping(Output &out, TokenDescription &value) {
     out.mapRequired("kind", value.Kind);
     switch (value.Kind) {
+      case tok::contextual_keyword:
       case tok::integer_literal:
       case tok::floating_literal:
       case tok::string_literal:


### PR DESCRIPTION
Contextual keywords are currently serialized without their `text`
leaving the consumer of the AST clueless as to which keyword was used.

---

Given the following example

```
var fruit: String {
  didSet {
    print("Fruit is now: \(fruit)")
  }
}
```

the following JSON AST is produced without any information of what kind of accessor was declared:

```
{
    "kind": "AccessorDecl",
    "layout": [
    {
        "kind": "AttributeList",
        "layout": [

        ],
        "presence": "Missing"
    },
    {
        "kind": "DeclModifier",
        "layout": [

        ],
        "presence": "Missing"
    },
    {
        "tokenKind": {
            "kind": "contextual_keyword",
        },
        "leadingTrivia": [
        {
            "kind": "Newline",
            "value": 1
        },
        {
            "kind": "Space",
            "value": 8
        }
        ],
        "trailingTrivia": [
        {
            "kind": "Space",
            "value": 1
        }
        ],
        "presence": "Present"
    },
    {
        "kind": "AccessorParameter",
        "layout": [

        ],
        "presence": "Missing"
    },
    {
        "kind": "CodeBlock",
        "layout": [/* ... */]
    }
}
```