### PR TITLE
Remove some unnecessary autoreleasepool calls from tests

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -2007,10 +2007,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.DictionaryIsCopied") {
 
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.NSDictionaryIsRetained") {
-  var nsd: NSDictionary = autoreleasepool {
+  var nsd: NSDictionary =
     NSDictionary(dictionary:
       getAsNSDictionary([10: 1010, 20: 1020, 30: 1030]))
-  }
 
   var d: [NSObject : AnyObject] = convertNSDictionaryToDictionary(nsd)
 
@@ -2026,10 +2025,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.NSDictionaryIsRetained") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.NSDictionaryIsCopied") {
-  var nsd: NSDictionary = autoreleasepool {
+  var nsd: NSDictionary =
     NSDictionary(dictionary:
       getAsNSDictionary([10: 1010, 20: 1020, 30: 1030]))
-  }
 
   var d: [TestBridgedKeyTy : TestBridgedValueTy] =
     convertNSDictionaryToDictionary(nsd)


### PR DESCRIPTION
Either the autoreleases no longer happen or they no longer cause problems.

rdar://27528234