### PR TITLE
Remove a direct setType on an expr in the constraint system.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7618,8 +7618,7 @@ Expr *ConstraintSystem::coerceToRValue(Expr *expr) {
                              return getType(expr);
                            },
                            [&](Expr *expr, Type type) {
-                             expr->setType(type);
-                             cacheType(expr);
+                             setType(expr, type);
                            });
 }
 


### PR DESCRIPTION
Noticed by inspection.
