### PR TITLE
[Syntax] Print contents of Unresolved(Dot|DeclRef)Expr

### DIFF
--- a/test/Syntax/round_trip_misc.swift
+++ b/test/Syntax/round_trip_misc.swift
@@ -28,3 +28,15 @@ typealias c = @foobar(a) () -> Void
 let d = \.foo
 let e = \.[1]
 let f = \.?.bar
+
+// selectors.
+#selector(Int.g)
+#selector(Int.h(_:))
+#selector(i(_:))
+#selector(getter: j)
+#selector(getter: .k)
+#selector(getter: Int.l)
+#selector(setter: Int.m)
+
+// overload references.
+let n = Int.o(_:)

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -354,6 +354,17 @@ EXPR_NODES = [
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 
+    Node('UnresolvedDeclRefExpr', kind='Expr',
+         children=[
+             Child("Name", kind='Token'),
+         ]),
+
+    Node('UnresolvedDotExpr', kind='Expr',
+         children=[
+             Child("Dot", kind='PrefixPeriodToken'),
+             Child("Name", kind='Token'),
+         ]),
+
     # unresolved-pattern-expr -> pattern
     Node('UnresolvedPatternExpr', kind='Expr',
          children=[


### PR DESCRIPTION
When parsing `#selector(foo(:))` some characters would be dropped resulting in a non-compiling document `#selector(foo()`.

While this fix does NOT implement the ObjCSelectorExpr it should prevent that data from being dropped.

Please let me know if you have any pointers on how I could improve my PR.