### PR TITLE
Sema: Add a fix-it for integer literal to option set conversion.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2464,6 +2464,12 @@ static bool isIntegerToStringIndexConversion(Type fromType, Type toType,
           toType->getCanonicalType().getString() == "String.CharacterView.Index");
 }
 
+static bool isOptionSetType(Type fromType, const ConstraintSystem &CS) {
+  return conformsToKnownProtocol(fromType,
+                                 KnownProtocolKind::OptionSet,
+                                 CS);
+}
+
 /// Attempts to add fix-its for these two mistakes:
 ///
 /// - Passing an integer where a type conforming to RawRepresentable is
@@ -2533,6 +2539,12 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
   };
 
   if (conformsToKnownProtocol(fromType, kind, CS)) {
+    if (isOptionSetType(toType, CS) &&
+        isa<IntegerLiteralExpr>(expr) &&
+        cast<IntegerLiteralExpr>(expr)->getDigitsText() == "0") {
+      diag.fixItReplace(expr->getSourceRange(), "[]");
+      return true;
+    }
     if (auto rawTy = isRawRepresentable(toType, kind, CS)) {
       // Produce before/after strings like 'Result(rawValue: RawType(<expr>))'
       // or just 'Result(rawValue: <expr>)'.

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -30,6 +30,8 @@ struct MyMask : OptionSet {
   static var Bingo: MyMask { return MyMask(1) }
 }
 
+let _: MyMask = 0
+
 func supported() -> MyMask {
   return Int(MyMask.Bingo.rawValue)
 }

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -27,6 +27,8 @@ struct MyMask : OptionSet {
   static var Bingo: MyMask { return MyMask(1) }
 }
 
+let _: MyMask = []
+
 func supported() -> MyMask {
   return MyMask(rawValue: UInt(MyMask.Bingo))
 }


### PR DESCRIPTION
If expression type is `IntegerLiteralExpr` and value is equal to `0`, 
suggest `[]` as a replacement.

Resolves [SR-6716](https://bugs.swift.org/browse/SR-6716).