### PR TITLE
[Runtime] Find (simple) nominal types based on a mangled name.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -887,7 +887,8 @@ NodePointer Demangler::popFunctionParamLabels(NodePointer Type) {
   if (popNode(Node::Kind::EmptyList))
     return createNode(Node::Kind::LabelList);
 
-  assert(Type->getKind() == Node::Kind::Type);
+  if (!Type || Type->getKind() != Node::Kind::Type)
+    return nullptr;
 
   auto FuncType = Type->getFirstChild();
   if (FuncType->getKind() == Node::Kind::DependentGenericType)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -92,23 +92,11 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
     input: UnsafeBufferPointer(start: stringPtr, count: count))
 }
 
-@_silgen_name("")
-internal func _getTypeByName(
-    _ name: UnsafePointer<UInt8>,
-    _ nameLength: UInt)
-  -> Any.Type?
-
 /// Lookup a class given a name. Until the demangled encoding of type
 /// names is stabilized, this is limited to top-level class names (Foo.bar).
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
-  let nameUTF8 = Array(name.utf8)
-  return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
-    let type = _getTypeByName(nameUTF8.baseAddress!,
-                              UInt(nameUTF8.endIndex))
-
-    return type
-  }
+  return _typeByMangledName(name);
 }
 
 @_silgen_name("swift_getTypeByMangledName")

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -157,12 +157,7 @@ namespace swift {
   /// Returns true if common value witnesses were used, false otherwise.
   void installCommonValueWitnesses(ValueWitnessTable *vwtable);
 
-  const Metadata *
-  _matchMetadataByMangledTypeName(const llvm::StringRef metadataNameRef,
-                                  const Metadata *metadata,
-                                  const NominalTypeDescriptor *ntd);
-
-  const Metadata *
+  const NominalTypeDescriptor *
   _searchConformancesByMangledTypeName(const llvm::StringRef typeName);
 
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -596,10 +596,9 @@ swift::swift_conformsToProtocol(const Metadata * const type,
   }
 }
 
-const Metadata *
+const NominalTypeDescriptor *
 swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
   auto &C = Conformances.get();
-  const Metadata *foundMetadata = nullptr;
 
   ScopedLock guard(C.SectionsToScanLock);
 
@@ -609,17 +608,12 @@ swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = C.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto metadata = record.getCanonicalTypeMetadata())
-        foundMetadata = _matchMetadataByMangledTypeName(typeName, metadata, nullptr);
-      else if (auto ntd = record.getNominalTypeDescriptor())
-        foundMetadata = _matchMetadataByMangledTypeName(typeName, nullptr, ntd);
-
-      if (foundMetadata != nullptr)
-        break;
+      if (auto ntd = record.getNominalTypeDescriptor()) {
+        if (ntd->Name.get() == typeName)
+          return ntd;
+      }
     }
-    if (foundMetadata != nullptr)
-      break;
   }
 
-  return foundMetadata;
+  return nullptr;
 }

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -115,6 +115,9 @@ DemangleToMetadataTests.test("nominal types") {
 
   // Nested struct
   expectEqual(type(of: S.Nested()), _typeByMangledName("4main1SV6NestedV")!)
+
+  // Class referenced by "ModuleName.ClassName" syntax.
+  expectEqual(type(of: C()), _typeByMangledName("main.C")!)
 }
 
 runAllTests()

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -91,5 +91,31 @@ DemangleToMetadataTests.test("existential metatype types") {
   expectEqual(type(of: AnyObject.self), _typeByMangledName("yXlm")!)
 }
 
+struct S {
+  struct Nested { }
+}
+
+enum E { case e }
+
+class C { }
+
+DemangleToMetadataTests.test("nominal types") {
+  // Simple Struct
+  expectEqual(type(of: S()), _typeByMangledName("4main1SV")!)
+
+  // Simple Enum
+  expectEqual(type(of: E.e), _typeByMangledName("4main1EO")!)
+
+  // Simple Class
+  expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
+
+  // Swift standard library types
+  expectEqual(type(of: Int()), _typeByMangledName("Si")!)
+  expectEqual(type(of: Int16()), _typeByMangledName("s5Int16V")!)
+
+  // Nested struct
+  expectEqual(type(of: S.Nested()), _typeByMangledName("4main1SV6NestedV")!)
+}
+
 runAllTests()
 


### PR DESCRIPTION
Extend `_typeByMangledName(_:)` to support lookup of nominal types (struct/enum/class). We support both the mangled name and the simplified `ModuleName.ClassName` syntax.

At present, we can only handle non-generic nominal types. Still, it's enough to replace the implementation of the Foundation-only `_typeByName(_:)`.