### PR TITLE
Handle deserialization of previously forward-referenced function [WIP]

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -469,6 +469,9 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
 
     fn->setSerialized(IsSerialized_t(isSerialized));
 
+    if (SILMod.getOptions().MergePartialModules)
+      fn->setLinkage(*linkage);
+
     // Don't override the transparency or linkage of a function with
     // an existing declaration, except if we deserialized a
     // PublicNonABI function, which has HiddenExternal when


### PR DESCRIPTION
We would drop SIL on the floor if another translation unit in the same module forward-referenced a serialized function. This is still WIP since I need tests.