### PR TITLE
[benchmark] Add a microbenchmark for the UnsafePointer.+

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SWIFT_BENCH_MODULES
     single-source/ObserverUnappliedMethod
     single-source/OpenClose
     single-source/Phonebook
+    single-source/PointerArithmetics
     single-source/PolymorphicCalls
     single-source/PopFront
     single-source/PopFrontGeneric

--- a/benchmark/single-source/PointerArithmetics.swift
+++ b/benchmark/single-source/PointerArithmetics.swift
@@ -1,0 +1,32 @@
+//===--- PointerArithmetics.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let PointerArithmetics = [
+  BenchmarkInfo(name: "PointerPlusInt", runFunction: run_PointerPlusInt, tags: [.validation, .api]),
+]
+
+@inline(never)
+public func run_PointerPlusInt(_ N: Int) {
+  var numbers = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+  var c = 0
+  withUnsafePointer(to: &numbers) {
+    $0.withMemoryRebound(to: Int.self, capacity: 10) { ptr in
+      for i in 1...N*10_000_000 {
+        c += (ptr + i%10).pointee
+      }
+    }
+  }
+  CheckResults(c != 0)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -81,6 +81,7 @@ import ObserverPartiallyAppliedMethod
 import ObserverUnappliedMethod
 import OpenClose
 import Phonebook
+import PointerArithmetics
 import PolymorphicCalls
 import PopFront
 import PopFrontGeneric
@@ -204,6 +205,7 @@ registerBenchmark(ObserverPartiallyAppliedMethod)
 registerBenchmark(ObserverUnappliedMethod)
 registerBenchmark(OpenClose)
 registerBenchmark(Phonebook)
+registerBenchmark(PointerArithmetics)
 registerBenchmark(PolymorphicCalls)
 registerBenchmark(PopFront)
 registerBenchmark(PopFrontArrayGeneric)


### PR DESCRIPTION
UnsafePointer implementation contains the following note:

> Note: The following family of operator overloads are redundant with
Strideable. However, optimizer improvements are needed before they can
be removed without affecting performance.

... but it looks like there is no benchmark to support this claim.