### PR TITLE
[+0-args][runtime] Add temporary runtime swift convention macros.

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -249,4 +249,16 @@
 
 #endif
 
+// These are temporary macros during the +0 cc exploration to cleanly support
+// both +0 and +1 in the runtime.
+#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
+#define SWIFT_NS_RELEASES_ARGUMENT NS_RELEASES_ARGUMENT
+#define SWIFT_CC_PLUSONE_GUARD(...) do { __VA_ARGS__ ; } while (0)
+#define SWIFT_CC_PLUSZERO_GUARD(...)
+#else
+#define SWIFT_NS_RELEASES_ARGUMENT
+#define SWIFT_CC_PLUSONE_GUARD(...)
+#define SWIFT_CC_PLUSZERO_GUARD(...)  do { __VA_ARGS__ ; } while (0)
+#endif
+
 #endif // SWIFT_RUNTIME_CONFIG_H


### PR DESCRIPTION
These are temporary staging macros to ease having a runtime that supports both
+0 and +1 conventions for functions exposed as Swift level functions in the
stdlib (and thus needing to follow the swift convention). The macros values are
toggled by the argument SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS and thus have
values described via the following table:

```
| SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENT | FALSE                         | TRUE                          |
|-----------------------------------------+-------------------------------+-------------------------------|
| SWIFT_NS_RELEASES_ARGUMENT              | NS_RELEASES_ARGUMENT          | ""                            |
| SWIFT_CC_PLUSONE_GUARD(...)             | do { __VA_ARGS__ ; } while(0) | ""                            |
| SWIFT_CC_PLUSZERO_GUARD(...)            | ""                            | do { __VA_ARGS__ ; } while(0) |
```

Thus instead of having to write an ugly #ifdef multiple times in each function
(for the arguments, destroys, and retains), we can just use these macros
instead.

In a subsequent commit I am going to cleanup the changes I made in the runtime
already to use these macros. So this is a NFC change.

rdar://34222540
