### PR TITLE
[stdlib] Use helper struct in StaticString tests

### DIFF
--- a/test/stdlib/StaticString.swift
+++ b/test/stdlib/StaticString.swift
@@ -3,6 +3,13 @@
 
 import StdlibUnittest
 
+struct UnicodeScalarRepresentation : ExpressibleByUnicodeScalarLiteral {
+  let value: StaticString
+
+  init(unicodeScalarLiteral value: StaticString) {
+    self.value = value
+  }
+}
 
 var StaticStringTestSuite = TestSuite("StaticString")
 
@@ -83,11 +90,9 @@ StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
 }
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/ASCII") {
-  // The type checker does not call the UnicodeScalar initializer even if
-  // passed a literal that consists from a single Unicode scalar.
-
   // U+005A LATIN CAPITAL LETTER Z
-  let str = StaticString(_builtinUnicodeScalarLiteral: UInt32(0x5a)._value)
+  let usr: UnicodeScalarRepresentation = "\u{005A}"
+  let str: StaticString = usr.value
   expectEqual("Z", str.unicodeScalar)
   expectFalse(str.hasPointerRepresentation)
   expectTrue(str.isASCII)
@@ -104,7 +109,8 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/ASCII") {
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/NonASCII") {
   // U+042B CYRILLIC CAPITAL LETTER YERU
-  let str = StaticString(_builtinUnicodeScalarLiteral: UInt32(0x042b)._value)
+  let usr: UnicodeScalarRepresentation = "\u{042B}"
+  let str: StaticString = usr.value
   expectEqual("Ы", str.unicodeScalar)
   expectFalse(str.hasPointerRepresentation)
   expectFalse(str.isASCII)
@@ -126,7 +132,8 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
   .crashOutputMatches(_isDebugAssertConfiguration() ?
     "StaticString should have pointer representation" : "")
   .code {
-  let str = StaticString(_builtinUnicodeScalarLiteral: UInt32(0x5a)._value)
+  let usr: UnicodeScalarRepresentation = "\u{005A}"
+  let str: StaticString = usr.value
   let strOpaque = _opaqueIdentity(str)
   expectCrashLater()
   strOpaque.utf8Start
@@ -139,7 +146,8 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
   .crashOutputMatches(_isDebugAssertConfiguration() ?
     "StaticString should have pointer representation" : "")
   .code {
-  let str = StaticString(_builtinUnicodeScalarLiteral: UInt32(0x5a)._value)
+  let usr: UnicodeScalarRepresentation = "\u{005A}"
+  let str: StaticString = usr.value
   let strOpaque = _opaqueIdentity(str)
   expectCrashLater()
   strOpaque.utf8CodeUnitCount


### PR DESCRIPTION
Use an `ExpressibleByUnicodeScalarLiteral` helper struct, instead of
calling `StaticString.init(_builtinUnicodeScalarLiteral:)` directly.