### PR TITLE
[stdlib] [SE-0067] Implement generic conversions to floating point

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2139,17 +2139,10 @@ extension BinaryFloatingPoint {
         return (source.sign == .minus ? -.infinity : .infinity, true)
       }
       // IEEE 754 requires that any NaN payload be propagated, if possible.
-      let payload_ = source.isSignalingNaN
-        ? source.significandBitPattern ^
-          Source.signalingNaN.significandBitPattern
-        : source.significandBitPattern ^ Source.nan.significandBitPattern
-      // For all extant conforming types,
-      //
-      //   .nan.significandBitPattern | .signalingNaN.significandBitPattern
-      //     == .signalingNaN.significandBitPattern
-      //
-      // However, there appears to be no semantic guarantee of this relation,
-      // either in Swift or in IEEE 754. Therefore, we proceed conservatively.
+      let payload_ =
+        source.significandBitPattern &
+          ~(Source.nan.significandBitPattern |
+            Source.signalingNaN.significandBitPattern)
       let mask =
         Self.greatestFiniteMagnitude.significandBitPattern &
           ~(Self.nan.significandBitPattern |

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -253,24 +253,20 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   init(_ value: ${src_ty.stdlib_name})
 
 % end
-  /*  TODO: Implement the following APIs once a revised integer protocol is
-      introduced that allows for them to be implemented. In particular, we
-      need to have an "index of most significant bit" operation and "get
-      absolute value as unsigned type" operation on the Integer protocol.
+  /// Creates a new value, rounded to the closest possible representation.
+  ///
+  /// If two representable values are equally close, the result is the value
+  /// with more trailing zeros in its significand bit pattern.
+  ///
+  /// - Parameter value: The integer to convert to a floating-point value.
+  init<Source : BinaryInteger>(_ value: Source)
 
-  /// Creates the closest representable value to the given integer.
+  /// Creates a new value, if the given integer can be represented exactly.
   ///
-  /// - Parameter value: The integer to represent as a floating-point value.
-  init<Source: Integer>(_ value: Source)
-
-  /// Creates a value that exactly represents the given integer.
+  /// If the given integer cannot be represented exactly, the result is `nil`.
   ///
-  /// If the given integer is outside the representable range of the type, the
-  /// result is `nil`.
-  ///
-  /// - Parameter value: The integer to represent as a floating-point value.
-  init?<Source: Integer>(exactly value: Source)
-  */
+  /// - Parameter value: The integer to convert to a floating-point value.
+  init?<Source : BinaryInteger>(exactly value: Source)
 
   /// The radix, or base of exponentiation, for a floating-point type.
   ///
@@ -1464,39 +1460,41 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
-  /// - Parameter value: A floating-point value.
+  /// - Parameter value: A floating-point value to be converted.
   init(_ value: Float)
 
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
-  /// - Parameter value: A floating-point value.
+  /// - Parameter value: A floating-point value to be converted.
   init(_ value: Double)
 
 #if !os(Windows) && (arch(i386) || arch(x86_64))
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
-  /// - Parameter value: A floating-point value.
+  /// - Parameter value: A floating-point value to be converted.
   init(_ value: Float80)
 #endif
 
-  /*  TODO: Implement these once it becomes possible to do so (requires revised
-      Integer protocol).
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
-  /// - Parameter value: A floating-point value.
-  init<Source: BinaryFloatingPoint>(_ value: Source)
+  /// If two representable values are equally close, the result is the value
+  /// with more trailing zeros in its significand bit pattern.
+  ///
+  /// - Parameter value: A floating-point value to be converted.
+  init<Source : BinaryFloatingPoint>(_ value: Source)
 
-  /// Creates a new instance equivalent to the exact given value.
+  /// Creates a new instance from the given value, if it can be represented
+  /// exactly.
   ///
-  /// If the value you pass as `value` can't be represented exactly, the result
-  /// of this initializer is `nil`.
+  /// If the given floating-point value cannot be represented exactly, the
+  /// result is `nil`. A value that is NaN ("not a number") cannot be
+  /// represented exactly if its payload cannot be encoded exactly.
   ///
-  /// - Parameter value: A floating-point value to represent.
-  init?<Source: BinaryFloatingPoint>(exactly value: Source)
-  */
+  /// - Parameter value: A floating-point value to be converted.
+  init?<Source : BinaryFloatingPoint>(exactly value: Source)
 
   /// The number of bits used to represent the type's exponent.
   ///
@@ -2050,6 +2048,248 @@ extension BinaryFloatingPoint {
     self.init(sign: signOf.sign,
       exponentBitPattern: magnitudeOf.exponentBitPattern,
       significandBitPattern: magnitudeOf.significandBitPattern)
+  }
+
+  public // @testable
+  static func _convert<Source : BinaryInteger>(
+    from source: Source
+  ) -> (value: Self, exact: Bool) {
+    guard _fastPath(source != 0) else { return (0, true) }
+
+    let magnitude = source.magnitude
+
+    let exponent = Int(magnitude._binaryLogarithm())
+    let exemplar = Self.greatestFiniteMagnitude
+    guard _fastPath(exponent <= exemplar.exponent) else {
+      return Source.isSigned && source < 0
+        ? (-.infinity, false)
+        : (.infinity, false)
+    }
+    let exponentBitPattern =
+      (1 as Self).exponentBitPattern /* (i.e., bias) */
+        + Self.RawExponent(exponent)
+
+    let maxSignificandWidth = exemplar.significandWidth
+    let shift = maxSignificandWidth &- exponent
+    let significandBitPattern = shift >= 0
+      ? Self.RawSignificand(magnitude) << shift & exemplar.significandBitPattern
+      : Self.RawSignificand(
+        magnitude >> -shift & Source.Magnitude(exemplar.significandBitPattern))
+
+    let value = Self(
+      sign: Source.isSigned && source < 0 ? .minus : .plus,
+      exponentBitPattern: exponentBitPattern,
+      significandBitPattern: significandBitPattern)
+
+    if exponent &- magnitude.trailingZeroBitCount <= maxSignificandWidth {
+      return (value, true)
+    }
+    // We promise to round to the closest representation, and if two
+    // representable values are equally close, the value with more trailing
+    // zeros in its significand bit pattern. Therefore, we must take a look at
+    // the bits that we've just truncated.
+    let ulp = (1 as Source.Magnitude) << -shift
+    let truncatedBits = magnitude & (ulp - 1)
+    if truncatedBits < ulp / 2 {
+      return (value, false)
+    }
+    let rounded = Source.isSigned && source < 0 ? value.nextDown : value.nextUp
+    guard _fastPath(
+      truncatedBits != ulp / 2 ||
+        exponentBitPattern.trailingZeroBitCount <
+          rounded.exponentBitPattern.trailingZeroBitCount) else {
+      return (value, false)
+    }
+    return (rounded, false)
+  }
+
+  /// Creates a new value, rounded to the closest possible representation.
+  ///
+  /// If two representable values are equally close, the result is the value
+  /// with more trailing zeros in its significand bit pattern.
+  ///
+  /// - Parameter value: The integer to convert to a floating-point value.
+  @_inlineable // FIXME(sil-serialize-all)
+  public init<Source : BinaryInteger>(_ value: Source) {
+    self = Self._convert(from: value).value
+  }
+
+  /// Creates a new value, if the given integer can be represented exactly.
+  ///
+  /// If the given integer cannot be represented exactly, the result is `nil`.
+  ///
+  /// - Parameter value: The integer to convert to a floating-point value.
+  @_inlineable // FIXME(sil-serialize-all)
+  public init?<Source : BinaryInteger>(exactly value: Source) {
+    let (value_, exact) = Self._convert(from: value)
+    guard exact else { return nil }
+    self = value_
+  }
+
+  public // @testable
+  static func _convert<Source : BinaryFloatingPoint>(
+    from source: Source
+  ) -> (value: Self, exact: Bool) {
+    guard _fastPath(!source.isZero) else {
+      return (source.sign == .minus ? -0.0 : 0, true)
+    }
+
+    guard _fastPath(source.isFinite) else {
+      if source.isInfinite {
+        return (source.sign == .minus ? -.infinity : .infinity, true)
+      }
+      // IEEE 754 requires that any NaN payload be propagated, if possible.
+      let payload_ = source.isSignalingNaN
+        ? source.significandBitPattern ^
+          Source.signalingNaN.significandBitPattern
+        : source.significandBitPattern ^ Source.nan.significandBitPattern
+      // For all extant conforming types,
+      //
+      //   .nan.significandBitPattern | .signalingNaN.significandBitPattern
+      //     == .signalingNaN.significandBitPattern
+      //
+      // However, there appears to be no semantic guarantee of this relation,
+      // either in Swift or in IEEE 754. Therefore, we proceed conservatively.
+      let mask =
+        Self.greatestFiniteMagnitude.significandBitPattern &
+          ~(Self.nan.significandBitPattern |
+            Self.signalingNaN.significandBitPattern)
+      let payload = Self.RawSignificand(truncatingIfNeeded: payload_) & mask
+      // Although .signalingNaN.exponentBitPattern == .nan.exponentBitPattern,
+      // we do not *need* to rely on this relation, and therefore we do not.
+      let value = source.isSignalingNaN
+        ? Self(
+          sign: source.sign,
+          exponentBitPattern: Self.signalingNaN.exponentBitPattern,
+          significandBitPattern: payload |
+            Self.signalingNaN.significandBitPattern)
+        : Self(
+          sign: source.sign,
+          exponentBitPattern: Self.nan.exponentBitPattern,
+          significandBitPattern: payload | Self.nan.significandBitPattern)
+      return payload_ == payload ? (value, true) : (value, false)
+    }
+
+    let exponent = source.exponent
+    var exemplar = Self.leastNormalMagnitude
+    let exponentBitPattern: Self.RawExponent
+    let leadingBitIndex: Int
+    let shift: Int
+    let significandBitPattern: Self.RawSignificand
+
+    if exponent < exemplar.exponent {
+      // The floating-point result is either zero or subnormal.
+      exemplar = Self.leastNonzeroMagnitude
+      let minExponent = exemplar.exponent
+      if exponent + 1 < minExponent {
+        return (source.sign == .minus ? -0.0 : 0, false)
+      }
+      if _slowPath(exponent + 1 == minExponent) {
+        // Although the most significant bit (MSB) of a subnormal source
+        // significand is explicit, Swift BinaryFloatingPoint APIs actually
+        // omit any explicit MSB from the count represented in
+        // significandWidth. For instance:
+        //
+        //   Double.leastNonzeroMagnitude.significandWidth == 0
+        //
+        // Therefore, we do not need to adjust our work here for a subnormal
+        // source.
+        return source.significandWidth == 0
+          ? (source.sign == .minus ? -0.0 : 0, false)
+          : (source.sign == .minus ? -exemplar : exemplar, false)
+      }
+
+      exponentBitPattern = 0 as Self.RawExponent
+      leadingBitIndex = Int(Self.Exponent(exponent) - minExponent)
+      shift =
+        leadingBitIndex &-
+        (source.significandWidth &+
+          source.significandBitPattern.trailingZeroBitCount)
+      let leadingBit = source.isNormal
+        ? (1 as Self.RawSignificand) << leadingBitIndex
+        : 0
+      significandBitPattern = leadingBit | (shift >= 0
+        ? Self.RawSignificand(source.significandBitPattern) << shift
+        : Self.RawSignificand(source.significandBitPattern >> -shift))
+    } else {
+      // The floating-point result is either normal or infinite.
+      exemplar = Self.greatestFiniteMagnitude
+      if exponent > exemplar.exponent {
+        return (source.sign == .minus ? -.infinity : .infinity, false)
+      }
+
+      exponentBitPattern = exponent < 0
+        ? (1 as Self).exponentBitPattern - Self.RawExponent(-exponent)
+        : (1 as Self).exponentBitPattern + Self.RawExponent(exponent)
+      leadingBitIndex = exemplar.significandWidth
+      shift =
+        leadingBitIndex &-
+          (source.significandWidth &+
+            source.significandBitPattern.trailingZeroBitCount)
+      let sourceLeadingBit = source.isSubnormal
+        ? (1 as Source.RawSignificand) <<
+          (source.significandWidth &+
+            source.significandBitPattern.trailingZeroBitCount)
+        : 0
+      significandBitPattern = shift >= 0
+        ? Self.RawSignificand(
+          sourceLeadingBit ^ source.significandBitPattern) << shift
+        : Self.RawSignificand(
+          (sourceLeadingBit ^ source.significandBitPattern) >> -shift)
+    }
+
+    let value = Self(
+      sign: source.sign,
+      exponentBitPattern: exponentBitPattern,
+      significandBitPattern: significandBitPattern)
+
+    if source.significandWidth <= leadingBitIndex {
+      return (value, true)
+    }
+    // We promise to round to the closest representation, and if two
+    // representable values are equally close, the value with more trailing
+    // zeros in its significand bit pattern. Therefore, we must take a look at
+    // the bits that we've just truncated.
+    let ulp = (1 as Source.RawSignificand) << -shift
+    let truncatedBits = source.significandBitPattern & (ulp - 1)
+    if truncatedBits < ulp / 2 {
+      return (value, false)
+    }
+    let rounded = source.sign == .minus ? value.nextDown : value.nextUp
+    guard _fastPath(
+      truncatedBits != ulp / 2 ||
+        exponentBitPattern.trailingZeroBitCount <
+          rounded.exponentBitPattern.trailingZeroBitCount) else {
+      return (value, false)
+    }
+    return (rounded, false)
+  }
+
+  /// Creates a new instance from the given value, rounded to the closest
+  /// possible representation.
+  ///
+  /// If two representable values are equally close, the result is the value
+  /// with more trailing zeros in its significand bit pattern.
+  ///
+  /// - Parameter value: A floating-point value to be converted.
+  @_inlineable // FIXME(sil-serialize-all)
+  public init<Source : BinaryFloatingPoint>(_ value: Source) {
+    self = Self._convert(from: value).value
+  }
+
+  /// Creates a new instance from the given value, if it can be represented
+  /// exactly.
+  ///
+  /// If the given floating-point value cannot be represented exactly, the
+  /// result is `nil`. A value that is NaN ("not a number") cannot be
+  /// represented exactly if its payload cannot be encoded exactly.
+  ///
+  /// - Parameter value: A floating-point value to be converted.
+  @_inlineable // FIXME(sil-serialize-all)
+  public init?<Source : BinaryFloatingPoint>(exactly value: Source) {
+    let (value_, exact) = Self._convert(from: value)
+    guard exact else { return nil }
+    self = value_
   }
 
   /// Returns a Boolean value indicating whether this instance should precede

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1489,7 +1489,12 @@ public protocol BinaryInteger :
   ///
   /// This property is a constant for instances of fixed-width integer
   /// types.
-  var bitWidth : Int { get }
+  var bitWidth: Int { get }
+
+  /// Returns the integer binary logarithm of this value.
+  ///
+  /// If the value is negative, a runtime error will occur.
+  func _binaryLogarithm() -> Self
 
   /// The number of trailing zeros in this value's binary representation.
   ///
@@ -1593,6 +1598,25 @@ extension BinaryInteger {
   public var _lowWord: UInt {
     var it = words.makeIterator()
     return it.next() ?? 0
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _binaryLogarithm() -> Self {
+    _precondition(self > 0)
+    let wordBitWidth = Magnitude.Words.Element.bitWidth
+    let reversedWords = magnitude.words.reversed()
+    // If, internally, a variable-width binary integer uses digits of greater
+    // bit width than that of Magnitude.Words.Element (i.e., UInt), then it is
+    // possible that more than one element of Magnitude.Words could be entirely
+    // zero.
+    let reversedWordsLeadingZeroBitCount =
+      zip(0..., reversedWords)
+        .first { $0.1 != 0 }
+        .map { $0.0 &* wordBitWidth &+ $0.1.leadingZeroBitCount }!
+    let logarithm =
+      reversedWords.count &* wordBitWidth &-
+        (reversedWordsLeadingZeroBitCount &+ 1)
+    return Self(logarithm)
   }
 
   /// Returns the quotient and remainder of this value divided by the given
@@ -2212,6 +2236,12 @@ extension FixedWidthInteger {
   /// The number of bits in the binary representation of this value.
   @_inlineable
   public var bitWidth: Int { return Self.bitWidth }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _binaryLogarithm() -> Self {
+    _precondition(self > 0)
+    return Self(Magnitude.bitWidth &- (magnitude.leadingZeroBitCount &+ 1))
+  }
 
   /// Creates an integer from its little-endian representation, changing the
   /// byte order if necessary.

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -80,6 +80,139 @@ func expectBitwiseEqual(
 
 var FloatingPoint = TestSuite("FloatingPoint")
 
+FloatingPoint.test("BinaryFloatingPoint/genericIntegerConversion") {
+  expectTrue(Double._convert(from: 0) == (value: 0, exact: true))
+
+  expectTrue(Double._convert(from: 1) == (value: 1, exact: true))
+  expectTrue(Double._convert(from: -1) == (value: -1, exact: true))
+
+  expectTrue(Double._convert(from: 42) == (value: 42, exact: true))
+  expectTrue(Double._convert(from: -42) == (value: -42, exact: true))
+
+  expectTrue(Double._convert(from: 100) == (value: 100, exact: true))
+  expectTrue(Double._convert(from: -100) == (value: -100, exact: true))
+
+  expectEqual(Double._convert(from: Int64.max).value, Double(Int64.max))
+  expectEqual(Double._convert(from: Int64.min).value, Double(Int64.min))
+
+  var x = ((Int64.max >> 11) + 1) << 11
+  expectEqual(Double._convert(from: x).value, Double(x))
+  x = (Int64.max >> 12) << 12 + 1
+  expectEqual(Double._convert(from: x).value, Double(x))
+  x = Int64.min + 1
+  expectEqual(Double._convert(from: x).value, Double(x))
+
+  expectEqual(Float._convert(from: Int64.max).value, Float(Int64.max))
+  expectEqual(Float._convert(from: Int64.min).value, Float(Int64.min))
+
+  expectEqual(Float._convert(from: DoubleWidth<UInt64>.max).value, .infinity)
+  expectEqual(
+    Float._convert(from: DoubleWidth<DoubleWidth<Int64>>.max).value, .infinity)
+  expectEqual(
+    Float._convert(from: DoubleWidth<DoubleWidth<Int64>>.min).value, -.infinity)
+}
+
+FloatingPoint.test("BinaryFloatingPoint/genericFloatingPointConversion") {
+  expectTrue(Double._convert(from: 0 as Float) == (value: 0, exact: true))
+  expectTrue(Double._convert(from: -0.0 as Float) == (value: -0.0, exact: true))
+  expectTrue(Double._convert(from: 1 as Float) == (value: 1, exact: true))
+  expectTrue(Double._convert(from: -1 as Float) == (value: -1, exact: true))
+  expectTrue(
+    Double._convert(from: Float.infinity) == (value: .infinity, exact: true))
+  expectTrue(
+    Double._convert(from: -Float.infinity) == (value: -.infinity, exact: true))
+  expectTrue(Double._convert(from: Float.nan).value.isNaN)
+  expectTrue(Float._convert(from: Double.nan).value.isNaN)
+  expectFalse(Double._convert(from: Float.nan).value.isSignalingNaN)
+  expectFalse(Float._convert(from: Double.nan).value.isSignalingNaN)
+  expectTrue(Double._convert(from: Float.signalingNaN).value.isSignalingNaN)
+  expectTrue(Float._convert(from: Double.signalingNaN).value.isSignalingNaN)
+
+  var x = Float(bitPattern: Float.nan.bitPattern | 0xf)
+  expectEqual(
+    Float._convert(from: Double._convert(from: x).value).value.bitPattern,
+    x.bitPattern)
+  x = Float(bitPattern: Float.signalingNaN.bitPattern | 0xf)
+  expectEqual(
+    Float._convert(from: Double._convert(from: x).value).value.bitPattern,
+    x.bitPattern)
+  var y = Double(bitPattern: Double.nan.bitPattern | 0xf)
+  expectEqual(
+    Double._convert(from: Float._convert(from: y).value).value.bitPattern,
+    y.bitPattern)
+  y = Double(bitPattern: Double.signalingNaN.bitPattern | 0xf)
+  expectEqual(
+    Double._convert(from: Float._convert(from: y).value).value.bitPattern,
+    y.bitPattern)
+  y = Double(bitPattern: Double.signalingNaN.bitPattern | (1 << 32 - 1))
+  expectNotEqual(
+    Double._convert(from: Float._convert(from: y).value).value.bitPattern,
+    y.bitPattern)
+  expectTrue(Float._convert(from: y).value.isSignalingNaN)
+  expectFalse(Float._convert(from: y).exact)
+
+  expectTrue(
+    Float._convert(from: Double.leastNonzeroMagnitude) ==
+      (value: 0, exact: false))
+  expectTrue(
+    Float._convert(from: -Double.leastNonzeroMagnitude) ==
+      (value: -0.0, exact: false))
+  expectTrue(
+    Double._convert(from: Double.leastNonzeroMagnitude) ==
+      (value: .leastNonzeroMagnitude, exact: true))
+  expectTrue(
+    Double._convert(from: -Double.leastNonzeroMagnitude) ==
+      (value: -.leastNonzeroMagnitude, exact: true))
+
+  y = Double._convert(from: Float.leastNonzeroMagnitude).value / 2
+  expectTrue(Float._convert(from: y) == (value: 0, exact: false))
+  y.negate()
+  expectTrue(Float._convert(from: y) == (value: -0.0, exact: false))
+  y.negate()
+  y = y.nextUp
+  expectTrue(
+    Float._convert(from: y) == (value: .leastNonzeroMagnitude, exact: false))
+  y.negate()
+  expectTrue(
+    Float._convert(from: y) == (value: -.leastNonzeroMagnitude, exact: false))
+
+  expectEqual(
+    Float._convert(from: Double.leastNormalMagnitude).value,
+    Float(Double.leastNormalMagnitude))
+  expectEqual(
+    Float._convert(from: -Double.leastNormalMagnitude).value,
+    Float(-Double.leastNormalMagnitude))
+
+  expectEqual(Float._convert(from: Double.pi).value, 3.14159265)
+
+  y = Double._convert(from: Float._convert(from: Double.pi).value).value.nextUp
+  expectEqual(Float._convert(from: y).value, 3.14159265)
+  y.negate()
+  expectEqual(Float._convert(from: y).value, -3.14159265)
+
+  expectTrue(
+    Float._convert(from: Double.greatestFiniteMagnitude) ==
+      (value: .infinity, exact: false))
+  expectTrue(
+    Float._convert(from: -Double.greatestFiniteMagnitude) ==
+      (value: -.infinity, exact: false))
+  expectTrue(
+    Double._convert(from: Double.greatestFiniteMagnitude) ==
+      (value: .greatestFiniteMagnitude, exact: true))
+  expectTrue(
+    Double._convert(from: -Double.greatestFiniteMagnitude) ==
+      (value: -.greatestFiniteMagnitude, exact: true))
+
+  expectEqual(
+    Float._convert(
+      from: Double._convert(from: Float.greatestFiniteMagnitude).value).value,
+    Float.greatestFiniteMagnitude)
+  expectEqual(
+    Float._convert(
+      from: Double._convert(from: Float.leastNonzeroMagnitude).value).value,
+    Float.leastNonzeroMagnitude)
+}
+
 func positiveOne<T: ExpressibleByIntegerLiteral>() -> T {
   return 1
 }

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -125,14 +125,10 @@ FloatingPoint.test("BinaryFloatingPoint/genericFloatingPointConversion") {
   expectTrue(Float._convert(from: Double.nan).value.isNaN)
   expectFalse(Double._convert(from: Float.nan).value.isSignalingNaN)
   expectFalse(Float._convert(from: Double.nan).value.isSignalingNaN)
-  expectTrue(Double._convert(from: Float.signalingNaN).value.isSignalingNaN)
-  expectTrue(Float._convert(from: Double.signalingNaN).value.isSignalingNaN)
+  expectTrue(Double._convert(from: Float.signalingNaN).value.isNaN)
+  expectTrue(Float._convert(from: Double.signalingNaN).value.isNaN)
 
-  var x = Float(bitPattern: Float.nan.bitPattern | 0xf)
-  expectEqual(
-    Float._convert(from: Double._convert(from: x).value).value.bitPattern,
-    x.bitPattern)
-  x = Float(bitPattern: Float.signalingNaN.bitPattern | 0xf)
+  let x = Float(bitPattern: Float.nan.bitPattern | 0xf)
   expectEqual(
     Float._convert(from: Double._convert(from: x).value).value.bitPattern,
     x.bitPattern)
@@ -140,15 +136,11 @@ FloatingPoint.test("BinaryFloatingPoint/genericFloatingPointConversion") {
   expectEqual(
     Double._convert(from: Float._convert(from: y).value).value.bitPattern,
     y.bitPattern)
-  y = Double(bitPattern: Double.signalingNaN.bitPattern | 0xf)
-  expectEqual(
-    Double._convert(from: Float._convert(from: y).value).value.bitPattern,
-    y.bitPattern)
-  y = Double(bitPattern: Double.signalingNaN.bitPattern | (1 << 32 - 1))
+  y = Double(bitPattern: Double.nan.bitPattern | (1 << 32 - 1))
   expectNotEqual(
     Double._convert(from: Float._convert(from: y).value).value.bitPattern,
     y.bitPattern)
-  expectTrue(Float._convert(from: y).value.isSignalingNaN)
+  expectTrue(Float._convert(from: y).value.isNaN)
   expectFalse(Float._convert(from: y).exact)
 
   expectTrue(


### PR DESCRIPTION
The following initializers, approved in [SE-0067](https://github.com/apple/swift-evolution/blob/master/proposals/0067-floating-point-protocols.md), are absent from currently shipping floating-point protocols

```swift
protocol FloatingPoint {
  // ...
  /// The closest representable value to the argument.
  init<Source: Integer>(_ value: Source)

  /// Fails if the argument cannot be exactly represented.
  init?<Source: Integer>(exactly value: Source)
  // ...
}

protocol BinaryFloatingPoint {
  // ...
  /// `value` rounded to the closest representable value.
  init<Source: BinaryFloatingPoint>(_ value: Source)

  /// Fails if `value` cannot be represented exactly as `Self`.
  init?<Source: BinaryFloatingPoint>(exactly value: Source)
  // ...
}
```

In this PR, the missing initializers are added to their respective protocols, adjusted for revised integer protocol names and furnished with updated documentation. Default implementations for all of the above initializers are provided for `BinaryFloatingPoint`, and tests for those default implementations are included.

## Some considerations

The default implementations provided here are not *unnecessarily* inefficient, but they are orders of magnitude slower than non-generic conversion initializers. For performance (and backwards compatibility) reasons, the non-generic conversion initializer requirements are maintained.

No default implementation is provided for `init<T : BinaryInteger>(_: T)` or `init?<T : BinaryInteger>(exactly: T)` on `FloatingPoint` itself. They are technically possible to implement (by serial division of the magnitude by powers of `radix`, calling `init(_: UInt64)` at each iteration), but they would be very slow. Although technically source-breaking without such default implementations, no first-party type conforms to `FloatingPoint` but not `BinaryFloatingPoint` (`Foundation.Decimal` does not conform to `FloatingPoint`), and no Swift decimal types are found among searchable open-source projects. Any hypothetical decimal type that conforms to `FloatingPoint` today is already required to implement the logic necessary to convert from binary integers, and efficient implementation of the new requirement would therefore be trivial.

Heterogeneous comparison methods approved in SE-0067 and still commented out have not been added in this PR. It could be added in a distinct PR, but such a move may or may not be wise at the moment. First, implicit generic conversions will incur the performance penalty discussed above. Second, the issue remains unresolved regarding comparison to a literal in generic contexts defaulting to heterogeneous comparison. Third, as noted in the commented-out code, the implementation of these heterogeneous comparison methods is not fully correct, although it is serviceable for built-in types.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
  
  
  