### PR TITLE
[4.1][stdlib] Add derived equality/comparison operators to concrete integer types

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3635,6 +3635,30 @@ ${assignmentOperatorComment(x.operator, True)}
   }
 
 %   end
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func != (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs == rhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(__always)
+  public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(rhs < lhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(__always)
+  public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs < rhs)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @inline(__always)
+  public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return rhs < lhs
+  }
 }
 
 

--- a/test/stdlib/IntegerCompatibility.swift
+++ b/test/stdlib/IntegerCompatibility.swift
@@ -83,3 +83,7 @@ func negativeShift(_ u8: UInt8) {
 func sr5176(description: String = "unambiguous Int32.init(bitPattern:)") {
   _ = Int32(bitPattern: 0) // should compile without ambiguity
 }
+
+func sr6634(x: UnsafeBufferPointer<UInt8>) -> Int {
+  return x.lazy.filter { $0 > 127 || $0 == 0 }.count // should be unambiguous
+}


### PR DESCRIPTION
* Explanation: This change helps resolve the ambiguities that started to arise after the recent constraint solver changes.
* Scope of Issue: Additive. The operators being added have always been there in form of default impleemntations on protocol extensions. Overloading them on concrete type takes advantage of certain shortcuts in the solver.
* Risk: Minimal
* Reviewed By: Pavel Yaskevich
* Testing: Automated test suite + a case for the regression reported in SR-6634
* Directions for QA: N/A
* Radar: <rdar://problem/36113283>
  