### PR TITLE
Protocol dispatch thunks

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -227,15 +227,6 @@ class LinkEntity {
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
-  static bool isFunction(ValueDecl *decl) {
-    return (isa<FuncDecl>(decl) || isa<EnumElementDecl>(decl) ||
-            isa<ConstructorDecl>(decl));
-  }
-
-  static bool hasGetterSetter(ValueDecl *decl) {
-    return (isa<VarDecl>(decl) || isa<SubscriptDecl>(decl));
-  }
-
   Kind getKind() const {
     return Kind(LINKENTITY_GET_FIELD(Data, Kind));
   }

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_library(swiftIRGen STATIC
   GenProto.cpp
   GenReflection.cpp
   GenStruct.cpp
+  GenThunk.cpp
   GenTuple.cpp
   GenType.cpp
   GenValueWitness.cpp

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1502,7 +1502,7 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
 
 /// Given that we're going to define a global value but already have a
 /// forward-declaration of it, update its linkage.
-static void updateLinkageForDefinition(IRGenModule &IGM,
+void irgen::updateLinkageForDefinition(IRGenModule &IGM,
                                        llvm::GlobalValue *global,
                                        const LinkEntity &entity) {
   // TODO: there are probably cases where we can avoid redoing the

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -18,6 +18,7 @@
 #define SWIFT_IRGEN_GENDECL_H
 
 #include "swift/Basic/OptimizationMode.h"
+#include "swift/SIL/SILLocation.h"
 #include "llvm/IR/CallingConv.h"
 #include "DebugTypeInfo.h"
 #include "IRGen.h"
@@ -30,8 +31,13 @@ namespace llvm {
 namespace swift {
 namespace irgen {
   class IRGenModule;
+  class LinkEntity;
   class LinkInfo;
   class Signature;
+
+  void updateLinkageForDefinition(IRGenModule &IGM,
+                                  llvm::GlobalValue *global,
+                                  const LinkEntity &entity);
 
   llvm::Function *createFunction(IRGenModule &IGM,
                                  LinkInfo &linkInfo,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5555,5 +5555,5 @@ llvm::Value *irgen::emitMetatypeInstanceType(IRGenFunction &IGF,
   // The instance type field of MetatypeMetadata is immediately after
   // the isa field.
   return emitInvariantLoadFromMetadataAtIndex(IGF, metatypeMetadata, 1,
-                                     IGF.IGM.TypeMetadataPtrTy);
+                                              IGF.IGM.TypeMetadataPtrTy);
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5524,6 +5524,18 @@ void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
 
   // Note that we emitted this protocol.
   SwiftProtocols.push_back(protocol);
+
+  // If the protocol is resilient, emit dispatch thunks.
+  if (isResilient(protocol, ResilienceExpansion::Minimal)) {
+    for (auto *member : protocol->getMembers()) {
+      if (auto *funcDecl = dyn_cast<FuncDecl>(member)) {
+        emitDispatchThunk(SILDeclRef(funcDecl));
+      }
+      if (auto *ctorDecl = dyn_cast<ConstructorDecl>(member)) {
+        emitDispatchThunk(SILDeclRef(ctorDecl, SILDeclRef::Kind::Allocator));
+      }
+    }
+  }
 }
 
 /// \brief Load a reference to the protocol descriptor for the given protocol.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3079,31 +3079,37 @@ void irgen::expandTrailingWitnessSignature(IRGenModule &IGM,
 
 FunctionPointer
 irgen::emitWitnessMethodValue(IRGenFunction &IGF,
-                              CanType baseTy,
-                              llvm::Value **baseMetadataCache,
-                              SILDeclRef member,
-                              ProtocolConformanceRef conformance,
-                              CanSILFunctionType fnType) {
-  auto fn = cast<AbstractFunctionDecl>(member.getDecl());
-  auto fnProto = cast<ProtocolDecl>(fn->getDeclContext());
+                              llvm::Value *wtable,
+                              SILDeclRef member) {
+  auto *fn = cast<AbstractFunctionDecl>(member.getDecl());
+  auto proto = cast<ProtocolDecl>(fn->getDeclContext());
 
-  assert(conformance.getRequirement() == fnProto);
-
-  // Find the witness table.
-  llvm::Value *wtable = emitWitnessTableRef(IGF, baseTy, baseMetadataCache,
-                                            conformance);
+  assert(!IGF.IGM.isResilient(proto, ResilienceExpansion::Maximal));
 
   // Find the witness we're interested in.
-  auto &fnProtoInfo = IGF.IGM.getProtocolInfo(conformance.getRequirement());
+  auto &fnProtoInfo = IGF.IGM.getProtocolInfo(proto);
   auto index = fnProtoInfo.getFunctionIndex(fn);
   llvm::Value *witnessFnPtr =
     emitInvariantLoadOfOpaqueWitness(IGF, wtable, index);
 
+  auto fnType = IGF.IGM.getSILTypes().getConstantFunctionType(member);
   Signature signature = IGF.IGM.getSignature(fnType);
   witnessFnPtr = IGF.Builder.CreateBitCast(witnessFnPtr,
                                            signature.getType()->getPointerTo());
 
   return FunctionPointer(witnessFnPtr, signature);
+}
+
+FunctionPointer
+irgen::emitWitnessMethodValue(IRGenFunction &IGF,
+                              CanType baseTy,
+                              llvm::Value **baseMetadataCache,
+                              SILDeclRef member,
+                              ProtocolConformanceRef conformance) {
+  llvm::Value *wtable = emitWitnessTableRef(IGF, baseTy, baseMetadataCache,
+                                            conformance);
+
+  return emitWitnessMethodValue(IGF, wtable, member);
 }
 
 Signature IRGenModule::getAssociatedTypeMetadataAccessFunctionSignature() {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -266,7 +266,8 @@ PolymorphicConvention::enumerateRequirements(const RequirementCallback &callback
   return enumerateGenericSignatureRequirements(Generics, callback);
 }
 
-void PolymorphicConvention::enumerateUnfulfilledRequirements(const RequirementCallback &callback) {
+void PolymorphicConvention::
+enumerateUnfulfilledRequirements(const RequirementCallback &callback) {
   enumerateRequirements([&](GenericRequirement requirement) {
     if (requirement.Protocol) {
       if (!Fulfillments.getWitnessTable(requirement.TypeParameter,
@@ -589,8 +590,9 @@ void EmitPolymorphicParameters::bindParameterSources(const GetParameterFn &getPa
   }
 }
 
-void EmitPolymorphicParameters::bindParameterSource(SILParameterInfo param, unsigned paramIndex,
-                         const GetParameterFn &getParameter) {
+void EmitPolymorphicParameters::
+bindParameterSource(SILParameterInfo param, unsigned paramIndex,
+                    const GetParameterFn &getParameter) {
   // Ignore indirect parameters for now.  This is potentially dumb.
   if (IGF.IGM.silConv.isSILIndirect(param))
     return;
@@ -3099,7 +3101,7 @@ irgen::emitWitnessMethodValue(IRGenFunction &IGF,
 
   Signature signature = IGF.IGM.getSignature(fnType);
   witnessFnPtr = IGF.Builder.CreateBitCast(witnessFnPtr,
-                                         signature.getType()->getPointerTo());
+                                           signature.getType()->getPointerTo());
 
   return FunctionPointer(witnessFnPtr, signature);
 }

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -52,15 +52,20 @@ namespace irgen {
   /// Set an LLVM value name for the given protocol witness table.
   void setProtocolWitnessTableName(IRGenModule &IGM, llvm::Value *value,
                                    CanType type, ProtocolDecl *protocol);
-  
+
+  /// Extract the method pointer from the given witness table
+  /// as a function value.
+  FunctionPointer emitWitnessMethodValue(IRGenFunction &IGF,
+                                         llvm::Value *wtable,
+                                         SILDeclRef member);
+
   /// Extract the method pointer from an archetype's witness table
   /// as a function value.
   FunctionPointer emitWitnessMethodValue(IRGenFunction &IGF,
                                          CanType baseTy,
                                          llvm::Value **baseMetadataCache,
                                          SILDeclRef member,
-                                         ProtocolConformanceRef conformance,
-                                         CanSILFunctionType fnType);
+                                         ProtocolConformanceRef conformance);
 
   /// Given a type T and an associated type X of some protocol P to
   /// which T conforms, return the type metadata for T.X.

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -1,0 +1,81 @@
+//===--- GenThunk.cpp - IR Generation for Method Dispatch Thunks ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements IR generation for class and protocol method dispatch
+//  thunks, which are used in resilient builds to hide vtable and witness table
+//  offsets from clients.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Callee.h"
+#include "Explosion.h"
+#include "GenDecl.h"
+#include "GenOpaque.h"
+#include "GenProto.h"
+#include "IRGenFunction.h"
+#include "IRGenModule.h"
+#include "ProtocolInfo.h"
+#include "Signature.h"
+#include "swift/IRGen/Linking.h"
+#include "llvm/IR/Function.h"
+
+using namespace swift;
+using namespace irgen;
+
+/// Find the entry point for a method dispatch thunk.
+llvm::Function *
+IRGenModule::getAddrOfDispatchThunk(SILDeclRef declRef,
+                                    ForDefinition_t forDefinition) {
+  LinkEntity entity = LinkEntity::forDispatchThunk(declRef);
+
+  llvm::Function *&entry = GlobalFuncs[entity];
+  if (entry) {
+    if (forDefinition) updateLinkageForDefinition(*this, entry, entity);
+    return entry;
+  }
+
+  auto fnType = getSILModule().Types.getConstantFunctionType(declRef);
+  Signature signature = getSignature(fnType);
+  LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
+
+  return createFunction(*this, link, signature);
+}
+
+static FunctionPointer lookupMethod(IRGenFunction &IGF,
+                                    SILDeclRef declRef) {
+  // Find the witness table.
+  llvm::Value *wtable = (IGF.CurFn->arg_end() - 1);
+
+  // Find the witness we're interested in.
+  return emitWitnessMethodValue(IGF, wtable, declRef);
+}
+
+llvm::Function *IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
+  auto *f = getAddrOfDispatchThunk(declRef, ForDefinition);
+
+  IRGenFunction IGF(*this, f);
+
+  // Look up the method.
+  auto fn = lookupMethod(IGF, declRef);
+
+  // Call the witness, forwarding all of the parameters.
+  auto params = IGF.collectParameters();
+  auto result = IGF.Builder.CreateCall(fn, params.claimAll());
+
+  // Return the result, if we have one.
+  if (result->getType()->isVoidTy())
+    IGF.Builder.CreateRetVoid();
+  else
+    IGF.Builder.CreateRet(result);
+
+  return f;
+}

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1046,6 +1046,11 @@ public:
   /// Cast the given constant to i8*.
   llvm::Constant *getOpaquePtr(llvm::Constant *pointer);
 
+  llvm::Function *getAddrOfDispatchThunk(SILDeclRef declRef,
+                                         ForDefinition_t forDefinition);
+
+  llvm::Function *emitDispatchThunk(SILDeclRef declRef);
+
   Address getAddrOfFieldOffset(VarDecl *D, bool isIndirect,
                                ForDefinition_t forDefinition);
   llvm::Function *getAddrOfValueWitness(CanType concreteType,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5243,6 +5243,17 @@ void IRGenSILFunction::visitWitnessMethodInst(swift::WitnessMethodInst *i) {
   ProtocolConformanceRef conformance = i->getConformance();
   SILDeclRef member = i->getMember();
 
+  if (IGM.isResilient(conformance.getRequirement(),
+                      ResilienceExpansion::Maximal)) {
+    auto *fnPtr = IGM.getAddrOfDispatchThunk(member, NotForDefinition);
+    auto fnType = IGM.getSILTypes().getConstantFunctionType(member);
+    auto sig = IGM.getSignature(fnType);
+    auto fn = FunctionPointer::forDirect(fnPtr, sig);
+
+    setLoweredFunctionPointer(i, fn);
+    return;
+  }
+
   // It would be nice if this weren't discarded.
   llvm::Value *baseMetadataCache = nullptr;
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5243,13 +5243,11 @@ void IRGenSILFunction::visitWitnessMethodInst(swift::WitnessMethodInst *i) {
   ProtocolConformanceRef conformance = i->getConformance();
   SILDeclRef member = i->getMember();
 
-  auto fnType = i->getType().castTo<SILFunctionType>();
-
   // It would be nice if this weren't discarded.
   llvm::Value *baseMetadataCache = nullptr;
 
   auto fn = emitWitnessMethodValue(*this, baseTy, &baseMetadataCache,
-                                   member, conformance, fnType);
+                                   member, conformance);
   
   setLoweredFunctionPointer(i, fn);
 }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -17,6 +17,7 @@
 #include "swift/IRGen/Linking.h"
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/Compiler.h"
@@ -24,6 +25,7 @@
 
 using namespace swift;
 using namespace irgen;
+using namespace Mangle;
 
 bool swift::irgen::useDllStorage(const llvm::Triple &triple) {
   return triple.isOSBinFormatCOFF() && !triple.isOSCygMing();
@@ -56,6 +58,24 @@ void LinkEntity::mangle(raw_ostream &buffer) const {
 std::string LinkEntity::mangleAsString() const {
   IRGenMangler mangler;
   switch (getKind()) {
+    case Kind::DispatchThunk:
+      return mangler.mangleEntity(getDecl(), /*isCurried=*/false,
+                                  ASTMangler::SymbolKind::SwiftDispatchThunk);
+
+    case Kind::DispatchThunkInitializer:
+      return mangler.mangleConstructorEntity(
+          cast<ConstructorDecl>(getDecl()),
+          /*isAllocating=*/false,
+          /*isCurried=*/false,
+          ASTMangler::SymbolKind::SwiftDispatchThunk);
+
+    case Kind::DispatchThunkAllocator:
+      return mangler.mangleConstructorEntity(
+          cast<ConstructorDecl>(getDecl()),
+          /*isAllocating=*/true,
+          /*isCurried=*/false,
+          ASTMangler::SymbolKind::SwiftDispatchThunk);
+
     case Kind::ValueWitness:
       return mangler.mangleValueWitness(getType(), getValueWitness());
 

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -312,7 +312,7 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
                                             ProfileCounter entryCount) {
 
   auto name = constant.mangle();
-  auto constantType = Types.getConstantType(constant).castTo<SILFunctionType>();
+  auto constantType = Types.getConstantFunctionType(constant);
   SILLinkage linkage = constant.getLinkage(forDefinition);
 
   if (auto fn = lookUpFunction(name)) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -118,13 +118,13 @@ getBridgingFn(Optional<SILDeclRef> &cacheSlot,
     // Check that the function takes the expected arguments and returns the
     // expected result type.
     SILDeclRef c(fd);
-    auto funcInfo = SGM.getConstantType(c).castTo<SILFunctionType>();
-    SILFunctionConventions fnConv(funcInfo, SGM.M);
+    auto funcTy = SGM.Types.getConstantFunctionType(c);
+    SILFunctionConventions fnConv(funcTy, SGM.M);
 
     if (inputTypes) {
       auto toSILType = [&SGM](Type ty) { return SGM.getLoweredType(ty); };
       if (fnConv.hasIndirectSILResults()
-          || funcInfo->getNumParameters() != inputTypes->size()
+          || funcTy->getNumParameters() != inputTypes->size()
           || !std::equal(
                  fnConv.getParameterSILTypes().begin(),
                  fnConv.getParameterSILTypes().end(),
@@ -443,10 +443,6 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
                           topLevelType, nullptr, Loc, IsBare, IsNotTransparent,
                           IsNotSerialized, ProfileCounter(), IsNotThunk,
                           SubclassScope::NotApplicable);
-}
-
-SILType SILGenModule::getConstantType(SILDeclRef constant) {
-  return Types.getConstantType(constant);
 }
 
 SILFunction *SILGenModule::getEmittedFunction(SILDeclRef constant,

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -140,15 +140,6 @@ public:
   static DeclName getMagicFunctionName(SILDeclRef ref);
   static DeclName getMagicFunctionName(DeclContext *dc);
   
-  /// Returns the type of a constant reference.
-  SILType getConstantType(SILDeclRef constant);
-  
-  /// Returns the calling convention for a function.
-  SILFunctionTypeRepresentation getDeclRefRepresentation(SILDeclRef constant) {
-    return getConstantType(constant).getAs<SILFunctionType>()
-      ->getRepresentation();
-  }
-
   /// Get the function for a SILDeclRef, or return nullptr if it hasn't been
   /// emitted yet.
   SILFunction *getEmittedFunction(SILDeclRef constant,

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -241,7 +241,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   auto superclassDtor = SILDeclRef(superclassDtorDecl,
                                    SILDeclRef::Kind::Deallocator)
     .asForeign();
-  auto superclassDtorType = SGM.getConstantType(superclassDtor);
+  auto superclassDtorType = SGM.Types.getConstantType(superclassDtor);
   SILValue superclassDtorValue = B.createObjCSuperMethod(
                                    cleanupLoc, selfValue, superclassDtor,
                                    superclassDtorType);

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -69,6 +69,8 @@ private:
 
   void addConformances(DeclContext *DC);
 
+  void addDispatchThunk(SILDeclRef declRef);
+
 public:
   TBDGenVisitor(StringSet &symbols, const llvm::Triple &triple,
                 const UniversalLinkageInfo &universalLinkInfo,

--- a/test/IRGen/protocol_resilience_thunks.swift
+++ b/test/IRGen/protocol_resilience_thunks.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %s
+
+// CHECK: %swift.type = type { [[INT:i32|i64]] }
+
+import resilient_protocol
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks26callResilientWitnessMethodyyx010resilient_A00E12BaseProtocolRzlF"(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.ResilientBaseProtocol)
+// CHECK: call swiftcc [[INT]] @"$S18resilient_protocol21ResilientBaseProtocolP11requirementSiyFTj"(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %T, i8** %T.ResilientBaseProtocol)
+// CHECK: ret void
+public func callResilientWitnessMethod<T : ResilientBaseProtocol>(_ value: T) {
+  value.requirement()
+}
+
+public protocol MyResilientProtocol {
+  func returnsVoid(x: Bool)
+
+  func returnsBool() -> Bool
+  func returnsAny() -> Any
+
+  func genericFunc<T>(_: T) -> T
+
+  var property: Bool { get set }
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11returnsVoid1xySb_tFTj"(i1, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS:%.*]] = load i8*, i8** %3
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (i1, %swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: call swiftcc void [[FN]](i1 %0, %swift.opaque* noalias nocapture swiftself %1, %swift.type* %2, i8** %3)
+// CHECK-NEXT: ret void
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP11returnsBoolSbyFTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %2, i32 1
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to i1 (%swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[FN]](%swift.opaque* noalias nocapture swiftself %0, %swift.type* %1, i8** %2)
+// CHECK-NEXT: ret i1 [[RESULT]]
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(%Any* noalias nocapture sret, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 2
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%Any*, %swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: call swiftcc void [[FN]](%Any* noalias nocapture sret %0, %swift.opaque* noalias nocapture swiftself %1, %swift.type* %2, i8** %3)
+// CHECK-NEXT: ret void
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type*, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %5, i32 3
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: call swiftcc void [[FN]](%swift.opaque* noalias nocapture sret %0, %swift.opaque* noalias nocapture %1, %swift.type* %2, %swift.opaque* noalias nocapture swiftself %3, %swift.type* %4, i8** %5)
+// CHECK-NEXT: ret void
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvgTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %2, i32 4
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to i1 (%swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 %5(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %1, i8** %2)
+// CHECK-NEXT: ret i1 [[RESULT]]
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1, %swift.opaque* nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 5
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (i1, %swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: call swiftcc void [[FN]](i1 %0, %swift.opaque* nocapture swiftself %1, %swift.type* %2, i8** %3)
+// CHECK-NEXT: ret void
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, {{i32|i64}} } @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvmTj"(i8*, [{{12|24}} x i8]* nocapture dereferenceable({{12|24}}), %swift.opaque* nocapture swiftself, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %4, i32 6
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to { i8*, [[INT]] } (i8*, [{{12|24}} x i8]*, %swift.opaque*, %swift.type*, i8**)*
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc { i8*, [[INT]] } [[FN]](i8* %0, [{{12|24}} x i8]* nocapture dereferenceable({{12|24}}) %1, %swift.opaque* nocapture swiftself %2, %swift.type* %3, i8** %4)
+// CHECK-NEXT: ret { i8*, [[INT]] } [[RESULT]]

--- a/test/TBD/protocol.swift
+++ b/test/TBD/protocol.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
+// RUN: %target-swift-frontend -enable-resilience -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 
 public protocol Public {
     func publicMethod()


### PR DESCRIPTION
This gets protocol dispatch thunks working well enough for performance evaluation.

We can now re-order protocol method and property requirements and call them resiliently. Still pending is a canonical ordering for associated types, so that associated types can be re-ordered resiliently, and also order-independent witness table instantiation.

Also I have a PR coming that redoes class dispatch thunks to be generated in IRGen instead of SILGen, as @rjmccall originally suggested.