### PR TITLE
The YAML mustQuote function now returns an enum instead of a bool.

### DIFF
--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -233,7 +233,7 @@ decl-attributes ::=
       return ScalarTraits<std::string>::input(Scalar, Context,                 \
                                               Val.STRING_MEMBER_NAME);         \
     }                                                                          \
-    static bool mustQuote(StringRef S) {                                       \
+    static QuotingType mustQuote(StringRef S) {                                \
       return ScalarTraits<std::string>::mustQuote(S);                          \
     }                                                                          \
   };                                                                           \


### PR DESCRIPTION
The YAML mustQuote function now returns an enum instead of a bool.

rdar://problem/36022642