### PR TITLE
[stdlib] Improve _binaryLogarithm implementation and add tests [NFCI]

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2053,6 +2053,7 @@ extension BinaryFloatingPoint {
       significandBitPattern: magnitudeOf.significandBitPattern)
   }
 
+  @_inlineable // FIXME(sil-serialize-all)
   public // @testable
   static func _convert<Source : BinaryInteger>(
     from source: Source
@@ -2129,6 +2130,7 @@ extension BinaryFloatingPoint {
     self = value_
   }
 
+  @_inlineable // FIXME(sil-serialize-all)
   public // @testable
   static func _convert<Source : BinaryFloatingPoint>(
     from source: Source

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1602,21 +1602,26 @@ extension BinaryInteger {
 
   @_inlineable // FIXME(sil-serialize-all)
   public func _binaryLogarithm() -> Self {
-    _precondition(self > 0)
-    let wordBitWidth = Magnitude.Words.Element.bitWidth
-    let reversedWords = magnitude.words.reversed()
+    _precondition(self > (0 as Self))
+    var (quotient, remainder) =
+      (bitWidth &- 1).quotientAndRemainder(dividingBy: UInt.bitWidth)
+    remainder = remainder &+ 1
+    var word = UInt(truncatingIfNeeded: self >> (bitWidth &- remainder))
     // If, internally, a variable-width binary integer uses digits of greater
     // bit width than that of Magnitude.Words.Element (i.e., UInt), then it is
-    // possible that more than one element of Magnitude.Words could be entirely
-    // zero.
-    let reversedWordsLeadingZeroBitCount =
-      zip(0..., reversedWords)
-        .first { $0.1 != 0 }
-        .map { $0.0 &* wordBitWidth &+ $0.1.leadingZeroBitCount }!
-    let logarithm =
-      reversedWords.count &* wordBitWidth &-
-        (reversedWordsLeadingZeroBitCount &+ 1)
-    return Self(logarithm)
+    // possible that `word` could be zero. Additionally, a signed variable-width
+    // binary integer may have a leading word that is zero to store a clear sign
+    // bit.
+    while word == 0 {
+      quotient = quotient &- 1
+      remainder = remainder &+ UInt.bitWidth
+      word = UInt(truncatingIfNeeded: self >> (bitWidth &- remainder))
+    }
+    // Note that the order of operations below is important to guarantee that
+    // we won't overflow.
+    return Self(
+      UInt.bitWidth &* quotient &+
+        (UInt.bitWidth &- (word.leadingZeroBitCount &+ 1)))
   }
 
   /// Returns the quotient and remainder of this value divided by the given
@@ -2239,8 +2244,8 @@ extension FixedWidthInteger {
 
   @_inlineable // FIXME(sil-serialize-all)
   public func _binaryLogarithm() -> Self {
-    _precondition(self > 0)
-    return Self(Magnitude.bitWidth &- (magnitude.leadingZeroBitCount &+ 1))
+    _precondition(self > (0 as Self))
+    return Self(Self.bitWidth &- (leadingZeroBitCount &+ 1))
   }
 
   /// Creates an integer from its little-endian representation, changing the

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -63,6 +63,170 @@ typealias UWord = UInt${word_bits}
 typealias DWord = Int${word_bits*2}
 typealias UDWord = UInt${word_bits*2}
 
+struct MockBinaryInteger<T : BinaryInteger> {
+  var _value: T
+
+  init(_ value: T) {
+    _value = value
+  }
+}
+
+extension MockBinaryInteger : CustomStringConvertible {
+  var description: String {
+    return _value.description
+  }
+}
+
+extension MockBinaryInteger : ExpressibleByIntegerLiteral {
+  init(integerLiteral value: T.IntegerLiteralType) {
+    _value = T(integerLiteral: value)
+  }
+}
+
+extension MockBinaryInteger : Comparable {
+  static func < (lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) -> Bool {
+    return lhs._value < rhs._value
+  }
+
+  static func == (
+    lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
+  ) -> Bool {
+    return lhs._value == rhs._value
+  }
+}
+
+extension MockBinaryInteger : Hashable {
+  var hashValue: Int {
+    return _value.hashValue
+  }
+}
+
+extension MockBinaryInteger : BinaryInteger {
+  static var isSigned: Bool {
+    return T.isSigned
+  }
+
+  init<Source>(_ source: Source) where Source : BinaryFloatingPoint {
+    _value = T(source)
+  }
+
+  init?<Source>(exactly source: Source) where Source : BinaryFloatingPoint {
+    guard let result = T(exactly: source) else { return nil }
+    _value = result
+  }
+
+  init<Source>(_ source: Source) where Source : BinaryInteger {
+    _value = T(source)
+  }
+
+  init?<Source>(exactly source: Source) where Source : BinaryInteger {
+    guard let result = T(exactly: source) else { return nil }
+    _value = result
+  }
+
+  init<Source>(truncatingIfNeeded source: Source) where Source : BinaryInteger {
+    _value = T(truncatingIfNeeded: source)
+  }
+
+  init<Source>(clamping source: Source) where Source : BinaryInteger {
+    _value = T(clamping: source)
+  }
+
+  var magnitude: MockBinaryInteger<T.Magnitude> {
+    return MockBinaryInteger<T.Magnitude>(_value.magnitude)
+  }
+
+  var words: T.Words {
+    return _value.words
+  }
+
+  var bitWidth: Int {
+    return _value.bitWidth
+  }
+
+  var trailingZeroBitCount: Int {
+    return _value.trailingZeroBitCount
+  }
+
+  static func + (
+    lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
+  ) -> MockBinaryInteger<T> {
+    return MockBinaryInteger(lhs._value + rhs._value)
+  }
+
+  static func += (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value += rhs._value
+  }
+
+  static func - (
+    lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
+  ) -> MockBinaryInteger<T> {
+    return MockBinaryInteger(lhs._value - rhs._value)
+  }
+
+  static func -= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value -= rhs._value
+  }
+
+  static func * (
+    lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
+  ) -> MockBinaryInteger<T> {
+    return MockBinaryInteger(lhs._value * rhs._value)
+  }
+
+  static func *= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value *= rhs._value
+  }
+
+  static func / (
+    lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
+  ) -> MockBinaryInteger<T> {
+    return MockBinaryInteger(lhs._value / rhs._value)
+  }
+
+  static func /= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value /= rhs._value
+  }
+
+  static func % (
+    lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
+  ) -> MockBinaryInteger<T> {
+    return MockBinaryInteger(lhs._value % rhs._value)
+  }
+
+  static func %= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value %= rhs._value
+  }
+
+  static func &= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value &= rhs._value
+  }
+
+  static func |= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value |= rhs._value
+  }
+
+  static func ^= (lhs: inout MockBinaryInteger<T>, rhs: MockBinaryInteger<T>) {
+    lhs._value ^= rhs._value
+  }
+
+  static prefix func ~ (x: MockBinaryInteger<T>) -> MockBinaryInteger<T> {
+    return MockBinaryInteger(~x._value)
+  }
+
+  static func >>= <RHS>(
+    lhs: inout MockBinaryInteger<T>, rhs: RHS
+  ) where RHS : BinaryInteger {
+    lhs._value >>= rhs
+  }
+
+  static func <<= <RHS>(
+    lhs: inout MockBinaryInteger<T>, rhs: RHS
+  ) where RHS : BinaryInteger {
+    lhs._value <<= rhs
+  }
+}
+
 import StdlibUnittest
 
 
