### PR TITLE
[stdlib] Don't try to construct invalid UnicodeScalars in CharacterSet

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -188,7 +188,7 @@ fileprivate final class _CharacterSetStorage : Hashable {
     
     @discardableResult
     fileprivate func insert(_ character: Unicode.Scalar) -> (inserted: Bool, memberAfterInsert: Unicode.Scalar) {
-        insert(charactersIn: character..<Unicode.Scalar(character.value + 1)!)
+        insert(charactersIn: character...character)
         // TODO: This should probably return the truth, but figuring it out requires two calls into NSCharacterSet
         return (true, character)
     }
@@ -204,7 +204,7 @@ fileprivate final class _CharacterSetStorage : Hashable {
     fileprivate func remove(_ character: Unicode.Scalar) -> Unicode.Scalar? {
         // TODO: Add method to CFCharacterSet to do this in one call
         let result : Unicode.Scalar? = contains(character) ? character : nil
-        remove(charactersIn: character..<Unicode.Scalar(character.value + 1)!)
+        remove(charactersIn: character...character)
         return result
     }
     

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -114,6 +114,16 @@ class TestCharacterSet : TestCharacterSetSuper {
       expectTrue(characters.contains(problematicChar))
     }
 
+    func testUpperBoundaryInsert_SR_2988() {
+      // "CharacterSet.insert(_: Unicode.Scalar) crashes on U+D7FF"
+      let problematicChar = UnicodeScalar(0xD7FF)!
+      var characters = CharacterSet()
+      characters.insert(problematicChar) // this should not crash
+      expectTrue(characters.contains(problematicChar))
+      characters.remove(problematicChar) // this should not crash
+      expectTrue(!characters.contains(problematicChar))
+    }
+
     func testInsertAndRemove() {
         var asciiUppercase = CharacterSet(charactersIn: UnicodeScalar(0x41)!...UnicodeScalar(0x5A)!)
         expectTrue(asciiUppercase.contains(UnicodeScalar(0x49)!))
@@ -330,6 +340,8 @@ CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
 CharacterSetTests.test("test_setOperationsOfEmptySet") { TestCharacterSet().test_setOperationsOfEmptySet() }
 CharacterSetTests.test("test_moreSetOperations") { TestCharacterSet().test_moreSetOperations() }
 CharacterSetTests.test("test_unconditionallyBridgeFromObjectiveC") { TestCharacterSet().test_unconditionallyBridgeFromObjectiveC() }
+CharacterSetTests.test("testClosedRanges_SR_2988") { TestCharacterSet().testClosedRanges_SR_2988() }
+CharacterSetTests.test("testUpperBoundaryInsert_SR_2988") { TestCharacterSet().testUpperBoundaryInsert_SR_2988() }
 runAllTests()
 #endif
 


### PR DESCRIPTION
Inserting and removing a single `Unicode.Scalar` in a `CharacterSet` must not
attempt to create a `Range<Unicode.Scalar>` because the `upperBound` value might
not always be a valid `UnicodeScalar`. This patch changes `insert(_:)` and `remove(_:)`
to construct and use a `ClosedRange<Unicode.Scalar>` instead.

This fixes what I believe to be a regression to the fix for [SR-2988](https://bugs.swift.org/browse/SR-2988).
