### PR TITLE
[Runtime/ABI] Optimize number of function metadata ABI endpoints

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -138,6 +138,14 @@ contain the following fields:
   If the function takes no arguments, **parameter type vector** as well as
   **parameter flags vector** are going to be empty.
 
+Currently we have specialized ABI endpoints to retrieve metadata for functions
+with 0/1/2/3 parameters - `swift_getFunctionTypeMetadata{0|1|2|3}` and the general
+one `swift_getFunctionTypeMetadata` which handles all other function types and
+functions with parameter flags e.g. `(inout Int) -> Void`. Based on the usage
+information collected from Swift Standard Library and Overlays as well as Source
+Compatibility Suite it was decided not to have specialized ABI endpoints for
+functions with parameter flags due their minimal use.
+
 Protocol Metadata
 ~~~~~~~~~~~~~~~~~
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1223,15 +1223,15 @@ protected:
         auto flags =
             TargetFunctionTypeFlags<StoredSize>::fromIntValue(flagsValue);
 
-        using Parameter =
-            ConstTargetMetadataPointer<Runtime, swift::TargetMetadata>;
-        auto totalSize = sizeof(TargetFunctionTypeMetadata<Runtime>) +
-                         flags.getNumParameters() * sizeof(Parameter);
+        auto totalSize =
+            sizeof(TargetFunctionTypeMetadata<Runtime>) +
+            flags.getNumParameters() * sizeof(FunctionTypeMetadata::Parameter);
 
         if (flags.hasParameterFlags())
           totalSize += flags.getNumParameters() * sizeof(uint32_t);
 
-        return _readMetadata(address, totalSize);
+        return _readMetadata(address,
+                             roundUpToAlignment(totalSize, sizeof(void *)));
       }
       case MetadataKind::HeapGenericLocalVariable:
         return _readMetadata<TargetGenericBoxHeapMetadata>(address);

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2910,34 +2910,6 @@ swift_getThinFunctionTypeMetadata3(const void *arg0,
                                    const void *arg2,
                                    const Metadata *resultMetadata);
 
