### PR TITLE
[IRGen] Replace duplicate code with new method

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -471,7 +471,7 @@ public:
   /// Look for a global variable by name.
   ///
   /// \return null if this module has no such global variable
- SILGlobalVariable *lookUpGlobalVariable(StringRef name) const {
+  SILGlobalVariable *lookUpGlobalVariable(StringRef name) const {
     return GlobalVariableMap.lookup(name);
   }
 
@@ -711,6 +711,8 @@ public:
     return ! getOptions().AssumeSingleThreaded;
   }
 };
+
+bool isDeclVisibleExternally(const ValueDecl *decl, const SILModule *module);
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){
   M.print(OS);

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -115,3 +115,18 @@ swift::getLinkageForProtocolConformance(const NormalProtocolConformance *C,
       return (definition ? SILLinkage::Public : SILLinkage::PublicExternal);
   }
 }
+
+bool swift::isDeclVisibleExternally(const ValueDecl *decl, const SILModule *module) {
+  AccessLevel access = decl->getEffectiveAccess();
+  switch (access) {
+  case AccessLevel::Private:
+  case AccessLevel::FilePrivate:
+    return false;
+  case AccessLevel::Internal:
+    return !module->isWholeModule();
+  case AccessLevel::Public:
+  case AccessLevel::Open:
+    return true;
+  }
+  llvm_unreachable("Unhandled access level in switch");
+}

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -407,22 +407,7 @@ protected:
 
   /// Retrieve the visibility information from the AST.
   bool isVisibleExternally(const ValueDecl *decl) {
-    AccessLevel access = decl->getEffectiveAccess();
-    SILLinkage linkage;
-    switch (access) {
-    case AccessLevel::Private:
-    case AccessLevel::FilePrivate:
-      linkage = SILLinkage::Private;
-      break;
-    case AccessLevel::Internal:
-      linkage = SILLinkage::Hidden;
-      break;
-    case AccessLevel::Public:
-    case AccessLevel::Open:
-      linkage = SILLinkage::Public;
-      break;
-    }
-    if (isPossiblyUsedExternally(linkage, Module->isWholeModule()))
+    if (isDeclVisibleExternally(decl, Module))
       return true;
 
     // If a vtable or witness table (method) is only visible in another module

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -911,16 +911,7 @@ static bool canBeChangedExternally(SILGlobalVariable *SILG) {
   // Use access specifiers from the declarations,
   // if possible.
   if (auto *Decl = SILG->getDecl()) {
-    switch (Decl->getEffectiveAccess()) {
-    case AccessLevel::Private:
-    case AccessLevel::FilePrivate:
-      return false;
-    case AccessLevel::Internal:
-      return !SILG->getModule().isWholeModule();
-    case AccessLevel::Public:
-    case AccessLevel::Open:
-      return true;
-    }
+    return isDeclVisibleExternally(Decl, &SILG->getModule());
   }
 
   if (SILG->getLinkage() == SILLinkage::Private)

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -127,25 +127,6 @@ class GlobalPropertyOpt {
     }
     return false;
   }
-
-  bool isVisibleExternally(VarDecl *decl) {
-    AccessLevel access = decl->getEffectiveAccess();
-    SILLinkage linkage;
-    switch (access) {
-      case AccessLevel::Private:
-      case AccessLevel::FilePrivate:
-        linkage = SILLinkage::Private;
-        break;
-      case AccessLevel::Internal:
-        linkage = SILLinkage::Hidden;
-        break;
-      case AccessLevel::Public:
-      case AccessLevel::Open:
-        linkage = SILLinkage::Public;
-        break;
-    }
-    return isPossiblyUsedExternally(linkage, M.isWholeModule());
-  }
   
   static bool canAddressEscape(SILValue V, bool acceptStore);
 
@@ -154,7 +135,7 @@ class GlobalPropertyOpt {
     Entry * &entry = FieldEntries[Field];
     if (!entry) {
       entry = new (EntryAllocator.Allocate()) Entry(SILValue(), Field);
-      if (isVisibleExternally(Field))
+      if (isDeclVisibleExternally(Field, &M))
         setAddressEscapes(entry);
     }
     return entry;

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -289,28 +289,7 @@ static bool isSameInitSequence(const InitSequence &LHS,
 
 /// Check if a given let property can be assigned externally.
 static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
-  AccessLevel access = Property->getEffectiveAccess();
-  SILLinkage linkage;
-  switch (access) {
-  case AccessLevel::Private:
-  case AccessLevel::FilePrivate:
-    linkage = SILLinkage::Private;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has private access\n");
-    break;
-  case AccessLevel::Internal:
-    linkage = SILLinkage::Hidden;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has internal access\n");
-    break;
-  case AccessLevel::Public:
-  case AccessLevel::Open:
-    linkage = SILLinkage::Public;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has public access\n");
-    break;
-  }
-
-  DEBUG(llvm::dbgs() << "Module of " << *Property << " WMO mode is: " << Module->isWholeModule() << "\n");
-
-  if (isPossiblyUsedExternally(linkage, Module->isWholeModule())) {
+  if (isDeclVisibleExternally(Property, Module)) {
     // If at least one of the properties of the enclosing type cannot be
     // used externally, then no initializer can be implemented externally as
     // it wouldn't be able to initialize such a property.

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -257,18 +257,8 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
     return false;
 
   // Only consider 'private' members, unless we are in whole-module compilation.
-  switch (CD->getEffectiveAccess()) {
-  case AccessLevel::Open:
+  if (isDeclVisibleExternally(CD, &AI.getModule()))
     return false;
-  case AccessLevel::Public:
-  case AccessLevel::Internal:
-    if (!AI.getModule().isWholeModule())
-      return false;
-    break;
-  case AccessLevel::FilePrivate:
-  case AccessLevel::Private:
-    break;
-  }
 
   // This is a private or a module internal class.
   //

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -171,18 +171,8 @@ static bool isKnownFinalClass(ClassDecl *CD, SILModule &M,
     return false;
 
   // Only consider 'private' members, unless we are in whole-module compilation.
-  switch (CD->getEffectiveAccess()) {
-  case AccessLevel::Open:
+  if (isDeclVisibleExternally(CD, &M))
     return false;
-  case AccessLevel::Public:
-  case AccessLevel::Internal:
-    if (!M.isWholeModule())
-      return false;
-    break;
-  case AccessLevel::FilePrivate:
-  case AccessLevel::Private:
-    break;
-  }
 
   // Take the ClassHierarchyAnalysis into account.
   // If a given class has no subclasses and
@@ -192,19 +182,6 @@ static bool isKnownFinalClass(ClassDecl *CD, SILModule &M,
   // of devirtualization.
   if (CHA) {
     if (!CHA->hasKnownDirectSubclasses(CD)) {
-      switch (CD->getEffectiveAccess()) {
-      case AccessLevel::Open:
-        return false;
-      case AccessLevel::Public:
-      case AccessLevel::Internal:
-        if (!M.isWholeModule())
-          return false;
-        break;
-      case AccessLevel::FilePrivate:
-      case AccessLevel::Private:
-        break;
-      }
-
       return true;
     }
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request removes duplicated code from `GlobalPropertyOpt::isVisibleExternally()`, `FunctionLivenessComputation::isVisibleExternally()` and the static function `isAssignableExternally()` in `LetPropertiesOpts.cpp`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6264](https://bugs.swift.org/browse/SR-6264).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
