### PR TITLE
Some improvements and simplifications regarding pass name printing inthe pass manager.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -72,9 +72,6 @@ class SILPassManager {
   /// The number of passes run so far.
   unsigned NumPassesRun = 0;
 
-  /// Number of optimization iterations run.
-  unsigned NumOptimizationIterations = 0;
-
   /// A mask which has one bit for each pass. A one for a pass-bit means that
   /// the pass doesn't need to run, because nothing has changed since the
   /// previous run of that pass.
@@ -138,9 +135,6 @@ public:
   /// \returns the associated IGenModule or null if this is not an IRGen
   /// pass manager.
   irgen::IRGenModule *getIRGenModule() { return IRMod; }
-
-  /// \brief Run one iteration of the optimization pipeline.
-  void runOneIteration();
 
   /// \brief Restart the function pass pipeline on the same function
   /// that is currently being processed.
@@ -272,9 +266,7 @@ public:
   }
 
 private:
-  void execute() {
-    runOneIteration();
-  }
+  void execute();
 
   /// Add a pass of a specific kind.
   void addPass(PassKind Kind);
@@ -282,17 +274,15 @@ private:
   /// Add a pass with a given name.
   void addPassForName(StringRef Name);
 
-  /// Run the SIL module transform \p SMT over all the functions in
+  /// Run the \p TransIdx'th SIL module transform over all the functions in
   /// the module.
-  void runModulePass(SILModuleTransform *SMT);
+  void runModulePass(unsigned TransIdx);
 
-  /// Run the pass \p SFT on the function \p F.
-  void runPassOnFunction(SILFunctionTransform *SFT, SILFunction *F);
+  /// Run the \p TransIdx'th pass on the function \p F.
+  void runPassOnFunction(unsigned TransIdx, SILFunction *F);
 
-  /// Run the passes in \p FuncTransforms. Return true
-  /// if the pass manager requested to stop the execution
-  /// of the optimization cycle (this is a debug feature).
-  void runFunctionPasses(ArrayRef<SILFunctionTransform *> FuncTransforms);
+  /// Run the passes in Transform from \p FromTransIdx to \p ToTransIdx.
+  void runFunctionPasses(unsigned FromTransIdx, unsigned ToTransIdx);
 
   /// A helper function that returns (based on SIL stage and debug
   /// options) whether we should continue running passes.
@@ -300,6 +290,10 @@ private:
 
   /// Return true if all analyses are unlocked.
   bool analysesUnlocked();
+
+  /// Dumps information about the pass with index \p TransIdx to llvm::dbgs().
+  void dumpPassInfo(const char *Title, unsigned TransIdx,
+                    SILFunction *F = nullptr);
 
   /// Displays the call graph in an external dot-viewer.
   /// This function is meant for use from the debugger.

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -14,15 +14,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// PASS(Id, Tag, Name)
+/// PASS(Id, Tag, Description)
 ///   Id is a pass "identifier", used for its enum case, PassKind::Id,
 ///   and type name, as returned by the global function swift::create##Id().
 ///
 ///   Tag identifies the pass as a command-line compatible option string.
 ///
-///   Name is the descriptive, human readable pass name.
+///   Description is a short description of the pass.
 ///
-///   All three if these fields are unique identifiers which may be used in test
+///   Id and Tag are unique identifiers which may be used in test
 ///   cases and tools to specify a pass by string. Different tools simply prefer
 ///   different identifier formats. Changing any of one these strings may change
 ///   the functionality of some tests.
@@ -32,15 +32,15 @@
 #error "Macro must be defined by includer"
 #endif
 
-/// IRGEN_PASS(Id, Tag, Name)
-///   This macro follows the same conventions as PASS(Id, Tag, Name),
+/// IRGEN_PASS(Id, Tag, Description)
+///   This macro follows the same conventions as PASS(Id, Tag, Description),
 ///   but is used for IRGen passes which are built outside of the
 ///   SILOptimizer library.
 ///   
 ///   An IRGen pass is created by IRGen and needs to be registered with the pass
 ///   manager dynamically.
 #ifndef IRGEN_PASS
