### PR TITLE
Revert "[Runtime] Reference ObjC class objects indirectly in conformance records"

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1354,8 +1354,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
     return ::isAvailableExternally(IGM, getProtocolConformance()->getDeclContext());
 
   case Kind::ObjCClassRef:
-    return false;
-
   case Kind::ValueWitness:
   case Kind::TypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
@@ -2215,13 +2213,10 @@ getTypeEntityInfo(IRGenModule &IGM, CanType conformingType) {
     // A reference to an Objective-C class object.
     assert(clas->isObjC() && "Must have an Objective-C class here");
 
-    // Form the class reference.
-    (void)IGM.getAddrOfObjCClassRef(clas);
-
     typeKind = TypeMetadataRecordKind::IndirectObjCClass;
-    entity = LinkEntity::forObjCClassRef(clas);
     defaultTy = IGM.TypeMetadataPtrTy;
     defaultPtrTy = IGM.TypeMetadataPtrTy;
+    entity = LinkEntity::forObjCClass(clas);
   } else {
     // Conformances for generics and concrete subclasses of generics
     // are represented by referencing the nominal type descriptor.

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -3,7 +3,7 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"\01l_protocol_conformances" = {{.*}} @"OBJC_CLASS_REF_$_Thingy"
+// CHECK: @"\01l_protocol_conformances" = {{.*}} @"got.OBJC_CLASS_$_Thingy"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -31,9 +31,9 @@ extension NSRect: Runcible {
 // CHECK:         %swift.protocol_conformance {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE]]
-// -- class object reference + 0x03 (indirect class object)
+// -- class object reference + 0x03 (class object reference, TODO: indirect me)
 // CHECK:           i32 add
-// CHECK:           @"OBJC_CLASS_REF_$_Gizmo"
+// CHECK:           @"got.OBJC_CLASS_$_Gizmo"
 // CHECK:           i32 3
 // -- witness table
 // CHECK:           @_T0So5GizmoC33protocol_conformance_records_objc8RuncibleACWP


### PR DESCRIPTION
This reverts commit 32ab89b0cc149a86cde206cca67bfeb27bd42521. The commit isn't *wrong*, but it triggers a crash in the linker (tracked by rdar://problem/26840634).