### PR TITLE
Un-XFAIL unused_containers with resilience

### DIFF
--- a/test/SILOptimizer/unused_containers.swift
+++ b/test/SILOptimizer/unused_containers.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -O -emit-sil | grep -v 'builtin "onFastPath"' | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts
-// XFAIL: resilient_stdlib
 
 //CHECK-LABEL: @$S17unused_containers16empty_array_testyyF
 //CHECK: bb0:


### PR DESCRIPTION
radar rdar://problem/36426676

PR testing on https://github.com/apple/swift/pull/13573 failed because this test unexpectedly passed. It now works with resilience enabled.