### PR TITLE
[ClangImporter] Handle diagnostics about cast types in macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 | Contents               |
 | :--------------------- |
+| [Swift 5.0](#swift-50) |
 | [Swift 4.1](#swift-41) |
 | [Swift 4.0](#swift-40) |
 | [Swift 3.1](#swift-31) |
@@ -18,6 +19,16 @@ CHANGELOG
 | [Swift 1.0](#swift-10) |
 
 </details>
+
+Swift 5.0
+---------
+
+* C macros containing casts are no longer imported to Swift if the type in the
+  cast is unavailable or deprecated, or produces some other diagnostic when
+  referenced. (These macros were already only imported under very limited
+  circumstances with very simple values, so this is unlikely to affect
+  real-world code.)
+
 
 Swift 4.1
 ---------

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -21,6 +21,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Sema/DelayedDiagnostic.h"
 #include "clang/Sema/Sema.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/APSIntType.h"
 #include "swift/AST/ASTContext.h"
@@ -361,10 +362,16 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       }
       auto identifierName = identifierInfo->getName();
       auto &identifier = impl.getClangASTContext().Idents.get(identifierName);
+
+      clang::sema::DelayedDiagnosticPool diagPool{
+          impl.getClangSema().DelayedDiagnostics.getCurrentPool()};
+      auto diagState = impl.getClangSema().DelayedDiagnostics.push(diagPool);
       auto parsedType = impl.getClangSema().getTypeName(identifier,
                                                         clang::SourceLocation(),
                                                         /*scope*/nullptr);
-      if (parsedType) {
+      impl.getClangSema().DelayedDiagnostics.popWithoutEmitting(diagState);
+
+      if (parsedType && diagPool.empty()) {
         castType = parsedType.get();
       } else {
         return nullptr;

--- a/test/ClangImporter/macros.swift
+++ b/test/ClangImporter/macros.swift
@@ -172,3 +172,9 @@ func testRecursion() {
   _ = RECURSION_IN_EXPR2 // expected-error {{use of unresolved identifier 'RECURSION_IN_EXPR2'}}
   _ = RECURSION_IN_EXPR3 // expected-error {{use of unresolved identifier 'RECURSION_IN_EXPR3'}}
 }
+
+func testNulls() {
+  let _: Int = UNAVAILABLE_ONE // expected-error {{use of unresolved identifier 'UNAVAILABLE_ONE'}}
+  let _: Int = DEPRECATED_ONE // expected-error {{use of unresolved identifier 'DEPRECATED_ONE'}}
+  let _: Int = OKAY_TYPED_ONE // expected-error {{cannot convert value of type 'okay_t' (aka 'UInt32') to specified type 'Int'}}
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -144,3 +144,12 @@
 
 #define RECURSION_WITH_EXPR3 RECURSION_WITH_EXPR3_HELPER + 1
 #define RECURSION_WITH_EXPR3_HELPER RECURSION_WITH_EXPR3 + 1
+
+
+// Casts with problematic types
+#define UNAVAILABLE_ONE ((unavailable_t)1)
+typedef unsigned unavailable_t __attribute__((unavailable));
+#define DEPRECATED_ONE ((deprecated_t)1)
+typedef unsigned deprecated_t __attribute__((deprecated));
+#define OKAY_TYPED_ONE ((okay_t)1)
+typedef unsigned okay_t;


### PR DESCRIPTION
The importer handles these by first trying to look up the type by name using Clang's Sema, but that lookup can cause diagnostics to be emitted (usually availability diagnostics). We could try to figure out how to propagate that to the macro when we import it, but for now just drop the macro instead if there are any diagnostics emitted when looking up the type.

This will be a small source compatibility break if anyone was using a macro defined in terms of a type that's deprecated or that has partial availability; the macro will now silently not be imported instead of producing an unsilenceable warning.

rdar://problem/36528212