### PR TITLE
[DefiniteInit] Correctly set the debug scope when creating a `store`.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2191,7 +2191,9 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
   }
   
   // Before the memory allocation, store zero in the control variable.
-  B.setInsertionPoint(&*std::next(TheMemory.MemoryInst->getIterator()));
+  auto *InsertPoint = &*std::next(TheMemory.MemoryInst->getIterator());
+  B.setInsertionPoint(InsertPoint);
+  B.setCurrentDebugScope(InsertPoint->getDebugScope());
   SILValue ControlVariableAddr = ControlVariableBox;
   auto Zero = B.createIntegerLiteral(Loc, IVType, 0);
   B.createStore(Loc, Zero, ControlVariableAddr,

--- a/test/SILOptimizer/definite-init-wrong-scope2.swift
+++ b/test/SILOptimizer/definite-init-wrong-scope2.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -emit-sil %s -Onone -Xllvm -sil-print-debuginfo \
+// RUN:   -o /dev/null -Xllvm -sil-print-after=definite-init \
+// RUN:   -Xllvm -sil-print-only-functions=$S8patatino4BearC6before7before26during5afterACSb_S3btKcfc \
+// RUN:   2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+func unwrap(_ b: Bool) throws -> Int {
+  return 0
+}
+class Bear {
+  let x: LifetimeTracked
+  init(n: Int, before: Bool) throws {
+    self.x = LifetimeTracked(0)
+  }
+  init(n: Int, after: Bool) throws {
+    self.x = LifetimeTracked(0)
+  }
+  convenience init(before: Bool, before2: Bool, during: Bool, after: Bool) throws {
+    try self.init(n: unwrap(before2), after: during)
+  }
+}
+
+// CHECK: %7 = integer_literal $Builtin.Int1, 0, loc {{.*}}:20:15, scope 1
+// CHECK-NEXT:  store %7 to [trivial] %5 : $*Builtin.Int1, loc {{.*}}:20:15, scope 1


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-6745

<rdar://problem/36474392>