### PR TITLE
SILGen: Fix crash when emitting implicit 'super.init()' delegation to throwing or failing initializer

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -682,6 +682,22 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   // Emit the constructor body.
   emitStmt(ctor->getBody());
 
+  // Emit the call to super.init() right before exiting from the initializer.
+  if (NeedsBoxForSelf) {
+    if (auto *SI = ctor->getSuperInitCall()) {
+      B.setInsertionPoint(ReturnDest.getBlock());
+
+      emitRValue(SI);
+
+      B.emitBlock(B.splitBlockForFallthrough(), ctor);
+
+      ReturnDest = JumpDest(B.getInsertionBB(),
+                            ReturnDest.getDepth(),
+                            ReturnDest.getCleanupLocation());
+      B.clearInsertionPoint();
+    }
+  }
+
   CleanupStateRestorationScope SelfCleanupSave(Cleanups);
 
   // Build a custom epilog block, since the AST representation of the
@@ -695,16 +711,11 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
            "emitting epilog in wrong scope");
 
     SILGenSavedInsertionPoint savedIP(*this, ReturnDest.getBlock());
-    assert(B.getInsertionBB()->empty() && "Epilog already set up?");
     auto cleanupLoc = CleanupLocation(ctor);
 
     // If we're using a box for self, reload the value at the end of the init
     // method.
     if (NeedsBoxForSelf) {
-      // Emit the call to super.init() right before exiting from the initializer.
-      if (Expr *SI = ctor->getSuperInitCall())
-        emitRValue(SI);
-
       ManagedValue storedSelf =
           ManagedValue::forUnmanaged(VarLocs[selfDecl].value);
       selfArg = B.createLoadCopy(cleanupLoc, storedSelf);

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -132,3 +132,29 @@ class ChildOfParentWithNoDefaultInit : ParentWithNoDefaultInit {
 // CHECK: return
   }
 }
+
+// <https://bugs.swift.org/browse/SR-5974> - auto-generated super.init()
+// delegation to a throwing or failing initializer
+class FailingParent {
+  init?() {}
+}
+
+class ThrowingParent {
+  init() throws {}
+}
+
+class FailingThrowingParent {
+  init?() throws {}
+}
+
+class FailingChild : FailingParent {
+  override init?() {}
+}
+
+class ThrowingChild : ThrowingParent {
+  override init() throws {}
+}
+
+class FailingThrowingChild : FailingThrowingParent {
+  override init?() throws {}
+}


### PR DESCRIPTION
If the base class defines a no-argument initializer, we allow the
'super.init()' call to be omitted. However, SILGen would generate
invalid SIL if the base class initializer was throwing or failing.

The problem was that we would attempt to insert instructions
after a try_apply or cond_br, which is invalid, because we would
incorrectly save and restore the insertion point when emitting the
delegation. This is incorrect, because a delegation to a throwing
or failing initializer emits new basic blocks.

Fixes <https://bugs.swift.org/browse/SR-5974>,
<rdar://problem/36256335>.