### PR TITLE
master-next: Update phi iteration for the LLVM SSAUpdater change in r 321783

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -161,6 +161,36 @@ public:
   const_arg_iterator args_begin() const { return ArgumentList.begin(); }
   const_arg_iterator args_end() const { return ArgumentList.end(); }
 
+  /// Iterator over the PHI arguments of a basic block.
+  /// Defines an implicit cast operator on the iterator, so that this iterator
+  /// can be used in the SSAUpdaterImpl.
+  template <typename PHIArgT = SILPHIArgument,
+            typename IteratorT = arg_iterator>
+  class phi_iterator_impl {
+  private:
+    IteratorT It;
+
+  public:
+    explicit phi_iterator_impl(IteratorT A) : It(A) {}
+    phi_iterator_impl &operator++() { ++It; return *this; }
+
+    operator PHIArgT *() { return cast<PHIArgT>(*It); }
+    bool operator==(const phi_iterator_impl& x) const { return It == x.It; }
+    bool operator!=(const phi_iterator_impl& x) const { return !operator==(x); }
+  };
+  typedef phi_iterator_impl<> phi_iterator;
+  typedef phi_iterator_impl<const SILPHIArgument,
+                            SILBasicBlock::const_arg_iterator>
+      const_phi_iterator;
+
+  inline iterator_range<phi_iterator> phis() {
+    return make_range(phi_iterator(args_begin()), phi_iterator(args_end()));
+  }
+  inline iterator_range<const_phi_iterator> phis() const {
+    return make_range(const_phi_iterator(args_begin()),
+                      const_phi_iterator(args_end()));
+  }
+
   ArrayRef<SILArgument *> getArguments() const { return ArgumentList; }
   using PHIArgumentArrayRefTy =
       TransformArrayRef<std::function<SILPHIArgument *(SILArgument *)>>;

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -248,29 +248,6 @@ public:
   static BlkSucc_iterator BlkSucc_begin(BlkT *BB) { return BB->succ_begin(); }
   static BlkSucc_iterator BlkSucc_end(BlkT *BB) { return BB->succ_end(); }
 
-  /// Iterator over the arguments (phis) of a basic block.
-  /// Defines an implicit cast operator on the iterator. So that this iterator
-  /// can be used in the SSAUpdaterImpl.
-  class PhiIt {
-  private:
-    SILBasicBlock::arg_iterator It;
-
-  public:
-    explicit PhiIt(SILBasicBlock *B) // begin iterator
-        : It(B->args_begin()) {}
-    PhiIt(SILBasicBlock *B, bool) // end iterator
-        : It(B->args_end()) {}
-    PhiIt &operator++() { ++It; return *this; }
-
-    operator SILPHIArgument *() { return cast<SILPHIArgument>(*It); }
-    bool operator==(const PhiIt& x) const { return It == x.It; }
-    bool operator!=(const PhiIt& x) const { return !operator==(x); }
-  };
-
-  typedef PhiIt PhiItT;
-  static PhiItT PhiItT_begin(BlkT *BB) { return PhiIt(BB); }
-  static PhiItT PhiItT_end(BlkT *BB) { return PhiIt(BB, true); }
-
   /// Iterator for PHI operands.
   class PHI_iterator {
   private:


### PR DESCRIPTION
This replaces the previous solution that requires non-upstream changes
to LLVM.