### PR TITLE
Make TypeChecker::coerceToRValue walk into the subexpr of ForceValueE…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2854,7 +2854,15 @@ Expr *TypeChecker::coerceToRValue(Expr *expr,
   // If the type is already materializable, then we're already done.
   if (!exprTy->hasLValueType())
     return expr;
-  
+
+  // Walk into force optionals and coerce the source.
+  if (auto *FVE = dyn_cast<ForceValueExpr>(expr)) {
+    auto sub = coerceToRValue(FVE->getSubExpr(), getType, setType);
+    FVE->setSubExpr(sub);
+    setType(FVE, getType(sub)->getAnyOptionalObjectType());
+    return FVE;
+  }
+
   // Load lvalues.
   if (auto lvalue = exprTy->getAs<LValueType>()) {
     expr->propagateLValueAccessKind(AccessKind::Read, getType);


### PR DESCRIPTION
…xpr.

This results in the load for the coercion ending up below the force.

I don't have a case where this makes a difference on master, with the
new IUO implementation this gets us closer to generating the same code
that we generate on master, where we rely on IUO types to force
results after we've coerced lvalues to rvalues.
