### PR TITLE
[Coverage] Defensively drop malformed coverage mappings

### DIFF
--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -38,24 +38,19 @@ static std::string getCoverageSection(IRGenModule &IGM) {
 }
 
 void IRGenModule::emitCoverageMapping() {
-  const auto &Mappings = getSILModule().getCoverageMapList();
+  std::vector<const SILCoverageMap *> Mappings;
+  for (const auto &M : getSILModule().getCoverageMapList())
+    if (M.hasSymtabEntry())
+      Mappings.push_back(&M);
+
   // If there aren't any coverage maps, there's nothing to emit.
   if (Mappings.empty())
     return;
 
-  assert(std::all_of(Mappings.begin(), Mappings.end(),
-                     [](const SILCoverageMap &M) {
-                       // TODO: We should use this check defensively s.t we
-                       // never emit malformed coverage data, instead of just
-                       // using it as a debugging tool.
-                       return M.hasSymtabEntry();
-                     }) &&
-         "Missing symtab entry for coverage mapping");
-
   std::vector<StringRef> Files;
   for (const auto &M : Mappings)
-    if (std::find(Files.begin(), Files.end(), M.getFile()) == Files.end())
-      Files.push_back(M.getFile());
+    if (std::find(Files.begin(), Files.end(), M->getFile()) == Files.end())
+      Files.push_back(M->getFile());
 
   // Awkwardly munge absolute filenames into a vector of StringRefs.
   // TODO: This is heinous - the same thing is happening in clang, but the API
@@ -94,23 +89,23 @@ void IRGenModule::emitCoverageMapping() {
   std::vector<CounterMappingRegion> Regions;
   for (const auto &M : Mappings) {
     unsigned FileID =
-        std::find(Files.begin(), Files.end(), M.getFile()) - Files.begin();
+        std::find(Files.begin(), Files.end(), M->getFile()) - Files.begin();
     Regions.clear();
-    for (const auto &MR : M.getMappedRegions())
+    for (const auto &MR : M->getMappedRegions())
       Regions.emplace_back(CounterMappingRegion::makeRegion(
           MR.Counter, /*FileID=*/0, MR.StartLine, MR.StartCol, MR.EndLine,
           MR.EndCol));
     // Append each function's regions into the encoded buffer.
     ArrayRef<unsigned> VirtualFileMapping(FileID);
     llvm::coverage::CoverageMappingWriter W(VirtualFileMapping,
-                                            M.getExpressions(), Regions);
+                                            M->getExpressions(), Regions);
     W.write(OS);
 
     std::string NameValue = llvm::getPGOFuncName(
-        M.getName(),
-        M.isPossiblyUsedExternally() ? llvm::GlobalValue::ExternalLinkage
+        M->getName(),
+        M->isPossiblyUsedExternally() ? llvm::GlobalValue::ExternalLinkage
                                      : llvm::GlobalValue::PrivateLinkage,
-        M.getFile());
+        M->getFile());
     llvm::createPGOFuncNameVar(
         *getModule(), llvm::GlobalValue::LinkOnceAnyLinkage, NameValue);
 
@@ -118,7 +113,7 @@ void IRGenModule::emitCoverageMapping() {
     unsigned MappingLen = CurrentSize - PrevSize;
     StringRef CoverageMapping(OS.str().c_str() + PrevSize, MappingLen);
 
-    uint64_t FuncHash = M.getHash();
+    uint64_t FuncHash = M->getHash();
 
     // Create a record for this function.
     llvm::Constant *FunctionRecordVals[] = {


### PR DESCRIPTION
The compiler shouldn't emit coverage mappings for functions which don't
contain profiling instrumentation. However, due to bugs in the profiling
code, this sometimes happens. In this case, it's better to defensively
drop just the malformed coverage mappings instead of allowing corrupted
profiles to be created.

Should address the failures in:
https://ci.swift.org/job/swift-master-source-compat-suite/1014