### PR TITLE
[Runtime] Support mangled name -> metadata for @objc protocols and classes

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2145,7 +2145,7 @@ struct TargetProtocolDescriptor {
   
   /// The list of protocols this protocol refines.
   ConstTargetMetadataPointer<Runtime, TargetProtocolDescriptorList>
-  InheritedProtocols;
+    InheritedProtocols;
   
   /// Unused by the Swift runtime.
   TargetPointer<Runtime, const void>

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -26,6 +26,10 @@ DemangleToMetadataTests.test("@objc protocols") {
               _typeByMangledName("yy4main2P1_pc")!)
 }
 
+DemangleToMetadataTests.test("Objective-C classes") {
+  expectEqual(type(of: NSObject()), _typeByMangledName("So8NSObjectC")!)
+}
+
 func f1_composition_NSCoding(_: NSCoding) { }
 
 DemangleToMetadataTests.test("Objective-C protocols") {

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+let DemangleToMetadataTests = TestSuite("DemangleToMetadataObjC")
+
+@objc class C : NSObject { }
+@objc enum E: Int { case a }
+@objc protocol P1 { }
+
+DemangleToMetadataTests.test("@objc classes") {
+  expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
+}
+
+DemangleToMetadataTests.test("@objc enums") {
+  expectEqual(type(of: E.a), _typeByMangledName("4main1EO")!)
+}
+
+func f1_composition_objc_protocol(_: P1) { }
+
+DemangleToMetadataTests.test("@objc protocols") {
+  expectEqual(type(of: f1_composition_objc_protocol),
+              _typeByMangledName("yy4main2P1_pc")!)
+}
+
+runAllTests()
+

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -26,5 +26,11 @@ DemangleToMetadataTests.test("@objc protocols") {
               _typeByMangledName("yy4main2P1_pc")!)
 }
 
+func f1_composition_NSCoding(_: NSCoding) { }
+
+DemangleToMetadataTests.test("Objective-C protocols") {
+  expectEqual(type(of: f1_composition_NSCoding), _typeByMangledName("yySo8NSCoding_pc")!)
+}
+
 runAllTests()
 


### PR DESCRIPTION
Introduce support for mapping from the mangled names of `@objc` protocols and classes (whether defined in Swift or an Objective-C) to type metadata.