### PR TITLE
IRGen: Have IRGenFunction() automatically initialize IRGenDebugInfo (…

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -77,14 +77,14 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
   }
 
   // DynamicSelfType is also sugar as far as debug info is concerned.
-  auto DeclSelfType = DeclType;
+  auto Sugared = DeclType;
   if (auto DynSelfTy = DeclType->getAs<DynamicSelfType>())
-    DeclSelfType = DynSelfTy->getSelfType();
+    Sugared = DynSelfTy->getSelfType();
 
   // Prefer the original, potentially sugared version of the type if
   // the type hasn't been mucked with by an optimization pass.
-  auto *Type = DeclSelfType->isEqual(RealType) ? DeclType.getPointer()
-                                               : RealType.getPointer();
+  auto *Type = Sugared->isEqual(RealType) ? DeclType.getPointer()
+                                          : RealType.getPointer();
   return getFromTypeInfo(DC, GE, Type, Info);
 }
 


### PR DESCRIPTION
…NFC)

This patch simplifies the code and makes it less likely that future
customers of IRGenFunction forget to emit debug info for artificial
functions.
