### PR TITLE
Field offset symbols of resilient classes have hidden linkage

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -90,9 +90,6 @@ class LinkEntity {
     // This field appears in the ValueWitness kind.
     ValueWitnessShift = 8, ValueWitnessMask = 0xFF00,
 
-    // These fields appear in the FieldOffset kind.
-    IsIndirectShift = 8, IsIndirectMask = 0x0100,
-
     // These fields appear in the TypeMetadata kind.
     MetadataAddressShift = 8, MetadataAddressMask = 0x0300,
     IsPatternShift = 10, IsPatternMask = 0x0400,
@@ -395,12 +392,9 @@ public:
     return entity;
   }
 
-  static LinkEntity forFieldOffset(VarDecl *decl, bool isIndirect) {
+  static LinkEntity forFieldOffset(VarDecl *decl) {
     LinkEntity entity;
-    entity.Pointer = decl;
-    entity.SecondaryPointer = nullptr;
-    entity.Data = LINKENTITY_SET_FIELD(Kind, unsigned(Kind::FieldOffset))
-                | LINKENTITY_SET_FIELD(IsIndirect, unsigned(isIndirect));
+    entity.setForDecl(Kind::FieldOffset, decl);
     return entity;
   }
 
@@ -669,11 +663,6 @@ public:
   }
   bool isForeignTypeMetadataCandidate() const {
     return getKind() == Kind::ForeignTypeMetadataCandidate;
-  }
-
-  bool isOffsetIndirect() const {
-    assert(getKind() == Kind::FieldOffset);
-    return LINKENTITY_GET_FIELD(Data, IsIndirect);
   }
 
   /// Determine whether this entity will be weak-imported.

--- a/include/swift/SIL/FormalLinkage.h
+++ b/include/swift/SIL/FormalLinkage.h
@@ -24,8 +24,6 @@ enum ForDefinition_t : bool;
 /// Formal linkage is a property of types and declarations that
 /// informs, but is not completely equivalent to, the linkage of
 /// symbols corresponding to those types and declarations.
-///
-/// Forms a semilattice with ^ as the meet operator.
 enum class FormalLinkage {
   /// This entity is visible in multiple Swift modules and has a
   /// unique file that is known to define it.
@@ -43,10 +41,8 @@ enum class FormalLinkage {
   /// have a unique file that is known to define it.
   HiddenNonUnique,
 
-  /// This entity is visible in only a single Swift file.
-  //
-  // In reality, these are by definition unique, but we use the
-  // non-unique flag to make merging more efficient.
+  /// This entity is visible in only a single Swift file. These are by
+  /// definition unique.
   Private,
 };
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -534,7 +534,6 @@ irgen::tryEmitConstantClassFragilePhysicalMemberOffset(IRGenModule &IGM,
   }
   case FieldAccess::NonConstantDirect:
   case FieldAccess::ConstantIndirect:
-  case FieldAccess::NonConstantIndirect:
     return nullptr;
   }
 }
