### PR TITLE
[gyb] Rework line-directives to support custom directive formatting

### DIFF
--- a/include/swift/Syntax/CMakeLists.txt
+++ b/include/swift/Syntax/CMakeLists.txt
@@ -1,5 +1,6 @@
+set(line_directive "#line" "%(line)d" "\"%(file)s\"")
 set(SWIFT_GYB_FLAGS
-  --line-directive "''")
+  --line-directive "'${line_directive}'")
 
 set(generated_include_sources
     SyntaxKind.h.gyb

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -1,5 +1,6 @@
+set(line_directive "#line" "%(line)d" "\"%(file)s\"")
 set(SWIFT_GYB_FLAGS
-  --line-directive "''")
+  --line-directive "'${line_directive}'")
 
 add_swift_library(swiftSyntax STATIC
   SyntaxNodes.cpp.gyb

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -12,7 +12,6 @@ except ImportError:
     from io import StringIO
 import textwrap
 import tokenize
-
 from bisect import bisect
 
 try:
@@ -550,7 +549,8 @@ class ParseContext(object):
         self.token_kind = None
 
 
-_default_line_directive = '// ###sourceLocation'
+_default_line_directive = \
+    '// ###sourceLocation(file: "%(file)s", line: %(line)d)'
 
 
 class ExecutionContext(object):
@@ -572,8 +572,9 @@ class ExecutionContext(object):
                 # We can only insert the line directive at a line break
                 if len(self.result_text) == 0 \
                    or self.result_text[-1].endswith('\n'):
-                    self.result_text.append('%s(file: "%s", line: %d)\n' % (
-                        self.line_directive, file, line + 1))
+                    substitutions = {'file': file, 'line': line + 1}
+                    format_str = self.line_directive + '\n'
+                    self.result_text.append(format_str % substitutions)
                 # But if the new text contains any line breaks, we can create
                 # one
                 elif '\n' in text:
@@ -770,7 +771,10 @@ def expand(filename, line_directive=_default_line_directive, **local_bindings):
     ... ''')
     >>> f.flush()
     >>> result = expand(
-    ...   f.name, line_directive='//#sourceLocation', x=2
+    ...     f.name,
+    ...     line_directive='//#sourceLocation(file: "%(file)s", ' + \
+    ...                    'line: %(line)d)',
+    ...     x=2
     ... ).replace(
     ...   '"%s"' % f.name, '"dummy.file"')
     >>> print(result, end='')
@@ -1070,7 +1074,9 @@ def execute_template(
     ... % else:
     ... THIS SHOULD NOT APPEAR IN THE OUTPUT
     ... ''')
-    >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
+    >>> out = execute_template(ast,
+    ... line_directive='//#sourceLocation(file: "%(file)s", line: %(line)d)',
+    ... x=1)
     >>> out = out.replace(file_name, "DUMMY-FILE")
     >>> print(out, end="")
     //#sourceLocation(file: "DUMMY-FILE", line: 1)
@@ -1090,12 +1096,31 @@ def execute_template(
     ... % end
     ... ${a}
     ... ''')
-    >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
+    >>> out = execute_template(ast,
+    ... line_directive='//#sourceLocation(file: "%(file)s", line: %(line)d)',
+    ... x=1)
     >>> out = out.replace(file_name, "DUMMY-FILE")
     >>> print(out, end="")
     //#sourceLocation(file: "DUMMY-FILE", line: 1)
     Nothing
     //#sourceLocation(file: "DUMMY-FILE", line: 6)
+    [0, 1, 2]
+
+    >>> ast = parse_template(file_name, text=
+    ... '''Nothing
+    ... % a = []
+    ... % for x in range(3):
+    ... %    a.append(x)
+    ... % end
+    ... ${a}
+    ... ''')
+    >>> out = execute_template(ast,
+    ...         line_directive='#line %(line)d "%(file)s"', x=1)
+    >>> out = out.replace(file_name, "DUMMY-FILE")
+    >>> print(out, end="")
+    #line 1 "DUMMY-FILE"
+    Nothing
+    #line 6 "DUMMY-FILE"
     [0, 1, 2]
     """
     execution_context = ExecutionContext(
@@ -1203,8 +1228,14 @@ def main():
         '--dump', action='store_true',
         default=False, help='Dump the parsed template to stdout')
     parser.add_argument(
-        '--line-directive', default='// ###sourceLocation',
-        help='Line directive prefix; empty => no line markers')
+        '--line-directive',
+        default=_default_line_directive,
+        help='''
+             Line directive format string, which will be
+             provided 2 substitutions, `%%(line)d` and `%%(file)s`.
+
+             Example: `// #sourceLocation(file: "%%(file)s", line: %%(line)d)`
+             ''')
 
     args = parser.parse_args(sys.argv[1:])
 


### PR DESCRIPTION
As per discussion on #10926, teach `gyb` to generate C-style `#line <line> <file>` line directives via a command-line flag.

This also re-enables line directives on the generated libSyntax API.