### PR TITLE
[silgen] When forwarding a tuple value, make sure that it is at +1.

### DIFF
--- a/test/SILGen/guaranteed_normal_args.swift
+++ b/test/SILGen/guaranteed_normal_args.swift
@@ -11,9 +11,31 @@ precedencegroup AssignmentPrecedence {
   assignment: true
 }
 
+public protocol ExpressibleByNilLiteral {
+  init(nilLiteral: ())
+}
+
+protocol IteratorProtocol {
+  associatedtype Element
+  mutating func next() ->  Element?
+}
+
+protocol Sequence {
+  associatedtype Element
+  associatedtype Iterator : IteratorProtocol where Iterator.Element == Element
+
+  func makeIterator() -> Iterator
+}
+
 enum Optional<T> {
 case none
 case some(T)
+}
+
+extension Optional : ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) {
+    self = .none
+  }
 }
 
 func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
@@ -40,6 +62,41 @@ typealias AnyObject = Builtin.AnyObject
 protocol Protocol {
   associatedtype AssocType
   static func useInput(_ input: Builtin.Int32, into processInput: (AssocType) -> ())
+}
+
+struct FakeArray<Element> {
+  // Just to make this type non-trivial
+  var k: Klass
+
+  // We are only interested in this being called. We are not interested in its
+  // implementation.
+  mutating func append(_ t: Element) {}
+}
+
+struct FakeDictionary<Key, Value> {
+}
+
+struct FakeDictionaryIterator<Key, Value> {
+  var dictionary: FakeDictionary<Key, Value>?
+
+  init(_ newDictionary: FakeDictionary<Key, Value>) {
+    dictionary = newDictionary
+  }
+}
+
+extension FakeDictionaryIterator : IteratorProtocol {
+  public typealias Element = (Key, Value)
+  public mutating func next() -> Element? {
+    return .none
+  }
+}
+
+extension FakeDictionary : Sequence {
+  public typealias Element = (Key, Value)
+  public typealias Iterator = FakeDictionaryIterator<Key, Value>
+  public func makeIterator() -> FakeDictionaryIterator<Key, Value> {
+    return FakeDictionaryIterator(self)
+  }
 }
 
 ///////////
@@ -108,3 +165,36 @@ struct ReabstractionThunkTest : Protocol {
   }
 }
 
+// Make sure that we provide a cleanup to x properly before we pass it to
+// result.
+extension FakeDictionary {
+  // CHECK-LABEL: sil hidden @$Ss14FakeDictionaryV20makeSureToCopyTuplesyyF : $@convention(method) <Key, Value> (FakeDictionary<Key, Value>) -> () {
+  // CHECK:   [[X:%.*]] = alloc_stack $(Key, Value), let, name "x"
+  // CHECK:   [[INDUCTION_VAR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<(Key, Value)>, #Optional.some!enumelt.1
+  // CHECK:   [[INDUCTION_VAR_0:%.*]] = tuple_element_addr [[INDUCTION_VAR]] : $*(Key, Value), 0
+  // CHECK:   [[INDUCTION_VAR_1:%.*]] = tuple_element_addr [[INDUCTION_VAR]] : $*(Key, Value), 1
+  // CHECK:   [[X_0:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 0
+  // CHECK:   [[X_1:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 1
+  // CHECK:   copy_addr [take] [[INDUCTION_VAR_0]] to [initialization] [[X_0]]
+  // CHECK:   copy_addr [take] [[INDUCTION_VAR_1]] to [initialization] [[X_1]]
+  // CHECK:   [[X_0:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 0
+  // CHECK:   [[X_1:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 1
+  // CHECK:   [[TMP_X:%.*]] = alloc_stack $(Key, Value)
+  // CHECK:   [[TMP_X_0:%.*]] = tuple_element_addr [[TMP_X]] : $*(Key, Value), 0
+  // CHECK:   [[TMP_0:%.*]] = alloc_stack $Key
+  // CHECK:   copy_addr [[X_0]] to [initialization] [[TMP_0]]
+  // CHECK:   copy_addr [take] [[TMP_0]] to [initialization] [[TMP_X_0]]
+  // CHECK:   [[TMP_X_1:%.*]] = tuple_element_addr [[TMP_X]] : $*(Key, Value), 1
+  // CHECK:   [[TMP_1:%.*]] = alloc_stack $Value
+  // CHECK:   copy_addr [[X_1]] to [initialization] [[TMP_1]]
+  // CHECK:   copy_addr [take] [[TMP_1]] to [initialization] [[TMP_X_1]]
+  // CHECK:   [[FUNC:%.*]] = function_ref @$Ss9FakeArrayV6appendyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout FakeArray<τ_0_0>) -> ()
+  // CHECK:   apply [[FUNC]]<(Key, Value)>([[TMP_X]],
+  // CHECK: } // end sil function '$Ss14FakeDictionaryV20makeSureToCopyTuplesyyF'
+  func makeSureToCopyTuples() {
+    var result = FakeArray<Element>(k: Klass())
+    for x in self {
+      result.append(x)
+    }
+  }
+}


### PR DESCRIPTION
[silgen] When forwarding a tuple value, make sure that it is at +1.

In the code, we assume generally that a value that is "forwarded" into memory is
forwarded at +1. This isn't enforced and when I tried to enforce it at +0, I
quickly hit assertion failures. So rather than fix the myriad places, I am using
ensurePlusOne to handle such cases without needing to change a bunch of the
code.

rdar://34222540