### PR TITLE
Make sure we copy the ImplicitlyUnwrappedOptionalAttr when cloning Pa…

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4309,6 +4309,11 @@ ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
 
   if (withTypes && PD->hasInterfaceType())
     setInterfaceType(PD->getInterfaceType()->getInOutObjectType());
+
+  // FIXME: We should clone the entire attribute list.
+  if (PD->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
+    getAttrs().add(new (PD->getASTContext())
+                       ImplicitlyUnwrappedOptionalAttr(/* implicit= */ true));
 }
 
 


### PR DESCRIPTION
…ramDecls.

We should have a more general fix that clones the attribute list here,
but it looks like some attributes have parameters and that it could be
a bit more involved than I can tackle at the moment, so I created
https://bugs.swift.org/browse/SR-6741.
