### PR TITLE
[stdlib] Documentation improvements

### DIFF
--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -11,6 +11,38 @@
 //===----------------------------------------------------------------------===//
 
 /// A fixed-width integer that is twice the size of its base type.
+///
+/// You can use the `DoubleWidth` type to continue calculations with the result
+/// of a full width arithmetic operation. Normally, when you perform a full
+/// width operation, the result is a tuple of the high and low components of
+/// the result.
+///
+///     let a = 2241543570477705381
+///     let b = 186319822866995413
+///     let c = a.multipliedFullWidth(by: b)
+///     // c == (22640526660490081, 7959093232766896457)
+///
+/// The tuple `c` can't be used in any further comparisons or calculations. To
+/// use this value, create a `DoubleWidth` instance from the result. You can
+/// use the `DoubleWidth` instance the way you use any other integer type.
+///
+///     let d = DoubleWidth(a.multipliedFullWidth(by: b))
+///     // d == 417644001000058515200174966092417353
+///
+///     // Check the calculation:
+///     print(d / DoubleWidth(a) == b)
+///     // Prints "true"
+///
+///     if d > Int.max {
+///         print("Too big to be an 'Int'!")
+///     } else {
+///         print("Small enough to fit in an 'Int'")
+///     }
+///     // Prints "Too big to be an 'Int'!"
+///
+/// The `DoubleWidth` type is intended for intermediate calculations, not as a
+/// replacement for a variable-width integer type. Nesting `DoubleWidth`
+/// instances, in particular, can result in undesirable performance.
 @_fixed_layout // FIXME(sil-serialize-all)
 public struct DoubleWidth<Base : FixedWidthInteger>
   : _ExpressibleByBuiltinIntegerLiteral

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -48,17 +48,28 @@
 /// `Comparable` protocols, which allow more uses of your custom type, such as
 /// constructing sets or sorting the elements of a collection.
 ///
-/// To adopt the `Equatable` protocol, implement the equal-to operator (`==`)
-/// as a static method of your type. The standard library provides an
+/// You can rely on automatic synthesis of the `Equatable` protocol's
+/// requirements for a custom type when you declare `Equatable` conformance in
+/// the type's original declaration and your type meets these criteria:
+///
+/// - For a `struct`, all its stored properties must conform to `Equatable`.
+/// - For an `enum`, all its associated values must conform to `Equatable`. (An
+///   `enum` without associated values has `Equatable` conformance even
+///   without the declaration.)
+///
+/// To customize your type's `Equatable` conformance, to adopt `Equatable` in a
+/// type that doesn't meet the criteria listed above, or to extend an existing
+/// type to conform to `Equatable`, implement the equal-to operator (`==`) as
+/// a static method of your type. The standard library provides an
 /// implementation for the not-equal-to operator (`!=`) for any `Equatable`
 /// type, which calls the custom `==` function and negates its result.
 ///
-/// As an example, consider a `StreetAddress` structure that holds the parts of
-/// a street address: a house or building number, the street name, and an
+/// As an example, consider a `StreetAddress` class that holds the parts of a
+/// street address: a house or building number, the street name, and an
 /// optional unit number. Here's the initial declaration of the
 /// `StreetAddress` type:
 ///
-///     struct StreetAddress {
+///     class StreetAddress {
 ///         let number: String
 ///         let street: String
 ///         let unit: String?
@@ -151,7 +162,7 @@
 /// triple-equals identical-to operator (`===`). For example:
 ///
 ///     let c = a
