### PR TITLE
[Runtime] Demangle (some) generic types to type metadata

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -27,6 +27,11 @@
 namespace swift {
 namespace Demangle {
 
+/// Strip generic arguments from the "spine" of a context node, producing a
+/// bare context to be used in (e.g.) forming nominal type descriptors.
+NodePointer stripGenericArgsFromContextNode(const NodePointer &node,
+                                            NodeFactory &factory);
+
 /// Describe a function parameter, parameterized on the type
 /// representation.
 template <typename BuiltType>
@@ -471,12 +476,18 @@ private:
     // in addition to a reference to the parent type. The
     // mangled name already includes the module and parent
     // types, if any.
+    Demangle::NodePointer nominalNode = node;
     if (moduleOrParentType->getKind() != NodeKind::Module) {
       parent = decodeMangledType(moduleOrParentType);
       if (!parent) return false;
+
+      // Remove any generic arguments from the context node, producing a
+      // node that reference the nominal type declaration.
+      nominalNode =
+        stripGenericArgsFromContextNode(node, Builder.getNodeFactory());
     }
 
-    typeDecl = Builder.createNominalTypeDecl(node);
+    typeDecl = Builder.createNominalTypeDecl(nominalNode);
     if (!typeDecl) return false;
 
     return true;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -185,6 +185,8 @@ public:
     return TR;
   }
 
+  Demangle::NodeFactory &getNodeFactory() { return Dem; }
+
   ///
   /// Factory methods for all TypeRef kinds
   ///

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -166,6 +166,10 @@ private:
   StoredPointer IndexedClassesCountPointer;
   StoredPointer LastIndexedClassesCount = 0;
 
+  Demangle::NodeFactory Factory;
+
+  Demangle::NodeFactory &getNodeFactory() { return Factory; }
+
 public:
   BuilderType Builder;
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -930,6 +930,21 @@ public:
   /// type is not a class (or not a class with a class object).
   const TargetClassMetadata<Runtime> *getClassObject() const;
 
+  /// Retrieve the generic arguments of this type, if it has any.
+  ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> const *
+  getGenericArgs() const {
+    auto description = getNominalTypeDescriptor();
+    if (!description)
+      return nullptr;
+
+    if (!description->GenericParams.hasGenericRequirements())
+      return nullptr;
+
+    auto asWords = reinterpret_cast<
+      ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> const *>(this);
+    return (asWords + description->GenericParams.getOffset(this));
+  }
+
 #if SWIFT_OBJC_INTEROP
   /// Get the ObjC class object for this type if it has one, or return null if
   /// the type is not a class (or not a class with a class object).
@@ -1853,17 +1868,6 @@ struct TargetValueMetadata : public TargetMetadata<Runtime> {
     return metadata->getKind() == MetadataKind::Struct
       || metadata->getKind() == MetadataKind::Enum
       || metadata->getKind() == MetadataKind::Optional;
-  }
-  
-  /// Retrieve the generic arguments of this type.
-  ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> const *
-  getGenericArgs() const {
-    if (!Description->GenericParams.hasGenericRequirements())
-      return nullptr;
-
-    auto asWords = reinterpret_cast<
-      ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> const *>(this);
-    return (asWords + Description->GenericParams.getOffset(this));
   }
 
   const TargetNominalTypeDescriptor<Runtime> *getDescription() const {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1029,7 +1029,7 @@ struct GenericContextDescriptor {
   /// to NumGenericRequirements; it counts only the type parameters
   /// and not any required witness tables.
   uint32_t NumPrimaryParams;
-  
+
   // TODO: add meaningful descriptions of the generic requirements.
 };
 

--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -8,5 +8,6 @@ add_swift_library(swiftDemangling STATIC
   OldRemangler.cpp
   Punycode.cpp
   Remangler.cpp
+  TypeDecoder.cpp
   )
 

--- a/lib/Demangling/TypeDecoder.cpp
+++ b/lib/Demangling/TypeDecoder.cpp
@@ -1,0 +1,63 @@
+//===--- TypeDecoder.cpp - Type decoding from a demangling tree -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements support routines for the TypeDecoder class template.
+//
+//===----------------------------------------------------------------------===//
+#include "swift/Demangling/TypeDecoder.h"
+
+using namespace swift;
+using namespace Demangle;
+
+NodePointer Demangle::stripGenericArgsFromContextNode(const NodePointer &node,
+                                                      NodeFactory &factory) {
+  switch (node->getKind()) {
+  case Demangle::Node::Kind::BoundGenericClass:
+  case Demangle::Node::Kind::BoundGenericEnum:
+  case Demangle::Node::Kind::BoundGenericStructure:
+    // Bound generic types have a 'Type' node under them, whose child is
+    // the non-generic reference. If we don't see that structure, do nothing.
+    if (node->getNumChildren() < 2 ||
+        node->getChild(0)->getKind() != Demangle::Node::Kind::Type ||
+        node->getChild(0)->getNumChildren() < 1)
+      return node;
+
+    // Strip generic arguments from that child, then return it.
+    return stripGenericArgsFromContextNode(node->getChild(0)->getChild(0),
+                                          factory);
+
+  case Demangle::Node::Kind::Class:
+  case Demangle::Node::Kind::Enum:
+  case Demangle::Node::Kind::Structure: {
+    if (node->getNumChildren() < 2)
+      return node;
+
+    auto newContext = stripGenericArgsFromContextNode(node->getChild(0),
+                                                      factory);
+    if (newContext == node->getChild(0)) return node;
+
+    auto newNode = factory.createNode(node->getKind());
+    newNode->addChild(newContext, factory);
+    for (unsigned i = 1, n = node->getNumChildren(); i != n; ++i)
+      newNode->addChild(node->getChild(i), factory);
+    return newNode;
+  }
+
+  case Demangle::Node::Kind::Module:
+    // Modules terminate the recursion.
+    return node;
+
+  default:
+    // FIXME: Handle local contexts.
+    return node;
+  }
+}

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -83,6 +83,7 @@ public:
 /// just finds and builds things in the AST.
 class RemoteASTTypeBuilder {
   ASTContext &Ctx;
+  Demangle::NodeFactory Factory;
 
   /// The notional context in which we're writing and type-checking code.
   /// Created lazily.
@@ -122,6 +123,8 @@ public:
     return Result<T>::emplaceFailure(defaultFailureKind,
                std::forward<DefaultFailureArgTys>(defaultFailureArgs)...);
   }
+
+  Demangle::NodeFactory &getNodeFactory() { return Factory; }
 
   Type createBuiltinType(const std::string &mangledName) {
     // TODO

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_library(swiftReflection STATIC TARGET_LIBRARY FORCE_BUILD_FOR_HOST_SDK
   "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
+  "${SWIFT_SOURCE_DIR}/lib/Demangling/TypeDecoder.cpp"
 
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
   LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -37,7 +37,9 @@ set(swift_runtime_objc_sources
     SwiftValue.mm
     Reflection.mm
     "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp")
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/TypeDecoder.cpp"
+    )
 
 set(swift_runtime_sources
     AnyHashableSupport.cpp

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -171,5 +171,24 @@ DemangleToMetadataTests.test("substitutions") {
     _typeByMangledName("x_6Assoc14main2P4PQz6Assoc24main2P4PQzt", substitutions: [[S.self]])!)
 }
 
+enum EG<T, U> { case a }
+
+class CG3<T, U, V> { }
+
+DemangleToMetadataTests.test("simple generic specializations") {
+  expectEqual([Int].self, _typeByMangledName("SaySiG")!)
+  expectEqual(EG<Int, String>.self, _typeByMangledName("4main2EGOySiSSG")!)
+  expectEqual(CG3<Int, Double, String>.self, _typeByMangledName("4main3CG3CySiSdSSG")!)
+}
+
+extension EG {
+  struct NestedSG<V> { }
+}
+
+DemangleToMetadataTests.test("nested generic specializations") {
+  // FIXME: Will equal EG<Int, String>.NestedSG<Double>.self
+  expectNil(_typeByMangledName("4main2EGO8NestedSGVySiSS_SdG"))
+}
+
 runAllTests()
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -185,9 +185,27 @@ extension EG {
   struct NestedSG<V> { }
 }
 
+extension C {
+  enum Nested<T, U> {
+    case a
+
+    struct Innermore {
+      struct Innermost<V> { }
+    }
+  }
+}
+
+class CG2<T, U> {
+  class Inner<V> { }
+}
+
 DemangleToMetadataTests.test("nested generic specializations") {
-  // FIXME: Will equal EG<Int, String>.NestedSG<Double>.self
-  expectNil(_typeByMangledName("4main2EGO8NestedSGVySiSS_SdG"))
+  expectEqual(EG<Int, String>.NestedSG<Double>.self,
+    _typeByMangledName("4main2EGO8NestedSGVySiSS_SdG")!)
+  expectEqual(C.Nested<Int, String>.Innermore.Innermost<Double>.self,
+    _typeByMangledName("4main1CC6NestedO9InnermoreV9InnermostVy_SiSS__SdG")!)
+  expectEqual(CG2<Int, String>.Inner<Double>.self,
+    _typeByMangledName("4main3CG2C5InnerCySiSS_SdG")!)
 }
 
 runAllTests()


### PR DESCRIPTION
Support for demangling some generic types---those with fewer than 3 total generic parameters and without any additional requirements---into type metadata.