### PR TITLE
[temp-rvalue] Teach the temprvalue to ignore @in_guaranteed uses.

### DIFF
--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -87,6 +87,24 @@ struct SILArgumentConvention {
     return Value <= SILArgumentConvention::Indirect_Out;
   }
 
+  bool isGuaranteedConvention() const {
+    switch (Value) {
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+    case SILArgumentConvention::Direct_Guaranteed:
+      return true;
+    case SILArgumentConvention::Indirect_Inout:
+    case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_In_Constant:
+    case SILArgumentConvention::Indirect_Out:
+    case SILArgumentConvention::Indirect_InoutAliasable:
+    case SILArgumentConvention::Direct_Unowned:
+    case SILArgumentConvention::Direct_Owned:
+    case SILArgumentConvention::Direct_Deallocating:
+      return false;
+    }
+    llvm_unreachable("covered switch isn't covered?!");
+  }
+
   /// Returns true if \p Value is a not-aliasing indirect parameter.
   /// The \p isInoutAliasing specifies what to assume about the inout
   /// convention.

--- a/test/SILOptimizer/bridged_casts_folding.sil
+++ b/test/SILOptimizer/bridged_casts_folding.sil
@@ -73,14 +73,14 @@ bb3(%8 : @owned $NSObjectSubclass):
 }
 
 // CHECK-LABEL: sil @anyhashable_cast_copy_on_success
-// CHECK:         copy_addr %0 to [initialization] [[TEMP:%.*]] : $*AnyHashable
-// CHECK-NEXT:    [[BRIDGED:%.*]] = apply {{.*}}([[TEMP]])
-// CHECK-NEXT:    destroy_addr [[TEMP]]
+// CHECK-NOT:         copy_addr
+// CHECK:    [[BRIDGED:%.*]] = apply {{.*}}(%0)
+// CHECK-NOT:    destroy_addr
 // CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to $NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 // CHECK:       [[YES]]{{.*}}:
-// CHECK-NEXT:    dealloc_stack [[TEMP]]
+// CHECK-NOT:    dealloc_stack
 // CHECK:       [[NO]]{{.*}}:
-// CHECK-NEXT:    dealloc_stack [[TEMP]]
+// CHECK-NOT:    dealloc_stack
 sil @anyhashable_cast_copy_on_success : $@convention(thin) (@in_guaranteed AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : @trivial $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -903,10 +903,10 @@ var anyHashable: AnyHashable = 0
 
 // CHECK-LABEL: $S21bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF
 // CHECK: [[GLOBAL:%[0-9]+]] = global_addr @$S21bridged_casts_folding11anyHashables03AnyE0Vv
-// CHECK: function_ref @$Ss11AnyHashableV10FoundationE19_bridgeToObjectiveCSo8NSObjectCyF
-// CHECK-NEXT: apply %3(%1)
-// CHECK-NEXT: destroy_addr %1
+// CHECK: [[FUNC:%.*]] = function_ref @$Ss11AnyHashableV10FoundationE19_bridgeToObjectiveCSo8NSObjectCyF
+// CHECK-NEXT: apply [[FUNC]]([[GLOBAL]])
 // CHECK-NEXT: unconditional_checked_cast {{%.*}} : $NSObject to $NSObjectSubclass
+// CHECK: } // end sil function '$S21bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF'
 @inline(never)
 public func testUncondCastSwiftToSubclass() -> NSObjectSubclass {
   return anyHashable as! NSObjectSubclass

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -5,12 +5,35 @@ sil_stage canonical
 import Builtin
 import Swift
 
+/////////////
+// Utility //
+/////////////
+
 struct GS<Base> {
   var _base: Base
   var _value: Builtin.Int64
 }
 
+class Klass {}
+
 sil @unknown : $@convention(thin) () -> ()
+
+sil @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
+bb0(%0 : $*Klass):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @inguaranteed_user_with_result : $@convention(thin) (@in_guaranteed Klass) -> @out Klass {
+bb0(%0 : $*Klass, %1 : $*Klass):
+  copy_addr %1 to [initialization] %0 : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+///////////
+// Tests //
+///////////
 
 // CHECK-LABEL: sil @rvalue_simple
 // CHECK: bb0(%0 : $*GS<B>, %1 : $*GS<B>):
@@ -341,4 +364,83 @@ bb4:
 bb5:
   %40 = tuple ()
   return %40 : $()
+}
+
+// Make sure that we can eliminate temporaries passed via a temporary rvalue to
+// an @in_guaranteed function.
+//
+// CHECK-LABEL: sil @inguaranteed_no_result : $@convention(thin) (@inout Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*Klass):
+// CHECK-NOT: copy_addr
+// CHECK: apply {{%.*}}([[ARG]])
+// CHECK-NOT: destroy_addr
+// CHECK: } // end sil function 'inguaranteed_no_result'
+sil @inguaranteed_no_result : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = alloc_stack $Klass
+  copy_addr %0 to [initialization] %1 : $*Klass
+  %5 = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
+  %6 = apply %5(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+  %9 = tuple ()
+  return %9 : $()
+}
+
+
+// Make sure that we can eliminate temporaries passed via a temporary rvalue to
+// an @in_guaranteed function.
+//
+// CHECK-LABEL: sil @inguaranteed_with_result : $@convention(thin) (@inout Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*Klass):
+// dead temp
+// CHECK: [[TMP_OUT:%.*]] = alloc_stack $Klass
+// CHECK-NOT: copy_addr
+// CHECK: apply {{%.*}}([[TMP_OUT]], [[ARG]])
+// CHECK-NOT: copy_addr
+// CHECK: destroy_addr [[TMP_OUT]]
+// CHECK-NOT: destroy_addr
+// CHECK: } // end sil function 'inguaranteed_with_result'
+sil @inguaranteed_with_result : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = alloc_stack $Klass
+  %1a = alloc_stack $Klass
+  copy_addr %0 to [initialization] %1 : $*Klass
+  %5 = function_ref @inguaranteed_user_with_result : $@convention(thin) (@in_guaranteed Klass) -> @out Klass
+  %6 = apply %5(%1a, %1) : $@convention(thin) (@in_guaranteed Klass) -> @out Klass
+  destroy_addr %1a : $*Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1a : $*Klass
+  dealloc_stack %1 : $*Klass
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// Make sure that we do not optimize this case.
+//
+// CHECK-LABEL: sil @non_overlapping_lifetime : $@convention(thin) (@in Klass) -> () {
+// CHECK: destroy_addr
+// CHECK: destroy_addr
+// CHECK: destroy_addr
+// CHECK: } // end sil function 'non_overlapping_lifetime'
+sil @non_overlapping_lifetime : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1a = alloc_stack $Klass
+
+  %1 = alloc_stack $Klass
+  %2 = alloc_stack $Klass
+  copy_addr %0 to [initialization] %2 : $*Klass
+  copy_addr [take] %2 to [initialization] %1 : $*Klass
+  dealloc_stack %2 : $*Klass
+  copy_addr %1 to [initialization] %1a : $*Klass
+  destroy_addr %0 : $*Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+
+  %3 = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
+  apply %3(%1a) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1a : $*Klass
+  dealloc_stack %1a : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
 }


### PR DESCRIPTION
This is a pattern that comes up very often in an all +0 normal argument
convention world.

rdar://34222540