### PR TITLE
Cherry-pick fix for rdar://36392957 4.1

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -385,7 +385,7 @@ struct StructLoweringState {
   SmallVector<SILInstruction *, 16> destroyValueInstsToMod;
   // All debug instructions.
   // to be modified *only if* the operands are used in "real" instructions
-  SmallVector<SILInstruction *, 16> debugInstsToMod;
+  SmallVector<DebugValueInst *, 16> debugInstsToMod;
 
   StructLoweringState(SILFunction *F, irgen::IRGenModule &Mod)
       : F(F), Mod(Mod) {}
@@ -1860,7 +1860,7 @@ static void rewriteFunction(StructLoweringState &pass,
     instr->getParent()->erase(instr);
   }
 
-  for (SILInstruction *instr : pass.debugInstsToMod) {
+  for (DebugValueInst *instr : pass.debugInstsToMod) {
     assert(instr->getAllOperands().size() == 1 &&
            "Debug instructions have one operand");
     for (Operand &operand : instr->getAllOperands()) {
@@ -1875,7 +1875,8 @@ static void rewriteFunction(StructLoweringState &pass,
         assert(currOperand->getType().isAddress() &&
                "Expected an address type");
         SILBuilderWithScope debugBuilder(instr);
-        debugBuilder.createDebugValueAddr(instr->getLoc(), currOperand);
+        debugBuilder.createDebugValueAddr(instr->getLoc(), currOperand,
+                                          instr->getVarInfo());
         instr->getParent()->erase(instr);
       }
     }

--- a/test/DebugInfo/LoadableByAddress-argument.swift
+++ b/test/DebugInfo/LoadableByAddress-argument.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+public struct Large {
+  let field1 : Int64 = 1
+  let field2 : Int64 = 2
+  let field3 : Int64 = 3
+  let field4 : Int64 = 4
+  let field5 : Int64 = 5
+  let field6 : Int64 = 6
+  let field7 : Int64 = 7
+  let field8 : Int64 = 8
+}
+
+// CHECK: !DILocalVariable(name: "largeArg", arg: 1
+public func f(_ largeArg : Large) {}


### PR DESCRIPTION
	• Explanation:  This fixes a bug in the LoadableByAddress transformation that causes it to drop the SILDebugVariable info when rewriting DebugValueInstrs.
	• Scope of Issue:  All Swift programs that use "large" structs in function arguments.
	• Origination: Introduced together with the LoadableByAddress transformation
	• Risk: None
	• Nominated Reviewers: @shajrawi 
	• Testing: regression test
	• Bug: rdar://36392957