### PR TITLE
[AST] NFC: Add ParameterList::getType accessor which supports callback for param types

### DIFF
--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -142,6 +142,11 @@ public:
   ParameterList *clone(const ASTContext &C,
                        OptionSet<CloneFlags> options = None) const;
 
+  /// Return a TupleType or ParenType for this parameter list,
+  /// based on types provided by a callback.
+  Type getType(const ASTContext &C,
+               llvm::function_ref<Type(ParamDecl *)> getType) const;
+
   /// Return a TupleType or ParenType for this parameter list, written in terms
   /// of contextual archetypes.
   Type getType(const ASTContext &C) const;

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -116,43 +116,40 @@ ParameterList *ParameterList::clone(const ASTContext &C,
   return create(C, params);
 }
 
-/// Return a TupleType or ParenType for this parameter list, written in terms
-/// of contextual archetypes.
-Type ParameterList::getType(const ASTContext &C) const {
+/// Return a TupleType or ParenType for this parameter list,
+/// based on types provided by a callback.
+Type ParameterList::getType(
+    const ASTContext &C, llvm::function_ref<Type(ParamDecl *)> getType) const {
   if (size() == 0)
     return TupleType::getEmpty(C);
-  
+
   SmallVector<TupleTypeElt, 8> argumentInfo;
-  
+
   for (auto P : *this) {
-    auto type = P->getType();
-    
-    argumentInfo.emplace_back(
-        type->getInOutObjectType(), P->getArgumentName(),
-        ParameterTypeFlags::fromParameterType(type, P->isVariadic(), P->isShared()).withInOut(P->isInOut()));
+    auto type = getType(P);
+    argumentInfo.emplace_back(type->getInOutObjectType(), P->getArgumentName(),
+                              ParameterTypeFlags::fromParameterType(
+                                  type, P->isVariadic(), P->isShared())
+                                  .withInOut(P->isInOut()));
   }
 
   return TupleType::get(argumentInfo, C);
 }
 
 /// Return a TupleType or ParenType for this parameter list, written in terms
+/// of contextual archetypes.
+Type ParameterList::getType(const ASTContext &C) const {
+  return getType(C, [](ParamDecl *P) { return P->getType(); });
+}
+
+/// Return a TupleType or ParenType for this parameter list, written in terms
 /// of interface types.
 Type ParameterList::getInterfaceType(const ASTContext &C) const {
-  if (size() == 0)
-    return TupleType::getEmpty(C);
-
-  SmallVector<TupleTypeElt, 8> argumentInfo;
-
-  for (auto P : *this) {
+  return getType(C, [](ParamDecl *P) {
     auto type = P->getInterfaceType();
     assert(!type->hasArchetype());
-
-    argumentInfo.emplace_back(
-        type->getInOutObjectType(), P->getArgumentName(),
-        ParameterTypeFlags::fromParameterType(type, P->isVariadic(), P->isShared()).withInOut(P->isInOut()));
-  }
-
-  return TupleType::get(argumentInfo, C);
+    return type;
+  });
 }
 
 


### PR DESCRIPTION
Deduplicates some code in `ParameterList::get{Interface}Type` and in prerequisite for
caching of the parameter types in the solver.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