-///     print(a === c, b === c, separator: ", ")
+///     print(c === a, c === b, separator: ", ")
 ///     // Prints "true, false"
 public protocol Equatable {
   /// Returns a Boolean value indicating whether two values are equal.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -688,7 +688,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///
   /// If this value and `other` are finite numbers, the remainder is in the
   /// closed range `-abs(other / 2)...abs(other / 2)`. The
-  /// `remainder(dividingBy:)` method is always exact.
+  /// `formRemainder(dividingBy:)` method is always exact.
   ///
   /// - Parameter other: The value to use when dividing this value.
   mutating func formRemainder(dividingBy other: Self)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -109,8 +109,14 @@ extension ${Self} : CustomDebugStringConvertible {
 
 extension ${Self}: BinaryFloatingPoint {
 
+  /// A type that can represent the absolute value of any possible value of
+  /// this type.
   public typealias Magnitude = ${Self}
+
+  /// A type that can represent any written exponent.
   public typealias Exponent = Int
+
+  /// A type that represents the encoded significand of a value.
   public typealias RawSignificand = ${RawSignificand}
 
   /// The number of bits used to represent the type's exponent.
@@ -980,6 +986,35 @@ extension ${Self}: BinaryFloatingPoint {
     lhs._value = Builtin.fdiv_FPIEEE${bits}(lhs._value, rhs._value)
   }
 
+  /// Replaces this value with the remainder of itself divided by the given
+  /// value.
+  ///
+  /// For two finite values `x` and `y`, the remainder `r` of dividing `x` by
+  /// `y` satisfies `x == y * q + r`, where `q` is the integer nearest to
+  /// `x / y`. If `x / y` is exactly halfway between two integers, `q` is
+  /// chosen to be even. Note that `q` is *not* `x / y` computed in
+  /// floating-point arithmetic, and that `q` may not be representable in any
+  /// available integer type.
+  ///
+  /// The following example calculates the remainder of dividing 8.625 by 0.75:
+  ///
+  ///     var x = 8.625
+  ///     print(x / 0.75)
+  ///     // Prints "11.5"
+  ///
+  ///     let q = (x / 0.75).rounded(.toNearestOrEven)
+  ///     // q == 12.0
+  ///     x.formRemainder(dividingBy: 0.75)
+  ///     // x == -0.375
+  ///
+  ///     let x1 = 0.75 * q + x
+  ///     // x1 == 8.625
+  ///
+  /// If this value and `other` are finite numbers, the remainder is in the
+  /// closed range `-abs(other / 2)...abs(other / 2)`. The
+  /// `formRemainder(dividingBy:)` method is always exact.
+  ///
+  /// - Parameter other: The value to use when dividing this value.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public mutating func formRemainder(dividingBy other: ${Self}) {
@@ -1454,10 +1489,13 @@ extension ${Self} {
     return ${Self}(_bits: Builtin.int_fabs_FPIEEE${bits}(_value))
   }
 
-  /// Creates the closest representable value to the given integer.
-  ///
-  /// - Parameter value: The integer to represent as a floating-point value.
   // FIXME(integers): implement properly
+  /// Creates a value that exactly represents the given integer.
+  ///
+  /// If the given integer is outside the representable range of this type or
+  /// can't be represented exactly, the result is `nil`.
+  ///
+  /// - Parameter source: The integer to represent as a floating-point value.
   @_inlineable // FIXME(sil-serialize-all)
   public init?<T : BinaryInteger>(exactly source: T) {
     fatalError()

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -28,17 +28,32 @@
 /// equal hash values are not necessarily equal to each other.
 ///
 /// - Important: Hash values are not guaranteed to be equal across different
-///   executions of your program. Do not save hash values to use in a
-///   future execution.
+///   executions of your program. Do not save hash values to use in a future
+///   execution.
 ///
 /// Conforming to the Hashable Protocol
 /// ===================================
 ///
 /// To use your own custom type in a set or as the key type of a dictionary,
-/// add `Hashable` conformance to your type by providing a `hashValue`
-/// property. The `Hashable` protocol inherits from the `Equatable` protocol,
-/// so you must also add an equal-to operator (`==`) function for your
-/// custom type.
+/// add `Hashable` conformance to your type. The `Hashable` protocol inherits
+/// from the `Equatable` protocol, so you must also satisfy that protocol's
+/// requirements.
+///
+/// A custom type's `Hashable` and `Equatable` requirements are automatically
+/// synthesized by the compiler when you declare `Hashable` conformance in the
+/// type's original declaration and your type meets these criteria:
+///
+/// - For a `struct`, all its stored properties must conform to `Hashable`.
+/// - For an `enum`, all its associated values must conform to `Hashable`. (An
+///   `enum` without associated values has `Hashable` conformance even without
+///   the declaration.)
+///
+/// To customize your type's `Hashable` conformance, to adopt `Hashable` in a
+/// type that doesn't meet the criteria listed above, or to extend an existing
+/// type to conform to `Hashable`, implement the `hashValue` property in your
+/// custom type. To ensure that your type meets the semantic requirements of
+/// the `Hashable` and `Equatable` protocols, it's a good idea to also
+/// customize your type's `Equatable` conformance to match.
 ///
 /// As an example, consider a `GridPoint` type that describes a location in a
 /// grid of buttons. Here's the initial declaration of the `GridPoint` type:

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -566,6 +566,8 @@ extension Set : Sequence {
   ///
   /// - Parameter member: An element to look for in the set.
   /// - Returns: `true` if `member` exists in the set; otherwise, `false`.
+  ///
+  /// - Complexity: O(1)
   @_inlineable // FIXME(sil-serialize-all)
   public func contains(_ member: Element) -> Bool {
     return _variantBuffer.maybeGet(member) != nil
@@ -650,6 +652,8 @@ extension Set : Collection {
   /// - Parameter member: An element to search for in the set.
   /// - Returns: The index of `member` if it exists in the set; otherwise,
   ///   `nil`.
+  ///
+  /// - Complexity: O(1)
   @_inlineable // FIXME(sil-serialize-all)
   public func index(of member: Element) -> Index? {
     return _variantBuffer.index(forKey: member)
@@ -1151,7 +1155,7 @@ extension Set : SetAlgebra {
   /// instances of equivalent elements, only the first instance is kept.
   ///
   ///     var attendees: Set = ["Alicia", "Bethany", "Diana"]
-  ///     let visitors = ["Diana", ""Marcia", "Nathaniel"]
+  ///     let visitors = ["Diana", "Marcia", "Nathaniel"]
   ///     attendees.formUnion(visitors)
   ///     print(attendees)
   ///     // Prints "["Diana", "Nathaniel", "Bethany", "Alicia", "Marcia"]"
@@ -1754,9 +1758,10 @@ public struct Dictionary<Key : Hashable, Value> {
   /// Creates a new dictionary from the key-value pairs in the given sequence.
   ///
   /// You use this initializer to create a dictionary when you have a sequence
-  /// of key-value tuples with unique keys. If your sequence might have
-  /// duplicate keys, use the `Dictionary(_:uniquingKeysWith:)` initializer
-  /// instead.
+  /// of key-value tuples with unique keys. Passing a sequence with duplicate
+  /// keys to this initializer results in a runtime error. If your
+  /// sequence might have duplicate keys, use the
+  /// `Dictionary(_:uniquingKeysWith:)` initializer instead.
   ///
   /// The following example creates a new dictionary using an array of strings
   /// as the keys and the integers in a countable range as the values:

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1293,7 +1293,7 @@ extension Numeric {
 ///     // r == 82
 ///     //   == 0b01010010
 ///
-///     let s = Int16(truncatingIfNeeded: s)     // extend 'r' to fill 16 bits
+///     let s = Int16(truncatingIfNeeded: r)     // extend 'r' to fill 16 bits
 ///     // s == 82
 ///     //   == 0b00000000_01010010
 ///
@@ -1648,6 +1648,14 @@ ${operatorComment(x.nonMaskingOperator, False)}
 // Strideable conformance
 extension BinaryInteger {
   // FIXME(ABI): using Int as the return type is wrong.
+  /// Returns the distance from this value to the given value, expressed as a
+  /// stride.
+  ///
+  /// For two values `x` and `y`, and a distance `n = x.distance(to: y)`,
+  /// `x.advanced(by: n) == y`.
+  ///
+  /// - Parameter other: The value to calculate the distance to.
+  /// - Returns: The distance from this value to `other`.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
   public func distance(to other: Self) -> Int {
@@ -1677,6 +1685,17 @@ extension BinaryInteger {
   }
 
   // FIXME(ABI): using Int as the parameter type is wrong.
+  /// Returns a value that is offset the specified distance from this value.
+  ///
+  /// Use the `advanced(by:)` method in generic code to offset a value by a
+  /// specified distance. If you're working directly with numeric values, use
+  /// the addition operator (`+`) instead of this method.
+  ///
+  /// For a value `x`, a distance `n`, and a value `y = x.advanced(by: n)`,
+  /// `x.distance(to: y) == n`.
+  ///
+  /// - Parameter n: The distance to advance this value.
+  /// - Returns: A value that is offset from this value by `n`.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
   public func advanced(by n: Int) -> Self {
@@ -1696,12 +1715,31 @@ extension BinaryInteger {
 
 extension Int {
   // FIXME(ABI): using Int as the return type is wrong.
+  /// Returns the distance from this value to the given value, expressed as a
+  /// stride.
+  ///
+  /// For two values `x` and `y`, and a distance `n = x.distance(to: y)`,
+  /// `x.advanced(by: n) == y`.
+  ///
+  /// - Parameter other: The value to calculate the distance to.
+  /// - Returns: The distance from this value to `other`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public func distance(to other: Int) -> Int {
     return other - self
   }
 
+  /// Returns a value that is offset the specified distance from this value.
+  ///
+  /// Use the `advanced(by:)` method in generic code to offset a value by a
+  /// specified distance. If you're working directly with numeric values, use
+  /// the addition operator (`+`) instead of this method.
+  ///
+  /// For a value `x`, a distance `n`, and a value `y = x.advanced(by: n)`,
+  /// `x.distance(to: y) == n`.
+  ///
+  /// - Parameter n: The distance to advance this value.
+  /// - Returns: A value that is offset from this value by `n`.
   // FIXME(ABI): using Int as the parameter type is wrong.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
@@ -3207,6 +3245,7 @@ ${assignmentOperatorComment(x.operator, True)}
   }
 
   // FIXME should be RandomAccessCollection
+  /// A type that represents the words of this integer.
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Words : BidirectionalCollection {
     public typealias Indices = CountableRange<Int>
@@ -3286,6 +3325,8 @@ ${assignmentOperatorComment(x.operator, True)}
       Builtin.${truncOrExt}OrBitCast_Int${word_bits}_Int${bits}(bits._value))
   }
 
+  /// A type that can represent the absolute value of any possible value of
+  /// this type.
   public typealias Magnitude = ${U}${Self}
 
 % if signed:

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -84,7 +84,8 @@ extension LazyCollection : Sequence {
     return _base.makeIterator()
   }
 
-  /// A value less than or equal to the number of elements in the collection.
+  /// A value less than or equal to the number of elements in the sequence,
+  /// calculated nondestructively.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -511,6 +511,32 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
 ///         myStorage.update(withValue: value)
 ///     }
 ///
+/// Use care when calling `isKnownUniquelyReferenced(_:)` from within a Boolean
+/// expression. In debug builds, an instance in the left-hand side of a `&&`
+/// or `||` expression may still be referenced when evaluating the right-hand
+/// side, inflating the instance's reference count. For example, this version
+/// of the `update(withValue)` method will re-copy `myStorage` on every call:
+///
+///     // Copies too frequently:
+///     mutating func badUpdate(withValue value: T) {
+///         if myStorage.shouldCopy || !isKnownUniquelyReferenced(&myStorage) {
+///             myStorage = self.copiedStorage()
+///         }
+///         myStorage.update(withValue: value)
+///     }
+///
+/// To avoid this behavior, swap the call `isKnownUniquelyReferenced(_:)` to
+/// the left-hand side or store the result of the first expression in a local
+/// constant:
+///
+///     mutating func goodUpdate(withValue value: T) {
+///         let shouldCopy = myStorage.shouldCopy
+///         if shouldCopy || !isKnownUniquelyReferenced(&myStorage) {
+///             myStorage = self.copiedStorage()
+///         }
+///         myStorage.update(withValue: value)
+///     }
+///
 /// `isKnownUniquelyReferenced(_:)` checks only for strong references to the
 /// given object---if `object` has additional weak or unowned references, the
 /// result may still be `true`. Because weak and unowned references cannot be

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -126,7 +126,8 @@ extension LazyMapCollection: Sequence {
     return Iterator(_base: _base.makeIterator(), _transform: _transform)
   }
 
-  /// A value less than or equal to the number of elements in the collection.
+  /// A value less than or equal to the number of elements in the sequence,
+  /// calculated nondestructively.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -46,6 +46,7 @@ extension ${Type[0]} : CustomReflectable {
 }
 
 extension ${Type[0]} : CustomPlaygroundQuickLookable {
+  /// A custom playground Quick Look for the `${Type[0]}` instance.
   @_inlineable // FIXME(sil-serialize-all)
   public var customPlaygroundQuickLook: PlaygroundQuickLook {
     return ${Type[1]}(${Type[2]})

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -146,9 +146,11 @@ public protocol TextOutputStreamable {
 public protocol CustomStringConvertible {
   /// A textual representation of this instance.
   ///
-  /// Instead of accessing this property directly, convert an instance of any
-  /// type to a string by using the `String(describing:)` initializer. For
-  /// example:
+  /// Calling this property directly is discouraged. Instead, convert an
+  /// instance of any type to a string by using the `String(describing:)`
+  /// initializer. This initializer works with any type, and uses the custom
+  /// `description` property for types that conform to
+  /// `CustomStringConvertible`:
   ///
   ///     struct Point: CustomStringConvertible {
   ///         let x: Int, y: Int
@@ -197,6 +199,13 @@ public protocol LosslessStringConvertible : CustomStringConvertible {
 /// `debugDescription` property directly or using
 /// `CustomDebugStringConvertible` as a generic constraint is discouraged.
 ///
+/// - Note: Calling the `dump(_:_:_:_:)` function and printing in the debugger
+///   uses both `String(reflecting:)` and `Mirror(reflecting:)` to collect
+///   information about an instance. If you implement
+///   `CustomDebugStringConvertible` conformance for your custom type, you may
+///   want to consider providing a custom mirror by implementing
+///   `CustomReflectable` conformance, as well.
+///
 /// Conforming to the CustomDebugStringConvertible Protocol
 /// =======================================================
 ///
@@ -231,6 +240,28 @@ public protocol LosslessStringConvertible : CustomStringConvertible {
 ///     // Prints "Point(x: 21, y: 30)"
 public protocol CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
+  ///
+  /// Calling this property directly is discouraged. Instead, convert an
+  /// instance of any type to a string by using the `String(reflecting:)`
+  /// initializer. This initializer works with any type, and uses the custom
+  /// `debugDescription` property for types that conform to
+  /// `CustomDebugStringConvertible`:
+  ///
+  ///     struct Point: CustomDebugStringConvertible {
+  ///         let x: Int, y: Int
+  ///
+  ///         var debugDescription: String {
+  ///             return "(\(x), \(y))"
+  ///         }
+  ///     }
+  ///
+  ///     let p = Point(x: 21, y: 30)
+  ///     let s = String(reflecting: p)
+  ///     print(s)
+  ///     // Prints "(21, 30)"
+  ///
+  /// The conversion of `p` to a string in the assignment to `s` uses the
+  /// `Point` type's `debugDescription` property.
   var debugDescription: String { get }
 }
 

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -18,8 +18,8 @@ public protocol RangeExpression {
   /// The type for which the expression describes a range.
   associatedtype Bound: Comparable
 
-  /// Returns the range of indices within the given collection described by
-  /// this range expression.
+  /// Returns the range of indices described by this range expression within
+  /// the given collection.
   ///
   /// You can use the `relative(to:)` method to convert a range expression,
   /// which could be missing one or both of its endpoints, into a concrete

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -46,7 +46,7 @@ equivalenceExplanation = """\
 
 extension Sequence {
   /// Returns a sequence of pairs (*n*, *x*), where *n* represents a
-  /// consecutive integer starting at zero, and *x* represents an element of
+  /// consecutive integer starting at zero and *x* represents an element of
   /// the sequence.
   ///
   /// This example enumerates the characters of the string "Swift" and prints

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -46,6 +46,8 @@
 /// - `x.union(y).contains(e)` implies `x.contains(e) || y.contains(e)`
 /// - `x.contains(e) && y.contains(e)` if and only if
 ///   `x.intersection(y).contains(e)`
+/// - `x.isSubset(of: y)` implies `x.union(y) == y`
+/// - `x.isSuperset(of: y)` implies `x.union(y) == x`
 /// - `x.isSubset(of: y)` if and only if `y.isSuperset(of: x)`
 /// - `x.isStrictSuperset(of: y)` if and only if
 ///   `x.isSuperset(of: y) && x != y`
@@ -237,7 +239,7 @@ public protocol SetAlgebra : Equatable, ExpressibleByArrayLiteral {
   /// the `attendees` set:
   ///
   ///     var attendees: Set = ["Alicia", "Bethany", "Diana"]
-  ///     let visitors: Set = ["Marcia", "Nathaniel"]
+  ///     let visitors: Set = ["Diana", "Marcia", "Nathaniel"]
   ///     attendees.formUnion(visitors)
   ///     print(attendees)
   ///     // Prints "["Diana", "Nathaniel", "Bethany", "Alicia", "Marcia"]"

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -35,8 +35,8 @@
 ///
 /// 1) Create a slice of the `absences` array that holds the second half of the
 ///    days.
-/// 2) Use the `max(by:)` method to determine the index of the day
-///    with the most absences.
+/// 2) Use the `max(by:)` method to determine the index of the day with the
+///    most absences.
 /// 3) Print the result using the index found in step 2 on the original
 ///    `absences` array.
 ///
@@ -52,10 +52,10 @@
 /// ------------------------
 ///
 /// A slice inherits the value or reference semantics of its base collection.
-/// That is, if a `Slice` instance is wrapped around a mutable
-/// collection that has value semantics, such as an array, mutating the
-/// original collection would trigger a copy of that collection, and not
-/// affect the base collection stored inside of the slice.
+/// That is, if a `Slice` instance is wrapped around a mutable collection that
+/// has value semantics, such as an array, mutating the original collection
+/// would trigger a copy of that collection, and not affect the base
+/// collection stored inside of the slice.
 ///
 /// For example, if you update the last element of the `absences` array from
 /// `0` to `2`, the `secondHalf` slice is unchanged.
@@ -66,12 +66,12 @@
 ///     print(secondHalf)
 ///     // Prints "[0, 3, 1, 0]"
 ///
-/// - Important: Use slices only for transient computation.
-///   A slice may hold a reference to the entire storage of a larger
-///   collection, not just to the portion it presents, even after the base
-///   collection's lifetime ends. Long-term storage of a slice may therefore
-///   prolong the lifetime of elements that are no longer otherwise
-///   accessible, which can erroneously appear to be memory leakage.
+/// Use slices only for transient computation. A slice may hold a reference to
+/// the entire storage of a larger collection, not just to the portion it
+/// presents, even after the base collection's lifetime ends. Long-term
+/// storage of a slice may therefore prolong the lifetime of elements that are
+/// no longer otherwise accessible, which can erroneously appear to be memory
+/// leakage.
 ///
 /// - Note: Using a `Slice` instance with a mutable collection requires that
 ///   the base collection's `subscript(_: Index)` setter does not invalidate

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -10,31 +10,136 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Conforming types are notionally continuous, one-dimensional
-/// values that can be offset and measured.
+/// A type representing continuous, one-dimensional values that can be offset
+/// and measured.
+///
+/// You can use a type that conforms to the `Strideable` protocol with the
+/// `stride(from:to:by:)` and `stride(from:through:by:)` functions. For
+/// example, you can use `stride(from:to:by:)` to iterate over an
+/// interval of floating-point values:
+///
+///     for radians in stride(from: 0.0, to: .pi * 2, by: .pi / 2) {
+///         let degrees = Int(radians * 180 / .pi)
+///         print("Degrees: \(degrees), radians: \(radians)")
+///     }
+///     // Degrees: 0, radians: 0.0
+///     // Degrees: 90, radians: 1.5707963267949
+///     // Degrees: 180, radians: 3.14159265358979
+///     // Degrees: 270, radians: 4.71238898038469
+///
+/// The last parameter of these functions is of the associated `Stride`
+/// type---the type that represents the distance between any two instances of
+/// the `Strideable` type.
+///
+/// Types that have an integer `Stride` can be used as the boundaries of a
+/// countable range or as the lower bound of an iterable one-sided range. For
+/// example, you can iterate over a range of `Int` and use sequence and
+/// collection methods.
+///
+///     var sum = 0
+///     for x in 1...100 {
+///         sum += x
+///     }
+///     // sum == 5050
+///
+///     let digits = (0..<10).map(String.init)
+///     // ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+///
+/// Conforming to the Strideable Protocol
+/// =====================================
+///
+/// To add `Strideable` conformance to a custom type, choose a `Stride` type
+/// that can represent the distance between two instances and implement the
+/// `advanced(by:)` and `distance(to:)` methods. For example, this
+/// hypothetical `Date` type stores its value as the number of days before or
+/// after January 1, 2000:
+///
+///     struct Date: Equatable, CustomStringConvertible {
+///         var daysAfterY2K: Int
+///
+///         var description: String {
+///             // ...
+///         }
+///     }
+///
+/// The `Stride` type for `Date` is `Int`, inferred from the parameter and
+/// return types of `advanced(by:)` and `distance(to:)`:
+///
+///     extension Date: Strideable {
+///         func advanced(by n: Int) -> Date {
+///             var result = self
+///             result.daysAfterY2K += n
+///             return result
+///         }
+///
+///         func distance(to other: Date) -> Int {
+///             return other.daysAfterY2K - self.daysAfterY2K
+///         }
+///     }
+///
+/// The `Date` type can now be used with the `stride(from:to:by:)` and
+/// `stride(from:through:by:)` functions and as the bounds of an iterable
+/// range.
+///
+///     let startDate = Date(daysAfterY2K: 0)   // January 1, 2000
+///     let endDate = Date(daysAfterY2K: 15)    // January 16, 2000
+///
+///     for date in stride(from: startDate, to: endDate, by: 7) {
+///         print(date)
+///     }
+///     // January 1, 2000
+///     // January 8, 2000
+///     // January 15, 2000
 ///
 /// - Important: The `Strideable` protocol provides default implementations for
 ///   the equal-to (`==`) and less-than (`<`) operators that depend on the
-///   `Stride` type's implementations. If a type conforming to `Strideable`
-///   is its own `Stride` type, it must provide concrete implementations of
-///   the two operators to avoid infinite recursion.
+///   `Stride` type's implementations. If a type conforming to `Strideable` is
+///   its own `Stride` type, it must provide concrete implementations of the
+///   two operators to avoid infinite recursion.
 public protocol Strideable : Comparable {
-  /// A type that represents the distance between two values of `Self`.
+  /// A type that represents the distance between two values.
   associatedtype Stride : SignedNumeric, Comparable
 
-  /// Returns a stride `x` such that `self.advanced(by: x)` approximates
-  /// `other`.
+  /// Returns the distance from this value to the given value, expressed as a 
+  /// stride.
   ///
-  /// If `Stride` conforms to `Integer`, then `self.advanced(by: x) == other`.
+  /// If this type's `Stride` type conforms to `BinaryInteger`, then for two
+  /// values `x` and `y`, and a distance `n = x.distance(to: y)`,
+  /// `x.advanced(by: n) == y`. Using this method with types that have a
+  /// noninteger `Stride` may result in an approximation.
   ///
-  /// - Complexity: O(1).
+  /// - Parameter other: The value to calculate the distance to.
+  /// - Returns: The distance from this value to `other`.
+  ///
+  /// - Complexity: O(1)
   func distance(to other: Self) -> Stride
 
-  /// Returns a `Self` `x` such that `self.distance(to: x)` approximates `n`.
+  /// Returns a value that is offset the specified distance from this value.
   ///
-  /// If `Stride` conforms to `Integer`, then `self.distance(to: x) == n`.
+  /// Use the `advanced(by:)` method in generic code to offset a value by a
+  /// specified distance. If you're working directly with numeric values, use
+  /// the addition operator (`+`) instead of this method.
   ///
-  /// - Complexity: O(1).
+  ///     func addOne<T: Strideable>(to x: T) -> T
+  ///         where T.Stride : ExpressibleByIntegerLiteral
+  ///     {
+  ///         return x.advanced(by: 1)
+  ///     }
+  ///
+  ///     let x = addOne(to: 5)
+  ///     // x == 6
+  ///     let y = addOne(to: 3.5)
+  ///     // y = 4.5
+  ///
+  /// If this type's `Stride` type conforms to `BinaryInteger`, then for a
+  /// value `x`, a distance `n`, and a value `y = x.advanced(by: n)`,
+  /// `x.distance(to: y) == n`. Using this method with types that have a
+  /// noninteger `Stride` may result in an approximation.
+  ///
+  /// - Parameter n: The distance to advance this value.
+  /// - Returns: A value that is offset from this value by `n`.
+  ///
+  /// - Complexity: O(1)
   func advanced(by n: Stride) -> Self
 
   /// `_step` is an implementation detail of Strideable; do not use it directly.
@@ -161,7 +266,7 @@ extension Strideable where Self : FloatingPoint, Self == Stride {
   }
 }
 
-/// An iterator for `StrideTo<Element>`.
+/// An iterator for a `StrideTo` instance.
 @_fixed_layout
 public struct StrideToIterator<Element : Strideable> {
   @_versioned
@@ -202,8 +307,10 @@ extension StrideToIterator: IteratorProtocol {
   }
 }
 
-/// A `Sequence` of values formed by striding over a half-open interval.
 // FIXME: should really be a Collection, as it is multipass
+/// A sequence of values formed by striding over a half-open interval.
+///
+/// Use the `stride(from:to:by:)` function to create `StrideTo` instances.
 @_fixed_layout
 public struct StrideTo<Element : Strideable> {
   @_versioned
@@ -318,9 +425,51 @@ where Element.Stride : BinaryInteger {
 }
 #endif
 
-/// Returns the sequence of values (`self`, `self + stride`, `self +
-/// 2 * stride`, ... *last*) where *last* is the last value in the
-/// progression that is less than `end`.
+/// Returns a sequence from a starting value to, but not including, an end
+/// value, stepping by the specified amount.
+///
+/// You can use this function to stride over values of any type that conforms
+/// to the `Strideable` protocol, such as integers or floating-point types.
+/// Starting with `start`, each successive value of the sequence adds `stride`
+/// until the next value would be equal to or beyond `end`.
+///
+///     for radians in stride(from: 0.0, to: .pi * 2, by: .pi / 2) {
+///         let degrees = Int(radians * 180 / .pi)
+///         print("Degrees: \(degrees), radians: \(radians)")
+///     }
+///     // Degrees: 0, radians: 0.0
+///     // Degrees: 90, radians: 1.5707963267949
+///     // Degrees: 180, radians: 3.14159265358979
+///     // Degrees: 270, radians: 4.71238898038469
+///
+/// You can use `stride(from:to:by:)` to create a sequence that strides upward
+/// or downward. Pass a negative value as `stride` to create a sequence from a
+/// higher start to a lower end:
+///
+///     for countdown in stride(from: 3, to: 0, by: -1) {
+///         print("\(countdown)...")
+///     }
+///     // 3...
+///     // 2...
+///     // 1...
+///
+/// If you pass a value as `stride` that moves away from `end`, the sequence
+/// contains no values.
+///
+///     for x in stride(from: 0, to: 10, by: -1) {
+///         print(x)
+///     }
+///     // Nothing is printed.
+///
+/// - Parameters:
+///   - start: The starting value to use for the sequence. If the sequence
+///     contains any values, the first one is `start`.
+///   - end: An end value to limit the sequence. `end` is never an element of
+///     the resulting sequence.
+///   - stride: The amount to step by with each iteration. A positive `stride`
+///     iterates upward; a negative `stride` iterates downward.
+/// - Returns: A sequence from `start` toward, but not including, `end`. Each
+///   value in the sequence steps by `stride`.
 @_inlineable
 public func stride<T>(
   from start: T, to end: T, by stride: T.Stride
@@ -328,7 +477,7 @@ public func stride<T>(
   return StrideTo(_start: start, end: end, stride: stride)
 }
 
-/// An iterator for `StrideThrough<Element>`.
+/// An iterator for a `StrideThrough` instance.
 @_fixed_layout
 public struct StrideThroughIterator<Element : Strideable> {
   @_versioned
@@ -379,8 +528,11 @@ extension StrideThroughIterator: IteratorProtocol {
   }
 }
 
-/// A `Sequence` of values formed by striding over a closed interval.
-// FIXME: should really be a CollectionType, as it is multipass
+// FIXME: should really be a Collection, as it is multipass
+/// A sequence of values formed by striding over a closed interval.
+///
+/// Use the `stride(from:through:by:)` function to create `StrideThrough` 
+/// instances.
 @_fixed_layout
 public struct StrideThrough<Element: Strideable> {
   @_versioned
@@ -508,11 +660,64 @@ where Element.Stride : BinaryInteger {
 }
 #endif
 
-/// Returns the sequence of values (`self`, `self + stride`, `self +
-/// 2 * stride`, ... *last*) where *last* is the last value in the
-/// progression less than or equal to `end`.
+/// Returns a sequence from a starting value toward, and possibly including, an end
+/// value, stepping by the specified amount.
 ///
-/// - Note: There is no guarantee that `end` is an element of the sequence.
+/// You can use this function to stride over values of any type that conforms
+/// to the `Strideable` protocol, such as integers or floating-point types.
+/// Starting with `start`, each successive value of the sequence adds `stride`
+/// until the next value would be beyond `end`.
+///
+///     for radians in stride(from: 0.0, through: .pi * 2, by: .pi / 2) {
+///         let degrees = Int(radians * 180 / .pi)
+///         print("Degrees: \(degrees), radians: \(radians)")
+///     }
+///     // Degrees: 0, radians: 0.0
+///     // Degrees: 90, radians: 1.5707963267949
+///     // Degrees: 180, radians: 3.14159265358979
+///     // Degrees: 270, radians: 4.71238898038469
+///     // Degrees: 360, radians: 6.28318530717959
+///
+/// You can use `stride(from:through:by:)` to create a sequence that strides 
+/// upward or downward. Pass a negative value as `stride` to create a sequence 
+/// from a higher start to a lower end:
+///
+///     for countdown in stride(from: 3, through: 1, by: -1) {
+///         print("\(countdown)...")
+///     }
+///     // 3...
+///     // 2...
+///     // 1...
+///
+/// The value you pass as `end` is not guaranteed to be included in the 
+/// sequence. If stepping from `start` by `stride` does not produce `end`, 
+/// the last value in the sequence will be one step before going beyond `end`.
+///
+///     for multipleOfThree in stride(from: 3, through: 10, by: 3) {
+///         print(multipleOfThree)
+///     }
+///     // 3
+///     // 6
+///     // 9
+///
+/// If you pass a value as `stride` that moves away from `end`, the sequence 
+/// contains no values.
+///
+///     for x in stride(from: 0, through: 10, by: -1) {
+///         print(x)
+///     }
+///     // Nothing is printed.
+///
+/// - Parameters:
+///   - start: The starting value to use for the sequence. If the sequence
+///     contains any values, the first one is `start`.
+///   - end: An end value to limit the sequence. `end` is an element of
+///     the resulting sequence if and only if it can be produced from `start` 
+///     using steps of `stride`.
+///   - stride: The amount to step by with each iteration. A positive `stride`
+///     iterates upward; a negative `stride` iterates downward.
+/// - Returns: A sequence from `start` toward, and possibly including, `end`. 
+///   Each value in the sequence is separated by `stride`.
 @_inlineable
 public func stride<T>(
   from start: T, through end: T, by stride: T.Stride

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -303,12 +303,11 @@ extension String {
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
-  // FIXME(integers): support a more general BinaryInteger protocol
-  // FIXME(integers): support larger bitwidths than 64
   @_inlineable // FIXME(sil-serialize-all)
   public init<T : FixedWidthInteger>(
     _ value: T, radix: Int = 10, uppercase: Bool = false
   ) {
+    // FIXME(integers): support a more general BinaryInteger protocol
     _precondition(2...36 ~= radix, "Radix must be between 2 and 36")
     if T.bitWidth <= 64 {
       self = _int64ToString(
@@ -347,12 +346,12 @@ extension String {
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
-  // FIXME(integers): tiebreaker between T : FixedWidthInteger and other obsoleted
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4)
   public init<T : FixedWidthInteger>(
     _ value: T, radix: Int = 10, uppercase: Bool = false
   ) where T : SignedInteger {
+    // FIXME(integers): tiebreaker between T : FixedWidthInteger and other obsoleted
     _precondition(2...36 ~= radix, "Radix must be between 2 and 36")
     if T.bitWidth <= 64 {
       self = _int64ToString(
@@ -391,11 +390,11 @@ extension String {
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
-  // FIXME(integers): support a more general BinaryInteger protocol
   @_inlineable // FIXME(sil-serialize-all)
   public init<T : FixedWidthInteger>(
     _ value: T, radix: Int = 10, uppercase: Bool = false
   ) where T : UnsignedInteger {
+    // FIXME(integers): support a more general BinaryInteger protocol
     _precondition(2...36 ~= radix, "Radix must be between 2 and 36")
     if T.bitWidth <= 64 {
       self = _uint64ToString(

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -92,7 +92,11 @@ extension String : StringProtocol, RangeReplaceableCollection {
     return _characters.index(after: i)
   }
 
-  // TODO: swift-3-indexing-model - add docs
+  /// Returns the position immediately before the given index.
+  ///
+  /// - Parameter i: A valid index of the collection. `i` must be greater than
+  ///   `startIndex`.
+  /// - Returns: The index value immediately before `i`.
   @_inlineable // FIXME(sil-serialize-all)
   public func index(before i: Index) -> Index {
     return _characters.index(before: i)

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -71,15 +71,30 @@ extension String {
 ///     // numericPrefix is the substring "126"
 ///
 /// When you need to store a substring or pass it to a function that requires a
-/// `String` instance, convert it using the `String.init(_:)` initializer.
+/// `String` instance, you can convert it to a `String` by using the
+/// `String(_:)` initializer. Calling this initializer copies the contents of
+/// the substring to a new string.
 ///
-///     _ = Int(numericPrefix, radix: 10)
+///     func parseAndAddOne(_ s: String) -> Int {
+///         return Int(s, radix: 10)! + 1
+///     }
+///     _ = parseAndAddOne(numericPrefix)
 ///     // error: cannot convert value...
-///     let prefix = Int(String(numericPrefix), radix: 10)
-///     // prefix == 126
+///     let incrementedPrefix = parseAndAddOne(String(numericPrefix))
+///     // incrementedPrefix == 127
 ///
-/// Calling this initializer copies the contents of the substring to a new
-/// string.
+/// Alternatively, you can convert the function that takes a `String` to one
+/// that is generic over the `StringProtocol` protocol. The following code
+/// declares a generic version of the `parseAndAddOne(_:)` function:
+///
+///     func genericParseAndAddOne<S: StringProtocol>(_ s: S) -> Int {
+///         return Int(s, radix: 10)! + 1
+///     }
+///     let genericallyIncremented = genericParseAndAddOne(numericPrefix)
+///     // genericallyIncremented == 127
+///
+/// You can call this generic function with an instance of either `String` or
+/// `Substring`.
 ///
 /// - Important: Don't store substrings longer than you need them to perform a
 ///   specific operation. A substring holds a reference to the entire storage

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -519,9 +519,14 @@ extension Unsafe${Mutable}BufferPointer {
   /// After executing `body`, this method rebinds memory back to the original
   /// `Element` type.
   ///
+  /// - Note: Only use this method to rebind the buffer's memory to a type
+  ///   with the same size and stride as the currently bound `Element` type.
+  ///   To bind a region of memory to a type that is a different size, convert
+  ///   the buffer to a raw buffer and use the `bindMemory(to:)` method.
+  ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
-  ///     buffer. The type `T` must have the same stride and be layout compatible
+  ///     buffer. The type `T` must have the same size and be layout compatible
   ///     with the pointer's `Element` type.
   ///   - body: A closure that takes a ${Mutable.lower()} typed buffer to the
   ///     same memory as this buffer, only bound to type `T`. The buffer argument 

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -792,6 +792,12 @@ public struct ${Self}<Pointee>: _Pointer {
   /// After executing `body`, this method rebinds memory back to the original
   /// `Pointee` type.
   ///
+  /// - Note: Only use this method to rebind the pointer's memory to a type
+  ///   with the same size and stride as the currently bound `Pointee` type.
+  ///   To bind a region of memory to a type that is a different size, convert
+  ///   the pointer to a raw pointer and use the `bindMemory(to:capacity:)`
+  ///   method.
+  ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
   ///     pointer. The type `T` must be the same size and be layout compatible


### PR DESCRIPTION
- Revise Equatable and Hashable for synthesized requirements
- Complete Strideable and stride(from:...:by:) documentation
- Revise DoubleWidth type docs
- Add complexity notes for Set.index(of:) and .contains(_:)
- Fix typos in Set.formUnion docs
- Add missing axioms for SetAlgebra (SR-6319)
- Improve guidance for description and debugDescription
- Add note about the result of passing duplicate keys to
  Dictionary(uniqueKeysWithValues:)
- Fix typo in BinaryInteger docs
- Update Substring docs with better conversion example
- Improve docs for withMemoryRebound and isKnownUniquelyReferenced
