### PR TITLE
TypeReconstruction: Fix reconstruction of InOutType [4.1]

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1673,7 +1673,7 @@ static void VisitNodeInOut(
   VisitNodeResult type_result;
   VisitNode(ast, cur_node->getFirstChild(), type_result);
   if (type_result._types.size() == 1 && type_result._types[0]) {
-    result._types.push_back(Type(LValueType::get(type_result._types[0])));
+    result._types.push_back(Type(InOutType::get(type_result._types[0])));
   } else {
     result._error = "couldn't resolve referent type";
   }

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -65,21 +65,21 @@ class Myclass2 {
     arr1.append(1)
 // FIXME: missing append()
 // CHECK: dref: FAILURE	for 'append' usr=s:Sa6appendyxF
-// CHECK: type: (@lvalue Array<Int>) -> (Int) -> ()
+// CHECK: type: (inout Array<Int>) -> (Int) -> ()
 
     var arr2 : [Mystruct1]
 // CHECK: decl: var arr2: [Mystruct1]
 // CHECK: type: Array<Mystruct1>
 
     arr2.append(Mystruct1())
-// CHECK: type: (@lvalue Array<Mystruct1>) -> (Mystruct1) -> ()
+// CHECK: type: (inout Array<Mystruct1>) -> (Mystruct1) -> ()
 
     var arr3 : [Myclass1]
 // CHECK: decl: var arr3: [Myclass1]
 // CHECK: type: Array<Myclass1>
 
     arr3.append(Myclass1())
-// CHECK: type: (@lvalue Array<Myclass1>) -> (Myclass1) -> ()
+// CHECK: type: (inout Array<Myclass1>) -> (Myclass1) -> ()
 
     _ = Myclass2.init()
 // CHECK: dref: init()
@@ -116,7 +116,7 @@ func f2() {
   e.method()
 // CHECK: (MyEnum) -> (MyEnum) -> Int
   e.compare(e)
-// CHECK: (@lvalue MyEnum) -> () -> ()
+// CHECK: (inout MyEnum) -> () -> ()
   e.mutatingMethod()
 }
 


### PR DESCRIPTION
* Description: A long-standing bug in type reconstruction, which is used by lldb. Would manifest as lldb crashes when looking at variables whose type is a function type with inout arguments.

* Scope of the issue: Reported externally.

* Risk: Low.

* Radar: <rdar://problem/34536112>.

* Tested: New test added. I'll ask @jimingham to add a test on the lldb side.

* Reviewed by: @DougGregor 