### PR TITLE
Revert "IUO: Add support for non-subscript dynamic lookup."

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1064,21 +1064,6 @@ namespace {
           }
         }
 
-        if (isDynamic) {
-          // Rewrite for implicit unwrapping if the solution requires it.
-          auto *dynamicLocator =
-              cs.getConstraintLocator(memberLocator.withPathElement(
-                  ConstraintLocator::DynamicLookupResult));
-
-          if (solution.getDisjunctionChoice(dynamicLocator)) {
-            auto *forceValue =
-                new (context) ForceValueExpr(ref, ref->getEndLoc());
-            auto optTy = cs.getType(forceValue->getSubExpr());
-            cs.setType(forceValue, optTy->getAnyOptionalObjectType());
-            ref = forceValue;
-          }
-        }
-
         // We also need to handle the implicitly unwrap of the result
         // of the called function if that's the type checking solution
         // we ended up with.

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -79,7 +79,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case ConditionalRequirement:
     case TypeParameterRequirement:
     case ImplicitlyUnwrappedDisjunctionChoice:
-    case DynamicLookupResult:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -253,10 +252,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case ImplicitlyUnwrappedDisjunctionChoice:
       out << "implictly unwrapped disjunction choice";
-      break;
-
-    case DynamicLookupResult:
-      out << "dynamic lookup result";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -129,8 +129,6 @@ public:
     TypeParameterRequirement,
     /// \brief Locator for a binding from an IUO disjunction choice.
     ImplicitlyUnwrappedDisjunctionChoice,
-    /// \brief A result of an expressoin involving dynamic lookup.
-    DynamicLookupResult,
   };
 
   /// \brief Determine the number of numeric values used for the given path
@@ -164,7 +162,6 @@ public:
     case Witness:
     case OpenedGeneric:
     case ImplicitlyUnwrappedDisjunctionChoice:
-    case DynamicLookupResult:
       return 0;
 
     case GenericArgument:
@@ -228,7 +225,6 @@ public:
     case ConditionalRequirement:
     case TypeParameterRequirement:
     case ImplicitlyUnwrappedDisjunctionChoice:
-    case DynamicLookupResult:
       return 0;
 
     case FunctionArgument:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1512,9 +1512,6 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   // Determine the type to which we'll bind the overload set's type.
   Type refType;
   Type openedFullType;
-
-  bool isDynamicResult = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-
   switch (auto kind = choice.getKind()) {
   case OverloadChoiceKind::Decl:
     // If we refer to a top-level decl with special type-checking semantics,
@@ -1528,6 +1525,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   case OverloadChoiceKind::DeclViaBridge:
   case OverloadChoiceKind::DeclViaDynamic:
   case OverloadChoiceKind::DeclViaUnwrappedOptional: {
+    bool isDynamicResult
+      = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
     // Retrieve the type of a reference to the specific declaration choice.
     if (auto baseTy = choice.getBaseType()) {
       assert(!baseTy->hasTypeParameter());
@@ -1571,7 +1570,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       // Subscript declarations are handled within
       // getTypeOfMemberReference(); their result types are optional.
       refType = OptionalType::get(refType->getRValueType());
-    }
+    } 
     // For a non-subscript declaration found via dynamic lookup, strip
     // off the lvalue-ness (FIXME: as a temporary hack. We eventually
     // want this to work) and make a reference to that declaration be
@@ -1580,37 +1579,9 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // Subscript declarations are handled within
     // getTypeOfMemberReference(); their result types are unchecked
     // optional.
-    else if (isDynamicResult && !isa<SubscriptDecl>(choice.getDecl())) {
-      Type ty = refType;
-
-      // If this is something we need to implicitly unwrap, set up a
-      // new type variable and disjunction that will allow us to make
-      // the choice of whether to do so.
-      if (choice.isImplicitlyUnwrappedValueOrReturnValue()) {
-        // Duplicate the structure of boundType, with fresh type
-        // variables. We'll create a binding disjunction using this,
-        // selecting between options for refType, which is either
-        // Optional or a function type returning Optional.
-        assert(boundType->hasTypeVariable());
-        Type ty = boundType.transform([this](Type elTy) -> Type {
-          if (auto *tv = dyn_cast<TypeVariableType>(elTy.getPointer())) {
-            return createTypeVariable(tv->getImpl().getLocator(),
-                                      tv->getImpl().getRawOptions());
-          }
-          return elTy;
-        });
-
-        buildDisjunctionForImplicitlyUnwrappedOptional(ty, refType, locator);
-      }
-
-      // Build the disjunction to attempt binding both T? and T (or
-      // function returning T? and function returning T).
-      buildDisjunctionForDynamicLookupResult(
-          boundType, ImplicitlyUnwrappedOptionalType::get(ty->getRValueType()),
-          locator);
-
+    else if (isDynamicResult && !isa<SubscriptDecl>(choice.getDecl())) {    
       refType = ImplicitlyUnwrappedOptionalType::get(refType->getRValueType());
-    }
+    } 
 
     // If the declaration is unavailable, note that in the score.
     if (choice.getDecl()->getAttrs().isUnavailable(getASTContext())) {
@@ -1698,8 +1669,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
                                               openedFullType,
                                               refType};
 
-  // We created appropriate disjunctions for dynamic result above.
-  if (!isDynamicResult && choice.isImplicitlyUnwrappedValueOrReturnValue()) {
+  if (choice.isImplicitlyUnwrappedValueOrReturnValue()) {
     // Build the disjunction to attempt binding both T? and T (or
     // function returning T? and function returning T).
     buildDisjunctionForImplicitlyUnwrappedOptional(boundType, refType, locator);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2443,15 +2443,6 @@ public:
     buildDisjunctionForOptionalVsUnderlying(boundTy, type, disjunctionLocator);
   }
 
-  // Build a disjunction for dynamic lookup results, which are
-  // implicitly unwrapped if needed.
-  void buildDisjunctionForDynamicLookupResult(Type boundTy, Type type,
-                                              ConstraintLocator *locator) {
-    auto *dynamicLocator =
-        getConstraintLocator(locator, ConstraintLocator::DynamicLookupResult);
-    buildDisjunctionForOptionalVsUnderlying(boundTy, type, dynamicLocator);
-  }
-
   /// \brief Resolve the given overload set to the given choice.
   void resolveOverload(ConstraintLocator *locator, Type boundType,
                        OverloadChoice choice, DeclContext *useDC);


### PR DESCRIPTION
Reverts apple/swift#13862

There's a problem with this code, but the fix for a private branch I am working on IUO things on (where IUOs are mostly gone from the types we generate) doesn't work on master, so I'm just going to back this out here and this support will eventually get merged in with other IUO changes.