### PR TITLE
[stdlib] Adding derived equality/comparison operators to concrete integer types

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3663,6 +3663,30 @@ ${assignmentOperatorComment(x.operator, True)}
   }
 
 %   end
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func != (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs == rhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(__always)
+  public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(rhs < lhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(__always)
+  public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs < rhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(__always)
+  public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return rhs < lhs
+  }
 }
 
 

--- a/test/stdlib/IntegerCompatibility.swift
+++ b/test/stdlib/IntegerCompatibility.swift
@@ -83,3 +83,7 @@ func negativeShift(_ u8: UInt8) {
 func sr5176(description: String = "unambiguous Int32.init(bitPattern:)") {
   _ = Int32(bitPattern: 0) // should compile without ambiguity
 }
+
+func sr6634(x: UnsafeBufferPointer<UInt8>) -> Int {
+  return x.lazy.filter { $0 > 127 || $0 == 0 }.count // should be unambiguous
+}


### PR DESCRIPTION
... to aid constraint solver in some cases.
  
Resolves: rdar://problem/36113283
Resolves: [SR-6634](https://bugs.swift.org/browse/SR-6634)
