### PR TITLE
[Runtime] Improve representation of protocol conformance records

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -418,22 +418,23 @@ a `swift_conformsToProtocol()` query). Each protocol conformance record
 contains:
 
 - The `protocol descriptor`_ describing the protocol of the conformance,
-  represented as an indirect 32-bit offset relative to the field.
-- A reference to the metadata for the **conforming type**, represented as
-  an indirect 32-bit offset relative to the field, whose form is
-  determined by the **protocol conformance flags** described below.
+  represented as an (possibly indirect) 32-bit offset relative to the field.
+  The low bit indicates whether it is an indirect offset; the second lowest
+  bit is reserved for future use.
+- A reference to the **conforming type**, represented as a 32-bit offset
+  relative to the field. The lower two bits indicate how the conforming
+  type is represented:
+    0. A direct reference to a nominal type descriptor.
+    1. An indirect reference to a nominal type descriptor.
+    2. A reference to nonunique, foreign type metadata.
+    3. A reference to a pointer to an Objective-C class object.
 - The **witness table field** that provides access to the witness table
-  describing the conformance itself; the form of this field is determined by
-  the lower two bits, and can be one of:
+  describing the conformance itself, represented as a direct 32-bit relative
+  offset. The lower two bits indicate how the witness table is represented:
     0. The **witness table field** is a reference to a witness table.
     1. The **witness table field** is a reference to a **witness table
        accessor** function for an unconditional conformance.
     2. The **witness table field** is a reference to a **witness table
        accessor** function for a conditional conformance.
     3. Reserved for future use.
-  All references are direct 32-bit offsets relative to the field.
-- The **protocol conformance flags** is a 32-bit field comprised of:
-
-  * **Bits 0-3** contain the type metadata record kind, which indicates how
-    the **conforming type** field is encoded.
-
+- A 32-bit value reserved for future use.

--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -417,21 +417,23 @@ section, which is scanned by the Swift runtime when needed (e.g., in response to
 a `swift_conformsToProtocol()` query). Each protocol conformance record
 contains:
 
-- The `protocol descriptor`_ describing the protocol of the conformance.
-- A reference to the metadata for the **conforming type**, whose form is
+- The `protocol descriptor`_ describing the protocol of the conformance,
+  represented as an indirect 32-bit offset relative to the field.
+- A reference to the metadata for the **conforming type**, represented as
+  an indirect 32-bit offset relative to the field, whose form is
   determined by the **protocol conformance flags** described below.
 - The **witness table field** that provides access to the witness table
-  describing the conformance itself; the form of this field is determined by the
-  **protocol conformance flags** described below.
-- The **protocol conformance flags** is a 32-bit field comprised of:
-
-  * **Bits 0-3** contain the type metadata record kind, which indicates how
-    the **conforming type** field is encoded.
-  * **Bits 4-5** contain the kind of witness table. The value can be one of:
-
+  describing the conformance itself; the form of this field is determined by
+  the lower two bits, and can be one of:
     0. The **witness table field** is a reference to a witness table.
     1. The **witness table field** is a reference to a **witness table
        accessor** function for an unconditional conformance.
     2. The **witness table field** is a reference to a **witness table
        accessor** function for a conditional conformance.
