### PR TITLE
Class resilience part 10

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -199,11 +199,6 @@ namespace swift {
     /// accesses.
     bool DisableTsanInoutInstrumentation = false;
 
-    /// \brief Staging flag for class resilience, which we do not want to enable
-    /// fully until more code is in place, to allow the standard library to be
-    /// tested with value type resilience only.
-    bool EnableClassResilience = false;
-
     /// Should we check the target OSs of serialized modules to see that they're
     /// new enough?
     bool EnableTargetOSChecking = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -442,10 +442,6 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
    HelpText<"Compile the module to export resilient interfaces for all "
             "public declarations by default">;
 
-def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
-   HelpText<"Compile the module to export resilient interfaces for all "
-            "public classes by default (doesn't work yet)">;
-
 def group_info_path : Separate<["-"], "group-info-path">,
   HelpText<"The path to collect the group information of the compiled module">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1011,9 +1011,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalPropertyBehaviors |=
     Args.hasArg(OPT_enable_experimental_property_behaviors);
 
-  Opts.EnableClassResilience |=
-    Args.hasArg(OPT_enable_class_resilience);
-
   if (auto A = Args.getLastArg(OPT_enable_deserialization_recovery,
                                OPT_disable_deserialization_recovery)) {
     Opts.EnableDeserializationRecovery

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -93,8 +93,7 @@ private:
     // Visit the superclass first.
     if (Type superclass = type->getSuperclass()) {
       auto *superclassDecl = superclass->getClassOrBoundGenericClass();
-      if (IGM.Context.LangOpts.EnableClassResilience &&
-          IGM.isResilient(superclassDecl, ResilienceExpansion::Maximal)) {
+      if (IGM.isResilient(superclassDecl, ResilienceExpansion::Maximal)) {
         // Just note that we have a resilient superclass and move on.
         //
         // Runtime metadata instantiation needs to slide our entries down

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -295,14 +295,6 @@ namespace {
 
           // If the superclass is resilient to us, we cannot statically
           // know the layout of either its instances or its class objects.
-          //
-          // FIXME: We need to implement indirect field/vtable entry access
-          // before we can enable this
-          if (!IGM.Context.LangOpts.EnableClassResilience) {
-            addFieldsForClass(superclass, superclassType);
-            NumInherited = Elements.size();
-          }
-
           ClassHasFixedSize = false;
 
           // Furthermore, if the superclass is a generic context, we have to

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3529,11 +3529,20 @@ namespace {
           IGF.Builder.CreateBitCast(superMetadata, IGF.IGM.Int8PtrTy),
           IGM.getPointerAlignment());
 
-      Address slot = IGF.Builder.CreateConstByteArrayGEP(
+      Address sizeSlot = IGF.Builder.CreateConstByteArrayGEP(
           metadataAsBytes,
           layout.getMetadataSizeOffset());
-      slot = IGF.Builder.CreateBitCast(slot, IGM.Int32Ty->getPointerTo());
-      llvm::Value *size = IGF.Builder.CreateLoad(slot);
+      sizeSlot = IGF.Builder.CreateBitCast(sizeSlot, IGM.Int32Ty->getPointerTo());
+      llvm::Value *size = IGF.Builder.CreateLoad(sizeSlot);
+
+      Address addressPointSlot = IGF.Builder.CreateConstByteArrayGEP(
+          metadataAsBytes,
+          layout.getMetadataAddressPointOffset());
+      addressPointSlot = IGF.Builder.CreateBitCast(addressPointSlot, IGM.Int32Ty->getPointerTo());
+      llvm::Value *addressPoint = IGF.Builder.CreateLoad(addressPointSlot);
+
+      size = IGF.Builder.CreateSub(size, addressPoint);
+
       if (IGM.SizeTy != IGM.Int32Ty)
         size = IGF.Builder.CreateZExt(size, IGM.SizeTy);
 

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -251,8 +251,7 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
       // to us, we will access metadata members relative to a base offset.
       if (forClass == Target) {
         if (Layout.HasResilientSuperclass ||
-            (IGM.Context.LangOpts.EnableClassResilience &&
-             IGM.isResilient(forClass, ResilienceExpansion::Maximal))) {
+            IGM.isResilient(forClass, ResilienceExpansion::Maximal)) {
           assert(!DynamicOffsetBase);
           DynamicOffsetBase = NextOffset;
         }

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -264,6 +264,11 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
       super::addClassSize();
     }
 
+    void addClassAddressPoint() {
+      Layout.MetadataAddressPoint = getNextOffset();
+      super::addClassAddressPoint();
+    }
+
     void addInstanceSize() {
       Layout.InstanceSize = getNextOffset();
       super::addInstanceSize();
@@ -343,6 +348,11 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
 Size ClassMetadataLayout::getMetadataSizeOffset() const {
   assert(MetadataSize.isStatic());
   return MetadataSize.getStaticOffset();
+}
+
+Size ClassMetadataLayout::getMetadataAddressPointOffset() const {
+  assert(MetadataAddressPoint.isStatic());
+  return MetadataAddressPoint.getStaticOffset();
 }
 
 Size ClassMetadataLayout::getInstanceSizeOffset() const {

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -170,6 +170,7 @@ private:
   bool HasResilientSuperclass = false;
 
   StoredOffset MetadataSize;
+  StoredOffset MetadataAddressPoint;
 
   StoredOffset InstanceSize;
   StoredOffset InstanceAlignMask;
@@ -217,6 +218,8 @@ public:
   }
 
   Size getMetadataSizeOffset() const;
+
+  Size getMetadataAddressPointOffset() const;
 
   Size getInstanceSizeOffset() const;
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -166,7 +166,7 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
 
   auto typeBytes = reinterpret_cast<const char *>(type);
   auto genericArgs = reinterpret_cast<const Metadata * const *>(
-               typeBytes + sizeof(void*) * description->GenericParams.Offset);
+      typeBytes + sizeof(void*) * description->GenericParams.getOffset(type));
 
   return _applyGenericArguments(genericArgs, description, node,
                                 description->GenericParams.NestingDepth,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1448,7 +1448,8 @@ static void _swift_initializeSuperclass(ClassMetadata *theClass) {
     if (genericParams.Flags.hasVTable()) {
       auto *vtable = description->getVTableDescriptor();
       for (unsigned i = 0, e = vtable->VTableSize; i < e; ++i) {
-        classWords[vtable->VTableOffset + i] = description->getMethod(i);
+        classWords[vtable->getVTableOffset(theClass) + i]
+          = description->getMethod(i);
       }
     }
   }
@@ -1470,23 +1471,23 @@ static void _swift_initializeSuperclass(ClassMetadata *theClass) {
 
     // Copy the generic requirements.
     if (genericParams.hasGenericRequirements()) {
-      unsigned numParamWords = genericParams.NumGenericRequirements;
-      memcpy(classWords + genericParams.Offset,
-             superWords + genericParams.Offset,
-             numParamWords * sizeof(uintptr_t));
+      memcpy(classWords + genericParams.getOffset(ancestor),
+             superWords + genericParams.getOffset(ancestor),
+             genericParams.NumGenericRequirements * sizeof(uintptr_t));
     }
 
     // Copy the vtable entries.
     if (genericParams.Flags.hasVTable()) {
       auto *vtable = description->getVTableDescriptor();
-      memcpy(classWords + vtable->VTableOffset,
-             superWords + vtable->VTableOffset,
+      memcpy(classWords + vtable->getVTableOffset(ancestor),
+             superWords + vtable->getVTableOffset(ancestor),
              vtable->VTableSize * sizeof(uintptr_t));
     }
 
     // Copy the field offsets.
     if (description->Class.hasFieldOffsetVector()) {
-      unsigned fieldOffsetVector = description->Class.FieldOffsetVectorOffset;
+      unsigned fieldOffsetVector =
+        description->Class.getFieldOffsetVectorOffset(ancestor);
       memcpy(classWords + fieldOffsetVector,
              superWords + fieldOffsetVector,
              description->Class.NumFields * sizeof(uintptr_t));

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -188,6 +188,7 @@ swift::swift_allocateGenericClassMetadata(GenericMetadata *pattern,
   // The pattern might have private prefix matter prior to the start
   // of metadata.
   assert(metadata->getClassAddressPoint() <= pattern->AddressPoint);
+  metadata->setClassSize(metadataSize);
 
   return metadata;
 }
@@ -1539,6 +1540,8 @@ swift::swift_relocateClassMetadata(ClassMetadata *self,
 
     rawNewClass += self->getClassAddressPoint();
     auto *newClass = (ClassMetadata *) rawNewClass;
+    newClass->setClassSize(metadataSize);
+
     assert(newClass->isTypeMetadata());
 
     return newClass;

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience -O %s
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -enable-class-resilience -I %t -module-name resilient_struct -o %t %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -enable-class-resilience -I %t -module-name resilient_class -o %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -enable-class-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -I %t -module-name resilient_struct -o %t %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -I %t -module-name resilient_class -o %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -I %t -module-name resilient_struct -o %t %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -I %t -module-name resilient_class -o %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -enable-class-resilience -I %t -module-name resilient_struct -o %t %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module -enable-resilience -enable-class-resilience -I %t -module-name resilient_class -o %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -enable-class-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s
+
+// CHECK: %swift.type = type { [[INT:i32|i64]] }
 
 sil_stage canonical
 
@@ -51,10 +53,13 @@ bb0(%0 : $ChildToResilientParent):
 
 // ChildToResilientParent is in our resilience domain - can load the superclass's metadata directly.
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T05super22ChildToResilientParentC6methodyyF(%T5super22ChildToResilientParentC* swiftself)
-// CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_T015resilient_class22ResilientOutsideParentCMa()
-// CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%T15resilient_class22ResilientOutsideParentC*)**
-// CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%T15resilient_class22ResilientOutsideParentC*)*, void (%T15resilient_class22ResilientOutsideParentC*)** [[OPAQUE_SUPER_METADATA]]
-// CHECK: [[FN_PTR:%[0-9]+]] = load void (%T15resilient_class22ResilientOutsideParentC*)*, void (%T15resilient_class22ResilientOutsideParentC*)** [[VTABLE_SLOT]]
+// CHECK: [[SUPER_METADATA:%.*]] = call %swift.type* @_T015resilient_class22ResilientOutsideParentCMa()
+// CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* @_T015resilient_class22ResilientOutsideParentCMo
+// CHECK: [[VTABLE_OFFSET:%.*]] = add [[INT]] [[BASE]], {{20|40}}
+// CHECK: [[SUPER_ADDR:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to i8*
+// CHECK: [[VTABLE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[SUPER_ADDR]], [[INT]] [[VTABLE_OFFSET]]
+// CHECK: [[VTABLE_SLOT:%.*]] = bitcast i8* [[VTABLE_ADDR]] to void (%T15resilient_class22ResilientOutsideParentC*)**
+// CHECK: [[FN_PTR:%.*]] = load void (%T15resilient_class22ResilientOutsideParentC*)*, void (%T15resilient_class22ResilientOutsideParentC*)** [[VTABLE_SLOT]]
 // CHECK: call void
 
 // static super.ChildToResilientParent.classMethod () -> ()
@@ -70,10 +75,13 @@ bb0(%0 : $@thick ChildToResilientParent.Type):
 
 // ChildToResilientParent is in our resilience domain - can load the superclass's metadata directly.
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T05super22ChildToResilientParentC11classMethodyyFZ(%swift.type* swiftself)
-// CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_T015resilient_class22ResilientOutsideParentCMa()
-// CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
-// CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[OPAQUE_SUPER_METADATA]]
-// CHECK: [[FN_PTR:%[0-9]+]] = load void (%swift.type*)*, void (%swift.type*)** [[VTABLE_SLOT]]
+// CHECK: [[SUPER_METADATA:%.*]] = call %swift.type* @_T015resilient_class22ResilientOutsideParentCMa()
+// CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* @_T015resilient_class22ResilientOutsideParentCMo
+// CHECK: [[VTABLE_OFFSET:%.*]] = add [[INT]] [[BASE]], {{24|48}}
+// CHECK: [[SUPER_ADDR:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to i8*
+// CHECK: [[VTABLE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[SUPER_ADDR]], [[INT]] [[VTABLE_OFFSET]]
+// CHECK: [[VTABLE_SLOT:%.*]] = bitcast i8* [[VTABLE_ADDR]] to void (%swift.type*)**
+// CHECK: [[FN_PTR:%.*]] = load void (%swift.type*)*, void (%swift.type*)** [[VTABLE_SLOT]]
 // CHECK: call swiftcc void
 
 // resilient_class.OutsideParent.method () -> ()
@@ -97,10 +105,10 @@ bb0(%0 : $ChildToFixedParent):
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T05super18ChildToFixedParentC6methodyyF(%T5super18ChildToFixedParentC* swiftself)
-// CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_T015resilient_class13OutsideParentCMa()
-// CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%T15resilient_class13OutsideParentC*)**
-// CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%T15resilient_class13OutsideParentC*)*, void (%T15resilient_class13OutsideParentC*)** [[OPAQUE_SUPER_METADATA]]
-// CHECK: [[FN_PTR:%[0-9]+]] = load void (%T15resilient_class13OutsideParentC*)*, void (%T15resilient_class13OutsideParentC*)** [[VTABLE_SLOT]]
+// CHECK: [[SUPER_METADATA:%.*]] = call %swift.type* @_T015resilient_class13OutsideParentCMa()
+// CHECK: [[OPAQUE_SUPER_METADATA:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%T15resilient_class13OutsideParentC*)**
+// CHECK: [[VTABLE_SLOT:%.*]] = getelementptr inbounds void (%T15resilient_class13OutsideParentC*)*, void (%T15resilient_class13OutsideParentC*)** [[OPAQUE_SUPER_METADATA]]
+// CHECK: [[FN_PTR:%.*]] = load void (%T15resilient_class13OutsideParentC*)*, void (%T15resilient_class13OutsideParentC*)** [[VTABLE_SLOT]]
 // CHECK: call swiftcc void
 
 // static super.ChildToFixedParent.classMethod () -> ()
@@ -117,10 +125,10 @@ bb0(%0 : $@thick ChildToFixedParent.Type):
 
 // ChildToFixedParent is in our resilience domain - load super metadata directly.
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T05super18ChildToFixedParentC11classMethodyyFZ(%swift.type* swiftself)
-// CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_T015resilient_class13OutsideParentCMa()
-// CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
-// CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[OPAQUE_SUPER_METADATA]]
-// CHECK: [[FN_PTR:%[0-9]+]] = load void (%swift.type*)*, void (%swift.type*)** [[VTABLE_SLOT]]
+// CHECK: [[SUPER_METADATA:%.*]] = call %swift.type* @_T015resilient_class13OutsideParentCMa()
+// CHECK: [[OPAQUE_SUPER_METADATA:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
+// CHECK: [[VTABLE_SLOT:%.*]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[OPAQUE_SUPER_METADATA]]
+// CHECK: [[FN_PTR:%.*]] = load void (%swift.type*)*, void (%swift.type*)** [[VTABLE_SLOT]]
 // CHECK: call swiftcc void
 
 // ext.super.resilient_class.ResilientOutsideChild.callSuperMethod () -> ()
@@ -139,13 +147,16 @@ bb0(%0 : $ResilientOutsideChild):
 
 // Extending a resilient class - load super metadata indirectly.
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T015resilient_class21ResilientOutsideChildC5superE15callSuperMethodyyF(%T15resilient_class21ResilientOutsideChildC* swiftself)
-// CHECK: [[METADATA:%[0-9]+]] = call %swift.type* @_T015resilient_class21ResilientOutsideChildCMa()
-// CHECK: [[OPAQUE_METADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to %swift.type**
-// CHECK: [[SUPER_METADATA_PTR:%[0-9]+]] = getelementptr inbounds %swift.type*, %swift.type** [[OPAQUE_METADATA]], i32 1
-// CHECK: [[SUPER_METADATA:%[0-9]+]] = load %swift.type*, %swift.type** [[SUPER_METADATA_PTR]]
-// CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%T15resilient_class22ResilientOutsideParentC*)**
-// CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%T15resilient_class22ResilientOutsideParentC*)*, void (%T15resilient_class22ResilientOutsideParentC*)** [[OPAQUE_SUPER_METADATA]]
-// CHECK: [[FN_PTR:%[0-9]+]] = load void (%T15resilient_class22ResilientOutsideParentC*)*, void (%T15resilient_class22ResilientOutsideParentC*)** [[VTABLE_SLOT]]
+// CHECK: [[METADATA:%.*]] = call %swift.type* @_T015resilient_class21ResilientOutsideChildCMa()
+// CHECK: [[OPAQUE_METADATA:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
+// CHECK: [[SUPER_METADATA_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[OPAQUE_METADATA]], i32 1
+// CHECK: [[SUPER_METADATA:%.*]] = load %swift.type*, %swift.type** [[SUPER_METADATA_PTR]]
+// CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* @_T015resilient_class22ResilientOutsideParentCMo
+// CHECK: [[VTABLE_OFFSET:%.*]] = add [[INT]] [[BASE]], {{20|40}}
+// CHECK: [[SUPER_ADDR:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to i8*
+// CHECK: [[VTABLE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[SUPER_ADDR]], [[INT]] [[VTABLE_OFFSET]]
+// CHECK: [[VTABLE_SLOT:%.*]] = bitcast i8* [[VTABLE_ADDR]] to void (%T15resilient_class22ResilientOutsideParentC*)*
+// CHECK: [[FN_PTR:%.*]] = load void (%T15resilient_class22ResilientOutsideParentC*)*, void (%T15resilient_class22ResilientOutsideParentC*)** [[VTABLE_SLOT]]
 // CHECK: call void
 
 // static ext.super.resilient_class.ResilientOutsideChild.callSuperClassMethod () -> ()
@@ -162,13 +173,16 @@ bb0(%0 : $@thick ResilientOutsideChild.Type):
 
 // Extending a resilient class - load super metadata indirectly.
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @_T015resilient_class21ResilientOutsideChildC5superE20callSuperClassMethodyyFZ(%swift.type* swiftself)
-// CHECK: [[METADATA:%[0-9]+]] = call %swift.type* @_T015resilient_class21ResilientOutsideChildCMa()
-// CHECK: [[OPAQUE_METADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to %swift.type**
-// CHECK: [[SUPER_METADATA_PTR:%[0-9]+]] = getelementptr inbounds %swift.type*, %swift.type** [[OPAQUE_METADATA]], i32 1
-// CHECK: [[SUPER_METADATA:%[0-9]+]] = load %swift.type*, %swift.type** [[SUPER_METADATA_PTR]]
-// CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
-// CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[OPAQUE_SUPER_METADATA]]
-// CHECK: [[FN_PTR:%[0-9]+]] = load void (%swift.type*)*, void (%swift.type*)** [[VTABLE_SLOT]]
+// CHECK: [[METADATA:%.*]] = call %swift.type* @_T015resilient_class21ResilientOutsideChildCMa()
+// CHECK: [[OPAQUE_METADATA:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
+// CHECK: [[SUPER_METADATA_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[OPAQUE_METADATA]], i32 1
+// CHECK: [[SUPER_METADATA:%.*]] = load %swift.type*, %swift.type** [[SUPER_METADATA_PTR]]
+// CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* @_T015resilient_class22ResilientOutsideParentCMo
+// CHECK: [[VTABLE_OFFSET:%.*]] = add [[INT]] [[BASE]], {{24|48}}
+// CHECK: [[SUPER_ADDR:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to i8*
+// CHECK: [[VTABLE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[SUPER_ADDR]], [[INT]] [[VTABLE_OFFSET]]
+// CHECK: [[VTABLE_SLOT:%.*]] = bitcast i8* [[VTABLE_ADDR]] to void (%swift.type*)**
+// CHECK: [[FN_PTR:%.*]] = load void (%swift.type*)*, void (%swift.type*)** [[VTABLE_SLOT]]
 // CHECK: call swiftcc void
 
 sil_vtable ChildToResilientParent {
@@ -202,10 +216,10 @@ sil_vtable Derived {
 }
 
 // CHECK-LABEL: define{{.*}} @test_super_method_of_generic_base
-// CHECK: [[METADATA:%[0-9]+]] = call %swift.type* @_T05super4BaseCyAA3StrVGMa()
-// CHECK: [[BASEMETADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to void (%T5super4BaseC*)**
-// CHECK: [[GEP:%[0-9]+]] = getelementptr inbounds void (%T5super4BaseC*)*, void (%T5super4BaseC*)** [[BASEMETADATA]]
-// CHECK: [[SUPERMT:%[0-9]+]] = load void (%T5super4BaseC*)*, void (%T5super4BaseC*)** [[GEP]]
+// CHECK: [[METADATA:%.*]] = call %swift.type* @_T05super4BaseCyAA3StrVGMa()
+// CHECK: [[BASEMETADATA:%.*]] = bitcast %swift.type* [[METADATA]] to void (%T5super4BaseC*)**
+// CHECK: [[GEP:%.*]] = getelementptr inbounds void (%T5super4BaseC*)*, void (%T5super4BaseC*)** [[BASEMETADATA]]
+// CHECK: [[SUPERMT:%.*]] = load void (%T5super4BaseC*)*, void (%T5super4BaseC*)** [[GEP]]
 // CHECK: ret void
 sil @test_super_method_of_generic_base : $@convention(method) (@guaranteed Derived) -> () {
 bb0(%0 : $Derived):


### PR DESCRIPTION
Implement runtime support for initializing the vtable and accessing metadata fields in a class whose superclass is resilient, by respecting the HasResilientSuperclass flag in the nominal type descriptor and interpreting certain offsets as being relative to the start of the class's immediate members.

This allows the `-enable-class-resilience` staging flag to be removed, finally!