@@ -652,4 +816,48 @@ tests.test("signum/concrete") {
 %   end
 % end
 }
+
+tests.test("binaryLogarithm/generic") {
+  expectEqual(
+    Int((42 as MockBinaryInteger<Int8>)._binaryLogarithm()),
+    Int((42 as Int8)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<UInt8>)._binaryLogarithm()),
+    Int((42 as UInt8)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<Int16>)._binaryLogarithm()),
+    Int((42 as Int16)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<UInt16>)._binaryLogarithm()),
+    Int((42 as UInt16)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<Int32>)._binaryLogarithm()),
+    Int((42 as Int32)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<UInt32>)._binaryLogarithm()),
+    Int((42 as UInt32)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<Int64>)._binaryLogarithm()),
+    Int((42 as Int64)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<UInt64>)._binaryLogarithm()),
+    Int((42 as UInt64)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<Int>)._binaryLogarithm()),
+    (42 as Int)._binaryLogarithm())
+  expectEqual(
+    Int((42 as MockBinaryInteger<UInt>)._binaryLogarithm()),
+    Int((42 as UInt)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<DoubleWidth<Int>>)._binaryLogarithm()),
+    Int((42 as DoubleWidth<Int>)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<DoubleWidth<UInt>>)._binaryLogarithm()),
+    Int((42 as DoubleWidth<UInt>)._binaryLogarithm()))
+  expectEqual(
+    Int((42 as MockBinaryInteger<DoubleWidth<DoubleWidth<Int>>>)
+      ._binaryLogarithm()),
+    Int((42 as DoubleWidth<DoubleWidth<Int>>)._binaryLogarithm()))
+}
+
 runAllTests()


### PR DESCRIPTION
This PR is a minor revision of some code introduced in #13782. Most prominently:

- The default implementation of `BinaryInteger._binaryLogarithm()` jettisons the use of `words`, instead using a simple bit shift.
- A test is added.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
