### PR TITLE
Fix an @available attribute

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -777,7 +777,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///   `endIndex`.
   func formIndex(after i: inout Index)
 
-  @available(swift, deprecated, message: "all index distances are now of type Int")
+  @available(*, deprecated, message: "all index distances are now of type Int")
   typealias IndexDistance = Int
 }
 


### PR DESCRIPTION
Incorrect usage of `@available` resulted in a warning (and potentially attribute not being used?).

  