### PR TITLE
libSyntax: optionally emit diagnostics for unknown expressions and declarations.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1556,8 +1556,8 @@ ERROR(availability_query_repeated_platform, none,
 //------------------------------------------------------------------------------
 // syntax parsing diagnostics
 //------------------------------------------------------------------------------
-ERROR(unknown_syntax_entity, PointsToFirstBadToken,
-     "unknown %0 syntax exists in the source", (StringRef))
+WARNING(unknown_syntax_entity, PointsToFirstBadToken,
+        "unknown %0 syntax exists in the source", (StringRef))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1553,6 +1553,12 @@ ERROR(pound_available_swift_not_allowed, none,
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))
 
+//------------------------------------------------------------------------------
+// syntax parsing diagnostics
+//------------------------------------------------------------------------------
+ERROR(unknown_syntax_entity, PointsToFirstBadToken,
+     "unknown %0 syntax exists in the source", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -256,6 +256,9 @@ namespace swift {
     /// this source file.
     bool KeepSyntaxInfoInSourceFile = false;
 
+    /// Whether to verify the parsed syntax tree and emit related diagnostics.
+    bool VerifySyntaxTree = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -73,10 +73,18 @@ struct alignas(1 << SyntaxAlignInBits) RootContextData {
   // Where to issue diagnostics.
   DiagnosticEngine &Diags;
 
+  SourceManager &SourceMgr;
+
+  unsigned BufferID;
+
   // Storage for Collected parts.
   std::vector<RC<RawSyntax>> Storage;
 
-  RootContextData(SourceFile &SF, DiagnosticEngine &Diags): SF(SF), Diags(Diags) {}
+  RootContextData(SourceFile &SF,
+                  DiagnosticEngine &Diags,
+                  SourceManager &SourceMgr,
+                  unsigned BufferID): SF(SF), Diags(Diags),
+                    SourceMgr(SourceMgr), BufferID(BufferID) {}
 };
 
 /// RAII object which receive RawSyntax parts. On destruction, this constructs
@@ -133,7 +141,7 @@ class alignas(1 << SyntaxAlignInBits) SyntaxParsingContext {
 public:
   /// Construct root context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SourceFile &SF,
-    DiagnosticEngine &Diags);
+    DiagnosticEngine &Diags, SourceManager &SourceMgr, unsigned BufferID);
 
   /// Designated constructor for child context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder)

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -515,8 +515,10 @@ static bool performCompile(CompilerInstance &Instance,
   FrontendOptions opts = Invocation.getFrontendOptions();
   FrontendOptions::ActionType Action = opts.RequestedAction;
 
-  if (Action == FrontendOptions::ActionType::EmitSyntax)
+  if (Action == FrontendOptions::ActionType::EmitSyntax) {
     Instance.getASTContext().LangOpts.KeepSyntaxInfoInSourceFile = true;
+    Instance.getASTContext().LangOpts.VerifySyntaxTree = true;
+  }
 
   // We've been asked to precompile a bridging header; we want to
   // avoid touching any other inputs and just parse, emit and exit.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -467,7 +467,8 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     TokReceiver(SF.shouldKeepSyntaxInfo() ?
                 new TokenRecorder(SF) :
                 new ConsumeTokenReceiver()),
-    SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF, Diags)) {
+    SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF, Diags, SourceMgr,
+                                           L->getBufferID())) {
   State = PersistentState;
   if (!State) {
     OwnedState.reset(new PersistentParserState());

--- a/test/Syntax/syntax_diagnostics.swift
+++ b/test/Syntax/syntax_diagnostics.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-frontend -emit-syntax -primary-file %s -verify
+
+typealias Inner: Foo // expected-error{{unknown declaration syntax exists in the source}} expected-error{{expected '=' in type alias declaration}}

--- a/test/Syntax/syntax_diagnostics.swift
+++ b/test/Syntax/syntax_diagnostics.swift
@@ -1,3 +1,3 @@
 // RUN: %target-swift-frontend -emit-syntax -primary-file %s -verify
 
-typealias Inner: Foo // expected-error{{unknown declaration syntax exists in the source}} expected-error{{expected '=' in type alias declaration}}
+typealias Inner: Foo // expected-warning{{unknown declaration syntax exists in the source}} expected-error{{expected '=' in type alias declaration}}

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -145,6 +145,7 @@ SourceFile *getSourceFile(CompilerInstance &Instance,
                           const char *MainExecutablePath) {
   CompilerInvocation Invocation;
   Invocation.getLangOptions().KeepSyntaxInfoInSourceFile = true;
+  Invocation.getLangOptions().VerifySyntaxTree = true;
   Invocation.getFrontendOptions().Inputs.addInputFile(InputFileName);
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(MainExecutablePath,


### PR DESCRIPTION
With more syntax nodes being specialized, we'd like this
straight-forward way to pinpoint unknown entities. This diagnostics
is only issued in -emit-syntax frontend action and swift-syntax-test
invocation.