### PR TITLE
[AST] NFC: Stop over-aligning DeclContexts

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -235,6 +235,14 @@ class alignas(1 << DeclContextAlignInBits) DeclContext {
     llvm_unreachable("Unhandled DeclContextKind");
   }
 
+  Decl *getAsDeclOrDeclExtensionContext() {
+    return ParentAndKind.getInt() == ASTHierarchy::Decl ?
+      reinterpret_cast<Decl*>(this + 1) : nullptr;
+  }
+  const Decl *getAsDeclOrDeclExtensionContext() const {
+    return const_cast<DeclContext*>(this)->getAsDeclOrDeclExtensionContext();
+  }
+
 public:
   DeclContext(DeclContextKind Kind, DeclContext *Parent)
       : ParentAndKind(Parent, getASTHierarchyFromKind(Kind)) {

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -185,8 +185,8 @@ struct ConformanceDiagnostic {
 /// the ASTHierarchy enum below.
 class alignas(1 << DeclContextAlignInBits) DeclContext {
   enum class ASTHierarchy : unsigned {
-    Expr,
     Decl,
+    Expr,
     FileUnit,
     Initializer,
     SerializedLocal,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3389,7 +3389,7 @@ public:
 
 
 /// \brief A base class for closure expressions.
-class AbstractClosureExpr : public Expr, public DeclContext {
+class AbstractClosureExpr : public DeclContext, public Expr {
   CaptureInfo Captures;
 
   /// \brief The set of parameters.
@@ -3398,8 +3398,8 @@ class AbstractClosureExpr : public Expr, public DeclContext {
 public:
   AbstractClosureExpr(ExprKind Kind, Type FnType, bool Implicit,
                       unsigned Discriminator, DeclContext *Parent)
-      : Expr(Kind, Implicit, FnType),
-        DeclContext(DeclContextKind::AbstractClosureExpr, Parent),
+      : DeclContext(DeclContextKind::AbstractClosureExpr, Parent),
+        Expr(Kind, Implicit, FnType),
         parameterList(nullptr) {
     Bits.AbstractClosureExpr.Discriminator = Discriminator;
   }

--- a/include/swift/AST/ExprNodes.def
+++ b/include/swift/AST/ExprNodes.def
@@ -48,6 +48,13 @@
 #define LITERAL_EXPR(Id, Parent) EXPR(Id, Parent)
 #endif
 
+/// A expression node with a DeclContext. For example: closures.
+///
+/// By default, these are treated like any other expression.
+#ifndef CONTEXT_EXPR
+#define CONTEXT_EXPR(Id, Parent) EXPR(Id, Parent)
+#endif
+
 /// A convenience for determining the range of expressions.  These will always
 /// appear immediately after the last member.
 #ifndef EXPR_RANGE
@@ -109,8 +116,8 @@ EXPR(KeyPathApplication, Expr)
 EXPR(TupleElement, Expr)
 EXPR(CaptureList, Expr)
 ABSTRACT_EXPR(AbstractClosure, Expr)
-  EXPR(Closure, AbstractClosureExpr)
-  EXPR(AutoClosure, AbstractClosureExpr)
+  CONTEXT_EXPR(Closure, AbstractClosureExpr)
+  CONTEXT_EXPR(AutoClosure, AbstractClosureExpr)
   EXPR_RANGE(AbstractClosure, Closure, AutoClosure)
 EXPR(InOut, Expr)
 EXPR(DynamicType, Expr)
@@ -183,5 +190,6 @@ LAST_EXPR(KeyPathDot)
 #undef LITERAL_EXPR
 #undef UNCHECKED_EXPR
 #undef ABSTRACT_EXPR
+#undef CONTEXT_EXPR
 #undef EXPR
 #undef LAST_EXPR

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -127,7 +127,7 @@ enum class ResilienceStrategy : unsigned {
 /// output binary and logical module (such as a single library or executable).
 ///
 /// \sa FileUnit
-class ModuleDecl : public TypeDecl, public DeclContext {
+class ModuleDecl : public DeclContext, public TypeDecl {
 public:
   typedef ArrayRef<std::pair<Identifier, SourceLoc>> AccessPathTy;
   typedef std::pair<ModuleDecl::AccessPathTy, ModuleDecl*> ImportedModule;

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -52,7 +52,7 @@ namespace swift {
 
   /// We frequently use three tag bits on all of these types.
   constexpr size_t DeclAlignInBits = 3;
-  constexpr size_t DeclContextAlignInBits = 4;
+  constexpr size_t DeclContextAlignInBits = 3;
   constexpr size_t ExprAlignInBits = 3;
   constexpr size_t StmtAlignInBits = 3;
   constexpr size_t TypeAlignInBits = 3;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1101,31 +1101,8 @@ bool AccessScope::allowsPrivateAccess(const DeclContext *useDC, const DeclContex
   return false;
 }
 
-DeclContext::ASTHierarchy
-DeclContext::getASTHierarchyFromKind(DeclContextKind Kind) {
-  switch (Kind) {
-  case DeclContextKind::AbstractClosureExpr:
-    return ASTHierarchy::Expr;
-  case DeclContextKind::Initializer:
-    return ASTHierarchy::Initializer;
-  case DeclContextKind::SerializedLocal:
-    return ASTHierarchy::SerializedLocal;
-  case DeclContextKind::FileUnit:
-    return ASTHierarchy::FileUnit;
-  case DeclContextKind::Module:
-  case DeclContextKind::TopLevelCodeDecl:
-  case DeclContextKind::AbstractFunctionDecl:
-  case DeclContextKind::SubscriptDecl:
-  case DeclContextKind::GenericTypeDecl:
-  case DeclContextKind::ExtensionDecl:
-    return ASTHierarchy::Decl;
-  }
-  llvm_unreachable("Unhandled DeclContextKind");
-}
-
-DeclContextKind
-DeclContext::getKindFromASTHierarchy(DeclContext::ASTHierarchy Hier) const {
-  switch (Hier) {
+DeclContextKind DeclContext::getContextKind() const {
+  switch (ParentAndKind.getInt()) {
   case ASTHierarchy::Expr:
     return DeclContextKind::AbstractClosureExpr;
   case ASTHierarchy::Initializer:

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -347,8 +347,8 @@ void SourceLookupCache::invalidate() {
 //===----------------------------------------------------------------------===//
 
 ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx)
-  : TypeDecl(DeclKind::Module, &ctx, name, SourceLoc(), { }),
-    DeclContext(DeclContextKind::Module, nullptr),
+  : DeclContext(DeclContextKind::Module, nullptr),
+    TypeDecl(DeclKind::Module, &ctx, name, SourceLoc(), { }),
     Flags({0, 0, 0}) {
   ctx.addDestructorCleanup(*this);
   setImplicit();

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -29,9 +29,7 @@
 
 namespace swift {
   class CanType;
-  class Decl;
   class ProtocolConformance;
-  class ProtocolDecl;
 
 namespace irgen {
   class ConformanceInfo; // private to GenProto.cpp
@@ -43,10 +41,11 @@ namespace irgen {
 /// introduced by the protocol.
 class WitnessTableEntry {
 public:
-  void *MemberOrAssociatedType;
+  llvm::PointerUnion<Decl *, TypeBase *> MemberOrAssociatedType;
   ProtocolDecl *Protocol;
 
-  WitnessTableEntry(void *member, ProtocolDecl *protocol)
+  WitnessTableEntry(llvm::PointerUnion<Decl *, TypeBase *> member,
+                    ProtocolDecl *protocol)
     : MemberOrAssociatedType(member), Protocol(protocol) {}
 
 public:
@@ -54,15 +53,15 @@ public:
 
   static WitnessTableEntry forOutOfLineBase(ProtocolDecl *proto) {
     assert(proto != nullptr);
-    return WitnessTableEntry(nullptr, proto);
+    return WitnessTableEntry({}, proto);
   }
 
   /// Is this a base-protocol entry?
-  bool isBase() const { return MemberOrAssociatedType == nullptr; }
+  bool isBase() const { return MemberOrAssociatedType.isNull(); }
 
   bool matchesBase(ProtocolDecl *proto) const {
     assert(proto != nullptr);
-    return MemberOrAssociatedType == nullptr && Protocol == proto;
+    return MemberOrAssociatedType.isNull() && Protocol == proto;
   }
 
   /// Given that this is a base-protocol entry, is the table
@@ -83,19 +82,21 @@ public:
   }
   
   bool isFunction() const {
-    return Protocol == nullptr &&
-           isa<AbstractFunctionDecl>(
-             static_cast<Decl*>(MemberOrAssociatedType));
+    auto decl = MemberOrAssociatedType.get<Decl*>();
+    return Protocol == nullptr && isa<AbstractFunctionDecl>(decl);
   }
 
   bool matchesFunction(AbstractFunctionDecl *func) const {
     assert(func != nullptr);
-    return MemberOrAssociatedType == func && Protocol == nullptr;
+    if (auto decl = MemberOrAssociatedType.dyn_cast<Decl*>())
+      return decl == func && Protocol == nullptr;
+    return false;
   }
 
   AbstractFunctionDecl *getFunction() const {
     assert(isFunction());
-    return static_cast<AbstractFunctionDecl*>(MemberOrAssociatedType);
+    auto decl = MemberOrAssociatedType.get<Decl*>();
+    return static_cast<AbstractFunctionDecl*>(decl);
   }
 
   static WitnessTableEntry forAssociatedType(AssociatedType ty) {
@@ -103,19 +104,20 @@ public:
   }
   
   bool isAssociatedType() const {
-    return Protocol == nullptr &&
-           isa<AssociatedTypeDecl>(
-             static_cast<Decl*>(MemberOrAssociatedType));
+    if (auto decl = MemberOrAssociatedType.dyn_cast<Decl*>())
+      return Protocol == nullptr && isa<AssociatedTypeDecl>(decl);
+    return false;
   }
 
   bool matchesAssociatedType(AssociatedType assocType) const {
-    return MemberOrAssociatedType == assocType.getAssociation() &&
-           Protocol == nullptr;
+    auto decl = MemberOrAssociatedType.get<Decl*>();
+    return decl == assocType.getAssociation() && Protocol == nullptr;
   }
 
   AssociatedTypeDecl *getAssociatedType() const {
     assert(isAssociatedType());
-    return static_cast<AssociatedTypeDecl*>(MemberOrAssociatedType);
+    auto decl = MemberOrAssociatedType.get<Decl*>();
+    return static_cast<AssociatedTypeDecl*>(decl);
   }
 
   static WitnessTableEntry forAssociatedConformance(AssociatedConformance conf){
@@ -124,17 +126,20 @@ public:
   }
 
   bool isAssociatedConformance() const {
-    return Protocol != nullptr && MemberOrAssociatedType != nullptr;
+    return Protocol != nullptr && !MemberOrAssociatedType.isNull();
   }
 
   bool matchesAssociatedConformance(const AssociatedConformance &conf) const {
-    return MemberOrAssociatedType == conf.getAssociation().getPointer() &&
-           Protocol == conf.getAssociatedRequirement();
+    if (auto type = MemberOrAssociatedType.dyn_cast<TypeBase*>())
+      return type == conf.getAssociation().getPointer() &&
+             Protocol == conf.getAssociatedRequirement();
+    return false;
   }
 
   CanType getAssociatedConformancePath() const {
     assert(isAssociatedConformance());
-    return CanType(static_cast<TypeBase *>(MemberOrAssociatedType));
+    auto type = MemberOrAssociatedType.get<TypeBase*>();
+    return CanType(type);
   }
 
   ProtocolDecl *getAssociatedConformanceRequirement() const {

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -110,8 +110,9 @@ public:
   }
 
   bool matchesAssociatedType(AssociatedType assocType) const {
-    auto decl = MemberOrAssociatedType.get<Decl*>();
-    return decl == assocType.getAssociation() && Protocol == nullptr;
+    if (auto decl = MemberOrAssociatedType.dyn_cast<Decl*>())
+      return decl == assocType.getAssociation() && Protocol == nullptr;
+    return false;
   }
 
   AssociatedTypeDecl *getAssociatedType() const {


### PR DESCRIPTION
DeclContexts as they exist today are "over aligned" when compared to their natural alignment boundary and therefore they can easily cause adjacent padding when dropped into the middle of objects via C++ inheritance, or when the clang importer prefaces Swift AST allocations with a pointer to the corresponding clang AST node.

With this change, we move DeclContexts to the front of the memory layout of AST nodes. This allows us to restore natural alignment, save memory, and as a side effect: more easily avoid "over alignment" in the future because DeclContexts now only need to directly track which AST node hierarchy they're associated with, not specific AST nodes within each hierarchy.

Finally, as a word of caution, after this change one can no longer assume that AST nodes safely convert back and forth with "void*". For example, WitnessTableEntry needed fixing with this change.