### PR TITLE
IUO: Hoist the IUO disjunction creation to a better place.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2501,12 +2501,9 @@ namespace {
     Type
     createTypeVariableAndDisjunctionForIUOCoercion(Type toType,
                                                    ConstraintLocator *locator) {
-      auto implicitUnwrapLocator = CS.getConstraintLocator(
-          locator, ConstraintLocator::ImplicitlyUnwrappedValue);
-      auto typeVar =
-          CS.createTypeVariable(implicitUnwrapLocator, /*options=*/0);
+      auto typeVar = CS.createTypeVariable(locator, /*options=*/0);
       CS.buildDisjunctionForImplicitlyUnwrappedOptional(typeVar, toType,
-                                                        implicitUnwrapLocator);
+                                                        locator);
       return typeVar;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1521,49 +1521,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::matchTypesBindTypeVar(
     return SolutionKind::Solved;
   }
 
-  // If we're binding an optional type, or function type that has an
-  // optional result type, this may be the result of an IUO
-  // declaration. These are candidates for creating a disjunction.
-  bool isOptional = false;
-  if (type->getRValueType()->getAnyOptionalObjectType()) {
-    isOptional = true;
-  } else if (auto *fnTy = type->getAs<AnyFunctionType>()) {
-    auto resultTy = fnTy->getResult();
-    while (resultTy->is<AnyFunctionType>())
-      resultTy = resultTy->castTo<AnyFunctionType>()->getResult();
-
-    // FIXME: work-around the fact that doesStorageProduceLValue returns true
-    // for
-    //        #selector(getter: NSMenuItem.action)
-    resultTy = resultTy->getRValueType();
-
-    if (resultTy->getAnyOptionalObjectType()) {
-      isOptional = true;
-    }
-  }
-
-  if (isOptional) {
-    SmallVector<LocatorPathElt, 4> path;
-    locator.getLocatorParts(path);
-
-    // Find the last element that is either an indication we need to
-    // create a disjunction, or an indication that we already have.
-    auto last = std::find_if(
-        path.rbegin(), path.rend(), [](LocatorPathElt &elt) -> bool {
-          return elt.getKind() == ConstraintLocator::ImplicitlyUnwrappedValue ||
-                 elt.getKind() ==
-                     ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice;
-        });
-
-    // If we need to create a disjunction for this value, do so.
-    if (last != path.rend() &&
-        last->getKind() == ConstraintLocator::ImplicitlyUnwrappedValue) {
-      buildDisjunctionForImplicitlyUnwrappedOptional(
-          typeVar, type, getConstraintLocator(locator));
-      return SolutionKind::Solved;
-    }
-  }
-
   assignFixedType(typeVar, type);
 
   return SolutionKind::Solved;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -78,7 +78,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case KeyPathComponent:
     case ConditionalRequirement:
     case TypeParameterRequirement:
-    case ImplicitlyUnwrappedValue:
     case ImplicitlyUnwrappedDisjunctionChoice:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
@@ -249,10 +248,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case TypeParameterRequirement:
       out << "type parameter requirement #" << llvm::utostr(elt.getValue());
-      break;
-
-    case ImplicitlyUnwrappedValue:
-      out << "implictly unwrapped value";
       break;
 
     case ImplicitlyUnwrappedDisjunctionChoice:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -127,13 +127,7 @@ public:
     ConditionalRequirement,
     /// A single requirement placed on the type parameters.
     TypeParameterRequirement,
-    /// \brief For Optional types that can be implicitly unwrapped as
-    /// needed to successfully type check.
-    ImplicitlyUnwrappedValue,
-    /// \brief For the disjunction choices that result from when we
-    /// see ImplicitlyUnwrappedValue. This is used to avoid infinite
-    /// recursion where we would split those types out again into
-    /// another disjunction.
+    /// \brief Locator for a binding from an IUO disjunction choice.
     ImplicitlyUnwrappedDisjunctionChoice,
   };
 
@@ -167,7 +161,6 @@ public:
     case Requirement:
     case Witness:
     case OpenedGeneric:
-    case ImplicitlyUnwrappedValue:
     case ImplicitlyUnwrappedDisjunctionChoice:
       return 0;
 
@@ -231,7 +224,6 @@ public:
     case KeyPathComponent:
     case ConditionalRequirement:
     case TypeParameterRequirement:
-    case ImplicitlyUnwrappedValue:
     case ImplicitlyUnwrappedDisjunctionChoice:
       return 0;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1669,17 +1669,14 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
                                               openedFullType,
                                               refType};
 
-  // Update the locator if this is an implicitly unwrapped
-  // value. Processing the bind constraint will generate a new
-  // disjunction constraint that attempts the Optional and if that
-  // doesn't succeed, the underlying type.
   if (choice.isImplicitlyUnwrappedValueOrReturnValue()) {
-    locator = getConstraintLocator(locator,
-                                   ConstraintLocator::ImplicitlyUnwrappedValue);
+    // Build the disjunction to attempt binding both T? and T (or
+    // function returning T? and function returning T).
+    buildDisjunctionForImplicitlyUnwrappedOptional(boundType, refType, locator);
+  } else {
+    // Add the type binding constraint.
+    addConstraint(ConstraintKind::Bind, boundType, refType, locator);
   }
-
-  // Add the type binding constraint.
-  addConstraint(ConstraintKind::Bind, boundType, refType, locator);
 
   if (TC.getLangOpts().DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2365,8 +2365,9 @@ public:
   // it's underlying type. We'll make the choice of the Optional
   // preferred, and select that if the expression type-checks
   // appropriately with that type.
-  void buildDisjunctionForImplicitlyUnwrappedOptional(
-      TypeVariableType *tv, Type type, ConstraintLocator *locator) {
+  void
+  buildDisjunctionForImplicitlyUnwrappedOptional(Type boundTy, Type type,
+                                                 ConstraintLocator *locator) {
 
     // Get a locator based on the anchor expression so that it's easy to
     // regenerate the same locator for lookup when applying the results.
@@ -2376,8 +2377,8 @@ public:
 
     // Create the constraint to bind to the optional type and make it
     // the favored choice.
-    auto *bindToOptional = Constraint::create(*this, ConstraintKind::Bind, tv,
-                                              type, disjunctionLocator);
+    auto *bindToOptional = Constraint::create(
+        *this, ConstraintKind::Bind, boundTy, type, disjunctionLocator);
     bindToOptional->setFavored();
 
     Type underlyingType;
@@ -2393,8 +2394,9 @@ public:
       underlyingType = LValueType::get(underlyingType);
     assert(!type->is<InOutType>());
 
-    auto *bindToUnderlying = Constraint::create(
-        *this, ConstraintKind::Bind, tv, underlyingType, disjunctionLocator);
+    auto *bindToUnderlying =
+        Constraint::create(*this, ConstraintKind::Bind, boundTy, underlyingType,
+                           disjunctionLocator);
 
     llvm::SmallVector<Constraint *, 2> choices = {bindToOptional,
                                                   bindToUnderlying};


### PR DESCRIPTION
We should just create the disjunction straight-away in resolveOverload
rather than doing it deep inside type variable binding.
