### PR TITLE
[stdlib] Move a + overload from extension String to extension Sequence

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -454,16 +454,14 @@ extension Collection {
 }
 //===----------------------------------------------------------------------===//
 
-extension String {
+extension Sequence where Element == String {
   @available(*, unavailable, message: "Operator '+' cannot be used to append a String to a sequence of strings")
-  public static func + <S : Sequence>(lhs: S, rhs: String) -> Never
-    where S.Iterator.Element == String {
-      fatalError()
+  public static func + (lhs: Self, rhs: String) -> Never {
+    fatalError()
   }
 
   @available(*, unavailable, message: "Operator '+' cannot be used to append a String to a sequence of strings")
-  public static func + <S : Sequence>(lhs: String, rhs: S) -> Never
-    where S.Iterator.Element == String {
-      fatalError()
+  public static func + (lhs: String, rhs: Self) -> Never {
+    fatalError()
   }
 }


### PR DESCRIPTION
This is a follow up to the https://github.com/apple/swift/pull/13697
The goal is to rearrange the `+` overloads and merge them into few distinct 'groups' to speed up the type checking.

/cc @xedin 