### PR TITLE
[CSRanking] Fix self types to be unrelated when comparing operator decls

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -209,8 +209,16 @@ static bool isNominallySuperclassOf(Type type1, Type type2) {
 /// Determine the relationship between the self types of the given declaration
 /// contexts..
 static std::pair<SelfTypeRelationship, Optional<ProtocolConformanceRef>>
-computeSelfTypeRelationship(TypeChecker &tc, DeclContext *dc, DeclContext *dc1,
-                            DeclContext *dc2) {
+computeSelfTypeRelationship(TypeChecker &tc, DeclContext *dc, ValueDecl *decl1,
+                            ValueDecl *decl2) {
+  // If both declarations are operators, even through they
+  // might have Self such types are unrelated.
+  if (decl1->isOperator() && decl2->isOperator())
+    return {SelfTypeRelationship::Unrelated, None};
+
+  auto *dc1 = decl1->getDeclContext();
+  auto *dc2 = decl2->getDeclContext();
+
   // If at least one of the contexts is a non-type context, the two are
   // unrelated.
   if (!dc1->isTypeContext() || !dc2->isTypeContext())
@@ -558,7 +566,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // appropriate constraints. The constraints themselves never fail, but
       // they help deduce type variables that were opened.
       auto selfTypeRelationship =
-          computeSelfTypeRelationship(tc, dc, outerDC1, outerDC2);
+          computeSelfTypeRelationship(tc, dc, decl1, decl2);
       auto relationshipKind = selfTypeRelationship.first;
       auto conformance = selfTypeRelationship.second;
       switch (relationshipKind) {

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -902,38 +902,6 @@ extension RangeReplaceableCollection
   }
 }
 
-extension Sequence {
-  /// Creates a new collection by concatenating the elements of a sequence and a
-  /// collection.
-  ///
-  /// The two arguments must have the same `Element` type. For example, you can
-  /// concatenate the elements of a `Range<Int>` instance and an integer array.
-  ///
-  ///     let numbers = [7, 8, 9, 10]
-  ///     let moreNumbers = 1...6 + numbers
-  ///     print(moreNumbers)
-  ///     // Prints "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
-  ///
-  /// The resulting collection has the type of argument on the right-hand side.
-  /// In the example above, `moreNumbers` has the same type as `numbers`, which
-  /// is `[Int]`.
-  ///
-  /// - Parameters:
-  ///   - lhs: A collection or finite sequence.
-  ///   - rhs: A range-replaceable collection.
-  @_inlineable
-  public static func + <
-    Other : RangeReplaceableCollection
-  >(lhs: Self, rhs: Other) -> Other
-  where Element == Other.Element {
-    var result = Other()
-    result.reserveCapacity(rhs.count + numericCast(lhs.underestimatedCount))
-    result.append(contentsOf: lhs)
-    result.append(contentsOf: rhs)
-    return result
-  }
-}
-
 extension RangeReplaceableCollection {
   /// Creates a new collection by concatenating the elements of a collection and
   /// a sequence.
@@ -962,6 +930,36 @@ extension RangeReplaceableCollection {
     // FIXME: what if lhs is a reference type?  This will mutate it.
     lhs.append(contentsOf: rhs)
     return lhs
+  }
+
+  /// Creates a new collection by concatenating the elements of a sequence and a
+  /// collection.
+  ///
+  /// The two arguments must have the same `Element` type. For example, you can
+  /// concatenate the elements of a `Range<Int>` instance and an integer array.
+  ///
+  ///     let numbers = [7, 8, 9, 10]
+  ///     let moreNumbers = 1...6 + numbers
+  ///     print(moreNumbers)
+  ///     // Prints "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+  ///
+  /// The resulting collection has the type of argument on the right-hand side.
+  /// In the example above, `moreNumbers` has the same type as `numbers`, which
+  /// is `[Int]`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A collection or finite sequence.
+  ///   - rhs: A range-replaceable collection.
+  @_inlineable
+  public static func + <
+    Other : Sequence
+  >(lhs: Other, rhs: Self) -> Self
+  where Element == Other.Element {
+    var result = Self()
+    result.reserveCapacity(rhs.count + numericCast(lhs.underestimatedCount))
+    result.append(contentsOf: lhs)
+    result.append(contentsOf: rhs)
+    return result
   }
 
   /// Appends the elements of a sequence to a range-replaceable collection.

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -269,7 +269,7 @@ func rdar19831698() {
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
   var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[Any]'}}
-  // expected-note @-1 {{expected an argument list of type '(Self, Other)'}}
+  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Self, Other), (Other, Self)}}
   var v75 = true + "str" // expected-error {{binary operator '+' cannot be applied to operands of type 'Bool' and 'String'}} expected-note {{expected an argument list of type '(String, String)'}}
 }
 

--- a/test/Sema/fixed_ambiguities/rdar36333688.swift
+++ b/test/Sema/fixed_ambiguities/rdar36333688.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+infix operator +=+ : AdditionPrecedence
+extension RangeReplaceableCollection {
+   public static func +=+ <
+     Other : Sequence
+   >(lhs: Self, rhs: Other) -> Self
+    where Element == Other.Element {
+     fatalError()
+   }
+
+   public static func +=+ <
+     Other : Sequence
+   >(lhs: Other, rhs: Self) -> Self
+    where Element == Other.Element {
+     fatalError()
+   }
+
+   public static func +=+ <
+    Other : RangeReplaceableCollection
+   >(lhs: Self, rhs: Other) -> Self
+    where Element == Other.Element {
+     fatalError()
+   }
+}
+
+func rdar36333688(_ first: Int, _ rest: Int...) {
+  // CHECK: function_ref @{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : RangeReplaceableCollection><τ_1_0 where τ_1_0 : RangeReplaceableCollection, τ_0_0.Element == τ_1_0.Element> (@in τ_0_0, @in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  let _ = [first] +=+ rest
+}


### PR DESCRIPTION
Such declarations should already have self bound as one of the parameters
which would enforce subtype relationship.

Resolves: rdar://problem/36333688

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
