### PR TITLE
[ClangImporter] Anonymous enums used as types can't be imported as Int

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -812,7 +812,7 @@ namespace {
         // Map anonymous enums with no fixed underlying type to Int /if/
         // they fit in an Int32. If not, this mapping isn't guaranteed to be
         // consistent for all platforms we care about.
-        if (!clangDecl->isFixed() &&
+        if (!clangDecl->isFixed() && clangDecl->isFreeStanding() &&
             clangDecl->getNumPositiveBits() < 32 &&
             clangDecl->getNumNegativeBits() <= 32)
           return Impl.getNamedSwiftType(Impl.getStdlibModule(), "Int");

--- a/test/ClangImporter/Inputs/enum-anon.h
+++ b/test/ClangImporter/Inputs/enum-anon.h
@@ -1,0 +1,31 @@
+enum {
+  Constant1,
+  Constant2
+};
+
+enum {
+  VarConstant1,
+  VarConstant2
+} global;
+
+typedef struct SR2511 {
+    int x;
+
+    enum {
+      SR2511A = 0, SR2511B, SR2511C
+    } y;
+
+    int z;
+} SR2511;
+
+#if __OBJC__
+enum : unsigned short {
+  USConstant1,
+  USConstant2
+};
+
+enum : unsigned short {
+  USVarConstant1,
+  USVarConstant2
+} usGlobal;
+#endif // __OBJC__

--- a/test/ClangImporter/enum-anon.swift
+++ b/test/ClangImporter/enum-anon.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-anon.h -DDIAGS -verify
+// RUN: %target-swift-frontend -emit-ir %s -import-objc-header %S/Inputs/enum-anon.h | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-runtime %s
+
+#if DIAGS
+func testDiags() {
+  let _: String = Constant2 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+  let _: String = VarConstant2 // expected-error {{cannot convert value of type 'UInt32' to specified type 'String'}}
+
+#if _runtime(_ObjC)
+  let us2 = USConstant2
+#else
+  let us2: UInt16 = 0
+#endif
+  let _: String = us2 // expected-error {{cannot convert value of type 'UInt16' to specified type 'String'}}
+
+#if _runtime(_ObjC)
+  let usVar2 = USVarConstant2
+#else
+  let usVar2: UInt16 = 0
+#endif
+  let _: String = usVar2 // expected-error {{cannot convert value of type 'UInt16' to specified type 'String'}}
+
+  let _: String = SR2511().y // expected-error {{cannot convert value of type 'UInt32' to specified type 'String'}}
+
+  // FIXME: This constant doesn't seem to be imported at all. At least one of
+  // the following two names should work.
+  let _: String = SR2511B // expected-error {{use of unresolved identifier 'SR2511B'}}
+  let _: String = SR2511.SR2511B // expected-error {{type 'SR2511' has no member 'SR2511B'}}
+}
+#endif
+
+// CHECK-LABEL: %TSo6SR2511V = type <{ %Ts5Int32V, %Ts6UInt32V, %Ts5Int32V }>
+// CHECK-LABEL: define{{.*}} i32 @"$S4main6testIR1xs5Int32VSPySo6SR2511VG_tF"(
+public func testIR(x: UnsafePointer<SR2511>) -> CInt {
+  // CHECK: store i32 1, i32* getelementptr inbounds (%Ts6UInt32V, %Ts6UInt32V* bitcast (i32* @global to %Ts6UInt32V*), i32 0, i32 0), align 4
+  global = VarConstant2
+
+#if _runtime(_ObjC)
+  // CHECK-objc: store i16 1, i16* getelementptr inbounds (%Ts6UInt16V, %Ts6UInt16V* bitcast (i16* @usGlobal to %Ts6UInt16V*), i32 0, i32 0), align 2
+  usGlobal = USVarConstant2
+#endif
+
+  // Force the definition of the type above.
+  // CHECK: ret
+  return x.pointee.z
+} // CHECK-NEXT: {{^}$}}


### PR DESCRIPTION
Normally we treat anonymous enums as defining constants, and since we don't know how those constants are going to be used we import them as Int when we know we can do so consistently across all platforms. But this isn't the right thing to do if the anonymous enum is being used as an ad-hoc type for a variable or field.

(This may *still* not be the right thing to do—maybe we want to import it with a made-up name like we do anonymous fields instead. But at least this way any such variables or fields become usable, when they previously crashed IRGen.)

[SR-2511](https://bugs.swift.org/browse/SR-2511) / rdar://problem/35702809