### PR TITLE
SwiftSyntax: Add a read-only syntax visitor.

### DIFF
--- a/test/SwiftSyntax/Inputs/visitor.swift
+++ b/test/SwiftSyntax/Inputs/visitor.swift
@@ -1,0 +1,6 @@
+func foo() {
+  func foo() {
+    func foo() {
+    }
+  }
+}

--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+import SwiftSyntax
+
+func getInput(_ file: String) -> URL {
+  var result = URL(fileURLWithPath: #file)
+  result.deleteLastPathComponent()
+  result.appendPathComponent("Inputs")
+  result.appendPathComponent(file)
+  return result
+}
+
+var VisitorTests = TestSuite("SyntaxVisitor")
+
+VisitorTests.test("Basic") {
+  class FuncCounter: SyntaxVisitor {
+    var funcCount = 0
+    override func visit(_ node: FunctionDeclSyntax) {
+      funcCount += 1
+      super.visit(node)
+    }
+  }
+  expectDoesNotThrow({
+    let parsed = try Syntax.parse(getInput("visitor.swift"))
+    let counter = FuncCounter()
+    let hashBefore = parsed.hashValue
+    counter.visit(parsed)
+    expectEqual(counter.funcCount, 3)
+    expectEqual(hashBefore, parsed.hashValue)
+  })
+}
+
+runAllTests()

--- a/tools/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -59,3 +59,32 @@ open class SyntaxRewriter {
     return Syntax.fromRaw(node.raw.replacingLayout(newLayout))
   }
 }
+
+open class SyntaxVisitor {
+    public init() {}
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+  open func visit(_ node: ${node.name}) {
+    visitChildren(node)
+  }
+%   end
+% end
+
+  open func visit(_ token: TokenSyntax) {}
+
+  public func visit(_ node: Syntax) {
+    switch node.raw.kind {
+    case .token: visit(node as! TokenSyntax)
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+    case .${node.swift_syntax_kind}: visit(node as! ${node.name})
+%   end
+% end
+    default: visitChildren(node)
+    }
+  }
+
+  func visitChildren(_ node: Syntax) {
+    node.children.forEach { visit($0) }
+  }
+}


### PR DESCRIPTION
Based on the feedbacks from our early adopters, separating syntax tree analysis
with transformation is a common pattern. Thus, we introduce a read-only
syntax tree visitor to help the analysis phase. This visitor never alters the
content of a tree being visited, in contrast to SyntaxRewriter which always does.