### PR TITLE
[Parser] Parse #keyPath in parseExprPostfixWithoutSuffix instead of parseExprUnary

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -486,8 +486,6 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
         new (Context) InOutExpr(Loc, SubExpr.get(), Type()));
   }
 
-  case tok::pound_keyPath:
-    return parseExprKeyPathObjC();
   case tok::backslash:
     return parseExprKeyPath();
 
@@ -1457,6 +1455,8 @@ Parser::parseExprPostfixWithoutSuffix(Diag<> ID, bool isExprBasic) {
   SyntaxParsingContext ExprContext(SyntaxContext, SyntaxContextKind::Expr);
   ParserResult<Expr> Result;
   switch (Tok.getKind()) {
+  case tok::pound_keyPath:
+    return parseExprKeyPathObjC();
   case tok::integer_literal: {
     StringRef Text = copyAndStripUnderscores(Context, Tok.getText());
     SourceLoc Loc = consumeToken(tok::integer_literal);

--- a/test/expr/postfix/keypath/keypath-objc.swift
+++ b/test/expr/postfix/keypath/keypath-objc.swift
@@ -59,6 +59,17 @@ func testKeyPath(a: A, b: B) {
   // Property of String property (which looks on NSString)
   let _: String = #keyPath(A.propString.URLsInText)
 
+  // String property with a suffix
+  let _: String = #keyPath(A.propString).description
+  let _ = #keyPath(A.propString).split(separator: ".")
+  func keyPathSwitch(keyPath: String?) {
+    switch keyPath {
+    case (#keyPath(A.propString))?: break
+    case #keyPath(A.propString)?: break
+    default: break
+    } 
+  }
+
   // Array property (make sure we look at the array element).
   let _: String = #keyPath(A.propArray)
   let _: String = #keyPath(A.propArray.URLsInText)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Moved the call to parseExprKeyPathObjC from parseExprUnary to parseExprPostfixWithoutSuffix. This allows to perform operations on #keyPath(...) as it now parses the suffix for it.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes [Swift JIRA]  (SR-5605) Parser fails on optional #keyPath in cas
Eg. `#keyPath(SomeClass.someProperty).description` is now possible

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->