### PR TITLE
libSyntax: several enhancements on source location bridging.

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -286,10 +286,6 @@ struct RawSyntax : public llvm::ThreadSafeRefCountedBase<RawSyntax> {
 
   bool isUnknown() const { return isUnknownKind(Kind); }
 
-  /// Get the absolute position of this raw syntax: its offset, line,
-  /// and column.
-  AbsolutePosition getAbsolutePosition(RC<RawSyntax> Root) const;
-
   /// Return a new raw syntax node with the given new layout element appended
   /// to the end of the node's layout.
   RC<RawSyntax> append(RC<RawSyntax> NewLayoutElement) const;
@@ -320,10 +316,6 @@ struct RawSyntax : public llvm::ThreadSafeRefCountedBase<RawSyntax> {
 
   /// Dump this piece of syntax recursively.
   void dump(llvm::raw_ostream &OS, unsigned Indent) const;
-
-private:
-  bool accumulateAbsolutePosition(AbsolutePosition &Pos,
-                                  const RawSyntax *UpToTargetNode) const;
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -38,6 +38,7 @@ class SyntaxASTMap;
 namespace syntax {
 
 struct SyntaxVisitor;
+class SourceFileSyntax;
 
 template <typename SyntaxNode>
 SyntaxNode make(RC<RawSyntax> Raw) {
@@ -177,6 +178,10 @@ public:
 
   /// Recursively visit this node.
   void accept(SyntaxVisitor &Visitor);
+
+  /// Get the absolute position of this raw syntax: its offset, line,
+  /// and column.
+  AbsolutePosition getAbsolutePosition(SourceFileSyntax Root) const;
 
   // TODO: hasSameStructureAs ?
 };

--- a/include/swift/Syntax/SyntaxVisitor.h.gyb
+++ b/include/swift/Syntax/SyntaxVisitor.h.gyb
@@ -40,6 +40,8 @@ struct SyntaxVisitor {
 
   virtual void visit(TokenSyntax token) {}
 
+  virtual void visitPre(Syntax node) {}
+  virtual void visitPost(Syntax node) {}
   void visit(Syntax node);
 
   void visitChildren(Syntax node) {

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -111,44 +111,6 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   OS << ')';
 }
 
-bool RawSyntax::accumulateAbsolutePosition(
-    AbsolutePosition &Pos, const RawSyntax *UpToTargetNode) const {
-  auto Found = this == UpToTargetNode;
-  for (auto LE : Layout) {
-    switch (LE->Kind) {
-    case SyntaxKind::Token: {
-      auto Tok = llvm::cast<RawTokenSyntax>(LE);
-      for (auto Leader : Tok->LeadingTrivia) {
-        Leader.accumulateAbsolutePosition(Pos);
-      }
-
-      if (Found) {
-        return true;
-      }
-
-      Pos.addText(Tok->getText());
-
-      for (auto Trailer : Tok->TrailingTrivia) {
-        Trailer.accumulateAbsolutePosition(Pos);
-      }
-      break;
-    }
-    default:
-      if (Found)
-        return true;
-      LE->accumulateAbsolutePosition(Pos, UpToTargetNode);
-      break;
-    }
-  }
-  return false;
-}
-
-AbsolutePosition RawSyntax::getAbsolutePosition(RC<RawSyntax> Root) const {
-  AbsolutePosition Pos;
-  Root->accumulateAbsolutePosition(Pos, this);
-  return Pos;
-}
-
 void AbsolutePosition::printLineAndColumn(llvm::raw_ostream &OS) const {
   OS << getLine() << ':' << getColumn();
 }

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/Syntax/Syntax.h"
 #include "swift/Syntax/SyntaxData.h"
+#include "swift/Syntax/SyntaxVisitor.h"
 
 using namespace swift;
 using namespace swift::syntax;
@@ -108,4 +109,65 @@ Syntax Syntax::getChild(const size_t N) const {
     ++ActualIndex;
   }
   return Syntax { Root, Data->getChild(ActualIndex).get() };
+}
+
+static void accumulateTrivia(AbsolutePosition &Pos, const Trivia &Trv) {
+  for (auto Piece: Trv) {
+    Piece.accumulateAbsolutePosition(Pos);
+  }
+}
+AbsolutePosition Syntax::getAbsolutePosition(SourceFileSyntax Root) const {
+  AbsolutePosition Pos;
+
+  /// This visitor collects all of the nodes before this node to calculate its
+  /// offset from the begenning of the file.
+  class Visitor: public SyntaxVisitor {
+    AbsolutePosition &Pos;
+    RawSyntax *Target;
+    bool Found = false;
+
+  public:
+    Visitor(AbsolutePosition &Pos, RawSyntax *Target): Pos(Pos),
+                                                       Target(Target) {}
+    ~Visitor() { assert(Found); }
+    void visitPre(Syntax Node) override {
+      // Check if this node is the target;
+      Found |= Node.getRaw().get() == Target;
+    }
+    void visit(TokenSyntax Node) override {
+      // Ignore missing node and ignore the nodes after this node.
+      if (Found || Node.isMissing())
+        return;
+      // Collect all the offsets.
+      auto Tok = llvm::cast<RawTokenSyntax>(Node.getRaw().get());
+      accumulateTrivia(Pos, Tok->LeadingTrivia);
+      Pos.addText(Tok->getText());
+      accumulateTrivia(Pos, Tok->TrailingTrivia);
+    }
+  } Calculator(Pos, getRaw().get());
+
+  /// This visitor visit the first token node of this node to accumulate its
+  /// leading trivia. Therefore, the calculated absolute location will point
+  /// to the actual token start.
+  class FirstTokenFinder: public SyntaxVisitor {
+    AbsolutePosition &Pos;
+    bool Found = false;
+
+  public:
+    FirstTokenFinder(AbsolutePosition &Pos): Pos(Pos) {}
+    void visit(TokenSyntax Node) override {
+      if (Found || Node.isMissing())
+        return;
+      Found = true;
+      auto Tok = llvm::cast<RawTokenSyntax>(Node.getRaw().get());
+      accumulateTrivia(Pos, Tok->LeadingTrivia);
+    }
+  } FTFinder(Pos);
+
+  // Visit the root to get all the nodes before this node.
+  Root.accept(Calculator);
+
+  // Visit this node to accumulate the leading trivia of its first token.
+  const_cast<Syntax*>(this)->accept(FTFinder);
+  return Pos;
 }

--- a/lib/Syntax/SyntaxVisitor.cpp.gyb
+++ b/lib/Syntax/SyntaxVisitor.cpp.gyb
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Syntax/SyntaxVisitor.h"
+#include "swift/Basic/Defer.h"
 
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
@@ -29,6 +30,8 @@ void swift::syntax::SyntaxVisitor::visit(${node.name} node) {
 % end
 
 void swift::syntax::SyntaxVisitor::visit(Syntax node) {
+  visitPre(node);
+  SWIFT_DEFER { visitPost(node); };
   switch (node.getKind()) {
   case SyntaxKind::Token: visit(make<TokenSyntax>(node.getRaw())); return;
 % for node in SYNTAX_NODES:

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -2,6 +2,8 @@
 // RUN: diff -u %s %t
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
 // RUN: diff -u %S/Outputs/round_trip_parse_gen.swift.withkinds %t.withkinds
+// RUN: %swift-syntax-test -input-source-filename %s -eof > %t
+// RUN: diff -u %s %t
 
 import <AccessPathComponent>ABC</AccessPathComponent></ImportDecl><ImportDecl>
 import <AccessPathComponent>A.</AccessPathComponent><AccessPathComponent>B.</AccessPathComponent><AccessPathComponent>C</AccessPathComponent></ImportDecl><ImportDecl><Attribute>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -2,6 +2,8 @@
 // RUN: diff -u %s %t
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
 // RUN: diff -u %S/Outputs/round_trip_parse_gen.swift.withkinds %t.withkinds
+// RUN: %swift-syntax-test -input-source-filename %s -eof > %t
+// RUN: diff -u %s %t
 
 import ABC
 import A.B.C


### PR DESCRIPTION
libSyntax nodes don't maintain absolute source location on each
individual node. Instead, the absolute locations are calculated on
demand with a given root by accumulating the length of all the other
nodes before the target node. This bridging is important for issuing
diagnostics from libSyntax entities.

With the observation that our current implementation of the source
location calculation has multiple bugs, this patch re-implemented this
bridging by using the newly-added syntax visitor. Also, we moved the function
from RawSyntax to Syntax for better visibility.

To test this source location calculation, we added a new action in
swift-syntax-test. This action parses a given file as a
SourceFileSyntax, calculates the absolute location of the
EOF token in the SourceFileSyntax, and dump the buffer from the start
of the input file to the absolute location of the EOF. Finally, we compare
the dump with the original input to ensure they are identical.
