### PR TITLE
[swift-4.1-branch][stdlib] Fix an @available attribute [NFC]

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -777,7 +777,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///   `endIndex`.
   func formIndex(after i: inout Index)
 
-  @available(swift, deprecated, message: "all index distances are now of type Int")
+  @available(*, deprecated, message: "all index distances are now of type Int")
   typealias IndexDistance = Int
 }
 


### PR DESCRIPTION
(cherry picked from commit f764ff33dba9ca6c5778b71c94209dace2ede9f4)

* Explanation: Incorrect usage of @available resulted in a warning (and potentially attribute not being used?).
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/36359481>