### PR TITLE
SwiftSyntax: make Syntax node Hashable.

### DIFF
--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -148,7 +148,7 @@ extension Syntax: Hashable {
   }
   /// Use reference value as the hashValue for this Syntax
   public var hashValue: Int {
-    return ObjectIdentifier(self).hashValue
+    return ObjectIdentifier(data).hashValue
   }
 }
 

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -22,7 +22,7 @@ public class Syntax: CustomStringConvertible {
 
   /// The root of the tree this node is currently in.
   internal let _root: SyntaxData
-  
+
   /// The data backing this node.
   /// - note: This is unowned, because the reference to the root data keeps it
   ///         alive. This means there is an implicit relationship -- the data
@@ -69,7 +69,7 @@ public class Syntax: CustomStringConvertible {
   public var isExpr: Bool {
     return raw.kind.isExpr
   }
-  
+
   /// Whether or not this node represents a Declaration.
   public var isDecl: Bool {
     return raw.kind.isDecl
@@ -105,7 +105,7 @@ public class Syntax: CustomStringConvertible {
   public var root: Syntax {
     return Syntax.make(root: _root,  data: _root)
   }
-  
+
   /// The sequence of indices that correspond to child nodes that are not
   /// missing.
   ///
@@ -141,10 +141,14 @@ extension Syntax: TextOutputStreamable {
   }
 }
 
-extension Syntax: Equatable {
+extension Syntax: Hashable {
   /// Determines if two nodes are equal to each other.
   public static func ==(lhs: Syntax, rhs: Syntax) -> Bool {
-    return lhs.data === rhs.data
+    return lhs.hashValue == rhs.hashValue
+  }
+  /// Use reference value as the hashValue for this Syntax
+  public var hashValue: Int {
+    return ObjectIdentifier(self).hashValue
   }
 }
 


### PR DESCRIPTION
This gives Syntax node a unique identifier and makes them friendly
to Set and Dictionary.

We used to compare RawSyntax's references to decide if two Syntax nodes
are identical. This is insufficient because (1) a RawSyntax can be
shared among several Syntax nodes, at least in theory; and (2) two
instances of RawSyntax can still have the same content.
