### PR TITLE
[Runtime] Search through protocols to resolve protocol declarations.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2586,7 +2586,8 @@ struct TargetProtocolRecord {
   /// The protocol referenced.
   ///
   /// The remaining low bit is reserved for future use.
-  RelativeIndirectablePointerIntPair<ProtocolDescriptor, /*reserved=*/bool>
+  RelativeIndirectablePointerIntPair<TargetProtocolDescriptor<Runtime>,
+                                     /*reserved=*/bool>
     Protocol;
 };
 using ProtocolRecord = TargetProtocolRecord<InProcess>;

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2580,6 +2580,17 @@ public:
 };
 using TypeMetadataRecord = TargetTypeMetadataRecord<InProcess>;
 
+/// The structure of a protocol reference record.
+template <typename Runtime>
+struct TargetProtocolRecord {
+  /// The protocol referenced.
+  ///
+  /// The remaining low bit is reserved for future use.
+  RelativeIndirectablePointerIntPair<ProtocolDescriptor, /*reserved=*/bool>
+    Protocol;
+};
+using ProtocolRecord = TargetProtocolRecord<InProcess>;
+
 /// The structure of a protocol conformance record.
 ///
 /// This contains enough static information to recover the witness table for a
@@ -3040,6 +3051,11 @@ inline constexpr unsigned swift_getFunctionPointerExtraInhabitantCount() {
 /// Return the type name for a given type metadata.
 std::string nameForMetadata(const Metadata *type,
                             bool qualified = true);
+
+/// Register a block of protocol records for dynamic lookup.
+SWIFT_RUNTIME_EXPORT
+void swift_registerProtocols(const ProtocolRecord *begin,
+                             const ProtocolRecord *end);
 
 /// Register a block of protocol conformance records for dynamic lookup.
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1202,6 +1202,14 @@ FUNCTION(Once, swift_once, DefaultCC,
          ARGS(OnceTy->getPointerTo(), Int8PtrTy, Int8PtrTy),
          ATTRS())
 
+// void swift_registerProtocols(const ProtocolRecord *begin,
+//                              const ProtocolRecord *end)
+FUNCTION(RegisterProtocols,
+         swift_registerProtocols, DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(ProtocolRecordPtrTy, ProtocolRecordPtrTy),
+         ATTRS(NoUnwind))
+
 // void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
 //                                         const ProtocolConformanceRecord *end)
 FUNCTION(RegisterProtocolConformances,

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -282,11 +282,11 @@ NodePointer Demangler::demangleSymbol(StringRef MangledName) {
   if (nextIf("_Tt"))
     return demangleObjCTypeName();
 
-  unsigned PrefixLength = getManglingPrefixLength(MangledName.data());
+  unsigned PrefixLength = getManglingPrefixLength(MangledName);
   if (PrefixLength == 0)
     return nullptr;
 
-  IsOldFunctionTypeMangling = isOldFunctionTypeMangling(MangledName.data());
+  IsOldFunctionTypeMangling = isOldFunctionTypeMangling(MangledName);
   Pos += PrefixLength;
 
   // If any other prefixes are accepted, please update Mangler::verify.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2345,7 +2345,7 @@ llvm::Constant *IRGenModule::emitSwiftProtocols() {
     sectionName = "__TEXT, __swift5_protos, regular, no_dead_strip";
     break;
   case llvm::Triple::ELF:
-    sectionName = "swift5_protos";
+    sectionName = "swift5_protocols";
     break;
   case llvm::Triple::COFF:
     sectionName = ".sw5prt$B";

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5521,6 +5521,9 @@ void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
   auto var = cast<llvm::GlobalVariable>(
           getAddrOfProtocolDescriptor(protocol, init.finishAndCreateFuture()));
   var->setConstant(true);
+
+  // Note that we emitted this protocol.
+  SwiftProtocols.push_back(protocol);
 }
 
 /// \brief Load a reference to the protocol descriptor for the given protocol.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -758,6 +758,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
     } else {
       // Emit protocol conformances into a section we can recognize at runtime.
       // In JIT mode these are manually registered above.
+      IGM.emitSwiftProtocols();
       IGM.emitProtocolConformances();
       IGM.emitTypeMetadataRecords();
       IGM.emitBuiltinReflectionMetadata();
@@ -939,7 +940,11 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
   // Okay, emit any definitions that we suddenly need.
   irgen.emitLazyDefinitions();
 
+  irgen.emitSwiftProtocols();
+
   irgen.emitProtocolConformances();
+
+  irgen.emitTypeMetadataRecords();
 
   irgen.emitReflectionMetadataVersion();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -147,6 +147,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   Int8Ty = llvm::Type::getInt8Ty(getLLVMContext());
   Int16Ty = llvm::Type::getInt16Ty(getLLVMContext());
   Int32Ty = llvm::Type::getInt32Ty(getLLVMContext());
+  Int32PtrTy = Int32Ty->getPointerTo();
   Int64Ty = llvm::Type::getInt64Ty(getLLVMContext());
   Int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
   Int8PtrPtrTy = Int8PtrTy->getPointerTo(0);
@@ -280,6 +281,12 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   OpaqueTy = llvm::StructType::create(LLVMContext, "swift.opaque");
   OpaquePtrTy = OpaqueTy->getPointerTo(DefaultAS);
+
+  ProtocolRecordTy =
+    createStructType(*this, "swift.protocolref", {
+      RelativeAddressTy
+    });
+  ProtocolRecordPtrTy = ProtocolRecordTy->getPointerTo();
 
   ProtocolConformanceRecordTy
     = createStructType(*this, "swift.protocol_conformance", {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -284,6 +284,10 @@ public:
   /// they are externally visible.
   void emitGlobalTopLevel();
 
+  /// Emit references to each of the protocol descriptors defined in this
+  /// IR module.
+  void emitSwiftProtocols();
+
   /// Emit the protocol conformance records needed by each IR module.
   void emitProtocolConformances();
 
@@ -431,6 +435,10 @@ public:
     llvm::IntegerType *Int32Ty;          /// i32
     llvm::IntegerType *RelativeAddressTy;
   };
+  union {
+    llvm::PointerType *Int32PtrTy;            /// i32 *
+    llvm::PointerType *RelativeAddressPtrTy;
+  };
   llvm::IntegerType *Int64Ty;          /// i64
   union {
     llvm::IntegerType *SizeTy;         /// usually i32 or i64
@@ -486,6 +494,8 @@ public:
   llvm::PointerType *ObjCSuperPtrTy;   /// %objc_super*
   llvm::StructType *ObjCBlockStructTy; /// %objc_block
   llvm::PointerType *ObjCBlockPtrTy;   /// %objc_block*
+  llvm::StructType *ProtocolRecordTy;
+  llvm::PointerType *ProtocolRecordPtrTy;
   llvm::StructType *ProtocolConformanceRecordTy;
   llvm::PointerType *ProtocolConformanceRecordPtrTy;
   llvm::StructType *NominalTypeDescriptorTy;
@@ -717,6 +727,7 @@ public:
   void addLazyFieldTypeAccessor(NominalTypeDecl *type,
                                 ArrayRef<FieldTypeInfo> fieldTypes,
                                 llvm::Function *fn);
+  llvm::Constant *emitSwiftProtocols();
   llvm::Constant *emitProtocolConformances();
   llvm::Constant *emitTypeMetadataRecords();
 
@@ -824,6 +835,8 @@ private:
   SmallVector<llvm::WeakTrackingVH, 4> ObjCNonLazyClasses;
   /// List of Objective-C categories, bitcast to i8*.
   SmallVector<llvm::WeakTrackingVH, 4> ObjCCategories;
+  /// List of non-ObjC protocols described by this module.
+  SmallVector<ProtocolDecl *, 4> SwiftProtocols;
   /// List of protocol conformances to generate records for.
   SmallVector<NormalProtocolConformance *, 4> ProtocolConformances;
   /// List of nominal types to generate type metadata records for.

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -34,6 +34,9 @@ struct SymbolInfo {
   void *symbolAddress;
 };
 
+/// Load the metadata from the image necessary to find protocols by name.
+void initializeProtocolLookup();
+
 /// Load the metadata from the image necessary to find a type's
 /// protocol conformance.
 void initializeProtocolConformanceLookup();
@@ -42,7 +45,7 @@ void initializeProtocolConformanceLookup();
 void initializeTypeMetadataRecordLookup();
 
 // Callbacks to register metadata from an image to the runtime.
-
+  void addImageProtocolsBlockCallback(const void *start, uintptr_t size);
 void addImageProtocolConformanceBlockCallback(const void *start,
                                               uintptr_t size);
 void addImageTypeMetadataRecordBlockCallback(const void *start,

--- a/stdlib/public/runtime/ImageInspectionCOFF.h
+++ b/stdlib/public/runtime/ImageInspectionCOFF.h
@@ -45,6 +45,7 @@ struct MetadataSections {
     size_t length;
   };
 
+  Range swift5_protocols;
   Range swift5_protocol_conformances;
   Range swift5_type_metadata;
   Range swift3_typeref;

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -42,6 +42,20 @@ void record(const swift::MetadataSections *sections) {
 }
 }
 
+void swift::initializeProtocolLookup() {
+  const swift::MetadataSections *sections = registered;
+  while (true) {
+    const swift::MetadataSections::Range &protocols =
+        sections->swift5_protocols;
+    if (protocols.length)
+      addImageProtocolsBlockCallback(reinterpret_cast<void *>(protocols.start),
+                                     protocols.length);
+
+    if (sections->next == registered)
+      break;
+    sections = sections->next;
+  }
+}
 void swift::initializeProtocolConformanceLookup() {
   const swift::MetadataSections *sections = registered;
   while (true) {
@@ -82,6 +96,12 @@ void swift_addNewDSOImage(const void *addr) {
       static_cast<const swift::MetadataSections *>(addr);
 
   record(sections);
+
+  const auto &protocols_section = sections->swift5_protocol_conformances;
+  const void *protocols =
+      reinterpret_cast<void *>(protocols_section.start);
+  if (protocols_section.length)
+    addImageProtocolsBlockCallback(protocols, protocols_section.length);
 
   const auto &protocol_conformances = sections->swift5_protocol_conformances;
   const void *conformances =

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -45,6 +45,7 @@ struct MetadataSections {
     size_t length;
   };
 
+  Range swift5_protocols;
   Range swift5_protocol_conformances;
   Range swift5_type_metadata;
   Range swift3_typeref;

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -29,6 +29,9 @@
 using namespace swift;
 
 namespace {
+/// The Mach-O section name for the section containing protocol descriptor
+/// references. This lives within SEG_TEXT.
+constexpr const char ProtocolsSection[] = "__swift5_protos";
 /// The Mach-O section name for the section containing protocol conformances.
 /// This lives within SEG_TEXT.
 constexpr const char ProtocolConformancesSection[] = "__swift5_proto";
@@ -60,6 +63,12 @@ void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
 }
 
 } // end anonymous namespace
+
+void swift::initializeProtocolLookup() {
+  _dyld_register_func_for_add_image(
+    addImageCallback<ProtocolsSection,
+                     addImageProtocolsBlockCallback>);
+}
 
 void swift::initializeProtocolConformanceLookup() {
   _dyld_register_func_for_add_image(

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -39,6 +39,7 @@ using namespace Demangle;
 #include <objc/objc.h>
 #endif
 
+#pragma mark Nominal type descriptor cache
 // Type Metadata Cache.
 
 namespace {
@@ -170,6 +171,14 @@ _findNominalTypeDescriptor(llvm::StringRef mangledName) {
   }
 
   return foundNominal;
+}
+
+
+#pragma mark Protocol descriptor cache
+
+void swift::swift_registerProtocols(const ProtocolRecord *begin,
+                                    const ProtocolRecord *end) {
+  // FIXME: Implement.
 }
 
 #pragma mark Metadata lookup via mangled name

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -24,6 +24,7 @@
   __attribute__((__visibility__("hidden"))) extern const char __stop_##name;
 
 extern "C" {
+DECLARE_SWIFT_SECTION(swift5_protocols)
 DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
 DECLARE_SWIFT_SECTION(swift5_type_metadata)
 
@@ -52,6 +53,7 @@ static void swift_image_constructor() {
       nullptr,
       nullptr,
 
+      SWIFT_SECTION_RANGE(swift5_protocols),
       SWIFT_SECTION_RANGE(swift5_protocol_conformances),
       SWIFT_SECTION_RANGE(swift5_type_metadata),
 

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -7,6 +7,13 @@ public protocol Runcible {
   func runce()
 }
 
+// CHECK-LABEL: @"\01l_protocols" = private constant [
+
+// CHECK: %swift.protocolref {
+// CHECK-SAME: @"$S28protocol_conformance_records8RuncibleMp"
+// CHECK-SAME: %swift.protocolref {
+// CHECK-SAME: @"$S28protocol_conformance_records5SpoonMp"
+
 // CHECK-LABEL: @"\01l_protocol_conformances" = private constant [
 
 // CHECK:         %swift.protocol_conformance {

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -78,12 +78,23 @@ DemangleToMetadataTests.test("metatype types") {
 
 func f2_any_anyobject(_: Any, _: AnyObject) { }
 
+class C { }
+
+protocol P1 { }
+protocol P2 { }
+
+func f1_composition(_: P1 & P2) { }
+func f1_composition_superclass(_: C & P1 & P2) { }
+
 DemangleToMetadataTests.test("existential types") {
   // Any, AnyObject
   expectEqual(type(of: f2_any_anyobject), _typeByMangledName("yyyp_yXltc")!)
 
-  // FIXME: References to protocols.
-  // FIXME: References to superclass.
+  // References to protocols.
+  expectEqual(type(of: f1_composition), _typeByMangledName("yy4main2P1_4main2P2pc")!)
+
+  // References to superclass.
+  expectEqual(type(of: f1_composition_superclass), _typeByMangledName("yy4main2P1_4main2P2AA1CCXcc")!)
 }
 
 DemangleToMetadataTests.test("existential metatype types") {
@@ -92,6 +103,12 @@ DemangleToMetadataTests.test("existential metatype types") {
 
   // AnyObject
   expectEqual(type(of: AnyObject.self), _typeByMangledName("yXlm")!)
+
+  // References to metatype of protocols.
+  expectEqual(type(of: (P1 & P2).self), _typeByMangledName("4main2P1_4main2P2pm")!)
+
+  // References to metatype involving protocols and superclass.
+  expectEqual(type(of: (C & P1 & P2).self), _typeByMangledName("4main2P1_4main2P2AA1CCXcm")!)
 }
 
 struct S {
@@ -99,8 +116,6 @@ struct S {
 }
 
 enum E { case e }
-
-class C { }
 
 DemangleToMetadataTests.test("nominal types") {
   // Simple Struct

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -84,6 +84,7 @@ protocol P1 { }
 protocol P2 { }
 
 func f1_composition(_: P1 & P2) { }
+func f1_composition_anyobject(_: AnyObject & P1) { }
 func f1_composition_superclass(_: C & P1 & P2) { }
 
 DemangleToMetadataTests.test("existential types") {
@@ -92,6 +93,9 @@ DemangleToMetadataTests.test("existential types") {
 
   // References to protocols.
   expectEqual(type(of: f1_composition), _typeByMangledName("yy4main2P1_4main2P2pc")!)
+
+  // Reference to protocol with AnyObject.
+  expectEqual(type(of: f1_composition_anyobject), _typeByMangledName("yy4main2P1_Xlc")!)
 
   // References to superclass.
   expectEqual(type(of: f1_composition_superclass), _typeByMangledName("yy4main2P1_4main2P2AA1CCXcc")!)


### PR DESCRIPTION
Introduce a new section containing protocol descriptor references, and use this section to allow us to find protocol descriptors by mangled name. Use this functionality to fully support protocol composition types within `_typeForMangledName`.