### PR TITLE
Remove IUO nested inside other type from benchmark.

### DIFF
--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -42,15 +42,6 @@ func genEnumArray() {
   // should be a nop
 }
 
-// Check the performance of destroying an array of implicit unwrapped
-// optional where the optional has a single payload of trivial
-// type. Destroying the elements should be a nop.
-@inline(never)
-func genIOUArray() {
-  _ = RefArray<Int!>(3)
-  // should be a nop
-}
-
 // Check the performance of destroying an array of structs where the
 // struct has multiple fields of trivial type. Destroying the
 // elements should be a nop.
@@ -68,7 +59,6 @@ func genStructArray() {
 public func run_ArrayOfGenericPOD(_ N: Int) {
   for _ in 0...N {
     genEnumArray()
-    genIOUArray()
     genStructArray()
   }
 }

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -21,7 +21,9 @@
 import TestsUtils
 
 public let ArrayOfGenericPOD = BenchmarkInfo(
-  name: "ArrayOfGenericPOD",
+  // Renamed benchmark to "2" when IUO test was removed, which
+  // effectively changed what we're benchmarking here.
+  name: "ArrayOfGenericPOD2",
   runFunction: run_ArrayOfGenericPOD,
   tags: [.validation, .api, .Array])
 


### PR DESCRIPTION
SE-0054 disallowed nesting IUO types within other types. We currently
give a warning for this, but eventually we'll either emit an error or
interpret the '!' as '?' (a plain optional).

Either way, this particular benchmark doesn't test anything different
than the one that uses plain optionals, so we should be able to remove it.
