### PR TITLE
Introduce PublicNonABI linkage for default argument generators and stored property initializers

### DIFF
--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -35,6 +35,17 @@ enum class SILLinkage : unsigned char {
   /// other object definitions with this name in the program.
   Public,
 
+  /// This is a special linkage used for symbols which are treated
+  /// as public for the purposes of SIL serialization and optimization,
+  /// but do not have public entry points in the generated binary.
+  ///
+  /// There is no external variant of this linkage, because from other
+  /// translation units in the same module, this behaves identically
+  /// to the HiddenExternal linkage.
+  ///
+  /// When deserialized, such declarations receive Shared linkage.
+  PublicNonABI,
+
   /// This object definition is visible only to the current Swift
   /// module (and thus should not be visible across linkage-unit
   /// boundaries).  There are no other object definitions with this
@@ -83,7 +94,7 @@ enum class SILLinkage : unsigned char {
 
 enum {
   /// The number of bits required to store a SILLinkage value.
-  NumSILLinkageBits = 3
+  NumSILLinkageBits = 4
 };
 
 /// Related to linkage: flag if a function or global variable is serialized,
@@ -125,15 +136,28 @@ inline SILLinkage stripExternalFromLinkage(SILLinkage linkage) {
 
 /// Add the 'external' attribute to \p linkage.
 inline SILLinkage addExternalToLinkage(SILLinkage linkage) {
-  if (linkage == SILLinkage::Public)
+  switch (linkage) {
+  case SILLinkage::Public:
     return SILLinkage::PublicExternal;
-  if (linkage == SILLinkage::Hidden)
+  case SILLinkage::PublicNonABI:
+    // An external reference to a public non-ABI function is only valid
+    // if the function was emitted in another translation unit of the
+    // same Swift module, so we treat it as hidden here.
     return SILLinkage::HiddenExternal;
-  if (linkage == SILLinkage::Shared)
+  case SILLinkage::Shared:
     return SILLinkage::SharedExternal;
-  if (linkage == SILLinkage::Private)
+  case SILLinkage::Hidden:
+    return SILLinkage::HiddenExternal;
+  case SILLinkage::Private:
     return SILLinkage::PrivateExternal;
-  return linkage;
+  case SILLinkage::PublicExternal:
+  case SILLinkage::SharedExternal:
+  case SILLinkage::PrivateExternal:
+  case SILLinkage::HiddenExternal:
+    return linkage;
+  }
+
+  llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
 /// Return whether the linkage indicates that an object has a
@@ -147,23 +171,24 @@ inline bool isAvailableExternally(SILLinkage linkage) {
 /// If \p is true then we are in whole-module compilation.
 inline bool isPossiblyUsedExternally(SILLinkage linkage, bool wholeModule) {
   if (wholeModule) {
-    return linkage <= SILLinkage::Public;
+    return linkage <= SILLinkage::PublicNonABI;
   }
   return linkage <= SILLinkage::Hidden;
 }
 
 inline bool hasPublicVisibility(SILLinkage linkage) {
   switch (linkage) {
-    case SILLinkage::Public:
-    case SILLinkage::PublicExternal:
-      return true;
-    case SILLinkage::Hidden:
-    case SILLinkage::Shared:
-    case SILLinkage::SharedExternal:
-    case SILLinkage::Private:
-    case SILLinkage::PrivateExternal:
-    case SILLinkage::HiddenExternal:
-      return false;
+  case SILLinkage::Public:
+  case SILLinkage::PublicExternal:
+  case SILLinkage::PublicNonABI:
+    return true;
+  case SILLinkage::Hidden:
+  case SILLinkage::Shared:
+  case SILLinkage::SharedExternal:
+  case SILLinkage::Private:
+  case SILLinkage::PrivateExternal:
+  case SILLinkage::HiddenExternal:
+    return false;
   }
 
   llvm_unreachable("Unhandled SILLinkage in switch.");
@@ -176,6 +201,7 @@ inline bool hasSharedVisibility(SILLinkage linkage) {
     return true;
   case SILLinkage::Public:
   case SILLinkage::PublicExternal:
+  case SILLinkage::PublicNonABI:
   case SILLinkage::Hidden:
   case SILLinkage::HiddenExternal:
   case SILLinkage::Private:
@@ -193,6 +219,7 @@ inline bool hasPrivateVisibility(SILLinkage linkage) {
     return true;
   case SILLinkage::Public:
   case SILLinkage::PublicExternal:
+  case SILLinkage::PublicNonABI:
   case SILLinkage::Hidden:
   case SILLinkage::HiddenExternal:
   case SILLinkage::Shared:

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 392; // Last change: accessor decls
+const uint16_t VERSION_MINOR = 393; // SILLinkage::PublicNonABI
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1478,6 +1478,7 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
                         : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
+  case SILLinkage::PublicNonABI:
     return RESULT(External, Hidden, Default);
 
   case SILLinkage::Private: {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -747,6 +747,7 @@ static bool parseSILLinkage(Optional<SILLinkage> &Result, Parser &P) {
 
   // Then use a string switch to try and parse the identifier.
   Result = llvm::StringSwitch<Optional<SILLinkage>>(P.Tok.getText())
+    .Case("non_abi", SILLinkage::PublicNonABI)
     .Case("hidden", SILLinkage::Hidden)
     .Case("shared", SILLinkage::Shared)
     .Case("public_external", SILLinkage::PublicExternal)

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -288,15 +288,13 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
 
   // Stored property initializers get the linkage of their containing type.
   if (isStoredPropertyInitializer()) {
-    // If the property is public, the initializer needs to be public, because
-    // it might be referenced from an inlineable initializer.
+    // If the type is public, the property initializer is referenced from
+    // inlinable initializers, and has PublicNonABI linkage.
     //
     // Note that we don't serialize the presence of an initializer, so there's
     // no way to reference one from another module except for this case.
-    //
-    // This is silly, and we need a proper resilience story here.
-    if (d->getEffectiveAccess() == AccessLevel::Public)
-      return maybeAddExternal(SILLinkage::Public);
+    if (isSerialized())
+      return maybeAddExternal(SILLinkage::PublicNonABI);
 
     // Otherwise, use the visibility of the type itself, because even if the
     // property is private, we might reference the initializer from another

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -271,6 +271,13 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   if (isClangImported())
     return SILLinkage::Shared;
 
+  // Default argument generators of Public functions have PublicNonABI linkage
+  // if the function was type-checked in Swift 4 mode.
+  if (kind == SILDeclRef::Kind::DefaultArgGenerator) {
+    if (isSerialized())
+      return maybeAddExternal(SILLinkage::PublicNonABI);
+  }
+
   bool neverPublic = false;
 
   // ivar initializers and destroyers are completely contained within the class

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -60,6 +60,12 @@ class SILModule::SerializationCallback : public SerializedSILLoader::Callback {
     case SILLinkage::Public:
       decl->setLinkage(SILLinkage::PublicExternal);
       return;
+    case SILLinkage::PublicNonABI:
+      // PublicNonABI functions receive SharedExternal linkage, so that
+      // they have "link once" semantics when deserialized by multiple
+      // translation units in the same Swift module.
+      decl->setLinkage(SILLinkage::SharedExternal);
+      return;
     case SILLinkage::Hidden:
       decl->setLinkage(SILLinkage::HiddenExternal);
       return;
@@ -67,8 +73,8 @@ class SILModule::SerializationCallback : public SerializedSILLoader::Callback {
       decl->setLinkage(SILLinkage::SharedExternal);
       return;
     case SILLinkage::Private:
-        decl->setLinkage(SILLinkage::PrivateExternal);
-        return;
+      decl->setLinkage(SILLinkage::PrivateExternal);
+      return;
     case SILLinkage::PublicExternal:
     case SILLinkage::HiddenExternal:
     case SILLinkage::SharedExternal:

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2192,6 +2192,7 @@ void SILFunction::dump(const char *FileName) const {
 static StringRef getLinkageString(SILLinkage linkage) {
   switch (linkage) {
   case SILLinkage::Public: return "public ";
+  case SILLinkage::PublicNonABI: return "non_abi ";
   case SILLinkage::Hidden: return "hidden ";
   case SILLinkage::Shared: return "shared ";
   case SILLinkage::Private: return "private ";

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -44,6 +44,7 @@ STATISTIC(TotalExternalFuncDecls, "Number of external funcs declarations");
 
 // Linkage statistics
 STATISTIC(TotalPublicFuncs, "Number of public funcs");
+STATISTIC(TotalPublicNonABIFuncs, "Number of public non-ABI funcs");
 STATISTIC(TotalHiddenFuncs, "Number of hidden funcs");
 STATISTIC(TotalPrivateFuncs, "Number of private funcs");
 STATISTIC(TotalSharedFuncs, "Number of shared funcs");
@@ -116,6 +117,9 @@ class InstCount : public SILFunctionTransform {
     switch (F->getLinkage()) {
     case SILLinkage::Public:
       ++TotalPublicFuncs;
+      break;
+    case SILLinkage::PublicNonABI:
+      ++TotalPublicNonABIFuncs;
       break;
     case SILLinkage::Hidden:
       ++TotalHiddenFuncs;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -37,6 +37,7 @@ enum SILStringEncoding : uint8_t {
 
 enum SILLinkageEncoding : uint8_t {
   SIL_LINKAGE_PUBLIC,
+  SIL_LINKAGE_PUBLIC_NON_ABI,
   SIL_LINKAGE_HIDDEN,
   SIL_LINKAGE_SHARED,
   SIL_LINKAGE_PRIVATE,
@@ -45,7 +46,7 @@ enum SILLinkageEncoding : uint8_t {
   SIL_LINKAGE_SHARED_EXTERNAL,
   SIL_LINKAGE_PRIVATE_EXTERNAL,
 };
-using SILLinkageField = BCFixed<3>;
+using SILLinkageField = BCFixed<4>;
 
 enum SILVTableEntryKindEncoding : uint8_t {
   SIL_VTABLE_ENTRY_NORMAL,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -64,6 +64,7 @@ toStableConstStringEncoding(ConstStringLiteralInst::Encoding encoding) {
 static unsigned toStableSILLinkage(SILLinkage linkage) {
   switch (linkage) {
   case SILLinkage::Public: return SIL_LINKAGE_PUBLIC;
+  case SILLinkage::PublicNonABI: return SIL_LINKAGE_PUBLIC_NON_ABI;
   case SILLinkage::Hidden: return SIL_LINKAGE_HIDDEN;
   case SILLinkage::Shared: return SIL_LINKAGE_SHARED;
   case SILLinkage::Private: return SIL_LINKAGE_PRIVATE;

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -125,8 +125,11 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
 void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   addSymbol(SILDeclRef(AFD));
 
-  // Default arguments (of public functions) are public symbols, as the default
-  // values are computed at the call site.
+  if (!SwiftModule->getASTContext().isSwiftVersion3())
+    return;
+
+  // In Swift 3, default arguments (of public functions) are public symbols,
+  // as the default values are computed at the call site.
   auto index = 0;
   auto paramLists = AFD->getParameterLists();
   // Skip the first arguments, which contains Self (etc.), can't be defaulted,

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -84,13 +84,7 @@ public:
       addSymbol("main");
   }
 
-  void visitPatternBindingDecl(PatternBindingDecl *PBD);
-
   void visitAbstractFunctionDecl(AbstractFunctionDecl *AFD);
-
-  void visitTypeAliasDecl(TypeAliasDecl *TAD) {
-    // any information here is encoded elsewhere
-  }
 
   void visitNominalTypeDecl(NominalTypeDecl *NTD);
 

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -5,7 +5,8 @@ sil_stage canonical
 // CHECK: define{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
-// CHECK: define{{( hidden)?}} swiftcc void @hidden_fragile_function_test() {{.*}} {
+// CHECK: define hidden swiftcc void @public_non_abi_function_test() {{.*}} {
+// CHECK: define hidden swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {
 // Public external functions are not emitted into clients.
@@ -33,6 +34,11 @@ sil public [transparent] [serialized] @public_transparent_fragile_function_test 
 }
 
 sil public [transparent] @public_transparent_function_test : $@convention(thin) () -> () {
+  %0 = tuple()
+  return %0 : $()
+}
+
+sil non_abi [serialized] @public_non_abi_function_test : $@convention(thin) () -> () {
   %0 = tuple()
   return %0 : $()
 }
@@ -138,6 +144,7 @@ sil public @use_all_symbols : $@convention(thin) () -> () {
   %0 = function_ref @public_fragile_function_test : $@convention(thin) () -> ()
   %t0 = function_ref @public_transparent_fragile_function_test : $@convention(thin) () -> ()
   %t1 = function_ref @public_transparent_function_test : $@convention(thin) () -> ()
+  %t2 = function_ref @public_non_abi_function_test : $@convention(thin) () -> ()
   %1 = function_ref @hidden_fragile_function_test : $@convention(thin) () -> ()
   %2 = function_ref @shared_fragile_function_test : $@convention(thin) () -> ()
   %3 = function_ref @private_fragile_function_test : $@convention(thin) () -> ()

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -36,22 +36,6 @@ sil_global @static_array : $TestArrayStorage = {
   %initval = object $TestArrayStorage (%3 : $Int32, [tail_elems] %4 : $Int64, %5 : $Int64)
 }
 
-// Linkage types.
-
-// CHECK-LABEL: sil shared @clang_thunk : $@convention(thin) () -> ()
-sil shared @clang_thunk : $() -> () {
-bb0:
-  %0 = tuple ()
-  return %0 : $()
-}
-
-// CHECK-LABEL: sil private @internal_fn : $@convention(thin) () -> ()
-sil private @internal_fn : $() -> () {
-bb0:
-  %0 = tuple ()
-  return %0 : $()
-}
-
 // Type references
 
 // Some cyclic type references between SIL function bodies.

--- a/test/SIL/Parser/linkage.sil
+++ b/test/SIL/Parser/linkage.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
+
+sil_stage raw // CHECK: sil_stage raw
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil @public_definition : $@convention(thin) () -> ()
+sil @public_definition : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil non_abi @always_emit_into_client_definition : $@convention(thin) () -> ()
+sil non_abi @always_emit_into_client_definition : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil shared @shared_definition : $@convention(thin) () -> ()
+sil shared @shared_definition : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil hidden @hidden_definition : $@convention(thin) () -> ()
+sil hidden @hidden_definition : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil private @private_definition : $@convention(thin) () -> ()
+sil private @private_definition : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil public_external @public_available_externally_definition : $@convention(thin) () -> ()
+sil public_external @public_available_externally_definition : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil @public_declaration : $@convention(thin) () -> ()
+sil @public_declaration : $() -> ()
+
+// CHECK-LABEL: sil hidden_external @hidden_declaration : $@convention(thin) () -> ()
+sil hidden_external @hidden_declaration : $() -> ()
+

--- a/test/SIL/Serialization/Inputs/def_public_non_abi.sil
+++ b/test/SIL/Serialization/Inputs/def_public_non_abi.sil
@@ -1,0 +1,4 @@
+sil non_abi [serialized] @public_non_abi_function : $@convention(thin) () -> () {
+  %0 = tuple ()
+  return %0 : $()
+}

--- a/test/SIL/Serialization/deserialize_generic.sil
+++ b/test/SIL/Serialization/deserialize_generic.sil
@@ -21,5 +21,5 @@ bb0:
 }
 
 // Make sure the function body is deserialized.
-// CHECK-LABEL: @$S11def_generic1AC23convertFromArrayLiteralyACyxGxd_tF : $@convention(method) <T> (@owned Array<T>, @guaranteed A<T>) -> @owned A<T> {
+// CHECK-LABEL: sil public_external [serialized] @$S11def_generic1AC23convertFromArrayLiteralyACyxGxd_tF : $@convention(method) <T> (@owned Array<T>, @guaranteed A<T>) -> @owned A<T> {
 sil @$S11def_generic1AC23convertFromArrayLiteralyACyxGxd_tF : $@convention(method) <T> (@owned Array<T>, @guaranteed A<T>) -> @owned A<T>

--- a/test/SIL/Serialization/public_non_abi.sil
+++ b/test/SIL/Serialization/public_non_abi.sil
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_public_non_abi.sil
+// RUN: %target-sil-opt -linker -I %t %s | %FileCheck %s
+
+sil_stage raw
+
+import def_public_non_abi
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil @top_level_code
+// CHECK: function_ref @public_non_abi_function : $@convention(thin) () -> ()
+// CHECK: return
+
+sil @top_level_code : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @public_non_abi_function : $@convention(thin) () -> ()
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// Make sure the function body is deserialized.
+// CHECK-LABEL: sil shared_external [serialized] @public_non_abi_function : $@convention(thin) () -> ()
+// CHECK: return
+sil hidden_external [serialized] @public_non_abi_function : $@convention(thin) () -> ()

--- a/test/SILGen/default_arguments_serialized.swift
+++ b/test/SILGen/default_arguments_serialized.swift
@@ -15,10 +15,10 @@ import default_arguments_other
 public func defaultString() -> String { return "hi" }
 
 // SWIFT3-LABEL: sil @$S28default_arguments_serialized19hasDefaultArguments1x1yySi_SStFfA_ : $@convention(thin) () -> Int
-// SWIFT4-LABEL: sil [serialized] @$S28default_arguments_serialized19hasDefaultArguments1x1yySi_SStFfA_ : $@convention(thin) () -> Int
+// SWIFT4-LABEL: sil non_abi [serialized] @$S28default_arguments_serialized19hasDefaultArguments1x1yySi_SStFfA_ : $@convention(thin) () -> Int
 
 // SWIFT3-LABEL: sil @$S28default_arguments_serialized19hasDefaultArguments1x1yySi_SStFfA0_ : $@convention(thin) () -> @owned String
-// SWIFT4-LABEL: sil [serialized] @$S28default_arguments_serialized19hasDefaultArguments1x1yySi_SStFfA0_ : $@convention(thin) () -> @owned String
+// SWIFT4-LABEL: sil non_abi [serialized] @$S28default_arguments_serialized19hasDefaultArguments1x1yySi_SStFfA0_ : $@convention(thin) () -> @owned String
 
 public func hasDefaultArguments(x: Int = 0, y: String = defaultString()) {}
 
@@ -55,7 +55,7 @@ public func callsOtherDefaultArguments() {
   otherDefaultArguments()
 }
 
-// CHECK-LABEL: sil [serialized] @$S23default_arguments_other0C16DefaultArguments1xySi_tFfA_ : $@convention(thin) () -> Int
+// CHECK-LABEL: sil hidden_external [serialized] @$S23default_arguments_other0C16DefaultArguments1xySi_tFfA_ : $@convention(thin) () -> Int
 
 // CHECK-LABEL: sil @$S23default_arguments_other0C16DefaultArguments1xySi_tF : $@convention(thin) (Int) -> ()
 

--- a/test/SILGen/fixed_layout_attribute.swift
+++ b/test/SILGen/fixed_layout_attribute.swift
@@ -20,7 +20,7 @@ public struct NonFixedStruct {
   public var storedProperty = global
 }
 
-// CHECK-LABEL: sil [transparent] @$S22fixed_layout_attribute14NonFixedStructV14storedPropertySivpfi : $@convention(thin) () -> Int
+// CHECK-LABEL: sil hidden [transparent] @$S22fixed_layout_attribute14NonFixedStructV14storedPropertySivpfi : $@convention(thin) () -> Int
 //
 //    ... okay to directly reference the addressor here:
 // CHECK: function_ref @$S22fixed_layout_attribute6globalSivau
@@ -31,7 +31,7 @@ public struct FixedStruct {
   public var storedProperty = global
 }
 
-// CHECK-LABEL: sil [transparent] [serialized] @$S22fixed_layout_attribute11FixedStructV14storedPropertySivpfi : $@convention(thin) () -> Int
+// CHECK-LABEL: sil non_abi [transparent] [serialized] @$S22fixed_layout_attribute11FixedStructV14storedPropertySivpfi : $@convention(thin) () -> Int
 //
 //    ... a fragile build can still reference the addressor:
 // FRAGILE: function_ref @$S22fixed_layout_attribute6globalSivau

--- a/test/SILGen/inlineable_attribute.swift
+++ b/test/SILGen/inlineable_attribute.swift
@@ -49,10 +49,13 @@ public class MyCls {
   _ = MyEnum.c
 }
 
-// CHECK-LABEL: sil [transparent] @$S20inlineable_attribute15HasInitializersV1xSivpfi : $@convention(thin) () -> Int
+// CHECK-LABEL: sil non_abi [transparent] [serialized] @$S20inlineable_attribute15HasInitializersV1xSivpfi : $@convention(thin) () -> Int
+// CHECK-LABEL: sil non_abi [transparent] [serialized] @$S20inlineable_attribute15HasInitializersV1ySivpfi : $@convention(thin) () -> Int
 
+@_fixed_layout
 public struct HasInitializers {
   public let x = 1234
+  internal let y = 4321
 
   @_inlineable public init() {}
 }

--- a/test/SILOptimizer/globalopt_linkage.swift
+++ b/test/SILOptimizer/globalopt_linkage.swift
@@ -9,8 +9,10 @@ struct MyStruct {
 let Global = 27
 
 func testit() -> Int {
-  return MyStruct.StaticVar + Global
+  return MyStruct.StaticVar + Global + PublicGlobal
 }
+
+public let PublicGlobal = 27
 
 _ = testit()
 
@@ -21,3 +23,6 @@ _ = testit()
 
 // CHECK:      // Global.getter
 // CHECK-NEXT: sil private @$S{{.*}}Global
+
+// CHECK:      // PublicGlobal.getter
+// CHECK-NEXT: sil non_abi @$S{{.*}}PublicGlobal

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 3 %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s
 
 public func publicNoArgs() {}
 public func publicSomeArgs(_: Int, x: Int) {}

--- a/test/multifile/default-arguments/one-module/Inputs/library.swift
+++ b/test/multifile/default-arguments/one-module/Inputs/library.swift
@@ -1,0 +1,2 @@
+public func publicHasDefaultArgument(x: Int = 0) {}
+internal func internalHasDefaultArgument(x: Int = 0) {}

--- a/test/multifile/default-arguments/one-module/main.swift
+++ b/test/multifile/default-arguments/one-module/main.swift
@@ -1,0 +1,10 @@
+// Try with and without whole module optimization, Swift 3 and Swift 4 mode
+
+// RUN: %target-build-swift -swift-version 3 %S/Inputs/library.swift %S/main.swift
+// RUN: %target-build-swift -swift-version 3 -whole-module-optimization %S/Inputs/library.swift %S/main.swift
+
+// RUN: %target-build-swift -swift-version 4 %S/Inputs/library.swift %S/main.swift
+// RUN: %target-build-swift -swift-version 4 -whole-module-optimization %S/Inputs/library.swift %S/main.swift
+
+publicHasDefaultArgument()
+internalHasDefaultArgument()

--- a/test/multifile/default-arguments/two-modules/Inputs/library.swift
+++ b/test/multifile/default-arguments/two-modules/Inputs/library.swift
@@ -1,0 +1,1 @@
+public func hasDefaultArgument(x: Int = 0) {}

--- a/test/multifile/default-arguments/two-modules/main.swift
+++ b/test/multifile/default-arguments/two-modules/main.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+
+// RUN: mkdir -p %t/onone %t/wmo
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library.%target-dylib-extension -swift-version 3
+// RUN: %target-build-swift %S/main.swift %t/onone/library.%target-dylib-extension -I %t/onone/ -o %t/onone/main -swift-version 3
+
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library.%target-dylib-extension -swift-version 3
+// RUN: %target-build-swift %S/main.swift %t/wmo/library.%target-dylib-extension -I %t/wmo/ -o %t/wmo/main -swift-version 3
+
+// RUN: mkdir -p %t/onone %t/wmo
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/Inputs/library.swift -o %t/onone/library.%target-dylib-extension -swift-version 4
+// RUN: %target-build-swift %S/main.swift %t/onone/library.%target-dylib-extension -I %t/onone/ -o %t/onone/main -swift-version 4
+
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/Inputs/library.swift -o %t/wmo/library.%target-dylib-extension -swift-version 4
+// RUN: %target-build-swift %S/main.swift %t/wmo/library.%target-dylib-extension -I %t/wmo/ -o %t/wmo/main -swift-version 4
+
+import library
+
+hasDefaultArgument()

--- a/validation-test/Evolution/Inputs/change_default_argument_to_magic.swift
+++ b/validation-test/Evolution/Inputs/change_default_argument_to_magic.swift
@@ -1,0 +1,10 @@
+
+#if BEFORE
+
+public func changeDefaultArgumentToMagic(name: String = "hello") {}
+
+#else
+
+public func changeDefaultArgumentToMagic(name: String = #file) {}
+
+#endif

--- a/validation-test/Evolution/test_change_default_argument_to_magic.swift
+++ b/validation-test/Evolution/test_change_default_argument_to_magic.swift
@@ -1,0 +1,14 @@
+// RUN: %target-resilience-test
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import change_default_argument_to_magic
+
+
+var ChangeDefaultArgumentToMagic = TestSuite("ChangeDefaultArgumentToMagic")
+
+ChangeDefaultArgumentToMagic.test("ChangeDefaultArgumentToMagic") {
+  changeDefaultArgumentToMagic()
+}
+
+runAllTests()


### PR DESCRIPTION
Fixes <rdar://problem/36429556>, <rdar://problem/33767513>, <https://bugs.swift.org/browse/SR-5647>.