### PR TITLE
Rename canUnsafeCastValue to checkABIForUnsafeScalarCast and comment.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -363,13 +363,16 @@ public:
   /// pointer.
   bool isPointerSizeAndAligned();
 
-  /// True if the layout of `fromType` is known to cover the layout of
-  /// `totype`. This is conservatively imprecise and is not
-  /// reflexive. `fromType` may be larger than the given type and still be
-  /// castable. It is the caller's responsibility to ensure that the overlapping
-  /// fields are layout compatible.
-  static bool canUnsafeCastValue(SILType fromType, SILType toType,
-                                 SILModule &M);
+  /// Return true if the layout of `toType` is an ABI compatible prefix of
+  /// `fromType` ignoring reference types. `fromType` may be larger than
+  /// `toType` and still be unsafe castable. `fromType` may contain references
+  /// in positions where `toType` does not contain references and still be
+  /// unsafe castable. This is used solely to determine whether an address cast
+  /// can be promoted to a cast between aggregates of scalar values without
+  /// confusing IRGen.
+  static bool canPerformABICompatibleUnsafeCastValue(SILType fromType,
+                                                     SILType toType,
+                                                     SILModule &M);
 
   /// True if `operTy` can be cast by single-reference value into `resultTy`.
   static bool canRefCast(SILType operTy, SILType resultTy, SILModule &M);

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -131,7 +131,7 @@ static bool canUnsafeCastStruct(SILType fromType, StructDecl *fromStruct,
 
   // Can the first element of fromStruct be cast by value into toType?
   SILType fromEltTy = fromType.getFieldType(*fromRange.begin(), M);
-  if (SILType::canUnsafeCastValue(fromEltTy, toType, M))
+  if (SILType::canPerformABICompatibleUnsafeCastValue(fromEltTy, toType, M))
     return true;
   
   // Otherwise, flatten one level of struct elements on each side.
@@ -149,7 +149,7 @@ static bool canUnsafeCastStruct(SILType fromType, StructDecl *fromStruct,
       
     SILType fromEltTy = fromType.getFieldType(*fromI, M);
     SILType toEltTy = toType.getFieldType(*toI, M);
-    if (!SILType::canUnsafeCastValue(fromEltTy, toEltTy, M))
+    if (!SILType::canPerformABICompatibleUnsafeCastValue(fromEltTy, toEltTy, M))
       return false;
   }
   // fromType's overlapping elements are compatible.
@@ -162,8 +162,9 @@ static bool canUnsafeCastTuple(SILType fromType, CanTupleType fromTupleTy,
                                SILType toType, SILModule &M) {
   unsigned numFromElts = fromTupleTy->getNumElements();
   // Can the first element of fromTupleTy be cast by value into toType?
-  if (numFromElts != 0 && SILType::canUnsafeCastValue(
-        fromType.getTupleElementType(0), toType, M)) {
+  if (numFromElts != 0
+      && SILType::canPerformABICompatibleUnsafeCastValue(
+             fromType.getTupleElementType(0), toType, M)) {
     return true;
   }
   // Otherwise, flatten one level of tuple elements on each side.
@@ -176,8 +177,9 @@ static bool canUnsafeCastTuple(SILType fromType, CanTupleType fromTupleTy,
     return false;
 
   for (unsigned i = 0; i != numToElts; ++i) {
-    if (!SILType::canUnsafeCastValue(fromType.getTupleElementType(i),
-                                      toType.getTupleElementType(i), M)) {
+    if (!SILType::canPerformABICompatibleUnsafeCastValue(
+            fromType.getTupleElementType(i), toType.getTupleElementType(i),
+            M)) {
       return false;
     }
   }
@@ -221,7 +223,8 @@ static bool canUnsafeCastEnum(SILType fromType, EnumDecl *fromEnum,
       continue;
 
     auto fromElementTy = fromType.getEnumElementType(fromElement, M);
-    if (SILType::canUnsafeCastValue(fromElementTy, toElementTy, M))
+    if (SILType::canPerformABICompatibleUnsafeCastValue(fromElementTy,
+                                                        toElementTy, M))
       return true;
   }
   return false;
@@ -263,8 +266,9 @@ static bool canUnsafeCastScalars(SILType fromType, SILType toType,
   return LeastFromWidth >= GreatestToWidth;
 }
 
-bool SILType::canUnsafeCastValue(SILType fromType, SILType toType,
-                                 SILModule &M) {
+bool SILType::canPerformABICompatibleUnsafeCastValue(SILType fromType,
+                                                     SILType toType,
+                                                     SILModule &M) {
   if (fromType == toType)
     return true;
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -236,9 +236,10 @@ SILCombiner::visitUncheckedAddrCastInst(UncheckedAddrCastInst *UADCI) {
   // larger OutputType (the actual memory object must be large enough to hold
   // both types). However, such address casts cannot be converted to value
   // casts.
-  if (!SILType::canUnsafeCastValue(InputTy, OutputTy, UADCI->getModule()))
+  if (!SILType::canPerformABICompatibleUnsafeCastValue(InputTy, OutputTy,
+                                                       UADCI->getModule())) {
     return nullptr;
-
+  }
   // For each user U of the unchecked_addr_cast...
   for (auto U : getNonDebugUses(UADCI))
     // Check if it is load. If it is not a load, bail...


### PR DESCRIPTION
This is an ABI-dependent routine, so at least should have ABI in the name.  In
the future, the compiler may introduce new ABI layout rules for select types
based on the deployment target. Code like this needs to be reviewed at that time.

Clarify the comments.