@@ -591,8 +590,7 @@ OwnedAddress irgen::projectPhysicalClassMemberAddress(IRGenFunction &IGF,
   }
     
   case FieldAccess::NonConstantDirect: {
-    Address offsetA = IGF.IGM.getAddrOfFieldOffset(field, /*indirect*/ false,
-                                                   NotForDefinition);
+    Address offsetA = IGF.IGM.getAddrOfFieldOffset(field, NotForDefinition);
     auto offsetVar = cast<llvm::GlobalVariable>(offsetA.getAddress());
     offsetVar->setConstant(false);
     auto offset = IGF.Builder.CreateLoad(offsetA, "offset");
@@ -602,22 +600,6 @@ OwnedAddress irgen::projectPhysicalClassMemberAddress(IRGenFunction &IGF,
   case FieldAccess::ConstantIndirect: {
     auto metadata = emitHeapMetadataRefForHeapObject(IGF, base, baseType);
     auto offset = emitClassFieldOffset(IGF, baseClass, field, metadata);
-    return emitAddressAtOffset(IGF, baseType, base, offset, field);
-  }
-    
-  case FieldAccess::NonConstantIndirect: {
-    auto metadata = emitHeapMetadataRefForHeapObject(IGF, base, baseType);
-    Address indirectOffsetA =
-      IGF.IGM.getAddrOfFieldOffset(field, /*indirect*/ true,
-                                   NotForDefinition);
-    auto offsetVar = cast<llvm::GlobalVariable>(indirectOffsetA.getAddress());
-    offsetVar->setConstant(false);
-    auto indirectOffset =
-      IGF.Builder.CreateLoad(indirectOffsetA, "indirect-offset");
-    auto offsetA =
-      IGF.emitByteOffsetGEP(metadata, indirectOffset, IGF.IGM.SizeTy);
-    auto offset =
-      IGF.Builder.CreateLoad(Address(offsetA, IGF.IGM.getPointerAlignment()));
     return emitAddressAtOffset(IGF, baseType, base, offset, field);
   }
   }
@@ -641,7 +623,7 @@ irgen::getPhysicalClassMemberAccessStrategy(IRGenModule &IGM,
 
   case FieldAccess::NonConstantDirect: {
     std::string symbol =
-      LinkEntity::forFieldOffset(field, /*indirect*/ false).mangleAsString();
+      LinkEntity::forFieldOffset(field).mangleAsString();
     return MemberAccessStrategy::getDirectGlobal(std::move(symbol),
                                  MemberAccessStrategy::OffsetKind::Bytes_Word);
   }
@@ -649,14 +631,6 @@ irgen::getPhysicalClassMemberAccessStrategy(IRGenModule &IGM,
   case FieldAccess::ConstantIndirect: {
     Size indirectOffset = getClassFieldOffsetOffset(IGM, baseClass, field);
     return MemberAccessStrategy::getIndirectFixed(indirectOffset,
-                                 MemberAccessStrategy::OffsetKind::Bytes_Word);
-  }
-
-  case FieldAccess::NonConstantIndirect: {
-    std::string symbol =
-      LinkEntity::forFieldOffset(field, /*indirect*/ true).mangleAsString();
-    return MemberAccessStrategy::getIndirectGlobal(std::move(symbol),
-                                 MemberAccessStrategy::OffsetKind::Bytes_Word,
                                  MemberAccessStrategy::OffsetKind::Bytes_Word);
   }
   }
@@ -1820,13 +1794,11 @@ namespace {
         // If the field offset is fixed relative to the start of the superclass,
         // reference the global from the ivar metadata so that the Objective-C
         // runtime will slide it down.
-        auto offsetAddr = IGM.getAddrOfFieldOffset(ivar, /*indirect*/ false,
-                                                   NotForDefinition);
+        auto offsetAddr = IGM.getAddrOfFieldOffset(ivar, NotForDefinition);
         offsetPtr = cast<llvm::Constant>(offsetAddr.getAddress());
         break;
       }
       case FieldAccess::ConstantIndirect:
-      case FieldAccess::NonConstantIndirect:
         // Otherwise, swift_initClassMetadata_UniversalStrategy() will point
         // the Objective-C runtime into the field offset vector of the
         // instantiated metadata.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3023,9 +3023,9 @@ static Address getAddrOfSimpleVariable(IRGenModule &IGM,
 /// object (if indirect).
 ///
 /// The result is always a GlobalValue.
-Address IRGenModule::getAddrOfFieldOffset(VarDecl *var, bool isIndirect,
+Address IRGenModule::getAddrOfFieldOffset(VarDecl *var,
                                           ForDefinition_t forDefinition) {
-  LinkEntity entity = LinkEntity::forFieldOffset(var, isIndirect);
+  LinkEntity entity = LinkEntity::forFieldOffset(var);
   return getAddrOfSimpleVariable(*this, GlobalVars, entity,
                                  SizeTy, getPointerAlignment(),
                                  forDefinition);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1301,10 +1301,27 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::CoroutineContinuationPrototype:
     return SILLinkage::PublicExternal;
 
+  case Kind::FieldOffset: {
+    auto *varDecl = cast<VarDecl>(getDecl());
+
+    auto linkage = getDeclLinkage(varDecl);
+
+    // Resilient classes don't expose field offset symbols.
+    if (!cast<ClassDecl>(varDecl->getDeclContext())->hasFixedLayout()) {
+      assert(linkage != FormalLinkage::PublicNonUnique &&
+             linkage != FormalLinkage::HiddenNonUnique &&
+            "Cannot have a resilient class with non-unique linkage");
+
+      if (linkage == FormalLinkage::PublicUnique)
+        linkage = FormalLinkage::HiddenUnique;
+    }
+
+    return getSILLinkage(linkage, forDefinition);
+  }
+
   case Kind::ObjCClass:
   case Kind::ObjCMetaclass:
   case Kind::SwiftMetaclassStub:
-  case Kind::FieldOffset:
   case Kind::NominalTypeDescriptor:
   case Kind::ClassMetadataBaseOffset:
   case Kind::ProtocolDescriptor:

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -838,8 +838,7 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
             KeyPathComponentHeader::forClassComponentWithUnresolvedIndirectOffset();
           fields.addInt32(header.getData());
           fields.addAlignmentPadding(getPointerAlignment());
-          auto offsetVar = getAddrOfFieldOffset(property, /*indirect*/ false,
-                                                NotForDefinition);
+          auto offsetVar = getAddrOfFieldOffset(property, NotForDefinition);
           fields.add(cast<llvm::Constant>(offsetVar.getAddress()));
           break;
         }
@@ -855,11 +854,6 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
           fields.addInt32(fieldOffset.getValue());
           break;
         }
-        case FieldAccess::NonConstantIndirect:
-          // An offset that depends on the instance's generic parameterization,
-          // whose vtable offset is also unknown.
-          // TODO: This doesn't happen until class resilience is enabled.
-          llvm_unreachable("not implemented");
         }
         break;
       }
