### PR TITLE
Change test Serialization/vtable-function-deserialization to remove redundant output.

### DIFF
--- a/test/Serialization/vtable-function-deserialization.swift
+++ b/test/Serialization/vtable-function-deserialization.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o Swift.swiftmodule -O -sil-inline-threshold 0 -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib -emit-module %S/Inputs/vtable-function-deserialization-input.swift -o %t/Swift.swiftmodule
+// RUN: %target-swift-frontend -emit-module -O -sil-inline-threshold 0 -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib -emit-module %S/Inputs/vtable-function-deserialization-input.swift -o %t/Swift.swiftmodule
 // RUN: %target-swift-frontend -I %t %s -emit-sil -o - -O -sil-link-all
 
 import Swift


### PR DESCRIPTION
<!-- What's in this pull request? -->
Test compiles one file but contains both -o Swift.swiftmodule and -o %t/Swift.swiftmodule. This PR removes the first -o.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
