### PR TITLE
Revert "build: switch to C++14"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,10 +389,6 @@ option(SWIFT_ENABLE_SOURCEKIT_TESTS
     "Enable running SourceKit tests"
     ${SWIFT_BUILD_SOURCEKIT_default})
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS FALSE)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-
 #
 # Assume a new enough ar to generate the index at construction time. This avoids
 # having to invoke ranlib as a secondary command.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -856,6 +856,9 @@ function(_add_swift_library_single target name)
   if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "WINDOWS")
     swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE} SWIFTLIB_INCLUDE)
     target_include_directories("${target}" SYSTEM PRIVATE ${SWIFTLIB_INCLUDE})
+    set_target_properties(${target}
+                          PROPERTIES
+                            CXX_STANDARD 14)
   endif()
 
   if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "WINDOWS" AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")


### PR DESCRIPTION
Reverts apple/swift#13515

This broke Ubuntu 14.04 builds.