### PR TITLE
[ConstraintSolver] Don't try to re-solve the constraint system to gather fixes

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -482,6 +482,28 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       kind = AllowedBindingKind::Exact;
     }
 
+    // If this is T := U? let's attempt both T := U and T := U?
+    if (kind == AllowedBindingKind::Subtypes &&
+        (constraint->getKind() == ConstraintKind::Conversion ||
+         constraint->getKind() == ConstraintKind::Subtype)) {
+      if (auto objTy = type->getOptionalObjectType()) {
+        // If T is a type variable, only attempt this if both the
+        // type variable we are trying bindings for, and the type
+        // variable we will attempt to bind, both have the same
+        // polarity with respect to being able to bind lvalues.
+        if (auto otherTypeVar = objTy->getAs<TypeVariableType>()) {
+          if (typeVar->getImpl().canBindToLValue() ==
+              otherTypeVar->getImpl().canBindToLValue()) {
+            alternateType = type;
+            type = objTy;
+          }
+        } else {
+          alternateType = type;
+          type = objTy;
+        }
+      }
+    }
+
     if (exactTypes.insert(type->getCanonicalType()).second)
       result.addPotentialBinding({type, kind, constraint->getKind()},
                                  /*allowJoinMeet=*/!adjustedIUO);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -739,26 +739,6 @@ bool ConstraintSystem::tryTypeVariableBindings(
                   {eltType, binding.Kind, binding.BindingSource});
           }
         }
-
-        // If we were unsuccessful solving for T?, try solving for T.
-        if (auto objTy = type->getOptionalObjectType()) {
-          if (exploredTypes.insert(objTy->getCanonicalType()).second) {
-            // If T is a type variable, only attempt this if both the
-            // type variable we are trying bindings for, and the type
-            // variable we will attempt to bind, both have the same
-            // polarity with respect to being able to bind lvalues.
-            if (auto otherTypeVar = objTy->getAs<TypeVariableType>()) {
-              if (typeVar->getImpl().canBindToLValue() ==
-                  otherTypeVar->getImpl().canBindToLValue()) {
-                newBindings.push_back(
-                    {objTy, binding.Kind, binding.BindingSource});
-              }
-            } else {
-              newBindings.push_back(
-                  {objTy, binding.Kind, binding.BindingSource});
-            }
-          }
-        }
       }
 
       if (binding.Kind != AllowedBindingKind::Supertypes)
@@ -1433,7 +1413,7 @@ bool ConstraintSystem::solve(Expr *const expr,
   // a single best solution to use, if not explicitly disabled
   // by constraint system options.
   if (!retainAllSolutions())
-    filterSolutions(solutions, state.ExprWeights);
+    filterSolutions(solutions, state.ExprWeights, /*minimize=*/true);
 
   // We fail if there is no solution.
   return solutions.empty();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1127,9 +1127,6 @@ private:
     /// \brief Depth of the solution stack.
     unsigned depth = 0;
 
-    /// \brief Whether to record failures or not.
-    bool recordFixes = false;
-
     /// \brief The set of type variable bindings that have changed while
     /// processing this constraint system.
     SavedTypeVariableBindings savedBindings;
@@ -1689,10 +1686,7 @@ public:
 
   /// \brief Whether we should attempt to fix problems.
   bool shouldAttemptFixes() {
-    if (!(Options & ConstraintSystemFlags::AllowFixes))
-      return false;
-
-    return !solverState || solverState->recordFixes;
+    return Options.contains(ConstraintSystemFlags::AllowFixes);
   }
 
   /// \brief Log and record the application of the fix. Return true iff any

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -11,7 +11,7 @@ func testNSArrayBridging(_ hive: Hive) {
 }
 
 func testNSDictionaryBridging(_ hive: Hive) {
-  _ = hive.beesByName as [String : Bee] // expected-error{{'[String : Bee]?' is not convertible to '[String : Bee]'; did you mean to use 'as!' to force downcast?}}
+  _ = hive.beesByName as [String : Bee] // expected-error{{value of optional type '[String : Bee]?' not unwrapped; did you mean to use '!' or '?'?}} {{22-22=!}}
 
   var dict1 = hive.anythingToBees
   let dict2: [AnyHashable : Bee] = dict1

--- a/test/ClangImporter/objc_failable_inits.swift
+++ b/test/ClangImporter/objc_failable_inits.swift
@@ -13,7 +13,7 @@ func testDictionary() {
 func testString() throws {
   // Optional
   let stringOpt = NSString(path: "blah", encoding: 0)
-  _ = stringOpt as NSString // expected-error{{'NSString?' is not convertible to 'NSString'; did you mean to use 'as!' to force downcast?}}
+  _ = stringOpt as NSString // expected-error{{value of optional type 'NSString?' not unwrapped; did you mean to use '!' or '?'?}} {{16-16=!}}
 
   // Implicitly unwrapped optional
   let stringIUO = NSString(path: "blah")

--- a/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -58,7 +58,11 @@ func bridgeNSNumberBackToSpecificType(object: ${ObjectType},
   _ = object as? ${Type}
   _ = object as! ${Type}
 
+  % if "Int" in Type or "Float" in Type or "Double" in Type:
   _ = optional as ${Type}? // expected-error{{use 'as!'}}
+  % else:
+  _ = optional as ${Type}? // expected-error{{cannot convert value of type '${ObjectType}?' to type '${Type}?' in coercion}}
+  % end
   _ = optional is ${Type}?
   _ = optional as? ${Type}?
   _ = optional as! ${Type}?

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -291,7 +291,7 @@ func rdar19836341(_ ns: NSString?, vns: NSString?) {
 
 // <rdar://problem/20029786> Swift compiler sometimes suggests changing "as!" to "as?!"
 func rdar20029786(_ ns: NSString?) {
-  var s: String = ns ?? "str" as String as String // expected-error{{cannot convert value of type 'NSString?' to expected argument type 'String?'}}
+  var s: String = ns ?? "str" as String as String // expected-error{{cannot convert value of type 'String' to expected argument type 'NSString'}}
   var s2 = ns ?? "str" as String as String // expected-error {{cannot convert value of type 'String' to expected argument type 'NSString'}}
 
   let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}

--- a/test/stdlib/StringCompatibilityDiagnostics3.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics3.swift
@@ -21,6 +21,6 @@ func testPopFirst() {
   dump(charSubView)
 
   var _ = String(str.utf8) ?? "" // expected-warning{{'init' is deprecated: Failable initializer was removed in Swift 4. When upgrading to Swift 4, please use non-failable String.init(_:UTF8View)}}
-  var _: String = String(str.utf8) // expected-error{{'init' is unavailable: Please use failable String.init?(_:UTF8View) when in Swift 3.2 mode}}
+  var _: String = String(str.utf8) // expected-error{{value of optional type 'String?' not unwrapped; did you mean to use '!' or '?'?}} {{35-35=!}}
 }
 

--- a/validation-test/compiler_crashers_fixed/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers_fixed/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 &_==nil

--- a/validation-test/compiler_crashers_fixed/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 [.a
 [Int?as?Int
 nil?


### PR DESCRIPTION
This allows the solver to run in "allow fixes" mode by default and
removes a re-typecheck before diagnostics.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
