### PR TITLE
[4.1] Sema: Look through inout when mapping IUOs to Optionals.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -613,6 +613,10 @@ ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 
+WARNING(deprecated_redecl_by_optionality, none,
+        "invalid redeclaration of %0 which differs only by the kind of optional passed as an inout argument (%1 vs. %2)",
+        (DeclName, Type, Type))
+
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (Identifier))
 ERROR(invalid_member_type,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -616,6 +616,8 @@ NOTE(invalid_redecl_prev,none,
 WARNING(deprecated_redecl_by_optionality, none,
         "invalid redeclaration of %0 which differs only by the kind of optional passed as an inout argument (%1 vs. %2)",
         (DeclName, Type, Type))
+NOTE(deprecated_redecl_by_optionality_note, none,
+     "overloading by kind of optional is deprecated and will be removed in a future release", ())
 
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (Identifier))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1702,8 +1702,15 @@ static Type mapSignatureType(ASTContext &ctx, Type type) {
 
 /// Map a signature type for a parameter.
 static Type mapSignatureParamType(ASTContext &ctx, Type type) {
-  /// Translate implicitly unwrapped optionals into strict optionals.
-  if (auto uncheckedOptOf = type->getImplicitlyUnwrappedOptionalObjectType()) {
+  // Translate implicitly unwrapped optionals into strict optionals.
+  if (auto inOutTy = type->getAs<InOutType>()) {
+    if (auto uncheckedOptOf =
+            inOutTy->getObjectType()
+                ->getImplicitlyUnwrappedOptionalObjectType()) {
+      type = InOutType::get(OptionalType::get(uncheckedOptOf));
+    }
+  } else if (auto uncheckedOptOf =
+                 type->getImplicitlyUnwrappedOptionalObjectType()) {
     type = OptionalType::get(uncheckedOptOf);
   }
 
@@ -1745,16 +1752,17 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
   if (curryLevels == 0) {
     // In an initializer, ignore optionality.
     if (isInitializer) {
-      if (auto objectType = type->getAnyOptionalObjectType())
+      if (auto inOutTy = type->getAs<InOutType>()) {
+        if (auto objectType =
+                inOutTy->getObjectType()->getAnyOptionalObjectType()) {
+          type = InOutType::get(objectType);
+        }
+      } else if (auto objectType = type->getAnyOptionalObjectType()) {
         type = objectType;
+      }
     }
 
-    // Translate implicitly unwrapped optionals into strict optionals.
-    if (auto uncheckedOptOf = type->getImplicitlyUnwrappedOptionalObjectType()) {
-      type = OptionalType::get(uncheckedOptOf);
-    }
-
-    return mapSignatureType(ctx, type);
+    return mapSignatureParamType(ctx, type);
   }
 
   auto funcTy = type->castTo<AnyFunctionType>();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -982,6 +982,54 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
           continue;
       }
 
+      // Signatures are the same, but interface types are not. We must
+      // have a type that we've massaged as part of signature
+      // interface type generation. If it's a result of remapping a
+      // function parameter from 'inout T!' to 'inout T?', emit a
+      // warning that these overloads are deprecated and will no
+      // longer be supported in the future.
+      if (!current->getInterfaceType()->isEqual(other->getInterfaceType())) {
+        auto diagnosed = false;
+        auto currFnTy = current->getInterfaceType()->getAs<AnyFunctionType>();
+        auto otherFnTy = other->getInterfaceType()->getAs<AnyFunctionType>();
+        if (currFnTy && otherFnTy) {
+          ArrayRef<AnyFunctionType::Param> currParams = currFnTy->getParams();
+          ArrayRef<AnyFunctionType::Param> otherParams = otherFnTy->getParams();
+
+          if (currParams.size() == otherParams.size()) {
+            for (unsigned i : indices(currParams)) {
+              if (currParams[i].isInOut() && otherParams[i].isInOut()) {
+                auto currParamTy = currParams[i]
+                                       .getType()
+                                       ->getAs<InOutType>()
+                                       ->getObjectType();
+                auto otherParamTy = otherParams[i]
+                                        .getType()
+                                        ->getAs<InOutType>()
+                                        ->getObjectType();
+                OptionalTypeKind currOTK;
+                OptionalTypeKind otherOTK;
+                (void)currParamTy->getAnyOptionalObjectType(currOTK);
+                (void)otherParamTy->getAnyOptionalObjectType(otherOTK);
+                if (currOTK != OTK_None && otherOTK != OTK_None &&
+                    currOTK != otherOTK) {
+                  tc.diagnose(current, diag::deprecated_redecl_by_optionality,
+                              current->getFullName(), currParamTy,
+                              otherParamTy);
+                  tc.diagnose(other, diag::invalid_redecl_prev,
+                              other->getFullName());
+                  diagnosed = true;
+                  break;
+                }
+              }
+            }
+
+            if (diagnosed)
+              break;
+          }
+        }
+      }
+
       // If the conflicting declarations have non-overlapping availability and,
       // we allow the redeclaration to proceed if...
       //

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -264,7 +264,25 @@ func optional(x: Int!) { } // expected-error{{invalid redeclaration of 'optional
 func optionalInOut(x: inout Int?) { } // expected-note{{previously declared}}
 // expected-note@-1 {{previously declared}}
 func optionalInOut(x: inout Int!) { } // expected-warning{{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
-// expected-warning@-1 {{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+  // expected-note@-1 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+  // expected-warning@-2 {{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+  // expected-note@-3 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+
+class optionalOverloads {
+  class func optionalInOut(x: inout Int?) { } // expected-note{{previously declared}}
+  // expected-note@-1 {{previously declared}}
+  class func optionalInOut(x: inout Int!) { } // expected-warning{{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+  // expected-note@-1 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+  // expected-warning@-2 {{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+  // expected-note@-3 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+
+  func optionalInOut(x: inout Int?) { } // expected-note{{previously declared}}
+  // expected-note@-1 {{previously declared}}
+  func optionalInOut(x: inout Int!) { } // expected-warning{{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+  // expected-note@-1 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+  // expected-warning@-2 {{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+  // expected-note@-3 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+}
 
 func optional_3() -> Int? { } // expected-note{{previously declared}}
 func optional_3() -> Int! { } // expected-error{{invalid redeclaration of 'optional_3()'}}

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -261,6 +261,9 @@ func inout2(x: inout Int) { }
 func optional(x: Int?) { } // expected-note{{previously declared}}
 func optional(x: Int!) { } // expected-error{{invalid redeclaration of 'optional(x:)'}}
 
+func optionalInOut(x: inout Int?) { } // expected-note{{previously declared}}
+func optionalInOut(x: inout Int!) { } // expected-error{{invalid redeclaration of 'optionalInOut(x:)'}}
+
 func optional_3() -> Int? { } // expected-note{{previously declared}}
 func optional_3() -> Int! { } // expected-error{{invalid redeclaration of 'optional_3()'}}
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -262,7 +262,9 @@ func optional(x: Int?) { } // expected-note{{previously declared}}
 func optional(x: Int!) { } // expected-error{{invalid redeclaration of 'optional(x:)'}}
 
 func optionalInOut(x: inout Int?) { } // expected-note{{previously declared}}
-func optionalInOut(x: inout Int!) { } // expected-error{{invalid redeclaration of 'optionalInOut(x:)'}}
+// expected-note@-1 {{previously declared}}
+func optionalInOut(x: inout Int!) { } // expected-warning{{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
+// expected-warning@-1 {{invalid redeclaration of 'optionalInOut(x:)' which differs only by the kind of optional passed as an inout argument ('Int!' vs. 'Int?')}}
 
 func optional_3() -> Int? { } // expected-note{{previously declared}}
 func optional_3() -> Int! { } // expected-error{{invalid redeclaration of 'optional_3()'}}


### PR DESCRIPTION
We translate IUOs to Optionals when generating signatures, but were
failing to look through inout in the process, so we were allowing
functions to be overloaded by Optional vs. IUO when the parameter was
inout.