### PR TITLE
IUO: Replace one ConstraintLocator with two.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3413,7 +3413,7 @@ namespace {
       auto *TR = expr->getCastTypeLoc().getTypeRepr();
       if (TR && TR->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional) {
         auto *locator = cs.getConstraintLocator(
-            expr, ConstraintLocator::ImplicitlyUnwrappedCoercionResult);
+            expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
         return solution.getDisjunctionChoice(locator);
       }
       return false;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2498,7 +2498,7 @@ namespace {
     createTypeVariableAndDisjunctionForIUOCoercion(Type toType,
                                                    ConstraintLocator *locator) {
       auto implicitUnwrapLocator = CS.getConstraintLocator(
-          locator, ConstraintLocator::ImplicitlyUnwrappedCoercionResult);
+          locator, ConstraintLocator::ImplicitlyUnwrappedValue);
       auto typeVar =
           CS.createTypeVariable(implicitUnwrapLocator, /*options=*/0);
       CS.buildDisjunctionForImplicitlyUnwrappedOptional(typeVar, toType,

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -78,7 +78,8 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case KeyPathComponent:
     case ConditionalRequirement:
     case TypeParameterRequirement:
-    case ImplicitlyUnwrappedCoercionResult:
+    case ImplicitlyUnwrappedValue:
+    case ImplicitlyUnwrappedDisjunctionChoice:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -250,8 +251,12 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       out << "type parameter requirement #" << llvm::utostr(elt.getValue());
       break;
 
-    case ImplicitlyUnwrappedCoercionResult:
-      out << "implictly unwrapped coercion result";
+    case ImplicitlyUnwrappedValue:
+      out << "implictly unwrapped value";
+      break;
+
+    case ImplicitlyUnwrappedDisjunctionChoice:
+      out << "implictly unwrapped disjunction choice";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -127,9 +127,14 @@ public:
     ConditionalRequirement,
     /// A single requirement placed on the type parameters.
     TypeParameterRequirement,
-    /// \brief A coercion to an Optional type that can potentially be
-    /// force-unwrapped to the underlying type.
-    ImplicitlyUnwrappedCoercionResult,
+    /// \brief For Optional types that can be implicitly unwrapped as
+    /// needed to successfully type check.
+    ImplicitlyUnwrappedValue,
+    /// \brief For the disjunction choices that result from when we
+    /// see ImplicitlyUnwrappedValue. This is used to avoid infinite
+    /// recursion where we would split those types out again into
+    /// another disjunction.
+    ImplicitlyUnwrappedDisjunctionChoice,
   };
 
   /// \brief Determine the number of numeric values used for the given path
@@ -162,7 +167,8 @@ public:
     case Requirement:
     case Witness:
     case OpenedGeneric:
-    case ImplicitlyUnwrappedCoercionResult:
+    case ImplicitlyUnwrappedValue:
+    case ImplicitlyUnwrappedDisjunctionChoice:
       return 0;
 
     case GenericArgument:
@@ -225,7 +231,8 @@ public:
     case KeyPathComponent:
     case ConditionalRequirement:
     case TypeParameterRequirement:
-    case ImplicitlyUnwrappedCoercionResult:
+    case ImplicitlyUnwrappedValue:
+    case ImplicitlyUnwrappedDisjunctionChoice:
       return 0;
 
     case FunctionArgument:


### PR DESCRIPTION
Replace ImplicitlyUnwrappedCoercionResult with the more general
ImplicitlyUnwrappedValue.

Add ImplicitlyUnwrappedDisjunctionChoice as a marker that indicates
that we've already created a disjunction from an
ImplicitlyUnwrappedValue, in order to avoid infinite recursion during
binding.

Also add support to buildDisjunctionForImplicitlyUnwrappedOptional for
functions returning optionals.

NFC.
