### PR TITLE
Preparing CompilerInstance for batch mode.

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -437,6 +437,16 @@ public:
     return PrimarySourceFiles;
   }
 
+  /// Gets the Primary Source File if one exists, otherwise the main
+  /// module. If multiple Primary Source Files exist, fails with an
+  /// assertion.
+  ModuleOrSourceFile getPrimarySourceFileOrMainModule() {
+    if (PrimarySourceFiles.empty())
+      return getMainModule();
+    else
+      return getPrimarySourceFile();
+  }
+
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
   /// \returns the primary SourceFile, or nullptr if there is no primary input;
   /// if there are _multiple_ primary inputs, fails with an assertion.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -39,6 +39,7 @@
 #include "swift/Serialization/Validation.h"
 #include "swift/Subsystems.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -336,14 +337,31 @@ class CompilerInstance {
   enum : unsigned { NO_SUCH_BUFFER = ~0U };
   unsigned MainBufferID = NO_SUCH_BUFFER;
 
-  /// PrimaryBufferID corresponds to PrimaryInput.
-  unsigned PrimaryBufferID = NO_SUCH_BUFFER;
-  bool isWholeModuleCompilation() { return PrimaryBufferID == NO_SUCH_BUFFER; }
+  /// Identifies the set of input buffers in the SourceManager that are
+  /// considered primaries.
+  llvm::SetVector<unsigned> PrimaryBufferIDs;
 
-  SourceFile *PrimarySourceFile = nullptr;
+  /// Identifies the set of SourceFiles that are considered primaries. An
+  /// invariant is that any SourceFile in this set with an associated
+  /// buffer will also have its buffer ID in PrimaryBufferIDs.
+  llvm::SetVector<SourceFile*> PrimarySourceFiles;
+
+  /// Return whether there is an entry in PrimaryInputs for buffer \BufID.
+  bool isPrimaryInput(unsigned BufID) const {
+    return PrimaryBufferIDs.count(BufID) != 0;
+  }
+
+  /// Record in PrimaryBufferIDs the fact that \BufID is a primary.
+  /// If \BufID is already in the set, do nothing.
+  void recordPrimaryInputBuffer(unsigned BufID);
+
+  /// Record in PrimarySourceFiles the fact that \SF is a primary, and
+  /// call recordPrimaryInputBuffer on \SF's buffer (if it exists).
+  void recordPrimarySourceFile(SourceFile *SF);
+
+  bool isWholeModuleCompilation() { return PrimaryBufferIDs.empty(); }
 
   void createSILModule();
-  void setPrimarySourceFile(SourceFile *SF);
 
 public:
   SourceManager &getSourceMgr() { return SourceMgr; }
@@ -371,7 +389,7 @@ public:
   }
 
   void setReferencedNameTracker(ReferencedNameTracker *tracker) {
-    assert(!PrimarySourceFile && "must be called before performSema()");
+    assert(PrimarySourceFiles.empty() && "must be called before performSema()");
     NameTracker = tracker;
   }
   ReferencedNameTracker *getReferencedNameTracker() {
@@ -413,9 +431,26 @@ public:
     return Invocation.getFrontendOptions().EnableSourceImport;
   }
 
+  /// Gets the set of SourceFiles which are the primary inputs for this
+  /// CompilerInstance.
+  const llvm::SetVector<SourceFile*> &getPrimarySourceFiles() {
+    return PrimarySourceFiles;
+  }
+
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
-  /// \returns the primary SourceFile, or nullptr if there is no primary input
-  SourceFile *getPrimarySourceFile() { return PrimarySourceFile; }
+  /// \returns the primary SourceFile, or nullptr if there is no primary input;
+  /// if there are _multiple_ primary inputs, fails with an assertion.
+  ///
+  /// FIXME: This should be removed eventually, once there are no longer any
+  /// codepaths that rely on a single primary file.
+  SourceFile *getPrimarySourceFile() {
+    if (PrimarySourceFiles.empty()) {
+      return nullptr;
+    } else {
+      assert(PrimarySourceFiles.size() == 1);
+      return *PrimarySourceFiles.begin();
+    }
+  }
 
   /// \brief Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation);

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -352,11 +352,11 @@ class CompilerInstance {
   }
 
   /// Record in PrimaryBufferIDs the fact that \BufID is a primary.
