### PR TITLE
check-swift-only_executable: Mark executable tests as such

### DIFF
--- a/test/Generics/conditional_conformances_execute_smoke.swift
+++ b/test/Generics/conditional_conformances_execute_smoke.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 
+// REQUIRES: executable_test
+
 // Smoke test to see that various conditional conformances correctly execute
 
 protocol P1 {

--- a/test/Interpreter/SDK/interpret_with_options.swift
+++ b/test/Interpreter/SDK/interpret_with_options.swift
@@ -4,6 +4,7 @@
 // RUN: %swift_driver -sdk %sdk -l%S/Inputs/libTestLoad.dylib %s | %FileCheck -check-prefix=WITH-LIB %s
 // RUN: cd %S && %swift_driver -sdk %sdk -lInputs/libTestLoad.dylib %s | %FileCheck -check-prefix=WITH-LIB %s
 // REQUIRES: OS=macosx
+// REQUIRES: executable_test
 
 import ObjectiveC
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -535,10 +535,12 @@ if config.variant_sdk != "":
 if platform.system() == 'Darwin' and (run_os == 'macosx' or run_os == 'darwin'):
     # Disable REPL tests if SDK overlay is not in the resource dir.
     # <rdar://problem/16678410> Adding more libraries with -lfoo to REPL is broken
-    config.available_features.add('swift_repl')
-    config.available_features.add('swift_interpreter')
+    if swift_test_mode != 'only_non_executable':
+      config.available_features.add('swift_repl')
+      config.available_features.add('swift_interpreter')
 elif platform.system() == 'Linux':
-    config.available_features.add('swift_interpreter')
+    if swift_test_mode != 'only_non_executable':
+      config.available_features.add('swift_interpreter')
 
 # swift-remoteast-test requires the ability to compile and run code
 # for the system we compiled the swift-remoteast-test executable on.

--- a/test/stdlib/Metal.swift
+++ b/test/stdlib/Metal.swift
@@ -3,6 +3,8 @@
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 
+// REQUIRES: executable_test
+
 import StdlibUnittest
 
 import Metal

--- a/test/stdlib/MetalKit.swift
+++ b/test/stdlib/MetalKit.swift
@@ -3,6 +3,8 @@
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 
+// REQUIRES: executable_test
+
 import StdlibUnittest
 
 import Metal


### PR DESCRIPTION
Executable tests need to be marked with 'REQUIRES: executable_test' for check-swift-only_executable and check-swift-only_non_executable to work.