### PR TITLE
[Demangle] Add back isSwiftSymbol() entry point for null-terminated strings

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -235,6 +235,11 @@ inline bool isMangledName(llvm::StringRef mangledName) {
 /// This includes the old (<= swift 3.x) mangling prefix "_T".
 bool isSwiftSymbol(llvm::StringRef mangledName);
 
+/// Returns true if the mangledName starts with the swift mangling prefix.
+///
+/// This includes the old (<= swift 3.x) mangling prefix "_T".
+bool isSwiftSymbol(const char *mangledName);
+
 /// Drops the Swift mangling prefix from the given mangled name, if there is
 /// one.
 ///

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -139,6 +139,11 @@ bool swift::Demangle::isSwiftSymbol(llvm::StringRef mangledName) {
   return getManglingPrefixLength(mangledName) != 0;
 }
 
+bool swift::Demangle::isSwiftSymbol(const char *mangledName) {
+  StringRef mangledNameRef(mangledName, 4);
+  return isSwiftSymbol(mangledNameRef);
+}
+
 bool swift::Demangle::isOldFunctionTypeMangling(llvm::StringRef mangledName) {
   return mangledName.size() >= 2 && mangledName[0] == '_' &&
       mangledName[1] == 'T';


### PR DESCRIPTION
This particular API can be safely used with a null-terminated string,
and is used by some clients (e.g., LLDB), so add back a "const char *"
variant that safely accesses a null-terminated string.
