### PR TITLE
[test] Re-enable tests that started XPASSing on resilience bot

### DIFF
--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME: https://bugs.swift.org/browse/SR-2808
-// XFAIL: resilient_stdlib
-
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME: https://bugs.swift.org/browse/SR-2808
-// XFAIL: resilient_stdlib
-
 import SwiftReflectionTest
 import Foundation
 


### PR DESCRIPTION
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-macos-resilience/164/

XPASS: validation-test/Reflection/reflect_Character.swift
XPASS: validation-test/Reflection/reflect_multiple_types.swift
