### PR TITLE
[Runtime] Round up tuple labels allocation size to alignment of a pointer

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -913,8 +913,9 @@ swift::swift_getTupleTypeMetadata(size_t numElements,
 
   // Allocate a copy of the labels string within the tuple type allocator.
   size_t labelsLen = strlen(labels);
+  size_t labelsAllocSize = roundUpToAlignment(labelsLen + 1, sizeof(void*));
   char *newLabels =
-    (char *)TupleTypes.getAllocator().Allocate(labelsLen + 1, alignof(char));
+    (char *)TupleTypes.getAllocator().Allocate(labelsAllocSize, alignof(char));
   strcpy(newLabels, labels);
   key.Labels = newLabels;
 
@@ -924,7 +925,7 @@ swift::swift_getTupleTypeMetadata(size_t numElements,
   // If we didn't manage to perform the insertion, free the memory associated
   // with the copy of the labels: nobody else can reference it.
   if (!result.second) {
-    TupleTypes.getAllocator().Deallocate(newLabels, labelsLen + 1);
+    TupleTypes.getAllocator().Deallocate(newLabels, labelsAllocSize);
   }
 
   // Done.

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -16,6 +16,9 @@ DemangleToMetadataTests.test("tuple types") {
   expectEqual(type(of: ((), b: ())), _typeByMangledName("yt_yt1bt")!)
   expectEqual(type(of: (a: (), ())), _typeByMangledName("yt1a_ytt")!)
   expectEqual(type(of: (a: (), b: ())), _typeByMangledName("yt1a_yt1bt")!)
+
+  // Initial creation of metadata via demangling a type name.
+  expectNotNil(_typeByMangledName("yt1a_yt3bcdt"))
 }
 
 func f0() { }


### PR DESCRIPTION
The metadata allocation functions assume this alignment, and we
weren't guaranteeing it.
