### PR TITLE
[stdlib] Fix bug in String(_:radix:uppercase:)

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -235,7 +235,7 @@ internal func _digitASCII(
 
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
-internal func _integerToString<T: FixedWidthInteger>(
+internal func _integerToString<T : FixedWidthInteger>(
   _ value: T, radix: Int, uppercase: Bool
 ) -> String {
   if value == 0 {
@@ -310,8 +310,11 @@ extension String {
     // FIXME(integers): support a more general BinaryInteger protocol
     _precondition(2...36 ~= radix, "Radix must be between 2 and 36")
     if T.bitWidth <= 64 {
-      self = _int64ToString(
-        Int64(value), radix: Int64(radix), uppercase: uppercase)
+      self = T.isSigned
+        ? _int64ToString(
+          Int64(value), radix: Int64(radix), uppercase: uppercase)
+        : _uint64ToString(
+          UInt64(value), radix: Int64(radix), uppercase: uppercase)
     } else {
       self = _integerToString(value, radix: radix, uppercase: uppercase)
     }

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -121,6 +121,15 @@ tests.test("${Self}/radixTooHigh") {
 
 % end
 
+tests.test("FixedWidthInteger/maxUInt64") {
+  func f<T : FixedWidthInteger>(_ x: T) -> String {
+    return String(x, radix: 16)
+  }
+  let x = f(UInt64.max)
+  let y = String(UInt64.max, radix: 16)
+  expectEqual(x, y)
+}
+
 % for Self in 'Float', 'Double', 'Float80':
 
 % if Self == 'Float80':


### PR DESCRIPTION
The implementation for `String<T : FixedWidthInteger>(_:radix:uppercase:)` is never called from concrete code because of other overloads `where T : SignedInteger` and `where T : UnsignedInteger`.

In the generic context, however, this function has a bug with certain unsigned 64-bit integers. Namely, an attempt is made to cast to `Int64`, which fails when the leading bit is nonzero. This PR fixes that bug.
