### PR TITLE
Add more dynamic lookup tests.

### DIFF
--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -251,3 +251,64 @@ func rdar29960565(_ o: AnyObject) {
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'privateFoo' declared here
 // <unknown>:0: error: unexpected note produced: 'internalFoo' declared here
+
+@objc protocol Q {}
+
+@objc class Dynamic : NSObject, Q {
+  @objc var s: String = ""
+  @objc func foo() -> String {}
+  @objc subscript(_: String) -> String {
+    get {
+      return "hi"
+    }
+    set {}
+  }
+}
+
+@objc class DynamicIUO : NSObject, Q {
+  @objc var t: String! = ""
+  @objc func bar() -> String! {}
+  @objc subscript(_: DynamicIUO) -> DynamicIUO! {
+    get {
+      return self
+    }
+    set {}
+  }
+}
+
+var dyn = Dynamic()
+var dyn_iuo = DynamicIUO()
+let s = "hi"
+var o: AnyObject = dyn
+let _: String = o.s
+let _: String = o.s!
+let _: String? = o.s
+let _: String = o.foo()
+let _: String = o.foo!()
+let _: String? = o.foo()
+let _: String = o[s]
+let _: String = o[s]!
+let _: String? = o[s]
+// FIXME: These should all produce lvalues that we can write through
+o.s = s // expected-error {{cannot assign to property: 'o' is immutable}}
+o.s! = s // expected-error {{cannot assign through '!': 'o' is immutable}}
+o[s] = s // expected-error {{cannot assign to immutable expression of type 'String!'}}
+o[s]! = s // expected-error {{cannot assign to immutable expression of type 'String'}}
+
+let _: String = o.t
+let _: String = o.t!
+let _: String = o.t!!
+let _: String? = o.t
+let _: String = o.bar()
+let _: String = o.bar!()
+let _: String = o.bar()!
+let _: String = o.bar!()!
+let _: String? = o.bar()
+let _: DynamicIUO = o[dyn_iuo]
+let _: DynamicIUO = o[dyn_iuo]!
+let _: DynamicIUO = o[dyn_iuo]!!
+let _: DynamicIUO? = o[dyn_iuo]
+// FIXME: These should all produce lvalues that we can write through
+o[dyn_iuo] = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO!!'}}
+o[dyn_iuo]! = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO!'}}
+o[dyn_iuo]!! = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO'}}


### PR DESCRIPTION
We weren't previously testing every combination of dynamic with and
without IUO, so I've added tests to attempt to improve the situation.

We currently produce rvalues for dynamic lookups, which is incorrect,
and can be seen in some of the test output.
