### PR TITLE
[DebugInfo] Avoid applying a misleading cleanup loc in case blocks

### DIFF
--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -502,6 +502,10 @@ private:
   }
 };
 
+/// Empty locations may be applied to instructions without any clear
+/// correspondence to an AST node.
+static inline RegularLocation getEmptyLocation() { return {SourceLoc()}; }
+
 /// Used to represent a return instruction in user code.
 ///
 /// Allowed on an BranchInst, ReturnInst.
@@ -705,7 +709,7 @@ class SILDebugLocation {
   SILLocation Location;
 
 public:
-  SILDebugLocation() : Scope(nullptr), Location(RegularLocation(SourceLoc())) {}
+  SILDebugLocation() : Scope(nullptr), Location(getEmptyLocation()) {}
   SILDebugLocation(SILLocation Loc, const SILDebugScope *DS)
       : Scope(DS), Location(Loc) {}
   SILLocation getLocation() const { return Location; }

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -502,9 +502,11 @@ private:
   }
 };
 
-/// Empty locations may be applied to instructions without any clear
-/// correspondence to an AST node.
-static inline RegularLocation getEmptyLocation() { return {SourceLoc()}; }
+/// Compiler-generated locations may be applied to instructions without any
+/// clear correspondence to an AST node.
+static inline RegularLocation getCompilerGeneratedLocation() {
+  return {SourceLoc()};
+}
 
 /// Used to represent a return instruction in user code.
 ///
@@ -709,7 +711,8 @@ class SILDebugLocation {
   SILLocation Location;
 
 public:
-  SILDebugLocation() : Scope(nullptr), Location(getEmptyLocation()) {}
+  SILDebugLocation()
+      : Scope(nullptr), Location(getCompilerGeneratedLocation()) {}
   SILDebugLocation(SILLocation Loc, const SILDebugScope *DS)
       : Scope(DS), Location(Loc) {}
   SILLocation getLocation() const { return Location; }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -522,7 +522,7 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,
   // Record the ArgNo of the artificial $error inout argument. 
   unsigned ArgNo = emitter.getNumArgs();
   if (throws) {
-    RegularLocation Loc = getEmptyLocation();
+    RegularLocation Loc = getCompilerGeneratedLocation();
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC))
       Loc = AFD->getThrowsLoc();
     else if (auto *ACE = dyn_cast<AbstractClosureExpr>(DC))

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -522,7 +522,7 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,
   // Record the ArgNo of the artificial $error inout argument. 
   unsigned ArgNo = emitter.getNumArgs();
   if (throws) {
-    RegularLocation Loc{SourceLoc()};
+    RegularLocation Loc = getEmptyLocation();
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC))
       Loc = AFD->getThrowsLoc();
     else if (auto *ACE = dyn_cast<AbstractClosureExpr>(DC))

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2177,7 +2177,7 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
   // Use an empty location for the alloc_stack. If Loc is variable declaration
   // the alloc_stack would look like the storage of that variable.
   auto *ControlVariableBox =
-      B.createAllocStack(RegularLocation(SourceLoc()), IVType);
+      B.createAllocStack(getEmptyLocation(), IVType);
   
   // Find all the return blocks in the function, inserting a dealloc_stack
   // before the return.

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2177,7 +2177,7 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
   // Use an empty location for the alloc_stack. If Loc is variable declaration
   // the alloc_stack would look like the storage of that variable.
   auto *ControlVariableBox =
