### PR TITLE
Revert "Disable ModelIO test on ios"

### DIFF
--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -3,11 +3,6 @@
 // UNSUPPORTED: OS=watchos
 // REQUIRES: objc_interop
 
-// Currently crashes on iphonesimulator.
-// rdar://35490456
-// UNSUPPORTED: OS=ios
-// UNSUPPORTED: OS=tvos
-
 import StdlibUnittest
 
 import Foundation


### PR DESCRIPTION
Reverts apple/swift#12883

Let's see if this is still an issue.