### PR TITLE
[SR 5641] Implement support for defer in the playground transform and PC macro.

### DIFF
--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -52,6 +52,8 @@ public:
       return S;
     case StmtKind::Brace:
       return transformBraceStmt(cast<BraceStmt>(S));
+    case StmtKind::Defer:
+      return transformDeferStmt(cast<DeferStmt>(S));
     case StmtKind::If:
       return transformIfStmt(cast<IfStmt>(S));
     case StmtKind::Guard:
@@ -281,6 +283,18 @@ public:
       }
     }
     return DCS;
+  }
+  
+  DeferStmt *transformDeferStmt(DeferStmt *DS) {
+    if (auto *FD = DS->getTempDecl()) {
+      auto Implicit = FD->isImplicit();
+      FD->setImplicit(false);
+      auto *D = transformDecl(FD);
+      D->setImplicit(Implicit);
+      assert(D == FD);
+    }
+    return DS;
+
   }
 
   Decl *transformDecl(Decl *D) {

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -287,6 +287,9 @@ public:
   
   DeferStmt *transformDeferStmt(DeferStmt *DS) {
     if (auto *FD = DS->getTempDecl()) {
+      // Temporarily unmark the DeferStmt's FuncDecl as implicit so it is
+      // transformed (as typically implicit Decls are skipped by the
+      // transformer).
       auto Implicit = FD->isImplicit();
       FD->setImplicit(false);
       auto *D = transformDecl(FD);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -126,6 +126,8 @@ public:
       return S;
     case StmtKind::Brace:
       return transformBraceStmt(cast<BraceStmt>(S));
+    case StmtKind::Defer:
+      return transformDeferStmt(cast<DeferStmt>(S));
     case StmtKind::If:
       return transformIfStmt(cast<IfStmt>(S));
     case StmtKind::Guard:
@@ -151,6 +153,17 @@ public:
     case StmtKind::DoCatch:
       return transformDoCatchStmt(cast<DoCatchStmt>(S));
     }
+  }
+
+  DeferStmt *transformDeferStmt(DeferStmt *DS) {
+    if (auto *FD = DS->getTempDecl()) {
+      auto Implicit = FD->isImplicit();
+      FD->setImplicit(false);
+      auto *D = transformDecl(FD);
+      D->setImplicit(Implicit);
+      assert(D == FD);
+    }
+    return DS;
   }
 
   // transform*() return their input if it's unmodified,

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -157,6 +157,9 @@ public:
 
   DeferStmt *transformDeferStmt(DeferStmt *DS) {
     if (auto *FD = DS->getTempDecl()) {
+      // Temporarily unmark the DeferStmt's FuncDecl as implicit so it is
+      // transformed (as typically implicit Decls are skipped by the
+      // transformer).
       auto Implicit = FD->isImplicit();
       FD->setImplicit(false);
       auto *D = transformDecl(FD);

--- a/test/PCMacro/defer.swift
+++ b/test/PCMacro/defer.swift
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+// FIXME: rdar://problem/30234450 PCMacro tests fail on linux in optimized mode
+// UNSUPPORTED: OS=linux-gnu
+
+#sourceLocation(file: "main.swift", line: 8)
+func foo() {
+  defer {
+    2
+  }
+  1
+}
+
+foo()
+
+// CHECK: [15:1-15:6] pc before
+// CHECK-NEXT: [8:1-8:11] pc before
+// CHECK-NEXT: [8:1-8:11] pc after
+// CHECK-NEXT: [12:3-12:4] pc before
+// CHECK-NEXT: [12:3-12:4] pc after
+// CHECK-NEXT: [10:5-10:6] pc before
+// CHECK-NEXT: [10:5-10:6] pc after
+// CHECK-NEXT: [15:1-15:6] pc after

--- a/test/PCMacro/nested_function.swift
+++ b/test/PCMacro/nested_function.swift
@@ -1,0 +1,49 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+// FIXME: rdar://problem/30234450 PCMacro tests fail on linux in optimized mode
+// UNSUPPORTED: OS=linux-gnu
+
+#sourceLocation(file: "main.swift", line: 8)
+func foo() {
+  func bar() {
+    2
+  }
+  
+  let baz: () -> Void = {
+    3
+  }
+  
+  1
+  bar()
+  baz()
+}
+
+foo()
+
+// CHECK: [22:1-22:6] pc before
+// CHECK-NEXT: [8:1-8:11] pc before
+// CHECK-NEXT: [8:1-8:11] pc after
+// CHECK-NEXT: [13:3-15:4] pc before
+// CHECK-NEXT: [13:3-15:4] pc after
+// CHECK-NEXT: [17:3-17:4] pc before
+// CHECK-NEXT: [17:3-17:4] pc after
+// CHECK-NEXT: [18:3-18:8] pc before
+// CHECK-NEXT: [9:3-9:13] pc before
+// CHECK-NEXT: [9:3-9:13] pc after
+// CHECK-NEXT: [10:5-10:6] pc before
+// CHECK-NEXT: [10:5-10:6] pc after
+// CHECK-NEXT: [18:3-18:8] pc after
+// CHECK-NEXT: [19:3-19:8] pc before
+// CHECK-NEXT: [14:5-14:6] pc before
+// CHECK-NEXT: [14:5-14:6] pc after
+// CHECK-NEXT: [14:5-14:6] pc before
+// CHECK-NEXT: [14:5-14:6] pc after
+// CHECK-NEXT: [19:3-19:8] pc after
+// CHECK-NEXT: [22:1-22:6] pc after

--- a/test/PlaygroundTransform/defer.swift
+++ b/test/PlaygroundTransform/defer.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+func foo() {
+	defer {
+		2
+	}
+	1
+}
+foo()
+// CHECK: {{.*}} $builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} $builtin_log[='1']
+// CHECK-NEXT: {{.*}} $builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} $builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} $builtin_log[='2']
+// CHECK-NEXT: {{.*}} $builtin_log_scope_exit


### PR DESCRIPTION
Implements handling of `defer` statements in both the playground transform and PC macro.

Original patch for the playground transform provided by @swiftix.

Resolves [SR-5641](https://bugs.swift.org/browse/SR-5641) and &lt;rdar://problem/33764082&gt;.