### PR TITLE
libSyntax: allow SyntaxCollection to specify acceptable element kinds. NFC

### DIFF
--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -91,7 +91,15 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
 % for node in SYNTAX_NODES:
 %     if node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}: {
+%       if node.collection_element_choices:
+%         element_checks = []
+%         for choice in node.collection_element_choices:
+%           element_checks.append("Member.getKind() == SyntaxKind::%s" % choice)
+%         all_checks = ' || '.join(element_checks)
+    return ${all_checks};
+%       else:
     return Member.is<${node.collection_element_type}>();
+%       end
   }
 %     end
 % end
@@ -165,6 +173,8 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
 % elif node.is_syntax_collection():
       std::vector<${node.collection_element_type}> Parts;
       for (auto &E: Elements) {
+        if (!canServeAsCollectionMember(SyntaxKind::${node.syntax_kind}, E))
+          return None;
         if (auto P = E.getAs<${node.collection_element_type}>()) {
           Parts.emplace_back(make<${node.collection_element_type}>(P->getRaw()));
         } else {

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -28,11 +28,9 @@ EXPR_NODES = [
     Node('DictionaryElementList', kind='SyntaxCollection',
          element='DictionaryElement'),
 
-    # FIXME: Enforce the requirement that the members can only be
-    # StringSegment or ExpressionSegment
     Node('StringInterpolationSegments', kind='SyntaxCollection',
-         element='Syntax',
-         element_name='Segment'),
+         element='Syntax', element_name='Segment',
+         element_choices=['StringSegment', 'ExpressionSegment']),
 
     # The try operator.
     # try foo()

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -17,7 +17,7 @@ class Node(object):
     """
 
     def __init__(self, name, kind=None, children=None,
-                 element=None, element_name=None):
+                 element=None, element_name=None, element_choices=None):
         self.syntax_kind = name
         self.swift_syntax_kind = lowercase_first_word(name)
         self.name = kind_to_type(self.syntax_kind)
@@ -35,6 +35,7 @@ class Node(object):
         # from its supertype, use that.
         self.collection_element_name = element_name or self.collection_element
         self.collection_element_type = kind_to_type(self.collection_element)
+        self.collection_element_choices = element_choices or []
 
     def is_base(self):
         """


### PR DESCRIPTION
Segments list in interpolated string literal accepts two syntax kinds as
elements: StringSegment and ExpressionSegment. This patch generates
factory methods to reject other kinds.