### PR TITLE
IUO: Start creating the DeclForImplicitlyUnwrappedOptional OverloadCh…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -8396,7 +8396,8 @@ ValueDecl *ConstraintSystem::findResolvedMemberRef(ConstraintLocator *locator) {
     if (resolved->Locator != locator) continue;
     
     // We only handle the simplest decl binding.
-    if (resolved->Choice.getKind() != OverloadChoiceKind::Decl)
+    if (resolved->Choice.getKind() != OverloadChoiceKind::Decl
+        && resolved->Choice.getKind() != OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional)
       return nullptr;
     return resolved->Choice.getDecl();
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -997,7 +997,14 @@ namespace {
                                       TVO_CanBindToLValue |
                                       TVO_CanBindToInOut);
 
-      OverloadChoice choice(CS.getType(base), decl, functionRefKind);
+      OverloadChoice choice;
+      if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
+        choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
+            CS.getType(base), decl, functionRefKind);
+      } else {
+        choice = OverloadChoice(CS.getType(base), decl, functionRefKind);
+      }
+
       auto locator = CS.getConstraintLocator(expr, ConstraintLocator::Member);
       CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
       return tv;
@@ -1295,11 +1302,18 @@ namespace {
       // resolve it. This records the overload for use later.
       auto tv = CS.createTypeVariable(locator,
                                       TVO_CanBindToLValue);
-      CS.resolveOverload(locator, tv,
-                         OverloadChoice(Type(), E->getDecl(),
-                                        E->getFunctionRefKind()),
-                         CurDC);
-      
+
+      OverloadChoice choice;
+      if (E->getDecl()
+              ->getAttrs()
+              .hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
+        choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
+            Type(), E->getDecl(), E->getFunctionRefKind());
+      } else {
+        choice = OverloadChoice(Type(), E->getDecl(), E->getFunctionRefKind());
+      }
+      CS.resolveOverload(locator, tv, choice, CurDC);
+
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
         if (VD->getInterfaceType() &&
             !VD->getInterfaceType()->is<TypeVariableType>()) {
@@ -1374,8 +1388,16 @@ namespace {
         if (decls[i]->isInvalid())
           continue;
 
-        choices.push_back(OverloadChoice(Type(), decls[i],
-                                         expr->getFunctionRefKind()));
+        OverloadChoice choice;
+        if (decls[i]
+                ->getAttrs()
+                .hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
+          choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
+              Type(), decls[i], expr->getFunctionRefKind());
+        } else {
+          choice = OverloadChoice(Type(), decls[i], expr->getFunctionRefKind());
+        }
+        choices.push_back(choice);
       }
 
       // If there are no valid overloads, give up.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3210,7 +3210,12 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       return OverloadChoice::getDeclViaUnwrappedOptional(ovlBaseTy, cand,
                                                          functionRefKind);
     }
-    
+
+    if (cand->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
+      return OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
+          baseTy, cand, functionRefKind);
+    }
+
     return OverloadChoice(ovlBaseTy, cand, functionRefKind);
   };
   

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -830,7 +830,8 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
         // Look through optional or IUO to get the underlying type the decl was
         // found in.
         substType = substType->getAnyOptionalObjectType();
-      } else if (cand.getKind() != OverloadChoiceKind::Decl) {
+      } else if (cand.getKind() != OverloadChoiceKind::Decl
+                 && cand.getKind() != OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional) {
         // Otherwise, if it is a remapping we can't handle, don't try to compute
         // a substitution.
         substType = Type();


### PR DESCRIPTION
…oice.

Use this in places where we have a decl that is marked with the
ImplicitlyUnwrappedOptionalAttr so that we can distinguish in the
solver which decls need to be potentially unwrapped in order to type
check successfully.
