### PR TITLE
IUO: Remove some uses of the two-param form of OptionalType::get.

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -662,8 +662,7 @@ public:
   /// The based abstraction pattern must be either opaque or based on
   /// a Clang or Swift type.  That is, it cannot be a tuple or an ObjC
   /// method type.
-  static AbstractionPattern getOptional(AbstractionPattern objectPattern,
-                                        OptionalTypeKind optionalKind);
+  static AbstractionPattern getOptional(AbstractionPattern objectPattern);
 
   /// Does this abstraction pattern have something that can be used as a key?
   bool hasCachingKey() const {

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -146,8 +146,7 @@ AbstractionPattern::getCurriedCFunctionAsMethod(CanType origType,
 }
 
 AbstractionPattern
-AbstractionPattern::getOptional(AbstractionPattern object,
-                                OptionalTypeKind optionalKind) {
+AbstractionPattern::getOptional(AbstractionPattern object) {
   switch (object.getKind()) {
   case Kind::Invalid:
     llvm_unreachable("querying invalid abstraction pattern!");
@@ -168,16 +167,16 @@ AbstractionPattern::getOptional(AbstractionPattern object,
     return AbstractionPattern::getOpaque();
   case Kind::ClangType:
     return AbstractionPattern(object.getGenericSignature(),
-                              OptionalType::get(optionalKind, object.getType())
+                              OptionalType::get(object.getType())
                                 ->getCanonicalType(),
                               object.getClangType());
   case Kind::Type:
     return AbstractionPattern(object.getGenericSignature(),
-                              OptionalType::get(optionalKind, object.getType())
+                              OptionalType::get(object.getType())
                                 ->getCanonicalType());
   case Kind::Discard:
     return AbstractionPattern::getDiscard(object.getGenericSignature(),
-                              OptionalType::get(optionalKind, object.getType())
+                              OptionalType::get(object.getType())
                                 ->getCanonicalType());
   }
   llvm_unreachable("bad kind");

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -784,7 +784,7 @@ static std::pair<AbstractionPattern, CanType> updateResultTypeForForeignError(
     substFormalResultType =
         OptionalType::get(substFormalResultType)->getCanonicalType();
     origResultType =
-        AbstractionPattern::getOptional(origResultType, OTK_Optional);
+        AbstractionPattern::getOptional(origResultType);
     return {origResultType, substFormalResultType};
 
   // These conventions don't require changes to the formal error type.

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -468,7 +468,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(TypeChecker &tc,
   } else if (name == C.Id_intValue) {
     // Synthesize `var intValue: Int? { get }`
     auto intType = C.getIntDecl()->getDeclaredType();
-    auto optionalIntType = OptionalType::get(OTK_Optional, intType);
+    auto optionalIntType = OptionalType::get(intType);
 
     auto synth = [rawType, intType](AbstractFunctionDecl *getterDecl) {
       if (rawType && rawType->isEqual(intType)) {


### PR DESCRIPTION
These are cases where it's clearly always identical to just using the
single-parameter form of OptionalType::get.
