### PR TITLE
[4.1] refactoring: Add a defensive check for empty nodes list. (#13765)

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1690,6 +1690,11 @@ static std::unique_ptr<llvm::SetVector<Expr*>>
   if (Info.Kind != RangeKind::SingleExpression
       && Info.Kind != RangeKind::PartOfExpression)
     return nullptr;
+
+  // FIXME: We should always have a valid node.
+  if (Info.ContainedNodes.empty())
+    return nullptr;
+
   Expr *E = Info.ContainedNodes[0].get<Expr*>();
 
   struct StringInterpolationExprFinder: public SourceEntityWalker {


### PR DESCRIPTION
This defensive check ensures convert-to-string-interpolation
refactoring doesn't continue when the selected AST nodes are empty.
We shouldn't need this check since the range info kind already implies its validity.

Tentatively fixing: rdar://35492432