### PR TITLE
Add support for specifying driver or frontend specific arguments via …

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -320,9 +320,9 @@ if test_options:
     config.swift_test_options += ' '
     config.swift_test_options += test_options
 
-config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS')
-if not config.sil_test_options:
-    config.sil_test_options = ''
+config.swift_frontend_test_options = os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
+config.swift_driver_test_options = os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
+config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
 clang_module_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-clang-module-cache")
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
@@ -340,8 +340,8 @@ config.substitutions.append( ('%{python}', sys.executable) )
 config.substitutions.append( ('%mcp_opt', mcp_opt) )
 config.substitutions.append( ('%swift_driver_plain', "%r" % config.swift) )
 config.substitutions.append( ('%swiftc_driver_plain', "%r" % config.swiftc) )
-config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s" % (config.swift, mcp_opt, config.swift_test_options)) )
-config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s" % (config.swiftc, mcp_opt, config.swift_test_options)) )
+config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s %s" % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s %s" % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
 config.substitutions.append( ('%sil-opt', "%r %s %s" % (config.sil_opt, mcp_opt, config.sil_test_options)) )
 config.substitutions.append( ('%sil-func-extractor', "%r %s" % (config.sil_func_extractor, mcp_opt)) )
 config.substitutions.append( ('%sil-llvm-gen', "%r %s" % (config.sil_llvm_gen, mcp_opt)) )
@@ -360,8 +360,8 @@ config.substitutions.append( ('%llvm-dis', config.llvm_dis) )
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(
     ('%swift',
-     "%r -frontend %s -disable-objc-attr-requires-foundation-module %s"
-       % (config.swift, mcp_opt, config.swift_test_options)) )
+     "%r -frontend %s -disable-objc-attr-requires-foundation-module %s %s"
+       % (config.swift, mcp_opt, config.swift_test_options, config.swift_frontend_test_options)) )
 
 config.clang_include_dir = \
   os.path.join(os.path.dirname(os.path.dirname(config.swift)), 'include')
@@ -604,11 +604,12 @@ if run_vendor == 'apple':
            (run_cpu, run_os, run_vers, clang_mcp_opt))
 
        config.target_build_swift = (
-           "%s %s %s -F %s -Xlinker -rpath -Xlinker %s %s %s %s" %
+           "%s %s %s -F %s -Xlinker -rpath -Xlinker %s %s %s %s %s" %
            (xcrun_prefix, config.swiftc, target_options,
             extra_frameworks_dir,
             "/tmp/swifttest-device/lib",
             sdk_overlay_linker_opt, config.swift_test_options,
+            config.swift_driver_test_options,
             swift_execution_tests_extra_flags))
        config.target_run = "unsupported"
 
@@ -632,10 +633,11 @@ if run_vendor == 'apple':
             (run_cpu, run_os, run_vers, clang_mcp_opt))
 
         config.target_build_swift = (
-            "%s %s %s -F %s %s %s %s" %
+            "%s %s %s -F %s %s %s %s %s" %
             (xcrun_prefix, config.swiftc, target_options,
              extra_frameworks_dir,
              sdk_overlay_linker_opt, config.swift_test_options,
+             config.swift_driver_test_options,
              swift_execution_tests_extra_flags))
         # FIXME: allow specification of simulator and version
         #
@@ -665,18 +667,20 @@ if run_vendor == 'apple':
             (run_cpu, run_os, run_vers, clang_mcp_opt))
 
         config.target_build_swift = (
-            "%s %s %s -F %s -Xlinker -rpath -Xlinker %s %s %s %s"
+            "%s %s %s -F %s -Xlinker -rpath -Xlinker %s %s %s %s %s"
             % (xcrun_prefix, config.swiftc, target_options,
                extra_frameworks_dir, extra_frameworks_dir,
                sdk_overlay_linker_opt, config.swift_test_options,
+               config.swift_driver_test_options,
                swift_execution_tests_extra_flags))
         config.target_run = ""
 
         if 'interpret' in lit_config.params:
             target_run_base = (
-                '%s %s %s -module-name main %s %s'
+                '%s %s %s -module-name main %s %s %s'
                 % (xcrun_prefix, config.swift, target_options,
                    config.swift_test_options,
+                   config.swift_driver_test_options,
                    swift_execution_tests_extra_flags))
             config.target_run_simple_swift = (
                 "%s %%s" % (target_run_base))
