### PR TITLE
IUO: Update the ClangImporter to surface whether decls are implicitly…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1215,6 +1215,8 @@ createValueConstructor(ClangImporter::Implementation &Impl,
                   SourceLoc(), var->getName(), var->getType(), structDecl);
     param->setInterfaceType(var->getInterfaceType());
     param->setValidationStarted();
+    Impl.recordForceUnwrapForDecl(
+        param, var->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>());
     valueParameters.push_back(param);
   }
 

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -90,7 +90,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
 
   if (const clang::Expr *parsed = parseNumericLiteral<>(Impl, tok)) {
     auto clangTy = parsed->getType();
-    auto literalType = Impl.importTypeIgnoreForceUnwrap(
+    auto literalType = Impl.importTypeIgnoreIUO(
         clangTy, ImportTypeKind::Value, isInSystemModule(DC),
         Bridgeability::None);
     if (!literalType)
@@ -100,7 +100,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
     if (castType.isNull()) {
       constantType = literalType;
     } else {
-      constantType = Impl.importTypeIgnoreForceUnwrap(
+      constantType = Impl.importTypeIgnoreIUO(
           castType, ImportTypeKind::Value, isInSystemModule(DC),
           Bridgeability::None);
       if (!constantType)
@@ -276,7 +276,7 @@ static Optional<std::pair<llvm::APSInt, Type>>
     if (auto literal = parseNumericLiteral<clang::IntegerLiteral>(impl,token)) {
       auto value = llvm::APSInt { literal->getValue(),
                                   literal->getType()->isUnsignedIntegerType() };
-      auto type = impl.importTypeIgnoreForceUnwrap(
+      auto type = impl.importTypeIgnoreIUO(
           literal->getType(), ImportTypeKind::Value, isInSystemModule(DC),
           Bridgeability::None);
       return {{ value, type }};

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -90,9 +90,9 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
 
   if (const clang::Expr *parsed = parseNumericLiteral<>(Impl, tok)) {
     auto clangTy = parsed->getType();
-    auto literalType = Impl.importType(clangTy, ImportTypeKind::Value,
-                                       isInSystemModule(DC),
-                                       Bridgeability::None);
+    auto literalType = Impl.importTypeIgnoreForceUnwrap(
+        clangTy, ImportTypeKind::Value, isInSystemModule(DC),
+        Bridgeability::None);
     if (!literalType)
       return nullptr;
 
@@ -100,9 +100,9 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
     if (castType.isNull()) {
       constantType = literalType;
     } else {
-      constantType = Impl.importType(castType, ImportTypeKind::Value,
-                                     isInSystemModule(DC),
-                                     Bridgeability::None);
+      constantType = Impl.importTypeIgnoreForceUnwrap(
+          castType, ImportTypeKind::Value, isInSystemModule(DC),
+          Bridgeability::None);
       if (!constantType)
         return nullptr;
     }
@@ -276,10 +276,9 @@ static Optional<std::pair<llvm::APSInt, Type>>
     if (auto literal = parseNumericLiteral<clang::IntegerLiteral>(impl,token)) {
       auto value = llvm::APSInt { literal->getValue(),
                                   literal->getType()->isUnsignedIntegerType() };
-      auto type  = impl.importType(literal->getType(),
-                                   ImportTypeKind::Value,
-                                   isInSystemModule(DC),
-                                   Bridgeability::None);
+      auto type = impl.importTypeIgnoreForceUnwrap(
+          literal->getType(), ImportTypeKind::Value, isInSystemModule(DC),
+          Bridgeability::None);
       return {{ value, type }};
     }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1010,8 +1010,26 @@ public:
   ///   Strictly speaking, though, this is a hack used to break cyclic
   ///   dependencies.
   ///
-  /// \returns The imported type, or null if this type could
-  ///   not be represented in Swift.
+  /// \returns An ImportedType value which holds the imported type. If
+  ///          this type is an Optional, it also has a flag which
+  ///          indicates if the Optional is implicitly unwrapped. If
+  ///          the type cannot be represented in Swift, then the type
+  ///          field will be null.
+  ImportedType
+  importType(clang::QualType type, ImportTypeKind kind,
+             bool allowNSUIntegerAsInt, Bridgeability topLevelBridgeability,
+             OptionalTypeKind optional = OTK_ImplicitlyUnwrappedOptional,
+             bool resugarNSErrorPointer = true);
+
+  /// \brief Import the given Clang type into Swift.
+  ///
+  /// For a description of parameters, see importType(). This differs
+  /// only in that it returns a Type rather than ImportedType, which
+  /// means that we do not retain the information of whether the type
+  /// returned might be an implicitly unwrapped optional.
+  ///
+  /// \returns The imported type, or null if this type could not be
+  ///   represented in Swift.
   Type importTypeIgnoreIUO(
       clang::QualType type, ImportTypeKind kind, bool allowNSUIntegerAsInt,
       Bridgeability topLevelBridgeability,
@@ -1025,11 +1043,6 @@ public:
   /// \returns A pair of the imported type and whether we should treat
   /// it as an optional that is implicitly unwrapped. The returned
   /// type is null if it cannot be represented in Swift.
-  ImportedType
-  importType(clang::QualType type, ImportTypeKind kind,
-             bool allowNSUIntegerAsInt, Bridgeability topLevelBridgeability,
-             OptionalTypeKind optional = OTK_ImplicitlyUnwrappedOptional,
-             bool resugarNSErrorPointer = true);
 
   /// \brief Import the given function type.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -584,7 +584,7 @@ public:
     RegisteredExternalDecls.push_back(D);
   }
 
-  void recordForceUnwrapForDecl(Decl *decl, bool isIUO) {
+  void recordImplicitUnwrapForDecl(Decl *decl, bool isIUO) {
 #if !defined(NDEBUG)
     Type ty;
     if (auto *FD = dyn_cast<FuncDecl>(decl)) {
@@ -608,9 +608,9 @@ public:
       assert(ty->getAnyOptionalObjectType());
     }
 
-    auto *forceAttr = new (SwiftContext)
+    auto *IUOAttr = new (SwiftContext)
         ImplicitlyUnwrappedOptionalAttr(/* implicit= */ true);
-    decl->getAttrs().add(forceAttr);
+    decl->getAttrs().add(IUOAttr);
   }
 
   /// \brief Retrieve the Clang AST context.
@@ -974,7 +974,7 @@ public:
   ///
   /// \returns The imported type, or null if this type could
   ///   not be represented in Swift.
-  Type importTypeIgnoreForceUnwrap(
+  Type importTypeIgnoreIUO(
       clang::QualType type, ImportTypeKind kind, bool allowNSUIntegerAsInt,
       Bridgeability topLevelBridgeability,
       OptionalTypeKind optional = OTK_ImplicitlyUnwrappedOptional,


### PR DESCRIPTION
… unwrapped.

Update several functions to return a Type/bool pair with the bool
representing whether the type is one that should be implicitly
unwrapped. This bool is surfaced up to the decl importing functions,
allowing them to set the appropriate decl attribute so that the
expression type checker will consider selecting the underlying type of
the optional involved during solving if the expression doesn't type
check with the optional type.

When importing Decls, use the IUO information to set the
ImplicitlyUnwrappedOptionalAttr attribute when appropriate.

We're still generating IUO types at the moment, so this change doesn't
really have much of an affect other than the creation of those
attributes.