+    3. Reserved for future use.
+  All references are direct 32-bit offsets relative to the field.
+- The **protocol conformance flags** is a 32-bit field comprised of:
+
+  * **Bits 0-3** contain the type metadata record kind, which indicates how
+    the **conforming type** field is encoded.
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -220,6 +220,8 @@ enum class ProtocolConformanceReferenceKind : unsigned {
   /// table whose conformance is conditional on additional requirements that
   /// must first be evaluated and then provided to the accessor function.
   ConditionalWitnessTableAccessor,
+  /// Reserved for future use.
+  Reserved,
 };
 
 // Type metadata record discriminant

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -253,13 +253,6 @@ public:
 
 // Protocol conformance discriminant
 struct ProtocolConformanceFlags : public TypeMetadataRecordFlags {
-private:
-  enum : int_type {
-    ConformanceKindMask = 0x00000030U,
-    ConformanceKindShift = 4,
-  };
-
-public:
   constexpr ProtocolConformanceFlags() : TypeMetadataRecordFlags(0) {}
   constexpr ProtocolConformanceFlags(int_type Data) : TypeMetadataRecordFlags(Data) {}
 
@@ -267,15 +260,6 @@ public:
                                         TypeMetadataRecordKind ptk) const {
     return ProtocolConformanceFlags(
                      (Data & ~TypeKindMask) | (int_type(ptk) << TypeKindShift));
-  }
-  constexpr ProtocolConformanceReferenceKind getConformanceKind() const {
-    return ProtocolConformanceReferenceKind((Data & ConformanceKindMask)
-                                     >> ConformanceKindShift);
-  }
-  constexpr ProtocolConformanceFlags withConformanceKind(
-                                  ProtocolConformanceReferenceKind pck) const {
-    return ProtocolConformanceFlags(
-       (Data & ~ConformanceKindMask) | (int_type(pck) << ConformanceKindShift));
   }
 };
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -192,21 +192,13 @@ enum class TypeMetadataRecordKind : unsigned {
   /// metadata.
   ///
   /// On platforms without ObjC interop, this indirection isn't necessary,
-  /// and classes could be emitted as UniqueDirectType.
+  /// and classes are emitted as UniqueDirectType.
   UniqueIndirectClass,
   
   /// The conformance is for a generic or resilient type.
   /// getNominalTypeDescriptor() points to the nominal type descriptor shared
   /// by all metadata instantiations of this type.
   UniqueNominalTypeDescriptor,
-  
-  /// The conformance is for a nongeneric class type.
-  /// getDirectType() points to the unique class object.
-  ///
-  /// FIXME: This shouldn't exist. On ObjC interop platforms, class references
-  /// must be indirected (using UniqueIndirectClass). On non-ObjC interop
-  /// platforms, the class object always is the type metadata.
-  UniqueDirectClass = 0xF,
 };
 
 /// Kinds of reference to protocol conformance.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -173,6 +173,14 @@ enum : unsigned {
   
 /// Kinds of type metadata/protocol conformance records.
 enum class TypeMetadataRecordKind : unsigned {
+  /// The conformance is for a nominal type referenced directly;
+  /// getNominalTypeDescriptor() points to the nominal type descriptor.
+  DirectNominalTypeDescriptor = 0x00,
+
+  /// The conformance is for a nominal type referenced directly;
+  /// getNominalTypeDescriptor() points to the nominal type descriptor.
+  IndirectNominalTypeDescriptor = 0x01,
+
   /// The conformance is for a nongeneric foreign struct or enum type.
   /// getDirectType() points to a nonunique metadata record for the type, which
   /// needs to be uniqued by the runtime.
@@ -186,11 +194,6 @@ enum class TypeMetadataRecordKind : unsigned {
   /// On platforms without ObjC interop, this indirection isn't necessary,
   /// and classes are emitted as UniqueDirectType.
   UniqueIndirectClass = 0x03,
-  
-  /// The conformance is for a generic or resilient type.
-  /// getNominalTypeDescriptor() points to the nominal type descriptor shared
-  /// by all metadata instantiations of this type.
-  UniqueNominalTypeDescriptor = 0x04,
 };
 
 /// Kinds of reference to protocol conformance.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -173,18 +173,10 @@ enum : unsigned {
   
 /// Kinds of type metadata/protocol conformance records.
 enum class TypeMetadataRecordKind : unsigned {
-  /// The conformance is universal and might apply to any type.
-  /// getDirectType() is nil.
-  Universal,
-
-  /// The conformance is for a nongeneric native struct or enum type.
-  /// getDirectType() points to the canonical metadata for the type.
-  UniqueDirectType,
-  
   /// The conformance is for a nongeneric foreign struct or enum type.
   /// getDirectType() points to a nonunique metadata record for the type, which
   /// needs to be uniqued by the runtime.
-  NonuniqueDirectType,
+  NonuniqueDirectType = 0x02,
   
   /// The conformance is for a nongeneric class type.
   /// getIndirectClass() points to a variable that contains the pointer to the
@@ -193,12 +185,12 @@ enum class TypeMetadataRecordKind : unsigned {
   ///
   /// On platforms without ObjC interop, this indirection isn't necessary,
   /// and classes are emitted as UniqueDirectType.
-  UniqueIndirectClass,
+  UniqueIndirectClass = 0x03,
   
   /// The conformance is for a generic or resilient type.
   /// getNominalTypeDescriptor() points to the nominal type descriptor shared
   /// by all metadata instantiations of this type.
-  UniqueNominalTypeDescriptor,
+  UniqueNominalTypeDescriptor = 0x04,
 };
 
 /// Kinds of reference to protocol conformance.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -177,23 +177,23 @@ enum class TypeMetadataRecordKind : unsigned {
   /// getNominalTypeDescriptor() points to the nominal type descriptor.
   DirectNominalTypeDescriptor = 0x00,
 
-  /// The conformance is for a nominal type referenced directly;
+  /// The conformance is for a nominal type referenced indirectly;
   /// getNominalTypeDescriptor() points to the nominal type descriptor.
   IndirectNominalTypeDescriptor = 0x01,
 
-  /// The conformance is for a nongeneric foreign struct or enum type.
+  /// The conformance is for a foreign type described by its type metadata.
   /// getDirectType() points to a nonunique metadata record for the type, which
   /// needs to be uniqued by the runtime.
   NonuniqueDirectType = 0x02,
   
-  /// The conformance is for a nongeneric class type.
-  /// getIndirectClass() points to a variable that contains the pointer to the
-  /// class object, which may be ObjC and thus require a runtime call to get
-  /// metadata.
+  /// The conformance is for an Objective-C class that has no nominal type
+  /// descriptor.
+  /// getIndirectObjCClass() points to a variable that contains the pointer to
+  /// the class object, which then requires a runtime call to get metadata.
   ///
-  /// On platforms without ObjC interop, this indirection isn't necessary,
-  /// and classes are emitted as UniqueDirectType.
-  UniqueIndirectClass = 0x03,
+  /// On platforms without Objective-C interoperability, this case is
+  /// unused.
+  IndirectObjCClass = 0x03,
 };
 
 /// Kinds of reference to protocol conformance.

--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -398,9 +398,6 @@ class RelativeDirectPointerIntPair {
     = delete;
 
   static Offset getMask() {
-    static_assert(alignof(PointeeTy) >= alignof(Offset),
-                 "pointee alignment must be at least as strict as offset type");
-
     return alignof(Offset) - 1;
   }
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2481,7 +2481,6 @@ public:
 
     case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
-    case TypeMetadataRecordKind::UniqueDirectClass:
       break;
         
     case TypeMetadataRecordKind::UniqueIndirectClass:
@@ -2501,7 +2500,6 @@ public:
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       break;
         
-    case TypeMetadataRecordKind::UniqueDirectClass:
     case TypeMetadataRecordKind::UniqueIndirectClass:
     case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
@@ -2595,33 +2593,12 @@ public:
     case TypeMetadataRecordKind::NonuniqueDirectType:
       break;
         
-    case TypeMetadataRecordKind::UniqueDirectClass:
     case TypeMetadataRecordKind::UniqueIndirectClass:
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       assert(false && "not direct type metadata");
     }
 
     return DirectType;
-  }
-  
-  // FIXME: This shouldn't exist
-  const TargetClassMetadata<Runtime> *getDirectClass() const {
-    switch (Flags.getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      return nullptr;
-    case TypeMetadataRecordKind::UniqueDirectClass:
-      break;
-        
-    case TypeMetadataRecordKind::UniqueDirectType:
-    case TypeMetadataRecordKind::NonuniqueDirectType:
-    case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
-    case TypeMetadataRecordKind::UniqueIndirectClass:
-      assert(false && "not direct class object");
-    }
-
-    const TargetMetadata<Runtime> *metadata = DirectType;
-    return static_cast<const TargetClassMetadata<Runtime>*>(metadata);
-    
   }
   
   const TargetClassMetadata<Runtime> * const *getIndirectClass() const {
@@ -2633,7 +2610,6 @@ public:
       break;
         
     case TypeMetadataRecordKind::UniqueDirectType:
-    case TypeMetadataRecordKind::UniqueDirectClass:
     case TypeMetadataRecordKind::NonuniqueDirectType:
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       assert(false && "not indirect class object");
@@ -2651,7 +2627,6 @@ public:
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       break;
         
-    case TypeMetadataRecordKind::UniqueDirectClass:
     case TypeMetadataRecordKind::UniqueIndirectClass:
     case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2460,23 +2460,22 @@ private:
   // Some description of the type that is resolvable at runtime.
   union {
     /// A direct reference to the metadata.
-    RelativeDirectPointer<const TargetMetadata<Runtime>> DirectType;
+    RelativeDirectPointerIntPair<const TargetMetadata<Runtime>,
+                                 TypeMetadataRecordKind> DirectType;
 
     /// The nominal type descriptor for a resilient or generic type.
-    RelativeDirectPointer<TargetNominalTypeDescriptor<Runtime>>
+    RelativeDirectPointerIntPair<TargetNominalTypeDescriptor<Runtime>,
+                                 TypeMetadataRecordKind>
       TypeDescriptor;
   };
 
-  /// Flags describing the type metadata record.
-  TypeMetadataRecordFlags Flags;
-  
 public:
   TypeMetadataRecordKind getTypeKind() const {
-    return Flags.getTypeKind();
+    return DirectType.getInt();
   }
   
   const TargetMetadata<Runtime> *getDirectType() const {
-    switch (Flags.getTypeKind()) {
+    switch (getTypeKind()) {
     case TypeMetadataRecordKind::NonuniqueDirectType:
       break;
         
@@ -2486,12 +2485,12 @@ public:
       assert(false && "not direct type metadata");
     }
 
-    return this->DirectType;
+    return this->DirectType.getPointer();
   }
 
   const TargetNominalTypeDescriptor<Runtime> *
   getNominalTypeDescriptor() const {
-    switch (Flags.getTypeKind()) {
+    switch (getTypeKind()) {
     case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
       break;
         
@@ -2501,7 +2500,7 @@ public:
       assert(false && "not generic metadata pattern");
     }
     
-    return this->TypeDescriptor;
+    return this->TypeDescriptor.getPointer();
   }
 
   /// Get the canonical metadata for the type referenced by this record, or

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2464,7 +2464,7 @@ private:
 
     /// The nominal type descriptor for a resilient or generic type.
     RelativeDirectPointer<TargetNominalTypeDescriptor<Runtime>>
-    TypeDescriptor;
+      TypeDescriptor;
   };
 
   /// Flags describing the type metadata record.
@@ -2477,10 +2477,6 @@ public:
   
   const TargetMetadata<Runtime> *getDirectType() const {
     switch (Flags.getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      return nullptr;
-
-    case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
       break;
         
@@ -2495,14 +2491,10 @@ public:
   const TargetNominalTypeDescriptor<Runtime> *
   getNominalTypeDescriptor() const {
     switch (Flags.getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      return nullptr;
-
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       break;
         
     case TypeMetadataRecordKind::UniqueIndirectClass:
-    case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
       assert(false && "not generic metadata pattern");
     }
@@ -2587,10 +2579,6 @@ public:
   
   const TargetMetadata<Runtime> *getDirectType() const {
     switch (Flags.getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      return nullptr;
-
-    case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
       break;
         
@@ -2604,13 +2592,9 @@ public:
   
   const TargetClassMetadata<Runtime> * const *getIndirectClass() const {
     switch (Flags.getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      return nullptr;
-
     case TypeMetadataRecordKind::UniqueIndirectClass:
       break;
         
-    case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       assert(false && "not indirect class object");
@@ -2622,14 +2606,10 @@ public:
   const TargetNominalTypeDescriptor<Runtime> *
   getNominalTypeDescriptor() const {
     switch (Flags.getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      return nullptr;
-
     case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
       break;
         
     case TypeMetadataRecordKind::UniqueIndirectClass:
-    case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
       assert(false && "not generic metadata pattern");
     }

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2566,9 +2566,9 @@ private:
                                  ProtocolConformanceReferenceKind>
       WitnessTableAccessor;
   };
-  
-  /// Flags describing the protocol conformance.
-  ProtocolConformanceFlags UnusedFlags;
+
+  /// Reserved word.
+  unsigned Reserved;
   
 public:
   const ProtocolDescriptor *getProtocol() const {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2665,6 +2665,9 @@ public:
     case ProtocolConformanceReferenceKind::WitnessTableAccessor:
     case ProtocolConformanceReferenceKind::ConditionalWitnessTableAccessor:
       assert(false && "not witness table");
+
+    case ProtocolConformanceReferenceKind::Reserved:
+      break;
     }
     return WitnessTable;
   }
@@ -2673,6 +2676,7 @@ public:
     switch (Flags.getConformanceKind()) {
     case ProtocolConformanceReferenceKind::WitnessTableAccessor:
     case ProtocolConformanceReferenceKind::ConditionalWitnessTableAccessor:
+    case ProtocolConformanceReferenceKind::Reserved:
       break;
         
     case ProtocolConformanceReferenceKind::WitnessTable:

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2543,12 +2543,12 @@ private:
     
     /// An indirect reference to the metadata.
     RelativeIndirectablePointer<const TargetClassMetadata<Runtime> *>
-    IndirectClass;
+      IndirectClass;
     
     /// The nominal type descriptor for a resilient or generic type which has
     /// instances that conform to the protocol.
     RelativeIndirectablePointer<TargetNominalTypeDescriptor<Runtime>>
-    TypeDescriptor;
+      TypeDescriptor;
   };
   
   

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2555,11 +2555,15 @@ private:
   // The conformance, or a generator function for the conformance.
   union {
     /// A direct reference to the witness table for the conformance.
-    RelativeDirectPointer<const WitnessTable> WitnessTable;
+    RelativeDirectPointerIntPair<const WitnessTable,
+                                 ProtocolConformanceReferenceKind>
+      WitnessTable;
     
     /// A function that produces the witness table given an instance of the
     /// type.
-    RelativeDirectPointer<WitnessTableAccessorFn> WitnessTableAccessor;
+    RelativeDirectPointerIntPair<WitnessTableAccessorFn,
+                                 ProtocolConformanceReferenceKind>
+      WitnessTableAccessor;
   };
   
   /// Flags describing the protocol conformance.
@@ -2569,7 +2573,7 @@ public:
   const ProtocolDescriptor *getProtocol() const {
     return Protocol;
   }
-  
+
   ProtocolConformanceFlags getFlags() const {
     return Flags;
   }
@@ -2577,8 +2581,9 @@ public:
   TypeMetadataRecordKind getTypeKind() const {
     return Flags.getTypeKind();
   }
+
   ProtocolConformanceReferenceKind getConformanceKind() const {
-    return Flags.getConformanceKind();
+    return WitnessTable.getInt();
   }
   
   const TargetMetadata<Runtime> *getDirectType() const {
@@ -2658,7 +2663,7 @@ public:
   
   /// Get the directly-referenced static witness table.
   const swift::WitnessTable *getStaticWitnessTable() const {
-    switch (Flags.getConformanceKind()) {
+    switch (getConformanceKind()) {
     case ProtocolConformanceReferenceKind::WitnessTable:
       break;
         
@@ -2669,11 +2674,11 @@ public:
     case ProtocolConformanceReferenceKind::Reserved:
       break;
     }
-    return WitnessTable;
+    return WitnessTable.getPointer();
   }
   
   WitnessTableAccessorFn *getWitnessTableAccessor() const {
-    switch (Flags.getConformanceKind()) {
+    switch (getConformanceKind()) {
     case ProtocolConformanceReferenceKind::WitnessTableAccessor:
     case ProtocolConformanceReferenceKind::ConditionalWitnessTableAccessor:
     case ProtocolConformanceReferenceKind::Reserved:
@@ -2682,7 +2687,7 @@ public:
     case ProtocolConformanceReferenceKind::WitnessTable:
       assert(false && "not witness table accessor");
     }
-    return WitnessTableAccessor;
+    return WitnessTableAccessor.getPointer();
   }
   
   /// Get the canonical metadata for the type referenced by this record, or

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -727,6 +727,7 @@ template <typename Runtime> struct TargetGenericMetadata;
 template <typename Runtime> struct TargetClassMetadata;
 template <typename Runtime> struct TargetStructMetadata;
 template <typename Runtime> struct TargetOpaqueMetadata;
+template <typename Runtime> struct TargetValueMetadata;
 
 // FIXME: https://bugs.swift.org/browse/SR-1155
 #pragma clang diagnostic push
@@ -902,7 +903,7 @@ public:
     case MetadataKind::Struct:
     case MetadataKind::Enum:
     case MetadataKind::Optional:
-      return static_cast<const TargetStructMetadata<Runtime> *>(this)
+      return static_cast<const TargetValueMetadata<Runtime> *>(this)
           ->Description;
     case MetadataKind::ForeignClass:
     case MetadataKind::Opaque:

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/TypeMemberVisitor.h"
 #include "swift/AST/Types.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
@@ -2339,13 +2340,6 @@ bool irgen::doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
 bool irgen::doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
                                                        CanType conformingType) {
   NominalTypeDecl *nom = conformingType->getAnyNominal();
-  auto *clas = dyn_cast<ClassDecl>(nom);
-  if (nom->isGenericContext() && (!clas || !clas->usesObjCGenericsModel()))
-    return true;
-
-  if (clas && doesClassMetadataRequireDynamicInitialization(IGM, clas))
-    return true;
-
-  return false;
+  return !isa<ClangModuleUnit>(nom->getModuleScopeContext());
 }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2227,7 +2227,7 @@ getTypeEntityInfo(IRGenModule &IGM, CanType conformingType) {
     // Form the class reference.
     (void)IGM.getAddrOfObjCClassRef(clas);
 
-    typeKind = TypeMetadataRecordKind::UniqueIndirectClass;
+    typeKind = TypeMetadataRecordKind::IndirectObjCClass;
     entity = LinkEntity::forObjCClassRef(clas);
     defaultTy = IGM.TypeMetadataPtrTy;
     defaultPtrTy = IGM.TypeMetadataPtrTy;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2218,7 +2218,7 @@ getTypeEntityInfo(IRGenModule &IGM, CanType conformingType) {
       defaultPtrTy = IGM.TypeMetadataPtrTy;
     } else {
       if (hasKnownSwiftMetadata(IGM, clas)) {
-        typeKind = TypeMetadataRecordKind::UniqueDirectClass;
+        typeKind = TypeMetadataRecordKind::UniqueDirectType;
         entity = LinkEntity::forTypeMetadata(
                          conformingType,
                          TypeMetadataAddress::AddressPoint,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2385,13 +2385,13 @@ llvm::Constant *IRGenModule::emitProtocolConformances() {
   StringRef sectionName;
   switch (TargetInfo.OutputObjectFormat) {
   case llvm::Triple::MachO:
-    sectionName = "__TEXT, __swift2_proto, regular, no_dead_strip";
+    sectionName = "__TEXT, __swift5_proto, regular, no_dead_strip";
     break;
   case llvm::Triple::ELF:
-    sectionName = "swift2_protocol_conformances";
+    sectionName = "swift5_protocol_conformances";
     break;
   case llvm::Triple::COFF:
-    sectionName = ".sw2prtc$B";
+    sectionName = ".sw5prtc$B";
     break;
   default:
     llvm_unreachable("Don't know how to emit protocol conformances for "

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -304,8 +304,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   TypeMetadataRecordTy
     = createStructType(*this, "swift.type_metadata_record", {
-      RelativeAddressTy,
-      Int32Ty
+      RelativeAddressTy
     });
   TypeMetadataRecordPtrTy
     = TypeMetadataRecordTy->getPointerTo(DefaultAS);

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -41,7 +41,7 @@ void swift::initializeProtocolConformanceLookup() {
   const swift::MetadataSections *sections = registered;
   while (true) {
     const swift::MetadataSections::Range &conformances =
-        sections->swift2_protocol_conformances;
+        sections->swift5_protocol_conformances;
     if (conformances.length)
       addImageProtocolConformanceBlockCallback(reinterpret_cast<void *>(conformances.start),
                                                conformances.length);
@@ -74,7 +74,7 @@ void swift_addNewDSOImage(const void *addr) {
 
   record(sections);
 
-  const auto &protocol_conformances = sections->swift2_protocol_conformances;
+  const auto &protocol_conformances = sections->swift5_protocol_conformances;
   const void *conformances =
       reinterpret_cast<void *>(protocol_conformances.start);
   if (protocol_conformances.length)

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -56,7 +56,7 @@ void swift::initializeTypeMetadataRecordLookup() {
   const swift::MetadataSections *sections = registered;
   while (true) {
     const swift::MetadataSections::Range &type_metadata =
-        sections->swift2_type_metadata;
+        sections->swift5_type_metadata;
     if (type_metadata.length)
       addImageTypeMetadataRecordBlockCallback(reinterpret_cast<void *>(type_metadata.start),
                                               type_metadata.length);
@@ -81,7 +81,7 @@ void swift_addNewDSOImage(const void *addr) {
     addImageProtocolConformanceBlockCallback(conformances,
                                              protocol_conformances.length);
 
-  const auto &type_metadata = sections->swift2_type_metadata;
+  const auto &type_metadata = sections->swift5_type_metadata;
   const void *metadata = reinterpret_cast<void *>(type_metadata.start);
   if (type_metadata.length)
     addImageTypeMetadataRecordBlockCallback(metadata, type_metadata.length);

--- a/stdlib/public/runtime/ImageInspectionCOFF.h
+++ b/stdlib/public/runtime/ImageInspectionCOFF.h
@@ -45,7 +45,7 @@ struct MetadataSections {
     size_t length;
   };
 
-  Range swift2_protocol_conformances;
+  Range swift5_protocol_conformances;
   Range swift2_type_metadata;
   Range swift3_typeref;
   Range swift3_reflstr;

--- a/stdlib/public/runtime/ImageInspectionCOFF.h
+++ b/stdlib/public/runtime/ImageInspectionCOFF.h
@@ -46,7 +46,7 @@ struct MetadataSections {
   };
 
   Range swift5_protocol_conformances;
-  Range swift2_type_metadata;
+  Range swift5_type_metadata;
   Range swift3_typeref;
   Range swift3_reflstr;
   Range swift3_fieldmd;

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -61,7 +61,7 @@ void swift::initializeTypeMetadataRecordLookup() {
   const swift::MetadataSections *sections = registered;
   while (true) {
     const swift::MetadataSections::Range &type_metadata =
-        sections->swift2_type_metadata;
+        sections->swift5_type_metadata;
     if (type_metadata.length)
       addImageTypeMetadataRecordBlockCallback(reinterpret_cast<void *>(type_metadata.start),
                                               type_metadata.length);
@@ -90,7 +90,7 @@ void swift_addNewDSOImage(const void *addr) {
     addImageProtocolConformanceBlockCallback(conformances,
                                              protocol_conformances.length);
 
-  const auto &type_metadata = sections->swift2_type_metadata;
+  const auto &type_metadata = sections->swift5_type_metadata;
   const void *metadata = reinterpret_cast<void *>(type_metadata.start);
   if (type_metadata.length)
     addImageTypeMetadataRecordBlockCallback(metadata, type_metadata.length);

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -46,7 +46,7 @@ void swift::initializeProtocolConformanceLookup() {
   const swift::MetadataSections *sections = registered;
   while (true) {
     const swift::MetadataSections::Range &conformances =
-        sections->swift2_protocol_conformances;
+        sections->swift5_protocol_conformances;
     if (conformances.length)
       addImageProtocolConformanceBlockCallback(reinterpret_cast<void *>(conformances.start),
                                                conformances.length);
@@ -83,7 +83,7 @@ void swift_addNewDSOImage(const void *addr) {
 
   record(sections);
 
-  const auto &protocol_conformances = sections->swift2_protocol_conformances;
+  const auto &protocol_conformances = sections->swift5_protocol_conformances;
   const void *conformances =
       reinterpret_cast<void *>(protocol_conformances.start);
   if (protocol_conformances.length)

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -45,7 +45,7 @@ struct MetadataSections {
     size_t length;
   };
 
-  Range swift2_protocol_conformances;
+  Range swift5_protocol_conformances;
   Range swift2_type_metadata;
   Range swift3_typeref;
   Range swift3_reflstr;

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -46,7 +46,7 @@ struct MetadataSections {
   };
 
   Range swift5_protocol_conformances;
-  Range swift2_type_metadata;
+  Range swift5_type_metadata;
   Range swift3_typeref;
   Range swift3_reflstr;
   Range swift3_fieldmd;

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -34,7 +34,7 @@ namespace {
 constexpr const char ProtocolConformancesSection[] = "__swift5_proto";
 /// The Mach-O section name for the section containing type references.
 /// This lives within SEG_TEXT.
-constexpr const char TypeMetadataRecordSection[] = "__swift2_types";
+constexpr const char TypeMetadataRecordSection[] = "__swift5_types";
 
 template<const char *SECTION_NAME,
          void CONSUME_BLOCK(const void *start, uintptr_t size)>

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -31,7 +31,7 @@ using namespace swift;
 namespace {
 /// The Mach-O section name for the section containing protocol conformances.
 /// This lives within SEG_TEXT.
-constexpr const char ProtocolConformancesSection[] = "__swift2_proto";
+constexpr const char ProtocolConformancesSection[] = "__swift5_proto";
 /// The Mach-O section name for the section containing type references.
 /// This lives within SEG_TEXT.
 constexpr const char TypeMetadataRecordSection[] = "__swift2_types";
@@ -46,7 +46,7 @@ void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
   using mach_header_platform = mach_header;
 #endif
   
-  // Look for a __swift2_proto section.
+  // Look for a __swift5_proto section.
   unsigned long size;
   const uint8_t *section =
   getsectiondata(reinterpret_cast<const mach_header_platform *>(mh),

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -135,13 +135,6 @@ const Metadata *TypeMetadataRecord::getCanonicalTypeMetadata() const {
         static_cast<const ForeignTypeMetadata *>(getDirectType());
     return swift_getForeignTypeMetadata(const_cast<ForeignTypeMetadata *>(FMD));
   }
-  case TypeMetadataRecordKind::UniqueDirectClass:
-    if (auto *ClassMetadata =
-          static_cast<const ::ClassMetadata *>(getDirectType())) {
-      return getMetadataForClass(ClassMetadata);
-    }
-    else
-      return nullptr;
   default:
     return nullptr;
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -128,8 +128,6 @@ swift::swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
 template<>
 const Metadata *TypeMetadataRecord::getCanonicalTypeMetadata() const {
   switch (getTypeKind()) {
-  case TypeMetadataRecordKind::UniqueDirectType:
-    return getDirectType();
   case TypeMetadataRecordKind::NonuniqueDirectType: {
     const ForeignTypeMetadata *FMD =
         static_cast<const ForeignTypeMetadata *>(getDirectType());

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -48,14 +48,8 @@ template<> void ProtocolConformanceRecord::dump() const {
   };
 
   switch (auto kind = getTypeKind()) {
-    case TypeMetadataRecordKind::Universal:
-      printf("universal");
-      break;
-    case TypeMetadataRecordKind::UniqueDirectType:
     case TypeMetadataRecordKind::NonuniqueDirectType:
-      printf("%s direct type ",
-             kind == TypeMetadataRecordKind::UniqueDirectType
-             ? "unique" : "nonunique");
+      printf("direct type nonunique ");
       if (const auto *ntd = getDirectType()->getNominalTypeDescriptor()) {
         printf("%s", ntd->Name.get());
       } else {
@@ -99,9 +93,6 @@ template<> void ProtocolConformanceRecord::dump() const {
 template <>
 const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
   switch (getTypeKind()) {
-  case TypeMetadataRecordKind::UniqueDirectType:
-    // Already unique.
-    return getDirectType();
   case TypeMetadataRecordKind::NonuniqueDirectType: {
     // Ask the runtime for the unique metadata record we've canonized.
     const ForeignTypeMetadata *FMD =
@@ -117,8 +108,6 @@ const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
     return nullptr;
       
   case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
-  case TypeMetadataRecordKind::Universal:
-    // The record does not apply to a single type.
     return nullptr;
   }
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -90,6 +90,9 @@ template<> void ProtocolConformanceRecord::dump() const {
       printf("conditional witness table accessor %s\n",
              symbolName((const void *)(uintptr_t)getWitnessTableAccessor()));
       break;
+    case ProtocolConformanceReferenceKind::Reserved:
+      printf("reserved witness table kind\n");
+      break;
   }
 }
 #endif
@@ -165,6 +168,9 @@ const {
             typeName.c_str(), demangledProtocolName.c_str());
     return nullptr;
   }
+
+  case ProtocolConformanceReferenceKind::Reserved:
+    return nullptr;
   }
 
   swift_runtime_unreachable(
@@ -591,6 +597,11 @@ swift::swift_conformsToProtocol(const Metadata * const type,
           C.cacheSuccess(type, P, record.getWitnessTable(type));
           break;
 
+        case ProtocolConformanceReferenceKind::Reserved:
+          // Always fail, because we cannot interpret a future conformance
+          // kind.
+          C.cacheFailure(metadata, P);
+          break;
         }
       }
     }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -62,10 +62,6 @@ template<> void ProtocolConformanceRecord::dump() const {
         printf("<structural type>");
       }
       break;
-    case TypeMetadataRecordKind::UniqueDirectClass:
-      printf("unique direct class %s",
-             class_getName(getDirectClass()));
-      break;
     case TypeMetadataRecordKind::UniqueIndirectClass:
       printf("unique indirect class %s",
              class_getName(*getIndirectClass()));
@@ -117,13 +113,6 @@ const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
     // metadata. The class additionally may be weak-linked, so we have to check
     // for null.
     if (auto *ClassMetadata = *getIndirectClass())
-      return getMetadataForClass(ClassMetadata);
-    return nullptr;
-      
-  case TypeMetadataRecordKind::UniqueDirectClass:
-    // The class may be ObjC, in which case we need to instantiate its Swift
-    // metadata.
-    if (auto *ClassMetadata = getDirectClass())
       return getMetadataForClass(ClassMetadata);
     return nullptr;
       

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -56,9 +56,9 @@ template<> void ProtocolConformanceRecord::dump() const {
         printf("<structural type>");
       }
       break;
-    case TypeMetadataRecordKind::UniqueIndirectClass:
-      printf("unique indirect class %s",
-             class_getName(*getIndirectClass()));
+    case TypeMetadataRecordKind::IndirectObjCClass:
+      printf("indirect Objective-C class %s",
+             class_getName(*getIndirectObjCClass()));
       break;
       
     case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
@@ -100,11 +100,11 @@ const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
         static_cast<const ForeignTypeMetadata *>(getDirectType());
     return swift_getForeignTypeMetadata(const_cast<ForeignTypeMetadata *>(FMD));
   }
-  case TypeMetadataRecordKind::UniqueIndirectClass:
+  case TypeMetadataRecordKind::IndirectObjCClass:
     // The class may be ObjC, in which case we need to instantiate its Swift
     // metadata. The class additionally may be weak-linked, so we have to check
     // for null.
-    if (auto *ClassMetadata = *getIndirectClass())
+    if (auto *ClassMetadata = *getIndirectObjCClass())
       return getMetadataForClass(ClassMetadata);
     return nullptr;
       

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -61,7 +61,8 @@ template<> void ProtocolConformanceRecord::dump() const {
              class_getName(*getIndirectClass()));
       break;
       
-    case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
+    case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
+    case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
       printf("unique nominal type descriptor %s", symbolName(getNominalTypeDescriptor()));
       break;
   }
@@ -107,7 +108,8 @@ const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
       return getMetadataForClass(ClassMetadata);
     return nullptr;
       
-  case TypeMetadataRecordKind::UniqueNominalTypeDescriptor:
+  case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
+  case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
     return nullptr;
   }
 
@@ -548,8 +550,9 @@ swift::swift_conformsToProtocol(const Metadata * const type,
       // An accessor function might still be necessary even if the witness table
       // can be shared.
       } else if (record.getTypeKind()
-                   == TypeMetadataRecordKind::UniqueNominalTypeDescriptor) {
-
+                   == TypeMetadataRecordKind::DirectNominalTypeDescriptor ||
+                 record.getTypeKind()
+                  == TypeMetadataRecordKind::IndirectNominalTypeDescriptor) {
         auto R = record.getNominalTypeDescriptor();
         auto P = record.getProtocol();
 

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -25,7 +25,7 @@
 
 extern "C" {
 DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
-DECLARE_SWIFT_SECTION(swift2_type_metadata)
+DECLARE_SWIFT_SECTION(swift5_type_metadata)
 
 DECLARE_SWIFT_SECTION(swift3_typeref)
 DECLARE_SWIFT_SECTION(swift3_reflstr)
@@ -53,7 +53,7 @@ static void swift_image_constructor() {
       nullptr,
 
       SWIFT_SECTION_RANGE(swift5_protocol_conformances),
-      SWIFT_SECTION_RANGE(swift2_type_metadata),
+      SWIFT_SECTION_RANGE(swift5_type_metadata),
 
       SWIFT_SECTION_RANGE(swift3_typeref),
       SWIFT_SECTION_RANGE(swift3_reflstr),

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -24,7 +24,7 @@
   __attribute__((__visibility__("hidden"))) extern const char __stop_##name;
 
 extern "C" {
-DECLARE_SWIFT_SECTION(swift2_protocol_conformances)
+DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
 DECLARE_SWIFT_SECTION(swift2_type_metadata)
 
 DECLARE_SWIFT_SECTION(swift3_typeref)
@@ -52,7 +52,7 @@ static void swift_image_constructor() {
       nullptr,
       nullptr,
 
-      SWIFT_SECTION_RANGE(swift2_protocol_conformances),
+      SWIFT_SECTION_RANGE(swift5_protocol_conformances),
       SWIFT_SECTION_RANGE(swift2_type_metadata),
 
       SWIFT_SECTION_RANGE(swift3_typeref),

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -3,7 +3,7 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"\01l_protocol_conformances" = {{.*}} @"got.OBJC_CLASS_$_Thingy"
+// CHECK: @"\01l_protocol_conformances" = {{.*}} @"OBJC_CLASS_REF_$_Thingy"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -16,7 +16,7 @@ public protocol Runcible {
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVAA8RuncibleAAWP
-// -- flags 0x00: direct nominal type descriptor
+// -- reserved
 // CHECK-SAME:           i32 0
 // CHECK-SAME:         },
 public struct NativeValueType: Runcible {
@@ -30,7 +30,7 @@ public struct NativeValueType: Runcible {
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP
-// -- flags 0x00: direct nominal type descriptor
+// -- reserved
 // CHECK-SAME:           i32 0
 // CHECK-SAME:         },
 public class NativeClassType: Runcible {
@@ -44,7 +44,7 @@ public class NativeClassType: Runcible {
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAWP
-// -- flags 0x00: direct nominal type descriptor
+// -- reserved
 // CHECK-SAME:           i32 0
 // CHECK-SAME:         },
 public struct NativeGenericType<T>: Runcible {
@@ -58,7 +58,7 @@ public struct NativeGenericType<T>: Runcible {
 // CHECK-SAME:           @got._T0SiMn
 // -- witness table
 // CHECK-SAME:           @_T0Si28protocol_conformance_records8RuncibleAAWP
-// -- flags 0x00: direct nominal type descriptor
+// -- reserved
 // CHECK-SAME:           i32 0
 // CHECK-SAME:         }
 extension Int: Runcible {
@@ -74,7 +74,7 @@ extension Int: Runcible {
 // CHECK-SAME:           @got._T016resilient_struct4SizeVMn
 // -- witness table
 // CHECK-SAME:           @_T016resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP
-// -- flags 0x00: direct nominal type descriptor
+// -- reserved
 // CHECK-SAME:           i32 0
 // CHECK-SAME:         }
 
@@ -93,7 +93,7 @@ public protocol Spoon { }
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVMn
 // -- witness table accessor
 // CHECK-SAME:           i32 add{{.*}}@_T028protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlWa{{.*}}i32 2),
-// -- flags 0x00: direct nominal type descriptor
+// -- reserved
 // CHECK-SAME:           i32 0
 // CHECK-SAME:         }
 extension NativeGenericType : Spoon where T: Spoon {

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -93,9 +93,9 @@ public protocol Spoon { }
 // -- nominal type descriptor
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVMn
 // -- witness table accessor
-// CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlWa
-// -- flags 0x04: unique nominal type descriptor + conditional accessor
-// CHECK-SAME:           i32 36
+// CHECK-SAME:           i32 add{{.*}}@_T028protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlWa{{.*}}i32 2),
+// -- flags 0x04: unique nominal type descriptor
+// CHECK-SAME:           i32 4
 // CHECK-SAME:         }
 extension NativeGenericType : Spoon where T: Spoon {
   public func runce() {}

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -13,11 +13,11 @@ public protocol Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE:@_T028protocol_conformance_records8RuncibleMp]]
 // -- type metadata
-// CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVMf
+// CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVAA8RuncibleAAWP
-// -- flags 0x01: unique direct metadata
-// CHECK-SAME:           i32 1
+// -- flags 0x04: unique nominal type descriptor
+// CHECK-SAME:           i32 4
 // CHECK-SAME:         },
 public struct NativeValueType: Runcible {
   public func runce() {}
@@ -27,11 +27,11 @@ public struct NativeValueType: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class metadata
-// CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCMf
+// CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP
-// -- flags 0x01: unique direct metadata
-// CHECK-SAME:           i32 1
+// -- flags 0x04: unique nominal type descriptor
+// CHECK-SAME:           i32 4
 // CHECK-SAME:         },
 public class NativeClassType: Runcible {
   public func runce() {}
@@ -55,11 +55,11 @@ public struct NativeGenericType<T>: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- type metadata
-// CHECK-SAME:           @got._T0SiN
+// CHECK-SAME:           @got._T0SiMn
 // -- witness table
 // CHECK-SAME:           @_T0Si28protocol_conformance_records8RuncibleAAWP
-// -- flags 0x01: unique direct metadata
-// CHECK-SAME:           i32 1
+// -- flags 0x04: unique nominal type descriptor
+// CHECK-SAME:           i32 4
 // CHECK-SAME:         }
 extension Int: Runcible {
   public func runce() {}
@@ -71,11 +71,11 @@ extension Int: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
-// CHECK-SAME:           @got._T016resilient_struct4SizeVN
+// CHECK-SAME:           @got._T016resilient_struct4SizeVMn
 // -- witness table
 // CHECK-SAME:           @_T016resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP
-// -- flags 0x01: unique direct metadata
-// CHECK-SAME:           i32 1
+// -- flags 0x04: unique nominal type descriptor
+// CHECK-SAME:           i32 4
 // CHECK-SAME:         }
 
 extension Size: Runcible {

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -16,8 +16,8 @@ public protocol Runcible {
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeValueTypeVAA8RuncibleAAWP
-// -- flags 0x04: unique nominal type descriptor
-// CHECK-SAME:           i32 4
+// -- flags 0x00: direct nominal type descriptor
+// CHECK-SAME:           i32 0
 // CHECK-SAME:         },
 public struct NativeValueType: Runcible {
   public func runce() {}
@@ -30,8 +30,8 @@ public struct NativeValueType: Runcible {
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP
-// -- flags 0x04: unique nominal type descriptor
-// CHECK-SAME:           i32 4
+// -- flags 0x00: direct nominal type descriptor
+// CHECK-SAME:           i32 0
 // CHECK-SAME:         },
 public class NativeClassType: Runcible {
   public func runce() {}
@@ -44,8 +44,8 @@ public class NativeClassType: Runcible {
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVMn
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAWP
-// -- flags 0x04: unique nominal type descriptor
-// CHECK-SAME:           i32 4
+// -- flags 0x00: direct nominal type descriptor
+// CHECK-SAME:           i32 0
 // CHECK-SAME:         },
 public struct NativeGenericType<T>: Runcible {
   public func runce() {}
@@ -58,8 +58,8 @@ public struct NativeGenericType<T>: Runcible {
 // CHECK-SAME:           @got._T0SiMn
 // -- witness table
 // CHECK-SAME:           @_T0Si28protocol_conformance_records8RuncibleAAWP
-// -- flags 0x04: unique nominal type descriptor
-// CHECK-SAME:           i32 4
+// -- flags 0x00: direct nominal type descriptor
+// CHECK-SAME:           i32 0
 // CHECK-SAME:         }
 extension Int: Runcible {
   public func runce() {}
@@ -74,8 +74,8 @@ extension Int: Runcible {
 // CHECK-SAME:           @got._T016resilient_struct4SizeVMn
 // -- witness table
 // CHECK-SAME:           @_T016resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP
-// -- flags 0x04: unique nominal type descriptor
-// CHECK-SAME:           i32 4
+// -- flags 0x00: direct nominal type descriptor
+// CHECK-SAME:           i32 0
 // CHECK-SAME:         }
 
 extension Size: Runcible {
@@ -93,8 +93,8 @@ public protocol Spoon { }
 // CHECK-SAME:           @_T028protocol_conformance_records17NativeGenericTypeVMn
 // -- witness table accessor
 // CHECK-SAME:           i32 add{{.*}}@_T028protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlWa{{.*}}i32 2),
-// -- flags 0x04: unique nominal type descriptor
-// CHECK-SAME:           i32 4
+// -- flags 0x00: direct nominal type descriptor
+// CHECK-SAME:           i32 0
 // CHECK-SAME:         }
 extension NativeGenericType : Spoon where T: Spoon {
   public func runce() {}

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -23,15 +23,14 @@ public struct NativeValueType: Runcible {
   public func runce() {}
 }
 
-// -- TODO class refs should be indirected through their ref variable
 // CHECK-SAME:         %swift.protocol_conformance {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
-// -- class object (TODO should be class ref variable)
+// -- class metadata
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCMf
 // -- witness table
 // CHECK-SAME:           @_T028protocol_conformance_records15NativeClassTypeCAA8RuncibleAAWP
-// -- flags 0x01: unique direct metadata (TODO should be 0x03 indirect class)
+// -- flags 0x01: unique direct metadata
 // CHECK-SAME:           i32 1
 // CHECK-SAME:         },
 public class NativeClassType: Runcible {
@@ -75,7 +74,7 @@ extension Int: Runcible {
 // CHECK-SAME:           @got._T016resilient_struct4SizeVN
 // -- witness table
 // CHECK-SAME:           @_T016resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP
-// -- flags 0x04: unique direct metadata
+// -- flags 0x01: unique direct metadata
 // CHECK-SAME:           i32 1
 // CHECK-SAME:         }
 

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -31,12 +31,12 @@ extension NSRect: Runcible {
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE]]
-// -- class object (TODO should be class ref variable)
-// CHECK:           @"got.OBJC_CLASS_$_Gizmo"
+// -- class object reference
+// CHECK:           @"OBJC_CLASS_REF_$_Gizmo"
 // -- witness table
 // CHECK:           @_T0So5GizmoC33protocol_conformance_records_objc8RuncibleACWP
-// -- flags 0x01: unique direct metadata (TODO should be 0x03 indirect class)
-// CHECK:           i32 1
+// -- flags 0x03: indirect class metadata
+// CHECK:           i32 3
 // CHECK:         }
 extension Gizmo: Runcible {
   public func runce() {}

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -17,25 +17,28 @@ public protocol Runcible {
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE:%swift.protocol\* @_T033protocol_conformance_records_objc8RuncibleMp]]
-// -- type metadata
+// -- type metadata + 0x02 (nonunique type metadata)
+// CHECK:           i32 add
 // CHECK:           @_T0SC6NSRectVN
+// CHECK:           i32 2
 // -- witness table
 // CHECK:           @_T0SC6NSRectV33protocol_conformance_records_objc8RuncibleACWP
-// -- flags 0x02: nonunique direct metadata
+// -- flags 0x02: nonunique type metadata
 // CHECK:           i32 2 },
 extension NSRect: Runcible {
   public func runce() {}
 }
 
-// -- TODO class refs should be indirected through their ref variable
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE]]
-// -- class object reference
+// -- class object reference + 0x03 (indirect class object)
+// CHECK:           i32 add
 // CHECK:           @"OBJC_CLASS_REF_$_Gizmo"
+// CHECK:           i32 3
 // -- witness table
 // CHECK:           @_T0So5GizmoC33protocol_conformance_records_objc8RuncibleACWP
-// -- flags 0x03: indirect class metadata
+// -- flags 0x03: indirect class object
 // CHECK:           i32 3
 // CHECK:         }
 extension Gizmo: Runcible {

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -23,8 +23,9 @@ public protocol Runcible {
 // CHECK:           i32 2
 // -- witness table
 // CHECK:           @_T0SC6NSRectV33protocol_conformance_records_objc8RuncibleACWP
-// -- flags 0x02: nonunique type metadata
-// CHECK:           i32 2 },
+// -- reserved
+// CHECK:           i32 0
+// CHECK:         },
 extension NSRect: Runcible {
   public func runce() {}
 }
@@ -38,8 +39,8 @@ extension NSRect: Runcible {
 // CHECK:           i32 3
 // -- witness table
 // CHECK:           @_T0So5GizmoC33protocol_conformance_records_objc8RuncibleACWP
-// -- flags 0x03: indirect class object
-// CHECK:           i32 3
+// -- reserved
+// CHECK:           i32 0
 // CHECK:         }
 extension Gizmo: Runcible {
   public func runce() {}


### PR DESCRIPTION
This pull request improves the runtime representation of protocol conformance records and type metadata records in several ways:

* Move conformance kind into the low bits of the witness table reference, and be explicit about the remaining reserved kind
* Reference Objective-C class objects indirectly, so the runtime can fix them up
* Eliminate `TypeMetadataRecordKind::UniqueDirectClass`, which is no longer necessary
* Use nominal type descriptors whenever we can, reducing the number of `TypeMetadataRecordKind` cases to 3 (nominal type descriptor, indirect Objective-C class object, and nonuniqued foreign type metadata). Pack the kind into the lower bits of type references in protocol conformance records and type metadata records.
* Eliminate the "flags" word from protocol conformance records, but leave the word reserved for conditional requirements.