### PR TITLE
[cmake] Add support for compiling all swift libraries with guaranteed…

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -313,6 +313,10 @@ function(_add_variant_swift_compile_flags
     list(APPEND result "-D" "INTERNAL_CHECKS_ENABLED")
   endif()
 
+  if (SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS)
+    list(APPEND result "-Xfrontend" "-enable-guaranteed-normal-arguments")
+  endif()
+
   set("${result_var_name}" "${result}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
… normal arguments.

I was using --extra-swift-args before, but lets do this for real now.

rdar://34222540