### PR TITLE
Fixed layout property initializer restriction

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2787,6 +2787,13 @@ public:
   
   void setBraces(SourceRange braces) { Braces = braces; }
 
+  /// \brief Should this declaration behave as if it must be accessed
+  /// resiliently, even when we're building a non-resilient module?
+  ///
+  /// This is used for diagnostics, because we do not want a behavior
+  /// change between builds with resilience enabled and disabled.
+  bool isFormallyResilient() const;
+
   /// \brief Do we need to use resilient access patterns outside of this type's
   /// resilience domain?
   bool isResilient() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3703,7 +3703,8 @@ ERROR(versioned_dynamic_not_supported,none,
   "%select{a '@_transparent' function|" \
   "an '@inline(__always)' function|" \
   "an '@_inlineable' function|" \
-  "a default argument value}"
+  "a default argument value|" \
+  "a property initializer in a '@_fixed_layout' type}"
 
 ERROR(local_type_in_inlineable_function,
       none, "type %0 cannot be nested inside " FRAGILE_FUNC_KIND "1",

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2273,7 +2273,7 @@ int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
   return 0;
 }
 
-bool NominalTypeDecl::isResilient() const {
+bool NominalTypeDecl::isFormallyResilient() const {
   // Private and (unversioned) internal types always have a
   // fixed layout.
   if (!getFormalAccessScope(/*useDC=*/nullptr,
@@ -2293,7 +2293,18 @@ bool NominalTypeDecl::isResilient() const {
   if ((isa<EnumDecl>(this) || isa<ProtocolDecl>(this)) && isObjC())
     return false;
 
-  // Otherwise, access via indirect "resilient" interfaces.
+  // Otherwise, the declaration behaves as if it was accessed via indirect
+  // "resilient" interfaces, even if the module is not built with resilience.
+  return true;
+}
+
+bool NominalTypeDecl::isResilient() const {
+  // If we're not formally resilient, don't check the module resilience
+  // strategy.
+  if (!isFormallyResilient())
+    return false;
+
+  // Otherwise, check the module.
   switch (getParentModule()->getResilienceStrategy()) {
   case ResilienceStrategy::Resilient:
     return true;

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -26,8 +26,10 @@ using FragileFunctionKind = TypeChecker::FragileFunctionKind;
 FragileFunctionKind TypeChecker::getFragileFunctionKind(const DeclContext *DC) {
   for (; DC->isLocalContext(); DC = DC->getParent()) {
     if (auto *DAI = dyn_cast<DefaultArgumentInitializer>(DC))
-      if (DAI->getResilienceExpansion() == ResilienceExpansion::Minimal)
-        return FragileFunctionKind::DefaultArgument;
+      return FragileFunctionKind::DefaultArgument;
+
+    if (auto *PBI = dyn_cast<PatternBindingInitializer>(DC))
+      return FragileFunctionKind::PropertyInitializer;
 
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
       // If the function is a nested function, we will serialize its body if

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2297,7 +2297,8 @@ public:
     Transparent,
     InlineAlways,
     Inlineable,
-    DefaultArgument
+    DefaultArgument,
+    PropertyInitializer
   };
 
   /// Given that \p DC is within a fragile context for some reason, describe

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -89,7 +89,6 @@ internal func _collectAllReferencesInsideObjectImpl(
 
 // This is a namespace for runtime functions related to management
 // of runtime function counters.
-@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _RuntimeFunctionCounters {
 #if os(Windows) && arch(x86_64)
@@ -228,8 +227,6 @@ extension _RuntimeFunctionCountersStats {
 // counters. This type should not be used directly. You should use its
 // wrappers GlobalRuntimeFunctionCountersState and
 // ObjectRuntimeFunctionCountersState instead.
-@_fixed_layout // FIXME(sil-serialize-all)
-@_versioned // FIXME(sil-serialize-all)
 internal struct _RuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
   /// Reserve enough space for 64 elements.
   typealias Counters =
@@ -420,7 +417,6 @@ extension _RuntimeFunctionCountersStats {
 
 /// This type should be used to collect statistics about the global runtime
 /// function pointers.
-@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _GlobalRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
   var state = _RuntimeFunctionCountersState()
@@ -458,7 +454,6 @@ struct _GlobalRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
 
 /// This type should be used to collect statistics about object runtime
 /// function pointers.
-@_fixed_layout // FIXME(sil-serialize-all)
 public // @testable
 struct _ObjectRuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
   var state = _RuntimeFunctionCountersState()

--- a/validation-test/compiler_crashers_2_fixed/0137-sr6730.swift
+++ b/validation-test/compiler_crashers_2_fixed/0137-sr6730.swift
@@ -1,0 +1,42 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+public protocol OptionalProtocol {
+  associatedtype Wrapped
+
+  var optional: Wrapped? { get }
+}
+
+extension Optional: OptionalProtocol {
+  public var optional: Wrapped? {
+    return self
+  }
+}
+
+public extension Sequence where Element: OptionalProtocol {
+  func skipNil() -> [Element.Wrapped] {
+    return self
+    .compactMap { $0.optional }
+  }
+}
+
+class A {}
+class A1: A {}
+class A2: A {}
+class A3: A {}
+
+final class V {
+  init() {
+    ([
+      self.a1, self.a2, self.a3
+      ] as [A])
+    .skipNil()
+    .forEach { self.f($0) }
+  }
+
+  func f(_ a: A) {}
+
+  private let a1 = A1()
+  private let a2 = A2()
+  private let a3 = A3()
+}
+


### PR DESCRIPTION
We used to inline stored property initializers into inlinable constructors. This is wrong because there's nothing preventing a stored property initializer from referencing private symbols. I prevented the optimizer from doing this in #13867, but it introduced a performance regression.

As a first step toward fixing the regression, require that stored property initializers of fixed layout types only reference public symbols, using the same logic we use for default arguments of public functions, and expressions inside inlinable function bodies.