### PR TITLE
[Sema] Diagnose use-before-declaration even for decls marked invalid.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -540,10 +540,8 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
         D->getDeclContext()->isLocalContext() &&
         D->getDeclContext() == DC &&
         Context.SourceMgr.isBeforeInBuffer(Loc, D->getLoc())) {
-      if (!D->isInvalid()) {
-        diagnose(Loc, diag::use_local_before_declaration, Name);
-        diagnose(D, diag::decl_declared_here, Name);
-      }
+      diagnose(Loc, diag::use_local_before_declaration, Name);
+      diagnose(D, diag::decl_declared_here, Name);
       return new (Context) ErrorExpr(UDRE->getSourceRange());
     }
     if (matchesDeclRefKind(D, UDRE->getRefKind()))

--- a/test/Sema/diag_use_before_declaration.swift
+++ b/test/Sema/diag_use_before_declaration.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// SR-5163
+func sr5163() {
+  func foo(_ x: Int) -> Int? { return 1 }
+  
+  func fn() {
+    let a = foo(c) // expected-error {{use of local variable 'c' before its declaration}}
+    guard let b = a else { return }
+    let c = b // expected-note {{'c' declared here}}
+  }
+}
+
+// SR-6726
+var foo: Int?
+
+func test() {
+  guard let bar = foo else { // expected-error {{use of local variable 'foo' before its declaration}}
+    return
+  }
+  let foo = String(bar) // expected-note {{'foo' declared here}}
+}


### PR DESCRIPTION
It was possible to construct a series of declarations such that a variable was used before declared but the declaration was also marked invalid. This would end up diagnosing nothing and thus result in an obscure assert crash in SILGen instead. 

Solution is just to diagnose the use-before-declaration always.

Resolves [SR-5163](https://bugs.swift.org/browse/SR-5163), and also [SR-6726](https://bugs.swift.org/browse/SR-6726).

Resolves: rdar://problem/36376947
