### PR TITLE
 Rewrite LogicalPathComponent::getMaterialized and supporting cleanup.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1914,53 +1914,6 @@ public:
     lowering.emitDestroyValue(*this, Loc, v);
   }
 
-  /// Convenience function for handling begin_borrow instructions in ownership
-  /// and non-ownership SIL. In non-ownership SIL we just forward the input
-  /// value. Otherwise, we emit the begin_borrow instruction.
-  SILValue emitBeginBorrowOperation(SILLocation Loc, SILValue Value) {
-    assert(!Value->getType().isAddress());
-    // If ownership is not enabled in the function, just return our original
-    // value.
-    if (!getFunction().hasQualifiedOwnership())
-      return Value;
-
-    // If we have a trivial value, just return the value. Trivial values have
-    // lifetimes independent of any other values.
-    //
-    // *NOTE* For now to be conservative since we do not have the ownership
-    // verifier everywhere, we use getType()::isTrivial() instead of
-    // getOwnershipKind().
-    if (Value->getType().isTrivial(getModule())) {
-      return Value;
-    }
-
-    // Otherwise, we have a non-trivial value, perform the borrow.
-    return createBeginBorrow(Loc, Value);
-  }
-
-  /// Convenience function for handling end_borrow instructions in ownership and
-  /// non-ownership SIL. In non-ownership SIL we just early exit. Otherwise, we
-  /// emit the end_borrow.
-  void emitEndBorrowOperation(SILLocation Loc, SILValue Borrowed,
-                              SILValue Original) {
-    assert(!Borrowed->getType().isAddress());
-    // If ownership is not enabled, just return.
-    if (!getFunction().hasQualifiedOwnership())
-      return;
-
-    // If we have a trivial value, just return. Trivial values have lifetimes
-    // independent of any other values.
-    //
-    // *NOTE* For now to be conservative since we do not have the ownership
-    // verifier everywhere, we use getType()::isTrivial() instead of
-    // getOwnershipKind().
-    if (Borrowed->getType().isTrivial(getModule())) {
-      return;
-    }
-
-    createEndBorrow(Loc, Borrowed, Original);
-  }
-
   SILValue emitTupleExtract(SILLocation Loc, SILValue Operand, unsigned FieldNo,
                             SILType ResultTy) {
     // Fold tuple_extract(tuple(x,y,z),2)

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -36,23 +36,38 @@ enum class InlineCost : unsigned {
 InlineCost instructionInlineCost(SILInstruction &I);
 
 class SILInliner : public TypeSubstCloner<SILInliner> {
-public:
   friend class SILInstructionVisitor<SILInliner>;
   friend class SILCloner<SILInliner>;
-  
-  enum class InlineKind {
-    MandatoryInline,
-    PerformanceInline
-  };
 
+public:
+  enum class InlineKind { MandatoryInline, PerformanceInline };
+
+private:
+  InlineKind IKind;
+
+  SILBasicBlock *CalleeEntryBB = nullptr;
+
+  /// \brief The location representing the inlined instructions.
+  ///
+  /// This location wraps the call site AST node that is being inlined.
+  /// Alternatively, it can be the SIL file location of the call site (in case
+  /// of SIL-to-SIL transformations).
+  Optional<SILLocation> Loc;
+  const SILDebugScope *CallSiteScope = nullptr;
+  SILFunction *CalleeFunction = nullptr;
+  llvm::SmallDenseMap<const SILDebugScope *, const SILDebugScope *>
+      InlinedScopeCache;
+  CloneCollector::CallbackType Callback;
+
+public:
   SILInliner(SILFunction &To, SILFunction &From, InlineKind IKind,
              SubstitutionList ApplySubs,
              SILOpenedArchetypesTracker &OpenedArchetypesTracker,
              CloneCollector::CallbackType Callback = nullptr)
       : TypeSubstCloner<SILInliner>(To, From, ApplySubs,
                                     OpenedArchetypesTracker, true),
-        IKind(IKind), CalleeEntryBB(nullptr),
-        Callback(Callback) {
+        IKind(IKind), CalleeFunction(&Original), Callback(Callback) {
+    // CalleeEntryBB is initialized later in case the callee is modified.
   }
 
   /// Returns true if we are able to inline \arg AI.
@@ -113,22 +128,6 @@ private:
       // Create an inlined version of the scope.
       return getOrCreateInlineScope(DS);
   }
-
-  InlineKind IKind;
-  
-  SILBasicBlock *CalleeEntryBB;
-
-  /// \brief The location representing the inlined instructions.
-  ///
-  /// This location wraps the call site AST node that is being inlined.
-  /// Alternatively, it can be the SIL file location of the call site (in case
-  /// of SIL-to-SIL transformations).
-  Optional<SILLocation> Loc;
-  const SILDebugScope *CallSiteScope = nullptr;
-  SILFunction *CalleeFunction;
-  llvm::SmallDenseMap<const SILDebugScope *,
-                      const SILDebugScope *> InlinedScopeCache;
-  CloneCollector::CallbackType Callback;
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -55,7 +55,7 @@ private:
   Optional<SILLocation> Loc;
   const SILDebugScope *CallSiteScope = nullptr;
   SILFunction *CalleeFunction = nullptr;
-  llvm::SmallDenseMap<const SILDebugScope *, const SILDebugScope *>
+  llvm::SmallDenseMap<const SILDebugScope *, const SILDebugScope *, 8>
       InlinedScopeCache;
   CloneCollector::CallbackType Callback;
 

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -94,6 +94,8 @@ public:
   void inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args);
 
 private:
+  SILValue borrowFunctionArgument(SILValue callArg, FullApplySite AI);
+
   void visitDebugValueInst(DebugValueInst *Inst);
   void visitDebugValueAddrInst(DebugValueAddrInst *Inst);
 

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1097,6 +1097,10 @@ visitFullApply(FullApplySite apply) {
     return {true, UseLifetimeConstraint::MustBeLive};
   case ParameterConvention::Indirect_In_Guaranteed:
   case ParameterConvention::Direct_Guaranteed:
+    // A +1 value may be passed to a guaranteed argument. From the caller's
+    // point of view, this is just like a normal non-consuming use.
+    // Direct_Guaranteed only accepts non-trivial types, but trivial types are
+    // already handled above.
     return visitApplyParameter(ValueOwnershipKind::Any,
                                UseLifetimeConstraint::MustBeLive);
   // The following conventions should take address types.

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1097,7 +1097,7 @@ visitFullApply(FullApplySite apply) {
     return {true, UseLifetimeConstraint::MustBeLive};
   case ParameterConvention::Indirect_In_Guaranteed:
   case ParameterConvention::Direct_Guaranteed:
-    return visitApplyParameter(ValueOwnershipKind::Guaranteed,
+    return visitApplyParameter(ValueOwnershipKind::Any,
                                UseLifetimeConstraint::MustBeLive);
   // The following conventions should take address types.
   case ParameterConvention::Indirect_Inout:

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -234,8 +234,8 @@ protected:
 
   /// Materialize this component into a temporary and return the temporary's
   /// address.
-  ManagedValue materializeIntoTemp(SILGenFunction &SGF, SILLocation loc,
-                                   ManagedValue base) &&;
+  ManagedValue materializeIntoTemporary(SILGenFunction &SGF, SILLocation loc,
+                                        ManagedValue base) &&;
 
 public:
   /// Clone the path component onto the heap.

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -232,6 +232,11 @@ protected:
     assert(isLogical() && "LogicalPathComponent Kind isn't logical");
   }
 
+  /// Materialize this component into a temporary and return the temporary's
+  /// address.
+  ManagedValue materializeIntoTemp(SILGenFunction &SGF, SILLocation loc,
+                                   ManagedValue base) &&;
+
 public:
   /// Clone the path component onto the heap.
   virtual std::unique_ptr<LogicalPathComponent>

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -218,9 +218,8 @@ public:
 };
 
 /// Materialize this component into a temporary.
-ManagedValue LogicalPathComponent::materializeIntoTemp(SILGenFunction &SGF,
-                                                       SILLocation loc,
-                                                       ManagedValue base) && {
+ManagedValue LogicalPathComponent::materializeIntoTemporary(
+    SILGenFunction &SGF, SILLocation loc, ManagedValue base) && {
   const TypeLowering &RValueTL = SGF.getTypeLowering(getTypeOfRValue());
   TemporaryInitializationPtr tempInit;
   RValue rvalue;
@@ -255,7 +254,7 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
                                                    ManagedValue base,
                                                    AccessKind kind) && {
   if (kind == AccessKind::Read)
-    return std::move(*this).materializeIntoTemp(SGF, loc, base);
+    return std::move(*this).materializeIntoTemporary(SGF, loc, base);
 
   // AccessKind is Write or ReadWrite. We need to emit a get and set.
   assert(SGF.InFormalEvaluationScope &&
@@ -265,7 +264,7 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
   // writeback.
   auto clonedComponent = clone(SGF, loc);
 
-  ManagedValue temp = std::move(*this).materializeIntoTemp(SGF, loc, base);
+  ManagedValue temp = std::move(*this).materializeIntoTemporary(SGF, loc, base);
 
   // Push a writeback for the temporary.
   pushWriteback(SGF, loc, std::move(clonedComponent), base,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -217,94 +217,47 @@ public:
                                        LValueOptions options);
 };
 
-static ManagedValue
-emitGetIntoTemporary(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
-                     std::unique_ptr<TemporaryInitialization> &&temporaryInit,
-                     LogicalPathComponent &&component) {
-  // Emit a 'get' into the temporary.
-  RValue value =
-    std::move(component).get(SGF, loc, base, SGFContext(temporaryInit.get()));
+/// Materialize this component into a temporary.
+ManagedValue LogicalPathComponent::materializeIntoTemp(SILGenFunction &SGF,
+                                                       SILLocation loc,
+                                                       ManagedValue base) && {
+  const TypeLowering &RValueTL = SGF.getTypeLowering(getTypeOfRValue());
+  TemporaryInitializationPtr tempInit;
+  RValue rvalue;
 
-  // Force the value into the temporary if necessary.
-  if (!value.isInContext()) {
-    std::move(value).forwardInto(SGF, loc, temporaryInit.get());
+  // If the RValue type has an openedExistential, then the RValue must be
+  // materialized before allocating a temporary for the RValue type. In that
+  // case, the RValue cannot be emitted directly into the temporary.
+  if (getTypeOfRValue().getSwiftRValueType()->hasOpenedExistential()) {
+    // Emit a 'get'.
+    rvalue = std::move(*this).get(SGF, loc, base, SGFContext());
+
+    // Create a temporary, whose type may depend on the 'get'.
+    tempInit = SGF.emitFormalAccessTemporary(loc, RValueTL);
+  } else {
+    // Create a temporary for a static (non-dependent) RValue type.
+    tempInit = SGF.emitFormalAccessTemporary(loc, RValueTL);
+
+    // Emit a 'get' directly into the temporary.
+    rvalue = std::move(*this).get(SGF, loc, base, SGFContext(tempInit.get()));
   }
+  // `this` is now dead.
 
-  return temporaryInit->getManagedAddress();
+  // Force `value` into a temporary if is wasn't emitted there.
+  if (!rvalue.isInContext())
+    std::move(rvalue).forwardInto(SGF, loc, tempInit.get());
+
+  return tempInit->getManagedAddress();
 }
 
 ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
                                                    SILLocation loc,
                                                    ManagedValue base,
                                                    AccessKind kind) && {
-  if (getTypeOfRValue().getSwiftRValueType()->hasOpenedExistential()) {
-    if (kind == AccessKind::Read) {
-      // Emit a 'get' into the temporary.
-      RValue value =
-        std::move(*this).get(SGF, loc, base, SGFContext());
+  if (kind == AccessKind::Read)
+    return std::move(*this).materializeIntoTemp(SGF, loc, base);
 
-      // Create a temporary.
-      std::unique_ptr<TemporaryInitialization> temporaryInit =
-        SGF.emitFormalAccessTemporary(loc,
-                                      SGF.getTypeLowering(getTypeOfRValue()));
-
-      std::move(value).forwardInto(SGF, loc, temporaryInit.get());
-
-      return temporaryInit->getManagedAddress();
-    }
-
-    assert(SGF.InFormalEvaluationScope &&
-         "materializing l-value for modification without writeback scope");
-
-    // Clone anything else about the component that we might need in the
-    // writeback.
-    auto clonedComponent = clone(SGF, loc);
-
-    SILValue mv;
-    {
-      FormalEvaluationScope Scope(SGF);
-
-      // Otherwise, we need to emit a get and set.  Borrow the base for
-      // the getter.
-      ManagedValue getterBase =
-        base ? base.formalAccessBorrow(SGF, loc) : ManagedValue();
-
-      // Emit a 'get' into a temporary and then pop the borrow of base.
-      RValue value =
-        std::move(*this).get(SGF, loc, getterBase, SGFContext());
-
-      mv = std::move(value).forwardAsSingleValue(SGF, loc);
-    }
-
-    auto &TL = SGF.getTypeLowering(getTypeOfRValue());
-
-    // Create a temporary.
-    std::unique_ptr<TemporaryInitialization> temporaryInit =
-      SGF.emitFormalAccessTemporary(loc, TL);
-
-    SGF.emitSemanticStore(loc, mv, temporaryInit->getAddress(),
-                          TL, IsInitialization);
-    temporaryInit->finishInitialization(SGF);
-
-    auto temporary = temporaryInit->getManagedAddress();
-
-    // Push a writeback for the temporary.
-    pushWriteback(SGF, loc, std::move(clonedComponent), base,
-                  MaterializedLValue(temporary));
-    return temporary.unmanagedBorrow();
-  }
-
-  // If this is just for a read, emit a load into a temporary memory
-  // location.
-  if (kind == AccessKind::Read) {
-    // Create a temporary.
-    std::unique_ptr<TemporaryInitialization> temporaryInit =
-        SGF.emitFormalAccessTemporary(loc,
-                                      SGF.getTypeLowering(getTypeOfRValue()));
-    return emitGetIntoTemporary(SGF, loc, base, std::move(temporaryInit),
-                                std::move(*this));
-  }
-
+  // AccessKind is Write or ReadWrite. We need to emit a get and set.
   assert(SGF.InFormalEvaluationScope &&
          "materializing l-value for modification without writeback scope");
 
@@ -312,29 +265,12 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
   // writeback.
   auto clonedComponent = clone(SGF, loc);
 
-  ManagedValue temporary;
-  {
-    // Create a temporary.
-    std::unique_ptr<TemporaryInitialization> temporaryInit =
-        SGF.emitFormalAccessTemporary(loc,
-                                      SGF.getTypeLowering(getTypeOfRValue()));
-
-    FormalEvaluationScope Scope(SGF);
-
-    // Otherwise, we need to emit a get and set.  Borrow the base for
-    // the getter.
-    ManagedValue getterBase =
-        base ? base.formalAccessBorrow(SGF, loc) : ManagedValue();
-
-    // Emit a 'get' into a temporary and then pop the borrow of base.
-    temporary = emitGetIntoTemporary(
-        SGF, loc, getterBase, std::move(temporaryInit), std::move(*this));
-  }
+  ManagedValue temp = std::move(*this).materializeIntoTemp(SGF, loc, base);
 
   // Push a writeback for the temporary.
   pushWriteback(SGF, loc, std::move(clonedComponent), base,
-                MaterializedLValue(temporary));
-  return temporary.unmanagedBorrow();
+                MaterializedLValue(temp));
+  return temp.unmanagedBorrow();
 }
 
 void LogicalPathComponent::writeback(SILGenFunction &SGF, SILLocation loc,

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -36,9 +36,6 @@ void SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
   assert(canInlineFunction(AI) &&
          "Asked to inline function that is unable to be inlined?!");
 
-  // Setup the callee function.
-  CalleeFunction = &Original;
-
   SILFunction &F = getBuilder().getFunction();
   assert(AI.getFunction() && AI.getFunction() == &F &&
          "Inliner called on apply instruction in wrong function?");

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -195,7 +195,7 @@ SILValue SILInliner::borrowFunctionArgument(SILValue callArg,
     return callArg;
   }
   auto *borrow = getBuilder().createBeginBorrow(AI.getLoc(), callArg);
-  if (auto tryAI = dyn_cast<TryApplyInst>(AI)) {
+  if (auto *tryAI = dyn_cast<TryApplyInst>(AI)) {
     SILBuilder returnBuilder(tryAI->getNormalBB()->begin());
     returnBuilder.createEndBorrow(AI.getLoc(), borrow, callArg);
 

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -6,42 +6,42 @@ import Builtin
 import Swift
 
 class C {
-  var i = 0
+  var i: Builtin.Int64
+  init(i: Builtin.Int64) { self.i = i }
 }
 
-sil [transparent] @calleeWithGuaranteed : $@convention(thin) (@guaranteed C) -> Int {
+sil [transparent] @calleeWithGuaranteed : $@convention(thin) (@guaranteed C) -> Builtin.Int64 {
 bb(%0 : @guaranteed $C):
   %1 = ref_element_addr %0 : $C, #C.i
-  %2 = load [trivial] %1 : $*Int
-  return %2 : $Int
+  %2 = load [trivial] %1 : $*Builtin.Int64
+  return %2 : $Builtin.Int64
 }
 
-// CHECK-LABEL: sil @callerWithOwned : $@convention(thin) (@owned C) -> Int {
+// CHECK-LABEL: sil @callerWithOwned : $@convention(thin) (@owned C) -> Builtin.Int64 {
 // CHECK: bb0(%0 : @owned $C):
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
-// CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Int
+// CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
 // CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
 // CHECK:   destroy_value %0 : $C
-// CHECK:   return [[VAL]] : $Int
+// CHECK:   return [[VAL]] : $Builtin.Int64
 // CHECK-LABEL: } // end sil function 'callerWithOwned'
-sil @callerWithOwned : $@convention(thin) (@owned C) -> Int {
+sil @callerWithOwned : $@convention(thin) (@owned C) -> Builtin.Int64 {
 bb(%0 : @owned $C):
-  %fn = function_ref @calleeWithGuaranteed : $@convention(thin) (@guaranteed C) -> Int
-  %call = apply %fn(%0) : $@convention(thin) (@guaranteed C) -> Int
+  %fn = function_ref @calleeWithGuaranteed : $@convention(thin) (@guaranteed C) -> Builtin.Int64
+  %call = apply %fn(%0) : $@convention(thin) (@guaranteed C) -> Builtin.Int64
   destroy_value %0 : $C
-  return %call : $Int
+  return %call : $Builtin.Int64
 }
 
 struct MyError : Error {}
 
-sil [transparent] @calleeWithGuaranteedThrows : $@convention(thin) (@guaranteed C) -> (Int, @error Error) {
+sil [transparent] @calleeWithGuaranteedThrows : $@convention(thin) (@guaranteed C) -> (Builtin.Int64, @error Error) {
 bb(%0 : @guaranteed $C):
   %1 = ref_element_addr %0 : $C, #C.i
-  %2 = load [trivial] %1 : $*Int
+  %2 = load [trivial] %1 : $*Builtin.Int64
   %3 = integer_literal $Builtin.Int64, 0
-  %4 = struct_extract %2 : $Int, #Int._value
-  %5 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+  %5 = builtin "cmp_eq_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
   cond_br %5, bb1, bb2
 
 bb1:
@@ -49,31 +49,31 @@ bb1:
   throw %6 : $Error
 
 bb2:
-  return %2 : $Int
+  return %2 : $Builtin.Int64
 }
 
-// CHECK-LABEL: sil @callerWithThrow : $@convention(thin) (@owned C) -> (Int, @error Error) {
+// CHECK-LABEL: sil @callerWithThrow : $@convention(thin) (@owned C) -> (Builtin.Int64, @error Error) {
 // CHECK: bb0(%0 : @owned $C):
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
-// CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Int
-// CHECK: bb{{.*}}([[RET:%.*]] : @trivial $Int):
+// CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
+// CHECK: bb{{.*}}([[RET:%.*]] : @trivial $Builtin.Int64):
 // CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
 // CHECK:   destroy_value %0 : $C
-// CHECK:   return [[RET]] : $Int
+// CHECK:   return [[RET]] : $Builtin.Int64
 // CHECK: bb{{.*}}([[ERR:%.*]] : @owned $Error):
 // CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
 // CHECK:   destroy_value %0 : $C
 // CHECK:   throw [[ERR]] : $Error
 // CHECK-LABEL: } // end sil function 'callerWithThrow'
-sil @callerWithThrow : $@convention(thin) (@owned C) -> (Int, @error Error) {
+sil @callerWithThrow : $@convention(thin) (@owned C) -> (Builtin.Int64, @error Error) {
 bb(%0 : @owned $C):
-  %fn = function_ref @calleeWithGuaranteedThrows : $@convention(thin) (@guaranteed C) -> (Int, @error Error)
-  try_apply %fn(%0) : $@convention(thin) (@guaranteed C) -> (Int, @error Error), normal bb1, error bb2
+  %fn = function_ref @calleeWithGuaranteedThrows : $@convention(thin) (@guaranteed C) -> (Builtin.Int64, @error Error)
+  try_apply %fn(%0) : $@convention(thin) (@guaranteed C) -> (Builtin.Int64, @error Error), normal bb1, error bb2
 
-bb1(%4 : @trivial $Int):
+bb1(%4 : @trivial $Builtin.Int64):
   destroy_value %0 : $C
-  return %4 : $Int
+  return %4 : $Builtin.Int64
 
 bb2(%5 : @owned $Error):
   destroy_value %0 : $C

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -1,0 +1,81 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining -enable-sil-ownership | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+class C {
+  var i = 0
+}
+
+sil [transparent] @calleeWithGuaranteed : $@convention(thin) (@guaranteed C) -> Int {
+bb(%0 : @guaranteed $C):
+  %1 = ref_element_addr %0 : $C, #C.i
+  %2 = load [trivial] %1 : $*Int
+  return %2 : $Int
+}
+
+// CHECK-LABEL: sil @callerWithOwned : $@convention(thin) (@owned C) -> Int {
+// CHECK: bb0(%0 : @owned $C):
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
+// CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
+// CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Int
+// CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
+// CHECK:   destroy_value %0 : $C
+// CHECK:   return [[VAL]] : $Int
+// CHECK-LABEL: } // end sil function 'callerWithOwned'
+sil @callerWithOwned : $@convention(thin) (@owned C) -> Int {
+bb(%0 : @owned $C):
+  %fn = function_ref @calleeWithGuaranteed : $@convention(thin) (@guaranteed C) -> Int
+  %call = apply %fn(%0) : $@convention(thin) (@guaranteed C) -> Int
+  destroy_value %0 : $C
+  return %call : $Int
+}
+
+struct MyError : Error {}
+
+sil [transparent] @calleeWithGuaranteedThrows : $@convention(thin) (@guaranteed C) -> (Int, @error Error) {
+bb(%0 : @guaranteed $C):
+  %1 = ref_element_addr %0 : $C, #C.i
+  %2 = load [trivial] %1 : $*Int
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = struct_extract %2 : $Int, #Int._value
+  %5 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %5, bb1, bb2
+
+bb1:
+  %6 = alloc_existential_box $Error, $MyError
+  throw %6 : $Error
+
+bb2:
+  return %2 : $Int
+}
+
+// CHECK-LABEL: sil @callerWithThrow : $@convention(thin) (@owned C) -> (Int, @error Error) {
+// CHECK: bb0(%0 : @owned $C):
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
+// CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
+// CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Int
+// CHECK: bb{{.*}}([[RET:%.*]] : @trivial $Int):
+// CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
+// CHECK:   destroy_value %0 : $C
+// CHECK:   return [[RET]] : $Int
+// CHECK: bb{{.*}}([[ERR:%.*]] : @owned $Error):
+// CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
+// CHECK:   destroy_value %0 : $C
+// CHECK:   throw [[ERR]] : $Error
+// CHECK-LABEL: } // end sil function 'callerWithThrow'
+sil @callerWithThrow : $@convention(thin) (@owned C) -> (Int, @error Error) {
+bb(%0 : @owned $C):
+  %fn = function_ref @calleeWithGuaranteedThrows : $@convention(thin) (@guaranteed C) -> (Int, @error Error)
+  try_apply %fn(%0) : $@convention(thin) (@guaranteed C) -> (Int, @error Error), normal bb1, error bb2
+
+bb1(%4 : @trivial $Int):
+  destroy_value %0 : $C
+  return %4 : $Int
+
+bb2(%5 : @owned $Error):
+  destroy_value %0 : $C
+  throw %5 : $Error
+}


### PR DESCRIPTION
Background: I'm attempting to add more access markers for exclusivity verification, but running into insurmountable complexity in SILGen. This is one small area where deep cleanup was necessary before making any changes.

Collapse this routine down to its fundamental logic, removing unnecessary hacks along the way. It's now self-documenting and robust.

The basic principle is that any special cases should use the same SILGen abstractions and utilities. The implementation should be identical except where the special case is logically distinct. i.e. the reason for the special case should be self-evident from the code.

This is not NFC. Unnecessary borrow scopes are no longer emitted for getters. More generally, there may have been some incidental behavior specific to a corner cases that becomes more uniform now.

To support this, the SIL ownership verifier and inliner can handle passing owned values to guaranteed args. This will unblock a lot of other SILGen simplification.