### PR TITLE
 [ABI] Pass only three direct args to nominal type access functions.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -181,7 +181,7 @@ enum : unsigned {
   /// Number of words reserved in generic metadata patterns.
   NumGenericMetadataPrivateDataWords = 16,
 };
-  
+
 /// Kinds of type metadata/protocol conformance records.
 enum class TypeMetadataRecordKind : unsigned {
   /// The conformance is for a nominal type referenced directly;
@@ -861,6 +861,13 @@ static inline EnumLayoutFlags getLayoutAlgorithm(EnumLayoutFlags flags) {
 static inline bool isValueWitnessTableMutable(EnumLayoutFlags flags) {
   return uintptr_t(flags) & uintptr_t(EnumLayoutFlags::IsVWTMutable);
 }
+
+/// The number of arguments that will be passed directly to a generic
+/// nominal type access function. The remaining arguments (if any) will be
+/// passed as an array. That array has enough storage for all of the arguments,
+/// but only fills in the elements not passed directly. The callee may
+/// mutate the array to fill in the direct arguments.
+constexpr unsigned NumDirectGenericTypeMetadataAccessFunctionArgs = 3;
 
 } // end namespace swift
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1200,7 +1200,9 @@ llvm::CallInst *IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
   auto call = Builder.CreateCall(accessFunction, callArgs);
   call->setDoesNotThrow();
   call->addAttribute(llvm::AttributeList::FunctionIndex,
-                     llvm::Attribute::ReadNone);
+                     allocatedArgsBuffer
+                       ? llvm::Attribute::InaccessibleMemOrArgMemOnly
+                       : llvm::Attribute::ReadNone);
 
   // If we allocated a buffer for the arguments, end it's lifetime.
   if (allocatedArgsBuffer)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -360,10 +360,8 @@ static llvm::Value *emitNominalMetadataRef(IRGenFunction &IGF,
                                                          genericArgs.Types,
                                                          NotForDefinition);
 
-  auto result = IGF.Builder.CreateCall(accessor, genericArgs.Values);
-  result->setDoesNotThrow();
-  result->addAttribute(llvm::AttributeList::FunctionIndex,
-                       llvm::Attribute::ReadNone);
+  auto result =
+    IGF.emitGenericTypeMetadataAccessFunctionCall(accessor, genericArgs.Values);
 
   IGF.setScopedLocalTypeData(theType, LocalTypeDataKind::forTypeMetadata(),
                              result);
@@ -1156,6 +1154,61 @@ void irgen::emitLazyCacheAccessFunction(IRGenModule &IGM,
   IGF.Builder.CreateRet(phi);
 }
 
