### PR TITLE
[silgen] Pass arguments to builtins at +1

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -190,14 +190,6 @@ static bool isValueAddressOrTrivial(SILValue V, SILModule &M) {
          V.getOwnershipKind() == ValueOwnershipKind::Any;
 }
 
-static bool isUnsafeGuaranteedBuiltin(SILInstruction *I) {
-  auto *BI = dyn_cast<BuiltinInst>(I);
-  if (!BI)
-    return false;
-  auto BuiltinKind = BI->getBuiltinKind();
-  return BuiltinKind == BuiltinValueKind::UnsafeGuaranteed;
-}
-
 // These operations forward both owned and guaranteed ownership.
 static bool isOwnershipForwardingValueKind(SILNodeKind K) {
   switch (K) {
@@ -239,22 +231,15 @@ static bool isGuaranteedForwardingValueKind(SILNodeKind K) {
 }
 
 static bool isGuaranteedForwardingValue(SILValue V) {
-  if (auto *SVI = dyn_cast<SingleValueInstruction>(V))
-    if (isUnsafeGuaranteedBuiltin(SVI))
-      return true;
   return isGuaranteedForwardingValueKind(
       V->getKindOfRepresentativeSILNodeInObject());
 }
 
 static bool isGuaranteedForwardingInst(SILInstruction *I) {
-  if (isUnsafeGuaranteedBuiltin(I))
-    return true;
   return isGuaranteedForwardingValueKind(SILNodeKind(I->getKind()));
 }
 
 static bool isOwnershipForwardingInst(SILInstruction *I) {
-  if (isUnsafeGuaranteedBuiltin(I))
-    return true;
   return isOwnershipForwardingValueKind(SILNodeKind(I->getKind()));
 }
 
@@ -1266,16 +1251,6 @@ public:
 
 } // end anonymous namespace
 
-OwnershipUseCheckerResult
-OwnershipCompatibilityBuiltinUseChecker::visitUnsafeGuaranteed(BuiltinInst *BI,
-                                                               StringRef Attr) {
-  // We accept owned or guaranteed values here.
-  if (compatibleWithOwnership(ValueOwnershipKind::Guaranteed))
-    return {true, UseLifetimeConstraint::MustBeLive};
-  return {compatibleWithOwnership(ValueOwnershipKind::Owned),
-          UseLifetimeConstraint::MustBeInvalidated};
-}
-
 // This is correct today since we do not have any builtins which return
 // @guaranteed parameters. This means that we can only have a lifetime ending
 // use with our builtins if it is owned.
@@ -1289,6 +1264,7 @@ OwnershipCompatibilityBuiltinUseChecker::visitUnsafeGuaranteed(BuiltinInst *BI,
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeLive, ErrorInMain)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeLive, UnexpectedError)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeLive, WillThrow)
+CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, UnsafeGuaranteed)
 CONSTANT_OWNERSHIP_BUILTIN(Trivial, MustBeLive, AShr)
 CONSTANT_OWNERSHIP_BUILTIN(Trivial, MustBeLive, Add)
 CONSTANT_OWNERSHIP_BUILTIN(Trivial, MustBeLive, Alignof)

--- a/lib/SIL/ValueOwnershipKindClassifier.cpp
+++ b/lib/SIL/ValueOwnershipKindClassifier.cpp
@@ -368,6 +368,9 @@ struct ValueOwnershipKindBuiltinVisitor
   }
 CONSTANT_OWNERSHIP_BUILTIN(Owned, Take)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, TryPin)
+// This returns a value at +1 that is destroyed strictly /after/ the
+// UnsafeGuaranteedEnd. This provides the guarantee that we want.
+CONSTANT_OWNERSHIP_BUILTIN(Owned, UnsafeGuaranteed)
 CONSTANT_OWNERSHIP_BUILTIN(Trivial, AShr)
 CONSTANT_OWNERSHIP_BUILTIN(Trivial, Add)
 CONSTANT_OWNERSHIP_BUILTIN(Trivial, And)
