### PR TITLE
[DefiniteInitialization] Preserve DebugInfo correctly.

### DIFF
--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend -primary-file %s -Onone -emit-sil -Xllvm \
+// RUN:   -sil-print-after=definite-init -Xllvm \
+// RUN:   -sil-print-only-functions=$S3del1MC4fromAcA12WithDelegate_p_tKcfc \
+// RUN:   -Xllvm -sil-print-debuginfo -o /dev/null 2>&1 | %FileCheck %s
+
+public protocol DelegateA {}
+public protocol DelegateB {}
+public protocol WithDelegate
+{
+    var delegate: DelegateA? { get }
+    func f() throws -> Int
+}
+public enum Err: Swift.Error {
+    case s(Int)
+}
+public class C {}
+public class M {
+    let field: C
+    var value : Int
+    public init(from d: WithDelegate) throws {
+        guard let delegate = d.delegate as? DelegateB
+        else { throw Err.s(0) }
+        self.field = C()
+        let i: Int = try d.f()
+        value = i
+    }
+}
+
+// Make sure the expanded sequence gets the right scope.
+
+// CHECK:   %49 = begin_access [modify] [dynamic] %48 : $*C, loc{{.*}}:23:20, scope 2
+// CHECK:   %50 = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 2
+// CHECK:   %51 = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 2
+// CHECK:   %52 = builtin "or_Int2"(%51 : $Builtin.Int2, %50 : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 2
+// CHECK:   store %52 to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 2
+// CHECK:   store %47 to [init] %49 : $*C, loc {{.*}}:23:20, scope 2
+// CHECK:   end_access %49 : $*C, loc {{.*}}:23:20, scope 2
+
+// Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
+
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 2
+// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 2
+// CHECK:   throw %92 : $Error, loc {{.*}}:20:12, scope 2


### PR DESCRIPTION
The scope was set incorrectly. Fixes SR-6722.

<rdar://problem/36414649>