### PR TITLE
IUO: Remove creation of IUO from emitArtificialTopLevel.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -432,8 +432,6 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     CanType NSStringTy = SGM.Types.getNSStringType();
     CanType OptNSStringTy
       = OptionalType::get(NSStringTy)->getCanonicalType();
-    CanType IUOptNSStringTy
-      = ImplicitlyUnwrappedOptionalType::get(NSStringTy)->getCanonicalType();
 
     // Look up UIApplicationMain.
     // FIXME: Doing an AST lookup here is gross and not entirely sound;
@@ -499,21 +497,9 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     assert(nameArgTy == fnConv.getSILArgumentType(2));
     auto managedName = ManagedValue::forUnmanaged(optName);
     SILValue nilValue;
-    if (optName->getType() == nameArgTy) {
-      nilValue = getOptionalNoneValue(mainClass,
-                                      getTypeLowering(OptNSStringTy));
-    } else {
-      assert(nameArgTy.getSwiftRValueType() == IUOptNSStringTy);
-      nilValue = getOptionalNoneValue(mainClass,
-                                      getTypeLowering(IUOptNSStringTy));
-      managedName = emitOptionalToOptional(
-          mainClass, managedName,
-          SILType::getPrimitiveObjectType(IUOptNSStringTy),
-          [](SILGenFunction &, SILLocation, ManagedValue input, SILType,
-             SGFContext) {
-        return input;
-      });
-    }
+    assert(optName->getType() == nameArgTy);
+    nilValue = getOptionalNoneValue(mainClass,
+                                    getTypeLowering(OptNSStringTy));
 
     // Fix up argv to have the right type.
     auto argvTy = fnConv.getSILArgumentType(1);


### PR DESCRIPTION
It looks like this is dead code that was once useful deal with
unaudited Objective C APIs.