@@ -954,8 +948,6 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
               getClassFieldIndex(*this,
                            SILType::getPrimitiveAddressType(baseTy), property));
             break;
-          case FieldAccess::NonConstantIndirect:
-            llvm_unreachable("not implemented");
           }
           
         } else {

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -74,10 +74,10 @@ public:
     return finalize();
   }
 
-  std::string mangleFieldOffsetFull(const ValueDecl *Decl, bool isIndirect) {
+  std::string mangleFieldOffset(const ValueDecl *Decl) {
     beginMangling();
     appendEntity(Decl);
-    appendOperator("Wv", isIndirect ? "i" : "d");
+    appendOperator("Wvd");
     return finalize();
   }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1051,8 +1051,7 @@ public:
 
   llvm::Function *emitDispatchThunk(SILDeclRef declRef);
 
-  Address getAddrOfFieldOffset(VarDecl *D, bool isIndirect,
-                               ForDefinition_t forDefinition);
+  Address getAddrOfFieldOffset(VarDecl *D, ForDefinition_t forDefinition);
   llvm::Function *getAddrOfValueWitness(CanType concreteType,
                                         ValueWitness index,
                                         ForDefinition_t forDefinition);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -114,7 +114,7 @@ std::string LinkEntity::mangleAsString() const {
       return mangler.mangleProtocolDescriptor(cast<ProtocolDecl>(getDecl()));
 
     case Kind::FieldOffset:
-      return mangler.mangleFieldOffsetFull(getDecl(), isOffsetIndirect());
+      return mangler.mangleFieldOffset(getDecl());
 
     case Kind::DirectProtocolWitnessTable:
       return mangler.mangleDirectProtocolWitnessTable(getProtocolConformance());

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -406,12 +406,7 @@ enum class FieldAccess : uint8_t {
   
   /// Instance variable offsets are kept in fields in metadata, but
   /// the offsets of those fields within the metadata are constant.
-  ConstantIndirect,
-  
-  /// Instance variable offsets are kept in fields in metadata, and
-  /// the offsets of those fields within the metadata must be loaded
-  /// from "indirect offset" global variables.
-  NonConstantIndirect
+  ConstantIndirect
 };
 
 struct ClassLayout {

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -389,8 +389,9 @@ static SILFunction *getCalleeFunction(
   if (CalleeFunction->isTransparent() == IsNotTransparent)
     return nullptr;
 
-  if (F->isSerialized() && !CalleeFunction->hasValidLinkageForFragileRef()) {
-    if (!CalleeFunction->hasValidLinkageForFragileInline()) {
+  if (F->isSerialized() &&
+      !CalleeFunction->hasValidLinkageForFragileInline()) {
+    if (!CalleeFunction->hasValidLinkageForFragileRef()) {
       llvm::errs() << "caller: " << F->getName() << "\n";
       llvm::errs() << "callee: " << CalleeFunction->getName() << "\n";
       llvm_unreachable("Should never be inlining a resilient function into "

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -274,13 +274,8 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
 
     auto var = dyn_cast<VarDecl>(value);
     auto hasFieldOffset = var && var->hasStorage() && !var->isStatic();
-    if (hasFieldOffset) {
-      // FIXME: a field only has one sort of offset, but it is moderately
-      // non-trivial to compute which one. Including both is less painful than
-      // missing the correct one (for now), so we do that.
-      addSymbol(LinkEntity::forFieldOffset(var, /*isIndirect=*/false));
-      addSymbol(LinkEntity::forFieldOffset(var, /*isIndirect=*/true));
-    }
+    if (hasFieldOffset)
+      addSymbol(LinkEntity::forFieldOffset(var));
 
     // The non-allocating forms of the destructors.
     if (auto dtor = dyn_cast<DestructorDecl>(value)) {

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -7,13 +7,13 @@
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 
-// CHECK: @"$S16class_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = {{(protected )?}}global [[INT]] 0
-// CHECK: @"$S16class_resilience26ClassWithResilientPropertyC5colors5Int32VvpWvd" = {{(protected )?}}global [[INT]] 0
+// CHECK: @"$S16class_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = hidden global [[INT]] 0
+// CHECK: @"$S16class_resilience26ClassWithResilientPropertyC5colors5Int32VvpWvd" = hidden global [[INT]] 0
 
-// CHECK: @"$S16class_resilience33ClassWithResilientlySizedPropertyC1r16resilient_struct9RectangleVvpWvd" = {{(protected )?}}global [[INT]] 0
-// CHECK: @"$S16class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32VvpWvd" = {{(protected )?}}global [[INT]] 0
+// CHECK: @"$S16class_resilience33ClassWithResilientlySizedPropertyC1r16resilient_struct9RectangleVvpWvd" = hidden global [[INT]] 0
+// CHECK: @"$S16class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32VvpWvd" = hidden global [[INT]] 0
 
-// CHECK: @"$S16class_resilience14ResilientChildC5fields5Int32VvpWvd" = {{(protected )?}}global [[INT]] {{8|16}}
+// CHECK: @"$S16class_resilience14ResilientChildC5fields5Int32VvpWvd" = hidden global [[INT]] {{8|16}}
 
 // CHECK: @"$S16class_resilience14ResilientChildCMo" = {{(protected )?}}global [[INT]] 0
 
@@ -21,11 +21,11 @@
 
 // CHECK: @"$S16class_resilience26ClassWithResilientPropertyCMo" = {{(protected )?}}constant [[INT]] {{52|80}}
 
-// CHECK: @"$S16class_resilience28ClassWithMyResilientPropertyC1rAA0eF6StructVvpWvd" = {{(protected )?}}constant [[INT]] {{8|16}}
-// CHECK: @"$S16class_resilience28ClassWithMyResilientPropertyC5colors5Int32VvpWvd" = {{(protected )?}}constant [[INT]] {{12|20}}
+// CHECK: @"$S16class_resilience28ClassWithMyResilientPropertyC1rAA0eF6StructVvpWvd" = hidden constant [[INT]] {{8|16}}
+// CHECK: @"$S16class_resilience28ClassWithMyResilientPropertyC5colors5Int32VvpWvd" = hidden constant [[INT]] {{12|20}}
 
-// CHECK: @"$S16class_resilience30ClassWithIndirectResilientEnumC1s14resilient_enum10FunnyShapeOvpWvd" = {{(protected )?}}constant [[INT]] {{8|16}}
-// CHECK: @"$S16class_resilience30ClassWithIndirectResilientEnumC5colors5Int32VvpWvd" = {{(protected )?}}constant [[INT]] {{12|24}}
+// CHECK: @"$S16class_resilience30ClassWithIndirectResilientEnumC1s14resilient_enum10FunnyShapeOvpWvd" = hidden constant [[INT]] {{8|16}}
+// CHECK: @"$S16class_resilience30ClassWithIndirectResilientEnumC5colors5Int32VvpWvd" = hidden constant [[INT]] {{12|24}}
 
 // CHECK: [[RESILIENTCHILD_NAME:@.*]] = private constant [36 x i8] c"16class_resilience14ResilientChildC\00"
 // CHECK: [[RESILIENTCHILD_FIELDS:@.*]] = private constant [7 x i8] c"field\00\00"

--- a/test/IRGen/protocol_resilience_thunks.swift
+++ b/test/IRGen/protocol_resilience_thunks.swift
@@ -20,6 +20,8 @@ public protocol MyResilientProtocol {
   func returnsBool() -> Bool
   func returnsAny() -> Any
 
+  func throwingFunc() throws
+
   func genericFunc<T>(_: T) -> T
 
   var property: Bool { get set }
@@ -45,29 +47,36 @@ public protocol MyResilientProtocol {
 // CHECK-NEXT: call swiftcc void [[FN]](%Any* noalias nocapture sret %0, %swift.opaque* noalias nocapture swiftself %1, %swift.type* %2, i8** %3)
 // CHECK-NEXT: ret void
 
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(%swift.opaque* noalias nocapture swiftself, %swift.error** swifterror, %swift.type*, i8**)
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 3
+// CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.error**, %swift.type*, i8**)*
+// CHECK-NEXT: call swiftcc void [[FN]](%swift.opaque* noalias nocapture swiftself %0, %swift.error** swifterror %1, %swift.type* %2, i8** %3)
+// CHECK-NEXT: ret void
+
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type*, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
-// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %5, i32 3
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %5, i32 4
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](%swift.opaque* noalias nocapture sret %0, %swift.opaque* noalias nocapture %1, %swift.type* %2, %swift.opaque* noalias nocapture swiftself %3, %swift.type* %4, i8** %5)
 // CHECK-NEXT: ret void
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvgTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
-// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %2, i32 4
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %2, i32 5
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to i1 (%swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 %5(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %1, i8** %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1, %swift.opaque* nocapture swiftself, %swift.type*, i8**)
-// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 5
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 6
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (i1, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](i1 %0, %swift.opaque* nocapture swiftself %1, %swift.type* %2, i8** %3)
 // CHECK-NEXT: ret void
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, {{i32|i64}} } @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvmTj"(i8*, [{{12|24}} x i8]* nocapture dereferenceable({{12|24}}), %swift.opaque* nocapture swiftself, %swift.type*, i8**)
-// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %4, i32 6
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %4, i32 7
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to { i8*, [[INT]] } (i8*, [{{12|24}} x i8]*, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: [[RESULT:%.*]] = call swiftcc { i8*, [[INT]] } [[FN]](i8* %0, [{{12|24}} x i8]* nocapture dereferenceable({{12|24}}) %1, %swift.opaque* nocapture swiftself %2, %swift.type* %3, i8** %4)

--- a/test/SILOptimizer/mandatory_inlining_resilience.sil
+++ b/test/SILOptimizer/mandatory_inlining_resilience.sil
@@ -1,0 +1,49 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+@_fixed_layout
+public struct S {
+  public let y: Int
+}
+
+sil_global [let] @my_global : $Int
+
+sil hidden [global_init] @private_function : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %4 = global_addr @my_global : $*Int
+  %5 = address_to_pointer %4 : $*Int to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// This function is transparent, but not serialized. We cannot inline it into
+// serialized_caller.
+sil [transparent] @transparent_callee : $@convention(thin) () -> Int {
+bb0:
+  %0 = function_ref @private_function : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int
+  %3 = load [trivial] %2 : $*Int
+  return %3 : $Int
+}
+
+// CHECK-LABEL: sil [serialized] @serialized_callee
+sil [serialized] @serialized_callee : $@convention(method) (@thin S.Type) -> S {
+bb0(%0 : @trivial $@thin S.Type):
+  %1 = alloc_box ${ var S }, var, name "self"
+  %2 = mark_uninitialized [rootself] %1 : ${ var S }
+  %3 = project_box %2 : ${ var S }, 0
+  // CHECK: function_ref @transparent_callee
+  %4 = function_ref @transparent_callee : $@convention(thin) () -> Int
+  %5 = apply %4() : $@convention(thin) () -> Int
+  %6 = struct_element_addr %3 : $*S, #S.y
+  assign %5 to %6 : $*Int
+  %8 = load [trivial] %3 : $*S
+  destroy_value %2 : ${ var S }
+  // CHECK: return
+  return %8 : $S
+}
+


### PR DESCRIPTION
Fixes <rdar://problem/34078503>.

Also fix an optimizer bug exposed after #13865 by building the standard library with resilience enabled. Yay for tightening up symbol visibility!