### PR TITLE
[build-script] Trust SDKROOT

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -412,10 +412,13 @@ class BuildScriptInvocation(object):
         # Set an appropriate default umask.
         os.umask(0o022)
 
+        if 'SDKROOT' in os.environ:
+            print('NOTE: Environment variable SDKROOT is set to "{}"'
+                  .format(os.environ['SDKROOT']))
+
         # Unset environment variables that might affect how tools behave.
         for v in [
                 'MAKEFLAGS',
-                'SDKROOT',
                 'MACOSX_DEPLOYMENT_TARGET',
                 'IPHONEOS_DEPLOYMENT_TARGET',
                 'TVOS_DEPLOYMENT_TARGET',

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -21,6 +21,7 @@ import sys
 from . import product
 from .. import cache_util
 from .. import shell
+from .. import xcrun
 
 
 class Ninja(product.Product):
@@ -33,23 +34,22 @@ class Ninja(product.Product):
             return
 
         env = None
-        if platform.system() == "Darwin":
-            from .. import xcrun
-            sysroot = xcrun.sdk_path("macosx")
-            osx_version_min = self.args.darwin_deployment_version_osx
+        if platform.system() == 'Darwin':
+            sysroot = os.environ.get('SDKROOT', xcrun.sdk_path('macosx'))
             assert sysroot is not None
+
+            osx_version_min = self.args.darwin_deployment_version_osx
             env = {
-                "CXX": self.toolchain.cxx,
-                "CFLAGS": (
-                    "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
-                ).format(sysroot=sysroot, osx_version=osx_version_min),
-                "LDFLAGS": (
-                    "-mmacosx-version-min={osx_version}"
-                ).format(osx_version=osx_version_min),
+                'CXX': self.toolchain.cxx,
+                'CFLAGS': ' '.join([
+                    '-isysroot', sysroot,
+                    '-mmacosx-version-min={}'.format(osx_version_min),
+                ]),
+                'LDFLAGS': '-mmacosx-version-min={}'.format(osx_version_min),
             }
         elif self.toolchain.cxx:
             env = {
-                "CXX": self.toolchain.cxx,
+                'CXX': self.toolchain.cxx,
             }
 
         # Ninja can only be built in-tree.  Copy the source tree to the build


### PR DESCRIPTION
# Purpose

This PR removes `SDKROOT` from the list of environment variables that are purged before building Swift in `build-script` and then prefers `SDKROOT` when determining `-isysroot` when building Ninja.
 
rdar://36341158