### PR TITLE
[Runtime] Never use type metadata references in conformance records.

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -440,7 +440,7 @@ contains:
 
     0. A direct reference to a nominal type descriptor.
     1. An indirect reference to a nominal type descriptor.
-    2. A reference to nonunique, foreign type metadata.
+    2. Reserved for future use.
     3. A reference to a pointer to an Objective-C class object.
 
 - The **witness table field** that provides access to the witness table

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -288,6 +288,7 @@ enum class ProtocolDispatchStrategy: uint8_t {
 class GenericParameterDescriptorFlags {
   typedef uint16_t int_type;
   enum : int_type {
+    IsNonUnique            = 0x0002,
     HasVTable              = 0x0004,
     HasResilientSuperclass = 0x0008,
   };
@@ -300,6 +301,17 @@ public:
   constexpr GenericParameterDescriptorFlags withHasVTable(bool b) const {
     return GenericParameterDescriptorFlags(b ? (Data | HasVTable)
                                              : (Data & ~HasVTable));
+  }
+
+  constexpr GenericParameterDescriptorFlags withIsUnique(bool b) const {
+    return GenericParameterDescriptorFlags(!b ? (Data | IsNonUnique)
+                                           : (Data & ~IsNonUnique));
+  }
+
+  /// Whether this nominal type descriptor is known to be nonunique, requiring
+  /// comparison operations to check string equality of the mangled name.
+  bool isUnique() const {
+    return !(Data & IsNonUnique);
   }
 
   /// If this type is a class, does it have a vtable?  If so, the number

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -181,10 +181,8 @@ enum class TypeMetadataRecordKind : unsigned {
   /// getNominalTypeDescriptor() points to the nominal type descriptor.
   IndirectNominalTypeDescriptor = 0x01,
 
-  /// The conformance is for a foreign type described by its type metadata.
-  /// getDirectType() points to a nonunique metadata record for the type, which
-  /// needs to be uniqued by the runtime.
-  NonuniqueDirectType = 0x02,
+  /// Reserved for future use.
+  Reserved = 0x02,
   
   /// The conformance is for an Objective-C class that has no nominal type
   /// descriptor.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1333,6 +1333,10 @@ public:
     return getGenericContexts()[i];
   }
 
+  bool isUnique() const {
+    return GenericParams.Flags.isUnique();
+  }
+
   bool hasVTable() const {
     return getKind() == NominalTypeKind::Class
       && GenericParams.Flags.hasVTable();
@@ -1355,6 +1359,9 @@ public:
            && i < numTrailingObjects(OverloadToken<MethodDescriptor>{}));
     return getMethodDescriptors()[i].Impl.get();
   }
+
+  /// Determine whether two nominal type descriptors are equivalent.
+  bool isEqual(const TargetNominalTypeDescriptor *other) const;
 
 private:
   size_t numTrailingObjects(OverloadToken<GenericContextDescriptor>) const {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2551,55 +2551,32 @@ using GenericWitnessTable = TargetGenericWitnessTable<InProcess>;
 template <typename Runtime>
 struct TargetTypeMetadataRecord {
 private:
-  // Some description of the type that is resolvable at runtime.
-  union {
-    /// A direct reference to the metadata.
-    RelativeDirectPointerIntPair<const TargetMetadata<Runtime>,
-                                 TypeMetadataRecordKind> DirectType;
-
-    /// The nominal type descriptor for a resilient or generic type.
-    RelativeDirectPointerIntPair<TargetNominalTypeDescriptor<Runtime>,
-                                 TypeMetadataRecordKind>
-      TypeDescriptor;
-  };
+  /// The nominal type descriptor.
+  RelativeDirectPointerIntPair<TargetNominalTypeDescriptor<Runtime>,
+                               TypeMetadataRecordKind>
+    TypeDescriptor;
 
 public:
   TypeMetadataRecordKind getTypeKind() const {
-    return DirectType.getInt();
+    return TypeDescriptor.getInt();
   }
   
-  const TargetMetadata<Runtime> *getDirectType() const {
-    switch (getTypeKind()) {
-    case TypeMetadataRecordKind::NonuniqueDirectType:
-      break;
-        
-    case TypeMetadataRecordKind::IndirectObjCClass:
-    case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
-    case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
-      assert(false && "not direct type metadata");
-    }
-
-    return this->DirectType.getPointer();
-  }
-
   const TargetNominalTypeDescriptor<Runtime> *
   getNominalTypeDescriptor() const {
     switch (getTypeKind()) {
     case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
       break;
-        
+
+    case TypeMetadataRecordKind::Reserved:
+      return nullptr;
+
     case TypeMetadataRecordKind::IndirectObjCClass:
-    case TypeMetadataRecordKind::NonuniqueDirectType:
     case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
       assert(false && "not generic metadata pattern");
     }
     
     return this->TypeDescriptor.getPointer();
   }
-
-  /// Get the canonical metadata for the type referenced by this record, or
-  /// return null if the record references a generic or universal type.
-  const TargetMetadata<Runtime> *getCanonicalTypeMetadata() const;
 };
 using TypeMetadataRecord = TargetTypeMetadataRecord<InProcess>;
 
@@ -2634,11 +2611,6 @@ private:
                                  TypeMetadataRecordKind>
       IndirectNominalTypeDescriptor;
 
-    /// A direct reference to the metadata, which must be uniqued before
-    /// being used.
-    RelativeDirectPointerIntPair<TargetMetadata<Runtime>,
-                                 TypeMetadataRecordKind> NonuniqueDirectType;
-    
     /// An indirect reference to the metadata.
     ///
     /// Only valid when the \c IndirectClassOrDirectType value is
@@ -2678,26 +2650,14 @@ public:
     return WitnessTable.getInt();
   }
   
-  const TargetMetadata<Runtime> *getDirectType() const {
-    switch (getTypeKind()) {
-    case TypeMetadataRecordKind::NonuniqueDirectType:
-      break;
-        
-    case TypeMetadataRecordKind::IndirectObjCClass:
-    case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
-    case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
-      assert(false && "not direct type metadata");
-    }
-
-    return NonuniqueDirectType.getPointer();
-  }
-  
   const TargetClassMetadata<Runtime> * const *getIndirectObjCClass() const {
     switch (getTypeKind()) {
     case TypeMetadataRecordKind::IndirectObjCClass:
       break;
         
-    case TypeMetadataRecordKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::Reserved:
+      return nullptr;
+
     case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
     case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
       assert(false && "not indirect class object");
@@ -2709,6 +2669,9 @@ public:
   const TargetNominalTypeDescriptor<Runtime> *
   getNominalTypeDescriptor() const {
     switch (getTypeKind()) {
+    case TypeMetadataRecordKind::Reserved:
+      return nullptr;
+
     case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
       return DirectNominalTypeDescriptor.getPointer();
 
@@ -2716,7 +2679,6 @@ public:
       return *IndirectNominalTypeDescriptor.getPointer();
 
     case TypeMetadataRecordKind::IndirectObjCClass:
-    case TypeMetadataRecordKind::NonuniqueDirectType:
       assert(false && "not generic metadata pattern");
     }
     

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2328,10 +2328,3 @@ bool irgen::doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
   auto &layout = selfTI.getClassLayout(IGM, selfType);
   return layout.MetadataRequiresDynamicInitialization;
 }
-
-bool irgen::doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
-                                                       CanType conformingType) {
-  NominalTypeDecl *nom = conformingType->getAnyNominal();
-  return !isa<ClangModuleUnit>(nom->getModuleScopeContext());
-}
-

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -172,14 +172,6 @@ namespace irgen {
   bool doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
                                                      ClassDecl *theClass);
     
-  /// Returns true if a conformance of the \p conformingType references the
-  /// nominal type descriptor of the type.
-  ///
-  /// Otherwise the conformance references the foreign metadata of the
-  /// \p conformingType.
-  bool doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
-                                                     CanType conformingType);
-  
   /// If the superclass came from another module, we may have dropped
   /// stored properties due to the Swift language version availability of
   /// their types. In these cases we can't precisely lay out the ivars in

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2205,6 +2205,9 @@ namespace {
         }
       }
 
