### PR TITLE
Do not test explicitly for IUO types in bridging peephole.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5063,11 +5063,10 @@ RValue RValueEmitter::emitForceValue(ForceValueExpr *loc, Expr *E,
     return SGF.emitRValue(injection->getSubExpr(), C);
   }
 
-  // If this is an implicit force of an ImplicitlyUnwrappedOptional,
-  // and we're emitting into an unbridging conversion, try adjusting the
-  // context.
-  if (loc->isImplicit() &&
-      E->getType()->getImplicitlyUnwrappedOptionalObjectType()) {
+  // If this is an implicit force of an Optional, and we're emitting
+  // into an unbridging conversion, try adjusting the context.
+  if (loc->isImplicit()) {
+    assert(E->getType()->getAnyOptionalObjectType());
     if (auto conv = C.getAsConversion()) {
       if (auto adjusted = conv->getConversion().adjustForInitialForceValue()) {
         auto value =


### PR DESCRIPTION
It should be enough to test for an implicit force of an optional,
which is what we'll be seeing when the changes to remove IUO from the
type system land.