+llvm::CallInst *IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
+                                              llvm::Function *accessFunction,
+                                              ArrayRef<llvm::Value *> args) {
+
+  ArrayRef<llvm::Value *> callArgs;
+  llvm::Value *callArgsVec[NumDirectGenericTypeMetadataAccessFunctionArgs + 1];
+  Address argsBuffer;
+  bool allocatedArgsBuffer = false;
+  if (args.size() > NumDirectGenericTypeMetadataAccessFunctionArgs) {
+    // Copy direct arguments.
+    for (unsigned i : range(NumDirectGenericTypeMetadataAccessFunctionArgs)) {
+      callArgsVec[i] = args[i];
+    }
+
+    // Allocate an array to pass the remaining arguments. Note that the
+    // buffer is allocated for the whole length so the callee can fill in
+    // the direct arguments and use the buffer.
+    auto argsBufferTy = llvm::ArrayType::get(IGM.Int8PtrTy, args.size());
+    argsBuffer = createAlloca(argsBufferTy, IGM.getPointerAlignment());
+
+    // Mark the beginning of the array lifetime.
+    Builder.CreateLifetimeStart(argsBuffer,
+                                IGM.getPointerSize() * args.size());
+    allocatedArgsBuffer = true;
+
+    // Fill in the non-direct arguments.
+    for (unsigned i : range(NumDirectGenericTypeMetadataAccessFunctionArgs,
+                            args.size())) {
+      Address elt = Builder.CreateStructGEP(argsBuffer, i,
+                                            IGM.getPointerSize() * i);
+      auto *arg =
+        Builder.CreateBitCast(args[i], elt.getType()->getPointerElementType());
+      Builder.CreateStore(arg, elt);
+    }
+
+    // Fill in the buffer.
+    callArgsVec[NumDirectGenericTypeMetadataAccessFunctionArgs] =
+      Builder.CreateBitCast(argsBuffer.getAddress(), IGM.Int8PtrPtrTy);
+    callArgs = callArgsVec;
+  } else {
+    callArgs = args;
+  }
+
+  auto call = Builder.CreateCall(accessFunction, callArgs);
+  call->setDoesNotThrow();
+  call->addAttribute(llvm::AttributeList::FunctionIndex,
+                     llvm::Attribute::ReadNone);
+
+  // If we allocated a buffer for the arguments, end it's lifetime.
+  if (allocatedArgsBuffer)
+    Builder.CreateLifetimeEnd(argsBuffer, IGM.getPointerSize() * args.size());
+
+  return call;
+}
+
 static llvm::Value *emitGenericMetadataAccessFunction(IRGenFunction &IGF,
                                                       NominalTypeDecl *nominal,
                                                       GenericArguments &genericArgs) {
@@ -1164,28 +1217,57 @@ static llvm::Value *emitGenericMetadataAccessFunction(IRGenFunction &IGF,
 
   // Collect input arguments to the generic metadata accessor, as laid out
   // by the GenericArguments class.
-  for (auto &arg : IGF.CurFn->args())
-    genericArgs.Values.push_back(&arg);
-  assert(genericArgs.Values.size() == genericArgs.Types.size());
+  unsigned argIdx = 0;
+  llvm::Argument *callerArgArray = nullptr;
+  for (auto &arg : IGF.CurFn->args()) {
+    // If this an argument passed directly, record it.
+    if (argIdx < NumDirectGenericTypeMetadataAccessFunctionArgs) {
+      genericArgs.Values.push_back(&arg);
+      ++argIdx;
+      continue;
+    }
+
+    assert(!callerArgArray && "Too many arguments");
+    callerArgArray = &arg;
+  }
+
   assert((genericArgs.Values.size() > 0 ||
           nominal->getGenericSignature()->areAllParamsConcrete())
          && "no generic args?!");
 
-  // Slam that information directly into the generic arguments buffer.
-  auto argsBufferTy =
-    llvm::StructType::get(IGF.IGM.LLVMContext, genericArgs.Types);
-  Address argsBuffer = IGF.createAlloca(argsBufferTy,
-                                        IGF.IGM.getPointerAlignment(),
-                                        "generic.arguments");
-  IGF.Builder.CreateLifetimeStart(argsBuffer,
-                          IGF.IGM.getPointerSize() * genericArgs.Values.size());
-  for (unsigned i = 0, e = genericArgs.Values.size(); i != e; ++i) {
-    Address elt = IGF.Builder.CreateStructGEP(argsBuffer, i,
-                                              IGF.IGM.getPointerSize() * i);
-    IGF.Builder.CreateStore(genericArgs.Values[i], elt);
+  Address argsBuffer;
+  if (callerArgArray) {
+    // The caller provided a buffer with enough space for all of the arguments;
+    // use that.
+    argsBuffer = Address(callerArgArray, IGF.IGM.getPointerAlignment());
+  } else {
+    // Allocate a buffer with enough storage for the arguments.
+    auto argsBufferTy =
+      llvm::StructType::get(IGF.IGM.LLVMContext, genericArgs.Types);
+    argsBuffer = IGF.createAlloca(argsBufferTy,
+                                  IGF.IGM.getPointerAlignment(),
+                                  "generic.arguments");
+    IGF.Builder.CreateLifetimeStart(argsBuffer,
+                            IGF.IGM.getPointerSize() * genericArgs.Values.size());
   }
 
-  // Cast to void*.
+  /// Store direct arguments into the buffer.
+  for (unsigned i = 0, e = genericArgs.Values.size(); i != e; ++i) {
+    Address elt;
+    if (callerArgArray) {
+      elt = IGF.Builder.CreateConstArrayGEP(argsBuffer, i,
+                                            IGF.IGM.getPointerSize());
+    } else {
+      elt = IGF.Builder.CreateStructGEP(argsBuffer, i,
+                                        IGF.IGM.getPointerSize() * i);
+    }
+
+    auto *arg =
+      IGF.Builder.CreateBitCast(genericArgs.Values[i],
+                                elt.getType()->getPointerElementType());
+    IGF.Builder.CreateStore(arg, elt);
+  }
+
   llvm::Value *arguments =
     IGF.Builder.CreateBitCast(argsBuffer.getAddress(), IGF.IGM.Int8PtrTy);
 
@@ -1196,8 +1278,11 @@ static llvm::Value *emitGenericMetadataAccessFunction(IRGenFunction &IGF,
   result->addAttribute(llvm::AttributeList::FunctionIndex,
                        llvm::Attribute::ReadOnly);
 
-  IGF.Builder.CreateLifetimeEnd(argsBuffer,
+  // If we allocated the array ourselves, end its lifetime.
+  if (!callerArgArray) {
+    IGF.Builder.CreateLifetimeEnd(argsBuffer,
                           IGF.IGM.getPointerSize() * genericArgs.Values.size());
+  }
 
   return result;
 
@@ -1569,12 +1654,7 @@ namespace {
             IGF.IGM.getAddrOfGenericTypeMetadataAccessFunction(
                 type->getDecl(), types, NotForDefinition);
 
-        auto result = IGF.Builder.CreateCall(accessor, args);
-        result->setDoesNotThrow();
-        result->addAttribute(llvm::AttributeList::FunctionIndex,
-                             llvm::Attribute::ReadNone);
-
-        return result;
+        return IGF.emitGenericTypeMetadataAccessFunctionCall(accessor, args);
       }
 
       // Otherwise, generic arguments are not lowered.

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -224,6 +224,11 @@ public:
 
   llvm::Value *emitAllocEmptyBoxCall();
 
+  // Emit a call to the given generic type metadata access function.
+  llvm::CallInst *emitGenericTypeMetadataAccessFunctionCall(
+                                          llvm::Function *accessFunction,
+                                          ArrayRef<llvm::Value *> args);
+
   // Emit a reference to the canonical type metadata record for the given AST
   // type. This can be used to identify the type at runtime. For types with
   // abstraction difference, the metadata contains the layout information for

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -545,6 +545,8 @@ public:
     auto accessFunction = typeDecl->getAccessFunction();
     if (!accessFunction) return BuiltType();
 
+    static_assert(NumDirectGenericTypeMetadataAccessFunctionArgs == 3,
+                  "Need to account for change in number of direct arguments");
     switch (allGenericArgs.size()) {
     case 0:
       return accessFunction();
@@ -568,10 +570,15 @@ public:
                                                           allGenericArgs[0],
                                                           allGenericArgs[1],
                                                           allGenericArgs[2]);
-
     default:
-      // FIXME: Implement.
-      return BuiltType();
+      using GenericMetadataAccessFunction4 =
+        const Metadata *(const void *, const void *, const void *,
+                         const void *);
+      return ((GenericMetadataAccessFunction4 *)accessFunction)(
+                                                      allGenericArgs[0],
+                                                      allGenericArgs[1],
+                                                      allGenericArgs[2],
+                                                      allGenericArgs.data());
     }
   }
 

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -154,48 +154,25 @@ func makeGenericMetatypes() {
 // CHECK:   ret %swift.type* [[METADATA]]
 
 // CHECK: define linkonce_odr hidden %swift.type* @"$S17generic_metatypes8FourArgsVyAA3FooVAA3BarCAeGGMa"() [[NOUNWIND_READNONE_OPT]]
+// CHECK:   [[BUFFER:%.*]] = alloca [4 x i8*]
 // CHECK:   [[T0:%.*]] = call %swift.type* @"$S17generic_metatypes3BarCMa"()
-// CHECK:   call %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]]) [[NOUNWIND_READNONE]]
-
-// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type*, %swift.type*, %swift.type*, %swift.type*)
-// CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type*, %swift.type* }
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.start
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 0
-// CHECK:   store %swift.type* %0, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 1
-// CHECK:   store %swift.type* %1, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 2
-// CHECK:   store %swift.type* %2, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 3
-// CHECK:   store %swift.type* %3, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @"$S17generic_metatypes8FourArgsVMP" {{.*}}, i8* [[BUFFER_PTR]])
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.end
-// CHECK:   ret %swift.type* [[METADATA]]
+// CHECK-NEXT: [[SLOT_3:%.*]] = getelementptr inbounds [4 x i8*], [4 x i8*]* [[BUFFER]], i32 0, i32 3
+// CHECK-NEXT:  [[T0_AS_VOIDPTR:%.*]] = bitcast %swift.type* [[T0]] to i8*
+// CHECK-NEXT:  store i8* [[T0_AS_VOIDPTR]], i8** [[SLOT_3]]
+// CHECK-NEXT:  [[BUFFER_PTR:%.*]] = bitcast [4 x i8*]* [[BUFFER]] to i8**
+// CHECK-NEXT:   call %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, i8** [[BUFFER_PTR]]) [[NOUNWIND_READNONE]]
+// CHECK: call void @llvm.lifetime.end.p0i8
 
 // CHECK: define linkonce_odr hidden %swift.type* @"$S17generic_metatypes8FiveArgsVyAA3FooVAA3BarCAegEGMa"() [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[T0:%.*]] = call %swift.type* @"$S17generic_metatypes3BarCMa"()
-// CHECK:   call %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE]]
+// CHECK:   call %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, i8**
 
-// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type*)
-// CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.start
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 0
-// CHECK:   store %swift.type* %0, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 1
-// CHECK:   store %swift.type* %1, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 2
-// CHECK:   store %swift.type* %2, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 3
-// CHECK:   store %swift.type* %3, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @"$S17generic_metatypes8FiveArgsVMP" {{.*}}, i8* [[BUFFER_PTR]])
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.end
-// CHECK:   ret %swift.type* [[METADATA]]
+// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type*, %swift.type*, %swift.type*, i8**)
+// CHECK-NOT: alloc
+// CHECK:   call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @"$S17generic_metatypes8FiveArgsVMP" {{.*}}, i8*
+// CHECK-NOT: call void @llvm.lifetime.end
+// CHECK:   ret %swift.type*
 
 // CHECK: attributes [[NOUNWIND_READNONE_OPT]] = { nounwind readnone "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "target-cpu"
 // CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -161,7 +161,7 @@ func makeGenericMetatypes() {
 // CHECK-NEXT:  [[T0_AS_VOIDPTR:%.*]] = bitcast %swift.type* [[T0]] to i8*
 // CHECK-NEXT:  store i8* [[T0_AS_VOIDPTR]], i8** [[SLOT_3]]
 // CHECK-NEXT:  [[BUFFER_PTR:%.*]] = bitcast [4 x i8*]* [[BUFFER]] to i8**
-// CHECK-NEXT:   call %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, i8** [[BUFFER_PTR]]) [[NOUNWIND_READNONE]]
+// CHECK-NEXT:   call %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, i8** [[BUFFER_PTR]]) [[NOUNWIND_ARGMEM:#[0-9]+]]
 // CHECK: call void @llvm.lifetime.end.p0i8
 
 // CHECK: define linkonce_odr hidden %swift.type* @"$S17generic_metatypes8FiveArgsVyAA3FooVAA3BarCAegEGMa"() [[NOUNWIND_READNONE_OPT]]
@@ -176,3 +176,4 @@ func makeGenericMetatypes() {
 
 // CHECK: attributes [[NOUNWIND_READNONE_OPT]] = { nounwind readnone "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "target-cpu"
 // CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
+// CHECK: attributes [[NOUNWIND_ARGMEM]] = { inaccessiblemem_or_argmemonly nounwind }

--- a/test/IRGen/generic_metatypes_arm.swift
+++ b/test/IRGen/generic_metatypes_arm.swift
@@ -153,47 +153,23 @@ func makeGenericMetatypes() {
 
 // CHECK: define linkonce_odr hidden %swift.type* @"$S17generic_metatypes8FourArgsVyAA3FooVAA3BarCAeGGMa"() [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[T0:%.*]] = call %swift.type* @"$S17generic_metatypes3BarCMa"()
-// CHECK:   call %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]]) [[NOUNWIND_READNONE]]
+// CHECK:   call %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, i8**
 
-// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type*, %swift.type*, %swift.type*, %swift.type*)
-// CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type*, %swift.type* }
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.start
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 0
-// CHECK:   store %swift.type* %0, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 1
-// CHECK:   store %swift.type* %1, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 2
-// CHECK:   store %swift.type* %2, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 3
-// CHECK:   store %swift.type* %3, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @"$S17generic_metatypes8FourArgsVMP" {{.*}}, i8* [[BUFFER_PTR]])
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.end
-// CHECK:   ret %swift.type* [[METADATA]]
+// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FourArgsVMa"(%swift.type*, %swift.type*, %swift.type*, i8**)
+// CHECK-NOT: alloc
+// CHECK:   call %swift.type* @swift_rt_swift_getGenericMetadata(
+// CHECK-NOT: call void @llvm.lifetime.end
+// CHECK:   ret %swift.type*
 
 // CHECK: define linkonce_odr hidden %swift.type* @"$S17generic_metatypes8FiveArgsVyAA3FooVAA3BarCAegEGMa"() [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[T0:%.*]] = call %swift.type* @"$S17generic_metatypes3BarCMa"()
-// CHECK:   call %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE]]
+// CHECK:   call %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, i8**
 
-// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type*)
-// CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.start
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 0
-// CHECK:   store %swift.type* %0, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 1
-// CHECK:   store %swift.type* %1, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 2
-// CHECK:   store %swift.type* %2, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 3
-// CHECK:   store %swift.type* %3, %swift.type** [[BUFFER_ELT]]
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @"$S17generic_metatypes8FiveArgsVMP" {{.*}}, i8* [[BUFFER_PTR]])
-// CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   call void @llvm.lifetime.end
-// CHECK:   ret %swift.type* [[METADATA]]
+// CHECK-LABEL: define hidden %swift.type* @"$S17generic_metatypes8FiveArgsVMa"(%swift.type*, %swift.type*, %swift.type*, i8**)
+// CHECK-NOT: alloca
+// CHECK:   call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @"$S17generic_metatypes8FiveArgsVMP" {{.*}}, i8*
+// CHECK-NOT:   call void @llvm.lifetime.end
+// CHECK:   ret %swift.type*
 
 // CHECK: attributes [[NOUNWIND_READNONE_OPT]] = { nounwind readnone "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "target-cpu"
 // CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -196,7 +196,9 @@ extension C {
 }
 
 class CG2<T, U> {
-  class Inner<V> { }
+  class Inner<V> {
+    struct Innermost<W1, W2, W3, W4> { }
+  }
 }
 
 DemangleToMetadataTests.test("nested generic specializations") {
@@ -206,6 +208,9 @@ DemangleToMetadataTests.test("nested generic specializations") {
     _typeByMangledName("4main1CC6NestedO9InnermoreV9InnermostVy_SiSS__SdG")!)
   expectEqual(CG2<Int, String>.Inner<Double>.self,
     _typeByMangledName("4main3CG2C5InnerCySiSS_SdG")!)
+  expectEqual(
+    CG2<Int, String>.Inner<Double>.Innermost<Int8, Int16, Int32, Int64>.self,
+    _typeByMangledName("4main3CG2C5InnerC9InnermostVySiSS_Sd_s4Int8Vs5Int16Vs5Int32Vs5Int64VG")!)
 }
 
 runAllTests()


### PR DESCRIPTION
The nominal type access functions took all of the generic arguments
directly, which is hard to call from the runtime. Instead, pass up to
three generic arguments directly (because it’s good for code size), 
and put the rest into an array.

Now that we have a suitable calling convention for the access function
of a generic nominal type descriptor with > 3 arguments, add support
for calling with an arbitrary number of generic arguments.