### PR TITLE
[benchmark] Add roman numeral conversion benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -108,6 +108,7 @@ set(SWIFT_BENCH_MODULES
     single-source/RecursiveOwnedParameter
     single-source/ReduceInto
     single-source/ReversedCollections
+    single-source/RomanNumbers
     single-source/SetTests
     single-source/SevenBoom
     single-source/Sim2DArray

--- a/benchmark/single-source/RomanNumbers.swift
+++ b/benchmark/single-source/RomanNumbers.swift
@@ -83,9 +83,7 @@ extension BinaryInteger {
 @inline(never)
 func checkRomanNumerals(upTo limit: Int) {
   for i in 0 ..< limit {
-    guard Int(romanNumeral: identity(i.romanNumeral)) == i else {
-      fatalError()
-    }
+    CheckResults(Int(romanNumeral: identity(i.romanNumeral)) == i)
   }
 }
 

--- a/benchmark/single-source/RomanNumbers.swift
+++ b/benchmark/single-source/RomanNumbers.swift
@@ -25,20 +25,20 @@ public let RomanNumbers = [
     tags: [.api, .String, .algorithm])
 ]
 
-let romanTable: [(Int, String)] = [
-  (1000, "M"),
-  (900, "CM"),
-  (500, "D"),
-  (400, "CD"),
-  (100, "C"),
-  (90, "XC"),
-  (50, "L"),
-  (40, "XL"),
-  (10, "X"),
-  (9, "IX"),
-  (5, "V"),
-  (4, "IV"),
-  (1, "I"),
+let romanTable: DictionaryLiteral<String, Int> = [
+  "M": 1000,
+  "CM": 900,
+  "D": 500,
+  "CD": 400,
+  "C": 100,
+  "XC": 90,
+  "L": 50,
+  "XL": 40,
+  "X": 10,
+  "IX": 9,
+  "V": 5,
+  "IV": 4,
+  "I": 1,
 ]
 
 extension BinaryInteger {
@@ -48,8 +48,7 @@ extension BinaryInteger {
   outer:
     while value > 0 {
       var position = 0
-      for i in position ..< romanTable.count {
-        let (v, s) = romanTable[i]
+      for (i, (key: s, value: v)) in romanTable[position...].enumerated() {
         if value >= v {
           result += s
           value -= Self(v)
@@ -68,8 +67,7 @@ extension BinaryInteger {
   outer:
     while !input.isEmpty {
       var position = 0
-      for i in position ..< romanTable.count {
-        let (v, s) = romanTable[i]
+      for (i, (key: s, value: v)) in romanTable[position...].enumerated() {
         if input.starts(with: s) {
           self += Self(v)
           input = input.dropFirst(s.count)

--- a/benchmark/single-source/RomanNumbers.swift
+++ b/benchmark/single-source/RomanNumbers.swift
@@ -1,0 +1,99 @@
+//===--- RomanNumbers.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+//
+// Mini benchmark implementing roman numeral conversions to/from integers.
+// Measures performance of Substring.starts(with:) and String.append(),
+// with very short string arguments.
+//
+
+public let RomanNumbers = [
+  BenchmarkInfo(
+    name: "RomanNumbers",
+    runFunction: run_RomanNumbers,
+    tags: [.api, .String, .algorithm])
+]
+
+let romanTable: [(Int, String)] = [
+  (1000, "M"),
+  (900, "CM"),
+  (500, "D"),
+  (400, "CD"),
+  (100, "C"),
+  (90, "XC"),
+  (50, "L"),
+  (40, "XL"),
+  (10, "X"),
+  (9, "IX"),
+  (5, "V"),
+  (4, "IV"),
+  (1, "I"),
+]
+
+extension BinaryInteger {
+  var romanNumeral: String {
+    var result = ""
+    var value = self
+  outer:
+    while value > 0 {
+      var position = 0
+      for i in position ..< romanTable.count {
+        let (v, s) = romanTable[i]
+        if value >= v {
+          result += s
+          value -= Self(v)
+          position = i
+          continue outer
+        }
+      }
+      fatalError("Unreachable")
+    }
+    return result
+  }
+
+  init?(romanNumeral: String) {
+    self = 0
+    var input = Substring(romanNumeral)
+  outer:
+    while !input.isEmpty {
+      var position = 0
+      for i in position ..< romanTable.count {
+        let (v, s) = romanTable[i]
+        if input.starts(with: s) {
+          self += Self(v)
+          input = input.dropFirst(s.count)
+          position = i
+          continue outer
+        }
+      }
+      return nil
+    }
+  }
+}
+
+@inline(never)
+func checkRomanNumerals(upTo limit: Int) {
+  for i in 0 ..< limit {
+    guard Int(romanNumeral: identity(i.romanNumeral)) == i else {
+      fatalError()
+    }
+  }
+}
+
+@inline(never)
+public func run_RomanNumbers(_ N: Int) {
+  for _ in 0 ..< 10 * N {
+    checkRomanNumerals(upTo: 1100)
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -96,6 +96,7 @@ import RangeIteration
 import RecursiveOwnedParameter
 import ReduceInto
 import ReversedCollections
+import RomanNumbers
 import SetTests
 import SevenBoom
 import Sim2DArray
@@ -217,6 +218,7 @@ registerBenchmark(RangeIteration)
 registerBenchmark(RecursiveOwnedParameter)
 registerBenchmark(ReduceInto)
 registerBenchmark(ReversedCollections)
+registerBenchmark(RomanNumbers)
 registerBenchmark(SetTests)
 registerBenchmark(SevenBoom)
 registerBenchmark(Sim2DArray)


### PR DESCRIPTION
This adds a minibenchmark for roman number conversion. Measures Substring slicing, Substring.starts(with:) and String.append(_:) with tiny String arguments.