-/// \brief Fetch a uniqued metadata for a C function type.
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getCFunctionTypeMetadata(size_t numArguments,
-                               const void * argsAndResult []);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getCFunctionTypeMetadata0(const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getCFunctionTypeMetadata1(const void *arg0,
-                                const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getCFunctionTypeMetadata2(const void *arg0,
-                                const void *arg1,
-                                const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getCFunctionTypeMetadata3(const void *arg0,
-                                const void *arg1,
-                                const void *arg2,
-                                const Metadata *resultMetadata);
-
 #if SWIFT_OBJC_INTEROP
 SWIFT_RUNTIME_EXPORT
 void

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2939,34 +2939,6 @@ swift_getCFunctionTypeMetadata3(const void *arg0,
                                 const Metadata *resultMetadata);
 
 #if SWIFT_OBJC_INTEROP
-/// \brief Fetch a uniqued metadata for a block type.
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getBlockTypeMetadata(size_t numArguments,
-                           const void *argsAndResult []);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getBlockTypeMetadata0(const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getBlockTypeMetadata1(const void *arg0,
-                            const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getBlockTypeMetadata2(const void *arg0,
-                            const void *arg1,
-                            const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getBlockTypeMetadata3(const void *arg0,
-                            const void *arg1,
-                            const void *arg2,
-                            const Metadata *resultMetadata);
-
 SWIFT_RUNTIME_EXPORT
 void
 swift_instantiateObjCClass(const ClassMetadata *theClass);

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2836,6 +2836,11 @@ swift_getFunctionTypeMetadata(FunctionTypeFlags flags,
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
+swift_getFunctionTypeMetadata0(FunctionTypeFlags flags,
+                               const Metadata *result);
+
+SWIFT_RUNTIME_EXPORT
+const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                const Metadata *arg0,
                                const Metadata *result);

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2882,34 +2882,6 @@ const FunctionTypeMetadata *swift_getFunctionTypeMetadata3WithFlags(
                                                 ParameterFlags flags2,
                                                 const Metadata *result);
 
-/// \brief Fetch a uniqued metadata for a thin function type.
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getThinFunctionTypeMetadata(size_t numArguments,
-                                  const void * argsAndResult []);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getThinFunctionTypeMetadata0(const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getThinFunctionTypeMetadata1(const void *arg0,
-                                   const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getThinFunctionTypeMetadata2(const void *arg0,
-                                   const void *arg1,
-                                   const Metadata *resultMetadata);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getThinFunctionTypeMetadata3(const void *arg0,
-                                   const void *arg1,
-                                   const void *arg2,
-                                   const Metadata *resultMetadata);
-
 #if SWIFT_OBJC_INTEROP
 SWIFT_RUNTIME_EXPORT
 void

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2847,26 +2847,10 @@ swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *
-swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
-                                        const Metadata *arg0,
-                                        ParameterFlags flags0,
-                                        const Metadata *result);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                const Metadata *arg0,
                                const Metadata *arg1,
                                const Metadata *result);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *
-swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
-                                        const Metadata *arg0,
-                                        ParameterFlags flags0,
-                                        const Metadata *arg1,
-                                        ParameterFlags flags1,
-                                        const Metadata *result);
 
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *swift_getFunctionTypeMetadata3(
@@ -2874,17 +2858,6 @@ const FunctionTypeMetadata *swift_getFunctionTypeMetadata3(
                                                 const Metadata *arg0,
                                                 const Metadata *arg1,
                                                 const Metadata *arg2,
-                                                const Metadata *result);
-
-SWIFT_RUNTIME_EXPORT
-const FunctionTypeMetadata *swift_getFunctionTypeMetadata3WithFlags(
-                                                FunctionTypeFlags flags,
-                                                const Metadata *arg0,
-                                                ParameterFlags flags0,
-                                                const Metadata *arg1,
-                                                ParameterFlags flags1,
-                                                const Metadata *arg2,
-                                                ParameterFlags flags2,
                                                 const Metadata *result);
 
 #if SWIFT_OBJC_INTEROP

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -771,6 +771,13 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
               TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
+// Metadata *swift_getFunctionTypeMetadata0(unsigned long flags,
+//                                          const Metadata *resultMetadata);
+FUNCTION(GetFunctionMetadata0, swift_getFunctionTypeMetadata0, DefaultCC,
+         RETURNS(TypeMetadataPtrTy),
+         ARGS(SizeTy, TypeMetadataPtrTy),
+         ATTRS(NoUnwind, ReadNone))
+
 // Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
 //                                          const Metadata *arg0,
 //                                          const Metadata *resultMetadata);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -786,16 +786,6 @@ FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1, DefaultCC,
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
 
-// Metadata *swift_getFunctionTypeMetadata1WithFlags(unsigned long flags,
-//                                                   const Metadata *arg0,
-//                                                   const uint32_t paramFlags,
-//                                                   const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata1WithFlags, swift_getFunctionTypeMetadata1WithFlags,
-         DefaultCC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadNone))
-
 // Metadata *swift_getFunctionTypeMetadata2(unsigned long flags,
 //                                          const Metadata *arg0,
 //                                          const Metadata *arg1,
@@ -805,19 +795,6 @@ FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
         RETURNS(TypeMetadataPtrTy),
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
-
-// Metadata *swift_getFunctionTypeMetadata2WithFlags(unsigned long flags,
-//                                                   const Metadata *arg0,
-//                                                   const uint32_t flags0,
-//                                                   const Metadata *arg1,
-//                                                   const uint32_t flags1,
-//                                                   const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata2WithFlags, swift_getFunctionTypeMetadata2WithFlags,
-         DefaultCC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy, Int32Ty,
-              TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getFunctionTypeMetadata3(unsigned long flags,
 //                                          const Metadata *arg0,
@@ -830,21 +807,6 @@ FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
              TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
-
-// Metadata *swift_getFunctionTypeMetadata3WithFlags(unsigned long flags,
-//                                                   const Metadata *arg0,
-//                                                   const uint32_t flags0,
-//                                                   const Metadata *arg1,
-//                                                   const uint32_t flags1,
-//                                                   const Metadata *arg2,
-//                                                   const uint32_t flags2,
-//                                                   const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata3WithFlags, swift_getFunctionTypeMetadata3WithFlags,
-         DefaultCC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy, Int32Ty,
-              TypeMetadataPtrTy, Int32Ty, TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);
 FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata, DefaultCC,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -769,7 +769,7 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
               TypeMetadataPtrTy->getPointerTo(0),
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadNone))
+         ATTRS(NoUnwind))
 
 // Metadata *swift_getFunctionTypeMetadata0(unsigned long flags,
 //                                          const Metadata *resultMetadata);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -795,6 +795,9 @@ namespace {
         arguments.push_back(result);
 
         switch (params.size()) {
+        case 0:
+          return IGF.IGM.getGetFunctionMetadata0Fn();
+
         case 1:
           return hasFlags ? IGF.IGM.getGetFunctionMetadata1WithFlagsFn()
                           : IGF.IGM.getGetFunctionMetadata1Fn();
@@ -819,6 +822,7 @@ namespace {
       };
 
       switch (numParams) {
+      case 0:
       case 1:
       case 2:
       case 3: {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -711,7 +711,7 @@ namespace {
       return llvm::UndefValue::get(IGF.IGM.TypeMetadataPtrTy);
     }
 
-    llvm::Value *getFunctionParameterRef(AnyFunctionType::CanParam param) {
+    llvm::Value *getFunctionParameterRef(AnyFunctionType::CanParam &param) {
       auto type = param.getType();
       if (param.getParameterFlags().isInOut())
         type = type->getInOutObjectType()->getCanonicalType();
@@ -812,12 +812,6 @@ namespace {
         }
       };
 
-      auto getArrayFor = [&](llvm::Type *elementType, unsigned size,
-                             const llvm::Twine &name) -> Address {
-        auto arrayTy = llvm::ArrayType::get(elementType, size);
-        return IGF.createAlloca(arrayTy, IGF.IGM.getPointerAlignment(), name);
-      };
-
       switch (numParams) {
       case 0:
       case 1:
@@ -837,46 +831,43 @@ namespace {
       }
 
       default:
-        auto *const Int32Ptr = IGF.IGM.Int32Ty->getPointerTo();
+        assert(!params.empty() && "0 parameter case is specialized!");
 
+        auto *const Int32Ptr = IGF.IGM.Int32Ty->getPointerTo();
         llvm::SmallVector<llvm::Value *, 8> arguments;
+
         arguments.push_back(flags);
 
-        Address parameters;
-        if (!params.empty()) {
-          parameters = getArrayFor(IGF.IGM.TypeMetadataPtrTy, numParams,
-                                   "function-parameters");
+        ConstantInitBuilder paramFlags(IGF.IGM);
+        auto flagsArr = paramFlags.beginArray();
 
-          IGF.Builder.CreateLifetimeStart(parameters,
-                                          IGF.IGM.getPointerSize() * numParams);
+        auto arrayTy =
+            llvm::ArrayType::get(IGF.IGM.TypeMetadataPtrTy, numParams);
+        Address parameters = IGF.createAlloca(
+            arrayTy, IGF.IGM.getTypeMetadataAlignment(), "function-parameters");
 
-          ConstantInitBuilder paramFlags(IGF.IGM);
-          auto flagsArr = paramFlags.beginArray();
-          collectParameters([&](unsigned i, llvm::Value *typeRef,
-                                ParameterFlags flags) {
-            auto argPtr = IGF.Builder.CreateStructGEP(parameters, i,
-                                                      IGF.IGM.getPointerSize());
-            IGF.Builder.CreateStore(typeRef, argPtr);
-            if (hasFlags)
-              flagsArr.addInt32(flags.getIntValue());
-          });
+        IGF.Builder.CreateLifetimeStart(parameters,
+                                        IGF.IGM.getPointerSize() * numParams);
 
-          auto parametersPtr =
-              IGF.Builder.CreateStructGEP(parameters, 0, Size(0));
-          arguments.push_back(parametersPtr.getAddress());
+        collectParameters([&](unsigned i, llvm::Value *typeRef,
+                              ParameterFlags flags) {
+          auto argPtr = IGF.Builder.CreateStructGEP(parameters, i,
+                                                    IGF.IGM.getPointerSize());
+          IGF.Builder.CreateStore(typeRef, argPtr);
+          if (i == 0)
+            arguments.push_back(argPtr.getAddress());
 
-          if (hasFlags) {
-            auto *flagsVar = flagsArr.finishAndCreateGlobal(
-                "parameter-flags", IGF.IGM.getPointerAlignment(),
-                /* constant */ true);
-            arguments.push_back(IGF.Builder.CreateBitCast(flagsVar, Int32Ptr));
-          } else {
-            flagsArr.abandon();
-            arguments.push_back(llvm::ConstantPointerNull::get(Int32Ptr));
-          }
+          if (hasFlags)
+            flagsArr.addInt32(flags.getIntValue());
+        });
+
+        if (hasFlags) {
+          auto *flagsVar = flagsArr.finishAndCreateGlobal(
+              "parameter-flags", IGF.IGM.getPointerAlignment(),
+              /* constant */ true);
+          arguments.push_back(IGF.Builder.CreateBitCast(flagsVar, Int32Ptr));
         } else {
-          arguments.push_back(llvm::ConstantPointerNull::get(
-              IGF.IGM.TypeMetadataPtrTy->getPointerTo()));
+          flagsArr.abandon();
           arguments.push_back(llvm::ConstantPointerNull::get(Int32Ptr));
         }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -799,16 +799,13 @@ namespace {
           return IGF.IGM.getGetFunctionMetadata0Fn();
 
         case 1:
-          return hasFlags ? IGF.IGM.getGetFunctionMetadata1WithFlagsFn()
-                          : IGF.IGM.getGetFunctionMetadata1Fn();
+          return IGF.IGM.getGetFunctionMetadata1Fn();
 
         case 2:
-          return hasFlags ? IGF.IGM.getGetFunctionMetadata2WithFlagsFn()
-                          : IGF.IGM.getGetFunctionMetadata2Fn();
+          return IGF.IGM.getGetFunctionMetadata2Fn();
 
         case 3:
-          return hasFlags ? IGF.IGM.getGetFunctionMetadata3WithFlagsFn()
-                          : IGF.IGM.getGetFunctionMetadata3Fn();
+          return IGF.IGM.getGetFunctionMetadata3Fn();
 
         default:
           llvm_unreachable("supports only 1/2/3 parameter functions");
@@ -826,11 +823,17 @@ namespace {
       case 1:
       case 2:
       case 3: {
-        llvm::SmallVector<llvm::Value *, 8> arguments;
-        auto *metadataFn = constructSimpleCall(arguments);
-        auto *call = IGF.Builder.CreateCall(metadataFn, arguments);
-        call->setDoesNotThrow();
-        return setLocal(CanType(type), call);
+        if (!hasFlags) {
+          llvm::SmallVector<llvm::Value *, 8> arguments;
+          auto *metadataFn = constructSimpleCall(arguments);
+          auto *call = IGF.Builder.CreateCall(metadataFn, arguments);
+          call->setDoesNotThrow();
+          return setLocal(CanType(type), call);
+        }
+
+        // If function type has parameter flags, let's emit
+        // the most general function to retrieve them.
+        LLVM_FALLTHROUGH;
       }
 
       default:

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -404,6 +404,14 @@ public:
 static SimpleGlobalCache<FunctionCacheEntry> FunctionTypes;
 
 const FunctionTypeMetadata *
+swift::swift_getFunctionTypeMetadata0(FunctionTypeFlags flags,
+                                      const Metadata *result) {
+  assert(flags.getNumParameters() == 0
+         && "wrong number of arguments in function metadata flags?!");
+  return swift_getFunctionTypeMetadata(flags, nullptr, nullptr, result);
+}
+
+const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                       const Metadata *arg0,
                                       const Metadata *result) {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -422,21 +422,6 @@ swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
 }
 
 const FunctionTypeMetadata *
-swift::swift_getFunctionTypeMetadata1WithFlags(FunctionTypeFlags flags,
-                                               const Metadata *arg0,
-                                               ParameterFlags flags0,
-                                               const Metadata *result) {
-  assert(flags.getNumParameters() == 1
-         && "wrong number of arguments in function metadata flags?!");
-  const Metadata *parameters[] = { arg0 };
-  const uint32_t parameterFlags[] = { flags0.getIntValue() };
-  return swift_getFunctionTypeMetadata(flags,
-                                       parameters,
-                                       parameterFlags,
-                                       result);
-}
-
-const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                       const Metadata *arg0,
                                       const Metadata *arg1,
@@ -445,26 +430,6 @@ swift::swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1 };
   return swift_getFunctionTypeMetadata(flags, parameters, nullptr, result);
-}
-
-const FunctionTypeMetadata *
-swift::swift_getFunctionTypeMetadata2WithFlags(FunctionTypeFlags flags,
-                                               const Metadata *arg0,
-                                               ParameterFlags flags0,
-                                               const Metadata *arg1,
-                                               ParameterFlags flags1,
-                                               const Metadata *result) {
-  assert(flags.getNumParameters() == 2
-         && "wrong number of arguments in function metadata flags?!");
-  const Metadata *parameters[] = { arg0, arg1 };
-  const uint32_t parameterFlags[] = {
-    flags0.getIntValue(),
-    flags1.getIntValue()
-  };
-  return swift_getFunctionTypeMetadata(flags,
-                                       parameters,
-                                       parameterFlags,
-                                       result);
 }
 
 const FunctionTypeMetadata *
@@ -477,29 +442,6 @@ swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
          && "wrong number of arguments in function metadata flags?!");
   const Metadata *parameters[] = { arg0, arg1, arg2 };
   return swift_getFunctionTypeMetadata(flags, parameters, nullptr, result);
-}
-
-const FunctionTypeMetadata *
-swift::swift_getFunctionTypeMetadata3WithFlags(FunctionTypeFlags flags,
-                                               const Metadata *arg0,
-                                               ParameterFlags flags0,
-                                               const Metadata *arg1,
-                                               ParameterFlags flags1,
-                                               const Metadata *arg2,
-                                               ParameterFlags flags2,
-                                               const Metadata *result) {
-  assert(flags.getNumParameters() == 3
-         && "wrong number of arguments in function metadata flags?!");
-  const Metadata *parameters[] = { arg0, arg1, arg2 };
-  const uint32_t parameterFlags[] = {
-    flags0.getIntValue(),
-    flags1.getIntValue(),
-    flags2.getIntValue()
-  };
-  return swift_getFunctionTypeMetadata(flags,
-                                       parameters,
-                                       parameterFlags,
-                                       result);
 }
 
 const FunctionTypeMetadata *

--- a/test/IRGen/c_function_pointer.sil
+++ b/test/IRGen/c_function_pointer.sil
@@ -27,4 +27,4 @@ entry:
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0yyXCMa()
 // --                                                                               0x3000001 -- C convention, 1 argument
-// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 196608, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+// CHECK: call %swift.type* @swift_getFunctionTypeMetadata0([[WORD:i(32|64)]] 196608, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))

--- a/test/IRGen/dynamic_cast_functions.swift
+++ b/test/IRGen/dynamic_cast_functions.swift
@@ -54,12 +54,14 @@ let j: (__shared Int) -> Void = { _ in }
 let k: (Int, inout Int) -> Void = { _,_ in }
 let l: (inout Int, Float, inout String) -> Void = { _,_,_ in }
 let m: (__shared Int, String, inout Float, Double) -> Void = { _,_,_,_ in }
+let n: () -> Int = { 42 }
 
 let i_any: Any = i
 let j_any: Any = j
 let k_any: Any = k
 let l_any: Any = l
 let m_any: Any = m
+let n_any: Any = n
 
 // CHECK: ok
 print((i_any as? (Int) -> Void) != nil ? "fail" : "ok")
@@ -117,3 +119,9 @@ print((m_any as? (__shared Int, String, Float, inout Double) -> Void) != nil ? "
 print((m_any as? (Int, __shared String, inout Float, Double) -> Void) != nil ? "fail" : "ok")
 // CHECK: ok
 print((m_any as? (__shared Int, String, inout Float, Double) -> Void) != nil ? "ok" : "fail")
+// CHECK: ok
+print((n_any as? () -> Int) != nil ? "ok" : "fail")
+// CHECK: ok
+print((n_any as? () -> Void) != nil ? "fail" : "ok")
+// CHECK: ok
+print((n_any as? (Int) -> Int) != nil ? "fail" : "ok")

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -13,19 +13,19 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(_: ()) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1WithFlags([[WORD]] 33554433, %swift.type* @_T0SiN, i32 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554433, %swift.type** %4, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* %2, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: (Int, Float)) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2WithFlags([[WORD]] 33554434, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SiN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554434, %swift.type** %5, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3WithFlags([[WORD]] 33554435, %swift.type* @_T0SiN, i32 1, %swift.type* @_T0SfN, i32 0, %swift.type* @_T0SSN, i32 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554435, %swift.type** %6, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, %swift.type* @_T0SfN, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
@@ -40,6 +40,6 @@ func test_arch() {
   // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 3
   // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
   // CHECK: [[T:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554436, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554436, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags.{{.*}}, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
 }

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -13,19 +13,19 @@ func test_arch() {
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(_: ()) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554433, %swift.type** %4, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554433, %swift.type** %3, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @parameter-flags, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD]] 1, %swift.type* %2, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: (Int, Float)) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554434, %swift.type** %5, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554434, %swift.type** %3, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata2([[WORD]] 2, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(a: Float, b: Int) -> () in })
 
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554435, %swift.type** %6, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554435, %swift.type** %3, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata3([[WORD]] 3, %swift.type* @_T0SfN, %swift.type* @_T0SfN, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
@@ -39,7 +39,6 @@ func test_arch() {
   // CHECK: store %swift.type* @_T0SSN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
   // CHECK: getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 3
   // CHECK: store %swift.type* @_T0s4Int8VN, %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
-  // CHECK: [[T:%.*]] = getelementptr inbounds [4 x %swift.type*], [4 x %swift.type*]* %function-parameters, i32 0, i32 0
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554436, %swift.type** %7, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags.{{.*}}, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 33554436, %swift.type** %3, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags.{{.*}}, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
 }

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -4,7 +4,7 @@ func arch<F>(_ f: F) {}
 
 // CHECK: define hidden swiftcc void @_T017function_metadata9test_archyyF()
 func test_arch() {
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 0, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata0([[WORD:i(32|64)]] 0, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
   arch( {() -> () in } )
 
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1([[WORD:i(32|64)]] 1, %swift.type* @_T0SiN, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1)) {{#[0-9]+}}

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -38,4 +38,4 @@ entry(%b : $*@convention(block) () -> ()):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
 // --                                                                               0x100_0001 = block convention, 1 arg
-// CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD:i(32|64)]] 65536, %swift.type** null, i32* null, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))
+// CHECK: call %swift.type* @swift_getFunctionTypeMetadata0([[WORD:i(32|64)]] 65536, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_T0ytN, i32 0, i32 1))


### PR DESCRIPTION
- Removes `swift_get{Block|C|Thin|FunctionTypeMetadata` of the function metadata stubs;
- Adds `swift_getFunctionTypeMetadata0` to handle metadata retrieval for functions with no arguments, which is a common use-case;
- Removes `swift_getFunctionTypeMetadata{1|2|3}WithFlags` and replaces their use with the general endpoint instead, since it was minimal;
- Updates to "Function Metadata" section of `doc/TypeMetadata.rst` to mention what endpoints we currently have and why we've decided not to include more specialized ones.

Resolves: rdar://problem/36278686

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
