### PR TITLE
[Reflection] Add weak storage flag to field type information

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -30,7 +30,9 @@ class FieldRecordFlags {
   using int_type = uint32_t;
   enum : int_type {
     // Is this an indirect enum case?
-    IsIndirectCase = 0x1
+    IsIndirectCase = 0x1,
+    // Is this a weak optional reference?
+    IsWeak = 0x2,
   };
   int_type Data = 0;
 
@@ -44,6 +46,15 @@ public:
       Data |= IsIndirectCase;
     else
       Data &= ~IsIndirectCase;
+  }
+
+  bool isWeak() const { return (Data & IsWeak) == IsWeak; }
+
+  void setWeak(bool Weak = true) {
+    if (Weak)
+      Data |= IsWeak;
+    else
+      Data &= ~IsWeak;
   }
 
   int_type getRawValue() const {
@@ -76,6 +87,8 @@ public:
   bool isIndirectCase() const {
     return Flags.isIndirectCase();
   }
+
+  bool isWeak() const { return Flags.isWeak(); }
 };
 
 struct FieldRecordIterator {

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -120,21 +120,24 @@ struct FieldTypeInfo {
   std::string Name;
   const TypeRef *TR;
   bool Indirect;
+  bool Weak;
 
-  FieldTypeInfo() : Name(""), TR(nullptr), Indirect(false) {}
-  FieldTypeInfo(const std::string &Name, const TypeRef *TR, bool Indirect)
-      : Name(Name), TR(TR), Indirect(Indirect) {}
+  FieldTypeInfo() : Name(""), TR(nullptr), Indirect(false), Weak(false) {}
+  FieldTypeInfo(const std::string &Name, const TypeRef *TR, bool Indirect,
+                bool Weak)
+      : Name(Name), TR(TR), Indirect(Indirect), Weak(Weak) {}
 
   static FieldTypeInfo forEmptyCase(std::string Name) {
-    return FieldTypeInfo(Name, nullptr, false);
+    return FieldTypeInfo(Name, nullptr, false, false);
   }
 
   static FieldTypeInfo forIndirectCase(std::string Name, const TypeRef *TR) {
-    return FieldTypeInfo(Name, TR, true);
+    return FieldTypeInfo(Name, TR, true, false);
   }
 
-  static FieldTypeInfo forField(std::string Name, const TypeRef *TR) {
-    return FieldTypeInfo(Name, TR, false);
+  static FieldTypeInfo forField(std::string Name, const TypeRef *TR,
+                                bool Weak) {
+    return FieldTypeInfo(Name, TR, false, Weak);
   }
 };
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -327,10 +327,11 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
   const uint32_t fieldRecordSize = 12;
   const NominalTypeDecl *NTD;
 
-  void addFieldDecl(const ValueDecl *value, CanType type,
-                    bool indirect=false) {
+  void addFieldDecl(const ValueDecl *value, CanType type, bool indirect = false,
+                    bool weak = false) {
     reflection::FieldRecordFlags flags;
     flags.setIsIndirectCase(indirect);
+    flags.setWeak(weak);
 
     B.addInt32(flags.getRawValue());
 
@@ -374,10 +375,11 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
 
     auto properties = NTD->getStoredProperties();
     B.addInt32(std::distance(properties.begin(), properties.end()));
-    for (auto property : properties)
-      addFieldDecl(property,
-                   property->getInterfaceType()
-                       ->getCanonicalType());
+    for (auto property : properties) {
+      auto type = property->getInterfaceType()->getCanonicalType();
+      addFieldDecl(property, type, /* indirect */ false,
+                   /* weak */ type->is<WeakStorageType>());
+    }
   }
 
   void layoutEnum() {

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -145,7 +145,8 @@ bool TypeRefBuilder::getFieldTypeRefs(
       continue;
     }
 
-    Fields.push_back(FieldTypeInfo::forField(FieldName, Substituted));
+    Fields.push_back(
+        FieldTypeInfo::forField(FieldName, Substituted, Field.isWeak()));
   }
   return true;
 }


### PR DESCRIPTION
This is intended to archive parity with field flags in IRGen
which are used in `emitFieldTypeAccessor`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
