### PR TITLE
[lit] Add a more discoverable error message when failing due to attem…

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -574,7 +574,9 @@ if run_vendor == 'apple':
     target_options_for_mock_sdk_after = sdk_overlay_dir_opt
 
     if 'arm' in run_cpu and swift_test_mode != 'only_non_executable':
-        raise RuntimeError('Device tests are not currently supported.')
+        raise RuntimeError('Device tests are currently only supported when '
+        'the swift_test_mode is "only_non_executable". Current '
+        'swift_test_mode is {}.'.format(swift_test_mode))
 
     if 'arm' in run_cpu:
        # iOS/tvOS/watchOS device


### PR DESCRIPTION
…pting to perform an oss executable lit test run.

We really should split executable/nonexecutable into its own option from
swift_test_mode. But at least when someone hits this failure now, what is
actually going on will be more discoverable.

NFC.