@@ -706,13 +710,13 @@ if run_vendor == 'apple':
         "%s ld -L%s" %
         (xcrun_prefix, os.path.join(test_resource_dir, config.target_sdk_name)))
     config.target_swift_frontend = (
-        "%s -frontend %s -sdk %s %s" %
+        "%s -frontend %s -sdk %s %s %s" %
         (config.swiftc, target_options, config.variant_sdk,
-         config.swift_test_options))
+         config.swift_test_options, config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = (
-        "%s -frontend %s -sdk %s %s" %
+        "%s -frontend %s -sdk %s %s %s" %
         (config.swiftc, target_options_for_mock_sdk, config.variant_sdk,
-         config.swift_test_options))
+         config.swift_test_options, config.swift_frontend_test_options))
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -766,25 +770,27 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_build_swift = (
-        '%s -target %s %s %s %s %s'
+        '%s -target %s %s %s %s %s %s'
         % (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt,
-           config.swift_test_options, swift_execution_tests_extra_flags))
+           config.swift_test_options, config.swift_driver_test_options,
+           swift_execution_tests_extra_flags))
     config.target_codesign = "echo"
     config.target_build_swift_dylib = (
         "%s -parse-as-library -emit-library -o '\\1'"
         % (config.target_build_swift))
     config.target_swift_frontend = (
-        '%s -frontend -target %s %s %s %s'
+        '%s -frontend -target %s %s %s %s %s'
         % (config.swift, config.variant_triple, resource_dir_opt, mcp_opt,
-        config.swift_test_options))
+        config.swift_test_options, config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = ''
     if 'interpret' in lit_config.params:
         target_run_base = (
-            '%s -target %s %s %s -module-name main %s %s'
+            '%s -target %s %s %s -module-name main %s %s %s'
             % (config.swift, config.variant_triple, resource_dir_opt,
                mcp_opt, config.swift_test_options,
+               config.swift_driver_test_options,
                swift_execution_tests_extra_flags))
         config.target_run_simple_swift = (
             '%s %%s' % (target_run_base))
@@ -837,18 +843,20 @@ elif run_os == 'linux-androideabi':
                             "arm-linux-androideabi",
                             "{}.x".format(config.android_ndk_gcc_version)))
     config.target_build_swift = (
-        '%s -target %s -sdk %s %s -Xlinker -pie %s %s %s %s'
+        '%s -target %s -sdk %s %s -Xlinker -pie %s %s %s %s %s'
         % (config.swiftc, config.variant_triple, config.variant_sdk,
            android_linker_opt, resource_dir_opt, mcp_opt,
-           config.swift_test_options, swift_execution_tests_extra_flags))
+           config.swift_test_options,
+           config.swift_driver_test_options, swift_execution_tests_extra_flags))
     config.target_codesign = "echo"
     config.target_build_swift_dylib = (
         "%s -parse-as-library -emit-library -o '\\1'"
         % (config.target_build_swift))
     config.target_swift_frontend = (
-        '%s -frontend -target %s -sdk %s %s %s %s'
+        '%s -frontend -target %s -sdk %s %s %s %s %s'
         % (config.swift, config.variant_triple, config.variant_sdk,
-           android_linker_opt, resource_dir_opt, mcp_opt))
+           android_linker_opt, resource_dir_opt, mcp_opt,
+           config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = os.path.join(

--- a/validation-test/compiler_crashers_2_fixed/0128-rdar35088384.swift
+++ b/validation-test/compiler_crashers_2_fixed/0128-rdar35088384.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-target-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
 protocol Command {}
 


### PR DESCRIPTION
…environment options.

Previously, we only had SWIFT_TEST_OPTIONS for this purpose and it applied
whether we were calling the driver or the frontend. This doesn't work well for
frontend arguments since in 1 context you pass in $ARGUMENT and in the other
context you have to pass in -Xfrontend $ARGUMENT. Instead now there are two
additional env vars that allows one to work around these issues:

SWIFT_DRIVER_TEST_OPTIONS
SWIFT_FRONTEND_TEST_OPTIONS

These only pass their arguments to the proper locations. *NOTE* I did not get
rid of SWIFT_TEST_OPTIONS since I did not want to stomp on any tools or
functionality that relies upon it and it seems like potentially it could be
useful (consider -Xllvm options which pass the same to the driver and the
frontend).

rdar://34222540
