### PR TITLE
[Runtime] Teach swift_getTupleTypeMetadata() to copy "labels" string.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -676,6 +676,40 @@ public:
 };
 using ParameterFlags = TargetParameterTypeFlags<uint32_t>;
 
+template <typename int_type>
+class TargetTupleTypeFlags {
+  enum : int_type {
+    NonConstantLabelsMask    = 1 << 0,
+  };
+  int_type Data;
+
+public:
+  constexpr TargetTupleTypeFlags(int_type Data) : Data(Data) {}
+
+  constexpr TargetTupleTypeFlags<int_type> withNonConstantLabels(
+                                             bool hasNonConstantLabels) const {
+    return TargetTupleTypeFlags<int_type>(
+                        (Data & NonConstantLabelsMask) |
+                          (hasNonConstantLabels ? NonConstantLabelsMask : 0));
+  }
+
+  bool hasNonConstantLabels() const { return Data & NonConstantLabelsMask; }
+
+  int_type getIntValue() const { return Data; }
+
+  static TargetTupleTypeFlags<int_type> fromIntValue(int_type Data) {
+    return TargetTupleTypeFlags(Data);
+  }
+
+  bool operator==(TargetTupleTypeFlags<int_type> other) const {
+    return Data == other.Data;
+  }
+  bool operator!=(TargetTupleTypeFlags<int_type> other) const {
+    return Data != other.Data;
+  }
+};
+using TupleTypeFlags = TargetTupleTypeFlags<uint32_t>;
+
 /// Field types and flags as represented in a nominal type's field/case type
 /// vector.
 class FieldType {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2878,6 +2878,7 @@ const TupleTypeMetadata *
 swift_getTupleTypeMetadata(size_t numElements,
                            const Metadata * const *elements,
                            const char *labels,
+                           TupleTypeFlags flags,
                            const ValueWitnessTable *proposedWitnesses);
 
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -876,11 +876,12 @@ FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata, DefaultCC,
 // Metadata *swift_getTupleTypeMetadata(size_t numElements,
 //                                      Metadata * const *elts,
 //                                      const char *labels,
+//                                      uint32_t flags,
 //                                      value_witness_table_t *proposed);
 FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy, TypeMetadataPtrTy->getPointerTo(0),
-              Int8PtrTy, WitnessTablePtrTy),
+              Int8PtrTy, Int32Ty, WitnessTablePtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_getTupleTypeMetadata2(Metadata *elt0, Metadata *elt1,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -687,10 +687,12 @@ namespace {
           if (i == 0) pointerToFirst = eltPtr.getAddress();
         }
 
+        TupleTypeFlags flags(0);
         llvm::Value *args[] = {
           llvm::ConstantInt::get(IGF.IGM.SizeTy, elements.size()),
           pointerToFirst,
           getTupleLabelsString(IGF.IGM, type),
+          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
           llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
         };
 
@@ -1661,11 +1663,13 @@ namespace {
           if (i == 0) pointerToFirst = eltPtr.getAddress();
         }
 
+        TupleTypeFlags flags(0);
         llvm::Value *args[] = {
           llvm::ConstantInt::get(IGF.IGM.SizeTy, elements.size()),
           pointerToFirst,
           // labels don't matter for layout
           llvm::ConstantPointerNull::get(IGF.IGM.Int8PtrTy),
+          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
           llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
         };
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -341,9 +341,12 @@ public:
                             std::string labels,
                             bool variadic) const {
     // TODO: 'variadic' should no longer exist
+    TupleTypeFlags flags(0);
+    if (!labels.empty())
+      flags = flags.withNonConstantLabels(true);
     return swift_getTupleTypeMetadata(elements.size(), elements.data(),
                                       labels.empty() ? nullptr : labels.c_str(),
-                                      /*proposedWitnesses=*/nullptr);
+                                      flags, /*proposedWitnesses=*/nullptr);
   }
 
   BuiltType createDependentMemberType(StringRef name, BuiltType base,

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -113,6 +113,6 @@ func tuple_existentials() {
   // 4 element tuple
   var t4 = (1,2,3,4)
   a = t4
-  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i64 4, {{.*}}, i8* null, i8** null)
+  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i64 4, {{.*}}, i8* null, i32 0, i8** null)
 }
 


### PR DESCRIPTION
Introduce a flags parameter to swift_getTupleTypeMetadata(). Add a flag
stating when the "labels" parameter points into nonconstant memory, in
which case we need to make a copy of the string before adding an entry
into the concurrent map.
