### PR TITLE
IUO: Do not short-circuit disjunctions if we had to apply fixes.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1943,11 +1943,12 @@ bool ConstraintSystem::solveSimplified(
       auto *lastChoice = lastSolvedChoice->first.getConstraint();
       auto &score = lastSolvedChoice->second;
       bool hasUnavailableOverloads = score.Data[SK_Unavailable] > 0;
+      bool hasFixes = score.Data[SK_Fix] > 0;
 
-      // Attempt to short-circuit disjunction only if
-      // score indicates that there are no unavailable
-      // overload choices present in the solution.
-      if (!hasUnavailableOverloads &&
+      // Attempt to short-circuit disjunction only if score indicates
+      // that there are no unavailable overload choices present in the
+      // solution, and the solution does not involve fixes.
+      if (!hasUnavailableOverloads && !hasFixes &&
           shortCircuitDisjunctionAt(&currentChoice, lastChoice,
                                     getASTContext()))
         break;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1787,9 +1787,10 @@ static bool shouldSkipDisjunctionChoice(ConstraintSystem &cs,
     auto &score = bestNonGenericScore->Data;
     // Let's skip generic overload choices only in case if
     // non-generic score indicates that there were no forced
-    // unwrappings of optional(s) and no unavailable overload
-    // choices present in the solution.
-    if (score[SK_ForceUnchecked] == 0 && score[SK_Unavailable] == 0)
+    // unwrappings of optional(s), no unavailable overload
+    // choices present in the solution, and no fixes required.
+    if (score[SK_ForceUnchecked] == 0 && score[SK_Unavailable] == 0
+        && score[SK_Fix] == 0)
       return true;
   }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -296,7 +296,7 @@ func rdar20029786(_ ns: NSString?) {
 
   let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}
 
-  var s4: String = ns ?? "str" // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}{{20-20=(}}{{31-31=) as String}}
+  var s4: String = ns ?? "str" // expected-error{{cannot convert value of type 'NSString' to specified type 'String'}}
   var s5: String = (ns ?? "str") as String // fixed version
 }
 


### PR DESCRIPTION
There are cases where disjunctions created for IUOs can be solved with
the Optional choice if a fix is applied. We do not want to stop with
this solution as we may be able to solve the constraint system without
a fix by selecting the non-Optional side.

I have opened a JIRA, SR-6626, to investigate one small regression in
diagnostics with this change.
