### PR TITLE
Re-apply "TypeReconstruction: Fix reconstruction of InOutType"

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -134,9 +134,6 @@ Decl *getDeclFromUSR(ASTContext &context, StringRef USR, std::string &error);
 Decl *getDeclFromMangledSymbolName(ASTContext &context, StringRef mangledName,
                                    std::string &error);
 
-Type getTypeFromMangledTypename(ASTContext &Ctx, StringRef mangledName,
-                                std::string &error);
-
 Type getTypeFromMangledSymbolname(ASTContext &Ctx, StringRef mangledName,
                                   std::string &error);
 

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1697,7 +1697,7 @@ static void VisitNodeInOut(
   VisitNodeResult type_result;
   VisitNode(ast, cur_node->getFirstChild(), type_result);
   if (type_result._types.size() == 1 && type_result._types[0]) {
-    result._types.push_back(Type(LValueType::get(type_result._types[0])));
+    result._types.push_back(Type(InOutType::get(type_result._types[0])));
   } else {
     result._error = "couldn't resolve referent type";
   }

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -2196,26 +2196,6 @@ Decl *ide::getDeclFromMangledSymbolName(ASTContext &context,
   return nullptr;
 }
 
-Type ide::getTypeFromMangledTypename(ASTContext &Ctx,
-                                     StringRef mangledName,
-                                     std::string &error) {
-  Demangle::Context DemangleCtx;
-  auto node = DemangleCtx.demangleTypeAsNode(mangledName);
-  VisitNodeResult result;
-
-  if (node)
-    VisitNode(&Ctx, node, result);
-  error = result._error;
-  if (error.empty() && result._types.size() == 1) {
-    return result._types.front().getPointer();
-  } else {
-    error = stringWithFormat("type for typename '%s' was not found",
-                             mangledName);
-    return Type();
-  }
-  return Type();
-}
-
 Type ide::getTypeFromMangledSymbolname(ASTContext &Ctx,
                                        StringRef mangledName,
                                        std::string &error) {

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -65,21 +65,21 @@ class Myclass2 {
     arr1.append(1)
 // FIXME: missing append()
 // CHECK: dref: FAILURE	for 'append' usr=s:Sa6appendyyxF
-// CHECK: type: (@lvalue Array<Int>) -> (Int) -> ()
+// CHECK: type: (inout Array<Int>) -> (Int) -> ()
 
     var arr2 : [Mystruct1]
 // CHECK: decl: var arr2: [Mystruct1]
 // CHECK: type: Array<Mystruct1>
 
     arr2.append(Mystruct1())
-// CHECK: type: (@lvalue Array<Mystruct1>) -> (Mystruct1) -> ()
+// CHECK: type: (inout Array<Mystruct1>) -> (Mystruct1) -> ()
 
     var arr3 : [Myclass1]
 // CHECK: decl: var arr3: [Myclass1]
 // CHECK: type: Array<Myclass1>
 
     arr3.append(Myclass1())
-// CHECK: type: (@lvalue Array<Myclass1>) -> (Myclass1) -> ()
+// CHECK: type: (inout Array<Myclass1>) -> (Myclass1) -> ()
 
     _ = Myclass2.init()
 // CHECK: dref: init()
@@ -116,7 +116,7 @@ func f2() {
   e.method()
 // CHECK: (MyEnum) -> (MyEnum) -> Int
   e.compare(e)
-// CHECK: (@lvalue MyEnum) -> () -> ()
+// CHECK: (inout MyEnum) -> () -> ()
   e.mutatingMethod()
 }
 


### PR DESCRIPTION
Fixes <rdar://problem/34536112>.

This patch is not changed. However there is an lldb-side fix at https://github.com/apple/swift-lldb/pull/274 which should fix the test breakage.