### PR TITLE
[stdlib][Gardening] Delete few redundant numericCasts

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1945,7 +1945,7 @@ extension ${Self} {
 
     let oldCount = _buffer.count
     let eraseCount = subrange.count
-    let insertCount = numericCast(newElements.count) as Int
+    let insertCount = newElements.count
     let growth = insertCount - eraseCount
 
     if _buffer.requestUniqueMutableBackingBuffer(

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -245,9 +245,9 @@ extension BidirectionalCollection where SubSequence == Self {
   public mutating func removeLast(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= numericCast(n),
+    _precondition(count >= n,
       "Can't remove more items from a collection than it contains")
-    self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
+    self = self[startIndex..<index(endIndex, offsetBy: -n)]
   }
 }
 
@@ -275,7 +275,7 @@ extension BidirectionalCollection {
       n >= 0, "Can't drop a negative number of elements from a collection")
     let end = index(
       endIndex,
-      offsetBy: numericCast(-n),
+      offsetBy: -n,
       limitedBy: startIndex) ?? startIndex
     return self[startIndex..<end]
   }
@@ -305,7 +305,7 @@ extension BidirectionalCollection {
       "Can't take a suffix of negative length from a collection")
     let start = index(
       endIndex,
-      offsetBy: numericCast(-maxLength),
+      offsetBy: -maxLength,
       limitedBy: startIndex) ?? startIndex
     return self[start..<endIndex]
   }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1150,7 +1150,7 @@ extension Collection {
   @_inlineable
   public var underestimatedCount: Int {
     // TODO: swift-3-indexing-model - review the following
-    return numericCast(count)
+    return count
   }
 
   /// The number of elements in the collection.
@@ -1213,17 +1213,17 @@ extension Collection {
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
     // TODO: swift-3-indexing-model - review the following
-    let count: Int = numericCast(self.count)
-    if count == 0 {
+    let n = self.count
+    if n == 0 {
       return []
     }
 
     var result = ContiguousArray<T>()
-    result.reserveCapacity(count)
+    result.reserveCapacity(n)
 
     var i = self.startIndex
 
-    for _ in 0..<count {
+    for _ in 0..<n {
       result.append(try transform(self[i]))
       formIndex(after: &i)
     }
@@ -1255,7 +1255,7 @@ extension Collection {
   public func dropFirst(_ n: Int) -> SubSequence {
     _precondition(n >= 0, "Can't drop a negative number of elements from a collection")
     let start = index(startIndex,
-      offsetBy: numericCast(n), limitedBy: endIndex) ?? endIndex
+      offsetBy: n, limitedBy: endIndex) ?? endIndex
     return self[start..<endIndex]
   }
 
@@ -1281,9 +1281,9 @@ extension Collection {
   public func dropLast(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
-    let amount = Swift.max(0, numericCast(count) - n)
+    let amount = Swift.max(0, count - n)
     let end = index(startIndex,
-      offsetBy: numericCast(amount), limitedBy: endIndex) ?? endIndex
+      offsetBy: amount, limitedBy: endIndex) ?? endIndex
     return self[startIndex..<end]
   }
   
@@ -1329,7 +1329,7 @@ extension Collection {
       maxLength >= 0,
       "Can't take a prefix of negative length from a collection")
     let end = index(startIndex,
-      offsetBy: numericCast(maxLength), limitedBy: endIndex) ?? endIndex
+      offsetBy: maxLength, limitedBy: endIndex) ?? endIndex
     return self[startIndex..<end]
   }
   
@@ -1376,9 +1376,9 @@ extension Collection {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")
-    let amount = Swift.max(0, numericCast(count) - maxLength)
+    let amount = Swift.max(0, count - maxLength)
     let start = index(startIndex,
-      offsetBy: numericCast(amount), limitedBy: endIndex) ?? endIndex
+      offsetBy: amount, limitedBy: endIndex) ?? endIndex
     return self[start..<endIndex]
   }
 
@@ -1677,9 +1677,9 @@ extension Collection where SubSequence == Self {
   public mutating func removeFirst(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= numericCast(n),
+    _precondition(count >= n,
       "Can't remove more items from a collection than it contains")
-    self = self[index(startIndex, offsetBy: numericCast(n))..<endIndex]
+    self = self[index(startIndex, offsetBy: n)..<endIndex]
   }
 }
 


### PR DESCRIPTION
...that slipped through when `IndexDistance` was eliminated.
