### PR TITLE
SIL: Remove isLessVisibleThan()

### DIFF
--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -203,33 +203,6 @@ inline bool hasPrivateVisibility(SILLinkage linkage) {
   llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
-/// Returns true if l1 is less visible than l2.
-inline bool isLessVisibleThan(SILLinkage l1, SILLinkage l2) {
-  if (l1 == SILLinkage::PublicExternal)
-    l1 = SILLinkage::Public;
-  else if (l1 == SILLinkage::HiddenExternal)
-    l1 = SILLinkage::Hidden;
-  else if (l1 == SILLinkage::Shared)
-    l1 = SILLinkage::Public;
-  else if (l1 == SILLinkage::SharedExternal)
-    l1 = SILLinkage::Public;
-  else if (l1 == SILLinkage::PrivateExternal)
-    l1 = SILLinkage::Private;
-
-  if (l2 == SILLinkage::PublicExternal)
-    l2 = SILLinkage::Public;
-  else if (l2 == SILLinkage::HiddenExternal)
-    l2 = SILLinkage::Hidden;
-  else if (l2 == SILLinkage::Shared)
-    l2 = SILLinkage::Public;
-  else if (l2 == SILLinkage::SharedExternal)
-    l2 = SILLinkage::Public;
-  else if (l2 == SILLinkage::PrivateExternal)
-    l2 = SILLinkage::Private;
-
-  return unsigned(l1) > unsigned(l2);
-}
-
 inline SILLinkage effectiveLinkageForClassMember(SILLinkage linkage,
                                                  SubclassScope scope) {
   switch (scope) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4537,9 +4537,7 @@ void SILWitnessTable::verify(const SILModule &M) const {
         // If a SILWitnessTable is going to be serialized, it must only
         // reference public or serializable functions.
         if (isSerialized()) {
-          assert((!isLessVisibleThan(F->getLinkage(), getLinkage()) ||
-                  (F->isSerialized() &&
-                   hasSharedVisibility(F->getLinkage()))) &&
+          assert(F->hasValidLinkageForFragileRef() &&
                  "Fragile witness tables should not reference "
                  "less visible functions.");
         }
@@ -4566,15 +4564,18 @@ void SILDefaultWitnessTable::verify(const SILModule &M) const {
       continue;
 
     SILFunction *F = E.getWitness();
-    // FIXME
-    #if 0
-    assert(!isLessVisibleThan(F->getLinkage(), getLinkage()) &&
+
+#if 0
+    // FIXME: For now, all default witnesses are private.
+    assert(F->hasValidLinkageForFragileRef() &&
            "Default witness tables should not reference "
            "less visible functions.");
-    #endif
+#endif
+
     assert(F->getLoweredFunctionType()->getRepresentation() ==
            SILFunctionTypeRepresentation::WitnessMethod &&
            "Default witnesses must have witness_method representation.");
+
     auto *witnessSelfProtocol = F->getLoweredFunctionType()
         ->getDefaultWitnessMethodProtocol();
     assert(witnessSelfProtocol == getProtocol() &&


### PR DESCRIPTION
Another cleanup before I add a new SILLinkage kind.

This operation is difficult to reason about and was only used by
the SIL verifier. Replace the SIL verifier checks with simpler
operations.

I still need to revisit and uncomment the default witness table
visibility check. Right now we serialize default witness tables,
but default witness thunks have private linkage, which is
clearly wrong.