### PR TITLE
Revert: [Conformance checking] Allow generic parameter when inferring type witnesses.

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -876,20 +876,6 @@ AssociatedTypeInference::computeAbstractTypeWitness(
       return derivedType;
   }
 
-  // If there is a generic parameter of the named type, use that.
-  if (auto gpList = dc->getGenericParamsOfContext()) {
-    GenericTypeParamDecl *foundGP = nullptr;
-    for (auto gp : *gpList) {
-      if (gp->getName() == assocType->getName()) {
-        foundGP = gp;
-        break;
-      }
-    }
-
-    if (foundGP)
-      return dc->mapTypeIntoContext(foundGP->getDeclaredInterfaceType());
-  }
-
   return Type();
 }
 

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -391,15 +391,15 @@ struct S13 : P13 { // expected-error{{type 'S13' does not conform to protocol 'P
   func foo(arg: inout Int) {}
 }
 
-// "Infer" associated type from generic parameter.
+// Don't "infer" associated type from generic parameter.
 protocol P14 {
-  associatedtype Value
+  associatedtype Value // expected-note 2{{protocol requires nested type 'Value'}}
 }
 
-struct P14a<Value>: P14 { }
+struct P14a<Value>: P14 { } // expected-error{{type 'P14a<Value>' does not conform to protocol 'P14'}}
 
 struct P14b<Value> { }
-extension P14b: P14 { }
+extension P14b: P14 { } // expected-error{{type 'P14b<Value>' does not conform to protocol 'P14'}}
 
 // Associated type defaults in overridden associated types.
 struct X15 { }


### PR DESCRIPTION
This well-intentioned change broke ReactiveCocoa-3.1, pull it out
until we can make the change without causing a regression. Fixes
SR-6658 / rdar://problem/36200459.
