### PR TITLE
[SourceKit] Catch up with upstream changes in llvm.

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -915,7 +915,7 @@ void ASTProducer::findSnapshotAndOpenFiles(
       LOG_WARN_FUNC("failed getting file contents for " << File << ": "
                                                         << Error);
       // File may not exist, continue and recover as if it was empty.
-      Content.Buffer = llvm::MemoryBuffer::getNewMemBuffer(0, File);
+      Content.Buffer = llvm::WritableMemoryBuffer::getNewMemBuffer(0, File);
     }
     Contents.push_back(std::move(Content));
   }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -279,7 +279,7 @@ getInputBufForRequest(Optional<StringRef> SourceFile,
       return nullptr;
     }
   } else {
-    InputBuf = llvm::MemoryBuffer::getNewMemBuffer(0, "<input>");
+    InputBuf = llvm::WritableMemoryBuffer::getNewMemBuffer(0, "<input>");
   }
 
   return InputBuf;


### PR DESCRIPTION
lldb `upstream-with-swift` doesn't currently build because it fetches `master-next`for swift and `upstream-with-swift` for llvm. 

The latter uses `WritableMemoryBuffer`, the former `MemoryBuffer`.
I'm not sure why lldb doesn't check out the `upstream-with-swift` branch for swift as well, and I think having this divergency will cause more problems down the road.

Thoughts?