+      // Whether the nominal type descriptor is known to be unique.
+      flags = flags.withIsUnique(asImpl().isUniqueDescriptor());
+
       // Calculate the number of generic parameters at each nesting depth.
       unsigned totalGenericParams = 0;
       SmallVector<unsigned, 2> numPrimaryParams;
@@ -2263,12 +2266,21 @@ namespace {
 
       return var;
     }
-    
+
+    // Imported declarations have nonunique nominal type descriptors.
+    bool isUniqueDescriptor() {
+      return !isa<ClangModuleUnit>(
+                                asImpl().getTarget()->getModuleScopeContext());
+    }
+
     // Derived class must provide:
     //   NominalTypeDecl *getTarget();
     //   unsigned getKind();
     //   unsigned getGenericParamsOffset();
     //   void addKindDependentFields();
+    //
+    // Derived class can override:
+    //   bool isUniqueDescriptor();
   };
   
   /// Build a doubly-null-terminated list of field names.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2081,10 +2081,9 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   NormalProtocolConformance *Conf = wt->getConformance();
   addProtocolConformanceRecord(Conf);
 
+  // Trigger the lazy emission of the foreign type metadata.
   CanType conformingType = Conf->getType()->getCanonicalType();
-  if (!doesConformanceReferenceNominalTypeDescriptor(*this, conformingType)) {
-    // Trigger the lazy emission of the foreign type metadata.
-    NominalTypeDecl *Nominal = conformingType->getAnyNominal();
+  if (NominalTypeDecl *Nominal = conformingType->getAnyNominal()) {
     if (auto *clas = dyn_cast<ClassDecl>(Nominal)) {
       if (clas->isForeign())
         getAddrOfForeignTypeMetadataCandidate(conformingType);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1052,6 +1052,21 @@ swift::swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
 }
 
 /***************************************************************************/
+/*** Nominal type descriptors **********************************************/
+/***************************************************************************/
+template<>
+bool NominalTypeDescriptor::isEqual(const NominalTypeDescriptor *other) const {
+  // Fast path: pointer equality.
+  if (this == other) return true;
+
+  // If both nominal type descriptors are known to be unique, we're done.
+  if (this->isUnique() && other->isUnique()) return false;
+
+  // Compare the mangled names.
+  return strcmp(this->Name.get(), other->Name.get()) == 0;
+}
+
+/***************************************************************************/
 /*** Common value witnesses ************************************************/
 /***************************************************************************/
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -124,20 +124,6 @@ swift::swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
   _registerTypeMetadataRecords(T, begin, end);
 }
 
-// copied from ProtocolConformanceRecord::getCanonicalTypeMetadata()
-template<>
-const Metadata *TypeMetadataRecord::getCanonicalTypeMetadata() const {
-  switch (getTypeKind()) {
-  case TypeMetadataRecordKind::NonuniqueDirectType: {
-    const ForeignTypeMetadata *FMD =
-        static_cast<const ForeignTypeMetadata *>(getDirectType());
-    return swift_getForeignTypeMetadata(const_cast<ForeignTypeMetadata *>(FMD));
-  }
-  default:
-    return nullptr;
-  }
-}
-
 // returns the type metadata for the type named by typeNode
 const Metadata *
 swift::_matchMetadataByMangledTypeName(const llvm::StringRef typeName,
@@ -171,9 +157,7 @@ _searchTypeMetadataRecords(const TypeMetadataState &T,
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = T.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto metadata = record.getCanonicalTypeMetadata())
-        foundMetadata = _matchMetadataByMangledTypeName(typeName, metadata, nullptr);
-      else if (auto ntd = record.getNominalTypeDescriptor())
+      if (auto ntd = record.getNominalTypeDescriptor())
         foundMetadata = _matchMetadataByMangledTypeName(typeName, nullptr, ntd);
 
       if (foundMetadata != nullptr)

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -48,13 +48,8 @@ template<> void ProtocolConformanceRecord::dump() const {
   };
 
   switch (auto kind = getTypeKind()) {
-    case TypeMetadataRecordKind::NonuniqueDirectType:
-      printf("direct type nonunique ");
-      if (const auto *ntd = getDirectType()->getNominalTypeDescriptor()) {
-        printf("%s", ntd->Name.get());
-      } else {
-        printf("<structural type>");
-      }
+    case TypeMetadataRecordKind::Reserved:
+      printf("unknown (reserved)");
       break;
     case TypeMetadataRecordKind::IndirectObjCClass:
       printf("indirect Objective-C class %s",
@@ -94,12 +89,8 @@ template<> void ProtocolConformanceRecord::dump() const {
 template <>
 const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata() const {
   switch (getTypeKind()) {
-  case TypeMetadataRecordKind::NonuniqueDirectType: {
-    // Ask the runtime for the unique metadata record we've canonized.
-    const ForeignTypeMetadata *FMD =
-        static_cast<const ForeignTypeMetadata *>(getDirectType());
-    return swift_getForeignTypeMetadata(const_cast<ForeignTypeMetadata *>(FMD));
-  }
+  case TypeMetadataRecordKind::Reserved:
+    return nullptr;
   case TypeMetadataRecordKind::IndirectObjCClass:
     // The class may be ObjC, in which case we need to instantiate its Swift
     // metadata. The class additionally may be weak-linked, so we have to check

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -23,6 +23,11 @@
 
 // CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [27 x i8] c"So21CCMutableRefrigeratorC\00"
 
+// CHECK-64: @_T0So21CCMutableRefrigeratorCMn = linkonce_odr hidden constant
+// CHECK-64-SAME: [[MUTABLE_REFRIGERATOR_NAME]]
+// CHECK-64-SAME: @get_field_types_CCMutableRefrigerator
+// CHECK-64-SAME: i16 1, i16 2, i32 0 }>
+
 // CHECK-64: @_T0So21CCMutableRefrigeratorCN = linkonce_odr hidden global <{ {{.*}} }> <{
 // CHECK-64-SAME: @initialize_metadata_CCMutableRefrigerator
 // CHECK-64-SAME: i32 trunc {{.*}} [[MUTABLE_REFRIGERATOR_NAME]] to i64

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -17,10 +17,8 @@ public protocol Runcible {
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE:%swift.protocol\* @_T033protocol_conformance_records_objc8RuncibleMp]]
-// -- type metadata + 0x02 (nonunique type metadata)
-// CHECK:           i32 add
-// CHECK:           @_T0SC6NSRectVN
-// CHECK:           i32 2
+// -- nominal type descriptor
+// CHECK:           @_T0SC6NSRectVMn
 // -- witness table
 // CHECK:           @_T0SC6NSRectV33protocol_conformance_records_objc8RuncibleACWP
 // -- reserved


### PR DESCRIPTION
Only foreign classes and other imported types were making use of the
type metadata reference form in conformance records. Switch those over
to using nominal type descriptors, so we're using nominal type
descriptors for everything possible. Only Objective-C-defined classes use
a different representation now; leave the now-unused representation
reserved for a future (probably mangling-based) format.

To make this work, make it possible to correctly compare nominal type
descriptors for equality. Pointer equality does not suffice because
the descriptors are not unique, so fall back to string comparisons of
the mangled name when forced to.