### PR TITLE
[ClangImporter] EnumInfo improvements

### DIFF
--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -308,6 +308,10 @@ void EnumInfo::determineConstantNamePrefix(ASTContext &ctx,
     // Don't use importFullName() here, we want to ignore the swift_name
     // and swift_private attributes.
     StringRef enumNameStr = decl->getName();
+    if (enumNameStr.empty())
+      enumNameStr = decl->getTypedefNameForAnonDecl()->getName();
+    assert(!enumNameStr.empty() && "should have been classified as Constants");
+
     StringRef commonWithEnum = getCommonPluralPrefix(checkPrefix, enumNameStr);
     size_t delta = commonPrefix.size() - checkPrefix.size();
 

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -34,7 +34,7 @@ using namespace swift;
 using namespace importer;
 
 /// Classify the given Clang enumeration to describe how to import it.
-void EnumInfo::classifyEnum(ASTContext &ctx, const clang::EnumDecl *decl,
+void EnumInfo::classifyEnum(const clang::EnumDecl *decl,
                             clang::Preprocessor &pp) {
   assert(decl);
   clang::PrettyStackTraceDecl trace(decl, clang::SourceLocation(),
@@ -52,7 +52,7 @@ void EnumInfo::classifyEnum(ASTContext &ctx, const clang::EnumDecl *decl,
   // First, check for attributes that denote the classification
   if (auto domainAttr = decl->getAttr<clang::NSErrorDomainAttr>()) {
     kind = EnumKind::Enum;
-    nsErrorDomain = ctx.AllocateCopy(domainAttr->getErrorDomain()->getName());
+    nsErrorDomain = domainAttr->getErrorDomain()->getName();
     return;
   }
   if (decl->hasAttr<clang::FlagEnumAttr>()) {
@@ -203,8 +203,7 @@ StringRef importer::getCommonPluralPrefix(StringRef singular,
 
 /// Determine the prefix to be stripped from the names of the enum constants
 /// within the given enum.
-void EnumInfo::determineConstantNamePrefix(ASTContext &ctx,
-                                           const clang::EnumDecl *decl) {
+void EnumInfo::determineConstantNamePrefix(const clang::EnumDecl *decl) {
   switch (getKind()) {
   case EnumKind::Enum:
   case EnumKind::Options:
@@ -324,16 +323,17 @@ void EnumInfo::determineConstantNamePrefix(ASTContext &ctx,
     commonPrefix = commonPrefix.slice(0, commonWithEnum.size() + delta);
   }
 
-  constantNamePrefix = ctx.AllocateCopy(commonPrefix);
+  constantNamePrefix = commonPrefix;
 }
 
 EnumInfo EnumInfoCache::getEnumInfo(const clang::EnumDecl *decl) {
-  if (enumInfos.count(decl)) {
+  auto iter = enumInfos.find(decl);
+  if (iter != enumInfos.end()) {
     ++EnumInfoNumCacheHits;
-    return enumInfos[decl];
+    return iter->second;
   }
   ++EnumInfoNumCacheMisses;
-  EnumInfo enumInfo(swiftCtx, decl, clangPP);
+  EnumInfo enumInfo(decl, clangPP);
   enumInfos[decl] = enumInfo;
   return enumInfo;
 }

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -65,12 +65,9 @@ class EnumInfo {
 public:
   EnumInfo() = default;
 
-  // TODO: wean ourselves off of the ASTContext, we just want a slab that will
-  // outlive us to store our strings on.
-  EnumInfo(ASTContext &ctx, const clang::EnumDecl *decl,
-           clang::Preprocessor &pp) {
-    classifyEnum(ctx, decl, pp);
-    determineConstantNamePrefix(ctx, decl);
+  EnumInfo(const clang::EnumDecl *decl, clang::Preprocessor &pp) {
+    classifyEnum(decl, pp);
+    determineConstantNamePrefix(decl);
   }
 
   EnumKind getKind() const { return kind; }
@@ -89,15 +86,13 @@ public:
   }
 
 private:
-  void determineConstantNamePrefix(ASTContext &ctx, const clang::EnumDecl *);
-  void classifyEnum(ASTContext &ctx, const clang::EnumDecl *,
-                    clang::Preprocessor &);
+  void determineConstantNamePrefix(const clang::EnumDecl *);
+  void classifyEnum(const clang::EnumDecl *, clang::Preprocessor &);
 };
 
 /// Provide a cache of enum infos, so that we don't have to re-calculate their
 /// information.
 class EnumInfoCache {
-  ASTContext &swiftCtx;
   clang::Preprocessor &clangPP;
 
   llvm::DenseMap<const clang::EnumDecl *, EnumInfo> enumInfos;
@@ -107,8 +102,7 @@ class EnumInfoCache {
   EnumInfoCache &operator = (const EnumInfoCache &) = delete;
 
 public:
-  EnumInfoCache(ASTContext &swiftContext, clang::Preprocessor &cpp)
-      : swiftCtx(swiftContext), clangPP(cpp) {}
+  explicit EnumInfoCache(clang::Preprocessor &cpp) : clangPP(cpp) {}
 
   EnumInfo getEnumInfo(const clang::EnumDecl *decl);
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -297,7 +297,7 @@ public:
   NameImporter(ASTContext &ctx, const PlatformAvailability &avail,
                clang::Sema &cSema, bool inferIAM)
       : swiftCtx(ctx), availability(avail), clangSema(cSema),
-        enumInfos(swiftCtx, clangSema.getPreprocessor()),
+        enumInfos(clangSema.getPreprocessor()),
         inferImportAsMember(inferIAM) {}
 
   /// Determine the Swift name for a Clang decl

--- a/test/ClangImporter/Inputs/enum-error.h
+++ b/test/ClangImporter/Inputs/enum-error.h
@@ -19,4 +19,10 @@ typedef NS_ERROR_ENUM(int, OtherErrorCode, OtherErrorDomain) {
   OtherC,
 };
 
+extern NSString *TypedefOnlyErrorDomain;
+typedef enum __attribute__((ns_error_domain(TypedefOnlyErrorDomain))) {
+  TypedefOnlyErrorBadness
+} TypedefOnlyError;
+
+
 TestError getErr();

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -21,6 +21,11 @@ func testDropCode(other: OtherError) -> OtherError.Code {
   return other.code
 }
 
+func testImportsCorrectly() {
+  _ = TypedefOnlyError.badness
+  _ = TypedefOnlyError.Code.badness
+}
+
 func testError() {
   let testErrorNSError = NSError(domain: TestErrorDomain,
                                  code: Int(TestError.TENone.rawValue),


### PR DESCRIPTION
- Handle `ns_error_domain` on anonymous enums with typedefs (instead of crashing)
- Stop copying EnumInfo strings into Swift's ASTContext (they're kept alive by Clang's ASTContext already)