### PR TITLE
[Runtime] Improvements to foreign class metadata

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -273,6 +273,19 @@ parameter vector contains witness tables for those protocols, as if laid out::
     AnsibleWitnessTable *U_Ansible;
   };
 
+Foreign Class Metadata
+~~~~~~~~~~~~~~~~~~~~~~
+
+Foreign class metadata describes "foreign" class types, which support Swift
+reference counting but are otherwise opaque to the Swift runtime.
+
+- The `nominal type descriptor`_ for the most-derived class type is stored at
+  **offset 0**.
+- The **super pointer** pointing to the metadata record for the superclass is
+  stored at **offset 1**. If the class is a root class, it is null.
+- Three **pointer-sized fields**, starting at **offset 2**, are reserved for
+  future use.
+
 Nominal Type Descriptor
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -729,6 +729,7 @@ template <typename Runtime> struct TargetClassMetadata;
 template <typename Runtime> struct TargetStructMetadata;
 template <typename Runtime> struct TargetOpaqueMetadata;
 template <typename Runtime> struct TargetValueMetadata;
+template <typename Runtime> struct TargetForeignClassMetadata;
 
 // FIXME: https://bugs.swift.org/browse/SR-1155
 #pragma clang diagnostic push
@@ -907,6 +908,8 @@ public:
       return static_cast<const TargetValueMetadata<Runtime> *>(this)
           ->Description;
     case MetadataKind::ForeignClass:
+      return static_cast<const TargetForeignClassMetadata<Runtime> *>(this)
+          ->Description;
     case MetadataKind::Opaque:
     case MetadataKind::Tuple:
     case MetadataKind::Function:
