### PR TITLE
[build-script] Stop expanding argument symlinks

### DIFF
--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -113,7 +113,6 @@ class PathType(object):
     def __call__(self, path):
         path = os.path.expanduser(path)
         path = os.path.abspath(path)
-        path = os.path.realpath(path)
 
         if self._assert_exists and not os.path.exists(path):
             raise ArgumentTypeError('{} does not exists'.format(path))


### PR DESCRIPTION
# Purpose

Stop expanding symlinks in paths, since an absolute path is likely the right choice.

rdar://36447266