### PR TITLE
[Runtime] Pack element count into the flags of swift_getTupleTypeMetadata

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -690,12 +690,19 @@ using ParameterFlags = TargetParameterTypeFlags<uint32_t>;
 template <typename int_type>
 class TargetTupleTypeFlags {
   enum : int_type {
-    NonConstantLabelsMask    = 1 << 0,
+    NumElementsMask = 0x0000FFFFU,
+    NonConstantLabelsMask = 0x01000000U,
   };
   int_type Data;
 
 public:
+  constexpr TargetTupleTypeFlags() : Data(0) {}
   constexpr TargetTupleTypeFlags(int_type Data) : Data(Data) {}
+
+  constexpr TargetTupleTypeFlags
+  withNumElements(unsigned numElements) const {
+    return TargetTupleTypeFlags((Data & ~NumElementsMask) | numElements);
+  }
 
   constexpr TargetTupleTypeFlags<int_type> withNonConstantLabels(
                                              bool hasNonConstantLabels) const {
@@ -703,6 +710,8 @@ public:
                         (Data & NonConstantLabelsMask) |
                           (hasNonConstantLabels ? NonConstantLabelsMask : 0));
   }
+
+  unsigned getNumElements() const { return Data & NumElementsMask; }
 
   bool hasNonConstantLabels() const { return Data & NonConstantLabelsMask; }
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -691,7 +691,7 @@ template <typename int_type>
 class TargetTupleTypeFlags {
   enum : int_type {
     NumElementsMask = 0x0000FFFFU,
-    NonConstantLabelsMask = 0x01000000U,
+    NonConstantLabelsMask = 0x00010000U,
   };
   int_type Data;
 
@@ -707,7 +707,7 @@ public:
   constexpr TargetTupleTypeFlags<int_type> withNonConstantLabels(
                                              bool hasNonConstantLabels) const {
     return TargetTupleTypeFlags<int_type>(
-                        (Data & NonConstantLabelsMask) |
+                        (Data & ~NonConstantLabelsMask) |
                           (hasNonConstantLabels ? NonConstantLabelsMask : 0));
   }
 
@@ -728,7 +728,7 @@ public:
     return Data != other.Data;
   }
 };
-using TupleTypeFlags = TargetTupleTypeFlags<uint32_t>;
+using TupleTypeFlags = TargetTupleTypeFlags<size_t>;
 
 /// Field types and flags as represented in a nominal type's field/case type
 /// vector.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2887,10 +2887,9 @@ swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
 ///   where the entrypoint is just being used to unique the metadata.
 SWIFT_RUNTIME_EXPORT
 const TupleTypeMetadata *
