### PR TITLE
Verify noescape closures for exclusivity diagnostics.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -77,6 +77,31 @@ SILValue stripExpectIntrinsic(SILValue V);
 /// ust return V.
 SILValue stripBorrow(SILValue V);
 
+/// Return a non-null SingleValueInstruction if the given instruction merely
+/// copies a value, possibly changing its type or ownership state, but otherwise
+/// having no effect.
+///
+/// This is useful for checking all users of a value to verify that the value is
+/// only used in recognizable patterns without otherwise "escaping". These are
+/// instructions that the use-visitor can recurse into. Note that the value's
+/// type may be changed by a cast.
+SingleValueInstruction *getSingleValueCopyOrCast(SILInstruction *I);
+
+/// Return true if the given instruction has no effect on it's operand values
+/// and produces no result. These are typically end-of scope markers.
+///
+/// This is useful for checking all users of a value to verify that the value is
+/// only used in recognizable patterns without otherwise "escaping".
+bool isIncidentalUse(SILInstruction *user);
+
+/// Return true if the given `user` instruction modifies the value's refcount
+/// without propagating the value or having any other effect aside from
+/// potentially destroying the value itself (and executing associated cleanups).
+///
+/// This is useful for checking all users of a value to verify that the value is
+/// only used in recognizable patterns without otherwise "escaping".
+bool onlyAffectsRefCount(SILInstruction *user);
+
 /// A utility class for evaluating whether a newly parsed or deserialized
 /// function has qualified or unqualified ownership.
 ///

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -234,6 +234,53 @@ SILValue swift::stripBorrow(SILValue V) {
   return V;
 }
 
