### PR TITLE
[ClangImporter] Don't drop CF retain/release functions with swift_name

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7347,14 +7347,17 @@ void ClangImporter::Implementation::importAttributes(
     if (FD->getNumParams() == 1 &&
          (FD->getName().endswith("Release") ||
           FD->getName().endswith("Retain") ||
-          FD->getName().endswith("Autorelease")))
-      if (auto t = FD->getParamDecl(0)->getType()->getAs<clang::TypedefType>())
+          FD->getName().endswith("Autorelease")) &&
+        !FD->getAttr<clang::SwiftNameAttr>()) {
+      if (auto t = FD->getParamDecl(0)->getType()->getAs<clang::TypedefType>()){
         if (isCFTypeDecl(t->getDecl())) {
           auto attr = AvailableAttr::createPlatformAgnostic(C,
             "Core Foundation objects are automatically memory managed");
           MappedDecl->getAttrs().add(attr);
           return;
         }
+      }
+    }
   }
 
   // Hack: mark any method named "print" with less than two parameters as

--- a/test/ClangImporter/Inputs/custom-modules/CoreCooling.h
+++ b/test/ClangImporter/Inputs/custom-modules/CoreCooling.h
@@ -38,6 +38,7 @@ typedef CCRefrigeratorRef CCFridgeRef;
 typedef const void *CCOpaqueTypeRef __attribute__((objc_bridge(id)));
 CCOpaqueTypeRef CCRetain(CCOpaqueTypeRef typeRef);
 void CCRelease(CCOpaqueTypeRef typeRef);
+CCOpaqueTypeRef CCMungeAndRetain(CCOpaqueTypeRef typeRef) __attribute__((swift_name("CCMungeAndRetain(_:)")));
 
 // Nullability
 void CCRefrigeratorOpenDoSomething(_Nonnull CCRefrigeratorRef fridge);

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -97,6 +97,7 @@ func testChainedAliases(_ fridge: CCRefrigerator) {
 func testBannedImported(_ object: CCOpaqueTypeRef) {
   CCRetain(object) // expected-error {{'CCRetain' is unavailable: Core Foundation objects are automatically memory managed}} expected-warning {{result of call to 'CCRetain' is unused}}
   CCRelease(object) // expected-error {{'CCRelease' is unavailable: Core Foundation objects are automatically memory managed}}
+  CCMungeAndRetain(object) // okay, has a custom swift_name
 }
 
 func testOutParametersGood() {


### PR DESCRIPTION
Swift uses ARC for CF types, so CFRetain and its variants aren't necessary. But sometimes functions *look* like retain/release variants (to the compiler, anyway) but actually do useful things, like CMBufferQueueDequeueAndRetain. Recognize this with the presence of a swift_name attribute (either from CF_SWIFT_NAME or from API notes).

rdar://problem/23480844