### PR TITLE
Revert " Remove extensions on ImplicitlyUnwrappedOptional from the stdlib."

### DIFF
--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -49,3 +49,48 @@ public enum ImplicitlyUnwrappedOptional<Wrapped> : ExpressibleByNilLiteral {
     self = .none
   }
 }
+
+#if _runtime(_ObjC)
+extension ImplicitlyUnwrappedOptional : _ObjectiveCBridgeable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> AnyObject {
+    switch self {
+    case .none:
+      _preconditionFailure("Attempt to bridge an implicitly unwrapped optional containing nil")
+
+    case .some(let x):
+      return Swift._bridgeAnythingToObjectiveC(x)
+    }
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ x: AnyObject,
+    result: inout ImplicitlyUnwrappedOptional<Wrapped>?
+  ) {
+    result = Swift._forceBridgeFromObjectiveC(x, Wrapped.self)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: AnyObject,
+    result: inout ImplicitlyUnwrappedOptional<Wrapped>?
+  ) -> Bool {
+    let bridged: Wrapped? =
+      Swift._conditionallyBridgeFromObjectiveC(x, Wrapped.self)
+    if let value = bridged {
+      result = value
+    }
+
+    return false
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?)
+      -> Wrapped! {
+    var result: ImplicitlyUnwrappedOptional<Wrapped>?
+    _forceBridgeFromObjectiveC(source!, result: &result)
+    return result!
+  }
+}
+#endif

--- a/test/Interpreter/dynamic_cast_optionals_to_nsobject.swift
+++ b/test/Interpreter/dynamic_cast_optionals_to_nsobject.swift
@@ -1,0 +1,36 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+// rdar://problem/36477954
+func AnyToNSObject(_ a: Any) {
+  if a is NSObject {
+    // ok
+  } else {
+    fatalError("argument is not bridgable to NSObject")
+  }
+}
+
+let opt: String? = "hello"
+AnyToNSObject(opt as Any)
+
+let doubleOpt: String?? = "hello"
+AnyToNSObject(doubleOpt as Any)
+
+let iuo: String! = "goodbye"
+AnyToNSObject(iuo as Any)
+
+let doubleIUO: String!! = "goodbye"
+AnyToNSObject(doubleIUO as Any)
+
+// rdar://problem/36559165
+let dict = NSMutableDictionary()
+let kSomeKey: String! = "kSomeKey"
+dict.setValue(true as Any, forKey: kSomeKey)
+// CHECK: value: 1
+print("value:", dict[kSomeKey] ?? "nil")
+
+// CHECK: ok
+print("ok")


### PR DESCRIPTION
Partially reverts apple/swift#12713

It looks like this probably broke conditional casts from IUOs to NSObject.