### PR TITLE
[stdlib] Fix some warnings about use of DefaultRandomAccessIndices

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -595,7 +595,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
   public typealias Indices = CountableRange<${Index}>
 %     elif Traversal == 'RandomAccess':
   // FIXME: this shouldn't be necessary, should come by default
-  public typealias Indices = DefaultRandomAccessIndices<${Self}<T>>
+  public typealias Indices = DefaultIndices<${Self}<T>>
 %     end
 
   public func _failEarlyRangeCheck(
@@ -869,7 +869,7 @@ public struct ${Self}<Element> : ${SelfProtocols} {
   public typealias Indices = CountableRange<${Index}>
 %  elif Traversal == 'RandomAccess':
   // FIXME: this shouldn't be necessary, should come by default
-  public typealias Indices = DefaultRandomAccessIndices<${Self}<Element>>
+  public typealias Indices = DefaultIndices<${Self}<Element>>
 %   end
 
 %   if Mutable or RangeReplaceable:

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -122,7 +122,7 @@ extension _ValidUTF8Buffer : BidirectionalCollection {
 }
 
 extension _ValidUTF8Buffer : RandomAccessCollection {
-  public typealias Indices = DefaultRandomAccessIndices<_ValidUTF8Buffer>
+  public typealias Indices = DefaultIndices<_ValidUTF8Buffer>
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)


### PR DESCRIPTION
These are now a deprecated type alias for a conditionally-conforming `DefaultIndices`.