-#define IRGEN_PASS(Id, Tag, Name) PASS(Id, Tag, Name)
+#define IRGEN_PASS(Id, Tag, Description) PASS(Id, Tag, Description)
 #endif
 
 /// PASS_RANGE(RANGE_ID, START, END)

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -80,7 +80,6 @@ namespace swift {
   PassKind PassKindFromString(StringRef ID);
   StringRef PassKindID(PassKind Kind);
   StringRef PassKindTag(PassKind Kind);
-  StringRef PassKindName(PassKind Kind);
 
 #define PASS(ID, TAG, NAME) SILTransform *create##ID();
 #define IRGEN_PASS(ID, TAG, NAME)

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -72,9 +72,6 @@ namespace swift {
       return Mod;
     }
 
-    /// Get the name of the transform.
-    llvm::StringRef getName() { return PassKindName(getPassKind()); }
-
     /// Get the transform's (command-line) tag.
     llvm::StringRef getTag() { return PassKindTag(getPassKind()); }
 

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -142,7 +142,7 @@ void swift::runSILOptimizationPassesWithFileSpecification(SILModule &M,
 /// Get the Pass ID enum value from an ID string.
 PassKind swift::PassKindFromString(StringRef IDString) {
   return llvm::StringSwitch<PassKind>(IDString)
-#define PASS(ID, TAG, NAME) .Case(#ID, PassKind::ID)
+#define PASS(ID, TAG, DESCRIPTION) .Case(#ID, PassKind::ID)
 #include "swift/SILOptimizer/PassManager/Passes.def"
       .Default(PassKind::invalidPassKind);
 }
@@ -152,7 +152,7 @@ PassKind swift::PassKindFromString(StringRef IDString) {
 /// by its type name.
 StringRef swift::PassKindID(PassKind Kind) {
   switch (Kind) {
-#define PASS(ID, TAG, NAME)                                                    \
+#define PASS(ID, TAG, DESCRIPTION)                                             \
   case PassKind::ID:                                                           \
     return #ID;
 #include "swift/SILOptimizer/PassManager/Passes.def"
@@ -167,24 +167,9 @@ StringRef swift::PassKindID(PassKind Kind) {
 /// This format is useful for command line options.
 StringRef swift::PassKindTag(PassKind Kind) {
   switch (Kind) {
-#define PASS(ID, TAG, NAME)                                                    \
+#define PASS(ID, TAG, DESCRIPTION)                                             \
   case PassKind::ID:                                                           \
     return TAG;
-#include "swift/SILOptimizer/PassManager/Passes.def"
-  case PassKind::invalidPassKind:
-    llvm_unreachable("Invalid pass kind?!");
-  }
-
-  llvm_unreachable("Unhandled PassKind in switch.");
-}
-
-/// Get a name string for the given pass Kind.
-/// This is a descriptive, human readable name.
-StringRef swift::PassKindName(PassKind Kind) {
-  switch (Kind) {
-#define PASS(ID, TAG, NAME)                                                    \
-  case PassKind::ID:                                                           \
-    return NAME;
 #include "swift/SILOptimizer/PassManager/Passes.def"
   case PassKind::invalidPassKind:
     llvm_unreachable("Invalid pass kind?!");

--- a/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
+++ b/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
@@ -25,7 +25,7 @@ PrettyStackTraceSILFunctionTransform::PrettyStackTraceSILFunctionTransform(
 
 void PrettyStackTraceSILFunctionTransform::print(llvm::raw_ostream &out) const {
   out << "While running pass #" << PassNumber
-      << " SILFunctionTransform \"" << SFT->getName()
+      << " SILFunctionTransform \"" << SFT->getID()
       << "\" on SILFunction ";
   if (!SFT->getFunction()) {
     out << " <<null>>";
@@ -36,5 +36,5 @@ void PrettyStackTraceSILFunctionTransform::print(llvm::raw_ostream &out) const {
 
 void PrettyStackTraceSILModuleTransform::print(llvm::raw_ostream &out) const {
   out << "While running pass #" << PassNumber
-      << " SILModuleTransform \"" << SMT->getName() << "\".\n";
+      << " SILModuleTransform \"" << SMT->getID() << "\".\n";
 }

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -Xllvm -sil-disable-pass="External Definition To Declaration" %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 // XFAIL: linux

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -Xllvm -sil-disable-pass="External Definition To Declaration" -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/zero_size_types.swift
+++ b/test/IRGen/zero_size_types.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xllvm -sil-disable-pass="Generic Function Specialization" %s -o %t/a.out
+// RUN: %target-build-swift -Xllvm -sil-disable-pass=GenericSpecializer %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/SIL/Serialization/public_external.sil
+++ b/test/SIL/Serialization/public_external.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -Xllvm -sil-disable-pass="External Definition To Declaration" -parse-sil -emit-module -module-name Swift -module-link-name swiftCore -parse-stdlib -parse-as-library -o - | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -emit-sorted-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -parse-sil -emit-module -module-name Swift -module-link-name swiftCore -parse-stdlib -parse-as-library -o - | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -emit-sorted-sil | %FileCheck %s
 
 sil_stage raw
 import Builtin

--- a/test/SIL/Serialization/visibility.sil
+++ b/test/SIL/Serialization/visibility.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -Xllvm -sil-disable-pass="External Definition To Declaration" -parse-sil -emit-module -o - -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -module-name Swift > %t.sil
+// RUN: %target-swift-frontend %s -parse-sil -emit-module -o - -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -module-name Swift > %t.sil
 // RUN: %FileCheck %s < %t.sil
 // RUN: %FileCheck -check-prefix=NEG-CHECK %s < %t.sil
 

--- a/test/SILGen/fragile_globals.swift
+++ b/test/SILGen/fragile_globals.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t %S/Inputs/ModuleA.swift
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t %S/Inputs/ModuleB.swift
-// RUN: %target-swift-frontend -parse-as-library -I%t %s -Xllvm -sil-disable-pass="SIL Global Optimization" -O -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -I%t %s -Xllvm -sil-disable-pass=GlobalOpt -O -emit-sil | %FileCheck %s
 
 import ModuleA
 import ModuleB

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass="Function Signature Optimization" -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s | %FileCheck %s
 // We want to check two things here:
 // - Correctness
 // - That certain "is" checks are eliminated based on static analysis at compile-time

--- a/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
+++ b/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -module-name devirt_single_module_in_multiple_files -O  %s %S/Inputs/BaseProblem.swift %S/Inputs/Problems.swift -parse-as-library -Xllvm -sil-disable-pass=Inlining -emit-sil 2>&1 | %FileCheck %s
+// RUN: %target-swiftc_driver -module-name devirt_single_module_in_multiple_files -O  %s %S/Inputs/BaseProblem.swift %S/Inputs/Problems.swift -parse-as-library -Xllvm -sil-disable-pass=inline -emit-sil 2>&1 | %FileCheck %s
 
 public func test() {
   let e = Evaluator()

--- a/test/SILOptimizer/globalopt_linkage.swift
+++ b/test/SILOptimizer/globalopt_linkage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -O -Xllvm -sil-disable-pass="Function Inlining" -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend  -O -Xllvm -sil-disable-pass=inline -emit-sil -primary-file %s | %FileCheck %s
 
 // Check if GlobalOpt generates the getters with the right linkage and the right mangling
 

--- a/test/SILOptimizer/pass_printer.swift
+++ b/test/SILOptimizer/pass_printer.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-after=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=AFTER %s
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=definite-init -Xllvm -sil-print-pass-name -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=DISABLE %s
 
-// BEFORE: SIL function before Guaranteed Passes Definite Initialization for Diagnostics (definite-init) (#1)
-// AFTER: SIL function after Guaranteed Passes Definite Initialization for Diagnostics (definite-init) (#1)
-// DISABLE: (Disabled) Stage: Guaranteed Passes Pass: Definite Initialization for Diagnostics (definite-init)
+// BEFORE: SIL function before #{{[0-9]+}}, stage Guaranteed Passes, pass {{[0-9]+}}: DefiniteInitialization (definite-init)
+// AFTER: SIL function after #{{[0-9]+}}, stage Guaranteed Passes, pass {{[0-9]+}}: DefiniteInitialization  (definite-init)
+// DISABLE: (Disabled) #{{[0-9]+}}, stage Guaranteed Passes, pass {{[0-9]+}}: DefiniteInitialization (definite-init)
 func foo() {}

--- a/test/SILOptimizer/spec_archetype_method.swift
+++ b/test/SILOptimizer/spec_archetype_method.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass="Function Signature Optimization" -disable-arc-opts -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -disable-arc-opts -emit-sil -primary-file %s | %FileCheck %s
 
 // We can't deserialize apply_inst with subst lists. When radar://14443304
 // is fixed then we should convert this test to a SIL test.

--- a/test/SILOptimizer/spec_conf1.swift
+++ b/test/SILOptimizer/spec_conf1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass="Function Signature Optimization" -disable-arc-opts -emit-sil -Xllvm -enable-destroyhoisting=false %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -disable-arc-opts -emit-sil -Xllvm -enable-destroyhoisting=false %s | %FileCheck %s
 
 // We can't deserialize apply_inst with subst lists. When radar://14443304
 // is fixed then we should convert this test to a SIL test.

--- a/test/SILOptimizer/spec_conf2.swift
+++ b/test/SILOptimizer/spec_conf2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass="Function Signature Optimization" -disable-arc-opts -emit-sil -Xllvm -enable-destroyhoisting=false %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -disable-arc-opts -emit-sil -Xllvm -enable-destroyhoisting=false %s | %FileCheck %s
 
 // We can't deserialize apply_inst with subst lists. When radar://14443304
 // is fixed then we should convert this test to a SIL test.

--- a/test/SILOptimizer/specialize_chain.swift
+++ b/test/SILOptimizer/specialize_chain.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -O -Xllvm -sil-disable-pass="Function Signature Optimization" -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend  -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil -primary-file %s | %FileCheck %s
 
 // We can't deserialize apply_inst with subst lists. When radar://14443304
 // is fixed then we should convert this test to a SIL test.

--- a/test/SILOptimizer/specialize_partial_apply.swift
+++ b/test/SILOptimizer/specialize_partial_apply.swift
@@ -1,9 +1,9 @@
 // First check the SIL.
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass="Function Signature Optimization" -module-name=test -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test -emit-sil -primary-file %s | %FileCheck %s
 
 // Also do an end-to-end test to check all components, including IRGen.
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -O -Xllvm -sil-disable-pass="Function Signature Optimization" -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 // REQUIRES: executable_test
 

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -Xllvm -sil-disable-pass="Function Signature Optimization" -emit-sil -o - -O %s | %FileCheck %s
+// RUN: %target-swift-frontend  -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil -o - -O %s | %FileCheck %s
 
 //////////////////
 // Declarations //

--- a/test/Serialization/class-roundtrip-module.swift
+++ b/test/Serialization/class-roundtrip-module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name def_class -o %t/stage1.swiftmodule %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t/def_class.swiftmodule %t/stage1.swiftmodule
-// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-disable-pass="External Definition To Declaration" -sil-debug-serialization -I %t %S/class.swift | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -emit-sil -sil-debug-serialization -I %t %S/class.swift | %FileCheck %s -check-prefix=SIL
 
 // SIL-LABEL: sil public_external [transparent] [serialized] @$SSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int

--- a/test/Serialization/class.swift
+++ b/test/Serialization/class.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-object -emit-module -o %t %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: llvm-bcanalyzer %t/def_class.swiftmodule | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-disable-pass="External Definition To Declaration" -sil-debug-serialization -I %t %s | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -emit-sil -sil-debug-serialization -I %t %s | %FileCheck %s -check-prefix=SIL
 // RUN: echo "import def_class; struct A : ClassProto {}" | not %target-swift-frontend -typecheck -I %t - 2>&1 | %FileCheck %s -check-prefix=CHECK-STRUCT
 
 // CHECK-NOT: UnknownCode

--- a/test/Serialization/transparent-std.swift
+++ b/test/Serialization/transparent-std.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t %S/Inputs/def_transparent_std.swift
 // RUN: llvm-bcanalyzer %t/def_transparent_std.swiftmodule | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -Xllvm -sil-disable-pass="External Definition To Declaration" -sil-debug-serialization -parse-stdlib -I %t %s | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -sil-debug-serialization -parse-stdlib -I %t %s | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 


### PR DESCRIPTION
* rename "Name" to "Description" in the pass definition, because it's not really the pass name, but the description of a pass
* remove the getName() from Transforms (which actually returned the description of a pass)
* in debug printing, print the pass ID and not the pass description. It makes it easier to correlate the debug output to the actual pass implementation.
* remove the iteration numbering in the pass manager, because we only run a single iteration anyway.
