### PR TITLE
[stdlib][NFC] Remove underscore from ArrayProtocol

### DIFF
--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_versioned
-internal protocol _ArrayProtocol
+internal protocol ArrayProtocol
   : RangeReplaceableCollection,
     ExpressibleByArrayLiteral
 {
@@ -72,7 +72,7 @@ internal protocol _ArrayProtocol
   var _buffer: _Buffer { get }
 }
 
-extension _ArrayProtocol {
+extension ArrayProtocol {
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1020,7 +1020,7 @@ public func _deallocateUninitialized${Self}<Element>(
 }
 %end
 
-extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
+extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   /// Creates a new, empty array.
   ///
   /// This is equivalent to initializing with an empty array literal.

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -105,7 +105,7 @@ func longArray() {
 [1,2].map // expected-error {{expression type '((Int) throws -> _) throws -> [_]' is ambiguous without more context}}
 
 
-// <rdar://problem/25563498> Type checker crash assigning array literal to type conforming to _ArrayProtocol
+// <rdar://problem/25563498> Type checker crash assigning array literal to type conforming to ArrayProtocol
 func rdar25563498<T : ExpressibleByArrayLiteral>(t: T) {
   var x: T = [1] // expected-error {{cannot convert value of type '[Int]' to specified type 'T'}}
   // expected-warning@-1{{variable 'x' was never used; consider replacing with '_' or removing it}}


### PR DESCRIPTION
This is an internal protocol used for extending both `Array` and `ContinguousArray` (and `ArraySlice` but hopefully that's not long for this world).

We might some day make this public via an evolution proposal, at which point it would lose its underscore, so removing underscore now (it isn't needed, since it's internal) to smooth that path if we do.