### PR TITLE
Serialize stored property initializers

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -439,6 +439,19 @@ IsSerialized_t SILDeclRef::isSerialized() const {
           return IsSerialized;
       }
     }
+
+    // Stored property initializers are inlinable if the type is explicitly
+    // marked as @_fixed_layout.
+    if (isStoredPropertyInitializer()) {
+      auto *nominal = cast<NominalTypeDecl>(d->getDeclContext());
+      auto scope = nominal->getFormalAccessScope(/*useDC=*/nullptr,
+                                                 /*respectVersionedAttr=*/true);
+      if (!scope.isPublic())
+        return IsNotSerialized;
+      if (nominal->isFormallyResilient())
+        return IsNotSerialized;
+      return IsSerialized;
+    }
   }
 
   // Declarations imported from Clang modules are serialized if

--- a/test/SILGen/fixed_layout_attribute.swift
+++ b/test/SILGen/fixed_layout_attribute.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -parse-as-library %s | %FileCheck %s --check-prefix=FRAGILE --check-prefix=CHECK
+// RUN: %target-swift-frontend -enable-resilience -emit-silgen -enable-sil-ownership -parse-as-library %s | %FileCheck %s --check-prefix=RESILIENT --check-prefix=CHECK
+
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -parse-as-library -enable-testing %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -parse-as-library -enable-testing -enable-resilience %s
+
+public let global = 0
+
+struct InternalStruct {
+  var storedProperty = global
+}
+
+// CHECK-LABEL: sil hidden [transparent] @$S22fixed_layout_attribute14InternalStructV14storedPropertySivpfi : $@convention(thin) () -> Int
+//
+//    ... okay to directly reference the addressor here:
+// CHECK: function_ref @$S22fixed_layout_attribute6globalSivau
+// CHECK: return
+
+public struct NonFixedStruct {
+  public var storedProperty = global
+}
+
+// CHECK-LABEL: sil [transparent] @$S22fixed_layout_attribute14NonFixedStructV14storedPropertySivpfi : $@convention(thin) () -> Int
+//
+//    ... okay to directly reference the addressor here:
+// CHECK: function_ref @$S22fixed_layout_attribute6globalSivau
+// CHECK: return
+
+@_fixed_layout
+public struct FixedStruct {
+  public var storedProperty = global
+}
+
+// CHECK-LABEL: sil [transparent] [serialized] @$S22fixed_layout_attribute11FixedStructV14storedPropertySivpfi : $@convention(thin) () -> Int
+//
+//    ... a fragile build can still reference the addressor:
+// FRAGILE: function_ref @$S22fixed_layout_attribute6globalSivau
+
+//    ... a resilient build has to use the getter because the addressor
+//    is not public, and the initializer is serialized:
+// RESILIENT: function_ref @$S22fixed_layout_attribute6globalSivg
+
+// CHECK: return
+
+// This would crash with -enable-testing
+private let privateGlobal = 0
+
+struct AnotherInternalStruct {
+  var storedProperty = privateGlobal
+}

--- a/validation-test/Evolution/Inputs/struct_add_initializer.swift
+++ b/validation-test/Evolution/Inputs/struct_add_initializer.swift
@@ -1,0 +1,34 @@
+
+public func getVersion() -> Int {
+#if BEFORE
+  return 0
+#else
+  return 1
+#endif
+}
+
+#if BEFORE
+
+@_fixed_layout
+public struct AddInitializer {
+  public var x: Int
+
+  // This could be @_inlineable, but we want to force inlining to take place
+  // at -Onone to get better test coverage.
+  @_transparent
+  public init() {
+    self.x = 0
+  }
+}
+
+#else
+
+@_fixed_layout
+public struct AddInitializer {
+  public var x: Int = 0
+
+  @_transparent
+  public init() {}
+}
+
+#endif

--- a/validation-test/Evolution/test_struct_add_initializer.swift
+++ b/validation-test/Evolution/test_struct_add_initializer.swift
@@ -1,0 +1,16 @@
+// RUN: %target-resilience-test
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import struct_add_initializer
+
+
+var StructAddInitializerTest = TestSuite("StructAddInitializer")
+
+StructAddInitializerTest.test("AddInitializer") {
+  let s = AddInitializer()
+
+  expectEqual(0, s.x)
+}
+
+runAllTests()


### PR DESCRIPTION
Follow-up to #13897 that hopefully fixes <rdar://problem/36454839>.

This almost, but doesn't quite address <rdar://problem/36429556>, because we still need to change the linkage of variable initializers to not be public. Getting that working will also let us address <https://bugs.swift.org/browse/SR-5647>, which gives default argument generators their final ABI.