### PR TITLE
[StackNesting] Preserve debug info correctly when solving.

### DIFF
--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -153,7 +153,7 @@ bool StackNesting::solve() {
 static SILInstruction *createDealloc(AllocationInst *Alloc,
                                      SILInstruction *InsertionPoint,
                                      SILLocation Location) {
-  SILBuilder B(InsertionPoint);
+  SILBuilderWithScope B(InsertionPoint);
   switch (Alloc->getKind()) {
     case SILInstructionKind::AllocStackInst:
       return B.createDeallocStack(Location, Alloc);

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -Onone -Xllvm \
+// RUN:   -sil-print-after=allocbox-to-stack -Xllvm \
+// RUN:   -sil-print-only-functions=$S3red19ThrowAddrOnlyStructV016throwsOptionalToG0ACyxGSgSi_tcfC \
+// RUN:   -Xllvm -sil-print-debuginfo -o /dev/null 2>&1 | %FileCheck %s
+
+// CHECK: bb5(%27 : @owned $Error):
+// CHECK:   dealloc_stack %6 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:27:68, scope 2
+// CHECK:   dealloc_stack %3 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:27:68, scope 2
+// CHECK:   br bb4(%27 : $Error), loc {{.*}}:27:15, scope 2
+
+protocol Patatino {
+  init()
+}
+struct ThrowAddrOnlyStruct<T : Patatino> {
+  var x : T
+  init(fail: ()) throws { x = T() }
+  init(failDuringDelegation: Int) throws {
+    try self.init(fail: ())
+  }
+  init?(throwsToOptional: Int) {
+    try? self.init(failDuringDelegation: throwsToOptional)
+  }
+  init(throwsOptionalToThrows: Int) throws {
+    self.init(throwsToOptional: throwsOptionalToThrows)!
+  }
+  init?(throwsOptionalToOptional: Int) {
+    try! self.init(throwsOptionalToThrows: throwsOptionalToOptional)
+  }
+}


### PR DESCRIPTION
Some of the `dealloc_stack` instructions inserted where getting
 a wrong scope. This manifests when running AllocBoxToStack because
it uses StackNesting as an utility. Yet another improvement in
debug informations at `-Onone`.

Fixes SR-6738.

Erik, looks like you wrote this pass so probably you're the best person to review this :)