### PR TITLE
[DebugInfo] Avoid applying a misleading cleanup loc in case blocks

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2317,7 +2317,13 @@ void PatternMatchEmission::emitCaseBody(CaseStmt *caseBlock) {
 
   // Implicitly break out of the pattern match statement.
   if (SGF.B.hasValidInsertionPoint()) {
-    SGF.emitBreakOutOf(CleanupLocation(caseBlock), PatternMatchStmt);
+    // Case blocks without trailing braces have ambiguous cleanup locations.
+    SILLocation cleanupLoc = getCompilerGeneratedLocation();
+    if (auto *braces = dyn_cast<BraceStmt>(caseBlock->getBody()))
+      if (braces->getNumElements() == 1 &&
+          dyn_cast_or_null<DoStmt>(braces->getElement(0).dyn_cast<Stmt *>()))
+        cleanupLoc = CleanupLocation(caseBlock);
+    SGF.emitBreakOutOf(cleanupLoc, PatternMatchStmt);
   }
 }
 

--- a/test/DebugInfo/patternmatching.swift
+++ b/test/DebugInfo/patternmatching.swift
@@ -23,7 +23,7 @@ switch p {
       markUsed(x)
       // SIL-CHECK:  dealloc_stack{{.*}}line:[[@LINE-1]]:17:cleanup
       // Verify that the branch has a location >= the cleanup.
-      // SIL-CHECK-NEXT:  br{{.*}}line:[[@LINE-3]]:17:cleanup
+      // SIL-CHECK-NEXT:  br{{.*}}no_loc
       // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg
@@ -56,5 +56,16 @@ switch p {
       // CHECK-SCOPES-SAME:                     scope: ![[SCOPE3]])
       markUsed(x)
     }
+
+switch p {
+    case (let x, let y) where x == 0:
+      if y == 0 { markUsed(x) }
+      else      { markUsed(y) } // SIL-CHECK-NOT: br{{.*}}line:[[@LINE]]:31:cleanup
+    case (let x, let y): do {
+      if y == 0 { markUsed(x) }
+      else      { markUsed(y) }
+    } // SIL-CHECK: br{{.*}}line:[[@LINE]]:5:cleanup
+}
+
 // CHECK: !DILocation(line: [[@LINE+1]],
 }


### PR DESCRIPTION
Switch cases without a trailing curly brace have ambiguous cleanup
locations. Here's what the current stepping behavior looks like:

  switch x {
    case ...:
      if true { foo() } // Step
      else    { bar() } // Step
  }

The second step can be misleading, because users might think that the
else branch is taken.

rdar://35628620