### PR TITLE
Support open_boxed_existential IRGen test under resilient_stdlib

### DIFF
--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -92,27 +92,6 @@ entry(%b : $Error):
   return %l : $Int
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc {{i[0-9]+}} @open_boxed_existential(%swift.error*)
-sil @open_boxed_existential : $@convention(thin) (@owned Error) -> Int {
-entry(%b : $Error):
-  // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])
-  // CHECK: [[OUT_ADDR:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 0
-  // CHECK: [[ADDR:%.*]] = load {{.*}} [[OUT_ADDR]]
-  // CHECK: [[OUT_TYPE:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 1
-  // CHECK: [[TYPE:%.*]] = load {{.*}} [[OUT_TYPE]]
-  // CHECK: [[OUT_WITNESS:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 2
-  // CHECK: [[WITNESS:%.*]] = load {{.*}} [[OUT_WITNESS]]
-  %o = open_existential_box %b : $Error to $*@opened("01234567-89AB-CDEF-0123-000000000000") Error
-  // CHECK: [[CODE_ADDR:%.*]] = getelementptr {{.*}} [[WITNESS]], i32 1
-  // CHECK: [[CODE:%.*]] = load {{.*}} [[CODE_ADDR]]
-  %m = witness_method $@opened("01234567-89AB-CDEF-0123-000000000000") Error, #Error._code!getter.1, %o : $*@opened("01234567-89AB-CDEF-0123-000000000000") Error : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
-  // CHECK: [[CODE_FN:%.*]] = bitcast i8* [[CODE]] to [[INT:i[0-9]+]] (%swift.opaque*, %swift.type*, i8**)*
-  // CHECK: [[RESULT:%.*]] = call swiftcc [[INT]] [[CODE_FN]](%swift.opaque* noalias nocapture swiftself [[ADDR]], %swift.type* [[TYPE]], i8** [[WITNESS]])
-  %c = apply %m<@opened("01234567-89AB-CDEF-0123-000000000000") Error>(%o) : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
-  // CHECK: ret [[INT]] [[RESULT]]
-  return %c : $Int
-}
-
 sil @dynamic_type_boxed_existential : $@convention(thin) (@owned Error) -> @thick Error.Type {
 entry(%b : $Error):
   // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])

--- a/test/IRGen/open_boxed_existential.sil
+++ b/test/IRGen/open_boxed_existential.sil
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
+
+// XFAIL: resilient_stdlib
+
+import Swift
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc {{i[0-9]+}} @open_boxed_existential(%swift.error*)
+sil @open_boxed_existential : $@convention(thin) (@owned Error) -> Int {
+entry(%b : $Error):
+  // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])
+  // CHECK: [[OUT_ADDR:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 0
+  // CHECK: [[ADDR:%.*]] = load {{.*}} [[OUT_ADDR]]
+  // CHECK: [[OUT_TYPE:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 1
+  // CHECK: [[TYPE:%.*]] = load {{.*}} [[OUT_TYPE]]
+  // CHECK: [[OUT_WITNESS:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 2
+  // CHECK: [[WITNESS:%.*]] = load {{.*}} [[OUT_WITNESS]]
+  %o = open_existential_box %b : $Error to $*@opened("01234567-89AB-CDEF-0123-000000000000") Error
+  // CHECK: [[CODE_ADDR:%.*]] = getelementptr {{.*}} [[WITNESS]], i32 1
+  // CHECK: [[CODE:%.*]] = load {{.*}} [[CODE_ADDR]]
+  %m = witness_method $@opened("01234567-89AB-CDEF-0123-000000000000") Error, #Error._code!getter.1, %o : $*@opened("01234567-89AB-CDEF-0123-000000000000") Error : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
+  // CHECK: [[CODE_FN:%.*]] = bitcast i8* [[CODE]] to [[INT:i[0-9]+]] (%swift.opaque*, %swift.type*, i8**)*
+  // CHECK: [[RESULT:%.*]] = call swiftcc [[INT]] [[CODE_FN]](%swift.opaque* noalias nocapture swiftself [[ADDR]], %swift.type* [[TYPE]], i8** [[WITNESS]])
+  %c = apply %m<@opened("01234567-89AB-CDEF-0123-000000000000") Error>(%o) : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
+  // CHECK: ret [[INT]] [[RESULT]]
+  return %c : $Int
+}
+

--- a/test/IRGen/open_boxed_existential_resilience.sil
+++ b/test/IRGen/open_boxed_existential_resilience.sil
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
+
+// REQUIRES: resilient_stdlib
+
+import Swift
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc {{i[0-9]+}} @open_boxed_existential(%swift.error*)
+sil @open_boxed_existential : $@convention(thin) (@owned Error) -> Int {
+entry(%b : $Error):
+  // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])
+  // CHECK: [[OUT_ADDR:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 0
+  // CHECK: [[ADDR:%.*]] = load {{.*}} [[OUT_ADDR]]
+  // CHECK: [[OUT_TYPE:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 1
+  // CHECK: [[TYPE:%.*]] = load {{.*}} [[OUT_TYPE]]
+  // CHECK: [[OUT_WITNESS:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 2
+  // CHECK: [[WITNESS:%.*]] = load {{.*}} [[OUT_WITNESS]]
+  %o = open_existential_box %b : $Error to $*@opened("01234567-89AB-CDEF-0123-000000000000") Error
+  %m = witness_method $@opened("01234567-89AB-CDEF-0123-000000000000") Error, #Error._code!getter.1, %o : $*@opened("01234567-89AB-CDEF-0123-000000000000") Error : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
+  // CHECK: [[RESULT:%.*]] =  call swiftcc [[INT:i[0-9]+]] @"$Ss5ErrorP5_codeSivgTj"(%swift.opaque* noalias nocapture swiftself [[ADDR]], %swift.type* [[TYPE]], i8** [[WITNESS]])
+  %c = apply %m<@opened("01234567-89AB-CDEF-0123-000000000000") Error>(%o) : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
+  // CHECK: ret [[INT]] [[RESULT]]
+  return %c : $Int
+}


### PR DESCRIPTION
rdar://problem/36426676

IRGen's `open_boxed_existential` test does a get on a (now resilient) Protocol (`Error`). When compiling with a resilient standard library the expected output is different: we access the getter via a dispatch thunk.