-      B.createAllocStack(getEmptyLocation(), IVType);
+      B.createAllocStack(getCompilerGeneratedLocation(), IVType);
   
   // Find all the return blocks in the function, inserting a dealloc_stack
   // before the return.

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -979,12 +979,10 @@ static void createArgumentRelease(SILBuilder &Builder, ArgumentDescriptor &AD) {
   if (Arg->getType().isAddress()) {
     assert(AD.PInfo->getConvention() == ParameterConvention::Indirect_In
            && F.getConventions().useLoweredAddresses());
-    Builder.createDestroyAddr(RegularLocation(SourceLoc()),
-                              F.getArguments()[AD.Index]);
+    Builder.createDestroyAddr(getEmptyLocation(), F.getArguments()[AD.Index]);
     return;
   }
-  Builder.createReleaseValue(RegularLocation(SourceLoc()),
-                             F.getArguments()[AD.Index],
+  Builder.createReleaseValue(getEmptyLocation(), F.getArguments()[AD.Index],
                              Builder.getDefaultAtomicity());
 }
 
@@ -1028,13 +1026,13 @@ OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD, SILBuilder &Builder,
   SILInstruction *Call = findOnlyApply(F);
   if (auto AI = dyn_cast<ApplyInst>(Call)) {
     Builder.setInsertionPoint(&*std::next(SILBasicBlock::iterator(AI)));
-    Builder.createRetainValue(RegularLocation(SourceLoc()), AI,
+    Builder.createRetainValue(getEmptyLocation(), AI,
                               Builder.getDefaultAtomicity());
   } else {
     SILBasicBlock *NormalBB = cast<TryApplyInst>(Call)->getNormalBB();
     Builder.setInsertionPoint(&*NormalBB->begin());
-    Builder.createRetainValue(RegularLocation(SourceLoc()),
-                              NormalBB->getArgument(0), Builder.getDefaultAtomicity());
+    Builder.createRetainValue(getEmptyLocation(), NormalBB->getArgument(0),
+                              Builder.getDefaultAtomicity());
   }
 }
 

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -979,10 +979,12 @@ static void createArgumentRelease(SILBuilder &Builder, ArgumentDescriptor &AD) {
   if (Arg->getType().isAddress()) {
     assert(AD.PInfo->getConvention() == ParameterConvention::Indirect_In
            && F.getConventions().useLoweredAddresses());
-    Builder.createDestroyAddr(getEmptyLocation(), F.getArguments()[AD.Index]);
+    Builder.createDestroyAddr(getCompilerGeneratedLocation(),
+                              F.getArguments()[AD.Index]);
     return;
   }
-  Builder.createReleaseValue(getEmptyLocation(), F.getArguments()[AD.Index],
+  Builder.createReleaseValue(getCompilerGeneratedLocation(),
+                             F.getArguments()[AD.Index],
                              Builder.getDefaultAtomicity());
 }
 
@@ -1026,12 +1028,13 @@ OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD, SILBuilder &Builder,
   SILInstruction *Call = findOnlyApply(F);
   if (auto AI = dyn_cast<ApplyInst>(Call)) {
     Builder.setInsertionPoint(&*std::next(SILBasicBlock::iterator(AI)));
-    Builder.createRetainValue(getEmptyLocation(), AI,
+    Builder.createRetainValue(getCompilerGeneratedLocation(), AI,
                               Builder.getDefaultAtomicity());
   } else {
     SILBasicBlock *NormalBB = cast<TryApplyInst>(Call)->getNormalBB();
     Builder.setInsertionPoint(&*NormalBB->begin());
-    Builder.createRetainValue(getEmptyLocation(), NormalBB->getArgument(0),
+    Builder.createRetainValue(getCompilerGeneratedLocation(),
+                              NormalBB->getArgument(0),
                               Builder.getDefaultAtomicity());
   }
 }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -50,7 +50,7 @@ swift::createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
 
   // Set up the builder we use to insert at our insertion point.
   SILBuilder B(InsertPt);
-  auto Loc = RegularLocation(SourceLoc());
+  auto Loc = getEmptyLocation();
 
   // If Ptr is refcounted itself, create the strong_retain and
   // return.
@@ -75,7 +75,7 @@ swift::createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
 
   // Setup the builder we will use to insert at our insertion point.
   SILBuilder B(InsertPt);
-  auto Loc = RegularLocation(SourceLoc());
+  auto Loc = getEmptyLocation();
 
   // If Ptr has reference semantics itself, create a strong_release.
   if (Ptr->getType().isReferenceCounted(B.getModule())) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -50,7 +50,7 @@ swift::createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
 
   // Set up the builder we use to insert at our insertion point.
   SILBuilder B(InsertPt);
-  auto Loc = getEmptyLocation();
+  auto Loc = getCompilerGeneratedLocation();
 
   // If Ptr is refcounted itself, create the strong_retain and
   // return.
@@ -75,7 +75,7 @@ swift::createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
 
   // Setup the builder we will use to insert at our insertion point.
   SILBuilder B(InsertPt);
-  auto Loc = getEmptyLocation();
+  auto Loc = getCompilerGeneratedLocation();
 
   // If Ptr has reference semantics itself, create a strong_release.
   if (Ptr->getType().isReferenceCounted(B.getModule())) {

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -35,7 +35,7 @@ static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
   }
 
   // Create the branch to the header.
-  SILBuilder(Preheader).createBranch(getEmptyLocation(), Header,
+  SILBuilder(Preheader).createBranch(getCompilerGeneratedLocation(), Header,
                                      Args);
 
   return Preheader;

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -35,7 +35,7 @@ static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
   }
 
   // Create the branch to the header.
-  SILBuilder(Preheader).createBranch(RegularLocation(SourceLoc()), Header,
+  SILBuilder(Preheader).createBranch(getEmptyLocation(), Header,
                                      Args);
 
   return Preheader;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -452,7 +452,7 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
   auto fn = existingFn;
 
   // TODO: use the correct SILLocation from module.
-  SILLocation loc = getEmptyLocation();
+  SILLocation loc = getCompilerGeneratedLocation();
 
   // If we have an existing function, verify that the types match up.
   if (fn) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -452,7 +452,7 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
   auto fn = existingFn;
 
   // TODO: use the correct SILLocation from module.
-  SILLocation loc = RegularLocation(SourceLoc());
+  SILLocation loc = getEmptyLocation();
 
   // If we have an existing function, verify that the types match up.
   if (fn) {

--- a/test/DebugInfo/patternmatching.swift
+++ b/test/DebugInfo/patternmatching.swift
@@ -23,7 +23,7 @@ switch p {
       markUsed(x)
       // SIL-CHECK:  dealloc_stack{{.*}}line:[[@LINE-1]]:17:cleanup
       // Verify that the branch has a location >= the cleanup.
-      // SIL-CHECK-NEXT:  br{{.*}}line:[[@LINE-3]]:17:cleanup
+      // SIL-CHECK-NEXT:  br{{.*}}no_loc
       // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg
@@ -56,5 +56,16 @@ switch p {
       // CHECK-SCOPES-SAME:                     scope: ![[SCOPE3]])
       markUsed(x)
     }
+
+switch p {
+    case (let x, let y) where x == 0:
+      if y == 0 { markUsed(x) }
+      else      { markUsed(y) } // SIL-CHECK-NOT: br{{.*}}line:[[@LINE]]:31:cleanup
+    case (let x, let y): do {
+      if y == 0 { markUsed(x) }
+      else      { markUsed(y) }
+    } // SIL-CHECK: br{{.*}}line:[[@LINE]]:5:cleanup
+}
+
 // CHECK: !DILocation(line: [[@LINE+1]],
 }


### PR DESCRIPTION
Switch cases without a trailing curly brace have ambiguous cleanup
locations. Here's what the current stepping behavior looks like:

  switch x {
    case ...:
      if true { foo() } // Step
      else    { bar() } // Step
  }

The second step can be misleading, because users might think that the
else branch is taken.

rdar://35628620
(cherry picked from commit b27ed065b6bb67c27a4e5f8e8863ee7c12f32065)