### PR TITLE
Revert "[Coverage] Clean up a few classes, NFC"

### DIFF
--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -22,16 +22,16 @@
 #include "swift/SIL/SILAllocated.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILPrintContext.h"
-#include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
+#include "llvm/ADT/ilist.h"
 #include "llvm/ProfileData/Coverage/CoverageMapping.h"
 
 namespace llvm {
 namespace coverage {
 struct CounterExpression;
 struct Counter;
-} // namespace coverage
-} // namespace llvm
+}
+}
 
 namespace swift {
 
@@ -133,7 +133,7 @@ public:
   void dump() const;
 };
 
-} // namespace swift
+} // end swift namespace
 
 namespace llvm {
 
@@ -142,8 +142,8 @@ namespace llvm {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct ilist_traits<::swift::SILCoverageMap>
-    : public ilist_default_traits<::swift::SILCoverageMap> {
+struct ilist_traits<::swift::SILCoverageMap> :
+public ilist_default_traits<::swift::SILCoverageMap> {
   typedef ::swift::SILCoverageMap SILCoverageMap;
 
 public:
@@ -153,6 +153,6 @@ private:
   void createNode(const SILCoverageMap &);
 };
 
-} // namespace llvm
+} // end llvm namespace
 
 #endif // SWIFT_SIL_SILCOVERAGEMAP_H

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -453,6 +453,20 @@ public:
   using coverage_map_const_iterator = CoverageMapListType::const_iterator;
   CoverageMapListType &getCoverageMapList() { return coverageMaps; }
   const CoverageMapListType &getCoverageMapList() const { return coverageMaps; }
+  coverage_map_iterator coverage_map_begin() { return coverageMaps.begin(); }
+  coverage_map_iterator coverage_map_end() { return coverageMaps.end(); }
+  coverage_map_const_iterator coverage_map_begin() const {
+    return coverageMaps.begin();
+  }
+  coverage_map_const_iterator coverage_map_end() const {
+    return coverageMaps.end();
+  }
+  iterator_range<coverage_map_iterator> getCoverageMaps() {
+    return {coverageMaps.begin(), coverageMaps.end()};
+  }
+  iterator_range<coverage_map_const_iterator> getCoverageMaps() const {
+    return {coverageMaps.begin(), coverageMaps.end()};
+  }
 
   llvm::yaml::Output *getOptRecordStream() { return OptRecordStream.get(); }
   void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -22,7 +22,6 @@
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/SIL/FormalLinkage.h"
-#include "swift/SIL/SILAllocated.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace swift {
@@ -46,15 +45,15 @@ private:
 
   std::string PGOFuncName;
 
-  uint64_t PGOFuncHash = 0;
+  uint64_t FunctionHash = 0;
 
   unsigned NumRegionCounters = 0;
 
   llvm::DenseMap<ASTNode, unsigned> RegionCounterMap;
 
-  llvm::DenseMap<ASTNode, ProfileCounter> RegionLoadedCounterMap;
+  llvm::DenseMap<ASTNode, ProfileCounter> PGORegionLoadedCounterMap;
 
-  llvm::DenseMap<ASTNode, ASTNode> RegionCondToParentMap;
+  llvm::DenseMap<ASTNode, ASTNode> PGORegionCondToParentMap;
 
   std::vector<std::tuple<std::string, uint64_t, std::string>> CoverageData;
 
@@ -79,7 +78,7 @@ public:
   StringRef getPGOFuncName() const { return PGOFuncName; }
 
   /// Get the function hash.
-  uint64_t getPGOFuncHash() const { return PGOFuncHash; }
+  uint64_t getPGOFuncHash() const { return FunctionHash; }
 
   /// Get the number of region counters.
   unsigned getNumRegionCounters() const { return NumRegionCounters; }

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/SIL/SILProfiler.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILProfiler.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/ProfileData/Coverage/CoverageMapping.h"
@@ -52,8 +52,8 @@ static void walkFunctionForProfiling(AbstractFunctionDecl *Root,
 
   // We treat class initializers as part of the constructor for profiling.
   if (auto *CD = dyn_cast<ConstructorDecl>(Root)) {
-    auto *NominalType =
-        CD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    auto *NominalType = CD->getDeclContext()
+        ->getAsNominalTypeOrNominalTypeExtensionContext();
     for (auto *Member : NominalType->getMembers()) {
       // Find pattern binding declarations that have initializers.
       if (auto *PBD = dyn_cast<PatternBindingDecl>(Member))
@@ -160,7 +160,8 @@ class CounterExpr {
     assert(K == Kind::Node && "only valid for Node");
   }
 
-  CounterExpr(Kind K, const CounterExpr &LHS) : K(K), LHS(&LHS) {
+  CounterExpr(Kind K, const CounterExpr &LHS)
+      : K(K), LHS(&LHS) {
     assert((K == Kind::Ref) && "only valid for Ref");
   }
 
@@ -280,9 +281,9 @@ struct PGOMapping : public ASTWalker {
 
   PGOMapping(llvm::DenseMap<ASTNode, ProfileCounter> &LoadedCounterMap,
              llvm::Expected<llvm::InstrProfRecord> &LoadedCounts,
-             llvm::DenseMap<ASTNode, ASTNode> &RegionCondToParentMap)
+             llvm::DenseMap<ASTNode, ASTNode> &PGORegionCondToParentMap)
       : NextCounter(0), LoadedCounterMap(LoadedCounterMap),
-        LoadedCounts(LoadedCounts), CondToParentMap(RegionCondToParentMap) {}
+        LoadedCounts(LoadedCounts), CondToParentMap(PGORegionCondToParentMap) {}
 
   unsigned getParentCounter() const {
     if (Parent.isNull())
@@ -574,6 +575,7 @@ private:
     if (ControlFlowAdjust)
       Count = &createCounter(CounterExpr::Sub(*Count, *ControlFlowAdjust));
 
+    //RegionStack.emplace_back(ASTNode(), *Count, getEndLoc(Scope), None);
     RegionStack.emplace_back(ASTNode(), *Count, getEndLoc(Scope), None);
   }
 
@@ -764,7 +766,7 @@ public:
 
     } else if (auto *RWS = dyn_cast<RepeatWhileStmt>(S)) {
       assert(RepeatWhileStack.back() == RWS && "Malformed repeat-while stack");
-      (void)RWS;
+      (void) RWS;
       RepeatWhileStack.pop_back();
 
     } else if (auto *CS = dyn_cast<ContinueStmt>(S)) {
@@ -843,6 +845,7 @@ public:
 
     return E;
   }
+
 };
 
 } // end anonymous namespace
@@ -893,7 +896,7 @@ void SILProfiler::assignRegionCounters() {
 
   NumRegionCounters = Mapper.NextCounter;
   // TODO: Mapper needs to calculate a function hash as it goes.
-  PGOFuncHash = 0x0;
+  FunctionHash = 0x0;
 
   if (EmitCoverageMapping) {
     CoverageMapping Coverage(SM);
@@ -902,11 +905,11 @@ void SILProfiler::assignRegionCounters() {
         M, CurrentFuncName,
         !llvm::GlobalValue::isLocalLinkage(
             getEquivalentPGOLinkage(CurrentFuncLinkage)),
-        PGOFuncHash, RegionCounterMap, CurrentFileName);
+        FunctionHash, RegionCounterMap, CurrentFileName);
   }
 
   if (llvm::IndexedInstrProfReader *IPR = M.getPGOReader()) {
-    auto LoadedCounts = IPR->getInstrProfRecord(PGOFuncName, PGOFuncHash);
+    auto LoadedCounts = IPR->getInstrProfRecord(PGOFuncName, FunctionHash);
     if (auto E = LoadedCounts.takeError()) {
       llvm::handleAllErrors(std::move(E), [](const llvm::InstrProfError &Err) {
         Err.log(llvm::dbgs());
@@ -915,8 +918,8 @@ void SILProfiler::assignRegionCounters() {
       llvm::dbgs() << PGOFuncName << "\n";
       return;
     }
-    PGOMapping pgoMapper(RegionLoadedCounterMap, LoadedCounts,
-                         RegionCondToParentMap);
+    PGOMapping pgoMapper(PGORegionLoadedCounterMap, LoadedCounts,
+                         PGORegionCondToParentMap);
     walkForProfiling(Root, pgoMapper);
   }
 }
@@ -925,8 +928,8 @@ ProfileCounter SILProfiler::getExecutionCount(ASTNode Node) {
   if (!Node || !M.getPGOReader() || !hasRegionCounters()) {
     return ProfileCounter();
   }
-  auto it = RegionLoadedCounterMap.find(Node);
-  if (it == RegionLoadedCounterMap.end()) {
+  auto it = PGORegionLoadedCounterMap.find(Node);
+  if (it == PGORegionLoadedCounterMap.end()) {
     return ProfileCounter();
   }
   return it->getSecond();
@@ -936,8 +939,8 @@ Optional<ASTNode> SILProfiler::getPGOParent(ASTNode Node) {
   if (!Node || !M.getPGOReader() || !hasRegionCounters()) {
     return None;
   }
-  auto it = RegionCondToParentMap.find(Node);
-  if (it == RegionCondToParentMap.end()) {
+  auto it = PGORegionCondToParentMap.find(Node);
+  if (it == PGORegionCondToParentMap.end()) {
     return None;
   }
   return it->getSecond();


### PR DESCRIPTION
Reverts apple/swift#13705

It looks like this is required in order to revert https://github.com/apple/swift/pull/13597, which appears to have resulted in some source compatibility suite builds to break.

See: https://ci.swift.org/job/swift-master-source-compat-suite/1014/