### PR TITLE
Outliner: Can't handle generic ObjC classes

### DIFF
--- a/test/SILOptimizer/Inputs/Outliner.h
+++ b/test/SILOptimizer/Inputs/Outliner.h
@@ -14,4 +14,11 @@
 - (NSString*) doSomething;
 @end
 
+@protocol FooProto <NSObject>
+@end
 
+@protocol SomeGenericClass <FooProto>
+@property (nonatomic, nullable, readonly, strong) NSString *version;
+- (NSString*) doSomething;
+- (id) doSomething2 : (NSArray<NSString*>*) arr;
+@end

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -140,3 +140,17 @@ public func dontCrash<T: Proto>(x : Gizmo2<T>) {
   print(s)
 
 }
+
+public func dontCrash2(_ c: SomeGenericClass) -> Bool {
+  guard let str = c.version else {
+      return false
+  }
+  guard let str2 = c.doSomething() else {
+      return false
+  }
+
+  let arr = [ "foo", "bar"]
+  c.doSomething2(arr)
+
+  return true
+}


### PR DESCRIPTION
The outliner can't handle outlining calls to generic objective c
classes resulting in crashes if it attempted so.

rdar://36395452