-  /// If \BufID is already in the set, do nothing.
+  /// If \p BufID is already in the set, do nothing.
   void recordPrimaryInputBuffer(unsigned BufID);
 
-  /// Record in PrimarySourceFiles the fact that \SF is a primary, and
-  /// call recordPrimaryInputBuffer on \SF's buffer (if it exists).
+  /// Record in PrimarySourceFiles the fact that \p SF is a primary, and
+  /// call recordPrimaryInputBuffer on \p SF's buffer (if it exists).
   void recordPrimarySourceFile(SourceFile *SF);
 
   bool isWholeModuleCompilation() { return PrimaryBufferIDs.empty(); }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -433,7 +433,7 @@ public:
 
   /// Gets the set of SourceFiles which are the primary inputs for this
   /// CompilerInstance.
-  const ArrayRef<SourceFile *> getPrimarySourceFiles() {
+  ArrayRef<SourceFile *> getPrimarySourceFiles() {
     return PrimarySourceFiles;
   }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -346,12 +346,12 @@ class CompilerInstance {
   /// buffer will also have its buffer ID in PrimaryBufferIDs.
   std::vector<SourceFile *> PrimarySourceFiles;
 
-  /// Return whether there is an entry in PrimaryInputs for buffer \BufID.
+  /// Return whether there is an entry in PrimaryInputs for buffer \p BufID.
   bool isPrimaryInput(unsigned BufID) const {
     return PrimaryBufferIDs.count(BufID) != 0;
   }
 
-  /// Record in PrimaryBufferIDs the fact that \BufID is a primary.
+  /// Record in PrimaryBufferIDs the fact that \p BufID is a primary.
   /// If \p BufID is already in the set, do nothing.
   void recordPrimaryInputBuffer(unsigned BufID);
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -344,7 +344,7 @@ class CompilerInstance {
   /// Identifies the set of SourceFiles that are considered primaries. An
   /// invariant is that any SourceFile in this set with an associated
   /// buffer will also have its buffer ID in PrimaryBufferIDs.
-  llvm::SetVector<SourceFile*> PrimarySourceFiles;
+  std::vector<SourceFile *> PrimarySourceFiles;
 
   /// Return whether there is an entry in PrimaryInputs for buffer \BufID.
   bool isPrimaryInput(unsigned BufID) const {
@@ -433,7 +433,7 @@ public:
 
   /// Gets the set of SourceFiles which are the primary inputs for this
   /// CompilerInstance.
-  const llvm::SetVector<SourceFile*> &getPrimarySourceFiles() {
+  const ArrayRef<SourceFile *> getPrimarySourceFiles() {
     return PrimarySourceFiles;
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -61,14 +61,16 @@ void CompilerInstance::createSILModule() {
       Invocation.getFrontendOptions().Inputs.isWholeModule());
 }
 
-void CompilerInstance::setPrimarySourceFile(SourceFile *SF) {
-  assert(SF);
+void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
+  PrimaryBufferIDs.insert(BufID);
+}
+
+void CompilerInstance::recordPrimarySourceFile(SourceFile *SF) {
   assert(MainModule && "main module not created yet");
-  assert(!PrimarySourceFile && "already has a primary source file");
-  assert(PrimaryBufferID == NO_SUCH_BUFFER || !SF->getBufferID().hasValue() ||
-         SF->getBufferID().getValue() == PrimaryBufferID);
-  PrimarySourceFile = SF;
-  PrimarySourceFile->setReferencedNameTracker(NameTracker);
+  PrimarySourceFiles.insert(SF);
+  SF->setReferencedNameTracker(NameTracker);
+  if (SF->getBufferID().hasValue())
+    recordPrimaryInputBuffer(SF->getBufferID().getValue());
 }
 
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
@@ -186,9 +188,9 @@ bool CompilerInstance::setUpInputs() {
 
   // Set the primary file to the code-completion point if one exists.
   if (codeCompletionBufferID.hasValue() &&
-      *codeCompletionBufferID != PrimaryBufferID) {
-    assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-    PrimaryBufferID = *codeCompletionBufferID;
+      !isPrimaryInput(*codeCompletionBufferID)) {
+    assert(PrimaryBufferIDs.empty() && "re-setting PrimaryBufferID");
+    recordPrimaryInputBuffer(*codeCompletionBufferID);
   }
 
   if (isInputSwift() && MainBufferID == NO_SUCH_BUFFER &&
@@ -214,8 +216,8 @@ bool CompilerInstance::setUpForInput(const InputFile &input) {
   }
 
   if (input.isPrimary()) {
-    assert(PrimaryBufferID == NO_SUCH_BUFFER && "re-setting PrimaryBufferID");
-    PrimaryBufferID = *bufferID;
+    assert(PrimaryBufferIDs.empty() && "re-setting PrimaryBufferID");
+    recordPrimaryInputBuffer(*bufferID);
   }
   return false;
 }
@@ -587,7 +589,7 @@ void CompilerInstance::parseLibraryFile(
   addAdditionalInitialImportsTo(NextInput, implicitImports);
 
   auto *DelayedCB = SecondaryDelayedCB;
-  if (BufferID == PrimaryBufferID) {
+  if (isPrimaryInput(BufferID)) {
     DelayedCB = PrimaryDelayedCB;
   }
   if (isWholeModuleCompilation())
@@ -595,7 +597,7 @@ void CompilerInstance::parseLibraryFile(
 
   auto &Diags = NextInput->getASTContext().Diags;
   auto DidSuppressWarnings = Diags.getSuppressWarnings();
-  auto IsPrimary = isWholeModuleCompilation() || BufferID == PrimaryBufferID;
+  auto IsPrimary = isWholeModuleCompilation() || isPrimaryInput(BufferID);
   Diags.setSuppressWarnings(DidSuppressWarnings || !IsPrimary);
 
   bool Done;
@@ -661,7 +663,7 @@ void CompilerInstance::parseAndTypeCheckMainFile(
   SharedTimer timer(
       "performSema-checkTypesWhileParsingMain-parseAndTypeCheckMainFile");
   bool mainIsPrimary =
-      (isWholeModuleCompilation() || MainBufferID == PrimaryBufferID);
+      (isWholeModuleCompilation() || isPrimaryInput(MainBufferID));
 
   SourceFile &MainFile =
       MainModule->getMainSourceFile(Invocation.getSourceFileKind());
@@ -724,7 +726,9 @@ void CompilerInstance::forEachFileToTypeCheck(
   if (isWholeModuleCompilation()) {
     forEachSourceFileIn(MainModule, [&](SourceFile &SF) { fn(SF); });
   } else {
-    fn(*PrimarySourceFile);
+    for (auto *SF : PrimarySourceFiles) {
+      fn(*SF);
+    }
   }
 }
 
@@ -746,8 +750,9 @@ SourceFile *CompilerInstance::createSourceFileForMainModule(
       SourceFile(*mainModule, fileKind, bufferID, importKind, keepSyntaxInfo);
   MainModule->addFile(*inputFile);
 
-  if (bufferID && *bufferID == PrimaryBufferID)
-    setPrimarySourceFile(inputFile);
+  if (bufferID && isPrimaryInput(*bufferID)) {
+    recordPrimarySourceFile(inputFile);
+  }
 
   return inputFile;
 }
@@ -813,6 +818,7 @@ void CompilerInstance::freeContextAndSIL() {
   TheSILModule.reset();
   MainModule = nullptr;
   SML = nullptr;
-  PrimarySourceFile = nullptr;
+  PrimaryBufferIDs.clear();
+  PrimarySourceFiles.clear();
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -67,7 +67,7 @@ void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
 
 void CompilerInstance::recordPrimarySourceFile(SourceFile *SF) {
   assert(MainModule && "main module not created yet");
-  PrimarySourceFiles.insert(SF);
+  PrimarySourceFiles.push_back(SF);
   SF->setReferencedNameTracker(NameTracker);
   if (SF->getBufferID().hasValue())
     recordPrimaryInputBuffer(SF->getBufferID().getValue());

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -453,8 +453,9 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
     C.NumReferencedMemberNames = R->getUsedMembers().size();
   }
 
-  if (auto *SF = Instance.getPrimarySourceFile()) {
-    countStatsOfSourceFile(Stats, Instance, SF);
+  if (!Instance.getPrimarySourceFiles().empty()) {
+    for (auto SF : Instance.getPrimarySourceFiles())
+      countStatsOfSourceFile(Stats, Instance, SF);
   } else if (auto *M = Instance.getMainModule()) {
     // No primary source file, but a main module; this is WMO-mode
     for (auto *F : M->getFiles()) {
@@ -630,8 +631,6 @@ static bool performCompile(CompilerInstance &Instance,
     return Context.hadError();
   }
 
-  SourceFile *PrimarySourceFile = Instance.getPrimarySourceFile();
-
   // We've been told to dump the AST (either after parsing or type-checking,
   // which is already differentiated in CompilerInstance::performSema()),
   // so dump or print the main source file and return.
@@ -642,7 +641,7 @@ static bool performCompile(CompilerInstance &Instance,
       Action == FrontendOptions::ActionType::DumpScopeMaps ||
       Action == FrontendOptions::ActionType::DumpTypeRefinementContexts ||
       Action == FrontendOptions::ActionType::DumpInterfaceHash) {
-    SourceFile *SF = PrimarySourceFile;
+    SourceFile *SF = Instance.getPrimarySourceFile();
     if (!SF) {
       SourceFileKind Kind = Invocation.getSourceFileKind();
       SF = &Instance.getMainModule()->getMainSourceFile(Kind);
@@ -717,9 +716,12 @@ static bool performCompile(CompilerInstance &Instance,
     (void)emitMakeDependencies(Context.Diags, *Instance.getDependencyTracker(),
                                opts);
 
-  if (shouldTrackReferences)
-    emitReferenceDependencies(Context.Diags, Instance.getPrimarySourceFile(),
-                              *Instance.getDependencyTracker(), opts);
+  if (shouldTrackReferences) {
+    for (auto *SF : Instance.getPrimarySourceFiles()) {
+      emitReferenceDependencies(Context.Diags, SF,
+                                *Instance.getDependencyTracker(), opts);
+    }
+  }
 
   if (!opts.LoadedModuleTracePath.empty())
     (void)emitLoadedModuleTrace(Context, *Instance.getDependencyTracker(),
@@ -730,7 +732,8 @@ static bool performCompile(CompilerInstance &Instance,
   if (Context.hadError()) {
     if (shouldIndex) {
       //  Emit the index store data even if there were compiler errors.
-      if (emitIndexData(PrimarySourceFile, Invocation, Instance))
+      if (emitIndexData(Instance.getPrimarySourceFile(),
+                        Invocation, Instance))
         return true;
     }
     return true;
@@ -749,7 +752,8 @@ static bool performCompile(CompilerInstance &Instance,
       return printAsObjC(opts.ObjCHeaderOutputPath, Instance.getMainModule(),
                          opts.ImplicitObjCHeaderPath, moduleIsPublic);
     if (shouldIndex) {
-      if (emitIndexData(PrimarySourceFile, Invocation, Instance))
+      if (emitIndexData(Instance.getPrimarySourceFile(),
+                        Invocation, Instance))
         return true;
     }
     return Context.hadError();
@@ -780,7 +784,7 @@ static bool performCompile(CompilerInstance &Instance,
       return SASTF && SASTF->isSIB();
     };
     if (opts.Inputs.hasPrimaryInputs()) {
-      FileUnit *PrimaryFile = PrimarySourceFile;
+      FileUnit *PrimaryFile = Instance.getPrimarySourceFile();
       if (!PrimaryFile) {
         for (FileUnit *fileUnit : Instance.getMainModule()->getFiles()) {
           if (auto SASTF = dyn_cast<SerializedASTFile>(fileUnit)) {
@@ -827,8 +831,7 @@ static bool performCompile(CompilerInstance &Instance,
     if (Invocation.getSILOptions().LinkMode == SILOptions::LinkAll)
       performSILLinking(SM.get(), true);
 
-    auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
+    auto DC = Instance.getPrimarySourceFileOrMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -884,8 +887,7 @@ static bool performCompile(CompilerInstance &Instance,
 
   auto SerializeSILModuleAction = [&]() {
     if (!opts.ModuleOutputPath.empty() || !opts.ModuleDocOutputPath.empty()) {
-      auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile)
-                                  : Instance.getMainModule();
+        auto DC = Instance.getPrimarySourceFileOrMainModule();
       if (!opts.ModuleOutputPath.empty()) {
         SerializationOptions serializationOpts;
         serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -956,8 +958,9 @@ static bool performCompile(CompilerInstance &Instance,
 
   // Get the main source file's private discriminator and attach it to
   // the compile unit's flags.
-  if (PrimarySourceFile) {
-    Identifier PD = PrimarySourceFile->getPrivateDiscriminator();
+  if (IRGenOpts.DebugInfoKind != IRGenDebugInfoKind::None &&
+      Instance.getPrimarySourceFile()) {
+    Identifier PD = Instance.getPrimarySourceFile()->getPrivateDiscriminator();
     if (!PD.empty())
       IRGenOpts.DWARFDebugFlags += (" -private-discriminator "+PD.str()).str();
   }
@@ -968,8 +971,7 @@ static bool performCompile(CompilerInstance &Instance,
   }
 
   if (Action == FrontendOptions::ActionType::EmitSIB) {
-    auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
+    auto DC = Instance.getPrimarySourceFileOrMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -988,7 +990,8 @@ static bool performCompile(CompilerInstance &Instance,
     if (Action == FrontendOptions::ActionType::MergeModules ||
         Action == FrontendOptions::ActionType::EmitModuleOnly) {
       if (shouldIndex) {
-        if (emitIndexData(PrimarySourceFile, Invocation, Instance))
+        if (emitIndexData(Instance.getPrimarySourceFile(),
+                          Invocation, Instance))
           return true;
       }
       return Context.hadError();
@@ -1019,7 +1022,8 @@ static bool performCompile(CompilerInstance &Instance,
   // TODO: remove once the frontend understands what action it should perform
   IRGenOpts.OutputKind = getOutputKind(Action);
   if (Action == FrontendOptions::ActionType::Immediate) {
-    assert(!PrimarySourceFile && "-i doesn't work in -primary-file mode");
+    assert(Instance.getPrimarySourceFiles().empty() &&
+           "-i doesn't work in -primary-file mode");
     IRGenOpts.UseJIT = true;
     IRGenOpts.DebugInfoKind = IRGenDebugInfoKind::Normal;
     const ProcessCmdLine &CmdLine = ProcessCmdLine(opts.ImmediateArgv.begin(),
@@ -1040,8 +1044,10 @@ static bool performCompile(CompilerInstance &Instance,
   auto &LLVMContext = getGlobalLLVMContext();
   std::unique_ptr<llvm::Module> IRModule;
   llvm::GlobalVariable *HashGlobal;
-  if (PrimarySourceFile) {
-    IRModule = performIRGeneration(IRGenOpts, *PrimarySourceFile, std::move(SM),
+  if (!Instance.getPrimarySourceFiles().empty()) {
+    IRModule = performIRGeneration(IRGenOpts,
+                                   *Instance.getPrimarySourceFile(),
+                                   std::move(SM),
                                    opts.getSingleOutputFilename(), LLVMContext,
                                    0, &HashGlobal);
   } else {
@@ -1054,7 +1060,7 @@ static bool performCompile(CompilerInstance &Instance,
   // Walk the AST for indexing after IR generation. Walking it before seems
   // to cause miscompilation issues.
   if (shouldIndex) {
-    if (emitIndexData(PrimarySourceFile, Invocation, Instance))
+    if (emitIndexData(Instance.getPrimarySourceFile(), Invocation, Instance))
       return true;
   }
 
@@ -1083,8 +1089,9 @@ static bool performCompile(CompilerInstance &Instance,
     const auto &SILOpts = Invocation.getSILOptions();
     const auto hasMultipleIGMs = SILOpts.hasMultipleIGMs();
     bool error;
-    if (PrimarySourceFile)
-      error = validateTBD(PrimarySourceFile, *IRModule, hasMultipleIGMs,
+    if (!Instance.getPrimarySourceFiles().empty())
+      error = validateTBD(Instance.getPrimarySourceFile(),
+                          *IRModule, hasMultipleIGMs,
                           allSymbols);
     else
       error = validateTBD(Instance.getMainModule(), *IRModule, hasMultipleIGMs,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -734,6 +734,9 @@ static bool performCompile(CompilerInstance &Instance,
                                opts);
 
   if (shouldTrackReferences) {
+    if (Instance.getPrimarySourceFiles().empty())
+      Context.Diags.diagnose(
+          SourceLoc(), diag::emit_reference_dependencies_without_primary_file);
     for (auto *SF : Instance.getPrimarySourceFiles()) {
       emitReferenceDependencies(Context.Diags, SF,
                                 *Instance.getDependencyTracker(), opts);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -504,10 +504,17 @@ createOptRecordFile(StringRef Filename, DiagnosticEngine &DE) {
   return File;
 }
 
+struct PostSILGenInputs {
+  std::unique_ptr<SILModule> TheSILModule;
+  bool astGuaranteedToCorrespondToSIL;
+  ModuleOrSourceFile ModuleOrPrimarySourceFile;
+};
+
 static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
                                           CompilerInvocation &Invocation,
                                           std::unique_ptr<SILModule> SM,
                                           bool astGuaranteedToCorrespondToSIL,
+                                          ModuleOrSourceFile MSF,
                                           bool moduleIsPublic,
                                           int &ReturnValue,
                                           FrontendObserver *observer,
@@ -783,16 +790,13 @@ static bool performCompile(CompilerInstance &Instance,
   assert(Action >= FrontendOptions::ActionType::EmitSILGen &&
          "All actions not requiring SILGen must have been handled!");
 
-  // The second boolean in each std::pair<> in this std::deque<> indicates
-  // whether the SIL is guaranteed to correspond to the the AST. This might be
-  // false if we loaded SIL from an SIB.
-  std::deque<std::pair<std::unique_ptr<SILModule>, bool>> SMs;
+  auto mod = Instance.getMainModule();
+  std::deque<PostSILGenInputs> PSGIs;
   if (auto SM = Instance.takeSILModule()) {
-    SMs.push_back(std::make_pair(std::move(SM), false));
+    PSGIs.push_back(PostSILGenInputs{std::move(SM), false, mod});
   }
 
-  if (SMs.empty()) {
-    auto mod = Instance.getMainModule();
+  if (PSGIs.empty()) {
     auto fileIsSIB = [](const FileUnit *File) -> bool {
       auto SASTF = dyn_cast<SerializedASTFile>(File);
       return SASTF && SASTF->isSIB();
@@ -807,9 +811,10 @@ static bool performCompile(CompilerInstance &Instance,
                   InputFile::
                     convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
                       SASTF->getFilename()))) {
-              assert(SMs.empty() && "Can only handle one primary AST input");
+              assert(PSGIs.empty() && "Can only handle one primary AST input");
               auto SM = performSILGeneration(*SASTF, SILOpts, None);
-              SMs.push_back(std::make_pair(std::move(SM), !fileIsSIB(SASTF)));
+              PSGIs.push_back(
+                  PostSILGenInputs{std::move(SM), !fileIsSIB(SASTF), mod});
             }
           }
         }
@@ -819,25 +824,26 @@ static bool performCompile(CompilerInstance &Instance,
         // once for each such input.
         for (auto *PrimaryFile : Instance.getPrimarySourceFiles()) {
           auto SM = performSILGeneration(*PrimaryFile, SILOpts, None);
-          SMs.push_back(std::make_pair(std::move(SM), !fileIsSIB(PrimaryFile)));
+          PSGIs.push_back(PostSILGenInputs{
+              std::move(SM), !fileIsSIB(PrimaryFile), PrimaryFile});
         }
       }
     } else {
       // If we have no primary inputs we are in WMO mode and need to build a
       // SILModule for the entire module.
       auto SM = performSILGeneration(mod, SILOpts, true);
-      SMs.push_back(std::make_pair(std::move(SM),
-                                   llvm::none_of(mod->getFiles(),
-                                                 fileIsSIB)));
+      PSGIs.push_back(PostSILGenInputs{
+          std::move(SM), llvm::none_of(mod->getFiles(), fileIsSIB), mod});
     }
   }
 
-  while (!SMs.empty()) {
-    auto pair = std::move(SMs.front());
-    SMs.pop_front();
+  while (!PSGIs.empty()) {
+    auto PSGI = std::move(PSGIs.front());
+    PSGIs.pop_front();
     if (performCompileStepsPostSILGen(Instance, Invocation,
-                                      std::move(pair.first),
-                                      pair.second,
+                                      std::move(PSGI.TheSILModule),
+                                      PSGI.astGuaranteedToCorrespondToSIL,
+                                      PSGI.ModuleOrPrimarySourceFile,
                                       moduleIsPublic,
                                       ReturnValue, observer, Stats))
       return true;
@@ -850,6 +856,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
                                           CompilerInvocation &Invocation,
                                           std::unique_ptr<SILModule> SM,
                                           bool astGuaranteedToCorrespondToSIL,
+                                          ModuleOrSourceFile MSF,
                                           bool moduleIsPublic,
                                           int &ReturnValue,
                                           FrontendObserver *observer,
@@ -883,14 +890,13 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     if (Invocation.getSILOptions().LinkMode == SILOptions::LinkAll)
       performSILLinking(SM.get(), true);
 
-    auto DC = Instance.getPrimarySourceFileOrMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
 
-      serialize(DC, serializationOpts, SM.get());
+      serialize(MSF, serializationOpts, SM.get());
     }
     return Context.hadError();
   }
@@ -939,7 +945,6 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
 
   auto SerializeSILModuleAction = [&]() {
     if (!opts.ModuleOutputPath.empty() || !opts.ModuleDocOutputPath.empty()) {
-        auto DC = Instance.getPrimarySourceFileOrMainModule();
       if (!opts.ModuleOutputPath.empty()) {
         SerializationOptions serializationOpts;
         serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -961,7 +966,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
         serializationOpts.SerializeOptionsForDebugging =
             !moduleIsPublic || opts.AlwaysSerializeDebuggingOptions;
 
-        serialize(DC, serializationOpts, SM.get());
+        serialize(MSF, serializationOpts, SM.get());
       }
     }
   };
@@ -1011,8 +1016,8 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   // Get the main source file's private discriminator and attach it to
   // the compile unit's flags.
   if (IRGenOpts.DebugInfoKind != IRGenDebugInfoKind::None &&
-      Instance.getPrimarySourceFile()) {
-    Identifier PD = Instance.getPrimarySourceFile()->getPrivateDiscriminator();
+      MSF.is<SourceFile*>()) {
+    Identifier PD = MSF.get<SourceFile*>()->getPrivateDiscriminator();
     if (!PD.empty())
       IRGenOpts.DWARFDebugFlags += (" -private-discriminator "+PD.str()).str();
   }
@@ -1023,14 +1028,13 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   }
 
   if (Action == FrontendOptions::ActionType::EmitSIB) {
-    auto DC = Instance.getPrimarySourceFileOrMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.SerializeAllSIL = true;
       serializationOpts.IsSIB = true;
 
-      serialize(DC, serializationOpts, SM.get());
+      serialize(MSF, serializationOpts, SM.get());
     }
     return Context.hadError();
   }
@@ -1042,7 +1046,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     if (Action == FrontendOptions::ActionType::MergeModules ||
         Action == FrontendOptions::ActionType::EmitModuleOnly) {
       if (shouldIndex) {
-        if (emitIndexData(Instance.getPrimarySourceFile(),
+        if (emitIndexData(MSF.dyn_cast<SourceFile*>(),
                           Invocation, Instance))
           return true;
       }
@@ -1074,7 +1078,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   // TODO: remove once the frontend understands what action it should perform
   IRGenOpts.OutputKind = getOutputKind(Action);
   if (Action == FrontendOptions::ActionType::Immediate) {
-    assert(Instance.getPrimarySourceFiles().empty() &&
+    assert(!MSF.is<SourceFile*>() &&
            "-i doesn't work in -primary-file mode");
     IRGenOpts.UseJIT = true;
     IRGenOpts.DebugInfoKind = IRGenDebugInfoKind::Normal;
@@ -1096,14 +1100,14 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   auto &LLVMContext = getGlobalLLVMContext();
   std::unique_ptr<llvm::Module> IRModule;
   llvm::GlobalVariable *HashGlobal;
-  if (!Instance.getPrimarySourceFiles().empty()) {
+  if (MSF.is<SourceFile*>()) {
     IRModule = performIRGeneration(IRGenOpts,
-                                   *Instance.getPrimarySourceFile(),
+                                   *MSF.get<SourceFile*>(),
                                    std::move(SM),
                                    opts.getSingleOutputFilename(), LLVMContext,
                                    0, &HashGlobal);
   } else {
-    IRModule = performIRGeneration(IRGenOpts, Instance.getMainModule(),
+    IRModule = performIRGeneration(IRGenOpts, MSF.get<ModuleDecl*>(),
                                    std::move(SM),
                                    opts.getSingleOutputFilename(), LLVMContext,
                                    &HashGlobal);
@@ -1112,7 +1116,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   // Walk the AST for indexing after IR generation. Walking it before seems
   // to cause miscompilation issues.
   if (shouldIndex) {
-    if (emitIndexData(Instance.getPrimarySourceFile(), Invocation, Instance))
+    if (emitIndexData(MSF.dyn_cast<SourceFile*>(), Invocation, Instance))
       return true;
   }
 
@@ -1141,12 +1145,13 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     const auto &SILOpts = Invocation.getSILOptions();
     const auto hasMultipleIGMs = SILOpts.hasMultipleIGMs();
     bool error;
-    if (!Instance.getPrimarySourceFiles().empty())
-      error = validateTBD(Instance.getPrimarySourceFile(),
+    if (MSF.is<SourceFile*>())
+      error = validateTBD(MSF.get<SourceFile*>(),
                           *IRModule, hasMultipleIGMs,
                           allSymbols);
     else
-      error = validateTBD(Instance.getMainModule(), *IRModule, hasMultipleIGMs,
+      error = validateTBD(MSF.get<ModuleDecl*>(),
+                          *IRModule, hasMultipleIGMs,
                           allSymbols);
     if (error)
       return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -798,8 +798,7 @@ static bool performCompile(CompilerInstance &Instance,
   if (auto SM = Instance.takeSILModule()) {
     PSGIs.push_back(PostSILGenInputs{std::move(SM), false, mod});
   }
-
-  if (PSGIs.empty()) {
+  else if (PSGIs.empty()) {
     auto fileIsSIB = [](const FileUnit *File) -> bool {
       auto SASTF = dyn_cast<SerializedASTFile>(File);
       return SASTF && SASTF->isSIB();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -827,7 +827,7 @@ static bool performCompile(CompilerInstance &Instance,
         for (auto *PrimaryFile : Instance.getPrimarySourceFiles()) {
           auto SM = performSILGeneration(*PrimaryFile, SILOpts, None);
           PSGIs.push_back(PostSILGenInputs{
-              std::move(SM), !fileIsSIB(PrimaryFile), PrimaryFile});
+              std::move(SM), true, PrimaryFile});
         }
       }
     } else {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -506,7 +506,7 @@ createOptRecordFile(StringRef Filename, DiagnosticEngine &DE) {
 
 struct PostSILGenInputs {
   std::unique_ptr<SILModule> TheSILModule;
-  bool astGuaranteedToCorrespondToSIL;
+  bool ASTGuaranteedToCorrespondToSIL;
   ModuleOrSourceFile ModuleOrPrimarySourceFile;
 };
 
@@ -845,7 +845,7 @@ static bool performCompile(CompilerInstance &Instance,
     PSGIs.pop_front();
     if (performCompileStepsPostSILGen(Instance, Invocation,
                                       std::move(PSGI.TheSILModule),
-                                      PSGI.astGuaranteedToCorrespondToSIL,
+                                      PSGI.ASTGuaranteedToCorrespondToSIL,
                                       PSGI.ModuleOrPrimarySourceFile,
                                       moduleIsPublic,
                                       ReturnValue, observer, Stats))

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -798,7 +798,7 @@ static bool performCompile(CompilerInstance &Instance,
   if (auto SM = Instance.takeSILModule()) {
     PSGIs.push_back(PostSILGenInputs{std::move(SM), false, mod});
   }
-  else if (PSGIs.empty()) {
+  else {
     auto fileIsSIB = [](const FileUnit *File) -> bool {
       auto SASTF = dyn_cast<SerializedASTFile>(File);
       return SASTF && SASTF->isSIB();

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -126,11 +126,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
                                       SourceFile *SF,
                                       DependencyTracker &depTracker,
                                       const FrontendOptions &opts) {
-  if (!SF) {
-    diags.diagnose(SourceLoc(),
-                   diag::emit_reference_dependencies_without_primary_file);
-    return true;
-  }
+  assert(SF && "Cannot emit reference dependencies without a SourceFile");
 
   // Before writing to the dependencies file path, preserve any previous file
   // that may have been there. No error handling -- this is just a nicety, it


### PR DESCRIPTION
<!-- What's in this pull request? -->
Use a SetVector for CompilerInstance::PrimaryBufferIDs, and create functions to test inclusion, test for WMO, and add a primary. 
Split up performCompile and Invoke part 2, performCompileStepsPostSILGen, once for each primary.
Move diagnostic for emit_reference_dependencies_without_primary_file.
Includes Graydon's commits.


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
