### PR TITLE
IUO: Create disjunctions for optional choices.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -523,7 +523,7 @@ namespace {
     Expr *buildDeclRef(ValueDecl *decl, DeclNameLoc loc, Type openedType,
                        ConstraintLocatorBuilder locator, bool implicit,
                        FunctionRefKind functionRefKind,
-                       AccessSemantics semantics) {
+                       AccessSemantics semantics, bool forceUnwrap) {
       // Determine the declaration selected for this overloaded reference.
       auto &ctx = cs.getASTContext();
       
@@ -553,7 +553,7 @@ namespace {
                          ConformanceCheckFlags::Used));
             if (conformance && conformance->isConcrete()) {
               if (auto witness =
-                        conformance->getConcrete()->getWitnessDecl(decl, &tc)) {
+                      conformance->getConcrete()->getWitnessDecl(decl, &tc)) {
                 // Hack up an AST that we can type-check (independently) to get
                 // it into the right form.
                 // FIXME: the hop through 'getDecl()' is because
@@ -582,11 +582,14 @@ namespace {
 
                 cs.cacheExprTypes(refExpr);
 
-               // Remove an outer function-conversion expression. This
-               // happens when we end up referring to a witness for a
-               // superclass conformance, and 'Self' differs.
-               if (auto fnConv = dyn_cast<FunctionConversionExpr>(refExpr))
-                 refExpr = fnConv->getSubExpr();
+                // Remove an outer function-conversion expression. This
+                // happens when we end up referring to a witness for a
+                // superclass conformance, and 'Self' differs.
+                if (auto fnConv = dyn_cast<FunctionConversionExpr>(refExpr))
+                  refExpr = fnConv->getSubExpr();
+
+                if (forceUnwrap)
+                  return forceUnwrapResult(refExpr);
 
                 return refExpr;
               }
@@ -599,10 +602,10 @@ namespace {
           TypeExpr::createImplicitHack(loc.getBaseNameLoc(), baseTy, ctx);
         cs.cacheExprTypes(base);
 
-        return buildMemberRef(base, openedType, SourceLoc(), decl,
-                              loc, openedFnType->getResult(),
-                              locator, locator, implicit, functionRefKind,
-                              semantics, /*isDynamic=*/false);
+        return buildMemberRef(base, openedType, SourceLoc(), decl, loc,
+                              openedFnType->getResult(), locator, locator,
+                              implicit, functionRefKind, semantics,
+                              /*isDynamic=*/false, forceUnwrap);
       }
 
       auto type = solution.simplifyType(openedType);
@@ -635,6 +638,9 @@ namespace {
                               loc, implicit, semantics, type);
       cs.cacheType(declRefExpr);
       declRefExpr->setFunctionRefKind(functionRefKind);
+      if (forceUnwrap)
+        return forceUnwrapResult(declRefExpr);
+
       return declRefExpr;
     }
 
@@ -877,9 +883,10 @@ namespace {
     Expr *buildMemberRef(Expr *base, Type openedFullType, SourceLoc dotLoc,
                          ValueDecl *member, DeclNameLoc memberLoc,
                          Type openedType, ConstraintLocatorBuilder locator,
-                         ConstraintLocatorBuilder memberLocator,
-                         bool Implicit, FunctionRefKind functionRefKind,
-                         AccessSemantics semantics, bool isDynamic) {
+                         ConstraintLocatorBuilder memberLocator, bool Implicit,
+                         FunctionRefKind functionRefKind,
+                         AccessSemantics semantics, bool isDynamic,
+                         bool forceUnwrap) {
       auto &tc = cs.getTypeChecker();
       auto &context = tc.Context;
 
@@ -932,9 +939,11 @@ namespace {
         auto ref = new (context) DeclRefExpr(memberRef, memberLoc, Implicit);
         cs.setType(ref, refTy);
         ref->setFunctionRefKind(functionRefKind);
-        return cs.cacheType(new (context)
-                                DotSyntaxBaseIgnoredExpr(base, dotLoc, ref,
-                                                         cs.getType(ref)));
+        auto *DSBI = cs.cacheType(new (context) DotSyntaxBaseIgnoredExpr(
+            base, dotLoc, ref, cs.getType(ref)));
+        if (forceUnwrap)
+          return forceUnwrapResult(DSBI);
+        return DSBI;
       }
 
       // The formal type of the 'self' value for the member's declaration.
@@ -1055,6 +1064,8 @@ namespace {
           }
         }
 
+        if (forceUnwrap)
+          return forceUnwrapResult(ref);
         return ref;
       }
 
@@ -1081,6 +1092,8 @@ namespace {
         cs.setType(memberRefExpr, simplifyType(openedType));
         Expr *result = memberRefExpr;
         closeExistential(result, locator);
+        if (forceUnwrap)
+          return forceUnwrapResult(result);
         return result;
       }
       
@@ -1101,6 +1114,8 @@ namespace {
       ApplyExpr *apply;
       if (isa<ConstructorDecl>(member)) {
         // FIXME: Provide type annotation.
+        if (forceUnwrap)
+          ref = forceUnwrapResult(ref);
         apply = new (context) ConstructorRefCallExpr(ref, base);
       } else if (!baseIsInstance && member->isInstanceMember()) {
         // Reference to an unbound instance method.
@@ -1109,10 +1124,15 @@ namespace {
                                                               cs.getType(ref));
         cs.cacheType(result);
         closeExistential(result, locator, /*force=*/openedExistential);
+        if (forceUnwrap)
+          return forceUnwrapResult(result);
         return result;
       } else {
         assert((!baseIsInstance || member->isInstanceMember()) &&
                "can't call a static method on an instance");
+        if (forceUnwrap)
+          ref = forceUnwrapResult(ref);
+
         apply = new (context) DotSyntaxCallExpr(ref, dotLoc, base);
         if (Implicit) {
           apply->setImplicit();
@@ -1357,8 +1377,9 @@ namespace {
     Expr *buildSubscript(Expr *base, Expr *index,
                          ArrayRef<Identifier> argLabels,
                          bool hasTrailingClosure,
-                         ConstraintLocatorBuilder locator,
-                         bool isImplicit, AccessSemantics semantics) {
+                         ConstraintLocatorBuilder locator, bool isImplicit,
+                         AccessSemantics semantics) {
+
       // Determine the declaration selected for this subscript operation.
       auto selected = getOverloadChoiceIfAvailable(
                         cs.getConstraintLocator(
@@ -1385,13 +1406,31 @@ namespace {
         return nullptr;
       }
 
-      auto choice = selected->choice;
-      
+      // Build the new subscript.
+      auto newSubscript = buildSubscriptHelper(base, index, argLabels,
+                                               *selected, hasTrailingClosure,
+                                               locator, isImplicit, semantics);
+
+      if (shouldForceUnwrapResult(cs.getConstraintLocator(locator)->getAnchor(),
+                                  selected->choice))
+        return forceUnwrapResult(newSubscript);
+
+      return newSubscript;
+    }
+
+    Expr *buildSubscriptHelper(Expr *base, Expr *index,
+                               ArrayRef<Identifier> argLabels,
+                               SelectedOverload &selected,
+                               bool hasTrailingClosure,
+                               ConstraintLocatorBuilder locator,
+                               bool isImplicit, AccessSemantics semantics) {
+      auto choice = selected.choice;
+
       // Apply a key path if we have one.
       if (choice.getKind() == OverloadChoiceKind::KeyPathApplication) {
-        auto applicationTy = simplifyType(selected->openedType)
-          ->castTo<FunctionType>();
-                
+        auto applicationTy =
+            simplifyType(selected.openedType)->castTo<FunctionType>();
+
         index = cs.coerceToRValue(index);
         // The index argument should be (keyPath: KeyPath<Root, Value>).
         // Dig the key path expression out of the argument tuple.
@@ -1494,7 +1533,7 @@ namespace {
       }
 
       // Figure out the index and result types.
-      auto subscriptTy = simplifyType(selected->openedType);
+      auto subscriptTy = simplifyType(selected.openedType);
       auto subscriptFnTy = subscriptTy->castTo<AnyFunctionType>();
       auto resultTy = subscriptFnTy->getResult();
 
@@ -1550,7 +1589,7 @@ namespace {
       }
 
       // Convert the base.
-      auto openedFullFnType = selected->openedFullType->castTo<FunctionType>();
+      auto openedFullFnType = selected.openedFullType->castTo<FunctionType>();
       auto openedBaseType = openedFullFnType->getInput();
       auto containerTy = solution.simplifyType(openedBaseType);
       base = coerceObjectArgumentToType(
@@ -2361,6 +2400,31 @@ namespace {
       return expr;
     }
 
+    bool shouldForceUnwrapResult(Expr *expr, OverloadChoice &choice) {
+      if (!choice.isImplicitlyUnwrappedValueOrReturnValue())
+        return false;
+
+      auto choiceLocator = cs.getConstraintLocator(
+          expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
+
+      return solution.getDisjunctionChoice(choiceLocator);
+    }
+
+    Expr *forceUnwrapResult(Expr *newExpr) {
+      auto ty = simplifyType(cs.getType(newExpr));
+
+      if (auto *fnTy = ty->getAs<AnyFunctionType>()) {
+        auto underlyingType = cs.replaceFinalResultTypeWithUnderlying(fnTy);
+
+        auto &ctx = cs.getTypeChecker().Context;
+        return cs.cacheType(new (ctx) ImplicitlyUnwrappedFunctionConversionExpr(
+            newExpr, underlyingType));
+      } else {
+        return coerceImplicitlyUnwrappedOptionalToValue(
+            newExpr, ty->getWithoutSpecifierType()->getAnyOptionalObjectType());
+      }
+    }
+
     Expr *visitDeclRefExpr(DeclRefExpr *expr) {
       auto locator = cs.getConstraintLocator(expr);
 
@@ -2377,13 +2441,11 @@ namespace {
       auto choice = selected->choice;
       auto decl = choice.getDecl();
 
-      // FIXME: Cannibalize the existing DeclRefExpr rather than allocating a
-      // new one?
+      auto forceUnwrap = shouldForceUnwrapResult(expr, choice);
       return buildDeclRef(decl, expr->getNameLoc(), selected->openedFullType,
-                          locator,
-                          expr->isImplicit(),
+                          locator, expr->isImplicit(),
                           expr->getFunctionRefKind(),
-                          expr->getAccessSemantics());
+                          expr->getAccessSemantics(), forceUnwrap);
     }
 
     Expr *visitSuperRefExpr(SuperRefExpr *expr) {
@@ -2415,10 +2477,11 @@ namespace {
       auto choice = selected.choice;
       auto decl = choice.getDecl();
 
+      auto forceUnwrap = shouldForceUnwrapResult(expr, choice);
       return buildDeclRef(decl, expr->getNameLoc(), selected.openedFullType,
                           locator, expr->isImplicit(),
                           choice.getFunctionRefKind(),
-                          AccessSemantics::Ordinary);
+                          AccessSemantics::Ordinary, forceUnwrap);
     }
 
     Expr *visitUnresolvedDeclRefExpr(UnresolvedDeclRefExpr *expr) {
@@ -2438,17 +2501,13 @@ namespace {
       auto selected = getOverloadChoice(memberLocator);
       bool isDynamic
         = selected.choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-      return buildMemberRef(expr->getBase(),
-                            selected.openedFullType,
-                            expr->getDotLoc(),
-                            selected.choice.getDecl(), expr->getNameLoc(),
-                            selected.openedType,
-                            cs.getConstraintLocator(expr),
-                            memberLocator,
-                            expr->isImplicit(),
-                            selected.choice.getFunctionRefKind(),
-                            expr->getAccessSemantics(),
-                            isDynamic);
+      auto forceUnwrap = shouldForceUnwrapResult(expr, selected.choice);
+      return buildMemberRef(
+          expr->getBase(), selected.openedFullType, expr->getDotLoc(),
+          selected.choice.getDecl(), expr->getNameLoc(), selected.openedType,
+          cs.getConstraintLocator(expr), memberLocator, expr->isImplicit(),
+          selected.choice.getFunctionRefKind(), expr->getAccessSemantics(),
+          isDynamic, forceUnwrap);
     }
 
     Expr *visitDynamicMemberRefExpr(DynamicMemberRefExpr *expr) {
@@ -2492,17 +2551,13 @@ namespace {
       // Build the member reference.
       bool isDynamic
         = selected.choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-      auto result = buildMemberRef(base,
-                                   selected.openedFullType,
-                                   expr->getDotLoc(), member, 
-                                   expr->getNameLoc(),
-                                   selected.openedType,
-                                   cs.getConstraintLocator(expr),
-                                   memberLocator,
-                                   expr->isImplicit(),
-                                   selected.choice.getFunctionRefKind(),
-                                   AccessSemantics::Ordinary,
-                                   isDynamic);
+      auto forceUnwrap = shouldForceUnwrapResult(expr, selected.choice);
+      auto result = buildMemberRef(
+          base, selected.openedFullType, expr->getDotLoc(), member,
+          expr->getNameLoc(), selected.openedType,
+          cs.getConstraintLocator(expr), memberLocator, expr->isImplicit(),
+          selected.choice.getFunctionRefKind(), AccessSemantics::Ordinary,
+          isDynamic, forceUnwrap);
       if (!result)
         return nullptr;
 
@@ -2519,8 +2574,7 @@ namespace {
         result = finishApply(apply, Type(), cs.getConstraintLocator(expr));
       }
 
-      result = coerceToType(result, resultTy, cs.getConstraintLocator(expr));
-      return result;
+      return coerceToType(result, resultTy, cs.getConstraintLocator(expr));
     }
     
   private:
@@ -2549,15 +2603,12 @@ namespace {
       // If the subexpression is a metatype, build a direct reference to the
       // constructor.
       if (cs.getType(base)->is<AnyMetatypeType>()) {
-        return buildMemberRef(base, openedType, dotLoc, ctor, nameLoc,
-                              cs.getType(expr),
-                              ConstraintLocatorBuilder(
-                                cs.getConstraintLocator(expr)),
-                              ctorLocator,
-                              implicit,
-                              functionRefKind,
-                              AccessSemantics::Ordinary,
-                              /*isDynamic=*/false);
+        return buildMemberRef(
+            base, openedType, dotLoc, ctor, nameLoc, cs.getType(expr),
+            ConstraintLocatorBuilder(cs.getConstraintLocator(expr)),
+            ctorLocator, implicit, functionRefKind, AccessSemantics::Ordinary,
+            /*isDynamic=*/false,
+            /*forceUnwrap=*/false);
       }
 
       // The subexpression must be either 'self' or 'super'.
@@ -2674,24 +2725,15 @@ namespace {
 
       case OverloadChoiceKind::Decl:
       case OverloadChoiceKind::DeclViaUnwrappedOptional:
-      case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
       case OverloadChoiceKind::DeclViaDynamic: {
         bool isDynamic
           = selected.choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-        auto member = buildMemberRef(base,
-                                     selected.openedFullType,
-                                     dotLoc,
-                                     selected.choice.getDecl(),
-                                     nameLoc,
-                                     selected.openedType,
-                                     cs.getConstraintLocator(expr),
-                                     memberLocator,
-                                     implicit,
-                                     selected.choice.getFunctionRefKind(),
-                                     AccessSemantics::Ordinary,
-                                     isDynamic);
-
-        return member;
+        auto forceUnwrap = shouldForceUnwrapResult(expr, selected.choice);
+        return buildMemberRef(
+            base, selected.openedFullType, dotLoc, selected.choice.getDecl(),
+            nameLoc, selected.openedType, cs.getConstraintLocator(expr),
+            memberLocator, implicit, selected.choice.getFunctionRefKind(),
+            AccessSemantics::Ordinary, isDynamic, forceUnwrap);
       }
 
       case OverloadChoiceKind::TupleIndex: {
@@ -3432,7 +3474,7 @@ namespace {
           return nullptr;
 
         return coerceImplicitlyUnwrappedOptionalToValue(
-            coerced, cs.getType(coerced)->getOptionalObjectType());
+            coerced, cs.getType(coerced)->getAnyOptionalObjectType());
       }
 
       return visitCoerceExpr(expr, None);
@@ -3517,7 +3559,7 @@ namespace {
           return nullptr;
 
         return coerceImplicitlyUnwrappedOptionalToValue(
-            coerced, cs.getType(coerced)->getOptionalObjectType());
+            coerced, cs.getType(coerced)->getAnyOptionalObjectType());
       }
 
       return handleForcedCheckedCastExpr(expr);
@@ -3597,7 +3639,7 @@ namespace {
           return nullptr;
 
         return coerceImplicitlyUnwrappedOptionalToValue(
-            coerced, cs.getType(coerced)->getOptionalObjectType());
+            coerced, cs.getType(coerced)->getAnyOptionalObjectType());
       }
 
       return handleConditionalCheckedCastExpr(expr);
@@ -7100,6 +7142,12 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   if (auto fnTy = cs.lookThroughImplicitlyUnwrappedOptionalType(cs.getType(fn)))
     fn = coerceImplicitlyUnwrappedOptionalToValue(fn, fnTy);
 
+  bool unwrapResult = false;
+  if (auto *IUOFnTy = dyn_cast<ImplicitlyUnwrappedFunctionConversionExpr>(fn)) {
+    unwrapResult = true;
+    fn = IUOFnTy->getSubExpr();
+  }
+
   // If we're applying a function that resulted from a covariant
   // function conversion, strip off that conversion.
   // FIXME: It would be nicer if we could build the ASTs properly in the
@@ -7204,8 +7252,15 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
           }
       }
     }
+
+    if (unwrapResult)
+      return forceUnwrapResult(result);
+
     return result;
   }
+
+  // FIXME: handle unwrapping everywhere else
+  assert(!unwrapResult);
 
   // If this is an UnresolvedType in the system, preserve it.
   if (cs.getType(fn)->is<UnresolvedType>()) {
@@ -7263,17 +7318,13 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   // Consider the constructor decl reference expr 'implicit', but the
   // constructor call expr itself has the apply's 'implicitness'.
   bool isDynamic = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-  Expr *declRef = buildMemberRef(fn,
-                                 selected->openedFullType,
-                                 /*dotLoc=*/SourceLoc(),
-                                 decl, DeclNameLoc(fn->getEndLoc()),
-                                 selected->openedType,
-                                 locator,
-                                 ctorLocator,
-                                 /*Implicit=*/true,
-                                 choice.getFunctionRefKind(),
-                                 AccessSemantics::Ordinary,
-                                 isDynamic);
+  auto forceUnwrap = shouldForceUnwrapResult(apply, choice);
+  Expr *declRef =
+      buildMemberRef(fn, selected->openedFullType,
+                     /*dotLoc=*/SourceLoc(), decl, DeclNameLoc(fn->getEndLoc()),
+                     selected->openedType, locator, ctorLocator,
+                     /*Implicit=*/true, choice.getFunctionRefKind(),
+                     AccessSemantics::Ordinary, isDynamic, forceUnwrap);
   if (!declRef)
     return nullptr;
   declRef->setImplicit(apply->isImplicit());
@@ -7963,15 +8014,13 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   ExprRewriter rewriter(cs, solution,
                         /*suppressDiagnostics=*/false);
 
-  auto memberRef = rewriter.buildMemberRef(base, openedFullType,
-                                           base->getStartLoc(),
-                                           witness,
-                                           DeclNameLoc(base->getEndLoc()),
-                                           openedType, dotLocator, dotLocator,
-                                           /*Implicit=*/true,
-                                           FunctionRefKind::SingleApply,
-                                           AccessSemantics::Ordinary,
-                                           /*isDynamic=*/false);
+  auto memberRef = rewriter.buildMemberRef(
+      base, openedFullType, base->getStartLoc(), witness,
+      DeclNameLoc(base->getEndLoc()), openedType, dotLocator, dotLocator,
+      /*Implicit=*/true, FunctionRefKind::SingleApply,
+      AccessSemantics::Ordinary,
+      /*isDynamic=*/false,
+      /*forceUnwrap=*/false);
   call->setFn(memberRef);
 
   // Call the witness.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -522,7 +522,6 @@ static bool diagnoseAmbiguity(ConstraintSystem &cs,
       case OverloadChoiceKind::DeclViaDynamic:
       case OverloadChoiceKind::DeclViaBridge:
       case OverloadChoiceKind::DeclViaUnwrappedOptional:
-      case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
         // FIXME: show deduced types, etc, etc.
         if (EmittedDecls.insert(choice.getDecl()).second)
           tc.diagnose(choice.getDecl(), diag::found_candidate);
@@ -8404,8 +8403,7 @@ ValueDecl *ConstraintSystem::findResolvedMemberRef(ConstraintLocator *locator) {
     if (resolved->Locator != locator) continue;
     
     // We only handle the simplest decl binding.
-    if (resolved->Choice.getKind() != OverloadChoiceKind::Decl
-        && resolved->Choice.getKind() != OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional)
+    if (resolved->Choice.getKind() != OverloadChoiceKind::Decl)
       return nullptr;
     return resolved->Choice.getDecl();
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -997,13 +997,8 @@ namespace {
                                       TVO_CanBindToLValue |
                                       TVO_CanBindToInOut);
 
-      OverloadChoice choice;
-      if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
-        choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
-            CS.getType(base), decl, functionRefKind);
-      } else {
-        choice = OverloadChoice(CS.getType(base), decl, functionRefKind);
-      }
+      OverloadChoice choice =
+          OverloadChoice(CS.getType(base), decl, functionRefKind);
 
       auto locator = CS.getConstraintLocator(expr, ConstraintLocator::Member);
       CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
@@ -1106,13 +1101,8 @@ namespace {
       // a known subscript here. This might be cleaner if we split off a new
       // UnresolvedSubscriptExpr from SubscriptExpr.
       if (auto decl = declOrNull) {
-        OverloadChoice choice;
-        if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
-          choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
-              baseTy, decl, FunctionRefKind::DoubleApply);
-        } else {
-          choice = OverloadChoice(baseTy, decl, FunctionRefKind::DoubleApply);
-        }
+        OverloadChoice choice =
+            OverloadChoice(baseTy, decl, FunctionRefKind::DoubleApply);
         CS.addBindOverloadConstraint(fnTy, choice, memberLocator,
                                      CurDC);
       } else {
@@ -1309,15 +1299,8 @@ namespace {
       auto tv = CS.createTypeVariable(locator,
                                       TVO_CanBindToLValue);
 
-      OverloadChoice choice;
-      if (E->getDecl()
-              ->getAttrs()
-              .hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
-        choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
-            Type(), E->getDecl(), E->getFunctionRefKind());
-      } else {
-        choice = OverloadChoice(Type(), E->getDecl(), E->getFunctionRefKind());
-      }
+      OverloadChoice choice =
+          OverloadChoice(Type(), E->getDecl(), E->getFunctionRefKind());
       CS.resolveOverload(locator, tv, choice, CurDC);
 
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
@@ -1394,15 +1377,8 @@ namespace {
         if (decls[i]->isInvalid())
           continue;
 
-        OverloadChoice choice;
-        if (decls[i]
-                ->getAttrs()
-                .hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
-          choice = OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
-              Type(), decls[i], expr->getFunctionRefKind());
-        } else {
-          choice = OverloadChoice(Type(), decls[i], expr->getFunctionRefKind());
-        }
+        OverloadChoice choice =
+            OverloadChoice(Type(), decls[i], expr->getFunctionRefKind());
         choices.push_back(choice);
       }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -131,26 +131,10 @@ static bool sameDecl(Decl *decl1, Decl *decl2) {
   return false;
 }
 
-static bool sameChoiceKind(const OverloadChoice &lhs,
-                           const OverloadChoice &rhs) {
-  if (lhs.getKind() == rhs.getKind())
-    return true;
-
-  if (lhs.getKind() == OverloadChoiceKind::Decl
-      && rhs.getKind() == OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional)
-    return true;
-
-  if (lhs.getKind() == OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional
-      && rhs.getKind() == OverloadChoiceKind::Decl)
-    return true;
-
-  return false;
-}
-
 /// \brief Compare two overload choices for equality.
 static bool sameOverloadChoice(const OverloadChoice &x,
                                const OverloadChoice &y) {
-  if (!sameChoiceKind(x, y))
+  if (x.getKind() != y.getKind())
     return false;
 
   switch (x.getKind()) {
@@ -163,7 +147,6 @@ static bool sameOverloadChoice(const OverloadChoice &x,
   case OverloadChoiceKind::DeclViaDynamic:
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaUnwrappedOptional:
-  case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
     return sameDecl(x.getDecl(), y.getDecl());
 
   case OverloadChoiceKind::TupleIndex:
@@ -834,14 +817,13 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     }
     
     // If the kinds of overload choice don't match...
-    if (!sameChoiceKind(choice1, choice2)) {
+    if (choice1.getKind() != choice2.getKind()) {
       identical = false;
       
       // A declaration found directly beats any declaration found via dynamic
       // lookup, bridging, or optional unwrapping.
-      if ((choice1.getKind() == OverloadChoiceKind::Decl
-           || choice1.getKind() == OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional) &&
-          (choice2.getKind() == OverloadChoiceKind::DeclViaDynamic || 
+      if ((choice1.getKind() == OverloadChoiceKind::Decl) &&
+          (choice2.getKind() == OverloadChoiceKind::DeclViaDynamic ||
            choice2.getKind() == OverloadChoiceKind::DeclViaBridge ||
            choice2.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional)) {
         score1 += weight;
@@ -851,8 +833,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       if ((choice1.getKind() == OverloadChoiceKind::DeclViaDynamic ||
            choice1.getKind() == OverloadChoiceKind::DeclViaBridge ||
            choice1.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional) &&
-          (choice2.getKind() == OverloadChoiceKind::Decl
-           || choice2.getKind() == OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional)) {
+          choice2.getKind() == OverloadChoiceKind::Decl) {
         score2 += weight;
         continue;
       }
@@ -874,7 +855,6 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     case OverloadChoiceKind::Decl:
     case OverloadChoiceKind::DeclViaBridge:
     case OverloadChoiceKind::DeclViaUnwrappedOptional:
-    case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
       break;
     }
     

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1521,6 +1521,49 @@ ConstraintSystem::SolutionKind ConstraintSystem::matchTypesBindTypeVar(
     return SolutionKind::Solved;
   }
 
+  // If we're binding an optional type, or function type that has an
+  // optional result type, this may be the result of an IUO
+  // declaration. These are candidates for creating a disjunction.
+  bool isOptional = false;
+  if (type->getRValueType()->getAnyOptionalObjectType()) {
+    isOptional = true;
+  } else if (auto *fnTy = type->getAs<AnyFunctionType>()) {
+    auto resultTy = fnTy->getResult();
+    while (resultTy->is<AnyFunctionType>())
+      resultTy = resultTy->castTo<AnyFunctionType>()->getResult();
+
+    // FIXME: work-around the fact that doesStorageProduceLValue returns true
+    // for
+    //        #selector(getter: NSMenuItem.action)
+    resultTy = resultTy->getRValueType();
+
+    if (resultTy->getAnyOptionalObjectType()) {
+      isOptional = true;
+    }
+  }
+
+  if (isOptional) {
+    SmallVector<LocatorPathElt, 4> path;
+    locator.getLocatorParts(path);
+
+    // Find the last element that is either an indication we need to
+    // create a disjunction, or an indication that we already have.
+    auto last = std::find_if(
+        path.rbegin(), path.rend(), [](LocatorPathElt &elt) -> bool {
+          return elt.getKind() == ConstraintLocator::ImplicitlyUnwrappedValue ||
+                 elt.getKind() ==
+                     ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice;
+        });
+
+    // If we need to create a disjunction for this value, do so.
+    if (last != path.rend() &&
+        last->getKind() == ConstraintLocator::ImplicitlyUnwrappedValue) {
+      buildDisjunctionForImplicitlyUnwrappedOptional(
+          typeVar, type, getConstraintLocator(locator));
+      return SolutionKind::Solved;
+    }
+  }
+
   assignFixedType(typeVar, type);
 
   return SolutionKind::Solved;
@@ -3205,11 +3248,6 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
                                     ->getAnyOptionalObjectType());
       return OverloadChoice::getDeclViaUnwrappedOptional(ovlBaseTy, cand,
                                                          functionRefKind);
-    }
-
-    if (cand->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
-      return OverloadChoice::getDeclForImplicitlyUnwrappedOptional(
-          baseTy, cand, functionRefKind);
     }
 
     return OverloadChoice(baseTy, cand, functionRefKind);

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -830,8 +830,7 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
         // Look through optional or IUO to get the underlying type the decl was
         // found in.
         substType = substType->getAnyOptionalObjectType();
-      } else if (cand.getKind() != OverloadChoiceKind::Decl
-                 && cand.getKind() != OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional) {
+      } else if (cand.getKind() != OverloadChoiceKind::Decl) {
         // Otherwise, if it is a remapping we can't handle, don't try to compute
         // a substitution.
         substType = Type();

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -358,10 +358,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
       Out << "decl-via-unwrapped-optional ";
       printDecl();
       break;
-    case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
-      Out << "decl-for-implicitly-unwrapped-optional ";
-      printDecl();
-      break;
     case OverloadChoiceKind::BaseType:
       Out << "base type";
       break;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3019,7 +3019,6 @@ void Solution::dump(raw_ostream &out) const {
     case OverloadChoiceKind::DeclViaDynamic:
     case OverloadChoiceKind::DeclViaBridge:
     case OverloadChoiceKind::DeclViaUnwrappedOptional:
-    case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
       choice.getDecl()->dumpRef(out);
       out << " as ";
       if (choice.getBaseType())
@@ -3196,7 +3195,6 @@ void ConstraintSystem::print(raw_ostream &out) {
       case OverloadChoiceKind::DeclViaDynamic:
       case OverloadChoiceKind::DeclViaBridge:
       case OverloadChoiceKind::DeclViaUnwrappedOptional:
-      case OverloadChoiceKind::DeclForImplicitlyUnwrappedOptional:
         if (choice.getBaseType())
           out << choice.getBaseType()->getString() << ".";
         out << choice.getDecl()->getBaseName() << ": "


### PR DESCRIPTION
When binding an optional value, or function that returns an optional
value, if that value was produced from a decl that was declared an
IUO, create a disjunction.

After solving, make use of the disjunction choices in rewriting
expressions to force optionals where needed.

This is disabled for now, as it results in a source compatibility
issue without associated changes that actually start generating
Optional<T> in place of ImplicitlyUnwrappedOptional<T>. It's
complicated, but basically having two '??' (one returning T, one
returning T?) and creating a disjunction where the first (favored)
choice is ImplicitlyUnwrappedOptional<T> and second is T results in
our selecting the wrong '??' in some cases.
