### PR TITLE
IUO: Fixup a diagnostic to add '!' after a type rather than forming a…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1056,7 +1056,7 @@ ERROR(iboutlet_non_optional,none,
 NOTE(note_make_optional,none,
       "add '?' to form the optional type %0", (Type))
 NOTE(note_make_implicitly_unwrapped_optional,none,
-      "add '!' to form the implicitly unwrapped optional type %0", (Type))
+      "add '!' to form the implicitly unwrapped optional type %0!", (Type))
 
 ERROR(invalid_ibdesignable_extension,none,
       "@IBDesignable can only be applied to classes and extensions "

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -498,7 +498,7 @@ void AttributeEarlyChecker::visitIBOutletAttr(IBOutletAttr *attr) {
                 OptionalType::get(type))
       .fixItInsert(symbolLoc, "?");
     TC.diagnose(symbolLoc, diag::note_make_implicitly_unwrapped_optional,
-                ImplicitlyUnwrappedOptionalType::get(type))
+                type)
       .fixItInsert(symbolLoc, "!");
   }
 }


### PR DESCRIPTION
…n IUO.
