### PR TITLE
[4.1] Revert removal of some extensions on ImplicitlyUnwrappedOptional<T>

### DIFF
--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -49,3 +49,48 @@ public enum ImplicitlyUnwrappedOptional<Wrapped> : ExpressibleByNilLiteral {
     self = .none
   }
 }
+
+#if _runtime(_ObjC)
+extension ImplicitlyUnwrappedOptional : _ObjectiveCBridgeable {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> AnyObject {
+    switch self {
+    case .none:
+      _preconditionFailure("Attempt to bridge an implicitly unwrapped optional containing nil")
+
+    case .some(let x):
+      return Swift._bridgeAnythingToObjectiveC(x)
+    }
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ x: AnyObject,
+    result: inout ImplicitlyUnwrappedOptional<Wrapped>?
+  ) {
+    result = Swift._forceBridgeFromObjectiveC(x, Wrapped.self)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: AnyObject,
+    result: inout ImplicitlyUnwrappedOptional<Wrapped>?
+  ) -> Bool {
+    let bridged: Wrapped? =
+      Swift._conditionallyBridgeFromObjectiveC(x, Wrapped.self)
+    if let value = bridged {
+      result = value
+    }
+
+    return false
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?)
+      -> Wrapped! {
+    var result: ImplicitlyUnwrappedOptional<Wrapped>?
+    _forceBridgeFromObjectiveC(source!, result: &result)
+    return result!
+  }
+}
+#endif


### PR DESCRIPTION
It breaks bridging to Objective C.