@@ -537,18 +540,6 @@ UNOWNED_OR_TRIVIAL_DEPENDING_ON_RESULT(ExtractElement)
 UNOWNED_OR_TRIVIAL_DEPENDING_ON_RESULT(InsertElement)
 UNOWNED_OR_TRIVIAL_DEPENDING_ON_RESULT(ZeroInitializer)
 #undef UNOWNED_OR_TRIVIAL_DEPENDING_ON_RESULT
-
-ValueOwnershipKind
-ValueOwnershipKindBuiltinVisitor::visitUnsafeGuaranteed(BuiltinInst *BI,
-                                                        StringRef Attr) {
-  assert(!BI->getType().isTrivial(BI->getModule()) &&
-         "Only non trivial types can have non trivial ownership");
-  auto Kind = BI->getArguments()[0].getOwnershipKind();
-  assert((Kind == ValueOwnershipKind::Owned ||
-          Kind == ValueOwnershipKind::Guaranteed) &&
-         "Invalid ownership kind for unsafe guaranteed?!");
-  return Kind;
-}
 
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *BI) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4192,7 +4192,9 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   auto builtinName = specializedEmitter.getBuiltinName();
   SmallVector<SILValue, 4> consumedArgs;
   for (auto arg : uncurriedArgs) {
-    consumedArgs.push_back(arg.forward(SGF));
+    // Builtins have a special convention that takes everything at +1.
+    auto maybePlusOne = arg.ensurePlusOne(SGF, uncurriedLoc.getValue());
+    consumedArgs.push_back(maybePlusOne.forward(SGF));
   }
   SILFunctionConventions substConv(substFnType, SGF.SGM.M);
   auto resultVal = SGF.B.createBuiltin(uncurriedLoc.getValue(), builtinName,

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -302,20 +302,6 @@ bb0(%0 : @owned $Ref):
   return %9999 : $()
 }
 
-sil @unsafeGuaranteedTest2 : $@convention(thin) (@owned Ref) -> () {
-bb0(%0 : @owned $Ref):
-  %1 = begin_borrow %0 : $Ref
-  %2 = builtin "unsafeGuaranteed"(%1 : $Ref) : $(Ref, Builtin.Int8)
-  %3 = begin_borrow %2 : $(Ref, Builtin.Int8)
-  %4 = tuple_extract %3 : $(Ref, Builtin.Int8), 1
-  end_borrow %3 from %2 : $(Ref, Builtin.Int8), $(Ref, Builtin.Int8)
-  builtin "unsafeGuaranteedEnd"(%4 : $Builtin.Int8) : $()
-  end_borrow %1 from %0 : $Ref, $Ref
-  destroy_value %0 : $Ref
-  %9999 = tuple()
-  return %9999 : $()
-}
-
 sil @unchecked_enum_data_propagates_ownership : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Optional<Builtin.NativeObject>):
   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>

--- a/test/SILGen/guaranteed_normal_args.swift
+++ b/test/SILGen/guaranteed_normal_args.swift
@@ -57,7 +57,7 @@ struct Buffer {
   }
 }
 
-typealias AnyObject = Builtin.AnyObject
+public typealias AnyObject = Builtin.AnyObject
 
 protocol Protocol {
   associatedtype AssocType
@@ -97,6 +97,10 @@ extension FakeDictionary : Sequence {
   public func makeIterator() -> FakeDictionaryIterator<Key, Value> {
     return FakeDictionaryIterator(self)
   }
+}
+
+public struct Unmanaged<Instance : AnyObject> {
+  internal unowned(unsafe) var _value: Instance
 }
 
 ///////////
@@ -196,5 +200,17 @@ extension FakeDictionary {
     for x in self {
       result.append(x)
     }
+  }
+}
+
+extension Unmanaged {
+  // Just make sure that we do not crash on this.
+  func unsafeGuaranteedTest<Result>(
+    _ body: (Instance) -> Result
+  ) -> Result {
+    let (guaranteedInstance, token) = Builtin.unsafeGuaranteed(_value)
+    let result = body(guaranteedInstance)
+    Builtin.unsafeGuaranteedEnd(token)
+    return result
   }
 }


### PR DESCRIPTION
This PR does 2 different things:

1. I removed my attempt to have the unsafe guaranteed builtin take a guaranteed value. It just makes things more complicated than needed.
2. With that in mind, I used ensurePlusOne to ensure that all values are passed to builtins at plus 1.

rdar://34222540