### PR TITLE
IUO: Convert an explicit check for IUO to check for any optional.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -392,9 +392,12 @@ ManagedValue Transform::transform(ManagedValue v,
     });
   }
 
-  // If the value is IUO, but the desired formal type isn't optional, force it.
-  if (inputOTK == OTK_ImplicitlyUnwrappedOptional
-      && outputOTK == OTK_None) {
+  // If the value is an optional, but the desired formal type isn't an
+  // optional, force it. We should only ever get here with values
+  // declared as implicitly unwrapped optionals because type checking
+  // should weed out cases involving plain optionals.
+  if (inputOTK != OTK_None && outputOTK == OTK_None) {
+    assert(inputOTK == OTK_ImplicitlyUnwrappedOptional);
     v = SGF.emitCheckedGetOptionalValueFrom(Loc, v,
                                             SGF.getTypeLowering(v.getType()),
                                             SGFContext());


### PR DESCRIPTION
We should only ever reach this point with an input type that is
optional and output type that is non-optional if in fact the input
type was originally declared as IUO. If we were to hit this point
today with a plain optional, we end up eventually hitting the
llvm_unreachable at the end of the function.
