### PR TITLE
Fix build failure due to race between two PRs.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3233,7 +3233,7 @@ namespace {
 
         // Otherwise, we know the offset at compile time, even if our
         // clients do not, so just emit a constant.
-        auto &layout = IGM.getMetadataLayout(theClass);
+        auto &layout = IGM.getClassMetadataLayout(theClass);
 
         auto value = layout.getStartOfImmediateMembers();
         auto *init = llvm::ConstantInt::get(IGM.SizeTy, value.getValue());


### PR DESCRIPTION
The first of the following commits did some renames that result in the
second to fail, but they were both in CI being tested simultaneously,
passed, and were merged.

https://github.com/apple/swift/pull/13704/commits/12a774abec634352eaf065097169710adf436ca7
https://github.com/apple/swift/pull/13718/commits/93af58deadc98e73659fa84836b26826d66bda8e
