### PR TITLE
Implement a few silcombine transformations for arrays

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6000,6 +6000,13 @@ public:
   SILValue getValue() const { return Operands[Value].get(); }
   SILValue getBase() const { return Operands[Base].get(); }
 
+  void setValue(SILValue newVal) {
+    Operands[Value].set(newVal);
+  }
+  void setBase(SILValue newVal) {
+    Operands[Base].set(newVal);
+  }
+  
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 };

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -240,6 +240,9 @@ public:
   SILInstruction *visitUnreachableInst(UnreachableInst *UI);
   SILInstruction *visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI);
   SILInstruction *visitEnumInst(EnumInst *EI);
+      
+  SILInstruction *visitMarkDependenceInst(MarkDependenceInst *MDI);
+  SILInstruction *visitInitExistentialRefInst(InitExistentialRefInst *IER);
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
 
   /// Instruction visitor helpers.

--- a/test/SILOptimizer/pointer_conversion.swift
+++ b/test/SILOptimizer/pointer_conversion.swift
@@ -22,9 +22,8 @@ func get<T>() -> T
 public func testArray() {
   let array: [Int] = get()
   takesConstRawPointer(array)
-  // CHECK: [[OWNER:%.+]] = unchecked_ref_cast
   // CHECK: [[POINTER:%.+]] = struct $UnsafeRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $_ContiguousArrayStorageBase
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on {{.*}} : $_ContiguousArrayStorageBase
   // CHECK: [[FN:%.+]] = function_ref @takesConstRawPointer
   // CHECK-NEXT: apply [[FN]]([[DEP_POINTER]])
   // CHECK-NOT: release
@@ -38,9 +37,8 @@ public func testArray() {
 public func testArrayToOptional() {
   let array: [Int] = get()
   takesOptConstRawPointer(array)
-  // CHECK: [[OWNER:%.+]] = unchecked_ref_cast
   // CHECK: [[POINTER:%.+]] = struct $UnsafeRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $_ContiguousArrayStorageBase
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on {{.*}} : $_ContiguousArrayStorageBase
   // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt.1, [[DEP_POINTER]]
   // CHECK: [[FN:%.+]] = function_ref @takesOptConstRawPointer
   // CHECK-NEXT: apply [[FN]]([[OPT_POINTER]])
@@ -117,7 +115,8 @@ public func arrayLiteralPromotion() {
   takesConstRawPointer([41,42,43,44])
   
   // Stack allocate the array.
-  // CHECK: alloc_ref [stack] [tail_elems $Int * {{.*}} : $Builtin.Word] $_ContiguousArrayStorage<Int>
+  // TODO: When stdlib checks are enabled, this becomes heap allocated... :-(
+  // CHECK: alloc_ref {{.*}}[tail_elems $Int * {{.*}} : $Builtin.Word] $_ContiguousArrayStorage<Int>
   
   // Store the elements.
   // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 41

--- a/test/SILOptimizer/pointer_conversion.swift
+++ b/test/SILOptimizer/pointer_conversion.swift
@@ -22,9 +22,9 @@ func get<T>() -> T
 public func testArray() {
   let array: [Int] = get()
   takesConstRawPointer(array)
-  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
-  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK: [[OWNER:%.+]] = unchecked_ref_cast
+  // CHECK: [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $_ContiguousArrayStorageBase
   // CHECK: [[FN:%.+]] = function_ref @takesConstRawPointer
   // CHECK-NEXT: apply [[FN]]([[DEP_POINTER]])
   // CHECK-NOT: release
@@ -38,9 +38,9 @@ public func testArray() {
 public func testArrayToOptional() {
   let array: [Int] = get()
   takesOptConstRawPointer(array)
-  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
-  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK: [[OWNER:%.+]] = unchecked_ref_cast
+  // CHECK: [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $_ContiguousArrayStorageBase
   // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt.1, [[DEP_POINTER]]
   // CHECK: [[FN:%.+]] = function_ref @takesOptConstRawPointer
   // CHECK-NEXT: apply [[FN]]([[OPT_POINTER]])
@@ -55,9 +55,8 @@ public func testArrayToOptional() {
 public func testMutableArray() {
   var array: [Int] = get()
   takesMutableRawPointer(&array)
-  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
-  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeMutableRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeMutableRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK: [[POINTER:%.+]] = struct $UnsafeMutableRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeMutableRawPointer on {{.*}} : $_ContiguousArrayStorageBase
   // CHECK: [[FN:%.+]] = function_ref @takesMutableRawPointer
   // CHECK-NEXT: apply [[FN]]([[DEP_POINTER]])
   // CHECK-NOT: release
@@ -72,9 +71,8 @@ public func testMutableArray() {
 public func testMutableArrayToOptional() {
   var array: [Int] = get()
   takesOptMutableRawPointer(&array)
-  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
-  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeMutableRawPointer (
-  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeMutableRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK: [[POINTER:%.+]] = struct $UnsafeMutableRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeMutableRawPointer on {{.*}} : $_ContiguousArrayStorageBase
   // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeMutableRawPointer>, #Optional.some!enumelt.1, [[DEP_POINTER]]
   // CHECK: [[FN:%.+]] = function_ref @takesOptMutableRawPointer
   // CHECK-NEXT: apply [[FN]]([[OPT_POINTER]])
@@ -112,3 +110,28 @@ public func testOptionalArray() {
   // CHECK-NEXT: [[NO_OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.none!enumelt
   // CHECK-NEXT: br [[CALL_BRANCH]]([[NO_POINTER]] : $Optional<UnsafeRawPointer>, [[NO_OWNER]] : $Optional<AnyObject>)
 } // CHECK: end sil function '_T018pointer_conversion17testOptionalArrayyyF'
+
+
+// CHECK-LABEL: sil @_T018pointer_conversion21arrayLiteralPromotionyyF
+public func arrayLiteralPromotion() {
+  takesConstRawPointer([41,42,43,44])
+  
+  // Stack allocate the array.
+  // CHECK: alloc_ref [stack] [tail_elems $Int * {{.*}} : $Builtin.Word] $_ContiguousArrayStorage<Int>
+  
+  // Store the elements.
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 41
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 42
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 43
+  // CHECK: [[ELT:%.+]] = integer_literal $Builtin.Int{{.*}}, 44
+  
+  // Call the function.
+  // CHECK: [[PTR:%.+]] = mark_dependence
+
+  // CHECK: [[FN:%.+]] = function_ref @takesConstRawPointer
+  // CHECK: apply [[FN]]([[PTR]])
+  
+  // Release the heap value.
+  // CHECK: strong_release
+}
+

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2083,6 +2083,19 @@ bb0(%0 : $B, %1 : $@sil_unowned B, %2 : $AnyObject, %3: $@sil_unmanaged AnyObjec
   return %9999 : $(B, @sil_unowned B, AnyObject, @sil_unmanaged AnyObject)
 }
 
+// CHECK-LABEL: sil @collapse_init_open_init_ref_cast
+// CHECK:       bb0([[Ref:%.*]]: $MyClass):
+// CHECK-NEXT:     init_existential_ref
+// CHECK-NEXT:     return
+sil @collapse_init_open_init_ref_cast : $@convention(thin) (MyClass) -> (AnyObject) {
+bb0(%0: $MyClass):
+  %1 = init_existential_ref %0 : $MyClass : $MyClass, $AnyObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %3 = init_existential_ref %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject, $AnyObject
+  return %3 : $AnyObject
+}
+
+
 // CHECK-LABEL: sil @collapse_existential_pack_unpack_unchecked_ref_cast
 // CHECK:       bb0([[Ref:%.*]]: $MyClass):
 // CHECK-NOT:     init_existential_ref
@@ -3429,3 +3442,22 @@ bb1(%4 : $Builtin.Int32):
 bb2(%5 : $MyErrorType):
   throw %5 : $MyErrorType
 }
+
+// CHECK-LABEL: sil @mark_dependence_base
+// CHECK: bb0(
+// CHECK-NOT: init_existential_ref
+// CHECK-NOT: enum
+// CHECK-NEXT: mark_dependence
+// CHECK-NEXT: load
+// CHECK: return
+sil @mark_dependence_base : $@convention(thin) (@inout Builtin.Int64, @owned B) -> Builtin.Int64 {
+bb0(%0 : $*Builtin.Int64, %1 : $B):
+  %x = init_existential_ref %1 : $B : $B, $AnyObject
+  %2 = enum $Optional<AnyObject>, #Optional.some!enumelt.1, %x : $AnyObject
+  %3 = mark_dependence %0 : $*Builtin.Int64 on %2 : $Optional<AnyObject>
+  %4 = load %3 : $*Builtin.Int64
+  return %4 : $Builtin.Int64
+}
+
+
+


### PR DESCRIPTION
 - Useless existential_ref <-> class conversions.
 - mark_dependence_inst depending on uninteresting instructions.
 - release(init_existential_ref(x)) -> release(x) when hasOneUse(x)
 - Update COWArrayOpt to handle the new forms generated by this.

these aren't massive performance wins, but do shrink the size of SIL when
dealing with arrays.

This updates and subsumes PR 12338