### PR TITLE
Revert "IUO: Convert an explicit check for IUO to check for any optional."

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -392,12 +392,9 @@ ManagedValue Transform::transform(ManagedValue v,
     });
   }
 
-  // If the value is an optional, but the desired formal type isn't an
-  // optional, force it. We should only ever get here with values
-  // declared as implicitly unwrapped optionals because type checking
-  // should weed out cases involving plain optionals.
-  if (inputOTK != OTK_None && outputOTK == OTK_None) {
-    assert(inputOTK == OTK_ImplicitlyUnwrappedOptional);
+  // If the value is IUO, but the desired formal type isn't optional, force it.
+  if (inputOTK == OTK_ImplicitlyUnwrappedOptional
+      && outputOTK == OTK_None) {
     v = SGF.emitCheckedGetOptionalValueFrom(Loc, v,
                                             SGF.getTypeLowering(v.getType()),
                                             SGFContext());


### PR DESCRIPTION
Reverts apple/swift#13826

This appears to have broken a source compatibility test: https://ci.swift.org/job/swift-master-source-compat-suite/1053/