@@ -1812,9 +1815,12 @@ struct TargetForeignClassMetadata
   : public TargetForeignTypeMetadata<Runtime> {
   using StoredPointer = typename Runtime::StoredPointer;
 
+  /// An out-of-line description of the type.
+  const TargetNominalTypeDescriptor<Runtime> *Description;
+
   /// The superclass of the foreign class, if any.
   ConstTargetMetadataPointer<Runtime, swift::TargetForeignClassMetadata>
-  SuperClass;
+    SuperClass;
 
   /// Reserved space.  For now, these should be zero-initialized.
   StoredPointer Reserved[3];

--- a/lib/IRGen/ForeignClassMetadataVisitor.h
+++ b/lib/IRGen/ForeignClassMetadataVisitor.h
@@ -1,0 +1,84 @@
+//===-- ForeignClassMetadataVisitor.h - foreign class metadata -*- C++ --*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A CRTP class useful for laying out foreign class metadata.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_FOREIGNCLASSMETADATAVISITOR_H
+#define SWIFT_IRGEN_FOREIGNCLASSMETADATAVISITOR_H
+
+#include "NominalMetadataVisitor.h"
+
+namespace swift {
+namespace irgen {
+
+/// A CRTP layout class for foreign class metadata.
+template <class Impl>
+class ForeignClassMetadataVisitor
+       : public NominalMetadataVisitor<Impl> {
+  using super = NominalMetadataVisitor<Impl>;
+protected:
+  ClassDecl *Target;
+  using super::asImpl;
+public:
+  ForeignClassMetadataVisitor(IRGenModule &IGM, ClassDecl *target)
+    : super(IGM), Target(target) {}
+
+  void layout() {
+    super::layout();
+    asImpl().addNominalTypeDescriptor();
+    asImpl().noteStartOfSuperClass();
+    asImpl().addSuperClass();
+    asImpl().addReservedWord();
+    asImpl().addReservedWord();
+    asImpl().addReservedWord();
+  }
+
+  bool requiresInitializationFunction() {
+    return Target->getSuperclassDecl() &&
+           Target->getSuperclassDecl()->isForeign();
+  }
+
+  CanType getTargetType() const {
+    return Target->getDeclaredType()->getCanonicalType();
+  }
+};
+
+/// An "implementation" of ForeignClassMetadataVisitor that just scans through
+/// the metadata layout, maintaining the offset of the next field.
+template <class Impl>
+class ForeignClassMetadataScanner : public ForeignClassMetadataVisitor<Impl> {
+  typedef ForeignClassMetadataVisitor<Impl> super;
+protected:
+  Size NextOffset = Size(0);
+
+  ForeignClassMetadataScanner(IRGenModule &IGM, ClassDecl *target)
+    : super(IGM, target) {}
+
+public:
+  void addMetadataFlags() { addPointer(); }
+  void addValueWitnessTable() { addPointer(); }
+  void addNominalTypeDescriptor() { addPointer(); }
+  void addSuperClass() { addPointer(); }
+  void addReservedWord() { addPointer(); }
+
+private:
+  void addPointer() {
+    NextOffset += super::IGM.getPointerSize();
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif // SWIFT_IRGEN_FOREIGNCLASSMETADATAVISITOR_H

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -903,11 +903,11 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
         } else {
           idKind = KeyPathComponentHeader::VTableOffset;
           auto dc = declRef.getDecl()->getDeclContext();
-          if (isa<ClassDecl>(dc)) {
+          if (isa<ClassDecl>(dc) && !cast<ClassDecl>(dc)->isForeign()) {
             auto overridden = declRef.getOverriddenVTableEntry();
             auto declaringClass =
               cast<ClassDecl>(overridden.getDecl()->getDeclContext());
-            auto &metadataLayout = getMetadataLayout(declaringClass);
+            auto &metadataLayout = getClassMetadataLayout(declaringClass);
             // FIXME: Resilience. We don't want vtable layout to be ABI, so this
             // should be encoded as a reference to the method dispatch thunk
             // instead.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4901,6 +4901,7 @@ namespace {
 
     void layout() {
       super::layout();
+      asImpl().addNominalTypeDescriptor();
       asImpl().addSuperClass();
       asImpl().addReservedWord();
       asImpl().addReservedWord();
@@ -5051,6 +5052,11 @@ namespace {
 
     void addMetadataFlags() {
       B.addInt(IGM.MetadataKindTy, (unsigned) MetadataKind::ForeignClass);
+    }
+
+    void addNominalTypeDescriptor() {
+      auto descriptor = ClassNominalTypeDescriptorBuilder(this->IGM, Target).emit();
+      B.add(descriptor);
     }
 
     void addSuperClass() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -41,6 +41,7 @@
 #include "ConstantBuilder.h"
 #include "EnumMetadataVisitor.h"
 #include "FixedTypeInfo.h"
+#include "ForeignClassMetadataVisitor.h"
 #include "GenArchetype.h"
 #include "GenClass.h"
 #include "GenDecl.h"
@@ -296,16 +297,22 @@ llvm::Value *irgen::emitObjCHeapMetadataRef(IRGenFunction &IGF,
 }
 
 /// Emit a reference to the type metadata for a foreign type.
-static llvm::Value *emitForeignTypeMetadataRef(IRGenFunction &IGF,
-                                               CanType type) {
-  llvm::Value *candidate = IGF.IGM.getAddrOfForeignTypeMetadataCandidate(type);
+static llvm::Value *uniqueForeignTypeMetadataRef(IRGenFunction &IGF,
+                                                 llvm::Value *candidate) {
   auto call = IGF.Builder.CreateCall(IGF.IGM.getGetForeignTypeMetadataFn(),
-                                candidate);
+                                     candidate);
   call->addAttribute(llvm::AttributeList::FunctionIndex,
                      llvm::Attribute::NoUnwind);
   call->addAttribute(llvm::AttributeList::FunctionIndex,
                      llvm::Attribute::ReadNone);
   return call;
+}
+
+/// Emit a reference to the type metadata for a foreign type.
+static llvm::Value *emitForeignTypeMetadataRef(IRGenFunction &IGF,
+                                               CanType type) {
+  llvm::Value *candidate = IGF.IGM.getAddrOfForeignTypeMetadataCandidate(type);
+  return uniqueForeignTypeMetadataRef(IGF, candidate);
 }
 
 /// Returns a metadata reference for a nominal type.
@@ -2189,11 +2196,13 @@ namespace {
       // GenericParameterDescriptorFlags Flags;
       GenericParameterDescriptorFlags flags;
       if (auto *cd = dyn_cast<ClassDecl>(ntd)) {
-        auto &layout = IGM.getMetadataLayout(cd);
-        if (layout.getVTableSize() > 0)
-          flags = flags.withHasVTable(true);
-        if (layout.hasResilientSuperclass())
-          flags = flags.withHasResilientSuperclass(true);
+        if (!cd->isForeign()) {
+          auto &layout = IGM.getClassMetadataLayout(cd);
+          if (layout.getVTableSize() > 0)
+            flags = flags.withHasVTable(true);
+          if (layout.hasResilientSuperclass())
+            flags = flags.withHasResilientSuperclass(true);
+        }
       }
 
       // Calculate the number of generic parameters at each nesting depth.
@@ -2428,7 +2437,13 @@ namespace {
                                        ClassDecl *c)
       : super(IGM), Target(c)
     {
-      auto &layout = IGM.getMetadataLayout(Target);
+      if (Target->isForeign()) {
+        VTable = nullptr;
+        VTableSize = 0;
+        return;
+      }
+
+      auto &layout = IGM.getClassMetadataLayout(Target);
 
       VTable = IGM.getSILModule().lookUpVTable(Target);
       VTableSize = layout.getVTableSize();
@@ -2834,7 +2849,7 @@ namespace {
       // fill indexes are word-indexed.
       auto *metadataWords = IGF.Builder.CreateBitCast(metadataValue, IGM.Int8PtrPtrTy);
 
-      auto genericReqtOffset = IGM.getMetadataLayout(Target)
+      auto genericReqtOffset = IGM.getNominalMetadataLayout(Target)
           .getGenericRequirementsOffset(IGF);
 
       for (auto &fillOp : FillOps) {
@@ -3145,7 +3160,7 @@ namespace {
         auto fn = entry.Method;
 
         auto *classDecl = cast<ClassDecl>(fn.getDecl()->getDeclContext());
-        auto &layout = IGM.getMetadataLayout(classDecl);
+        auto &layout = IGM.getClassMetadataLayout(classDecl);
 
         auto offset = layout.getMethodInfo(IGF, fn).getOffset();
 
@@ -3493,7 +3508,7 @@ namespace {
       if (!HasResilientSuperclass)
         return;
 
-      auto &layout = IGM.getMetadataLayout(Target);
+      auto &layout = IGM.getClassMetadataLayout(Target);
 
       // Load the size of the superclass metadata.
       Address metadataAsBytes(
@@ -3747,7 +3762,7 @@ namespace {
       if (doesClassMetadataRequireDynamicInitialization(IGM, Target)) {
         auto templateSize = IGM.getSize(Size(B.getNextOffsetFromGlobal()));
         auto numImmediateMembers = IGM.getSize(
-          Size(IGM.getMetadataLayout(Target).getNumImmediateMembers()));
+          Size(IGM.getClassMetadataLayout(Target).getNumImmediateMembers()));
         metadata = IGF.Builder.CreateCall(IGF.IGM.getRelocateClassMetadataFn(),
                                           {metadata, templateSize,
                                            numImmediateMembers});
@@ -3838,7 +3853,7 @@ namespace {
       }
 
       auto numImmediateMembers =
-        IGM.getSize(Size(IGM.getMetadataLayout(Target).getNumImmediateMembers()));
+        IGM.getSize(Size(IGM.getClassMetadataLayout(Target).getNumImmediateMembers()));
 
       return IGF.Builder.CreateCall(IGM.getAllocateGenericClassMetadataFn(),
                                     {metadataPattern, arguments, superMetadata,
@@ -4230,7 +4245,7 @@ std::pair<llvm::Value *, llvm::Value *>
 irgen::emitClassResilientInstanceSizeAndAlignMask(IRGenFunction &IGF,
                                                   ClassDecl *theClass,
                                                   llvm::Value *metadata) {
-  auto &layout = IGF.IGM.getMetadataLayout(theClass);
+  auto &layout = IGF.IGM.getClassMetadataLayout(theClass);
 
   Address metadataAsBytes(IGF.Builder.CreateBitCast(metadata, IGF.IGM.Int8PtrTy),
                           IGF.IGM.getPointerAlignment());
@@ -4487,7 +4502,7 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
   auto declaringClass = cast<ClassDecl>(overridden.getDecl()->getDeclContext());
 
   auto methodInfo =
-    IGF.IGM.getMetadataLayout(declaringClass).getMethodInfo(IGF, overridden);
+    IGF.IGM.getClassMetadataLayout(declaringClass).getMethodInfo(IGF, overridden);
   auto offset = methodInfo.getOffset();
 
   auto slot = IGF.emitAddressAtOffset(metadata, offset,
@@ -4887,37 +4902,6 @@ llvm::Value *IRGenFunction::emitObjCSelectorRefLoad(StringRef selector) {
 //===----------------------------------------------------------------------===//
 
 namespace {
-  /// A CRTP layout class for foreign class metadata.
-  template <class Impl>
-  class ForeignClassMetadataVisitor
-         : public NominalMetadataVisitor<Impl> {
-    using super = NominalMetadataVisitor<Impl>;
-  protected:
-    ClassDecl *Target;
-    using super::asImpl;
-  public:
-    ForeignClassMetadataVisitor(IRGenModule &IGM, ClassDecl *target)
-      : super(IGM), Target(target) {}
-
-    void layout() {
-      super::layout();
-      asImpl().addNominalTypeDescriptor();
-      asImpl().addSuperClass();
-      asImpl().addReservedWord();
-      asImpl().addReservedWord();
-      asImpl().addReservedWord();
-    }
-
-    bool requiresInitializationFunction() {
-      // TODO: superclasses?
-      return false;
-    }
-           
-    CanType getTargetType() const {
-      return Target->getDeclaredType()->getCanonicalType();
-    }
-  };
-  
   /// An adapter that turns a metadata layout class into a foreign metadata
   /// layout class.
   ///
@@ -5034,8 +5018,23 @@ namespace {
       : ForeignMetadataBuilderBase(IGM, target, B) {}
 
     void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {
-      // TODO: superclasses?
-      llvm_unreachable("no supported forms of initialization");
+      // Dig out the address of the superclass field.
+      auto &layout = IGF.IGM.getForeignMetadataLayout(Target);
+      Address metadataWords(IGF.Builder.CreateBitCast(metadata,
+                                                      IGM.Int8PtrPtrTy),
+                            IGM.getPointerAlignment());
+      auto superclassField =
+        createPointerSizedGEP(IGF, metadataWords,
+                              layout.getSuperClassOffset().getStaticOffset());
+      superclassField =
+        IGF.Builder.CreateBitCast(
+                          superclassField,
+                          llvm::PointerType::get(IGM.TypeMetadataPtrTy, 0));
+
+      // Unique the superclass field and write it back.
+      auto superclass = IGF.Builder.CreateLoad(superclassField);
+      auto uniquedSuperclass = uniqueForeignTypeMetadataRef(IGF, superclass);
+      IGF.Builder.CreateStore(uniquedSuperclass, superclassField);
     }
 
     // Visitor methods.
@@ -5059,9 +5058,21 @@ namespace {
       B.add(descriptor);
     }
 
+    void noteStartOfSuperClass() { }
+
     void addSuperClass() {
-      // TODO: superclasses
-      B.addNullPointer(IGM.TypeMetadataPtrTy);
+      auto superclassDecl = Target->getSuperclassDecl();
+      if (!superclassDecl || !superclassDecl->isForeign()) {
+        B.addNullPointer(IGM.TypeMetadataPtrTy);
+        return;
+      }
+
+      auto superclassType =
+        superclassDecl->swift::TypeDecl::getDeclaredInterfaceType()
+          ->getCanonicalType();
+      auto superclass =
+        IGM.getAddrOfForeignTypeMetadataCandidate(superclassType);
+      B.add(superclass);
     }
 
     void addReservedWord() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -110,6 +110,7 @@ namespace irgen {
   class EnumMetadataLayout;
   class ExplosionSchema;
   class FixedTypeInfo;
+  class ForeignClassMetadataLayout;
   class ForeignFunctionInfo;
   class FormalType;
   class HeapLayout;
@@ -667,10 +668,12 @@ public:
 
   SpareBitVector getSpareBitsForType(llvm::Type *scalarTy, Size size);
 
-  NominalMetadataLayout &getMetadataLayout(NominalTypeDecl *decl);
+  MetadataLayout &getMetadataLayout(NominalTypeDecl *decl);
+  NominalMetadataLayout &getNominalMetadataLayout(NominalTypeDecl *decl);
   StructMetadataLayout &getMetadataLayout(StructDecl *decl);
-  ClassMetadataLayout &getMetadataLayout(ClassDecl *decl);
+  ClassMetadataLayout &getClassMetadataLayout(ClassDecl *decl);
   EnumMetadataLayout &getMetadataLayout(EnumDecl *decl);
+  ForeignClassMetadataLayout &getForeignMetadataLayout(ClassDecl *decl);
 
 private:
   TypeConverter &Types;

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -49,8 +49,8 @@ public:
   enum class Kind {
     Class,
     Struct,
-    Enum
-    // Update NominalMetadataLayout::classof if you add a non-nominal layout.
+    Enum,
+    ForeignClass,
   };
 
   class StoredOffset {
@@ -151,7 +151,15 @@ public:
   Offset getGenericRequirementsOffset(IRGenFunction &IGF) const;
 
   static bool classof(const MetadataLayout *layout) {
-    return true; // No non-nominal metadata for now.
+    switch (layout->getKind()) {
+    case MetadataLayout::Kind::Class:
+    case MetadataLayout::Kind::Enum:
+    case MetadataLayout::Kind::Struct:
+      return true;
+
+    case MetadataLayout::Kind::ForeignClass:
+      return false;
+    }
   }
 };
 
@@ -335,6 +343,22 @@ public:
 
   static bool classof(const MetadataLayout *layout) {
     return layout->getKind() == Kind::Struct;
+  }
+};
+
+/// Layout for foreign class type metadata.
+class ForeignClassMetadataLayout : public MetadataLayout {
+  ClassDecl *Class;
+  StoredOffset SuperClassOffset;
+
+  friend class IRGenModule;
+  ForeignClassMetadataLayout(IRGenModule &IGM, ClassDecl *theClass);
+
+public:
+  StoredOffset getSuperClassOffset() const { return SuperClassOffset; }
+
+  static bool classof(const MetadataLayout *layout) {
+    return layout->getKind() == Kind::ForeignClass;
   }
 };
 

--- a/test/IRGen/Inputs/usr/include/CoreCooling.h
+++ b/test/IRGen/Inputs/usr/include/CoreCooling.h
@@ -8,3 +8,5 @@ CCRefrigeratorRef CCRefrigeratorCreate(CCPowerSupplyRef power);
 
 void CCRefrigeratorOpen(CCRefrigeratorRef fridge);
 void CCRefrigeratorClose(CCRefrigeratorRef fridge);
+
+typedef struct __attribute__((objc_bridge(id))) __CCRefrigerator *CCMutableRefrigeratorRef;

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -5,6 +5,7 @@
 
 // CHECK: [[TYPE:%swift.type]] = type
 // CHECK: [[REFRIGERATOR:%TSo14CCRefrigeratorC]] = type
+// CHECK: [[MUTABLE_REFRIGERATOR:%TSo21CCMutableRefrigeratorC]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 
 // CHECK: [[REFRIGERATOR_NAME:@.*]] = private constant [20 x i8] c"So14CCRefrigeratorC\00"
@@ -20,6 +21,14 @@
 // CHECK-64-SAME: i64 0,
 // CHECK-64-SAME: i8** @_T0BOWV, i64 16, {{.*}}_T0So14CCRefrigeratorCMn, [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
+// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [27 x i8] c"So21CCMutableRefrigeratorC\00"
+
+// CHECK-64: @_T0So21CCMutableRefrigeratorCN = linkonce_odr hidden global <{ {{.*}} }> <{
+// CHECK-64-SAME: @initialize_metadata_CCMutableRefrigerator
+// CHECK-64-SAME: i32 trunc {{.*}} [[MUTABLE_REFRIGERATOR_NAME]] to i64
+// CHECK-64-SAME: i64 1,
+// CHECK-64-SAME: i8** @_T0BOWV, i64 16, {{.*}}_T0So21CCMutableRefrigeratorCMn, [[TYPE]]* bitcast{{.*}}@_T0So14CCRefrigeratorCN{{.*}} to %swift.type*), i8* null, i8* null, i8* null }>
+
 sil_stage canonical
 
 import CoreCooling
@@ -27,20 +36,32 @@ import Swift
 
 sil public_external @generic_function : $@convention(thin) <T where T : AnyObject> (@owned T) -> ()
 
-sil @call_generic : $@convention(thin) (@owned CCRefrigerator) -> () {
-bb0(%0 : $CCRefrigerator):
-  %1 = function_ref @generic_function : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@owned τ_0_0) -> ()
-  %2 = apply %1<CCRefrigerator>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@owned τ_0_0) -> ()
-  %3 = tuple ()
-  return %3 : $()
+sil @call_generic : $@convention(thin) (@owned CCRefrigerator, @owned CCMutableRefrigerator) -> () {
+bb0(%0 : $CCRefrigerator, %1: $CCMutableRefrigerator):
+  %2 = function_ref @generic_function : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@owned τ_0_0) -> ()
+  %3 = apply %2<CCRefrigerator>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@owned τ_0_0) -> ()
+  %4 = apply %2<CCMutableRefrigerator>(%1) : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@owned τ_0_0) -> ()
+  %5 = tuple ()
+  return %5 : $()
 }
 
-// CHECK:    define{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*) {{.*}} {
+// CHECK:    define{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*, [[MUTABLE_REFRIGERATOR]]*) {{.*}} {
 // CHECK:      [[T0:%.*]] = bitcast [[REFRIGERATOR]]* %0 to [[OBJC]]*
 // CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @_T0So14CCRefrigeratorCMa()
+// CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T1]])
+// CHECK:      [[T0:%.*]] = bitcast [[MUTABLE_REFRIGERATOR]]* %1 to [[OBJC]]*
+// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @_T0So21CCMutableRefrigeratorCMa()
 // CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T1]])
 // CHECK-NEXT: ret void
 
 // CHECK:    define linkonce_odr hidden [[TYPE]]* @_T0So14CCRefrigeratorCMa()
 // CHECK-32:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @_T0So14CCRefrigeratorCN to i8*), i32 12) to [[TYPE]]*))
 // CHECK-64:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @_T0So14CCRefrigeratorCN to i8*), i64 24) to [[TYPE]]*))
+
+// CHECK:    define private void @initialize_metadata_CCMutableRefrigerator(%swift.type*)
+// CHECK-64:   [[T0:%.*]] = bitcast %swift.type* %0 to i8**
+// CHECK-64:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[T0]], i32 2
+// CHECK-64:   [[T2:%.*]] = bitcast i8** [[T1]] to %swift.type**
+// CHECK-64:   [[T3:%.*]] = load %swift.type*, %swift.type** [[T2]]
+// CHECK-64:   [[T4:%.*]] = call %swift.type* @swift_getForeignTypeMetadata(%swift.type* [[T3]])
+// CHECK-64:  store %swift.type* [[T4]], %swift.type** [[T2]]

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -12,13 +12,13 @@
 // CHECK-32: @_T0So14CCRefrigeratorCN = linkonce_odr hidden global <{ {{.*}} }> <{
 // CHECK-32-SAME: [[REFRIGERATOR_NAME]] to i32
 // CHECK-32-SAME: i32 0,
-// CHECK-32-SAME: i8** @_T0BOWV, i32 16, [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK-32-SAME: i8** @_T0BOWV, i32 16, {{.*}}_T0So14CCRefrigeratorCMn, [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
 // CHECK-64: @_T0So14CCRefrigeratorCN = linkonce_odr hidden global <{ {{.*}} }> <{
 // CHECK-64-SAME: i32 0,
 // CHECK-64-SAME: i32 trunc {{.*}} [[REFRIGERATOR_NAME]] to i64
 // CHECK-64-SAME: i64 0,
-// CHECK-64-SAME: i8** @_T0BOWV, i64 16, [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK-64-SAME: i8** @_T0BOWV, i64 16, {{.*}}_T0So14CCRefrigeratorCMn, [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
 sil_stage canonical
 


### PR DESCRIPTION
Improve foreign class metadata in a few ways:

* Add a nominal type descriptor field, so we have nominal type descriptors for all nominal types
* Fill in the superclass of foreign class metadata, when known