### PR TITLE
Reapply "Normalize version tuples in availability attributes coming from clang to use ".""

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7174,7 +7174,8 @@ void ClangImporter::Implementation::importAttributes(
 
       StringRef message = avail->getMessage();
 
-      const auto &deprecated = avail->getDeprecated();
+      clang::VersionTuple deprecated = avail->getDeprecated();
+
       if (!deprecated.empty()) {
         if (platformAvailability.deprecatedAsUnavailableFilter &&
             platformAvailability.deprecatedAsUnavailableFilter(
@@ -7186,8 +7187,14 @@ void ClangImporter::Implementation::importAttributes(
         }
       }
 
-      const auto &obsoleted = avail->getObsoleted();
-      const auto &introduced = avail->getIntroduced();
+      clang::VersionTuple obsoleted = avail->getObsoleted();
+      clang::VersionTuple introduced = avail->getIntroduced();
+
+      // Swift only allows "." separators.
+      obsoleted.UseDotAsSeparator();
+      introduced.UseDotAsSeparator();
+      deprecated.UseDotAsSeparator();
+
       const auto &replacement = avail->getReplacement();
 
       StringRef swiftReplacement = "";

--- a/test/IDE/Inputs/print_clang_header/header-to-print-availability.h
+++ b/test/IDE/Inputs/print_clang_header/header-to-print-availability.h
@@ -1,0 +1,6 @@
+@interface MaybeAvailable
+-(void)method1 __attribute__((availability(macosx, introduced=10.1)));
+-(void)method2 __attribute__((availability(macosx, introduced=10_1)));
+-(void)method3 __attribute__((availability(macosx, deprecated=10_10)));
+-(void)method4 __attribute__((availability(macosx, introduced=10_1, deprecated=10_10, obsoleted=10_11)));
+@end

--- a/test/IDE/Inputs/print_clang_header/header-to-print-availability.h.module.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print-availability.h.module.printed.txt
@@ -1,0 +1,18 @@
+class MaybeAvailable {
+  @available(OSX 10.1, *)
+  class func method1()
+  @available(OSX 10.1, *)
+  func method1()
+  @available(OSX 10.1, *)
+  class func method2()
+  @available(OSX 10.1, *)
+  func method2()
+  @available(OSX, deprecated: 10.10)
+  class func method3()
+  @available(OSX, deprecated: 10.10)
+  func method3()
+  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
+  class func method4()
+  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
+  func method4()
+}

--- a/test/IDE/Inputs/print_clang_header/header-to-print-availability.h.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print-availability.h.printed.txt
@@ -1,0 +1,18 @@
+class MaybeAvailable {
+  @available(OSX 10.1, *)
+  class func method1()
+  @available(OSX 10.1, *)
+  func method1()
+  @available(OSX 10.1, *)
+  class func method2()
+  @available(OSX 10.1, *)
+  func method2()
+  @available(OSX, deprecated: 10.10)
+  class func method3()
+  @available(OSX, deprecated: 10.10)
+  func method3()
+  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
+  class func method4()
+  @available(OSX, introduced: 10.1, deprecated: 10.10, obsoleted: 10.11)
+  func method4()
+}

--- a/test/IDE/Inputs/print_clang_header/module.modulemap
+++ b/test/IDE/Inputs/print_clang_header/module.modulemap
@@ -1,0 +1,3 @@
+module HeaderToPrintAvailability {
+  header "header-to-print-availability.h"
+}

--- a/test/IDE/print_clang_header_availability.swift
+++ b/test/IDE/print_clang_header_availability.swift
@@ -1,0 +1,13 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+
+// RUN: echo '#include "header-to-print-availability.h"' > %t.m
+// RUN: cp %S/Inputs/print_clang_header/header-to-print-availability.h %t/
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %t/header-to-print-availability.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %t > %t.txt
+// RUN: diff -u %S/Inputs/print_clang_header/header-to-print-availability.h.printed.txt %t.txt
+
+// RUN: echo '@import HeaderToPrintAvailability;' > %t.module.m
+// Test header interface printing from a clang module.
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print-availability.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.module.m -I %S/Inputs/print_clang_header > %t.module.txt
+// RUN: diff -u %S/Inputs/print_clang_header/header-to-print-availability.h.module.printed.txt %t.module.txt


### PR DESCRIPTION
This reapplies f1c48daf70e3ac66 with the test split up so that the
availability bits don't affect other platforms.

Seen as `@available` attributes being printed with `_` in interface
generation, but fixing it in the importer means they can't leak into
anywhere else.

rdar://problem/30451293