### PR TITLE
[CSSolver] Hide witness overloads behind protocol requirements they match

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1370,16 +1370,16 @@ namespace {
       SmallVector<OverloadChoice, 4> choices;
       
       for (unsigned i = 0, n = decls.size(); i != n; ++i) {
+        auto *choice = decls[i];
         // If the result is invalid, skip it.
         // FIXME: Note this as invalid, in case we don't find a solution,
         // so we don't let errors cascade further.
-        CS.getTypeChecker().validateDecl(decls[i]);
-        if (decls[i]->isInvalid())
+        CS.getTypeChecker().validateDecl(choice);
+        if (choice->isInvalid())
           continue;
 
-        OverloadChoice choice =
-            OverloadChoice(Type(), decls[i], expr->getFunctionRefKind());
-        choices.push_back(choice);
+        choices.push_back(
+            OverloadChoice(Type(), choice, expr->getFunctionRefKind()));
       }
 
       // If there are no valid overloads, give up.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/SaveAndRestore.h"
 #include <memory>
 #include <tuple>
+#include <deque>
 
 using namespace swift;
 using namespace constraints;
@@ -1886,17 +1887,17 @@ bool ConstraintSystem::solveSimplified(
   // this might happen when there are multiple binary operators
   // chained together. If so, disable choices which differ
   // from currently selected representative.
-  auto pruneOverloadSet = [&](Constraint *disjunction) -> bool {
+  auto pruneOverloadSet = [&](Constraint *disjunction,
+                              llvm::SmallVectorImpl<Constraint *> &disabled) {
     auto *choice = disjunction->getNestedConstraints().front();
     auto *typeVar = choice->getFirstType()->getAs<TypeVariableType>();
     if (!typeVar)
-      return false;
+      return;
 
     auto *repr = typeVar->getImpl().getRepresentative(nullptr);
     if (!repr || repr == typeVar)
-      return false;
+      return;
 
-    bool isPruned = false;
     for (auto resolved = resolvedOverloadSets; resolved;
          resolved = resolved->Previous) {
       if (!resolved->BoundType->isEqual(repr))
@@ -1904,7 +1905,7 @@ bool ConstraintSystem::solveSimplified(
 
       auto &representative = resolved->Choice;
       if (!representative.isDecl())
-        return false;
+        return;
 
       // Disable all of the overload choices which are different from
       // the one which is currently picked for representative.
@@ -1915,28 +1916,38 @@ bool ConstraintSystem::solveSimplified(
 
         if (choice.getDecl() != representative.getDecl()) {
           constraint->setDisabled();
-          isPruned = true;
+          disabled.push_back(constraint);
         }
       }
       break;
     }
-
-    return isPruned;
   };
 
-  bool hasDisabledChoices = pruneOverloadSet(disjunction);
+  llvm::SmallVector<Constraint *, 16> modifiedChoices;
+  pruneOverloadSet(disjunction, modifiedChoices);
 
   Optional<std::pair<DisjunctionChoice, Score>> lastSolvedChoice;
   Optional<Score> bestNonGenericScore;
 
   ++solverState->NumDisjunctions;
   auto constraints = disjunction->getNestedConstraints();
-  // Try each of the constraints within the disjunction.
+
+  std::deque<std::pair<unsigned, Constraint *>> choices;
   for (auto index : indices(constraints)) {
-    auto currentChoice =
-        DisjunctionChoice(this, disjunction, constraints[index]);
-    if (shouldSkipDisjunctionChoice(*this, currentChoice, bestNonGenericScore))
+    auto *choice = constraints[index];
+    if (!choice->isDisabled())
+      choices.push_back({index, choice});
+  }
+
+  // Try each of the constraints within the disjunction.
+  while (!choices.empty()) {
+    auto choice = choices.front();
+    auto currentChoice = DisjunctionChoice(this, disjunction, choice.second);
+
+    if (shouldSkipDisjunctionChoice(*this, currentChoice, bestNonGenericScore)) {
+      choices.pop_front();
       continue;
+    }
 
     // We already have a solution; check whether we should
     // short-circuit the disjunction.
@@ -1975,7 +1986,7 @@ bool ConstraintSystem::solveSimplified(
     if (disjunction->shouldRememberChoice()) {
       auto locator = disjunction->getLocator();
       assert(locator && "remembered disjunction doesn't have a locator?");
-      DisjunctionChoices.push_back({locator, index});
+      DisjunctionChoices.push_back({locator, choice.first});
     }
 
     if (auto score = currentChoice.solve(solutions, allowFreeTypeVariables)) {
@@ -1986,6 +1997,19 @@ bool ConstraintSystem::solveSimplified(
       }
 
       lastSolvedChoice = {currentChoice, *score};
+
+      // Let's enable any hidden witness choices we might have
+      // if this was the protocol requirement choice.
+      for (auto witness : Witnesses[choice.second]) {
+        auto *choice = witness.second;
+
+        if (!choice->isDisabled())
+          continue;
+
+        choices.push_front(witness);
+        choice->setEnabled();
+        modifiedChoices.push_back(choice);
+      }
 
       // If we see a tuple-to-tuple conversion that succeeded, we're done.
       // FIXME: This should be more general.
@@ -1999,18 +2023,20 @@ bool ConstraintSystem::solveSimplified(
       auto &log = getASTContext().TypeCheckerDebug->getStream();
       log.indent(solverState->depth) << ")\n";
     }
+
+    choices.pop_front();
   }
 
   // Put the disjunction constraint back in its place.
   InactiveConstraints.insert(afterDisjunction, disjunction);
   CG.addConstraint(disjunction);
 
-  if (hasDisabledChoices) {
-    // Re-enable previously disabled overload choices.
-    for (auto *choice : disjunction->getNestedConstraints()) {
-      if (choice->isDisabled())
-        choice->setEnabled();
-    }
+  // Undo all of the changes done to disjunction choices.
+  for (auto *choice : modifiedChoices) {
+    if (choice->isDisabled())
+      choice->setEnabled();
+    else
+      choice->setDisabled();
   }
 
   // If we are exiting due to an expression that is too complex, do

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -490,10 +490,11 @@ public:
     IsActive = active;
   }
 
-  /// Whether this constraint is active, i.e., in the worklist.
+  /// Whether this constraint is disable, i.e.,
+  /// shouldn't be considered by the solver.
   bool isDisabled() const { return IsDisabled; }
 
-  /// Set whether this constraint is active or not.
+  /// Set whether this constraint is disabled.
   void setDisabled() {
     assert(!isActive() && "Cannot disable constraint marked as active!");
     IsDisabled = true;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -18,6 +18,8 @@
 #include "ConstraintSystem.h"
 #include "ConstraintGraph.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Compiler.h"
@@ -1381,13 +1383,71 @@ void ConstraintSystem::addOverloadSet(Type boundType,
     
     overloads.push_back(bindOverloadConstraint);
   }
-  
+
+  // Collects all of the protocol requirement choices we have
+  // in this overload set, this would allow us to hide their
+  // witnesses until the requirement itself matches.
+  llvm::SmallVector<std::pair<Constraint *, ValueDecl *>, 8> requirements;
+
   for (auto choice : choices) {
     if (favoredChoice && (favoredChoice == &choice))
       continue;
-    
-    overloads.push_back(Constraint::createBindOverload(*this, boundType, choice,
-                                                       useDC, locator));
+
+    auto *constraint = Constraint::createBindOverload(*this, boundType, choice,
+                                                      useDC, locator);
+    overloads.push_back(constraint);
+    if (!choice.isDecl())
+      continue;
+
+    auto *decl = choice.getDecl();
+    if (isa<ProtocolDecl>(decl->getDeclContext())) {
+      if (decl->isProtocolRequirement())
+        requirements.push_back({constraint, decl});
+    }
+  }
+
+  // Try to hide witness choices under the main requirement
+  // choice, that helps to significately reduce the number
+  // of choices we consider blindly.
+  for (auto index : indices(overloads)) {
+    auto *constraint = overloads[index];
+    auto choice = constraint->getOverloadChoice();
+    if (!choice.isDecl())
+      continue;
+
+    auto *decl = choice.getDecl();
+    auto *nominal =
+        decl->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    if (!nominal)
+      continue;
+
+    auto type = nominal->getDeclaredType();
+    for (auto &req : requirements) {
+      const auto &requirement = req.second;
+      auto *protocol = dyn_cast<ProtocolDecl>(requirement->getDeclContext());
+      assert(protocol && "requirement has to have protocol context!");
+
+      ConformanceCheckOptions options;
+      options |= ConformanceCheckFlags::InExpression;
+      options |= ConformanceCheckFlags::SuppressDependencyTracking;
+      options |= ConformanceCheckFlags::SkipConditionalRequirements;
+
+      auto result = TC.conformsToProtocol(type, protocol,
+                                          decl->getDeclContext(), options);
+
+      if (!result || !result->isConcrete())
+        continue;
+
+      auto conformance = result->getConcrete();
+      auto wintess = conformance->getWitnessDecl(req.second, &TC);
+      if (wintess == decl) {
+        // Looks like this choice satisfies protocol requirement
+        // already present in the overload set, let's record and
+        // hide the witness.
+        Witnesses[req.first].push_back({index, constraint});
+        constraint->setDisabled();
+      }
+    }
   }
 
   addDisjunctionConstraint(overloads, locator, ForgetChoice, favoredChoice);
@@ -1642,11 +1702,11 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   }
   }
   assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");
-  
-  // If we're binding to an init member, the 'throws' need to line up between
-  // the bound and reference types.
+
   if (choice.isDecl()) {
-    auto decl = choice.getDecl();
+    auto *decl = choice.getDecl();
+    // If we're binding to an init member, the 'throws' need to line up between
+    // the bound and reference types.
     if (auto CD = dyn_cast<ConstructorDecl>(decl)) {
       auto boundFunctionType = boundType->getAs<AnyFunctionType>();
         

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -914,6 +914,13 @@ public:
   /// The original CS if this CS was created as a simplification of another CS
   ConstraintSystem *baseCS = nullptr;
 
+  /// Collects all of the witnesses to protocol requirements we have
+  /// found in the overload sets, so they can be enabled/disabled on
+  /// demain as we solve the system.
+  llvm::SmallDenseMap<Constraint *,
+                      llvm::SmallVector<std::pair<unsigned, Constraint *>, 8>>
+      Witnesses;
+
 private:
 
   /// \brief Allocator used for all of the related constraint systems.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -486,46 +486,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   var significand: Self { get }
 
-  /// Adds two values and produces their sum, rounded to a
-  /// representable value.
-  ///
-  /// The addition operator (`+`) calculates the sum of its two arguments. For
-  /// example:
-  ///
-  ///     let x = 1.5
-  ///     let y = x + 2.25
-  ///     // y == 3.75
-  ///
-  /// The `+` operator implements the addition operation defined by the
-  /// [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - lhs: The first value to add.
-  ///   - rhs: The second value to add.
-  static func +(_ lhs: Self, _ rhs: Self) -> Self
-
-  /// Adds two values and stores the result in the left-hand-side variable,
-  /// rounded to a representable value.
-  ///
-  /// - Parameters:
-  ///   - lhs: The first value to add.
-  ///   - rhs: The second value to add.
-  static func +=(_ lhs: inout Self, _ rhs: Self)
-
-  /// Calculates the additive inverse of a value.
-  ///
-  /// The unary minus operator (prefix `-`) calculates the negation of its
-  /// operand. The result is always exact.
-  ///
-  ///     let x = 21.5
-  ///     let y = -x
-  ///     // y == -21.5
-  ///
-  /// - Parameter operand: The value to negate.
-  static prefix func - (_ operand: Self) -> Self
-
   /// Replaces this value with its additive inverse.
   ///
   /// The result is always exact. This example uses the `negate()` method to
@@ -535,62 +495,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///     x.negate()
   ///     // x == -21.5
   mutating func negate()
-
-  /// Subtracts one value from another and produces their difference, rounded
-  /// to a representable value.
-  ///
-  /// The subtraction operator (`-`) calculates the difference of its two
-  /// arguments. For example:
-  ///
-  ///     let x = 7.5
-  ///     let y = x - 2.25
-  ///     // y == 5.25
-  ///
-  /// The `-` operator implements the subtraction operation defined by the
-  /// [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - lhs: A numeric value.
-  ///   - rhs: The value to subtract from `lhs`.
-  static func -(_ lhs: Self, _ rhs: Self) -> Self
-
-  /// Subtracts the second value from the first and stores the difference in
-  /// the left-hand-side variable, rounding to a representable value.
-  ///
-  /// - Parameters:
-  ///   - lhs: A numeric value.
-  ///   - rhs: The value to subtract from `lhs`.
-  static func -=(_ lhs: inout Self, _ rhs: Self)
-
-  /// Multiplies two values and produces their product, rounding to a
-  /// representable value.
-  ///
-  /// The multiplication operator (`*`) calculates the product of its two
-  /// arguments. For example:
-  ///
-  ///     let x = 7.5
-  ///     let y = x * 2.25
-  ///     // y == 16.875
-  ///
-  /// The `*` operator implements the multiplication operation defined by the
-  /// [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - lhs: The first value to multiply.
-  ///   - rhs: The second value to multiply.
-  static func *(_ lhs: Self, _ rhs: Self) -> Self
-
-  /// Multiplies two values and stores the result in the left-hand-side
-  /// variable, rounding to a representable value.
-  ///
-  /// - Parameters:
-  ///   - lhs: The first value to multiply.
-  ///   - rhs: The second value to multiply.
-  static func *=(_ lhs: inout Self, _ rhs: Self)
 
   /// Returns the quotient of dividing the first value by the second, rounded
   /// to a representable value.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1506,7 +1506,7 @@ public protocol BinaryInteger :
   ///     // x.trailingZeroBitCount == 3
   var trailingZeroBitCount: Int { get }
 
-% for x in chain(*binaryArithmetic.values()):
+% for x in binaryArithmetic['BinaryInteger']:
   // defaulted using an in-place counterpart, but can be used as an
   // optimization hook
 ${operatorComment(x.operator, False)}


### PR DESCRIPTION
If overload set contains both protocol requirement and its witnesses
let's only leave requirement itself active until we know that it matches,
in such case we'd re-enable witness methods and attempt them. This
helps to significantly reduce the number of overload choices we consider
upfront e.g. for '==' operator we can hide 53 choices behind Equatable
protocol from total number of 68 choices.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