-swift_getTupleTypeMetadata(size_t numElements,
+swift_getTupleTypeMetadata(TupleTypeFlags flags,
                            const Metadata * const *elements,
                            const char *labels,
-                           TupleTypeFlags flags,
                            const ValueWitnessTable *proposedWitnesses);
 
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -879,7 +879,7 @@ FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata, DefaultCC,
 //                                      value_witness_table_t *proposed);
 FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(Int32Ty, TypeMetadataPtrTy->getPointerTo(0),
+         ARGS(SizeTy, TypeMetadataPtrTy->getPointerTo(0),
               Int8PtrTy, WitnessTablePtrTy),
          ATTRS(NoUnwind, ReadOnly))
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -873,15 +873,14 @@ FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata, DefaultCC,
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
-// Metadata *swift_getTupleTypeMetadata(size_t numElements,
+// Metadata *swift_getTupleTypeMetadata(TupleTypeFlags flags,
 //                                      Metadata * const *elts,
 //                                      const char *labels,
-//                                      uint32_t flags,
 //                                      value_witness_table_t *proposed);
 FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy->getPointerTo(0),
-              Int8PtrTy, Int32Ty, WitnessTablePtrTy),
+         ARGS(Int32Ty, TypeMetadataPtrTy->getPointerTo(0),
+              Int8PtrTy, WitnessTablePtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_getTupleTypeMetadata2(Metadata *elt0, Metadata *elt1,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -690,7 +690,7 @@ namespace {
         TupleTypeFlags flags =
           TupleTypeFlags().withNumElements(elements.size());
         llvm::Value *args[] = {
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
+          llvm::ConstantInt::get(IGF.IGM.SizeTy, flags.getIntValue()),
           pointerToFirst,
           getTupleLabelsString(IGF.IGM, type),
           llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
@@ -1667,7 +1667,7 @@ namespace {
           TupleTypeFlags().withNumElements(elements.size());
 
         llvm::Value *args[] = {
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
+          llvm::ConstantInt::get(IGF.IGM.SizeTy, flags.getIntValue()),
           pointerToFirst,
           // labels don't matter for layout
           llvm::ConstantPointerNull::get(IGF.IGM.Int8PtrTy),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -687,12 +687,12 @@ namespace {
           if (i == 0) pointerToFirst = eltPtr.getAddress();
         }
 
-        TupleTypeFlags flags(0);
+        TupleTypeFlags flags =
+          TupleTypeFlags().withNumElements(elements.size());
         llvm::Value *args[] = {
-          llvm::ConstantInt::get(IGF.IGM.SizeTy, elements.size()),
+          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
           pointerToFirst,
           getTupleLabelsString(IGF.IGM, type),
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
           llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
         };
 
@@ -1663,13 +1663,14 @@ namespace {
           if (i == 0) pointerToFirst = eltPtr.getAddress();
         }
 
-        TupleTypeFlags flags(0);
+        TupleTypeFlags flags =
+          TupleTypeFlags().withNumElements(elements.size());
+
         llvm::Value *args[] = {
-          llvm::ConstantInt::get(IGF.IGM.SizeTy, elements.size()),
+          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
           pointerToFirst,
           // labels don't matter for layout
           llvm::ConstantPointerNull::get(IGF.IGM.Int8PtrTy),
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()),
           llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
         };
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1010,7 +1010,7 @@ swift::swift_getTupleTypeMetadata2(const Metadata *elt0, const Metadata *elt1,
                                    const char *labels,
                                    const ValueWitnessTable *proposedWitnesses) {
   const Metadata *elts[] = { elt0, elt1 };
-  return swift_getTupleTypeMetadata(TupleTypeFlags(0).withNumElements(2),
+  return swift_getTupleTypeMetadata(TupleTypeFlags().withNumElements(2),
                                     elts, labels, proposedWitnesses);
 }
 
@@ -1020,7 +1020,7 @@ swift::swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
                                    const char *labels,
                                    const ValueWitnessTable *proposedWitnesses) {
   const Metadata *elts[] = { elt0, elt1, elt2 };
-  return swift_getTupleTypeMetadata(TupleTypeFlags(0).withNumElements(3),
+  return swift_getTupleTypeMetadata(TupleTypeFlags().withNumElements(3),
                                     elts, labels, proposedWitnesses);
 }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -890,11 +890,12 @@ void performBasicLayout(BasicLayout &layout,
 } // end anonymous namespace
 
 const TupleTypeMetadata *
-swift::swift_getTupleTypeMetadata(size_t numElements,
+swift::swift_getTupleTypeMetadata(TupleTypeFlags flags,
                                   const Metadata * const *elements,
                                   const char *labels,
-                                  TupleTypeFlags flags,
                                   const ValueWitnessTable *proposedWitnesses) {
+  auto numElements = flags.getNumElements();
+
   // Bypass the cache for the empty tuple. We might reasonably get called
   // by generic code, like a demangler that produces type objects.
   if (numElements == 0) return &METADATA_SYM(EMPTY_TUPLE_MANGLING);
@@ -1009,8 +1010,8 @@ swift::swift_getTupleTypeMetadata2(const Metadata *elt0, const Metadata *elt1,
                                    const char *labels,
                                    const ValueWitnessTable *proposedWitnesses) {
   const Metadata *elts[] = { elt0, elt1 };
-  return swift_getTupleTypeMetadata(2, elts, labels, TupleTypeFlags(0),
-                                    proposedWitnesses);
+  return swift_getTupleTypeMetadata(TupleTypeFlags(0).withNumElements(2),
+                                    elts, labels, proposedWitnesses);
 }
 
 const TupleTypeMetadata *
@@ -1019,8 +1020,8 @@ swift::swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
                                    const char *labels,
                                    const ValueWitnessTable *proposedWitnesses) {
   const Metadata *elts[] = { elt0, elt1, elt2 };
-  return swift_getTupleTypeMetadata(3, elts, labels, TupleTypeFlags(0),
-                                    proposedWitnesses);
+  return swift_getTupleTypeMetadata(TupleTypeFlags(0).withNumElements(3),
+                                    elts, labels, proposedWitnesses);
 }
 
 /***************************************************************************/

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -498,12 +498,12 @@ public:
                             std::string labels,
                             bool variadic) const {
     // TODO: 'variadic' should no longer exist
-    TupleTypeFlags flags(0);
+    auto flags = TupleTypeFlags(0).withNumElements(elements.size());
     if (!labels.empty())
       flags = flags.withNonConstantLabels(true);
-    return swift_getTupleTypeMetadata(elements.size(), elements.data(),
+    return swift_getTupleTypeMetadata(flags, elements.data(),
                                       labels.empty() ? nullptr : labels.c_str(),
-                                      flags, /*proposedWitnesses=*/nullptr);
+                                      /*proposedWitnesses=*/nullptr);
   }
 
   BuiltType createDependentMemberType(StringRef name, BuiltType base,

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -498,7 +498,7 @@ public:
                             std::string labels,
                             bool variadic) const {
     // TODO: 'variadic' should no longer exist
-    auto flags = TupleTypeFlags(0).withNumElements(elements.size());
+    auto flags = TupleTypeFlags().withNumElements(elements.size());
     if (!labels.empty())
       flags = flags.withNonConstantLabels(true);
     return swift_getTupleTypeMetadata(flags, elements.data(),

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -113,6 +113,6 @@ func tuple_existentials() {
   // 4 element tuple
   var t4 = (1,2,3,4)
   a = t4
-  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i64 4, {{.*}}, i8* null, i32 0, i8** null)
+  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i32 4, {{.*}}, i8* null, i8** null)
 }
 

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -113,6 +113,6 @@ func tuple_existentials() {
   // 4 element tuple
   var t4 = (1,2,3,4)
   a = t4
-  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i32 4, {{.*}}, i8* null, i8** null)
+  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i64 4, {{.*}}, i8* null, i8** null)
 }
 


### PR DESCRIPTION
Reduces the # of parameters we need to pass to this runtime API.
