### PR TITLE
[stdlib] Annotate types with @_fixed_layout

### DIFF
--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -12,7 +12,9 @@
 
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
-@objc public enum MachErrorCode : Int32 {
+@_fixed_layout // FIXME(sil-serialize-all)
+@objc
+public enum MachErrorCode : Int32 {
   case success                  = 0
 
   /// Specified address is not currently valid.

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -15,7 +15,9 @@
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Enumeration describing POSIX error codes.
-@objc public enum POSIXErrorCode : Int32 {
+@_fixed_layout // FIXME(sil-serialize-all)
+@objc
+public enum POSIXErrorCode : Int32 {
   /// Operation not permitted.
   case EPERM           = 1
   /// No such file or directory.
@@ -267,6 +269,7 @@
 #elseif os(Linux) || os(Android)
 
 /// Enumeration describing POSIX error codes.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum POSIXErrorCode : Int32 {
   /// Operation not permitted.
   case EPERM           = 1

--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
+@_fixed_layout // FIXME(sil-serialize-all)
+@_versioned // FIXME(sil-serialize-all)
 struct _Prespecialize {
   // Create specializations for the arrays of most
   // popular builtin integer and floating point types.

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -68,6 +68,7 @@ public struct Character {
   // to discriminate between small and large representations.  Since a grapheme
   // cluster cannot have U+0000 anywhere but in its first scalar, we can store
   // zero in empty code units above the first one.
+  @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned
   internal enum Representation {
     case smallUTF16(Builtin.Int63)

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -13,6 +13,7 @@
 // FIXME: swift-3-indexing-model: Generalize all tests to check both
 // [Closed]Range and [Closed]CountableRange.
 
+@_fixed_layout // FIXME(sil-serialize-all)
 @_versioned
 internal enum _ClosedRangeIndexRepresentation<Bound>
   where

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1101,6 +1101,7 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
 //===----------------------------------------------------------------------===//
 
 /// An error that occurs during the encoding of a value.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum EncodingError : Error {
   /// The context in which the error occurred.
   @_fixed_layout // FIXME(sil-serialize-all)
@@ -1189,6 +1190,7 @@ public enum EncodingError : Error {
 }
 
 /// An error that occurs during the decoding of a value.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum DecodingError : Error {
   /// The context in which the error occurred.
   @_fixed_layout // FIXME(sil-serialize-all)

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -13,6 +13,7 @@
 import SwiftShims
 
 /// Command-line arguments for the current process.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum _DebuggerSupport {
+  @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal enum CollectionStatus {
     case NotACollection

--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -181,6 +181,7 @@ extension DoubleWidth : Numeric {
 extension DoubleWidth : FixedWidthInteger {
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Words : Collection {
+    @_fixed_layout // FIXME(sil-serialize-all)
     public enum _IndexValue {
       case low(Low.Words.Index)
       case high(High.Words.Index)

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1218,6 +1218,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
 }
 
 /// The sign of a floating-point value.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum FloatingPointSign: Int {
   /// The sign for a positive value.
   case plus
@@ -1227,6 +1228,7 @@ public enum FloatingPointSign: Int {
 }
 
 /// The IEEE 754 floating-point classes.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum FloatingPointClassification {
   /// A signaling NaN ("not a number").
   ///
@@ -1265,6 +1267,7 @@ public enum FloatingPointClassification {
 }
 
 /// A rule for rounding a floating-point number.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum FloatingPointRoundingRule {
   /// Round to the closest allowed value; if two values are equally close, the
   /// one with greater magnitude is chosen.

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -4632,6 +4632,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   }
 }
 #else
+@_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}> { }
 #endif
@@ -6231,6 +6232,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
 #endif
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal enum ${Self}IteratorRepresentation<${TypeParametersDecl}> {
   internal typealias _Iterator = ${Self}Iterator<${TypeParameters}>
   internal typealias _NativeBuffer =

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -23,6 +23,7 @@
 
 import SwiftShims
 
+@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _Hashing {
   // FIXME(ABI)#41 : make this an actual public API.
@@ -45,6 +46,7 @@ struct _Hashing {
   }
 }
 
+@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _HashingDetail {
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -48,6 +48,7 @@ extension JoinedSequence {
     @_versioned // FIXME(sil-serialize-all)
     internal var _separator: ContiguousArray<Element>.Iterator?
     
+    @_fixed_layout // FIXME(sil-serialize-all)
     @_versioned // FIXME(sil-serialize-all)
     internal enum JoinIteratorState {
       case start

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -163,6 +163,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
 public class PartialKeyPath<Root>: AnyKeyPath { }
 
 // MARK: Concrete implementations
+@_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum KeyPathKind { case readOnly, value, reference }
 
@@ -399,6 +400,7 @@ public class ReferenceWritableKeyPath<
 
 // MARK: Implementation details
 
+@_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum KeyPathComponentKind {
   /// The keypath projects within the storage of the outer value, like a
@@ -459,6 +461,7 @@ internal struct ComputedPropertyID: Hashable {
 }
 
 @_versioned // FIXME(sil-serialize-all)
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct ComputedArgumentWitnesses {
   internal typealias Destroy = @convention(thin)
     (_ instanceArguments: UnsafeMutableRawPointer, _ size: Int) -> ()
@@ -484,6 +487,7 @@ internal struct ComputedArgumentWitnesses {
   internal let hash: Hash
 }
 
+@_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum KeyPathComponent: Hashable {
   @_fixed_layout // FIXME(sil-serialize-all)
@@ -741,6 +745,7 @@ internal struct RawKeyPathComponent {
   @_versioned // FIXME(sil-serialize-all)
   internal var body: UnsafeRawBufferPointer
   
+  @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal struct Header {
     @_inlineable // FIXME(sil-serialize-all)
@@ -1188,6 +1193,7 @@ internal struct RawKeyPathComponent {
       count: buffer.count - componentSize)
   }
 
+  @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal enum ProjectionResult<NewValue, LeafValue> {
     /// Continue projecting the key path with the given new value.

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -39,6 +39,7 @@
 ///     let pointPointer = UnsafeMutableRawPointer.allocate(
 ///             bytes: count * MemoryLayout<Point>.stride,
 ///             alignedTo: MemoryLayout<Point>.alignment)
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum MemoryLayout<T> {
   /// The contiguous memory footprint of `T`, in bytes.
   ///

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -45,6 +45,7 @@ public struct Mirror {
   /// Note that the effect of this setting goes no deeper than the
   /// nearest descendant class that overrides `customMirror`, which
   /// in turn can determine representation of *its* descendants.
+  @_fixed_layout // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal enum _DefaultDescendantRepresentation {
     /// Generate a default mirror for descendant classes that don't
@@ -68,6 +69,7 @@ public struct Mirror {
   /// its mirror represents ancestor classes by initializing the mirror
   /// with an `AncestorRepresentation`. This setting has no effect on mirrors
   /// reflecting value type instances.
+  @_fixed_layout // FIXME(sil-serialize-all)
   public enum AncestorRepresentation {
 
     /// Generates a default mirror for all ancestor classes.

--- a/stdlib/public/core/ObjCMirrors.swift
+++ b/stdlib/public/core/ObjCMirrors.swift
@@ -29,6 +29,7 @@ internal func _getObjCSummary(_ data: _MagicMirrorData) -> String {
   return _cocoaStringToSwiftString_NonASCII(theDescription)
 }
 
+@_fixed_layout // FIXME(sil-serialize-all)
 public // SPI(runtime)
 struct _ObjCMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
@@ -63,6 +64,7 @@ struct _ObjCMirror : _Mirror {
   public var disposition: _MirrorDisposition { return .objCObject }
 }
 
+@_fixed_layout // FIXME(sil-serialize-all)
 public // SPI(runtime)
 struct _ObjCSuperMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -103,6 +103,7 @@ extension LazySequenceProtocol {
 
 /// A position in the base collection of a `LazyPrefixWhileCollection` or the
 /// end of that collection.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum _LazyPrefixWhileIndexRepresentation<Base : Collection> {
   case index(Base.Index)
   case pastEnd

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -1209,6 +1209,7 @@ extension Strideable where Stride: SignedInteger {
 
 // FIXME: replace this with a computed var named `...` when the language makes
 // that possible.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum UnboundedRange_ {
   @_inlineable // FIXME(sil-serialize-all)
   public static postfix func ... (_: UnboundedRange_) -> () {

--- a/stdlib/public/core/ReflectionLegacy.swift
+++ b/stdlib/public/core/ReflectionLegacy.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// How children of this value should be presented in the IDE.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum _MirrorDisposition {
   /// As a struct.
   case `struct`
@@ -136,6 +137,7 @@ public struct _MagicMirrorData {
 }
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _OpaqueMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData
@@ -187,6 +189,7 @@ internal func _getTupleCount(_: _MagicMirrorData) -> Int
 internal func _getTupleChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _TupleMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData
@@ -232,6 +235,7 @@ internal func _getStructCount(_: _MagicMirrorData) -> Int
 internal func _getStructChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _StructMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData
@@ -286,6 +290,7 @@ internal func _swift_EnumMirror_caseName(
     _ data: _MagicMirrorData) -> UnsafePointer<CChar>
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _EnumMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData
@@ -401,6 +406,7 @@ internal func _getClassPlaygroundQuickLook(
 #endif
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _ClassMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData
@@ -447,6 +453,7 @@ internal struct _ClassMirror : _Mirror {
 }
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _ClassSuperMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData
@@ -488,6 +495,7 @@ internal struct _ClassSuperMirror : _Mirror {
 }
 
 @_versioned
+@_fixed_layout // FIXME(sil-serialize-all)
 internal struct _MetatypeMirror : _Mirror {
   @_versioned // FIXME(sil-serialize-all)
   internal let data: _MagicMirrorData

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -89,6 +89,7 @@ internal func _collectAllReferencesInsideObjectImpl(
 
 // This is a namespace for runtime functions related to management
 // of runtime function counters.
+@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _RuntimeFunctionCounters {
 #if os(Windows) && arch(x86_64)
@@ -227,6 +228,8 @@ extension _RuntimeFunctionCountersStats {
 // counters. This type should not be used directly. You should use its
 // wrappers GlobalRuntimeFunctionCountersState and
 // ObjectRuntimeFunctionCountersState instead.
+@_fixed_layout // FIXME(sil-serialize-all)
+@_versioned // FIXME(sil-serialize-all)
 internal struct _RuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
   /// Reserve enough space for 64 elements.
   typealias Counters =
@@ -417,6 +420,7 @@ extension _RuntimeFunctionCountersStats {
 
 /// This type should be used to collect statistics about the global runtime
 /// function pointers.
+@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _GlobalRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
   var state = _RuntimeFunctionCountersState()
@@ -454,6 +458,7 @@ struct _GlobalRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
 
 /// This type should be used to collect statistics about object runtime
 /// function pointers.
+@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _ObjectRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
   var state = _RuntimeFunctionCountersState()

--- a/stdlib/public/core/SipHash.swift.gyb
+++ b/stdlib/public/core/SipHash.swift.gyb
@@ -19,6 +19,7 @@
 /// * Daniel J. Bernstein <djb@cr.yp.to>
 //===----------------------------------------------------------------------===//
 
+@_fixed_layout // FIXME(sil-serialize-all)
 @_versioned
 internal enum _SipHashDetail {
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -19,6 +19,7 @@ extension String {
     internal var _cache: _Cache
 
     internal typealias _UTF8Buffer = _ValidUTF8Buffer<UInt64>
+    @_fixed_layout // FIXME(sil-serialize-all)
     @_versioned
     internal enum _Cache {
     case utf16

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -924,5 +924,6 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
 }
 
 /// A namespace for Unicode utilities.
+@_fixed_layout // FIXME(sil-serialize-all)
 public enum Unicode {}
 

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 extension Unicode {
   /// The result of attempting to parse a `T` from some input.
+  @_fixed_layout // FIXME(sil-serialize-all)
   public enum ParseResult<T> {
   /// A `T` was parsed successfully
   case valid(T)


### PR DESCRIPTION
This will allows us to build the standard library in resilient mode by
default, hopefully, without performance regression.

<rdar://problem/36362648>