### PR TITLE
swift-ide-test: Correctly infer -enable-objc-interop from a target

### DIFF
--- a/test/IDE/enable_objc_interop.swift
+++ b/test/IDE/enable_objc_interop.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -source-filename %s -annotate 2>&1 >/dev/null | %FileCheck %s -check-prefix=CHECK-%target-runtime
+
+#if _runtime(_ObjC)
+foo
+// CHECK-objc: unresolved identifier 'foo'
+// CHECK-objc-NOT: unresolved identifier 'bar'
+// CHECK-objc-NOT: unresolved identifier 'baz'
+
+#elseif _runtime(_Native)
+bar
+// CHECK-native-NOT: unresolved identifier 'foo'
+// CHECK-native: unresolved identifier 'bar'
+// CHECK-native-NOT: unresolved identifier 'baz'
+
+#else
+baz
+#endif

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3007,6 +3007,14 @@ int main(int argc, char *argv[]) {
 
   InitInvok.setSDKPath(options::SDK);
   InitInvok.getLangOptions().KeepSyntaxInfoInSourceFile = true;
+  if (options::DisableObjCInterop) {
+    InitInvok.getLangOptions().EnableObjCInterop = false;
+  } else if (options::EnableObjCInterop) {
+    InitInvok.getLangOptions().EnableObjCInterop = true;
+  } else if (!options::Triple.empty()) {
+    InitInvok.getLangOptions().EnableObjCInterop =
+        llvm::Triple(options::Triple).isOSDarwin();
+  }
   if (!options::Triple.empty())
     InitInvok.setTargetTriple(options::Triple);
   if (!options::SwiftVersion.empty()) {
@@ -3019,14 +3027,6 @@ int main(int argc, char *argv[]) {
       if (auto actual = swiftVersion.getValue().getEffectiveLanguageVersion())
         InitInvok.getLangOptions().EffectiveLanguageVersion = actual.getValue();
     }
-  }
-  if (options::DisableObjCInterop) {
-    InitInvok.getLangOptions().EnableObjCInterop = false;
-  } else if (options::EnableObjCInterop) {
-    InitInvok.getLangOptions().EnableObjCInterop = true;
-  } else {
-    InitInvok.getLangOptions().EnableObjCInterop =
-        llvm::Triple(InitInvok.getTargetTriple()).isOSDarwin();
   }
   InitInvok.getClangImporterOptions().ModuleCachePath =
     options::ModuleCachePath;


### PR DESCRIPTION
Note that this *still* isn't correct when there *isn't* an explicit target, because LangOptions doesn't set up platform conditions when no target is explicitly set. But it's a step forward.

(Sorry I didn't catch this the first time around, @fjricci.)