### PR TITLE
[AST] Perf: targeted use of __builtin_assume() in dyn_cast wrappers

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -25,6 +25,7 @@
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/OptionSet.h"
+#include "swift/Basic/Compiler.h"
 #include <functional>
 #include <string>
 
@@ -536,7 +537,9 @@ template <class X> inline CanTypeWrapper<X> cast_or_null(CanType type) {
   return CanTypeWrapper<X>(cast_or_null<X>(type.getPointer()));
 }
 template <class X> inline CanTypeWrapper<X> dyn_cast(CanType type) {
-  return CanTypeWrapper<X>(dyn_cast<X>(type.getPointer()));
+  auto Ty = type.getPointer();
+  SWIFT_ASSUME(Ty != nullptr);
+  return CanTypeWrapper<X>(dyn_cast<X>(Ty));
 }
 template <class X> inline CanTypeWrapper<X> dyn_cast_or_null(CanType type) {
   return CanTypeWrapper<X>(dyn_cast_or_null<X>(type.getPointer()));
@@ -554,7 +557,9 @@ inline CanTypeWrapper<X> cast(CanTypeWrapper<P> type) {
 }
 template <class X, class P>
 inline CanTypeWrapper<X> dyn_cast(CanTypeWrapper<P> type) {
-  return CanTypeWrapper<X>(dyn_cast<X>(type.getPointer()));
+  auto Ty = type.getPointer();
+  SWIFT_ASSUME(Ty != nullptr);
+  return CanTypeWrapper<X>(dyn_cast<X>(Ty));
 }
 template <class X, class P>
 inline CanTypeWrapper<X> dyn_cast_or_null(CanTypeWrapper<P> type) {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -446,7 +446,9 @@ public:
   template <typename T>
   T *getAs() {
     static_assert(!isSugaredType<T>(), "getAs desugars types");
-    return dyn_cast<T>(getDesugaredType());
+    auto Ty = getDesugaredType();
+    SWIFT_ASSUME(Ty != nullptr);
+    return dyn_cast<T>(Ty);
   }
 
   template <typename T>

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -19,6 +19,11 @@
 #define SWIFT_COMPILER_IS_MSVC 0
 #endif
 
+// Workaround non-clang compilers
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 #if SWIFT_COMPILER_IS_MSVC && _MSC_VER < 1910
 // Work around MSVC bug: attempting to reference a deleted function
 // https://connect.microsoft.com/VisualStudio/feedback/details/3116505
@@ -26,6 +31,13 @@
   { llvm_unreachable("Delete operator should not be called."); }
 #else
 #define SWIFT_DELETE_OPERATOR_DELETED = delete;
+#endif
+
+// __builtin_assume() is an optimization hint.
+#if __has_builtin(__builtin_assume)
+#define SWIFT_ASSUME(x) __builtin_assume(x)
+#else
+#define SWIFT_ASSUME(x)
 #endif
 
 #endif // SWIFT_BASIC_COMPILER_H


### PR DESCRIPTION
Workaround:
https://bugs.llvm.org/show_bug.cgi?id=35790
See also:
https://bugs.llvm.org/show_bug.cgi?id=28430