+SingleValueInstruction *swift::getSingleValueCopyOrCast(SILInstruction *I) {
+  if (auto *convert = dyn_cast<ConversionInst>(I))
+    return convert;
+
+  switch (I->getKind()) {
+  default:
+    return nullptr;
+  case SILInstructionKind::CopyValueInst:
+  case SILInstructionKind::CopyBlockInst:
+  case SILInstructionKind::BeginBorrowInst:
+  case SILInstructionKind::BeginAccessInst:
+    return cast<SingleValueInstruction>(I);
+  }
+}
+
+bool swift::isIncidentalUse(SILInstruction *user) {
+  switch (user->getKind()) {
+  default:
+    return false;
+  case SILInstructionKind::DebugValueInst:
+  case SILInstructionKind::EndAccessInst:
+  case SILInstructionKind::EndBorrowInst:
+  case SILInstructionKind::EndLifetimeInst:
+  case SILInstructionKind::FixLifetimeInst:
+    return true;
+  }
+}
+
+bool swift::onlyAffectsRefCount(SILInstruction *user) {
+  switch (user->getKind()) {
+  default:
+    return false;
+  case SILInstructionKind::AutoreleaseValueInst:
+  case SILInstructionKind::DestroyValueInst:
+  case SILInstructionKind::ReleaseValueInst:
+  case SILInstructionKind::RetainValueInst:
+  case SILInstructionKind::StrongReleaseInst:
+  case SILInstructionKind::StrongRetainInst:
+  case SILInstructionKind::UnmanagedAutoreleaseValueInst:
+  case SILInstructionKind::UnmanagedReleaseValueInst:
+  case SILInstructionKind::UnmanagedRetainValueInst:
+  case SILInstructionKind::UnownedReleaseInst:
+  case SILInstructionKind::UnownedRetainInst:
+    return true;
+  }
+}
+
 namespace {
 
 enum class OwnershipQualifiedKind {

--- a/test/SILOptimizer/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/closure_specialize_consolidated.sil
@@ -61,33 +61,41 @@ bb0(%0 : $*S):
   return %6 : $()
 }
 
-// Check that a specialization of address_closure_user was generated which does not
+// CHECK-LABEL: sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+bb0(%0 : $@callee_owned () -> ()):
+  %1 = apply %0() : $@callee_owned () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Check that a specialization of address_closure_noescape_user was generated which does not
 // take a closure as a parameter anymore.
-// CHECK-LABEL: sil shared @{{.*}}address_closure_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
 // CHECK: function_ref @address_closure_trivial : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
 // CHECK: partial_apply %{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
 // CHECK: apply
 // CHECK: return
 
-// Check that a specialization of address_closure_user was generated which does not
+// Check that a specialization of address_closure_noescape_user was generated which does not
 // take a closure as a parameter anymore.
-// CHECK-LABEL: sil shared @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
 // CHECK: function_ref @address_closure_trivial_mutating : $@convention(thin) (@inout_aliasable Int32) -> ()
 // CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
 // CHECK: apply
 // CHECK: return
 
-// Check that a specialization of address_closure_user was generated which does not
+// Check that a specialization of address_closure_noescape_user was generated which does not
 // take a closure as a parameter anymore.
-// CHECK-LABEL: sil shared @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
 // CHECK: function_ref @address_closure_existential : $@convention(thin) (@inout_aliasable P) -> ()
 // CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
 // CHECK: apply
 // CHECK: return
 
-// Check that a specialization of address_closure_user was generated which does not
+// Check that a specialization of address_closure_noescape_user was generated which does not
 // take a closure as a parameter anymore.
-// CHECK-LABEL: sil shared @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: function_ref @address_closure_struct1 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: apply
@@ -95,7 +103,7 @@ bb0(%0 : $*S):
 
 // Check that a specialization of address_closure_user was generated which does not
 // take a closure as a parameter anymore.
-// CHECK-LABEL: sil shared @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: function_ref @address_closure_struct2 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: apply
@@ -103,16 +111,16 @@ bb0(%0 : $*S):
 
 // Check that a specialization of address_closure_user was generated which does not
 // take a closure as a parameter anymore.
-// CHECK-LABEL: sil shared @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
 // CHECK: function_ref @address_closure_class1 : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
 // CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
 // CHECK: apply
 // CHECK: return
 
-// CHECK-LABEL: sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
-sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
-bb0(%0 : $@callee_owned () -> ()):
-  %1 = apply %0() : $@callee_owned () -> ()
+// CHECK-LABEL: sil @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> () {
+sil @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> () {
+bb0(%0 : $@noescape @callee_owned () -> ()):
+  %1 = apply %0() : $@noescape @callee_owned () -> ()
   %9999 = tuple()
   return %9999 : $()
 }
@@ -201,7 +209,7 @@ bb0(%0 : $Int32, %1 : $*Int32):
 
 // CHECK-LABEL: sil @address_caller_trivial
 // CHECK-NOT: partial_apply
-// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
 // CHECK: return
@@ -209,12 +217,13 @@ sil @address_caller_trivial: $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %2 = alloc_stack $Int32, var, name "xx"
   store %0 to %2 : $*Int32
-  // function_ref address_closure_user(f:)
-  %4 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // function_ref address_closure_noescape_user(f:)
+  %4 = function_ref @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   // function_ref address_closure_trivial(x:)
   %5 = function_ref @address_closure_trivial : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
   %6 = partial_apply %5(%0, %2) : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
-  %7 = apply %4(%6) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %6b = convert_function %6 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %7 = apply %4(%6b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %8 = load %2 : $*Int32
   dealloc_stack %2 : $*Int32
   return %8 : $Int32
@@ -238,7 +247,7 @@ bb0(%0 : $*Int32):
 
 // CHECK-LABEL: sil @address_caller_trivial_mutating
 // CHECK-NOT: partial_apply
-// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
 // CHECK: return
@@ -246,10 +255,11 @@ sil @address_caller_trivial_mutating: $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %2 = alloc_stack $Int32, var, name "xx"
   store %0 to %2 : $*Int32
-  %4 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %4 = function_ref @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %5 = function_ref @address_closure_trivial_mutating : $@convention(thin) (@inout_aliasable Int32) -> ()
   %6 = partial_apply %5(%2) : $@convention(thin) (@inout_aliasable Int32) -> ()
-  %7 = apply %4(%6) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %6b = convert_function %6 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %7 = apply %4(%6b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %8 = load %2 : $*Int32
   dealloc_stack %2 : $*Int32
   return %8 : $Int32
@@ -294,17 +304,17 @@ bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q, %3 : $*Q):
 // CHECK: apply [[PARTIAL_APPLY]]
 // CHECK: return
 
-sil @address_closure_user_out_result : $@convention(thin) (@owned @callee_owned (@in Q) -> @out Q) -> @out Q {
-bb0(%0 : $*Q, %1 : $@callee_owned (@in Q) -> @out Q):
+sil @address_closure_user_out_result : $@convention(thin) (@owned @noescape @callee_owned (@in Q) -> @out Q) -> @out Q {
+bb0(%0 : $*Q, %1 : $@noescape @callee_owned (@in Q) -> @out Q):
   %4 = alloc_stack $Q
   %5 = init_existential_addr %4 : $*Q, $S
   %6 = function_ref @S_init : $@convention(method) (@thin S.Type) -> @owned S
   %7 = metatype $@thin S.Type
   %8 = apply %6(%7) : $@convention(method) (@thin S.Type) -> @owned S
   store %8 to %5 : $*S
-  %10 = apply %1(%0, %4) : $@callee_owned (@in Q) -> @out Q
+  %10 = apply %1(%0, %4) : $@noescape @callee_owned (@in Q) -> @out Q
   dealloc_stack %4 : $*Q
-  strong_release %1 : $@callee_owned (@in Q) -> @out Q
+  strong_release %1 : $@noescape @callee_owned (@in Q) -> @out Q
   %13 = tuple ()
   return %13 : $()
 }
@@ -321,10 +331,11 @@ bb0(%0 : $*Q, %1 : $@callee_owned (@in Q) -> @out Q):
 // CHECK: return
 sil @address_caller_out_result: $@convention(thin) (@in Q, @in Q) -> @out Q {
 bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q):
-  %5 = function_ref @address_closure_user_out_result : $@convention(thin) (@owned @callee_owned (@in Q) -> @out Q) -> @out Q
+  %5 = function_ref @address_closure_user_out_result : $@convention(thin) (@owned @noescape @callee_owned (@in Q) -> @out Q) -> @out Q
   %6 = function_ref @address_closure_out_result : $@convention(thin) (@in Q, @inout_aliasable Q, @inout_aliasable Q) -> @out Q
   %7 = partial_apply %6(%1, %2) : $@convention(thin) (@in Q, @inout_aliasable Q, @inout_aliasable Q) -> @out Q 
-  %8 = apply %5(%0, %7) : $@convention(thin) (@owned @callee_owned (@in Q) -> @out Q) -> @out Q
+  %7b = convert_function %7 : $@callee_owned (@in Q) -> @out Q to $@noescape @callee_owned (@in Q) -> @out Q
+  %8 = apply %5(%0, %7b) : $@convention(thin) (@owned @noescape @callee_owned (@in Q) -> @out Q) -> @out Q
   destroy_addr %2 : $*Q
   destroy_addr %1 : $*Q
   %11 = tuple ()
@@ -333,8 +344,8 @@ bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q):
 
 // CHECK-LABEL: sil @address_caller_existential
 // CHECK-NOT: partial_apply
-// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
-// CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
+// CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
 // CHECK: apply [[SPECIALIZED_FN2]]{{.*}}
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
@@ -345,11 +356,12 @@ bb0(%0 : $*P, %1 : $*P, %2 : $*P, %3 : $Int32):
   copy_addr %1 to [initialization] %7 : $*P
   %9 = function_ref @address_closure_existential : $@convention(thin) (@inout_aliasable P) -> ()
   %10 = partial_apply %9(%7) : $@convention(thin) (@inout_aliasable P) -> ()
-  %12 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %10b = convert_function %10 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %12 = function_ref @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   strong_retain %10 : $@callee_owned () -> ()
-  %14 = apply %12(%10) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %14 = apply %12(%10b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   strong_retain %10 : $@callee_owned () -> ()
-  %16 = apply %12(%10) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %16 = apply %12(%10b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %17 = integer_literal $Builtin.Int32, 10
   %18 = struct_extract %3 : $Int32, #Int32._value
   %19 = builtin "cmp_slt_Int32"(%17 : $Builtin.Int32, %18 : $Builtin.Int32) : $Builtin.Int1
@@ -404,9 +416,9 @@ bb0(%0 : $*S, %1 : $S):
 
 // CHECK-LABEL: sil @address_caller_struct
 // CHECK-NOT: partial_apply
-// CHECK: [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
+// CHECK: [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
 // CHECK: apply [[SPECIALIZED_FN1]]
-// CHECK: [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
+// CHECK: [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
 // CHECK: apply [[SPECIALIZED_FN2]]
 // CHECK-NOT: partial_apply
 // CHECK: return
@@ -415,16 +427,18 @@ bb0(%0 : $S, %1 : $S):
   %4 = alloc_stack $S, var, name "xx"
   %5 = struct_extract %0 : $S, #S.c
   store %0 to %4 : $*S
-  %7 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %7 = function_ref @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %8 = function_ref @address_closure_struct1 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
   %9 = partial_apply %8(%4, %1) : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+  %9b = convert_function %9 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
   retain_value %0 : $S
   retain_value %1 : $S
-  %12 = apply %7(%9) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %12 = apply %7(%9b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %13 = function_ref @address_closure_struct2 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
   %14 = partial_apply %13(%4, %0) : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+  %14b = convert_function %14 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
   retain_value %5 : $Optional<C>
-  %16 = apply %7(%14) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %16 = apply %7(%14b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %17 = load %4 : $*S
   dealloc_stack %4 : $*S
   return %17 : $S
@@ -441,8 +455,8 @@ bb0(%0 : $*C, %1 : $C):
 
 // CHECK-LABEL: sil @address_caller_class1
 // CHECK-NOT: partial_apply
-// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
-// CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
 // CHECK: apply [[SPECIALIZED_FN2]]{{.*}}
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
@@ -453,13 +467,14 @@ bb0(%0 : $C, %1 : $C):
   store %0 to %4 : $*C
   %7 = function_ref @address_closure_class1 : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
   %8 = partial_apply %7(%4, %1) : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
-  %10 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %8b = convert_function %8 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %10 = function_ref @address_closure_noescape_user : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   strong_retain %0 : $C
   strong_retain %1 : $C
   strong_retain %8 : $@callee_owned () -> ()
-  %14 = apply %10(%8) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %14 = apply %10(%8b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   strong_retain %8 : $@callee_owned () -> ()
-  %16 = apply %10(%8) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %16 = apply %10(%8b) : $@convention(thin) (@owned @noescape @callee_owned () -> ()) -> ()
   %17 = load %4 : $*C
   strong_retain %17 : $C
   strong_release %8 : $@callee_owned () -> ()
@@ -661,13 +676,13 @@ bb4:
 sil [noinline] @$S4test3barSiAA1P_p_SitF : $@convention(thin) (@in P, Int32) -> Int32 {
 bb0(%0 : $*P, %1 : $Int32):
   %2 = open_existential_addr mutable_access %0 : $*P to $*@opened("01234567-89ab-cdef-0123-000000000000") P
-  %3 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000") P, #P.foo!1, %2 : $*@opened("01234567-89ab-cdef-0123-000000000000") P : $@convention(witness_method: P) @callee_owned <T: P> (@owned @callee_owned (Int32) -> Int32, Int32, @inout T) -> Int32
+  %3 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000") P, #P.foo!1, %2 : $*@opened("01234567-89ab-cdef-0123-000000000000") P : $@convention(witness_method: P) @callee_owned <T: P> (@callee_owned (Int32) -> Int32, Int32, @inout T) -> Int32
   %4 = integer_literal $Builtin.Int32, 2
   %5 = struct $Int32 (%4 : $Builtin.Int32)
   // function_ref test.baz (Swift.Int32)(m : Swift.Int32) -> Swift.Int32
   %6 = function_ref @$S4test3bazSiSi1m_tcSiF : $@convention(thin) (Int32, Int32) -> Int32
   %7 = partial_apply %6(%5) : $@convention(thin) (Int32, Int32) -> Int32
-  %8 = apply %3<@opened("01234567-89ab-cdef-0123-000000000000") P>(%7, %1, %2) : $@convention(witness_method: P) @callee_owned <T: P> (@owned @callee_owned (Int32) -> Int32, Int32, @inout T) -> Int32
+  %8 = apply %3<@opened("01234567-89ab-cdef-0123-000000000000") P>(%7, %1, %2) : $@convention(witness_method: P) @callee_owned <T: P> (@callee_owned (Int32) -> Int32, Int32, @inout T) -> Int32
   destroy_addr %0 : $*P
   return %8 : $Int32
 }
@@ -687,7 +702,7 @@ bb0(%0 : $Builtin.Int32):
   unreachable
 }
 
-sil hidden [serialized] @thunk : $@convention(thin) (@owned @callee_owned () -> ()) -> @out () {
+sil hidden [serialized] @thunk : $@convention(thin) (@callee_owned () -> ()) -> @out () {
 bb0(%0 : $*(), %1 : $@callee_owned () -> ()):
   apply %1() : $@callee_owned () -> ()
   %9999 = tuple()
@@ -702,9 +717,9 @@ bb0:
   %f1 = function_ref @callee : $@convention(thin) (Builtin.Int32) -> ()
   %i1 = integer_literal $Builtin.Int32, 24
   %p1 = partial_apply %f1(%i1) : $@convention(thin) (Builtin.Int32) -> ()
-  %f2 = function_ref @thunk : $@convention(thin) (@owned @callee_owned () -> ()) -> @out ()
+  %f2 = function_ref @thunk : $@convention(thin) (@callee_owned () -> ()) -> @out ()
   %s1 = alloc_stack $()
-  %a1 = apply %f2(%s1, %p1) : $@convention(thin) (@owned @callee_owned () -> ()) -> @out ()
+  %a1 = apply %f2(%s1, %p1) : $@convention(thin) (@callee_owned () -> ()) -> @out ()
   dealloc_stack %s1 : $*()
   unreachable
 }

--- a/test/SILOptimizer/verify_noescape_closure.sil
+++ b/test/SILOptimizer/verify_noescape_closure.sil
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all -enforce-exclusivity=unchecked -diagnose-static-exclusivity %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+// REQUIRES: asserts
+
+// The test in this file is meant to fail during verification which currently
+// only runs in the diagnose-static-exclusivity pass, but will eventually run in
+// SIL verification.
+
+import Builtin
+import Swift
+
+// CHECK: Argument must be @noescape function type: %{{.*}} = partial_apply
+// CHECK: A partial_apply with @inout_aliasable may only be used as a @noescape function type argument.
+
+sil @takesEscapingClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+sil hidden @closureWithArgument : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%1 : $*Int):
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil @missingNoescape : $@convention(thin) (Int) ->() {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesEscapingClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %5 = function_ref @closureWithArgument : $@convention(thin) (@inout_aliasable Int) -> ()
+  %6 = partial_apply %5(%3) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %8 = apply %4(%6) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %9 = tuple ()
+  return %9 : $()
+}


### PR DESCRIPTION
Verify @inout_aliasable captures.
    
This is currently only done in DiagnoseStaticExclusivity because AllocBoxToStack
doesn't know how to set @noescape function types yet.

Negative test cases need to be added. This PR is currently just for SCK testing and review.
