### PR TITLE
Minor fixes

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -20,7 +20,8 @@
   (fill-column . 80)
   (c-file-style . "swift"))
  (c++-mode
-  (whitespace-style face lines indentation:space))
+  (whitespace-style face lines indentation:space)
+  (flycheck-clang-language-standard . "c++14"))
  (c-mode
   (whitespace-style face lines indentation:space))
  (objc-mode

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -49,8 +49,10 @@ makeFileName(StringRef Prefix,
   std::string tmp;
   raw_string_ostream stream(tmp);
   auto now = std::chrono::system_clock::now();
+  auto dur = now.time_since_epoch();
+  auto usec = std::chrono::duration_cast<std::chrono::microseconds>(dur);
   stream << Prefix
-         << "-" << now.time_since_epoch().count()
+         << "-" << usec.count()
          << "-" << ProgramName
          << "-" << AuxName
          << "-" << Process::GetRandomNumber()

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -87,6 +87,9 @@ def write_catapult_trace(args):
     vargs = vars_of_args(args)
     for path in args.remainder:
         allstats += load_stats_dir(path, **vargs)
+    allstats.sort(key=attrgetter('start_usec'))
+    for i in range(len(allstats)):
+        allstats[i].jobid = i
     json.dump([s.to_catapult_trace_obj() for s in allstats], args.output)
 
 


### PR DESCRIPTION
3 minor changes that came up while working on batch mode. The flycheck fix is quite optional but the stats dir changes are somewhat more important for measuring on linux and writing visually-useful catapult traces. 