### PR TITLE
[sil-opt] When a target triple is not specified, use the default targ…

### DIFF
--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -116,7 +116,8 @@ SDKPath("sdk", llvm::cl::desc("The path to the SDK for use with the clang "
         llvm::cl::init(""));
 
 static llvm::cl::opt<std::string>
-Target("target", llvm::cl::desc("target triple"));
+Target("target", llvm::cl::desc("target triple"),
+       llvm::cl::init(llvm::sys::getDefaultTargetTriple()));
 
 static llvm::cl::opt<OptGroup> OptimizationGroup(
     llvm::cl::desc("Predefined optimization groups:"),


### PR DESCRIPTION
…et triple.

This is common sense behavior that the rest of the compiler toolchain follows
and also enables one to dump the standard library without specifying an explicit
target.
