### PR TITLE
[Mangled name to metadata] Minor fixes/tests

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -138,9 +138,18 @@ _searchTypeMetadataRecords(const TypeMetadataState &T,
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = T.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto ntd = record.getNominalTypeDescriptor()) {
-        if (ntd->Name.get() == typeName)
-          return ntd;
+      switch (record.getTypeKind()) {
+      case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
+      case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
+        if (auto ntd = record.getNominalTypeDescriptor()) {
+          if (ntd->Name.get() == typeName)
+            return ntd;
+        }
+        break;
+
+      case TypeMetadataRecordKind::IndirectObjCClass:
+      case TypeMetadataRecordKind::Reserved:
+        break;
       }
     }
   }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -608,9 +608,18 @@ swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = C.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto ntd = record.getNominalTypeDescriptor()) {
-        if (ntd->Name.get() == typeName)
-          return ntd;
+      switch (record.getTypeKind()) {
+      case TypeMetadataRecordKind::DirectNominalTypeDescriptor:
+      case TypeMetadataRecordKind::IndirectNominalTypeDescriptor:
+        if (auto ntd = record.getNominalTypeDescriptor()) {
+          if (ntd->Name.get() == typeName)
+            return ntd;
+        }
+        break;
+
+      case TypeMetadataRecordKind::IndirectObjCClass:
+      case TypeMetadataRecordKind::Reserved:
+        break;
       }
     }
   }

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -69,6 +69,10 @@ DemangleToMetadataTests.test("function types") {
 
   // Mix-and-match.
   expectEqual(type(of: f2_variadic_inout), _typeByMangledName("yyytd_ytztc")!)
+
+  // A function type that hasn't been built before.
+  expectEqual("(Int, Float, Double, String, Character, UInt, Bool) -> ()",
+    String(describing: _typeByMangledName("yySi_SfSdSSs9CharacterVSuSbtc")!))
 }
 
 DemangleToMetadataTests.test("metatype types") {
@@ -82,6 +86,7 @@ class C { }
 
 protocol P1 { }
 protocol P2 { }
+protocol P3 { }
 
 func f1_composition(_: P1 & P2) { }
 func f1_composition_anyobject(_: AnyObject & P1) { }
@@ -99,6 +104,9 @@ DemangleToMetadataTests.test("existential types") {
 
   // References to superclass.
   expectEqual(type(of: f1_composition_superclass), _typeByMangledName("yy4main2P1_4main2P2AA1CCXcc")!)
+
+  // Demangle an existential type that hasn't been seen before.
+  expectEqual("P1 & P2 & P3", String(describing: _typeByMangledName("4main2P1_4main2P24main2P3p")!))
 }
 
 DemangleToMetadataTests.test("existential metatype types") {

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -36,5 +36,9 @@ DemangleToMetadataTests.test("Objective-C protocols") {
   expectEqual(type(of: f1_composition_NSCoding), _typeByMangledName("yySo8NSCoding_pc")!)
 }
 
+DemangleToMetadataTests.test("Classes that don't exist") {
+  expectNil(_typeByMangledName("4main4BoomC"))
+}
+
 runAllTests()
 


### PR DESCRIPTION
Two minor fixes:
* Add tests for demangling never-before-seen function and existential types to metadata
* Skip Objective-C type records when looking for types