### PR TITLE
Runtime: Fix memory leak in swift_EnumCaseName()

### DIFF
--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -612,11 +612,19 @@ const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
 #else
     false;
 #endif
+
   ::new (&mirror) MagicMirror(mirrorValue, mirrorType, take);
 
   MagicMirror *theMirror = reinterpret_cast<MagicMirror *>(&mirror);
   MagicMirrorData data = theMirror->Data;
   const char *result = swift_EnumMirror_caseName(data.Owner, data.Value, data.Type);
+
+#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
+  // Destroy the whole original value if we couldn't take it.
+  if (!take)
+      type->vw_destroy(value);
+#endif
+
   return result;
 }
 

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -962,6 +962,16 @@ Reflection.test("Enum/IndirectGeneric/DefaultMirror") {
     "\(list)")
 }
 
+enum MyError: Error {
+  case myFirstError(LifetimeTracked)
+}
+
+Reflection.test("Enum/CaseName/Error") {
+  // Just make sure this doesn't leak.
+  let e: Error = MyError.myFirstError(LifetimeTracked(0))
+  _ = String(describing: e)
+}
+
 class Brilliant : CustomReflectable {
   let first: Int
   let second: String


### PR DESCRIPTION
If the value was wrapped in an existential buffer, we would never
release the original value even though it was passed in at +1.

Fixes <rdar://problem/36153982>, <https://bugs.swift.org/browse/SR-6536>.