### PR TITLE
IUO: Update AST printer to print '!' for Optionals that are implicitl…

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -312,6 +312,13 @@ struct PrintOptions {
   /// of the alias.
   bool PrintNameAliasUnderlyingType = false;
 
+  /// When printing an Optional<T>, rather than printing 'T?', print
+  /// 'T!'. Used as a modifier only when we know we're printing
+  /// something that was declared as an implicitly unwrapped optional
+  /// at the top level. This is stripped out of the printing options
+  /// for optionals that are nested within other optionals.
+  bool PrintOptionalAsImplicitlyUnwrapped = false;
+
   /// \brief Print dependent types as references into this generic environment.
   GenericEnvironment *GenericEnv = nullptr;
 


### PR DESCRIPTION
…y unwrapped.

Once we generate Optional<T> for T! we'll need this to ensure that we
continue to print '!' in places where the user specified it.
