### PR TITLE
Existential Specializer Pass

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -50,6 +50,9 @@ public:
   /// Remove all runtime assertions during optimizations.
   bool RemoveRuntimeAsserts = false;
 
+  /// Enable existential specializer optimization.
+  bool ExistentialSpecializer = false;
+
   /// Controls whether the SIL ARC optimizations are run.
   bool EnableARCOptimizations = true;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -393,6 +393,9 @@ def sil_unroll_threshold : Separate<["-"], "sil-unroll-threshold">,
   MetaVarName<"<250>">,
   HelpText<"Controls the aggressiveness of loop unrolling">;
 
+def sil_existential_specializer : Flag<["-"], "sil-existential-specializer">,
+  HelpText<"Enable SIL existential specializer optimization">;
+
 def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
   HelpText<"Merge SIL from all partial swiftmodules into the final module">;
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -156,6 +156,8 @@ PASS(DeadStoreElimination, "dead-store-elim",
      "Dead Store Elimination")
 PASS(GenericSpecializer, "generic-specializer",
      "Generic Function Specialization on Static Types")
+PASS(ExistentialSpecializer, "existential-specializer",
+     "Existential Specializer")
 PASS(GlobalOpt, "global-opt",
      "SIL Global Optimization")
 PASS(GlobalPropertyOpt, "global-property-opt",

--- a/include/swift/SILOptimizer/Utils/Existential.h
+++ b/include/swift/SILOptimizer/Utils/Existential.h
@@ -17,9 +17,11 @@
 
 namespace swift {
 
-/// Find InitExistential from global_addr and copy_addr.
-SILValue findInitExistentialFromGlobalAddr(GlobalAddrInst *GAI,
-                                           CopyAddrInst *CAI);
+/// Find init_existential from global_addr, if any.
+SILValue findInitExistentialFromGlobalAddrAndCopyAddr(GlobalAddrInst *GAI,
+                                                  CopyAddrInst *CAI);
+SILValue findInitExistentialFromGlobalAddrAndApply(GlobalAddrInst *GAI,
+                                                  ApplySite AI, int ArgIdx);
 
 /// Returns the address of an object with which the stack location \p ASI is
 /// initialized. This is either a init_existential_addr or the destination of a

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -573,6 +573,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       return true;
     }
   }
+  if (Args.hasArg(OPT_sil_existential_specializer)) {
+    Opts.ExistentialSpecializer = true;
+  }
   if (const Arg *A = Args.getLastArg(OPT_num_threads)) {
     if (StringRef(A->getValue()).getAsInteger(10, Opts.NumThreads)) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,

--- a/lib/SILOptimizer/FunctionSignatureTransforms/CMakeLists.txt
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/CMakeLists.txt
@@ -3,4 +3,5 @@ set(FUNCTIONSIGNATURETRANSFORMS_SOURCES
   FunctionSignatureTransforms/DeadArgumentTransform.cpp
   FunctionSignatureTransforms/ArgumentExplosionTransform.cpp
   FunctionSignatureTransforms/OwnedToGuaranteedTransform.cpp
+  FunctionSignatureTransforms/ExistentialSpecializer.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -1,0 +1,809 @@
+//===--- ExistentialSpecializer.cpp - Specialization of functions -----===//
+//===---                 with existential arguments               -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Specialize functions with existential parameters to generic ones.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-existential-specializer"
+#include "ExistentialSpecializer.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignatureBuilder.h"
+#include "swift/SIL/OptimizationRemark.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
+#include "swift/SILOptimizer/Utils/Existential.h"
+#include "swift/SILOptimizer/Utils/Generics.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/Utils/SpecializationMangler.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+
+using namespace swift;
+
+STATISTIC(NumFunctionsWithExistentialArgsSpecialized,
+          "Number of functions with existential args specialized");
+using ArgIndexList = llvm::SmallVector<unsigned, 8>;
+
+/// Find the set of return instructions in a function.
+static void findReturnInsts(SILFunction *F,
+                            llvm::SmallPtrSet<ReturnInst *, 4> &ReturnInsts) {
+  for (auto &BB : *F) {
+    TermInst *TI = BB.getTerminator();
+    if (auto *RI = dyn_cast<ReturnInst>(TI)) {
+      ReturnInsts.insert(RI);
+    }
+  }
+}
+
+/// Create a new function name for the newly generated protocol constrained
+/// generic function.
+std::string
+ExistentialSpecializerTransform::createExistentialSpecializedFunctionName() {
+  for (auto const &IdxIt : ExistentialArgDescriptor) {
+    int Idx = IdxIt.first;
+    Mangler.setArgumentExistentialToGeneric(Idx);
+  }
+
+  SILModule &M = F->getModule();
+  int UniqueID = 0;
+  std::string MangledName;
+  do {
+    MangledName = Mangler.mangle(UniqueID);
+    ++UniqueID;
+  } while (M.hasFunction(MangledName));
+  return MangledName;
+}
+
+/// Create the signature for the newly generated protocol constrained generic
+/// function.
+CanSILFunctionType
+ExistentialSpecializerTransform::createExistentialSpecializedFunctionType() {
+
+  CanSILFunctionType FTy = F->getLoweredFunctionType();
+  auto ExpectedFTy = F->getLoweredType().castTo<SILFunctionType>();
+  SILModule &M = F->getModule();
+  auto *Mod = F->getModule().getSwiftModule();
+  auto &Ctx = M.getASTContext();
+  GenericSignature *NewGenericSig;
+  GenericEnvironment *NewGenericEnv;
+
+  // Form a new generic signature based on the old one.
+  GenericSignatureBuilder Builder(Ctx);
+
+  /// If the original function is generic, then maintain the same.
+  auto OrigGenericSig = FTy->getGenericSignature();
+  /// First, add the old generic signature.
+  Builder.addGenericSignature(OrigGenericSig);
+
+  /// Original list of parameters
+  SmallVector<SILParameterInfo, 4> params;
+  params.append(ExpectedFTy->getParameters().begin(),
+                ExpectedFTy->getParameters().end());
+
+  int GPIdx = 0;
+  /// Convert the protocol arguments of F to generic ones.
+  for (auto const &IdxIt : ExistentialArgDescriptor) {
+    int Idx = IdxIt.first;
+    auto &param = params[Idx];
+    auto PType = param.getType();
+
+    assert(PType->is<ProtocolType>() || PType->is<ProtocolCompositionType>());
+    /// Generate new generic parameter.
+    auto *NewGenericParam = GenericTypeParamType::get(0, GPIdx++, Ctx);
+    Builder.addGenericParameter(NewGenericParam);
+    Requirement NewRequirement(RequirementKind::Conformance, NewGenericParam,
+                               PType);
+    auto Source =
+        GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
+    Builder.addRequirement(NewRequirement, Source, Mod);
+    Arg2GenericTypeMap[Idx] = NewGenericParam;
+  }
+
+  /// Compute the generic signature.
+  NewGenericSig = std::move(Builder).computeGenericSignature(SourceLoc(), true);
+  NewGenericEnv = NewGenericSig->createGenericEnvironment();
+
+  /// Create a lambda for GenericParams.
+  auto getCanonicalType = [&](Type t) -> CanType {
+    return t->getCanonicalType(NewGenericSig);
+  };
+
+  /// Create the complete list of parameters.
+  int Idx = 0;
+  llvm::SmallVector<SILParameterInfo, 8> InterfaceParams;
+  InterfaceParams.reserve(params.size());
+  for (auto &param : params) {
+    if (Arg2GenericTypeMap[Idx]) {
+      auto GenericParam = Arg2GenericTypeMap[Idx];
+      InterfaceParams.push_back(SILParameterInfo(getCanonicalType(GenericParam),
+                                                 param.getConvention()));
+    } else {
+      auto paramIfaceTy = param.getType()->mapTypeOutOfContext();
+      InterfaceParams.push_back(SILParameterInfo(getCanonicalType(paramIfaceTy),
+                                                 param.getConvention()));
+    }
+    Idx++;
+  }
+
+  /// Now add the result type.
+  llvm::SmallVector<SILResultInfo, 8> InterfaceResults;
+  for (auto &result : ExpectedFTy->getResults()) {
+    auto resultIfaceTy = result.getType()->mapTypeOutOfContext();
+    auto InterfaceResult = result.getWithType(getCanonicalType(resultIfaceTy));
+    InterfaceResults.push_back(InterfaceResult);
+  }
+
+  /// Now add the errors.
+  Optional<SILResultInfo> InterfaceErrorResult;
+  if (ExpectedFTy->hasErrorResult()) {
+    auto errorResult = ExpectedFTy->getErrorResult();
+    auto errorIfaceTy = errorResult.getType()->mapTypeOutOfContext();
+    InterfaceErrorResult =
+        SILResultInfo(getCanonicalType(errorIfaceTy),
+                      ExpectedFTy->getErrorResult().getConvention());
+  }
+
+  /// Now add the yields.
+  llvm::SmallVector<SILYieldInfo, 8> InterfaceYields;
+  for (SILYieldInfo InterfaceYield : FTy->getYields()) {
+    InterfaceYields.push_back(InterfaceYield);
+  }
+
+  /// Finally the ExtInfo.
+  auto ExtInfo = FTy->getExtInfo();
+  ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
+  auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrNone();
+
+  /// Return the new signature.
+  return SILFunctionType::get(
+      NewGenericSig, ExtInfo, FTy->getCoroutineKind(),
+      FTy->getCalleeConvention(), InterfaceParams, InterfaceYields,
+      InterfaceResults, InterfaceErrorResult, Ctx, witnessMethodConformance);
+}
+
+/// Determine the arguments for the new function.
+/// Copy the old body from F, but add a new init_existential.
+/// to make the code compatible. Also rewrite the body.
+void ExistentialSpecializerTransform::populateSpecializedGenericFunction() {
+
+  SILModule &M = F->getModule();
+  auto &Ctx = M.getASTContext();
+
+  /// The arguments to the branch instruction.
+  SmallVector<SILValue, 8> BranchArgs;
+
+  /// Create a new debug scope.
+  ScopeCloner SC(*NewF);
+  auto DebugScope = SC.getOrCreateClonedScope(F->getDebugScope());
+
+  /// Set Unqualified ownership, if any.
+  if (!F->hasQualifiedOwnership()) {
+    NewF->setUnqualifiedOwnership();
+  }
+
+  /// Create the entry basic block.
+  SILBasicBlock *NewFBody = NewF->createBasicBlock();
+
+  /// Builder to hold new instructions. It must have a ScopeClone with a
+  /// debugscope that is inherited from the F.
+  SILBuilder NewFBuilder(NewFBody);
+  NewFBuilder.setCurrentDebugScope(DebugScope);
+  SILOpenedArchetypesTracker OpenedArchetypesTrackerNewF(NewF);
+  NewFBuilder.setOpenedArchetypesTracker(&OpenedArchetypesTrackerNewF);
+  /// Determine the location for the new init_existential_ref.
+  auto InsertLoc = F->begin()->begin()->getLoc();
+  llvm::SmallDenseMap<int, SILInstruction *> Arg2AllocStackMap;
+  bool MissingDestroyUse = false;
+  for (auto &ArgDesc : ArgumentDescList) {
+    /// For all Generic Arguments.
+    if (Arg2GenericTypeMap[ArgDesc.Index]) {
+      auto GenericParam = Arg2GenericTypeMap[ArgDesc.Index];
+      SILType GenericSILType =
+          M.Types.getLoweredType(NewF->mapTypeIntoContext(GenericParam));
+      auto *NewArg = NewFBody->createFunctionArgument(GenericSILType);
+      NewArg->setOwnershipKind(ValueOwnershipKind(
+          M, GenericSILType, ArgDesc.Arg->getArgumentConvention()));
+      /// Determine the Conformances.
+      SmallVector<ProtocolConformanceRef, 1> NewConformances;
+      auto ContextTy =
+          NewF->mapTypeIntoContext(GenericParam->getCanonicalType());
+      auto OpenedArchetype = ContextTy->getAs<ArchetypeType>();
+      for (auto proto : OpenedArchetype->getConformsTo()) {
+        NewConformances.push_back(ProtocolConformanceRef(proto));
+      }
+      ArrayRef<ProtocolConformanceRef> Conformances =
+          Ctx.AllocateCopy(NewConformances);
+      auto ExistentialRepr =
+          ArgDesc.Arg->getType().getPreferredExistentialRepresentation(M);
+      switch (ExistentialRepr) {
+      case ExistentialRepresentation::Opaque: {
+        /// Create this sequence for init_existential_addr.:
+        /// bb0(%0 : $*T):
+        /// %3 = alloc_stack $P
+        /// %4 = init_existential_addr %3 : $*P, $T
+        /// copy_addr %0 to [initialization] %4 : $*T
+        /// destroy_addr %0 : $*T
+        /// %7 = open_existential_addr immutable_access %3 : $*P to
+        /// $*@opened("105977B0-D8EB-11E4-AC00-3C0754644993") P
+        auto *ASI =
+            NewFBuilder.createAllocStack(InsertLoc, ArgDesc.Arg->getType());
+        Arg2AllocStackMap[ArgDesc.Index] = ASI;
+
+        auto *EAI = NewFBuilder.createInitExistentialAddr(
+            InsertLoc, ASI, NewArg->getType().getASTType()->getCanonicalType(),
+            NewArg->getType(), Conformances);
+        /// If DestroyAddr is already there, then do not use [take].
+        NewFBuilder.createCopyAddr(
+            InsertLoc, NewArg, EAI,
+            ExistentialArgDescriptor[ArgDesc.Index].DestroyAddrUse
+                ? IsTake_t::IsNotTake
+                : IsTake_t::IsTake,
+            IsInitialization_t::IsInitialization);
+        if (ExistentialArgDescriptor[ArgDesc.Index].DestroyAddrUse) {
+          NewFBuilder.createDestroyAddr(InsertLoc, NewArg);
+        } else {
+          MissingDestroyUse = true;
+        }
+        BranchArgs.push_back(ASI);
+        break;
+      }
+      case ExistentialRepresentation::Class: {
+        ///  Create an init_existential.
+        /// %5 = init_existential_ref %0 : $T : $T, $P
+        auto *InitRef = NewFBuilder.createInitExistentialRef(
+            InsertLoc, ArgDesc.Arg->getType(),
+            NewArg->getType().getASTType()->getCanonicalType(), NewArg,
+            Conformances);
+        BranchArgs.push_back(InitRef);
+        break;
+      }
+      default: {
+        assert(true);
+        break;
+      }
+      };
+    } else {
+      auto NewArg = NewFBody->createFunctionArgument(ArgDesc.Arg->getType(),
+                                                     ArgDesc.Decl);
+      NewArg->setOwnershipKind(ValueOwnershipKind(
+          M, ArgDesc.Arg->getType(), ArgDesc.Arg->getArgumentConvention()));
+      BranchArgs.push_back(NewArg);
+    }
+  }
+
+  /// Then we splice the body of F to NewF after the first basic block.
+  auto It = NewF->begin();
+  It++;
+  NewF->getBlocks().splice(It, F->getBlocks());
+
+  /// Determine the old entry.
+  auto NewIt = NewF->begin();
+  NewIt++;
+  SILBasicBlock *OldEntryBB = &(*NewIt);
+
+  /// Create a fake branch instruction, which will be eliminated by the merge
+  /// function call below. Clean this up in the next version.
+  NewFBuilder.createBranch(InsertLoc, OldEntryBB, BranchArgs);
+  ///  Merge the first and second basic blocks since it is just a direct branch.
+  ///  This is ugly though, with desired effect.
+  mergeBasicBlockWithSuccessor(&(*(NewF->begin())), nullptr, nullptr);
+
+  /// If there is an argument with no DestroyUse, insert DeallocStack
+  /// before return Instruction.
+  llvm::SmallPtrSet<ReturnInst *, 4> ReturnInsts;
+  if (MissingDestroyUse)
+    findReturnInsts(NewF, ReturnInsts);
+
+  /// Walk over destroy_addr instructions and perform fixups.
+  for (auto &ArgDesc : reversed(ArgumentDescList)) {
+    int ArgIndex = ArgDesc.Index;
+    if (Arg2AllocStackMap.count(ArgIndex) > 0) {
+      auto *ASI = dyn_cast<AllocStackInst>(Arg2AllocStackMap[ArgIndex]);
+      if (ExistentialArgDescriptor[ArgIndex].DestroyAddrUse) {
+        for (Operand *ASIUse : ASI->getUses()) {
+          auto *ASIUser = ASIUse->getUser();
+          if (auto *DAI = dyn_cast<DestroyAddrInst>(ASIUser)) {
+            SILBuilder Builder(ASIUser);
+            Builder.setInsertionPoint(&*std::next(ASIUser->getIterator()));
+            Builder.createDeallocStack(DAI->getLoc(), ASI);
+          }
+        }
+      } else { // Need to insert DeallocStack before return.
+        for (auto *I : ReturnInsts) {
+          SILBuilder Builder(I->getParent());
+          Builder.setInsertionPoint(I);
+          Builder.createDeallocStack(ASI->getLoc(), ASI);
+        }
+      }
+    }
+  }
+}
+
+/// Create the Thunk Body with always_inline attribute.
+void ExistentialSpecializerTransform::populateThunkBody() {
+
+  SILModule &M = F->getModule();
+
+  F->setThunk(IsThunk);
+  F->setInlineStrategy(AlwaysInline);
+
+  /// Create a basic block and the function arguments.
+  SILBasicBlock *ThunkBody = F->createBasicBlock();
+  for (auto &ArgDesc : ArgumentDescList) {
+    ThunkBody->createFunctionArgument(ArgDesc.Arg->getType(), ArgDesc.Decl);
+  }
+
+  /// Builder to add new instructions in the Thunk.
+  SILBuilder Builder(ThunkBody);
+  SILOpenedArchetypesTracker OpenedArchetypesTracker(F);
+  Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+  Builder.setCurrentDebugScope(ThunkBody->getParent()->getDebugScope());
+
+  /// Location to insert new instructions.
+  SILLocation Loc = ThunkBody->getParent()->getLocation();
+
+  /// Create the function_ref instruction to the NewF.
+  FunctionRefInst *FRI = Builder.createFunctionRef(Loc, NewF);
+
+  auto GenCalleeType = NewF->getLoweredFunctionType();
+  auto CalleeGenericSig = GenCalleeType->getGenericSignature();
+
+  /// Determine arguments to Apply.
+  /// Generate opened existentials for generics.
+  llvm::SmallVector<SILValue, 8> ApplyArgs;
+
+  /// Ideally this should be a SubstitutionMap. TODO.
+  llvm::DenseMap<SubstitutableType *, Type> Generic2OpenedTypeMap;
+  for (auto &ArgDesc : ArgumentDescList) {
+    if (Arg2GenericTypeMap[ArgDesc.Index]) {
+      ArchetypeType *Opened;
+      SILValue OrigOperand = ThunkBody->getArgument(ArgDesc.Index);
+      auto SwiftType = ArgDesc.Arg->getType().getASTType();
+      auto OpenedType =
+          SwiftType->openAnyExistentialType(Opened)->getCanonicalType();
+      auto OpenedSILType = NewF->getModule().Types.getLoweredType(OpenedType);
+      SILValue archetypeValue;
+      auto ExistentialRepr =
+          ArgDesc.Arg->getType().getPreferredExistentialRepresentation(M);
+      switch (ExistentialRepr) {
+      case ExistentialRepresentation::Opaque: {
+        archetypeValue = Builder.createOpenExistentialAddr(
+            Loc, OrigOperand, OpenedSILType, OpenedExistentialAccess::Mutable);
+        ApplyArgs.push_back(archetypeValue);
+        break;
+      }
+      case ExistentialRepresentation::Class: {
+        archetypeValue =
+            Builder.createOpenExistentialRef(Loc, OrigOperand, OpenedSILType);
+        ApplyArgs.push_back(archetypeValue);
+        break;
+      }
+      default: {
+        assert(true);
+        break;
+      }
+      };
+      auto GenericParam = Arg2GenericTypeMap[ArgDesc.Index];
+      Generic2OpenedTypeMap[GenericParam] = OpenedType;
+    } else {
+      auto CallerArg = ThunkBody->getArgument(ArgDesc.Index);
+      auto SwiftType = CallerArg->getType().getASTType();
+      if (auto *GP = SwiftType->getAs<GenericTypeParamType>()) {
+        ArchetypeType *Opened;
+        auto OpenedType =
+            SwiftType->openAnyExistentialType(Opened)->getCanonicalType();
+        Generic2OpenedTypeMap[GP] = OpenedType;
+      }
+      ApplyArgs.push_back(ThunkBody->getArgument(ArgDesc.Index));
+    }
+  }
+
+  /// Create substitutions for Apply instructions.
+  auto SubMap =
+      SubstitutionMap::get(CalleeGenericSig,
+                           [&](SubstitutableType *type) -> Type {
+                             return Generic2OpenedTypeMap[type];
+                           },
+                           LookUpConformanceInSignature(*CalleeGenericSig));
+
+  /// Perform the substitutions.
+  auto SubstCalleeType = GenCalleeType->substGenericArgs(M, SubMap);
+  SILType::getPrimitiveObjectType(SubstCalleeType);
+
+  /// Obtain the Result Type.
+  SILValue ReturnValue;
+  SILType LoweredType = NewF->getLoweredType();
+  SILFunctionConventions Conv(SubstCalleeType, M);
+  SILType ResultType = Conv.getSILResultType();
+  auto FunctionTy = LoweredType.castTo<SILFunctionType>();
+
+  /// If the original function has error results,  we need to generate a
+  /// try_apply to call a function with an error result.
+  if (FunctionTy->hasErrorResult()) {
+    SILFunction *Thunk = ThunkBody->getParent();
+    SILBasicBlock *NormalBlock = Thunk->createBasicBlock();
+    ReturnValue =
+        NormalBlock->createPHIArgument(ResultType, ValueOwnershipKind::Owned);
+    SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
+    SILType Error =
+        SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
+    auto *ErrorArg =
+        ErrorBlock->createPHIArgument(Error, ValueOwnershipKind::Owned);
+    Builder.createTryApply(Loc, FRI, SubMap, ApplyArgs, NormalBlock,
+                           ErrorBlock);
+
+    Builder.setInsertionPoint(ErrorBlock);
+    Builder.createThrow(Loc, ErrorArg);
+    Builder.setInsertionPoint(NormalBlock);
+  } else {
+    /// Create the Apply with substitutions
+    ReturnValue = Builder.createApply(Loc, FRI, SubMap, ApplyArgs, false);
+  }
+
+  /// Set up the return results.
+  if (NewF->isNoReturnFunction()) {
+    Builder.createUnreachable(Loc);
+  } else {
+    Builder.createReturn(Loc, ReturnValue);
+  }
+}
+
+/// Strategy to specialize existentail arguments:
+/// (1) Create a protocol constrained generic function from the old function;
+/// (2) Create a thunk for the original function that invokes (1) including
+/// setting
+///     its inline strategy as always inline.
+void ExistentialSpecializerTransform::createExistentialSpecializedFunction() {
+  SILModule &M = F->getModule();
+  std::string Name = createExistentialSpecializedFunctionName();
+  SILLinkage linkage = getSpecializedLinkage(F, F->getLinkage());
+
+  /// Create devirtualized function type.
+  auto NewFTy = createExistentialSpecializedFunctionType();
+
+  auto NewFGenericSig = NewFTy->getGenericSignature();
+  auto NewFGenericEnv = NewFGenericSig->createGenericEnvironment();
+
+  /// Step 1: Create the new protocol constrained generic function.
+  NewF = M.createFunction(linkage, Name, NewFTy, NewFGenericEnv,
+                          F->getLocation(), F->isBare(), F->isTransparent(),
+                          F->isSerialized(), F->getEntryCount(), F->isThunk(),
+                          F->getClassSubclassScope(), F->getInlineStrategy(),
+                          F->getEffectsKind(), nullptr, F->getDebugScope());
+
+  /// Populate the body of NewF.
+  populateSpecializedGenericFunction();
+
+  /// Step 2: Create the thunk with always_inline and populate its body.
+  populateThunkBody();
+
+  assert(F->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+
+  DEBUG(llvm::dbgs() << "After ExistentialSpecializer Pass\n"; F->dump();
+        NewF->dump(););
+}
+
+namespace {
+
+/// ExistentialSpecializer class.
+class ExistentialSpecializer : public SILFunctionTransform {
+
+  /// Determine if the current function is a target for existential
+  /// specialization of args.
+  bool canSpecializeExistentialArgsInFunction(
+      ApplySite &Apply,
+      llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
+          &ExistentialArgDescriptor);
+
+  /// Can Callee be specialized?
+  bool canSpecializeCalleeFunction(ApplySite &Apply);
+
+  /// Specialize existential args in function F.
+  void specializeExistentialArgsInAppliesWithinFunction(SILFunction &F);
+
+  /// CallerAnalysis information.
+  CallerAnalysis *CA;
+
+public:
+  void run() override {
+
+    auto *F = getFunction();
+
+    /// Don't optimize functions that should not be optimized.
+    if (!F->shouldOptimize()) {
+      return;
+    }
+
+    /// Get CallerAnalysis information handy.
+    CA = PM->getAnalysis<CallerAnalysis>();
+
+    /// Perform specialization.
+    specializeExistentialArgsInAppliesWithinFunction(*F);
+  }
+};
+} // namespace
+
+/// Find concrete type from init_existential refs/addrs.
+static bool findConcreteTypeFromIE(SILValue Arg, CanType &ConcreteType) {
+  if (auto *IER = dyn_cast<InitExistentialRefInst>(Arg)) {
+    ConcreteType = IER->getFormalConcreteType();
+    return true;
+  } else if (auto *IE = dyn_cast<InitExistentialAddrInst>(Arg)) {
+    ConcreteType = IE->getFormalConcreteType();
+    return true;
+  }
+  return false;
+}
+
+/// Find the concrete type of the existential argument. Wrapper
+/// for findInitExistential in Local.h/cpp. In future, this code
+/// can move to Local.h/cpp.
+static bool findConcreteType(ApplySite AI, SILValue Arg, int ArgIdx,
+                             CanType &ConcreteType) {
+  bool isCopied = false;
+
+  /// Ignore any unconditional cast instructions. Is it Safe? Do we need to
+  /// also add UnconditionalCheckedCastAddrInst? TODO.
+  if (auto *Instance = dyn_cast<UnconditionalCheckedCastInst>(Arg)) {
+    Arg = Instance->getOperand();
+  }
+
+  /// Return init_existential if the Arg is global_addr.
+  if (auto *GAI = dyn_cast<GlobalAddrInst>(Arg)) {
+    SILValue InitExistential =
+        findInitExistentialFromGlobalAddrAndApply(GAI, AI, ArgIdx);
+    /// If the Arg is already init_existential, return the concrete type.
+    if (findConcreteTypeFromIE(InitExistential, ConcreteType)) {
+      return true;
+    }
+  }
+
+  SILValue OrigArg = Arg;
+  /// Handle AllocStack instruction separately.
+  if (auto *Instance = dyn_cast<AllocStackInst>(Arg)) {
+    if (SILValue Src =
+            getAddressOfStackInit(Instance, AI.getInstruction(), isCopied)) {
+      Arg = Src;
+    }
+  }
+
+  /// If the Arg is already init_existential after getAddressofStackInit
+  /// call, return the concrete type.
+  if (findConcreteTypeFromIE(Arg, ConcreteType)) {
+    return true;
+  }
+
+  /// Call findInitExistential and determine the init_existential.
+  ArchetypeType *OpenedArchetype = nullptr;
+  SILValue OpenedArchetypeDef;
+  auto FAS = FullApplySite::isa(AI.getInstruction());
+  if (!FAS)
+    return false;
+  SILInstruction *InitExistential = findInitExistential(
+      FAS, OrigArg, OpenedArchetype, OpenedArchetypeDef, isCopied);
+  if (!InitExistential) {
+    DEBUG(llvm::dbgs() << "ExistentialSpecializer Pass: Bail! Due to "
+                          "findInitExistential\n";);
+    return false;
+  }
+
+  /// Return the concrete type from init_existential returned from
+  /// findInitExistential.
+  if (auto *IER = dyn_cast<InitExistentialRefInst>(InitExistential)) {
+    ConcreteType = IER->getFormalConcreteType();
+    return true;
+  } else if (auto *IE = dyn_cast<InitExistentialAddrInst>(InitExistential)) {
+    ConcreteType = IE->getFormalConcreteType();
+    return true;
+  }
+
+  return false;
+}
+
+/// Check if the callee uses the arg in a destroy_use instruction.
+static void
+findIfCalleeUsesArgInDestroyUse(SILValue Arg,
+                                ExistentialTransformArgumentDescriptor &ETAD) {
+  for (Operand *ArgUse : Arg->getUses()) {
+    auto *ArgUser = ArgUse->getUser();
+    if (isa<DestroyAddrInst>(ArgUser)) {
+      ETAD.DestroyAddrUse = true;
+      break;
+    }
+  }
+}
+
+/// Check if any argument to a function meet the criteria for specialization.
+bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
+    ApplySite &Apply,
+    llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
+        &ExistentialArgDescriptor) {
+  auto *F = Apply.getReferencedFunction();
+  auto Args = F->begin()->getFunctionArguments();
+  bool returnFlag = false;
+  const CallerAnalysis::FunctionInfo &FuncInfo = CA->getCallerInfo(F);
+  auto *PAI = dyn_cast<PartialApplyInst>(Apply.getInstruction());
+  int minPartialAppliedArgs = FuncInfo.getMinPartialAppliedArgs();
+
+  /// Analyze the argument for protocol conformance.
+  for (unsigned Idx = 0, Num = Args.size(); Idx < Num; ++Idx) {
+    if (PAI && (Idx < Num - minPartialAppliedArgs))
+      continue;
+    auto Arg = Args[Idx];
+    auto ArgType = Arg->getType();
+    auto SwiftArgType = ArgType.getASTType();
+    if (!ArgType || !SwiftArgType || !(ArgType.isExistentialType()) ||
+        ArgType.isAnyObject() || SwiftArgType->isAny())
+      continue;
+    auto ExistentialRepr =
+        Arg->getType().getPreferredExistentialRepresentation(F->getModule());
+    if (!(ExistentialRepr == ExistentialRepresentation::Opaque ||
+          ExistentialRepr == ExistentialRepresentation::Class))
+      continue;
+
+    /// Find concrete type.
+    CanType ConcreteType;
+    int ApplyArgIdx = PAI ? Idx - Num + minPartialAppliedArgs : Idx;
+    auto ApplyArg = Apply.getArgument(ApplyArgIdx);
+    if (!findConcreteType(Apply, ApplyArg, ApplyArgIdx, ConcreteType)) {
+      DEBUG(llvm::dbgs()
+                << "ExistentialSpecializer Pass: Bail! Due to findConcreteType "
+                   "for callee:"
+                << F->getName() << " in caller:"
+                << Apply.getInstruction()->getParent()->getParent()->getName()
+                << "\n";);
+      continue;
+    }
+
+    /// Find attributes of the argument: destroy_use, immutable_access.
+    ExistentialTransformArgumentDescriptor ETAD;
+    ETAD.AccessType = OpenedExistentialAccess::Immutable;
+    ETAD.DestroyAddrUse = false;
+    if ((Args[Idx]->getType().getPreferredExistentialRepresentation(
+            F->getModule())) != ExistentialRepresentation::Class)
+      findIfCalleeUsesArgInDestroyUse(Arg, ETAD);
+
+    /// Save the protocol declaration.
+    ExistentialArgDescriptor[Idx] = ETAD;
+    DEBUG(llvm::dbgs() << "ExistentialSpecializer Pass:Function: "
+                       << F->getName() << " Arg:" << Idx
+                       << "has a concrete type.\n");
+    returnFlag |= true;
+  }
+  return returnFlag;
+}
+
+/// Can we specialize this function?
+bool ExistentialSpecializer::canSpecializeCalleeFunction(ApplySite &Apply) {
+
+  /// Disallow generic callees.
+  if (Apply.hasSubstitutions()) {
+    return false;
+  }
+
+  /// Determine the caller of the apply.
+  auto *Callee = Apply.getReferencedFunction();
+  if (!Callee)
+    return false;
+
+  /// Callee should be optimizable.
+  if (!Callee->shouldOptimize())
+    return false;
+
+  /// External function definitions.
+  if ((!Callee->isDefinition()) || Callee->isExternalDeclaration())
+    return false;
+
+  /// For now ignore functions with indirect results.
+  if (Callee->getConventions().hasIndirectSILResults())
+    return false;
+
+  /// Do not optimize always_inlinable functions.
+  if (Callee->getInlineStrategy() == Inline_t::AlwaysInline)
+    return false;
+
+  /// Only choose a select few function representations for specilization.
+  if (Callee->getRepresentation() ==
+          SILFunctionTypeRepresentation::ObjCMethod ||
+      Callee->getRepresentation() == SILFunctionTypeRepresentation::Block) {
+    return false;
+  }
+  return true;
+}
+
+/// Specialize existential args passed to a function.
+void ExistentialSpecializer::specializeExistentialArgsInAppliesWithinFunction(
+    SILFunction &F) {
+  bool Changed = false;
+  for (auto &BB : F) {
+    for (auto It = BB.begin(), End = BB.end(); It != End; ++It) {
+      auto *I = &*It;
+
+      /// Is it an apply site?
+      ApplySite Apply = ApplySite::isa(I);
+      if (!Apply)
+        continue;
+
+      /// Can the callee be specialized?
+      if (!canSpecializeCalleeFunction(Apply)) {
+        DEBUG(llvm::dbgs() << "ExistentialSpecializer Pass: Bail! Due to "
+                              "canSpecializeCalleeFunction.\n";
+              I->dump(););
+        continue;
+      }
+
+      auto *Callee = Apply.getReferencedFunction();
+
+      /// Determine the arguments that can be specialized.
+      llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
+          ExistentialArgDescriptor;
+      if (!canSpecializeExistentialArgsInFunction(Apply,
+                                                  ExistentialArgDescriptor)) {
+        DEBUG(llvm::dbgs()
+              << "ExistentialSpecializer Pass: Bail! Due to "
+                 "canSpecializeExistentialArgsInFunction in function: "
+              << Callee->getName() << " -> abort\n");
+        continue;
+      }
+
+      DEBUG(llvm::dbgs() << "ExistentialSpecializer Pass: Function::"
+                         << Callee->getName()
+                         << " has an existential argument and can be optimized "
+                            "via ExistentialSpecializer\n");
+
+      /// Name Mangler for naming the protocol constrained generic method.
+      auto P = Demangle::SpecializationPass::FunctionSignatureOpts;
+      Mangle::FunctionSignatureSpecializationMangler Mangler(
+          P, Callee->isSerialized(), Callee);
+
+      /// Save the arguments in a descriptor.
+      llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
+      auto Args = Callee->begin()->getFunctionArguments();
+      for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+        ArgumentDescList.emplace_back(Args[i]);
+      }
+
+      /// This is the function to optimize for existential specilizer.
+      DEBUG(llvm::dbgs()
+            << "*** Running ExistentialSpecializer Pass on function: "
+            << Callee->getName() << " ***\n");
+
+      /// Instantiate the ExistentialSpecializerTransform pass.
+      ExistentialSpecializerTransform EST(Callee, Mangler, ArgumentDescList,
+                                          ExistentialArgDescriptor);
+
+      /// Run the protocol devirtualizer.
+      Changed = EST.run();
+
+      if (Changed) {
+        /// Update statistics on the number of functions devirtualized.
+        ++NumFunctionsWithExistentialArgsSpecialized;
+
+        /// Make sure the PM knows about the new specialized inner function.
+        notifyAddFunction(EST.getExistentialSpecializedFunction(), Callee);
+
+        /// Invalidate analysis results of Callee.
+        PM->invalidateAnalysis(Callee,
+                               SILAnalysis::InvalidationKind::Everything);
+      }
+    }
+  }
+  return;
+}
+
+SILTransform *swift::createExistentialSpecializer() {
+  return new ExistentialSpecializer();
+}

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.h
@@ -1,0 +1,98 @@
+//===--- ExistentialSpecializer.h - Existential Specializer ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains utilities for transforming existentials.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_EXISTENTIALSPECIALIZER_H
+#define SWIFT_SIL_EXISTENTIALSPECIALIZER_H
+#include "FunctionSignatureOpts.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Utils/Existential.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/Utils/SpecializationMangler.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+namespace swift {
+
+/// A descriptor to carry information from ExistentialTransform analysis
+/// to transformation.
+struct ExistentialTransformArgumentDescriptor {
+  OpenedExistentialAccess AccessType;
+  bool DestroyAddrUse;
+};
+
+/// ExistentialSpecializer transformation class that creates a protocol
+/// constrained generic and a thunk.
+class ExistentialSpecializerTransform {
+  /// The original function to analyze and transform.
+  SILFunction *F;
+
+  /// The newly created inner function.
+  SILFunction *NewF;
+
+  /// The function signature mangler we are using.
+  Mangle::FunctionSignatureSpecializationMangler &Mangler;
+
+  /// List of arguments and their descriptors to specialize
+  llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
+      &ExistentialArgDescriptor;
+
+  /// Argument to Generic Type Map for NewF.
+  llvm::SmallDenseMap<int, GenericTypeParamType *> Arg2GenericTypeMap;
+
+  // Allocate the argument descriptors.
+  llvm::SmallVector<ArgumentDescriptor, 4> &ArgumentDescList;
+
+  /// Create the Devirtualized Inner Function.
+  void createExistentialSpecializedFunction();
+
+  /// Create a name for the inner function.
+  std::string createExistentialSpecializedFunctionName();
+
+  /// Create the new devirtualized protocol function signature.
+  CanSILFunctionType createExistentialSpecializedFunctionType();
+
+  /// Populate the body of NewF.
+  void populateSpecializedGenericFunction();
+
+  /// Create the thunk.
+  void populateThunkBody();
+
+public:
+  /// Constructor.
+  ExistentialSpecializerTransform(
+      SILFunction *F, Mangle::FunctionSignatureSpecializationMangler &Mangler,
+      llvm::SmallVector<ArgumentDescriptor, 4> &ADL,
+      llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
+          &ExistentialArgDescriptor)
+      : F(F), NewF(nullptr), Mangler(Mangler),
+        ExistentialArgDescriptor(ExistentialArgDescriptor),
+        ArgumentDescList(ADL) {}
+
+  /// Return the optimized iner function.
+  SILFunction *getExistentialSpecializedFunction() { return NewF; }
+
+  /// External function for the optimization.
+  bool run() {
+    createExistentialSpecializedFunction();
+    return true;
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -238,6 +238,9 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   // Promote stack allocations to values.
   P.addMem2Reg();
 
+  // Run the existential pecializer Pass.
+  P.addExistentialSpecializer();
+
   // Cleanup, which is important if the inliner has restarted the pass pipeline.
   P.addPerformanceConstantPropagation();
   P.addSimplifyCFG();
@@ -245,7 +248,7 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
 
   // Mainly for Array.append(contentsOf) optimization.
   P.addArrayElementPropagation();
-  
+
   // Run the devirtualizer, specializer, and inliner. If any of these
   // makes a change we'll end up restarting the function passes on the
   // current function (after optimizing any new callees).

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -29,6 +29,7 @@
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallBitVector.h"
 
 namespace swift {
 
@@ -294,6 +295,15 @@ private:
   SILInstruction *propagateConcreteTypeOfInitExistential(FullApplySite AI,
                                                          WitnessMethodInst *WMI);
   SILInstruction *propagateConcreteTypeOfInitExistential(FullApplySite AI);
+
+  /// Create Apply Instruction with concrete types for arguments.
+  SILInstruction *
+  createApplyWithConcreteType(FullApplySite AI,
+                              llvm::SmallVector<SILValue, 8> &Args,
+                              SubstitutionMap &SubMap);
+
+  /// Propagate concrete types to all apply arguments.
+  SILInstruction *propagateConcreteTypeOfInitExistentialToAllApplyArgs(FullApplySite AI);
 
   /// Perform one SILCombine iteration.
   bool doOneIteration(SILFunction &F, unsigned Iteration);

--- a/test/SILOptimizer/existential_specializer.sil
+++ b/test/SILOptimizer/existential_specializer.sil
@@ -1,0 +1,521 @@
+// RUN: %target-sil-opt -wmo -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -existential-specializer -inline -sil-combine -generic-specializer  -allocbox-to-stack -copy-forwarding -lower-aggregate-instrs -mem2reg -devirtualizer -late-inline -dead-arg-signature-opt -dce -sil-deadfuncelim | %FileCheck %s
+//
+import Builtin
+import Swift
+
+// Class protocol test.
+internal protocol SomeProtocol : AnyObject {
+  func foo() -> Int32
+}
+
+internal class SomeClass : SomeProtocol {
+  init()
+  func foo() -> Int32
+}
+
+/// Class protocol composition test.
+internal protocol SomeClassProtocolComp : class {
+  func foo_cpc() -> Int32
+}
+internal protocol SomeOtherClassProtocolComp : class {
+  func bar_cpc() -> Int32
+}
+internal class SomeClassComp : SomeClassProtocolComp, SomeOtherClassProtocolComp{
+  init()
+  func foo_cpc() -> Int32
+  func bar_cpc() -> Int32
+}
+
+// Non-class protocol test.
+internal protocol SomeNoClassProtocol {
+  func foo_ncp() -> Int32
+}
+internal class SomeNoClass : SomeNoClassProtocol{
+  init()
+  func foo_ncp() -> Int32
+}
+
+// Non class protocol composition test.
+internal protocol SomeNoClassProtocolComp  {
+  func foo_ncpc()  -> Int32
+}
+internal protocol SomeOtherNoClassProtocolComp  {
+  func bar_ncpc()  -> Int32
+}
+internal class SomeNoClassComp: SomeNoClassProtocolComp, SomeOtherNoClassProtocolComp {
+  init()
+  func foo_ncpc() -> Int32
+  func bar_ncpc() -> Int32 
+}
+sil_global hidden [let] @$GV : $SomeProtocol
+sil_global hidden [let] @$GVNoClass : $SomeNoClassProtocol
+
+sil private [transparent] [thunk] @foo : $@convention(witness_method: SomeProtocol) (@guaranteed SomeClass) -> Int32 {
+bb0(%0 : $SomeClass):
+  %1 = integer_literal $Builtin.Int32, 10 
+  %2 = struct $Int32 (%1 : $Builtin.Int32) 
+  return %2 : $Int32 
+} 
+sil private [transparent] [thunk] @foo_cpc : $@convention(witness_method: SomeClassProtocolComp) (@guaranteed SomeClassComp) -> Int32 {
+bb0(%0 : $SomeClassComp):
+  %1 = integer_literal $Builtin.Int32, 10 
+  %2 = struct $Int32 (%1 : $Builtin.Int32) 
+  return %2 : $Int32 
+} 
+sil private [transparent] [thunk] @bar_cpc : $@convention(witness_method: SomeOtherClassProtocolComp) (@guaranteed SomeClassComp) -> Int32 {
+bb0(%0 : $SomeClassComp):
+  %1 = integer_literal $Builtin.Int32, 20 
+  %2 = struct $Int32 (%1 : $Builtin.Int32) 
+  return %2 : $Int32 
+} 
+sil hidden [thunk] [always_inline] @foo_ncp_ : $@convention(witness_method:SomeNoClassProtocol) (@in_guaranteed SomeNoClass) -> Int32 {
+bb0(%0 : $*SomeNoClass):
+  %1 = load %0 : $*SomeNoClass 
+  %2 = class_method %1 : $SomeNoClass, #SomeNoClass.foo_ncp!1 : (SomeNoClass) -> () -> Int32, $@convention(method) (@guaranteed SomeNoClass) -> Int32
+  %3 = apply %2(%1) : $@convention(method) (@guaranteed SomeNoClass) -> Int32 
+  return %3 : $Int32
+}
+sil hidden [thunk] [always_inline] @foo_ncp : $@convention(method) (@guaranteed SomeNoClass) -> Int32 {
+bb0(%0: $SomeNoClass):
+  %1 = integer_literal $Builtin.Int32, 10 
+  %2 = struct $Int32 (%1 : $Builtin.Int32) 
+  return %2 : $Int32 
+} 
+sil hidden [thunk] [always_inline] @foo_ncpc_ : $@convention(witness_method:SomeNoClassProtocolComp) (@in_guaranteed SomeNoClassComp) -> Int32 {
+bb0(%0 : $*SomeNoClassComp):
+  %1 = load %0 : $*SomeNoClassComp 
+  %2 = class_method %1 : $SomeNoClassComp, #SomeNoClassComp.foo_ncpc!1 : (SomeNoClassComp) -> () -> Int32, $@convention(method) (@guaranteed SomeNoClassComp) -> Int32
+  %3 = apply %2(%1) : $@convention(method) (@guaranteed SomeNoClassComp) -> Int32 
+  return %3 : $Int32
+}
+sil hidden [thunk] [always_inline] @foo_ncpc : $@convention(method) (@guaranteed SomeNoClassComp) -> Int32 {
+bb0(%0: $SomeNoClassComp):
+  %1 = integer_literal $Builtin.Int32, 10 
+  %2 = struct $Int32 (%1 : $Builtin.Int32) 
+  return %2 : $Int32 
+} 
+sil hidden [thunk] [always_inline] @bar_ncpc_ : $@convention(witness_method:SomeOtherNoClassProtocolComp) (@in_guaranteed SomeNoClassComp) -> Int32 {
+bb0(%0 : $*SomeNoClassComp):
+  %1 = load %0 : $*SomeNoClassComp 
+  %2 = class_method %1 : $SomeNoClassComp, #SomeNoClassComp.bar_ncpc!1 : (SomeNoClassComp) -> () -> Int32, $@convention(method) (@guaranteed SomeNoClassComp) -> Int32
+  %3 = apply %2(%1) : $@convention(method) (@guaranteed SomeNoClassComp) -> Int32 
+  return %3 : $Int32
+}
+sil hidden [thunk] [always_inline] @bar_ncpc : $@convention(method) (@guaranteed SomeNoClassComp) -> Int32 {
+bb0(%0: $SomeNoClassComp):
+  %1 = integer_literal $Builtin.Int32, 20 
+  %2 = struct $Int32 (%1 : $Builtin.Int32) 
+  return %2 : $Int32 
+} 
+
+// CHECK-LABEL: sil @something_cp :
+// CHECK: bb0
+// CHECK: alloc_ref
+// CHECK-NOT: init_existential_ref
+// CHECK: [[FUNC:%.*]] = function_ref @$S26something_to_specialize_cpTf4e_n4main9SomeClassC_Tg5 : $@convention(thin) (@guaranteed SomeClass) -> Int32 
+// CHECK: apply
+// CHECK: return
+// CHECK: } // end sil function 'something_cp'
+sil @something_cp : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = alloc_ref $SomeClass
+  %1 = init_existential_ref %0 : $SomeClass : $SomeClass, $SomeProtocol
+  %2 = function_ref @something_to_specialize_cp : $@convention(thin) (@guaranteed SomeProtocol) -> Int32
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed SomeProtocol) -> Int32
+  return %3 : $Int32
+} 
+
+// CHECK-LABEL: sil @something_cpc :
+// CHECK: bb0
+// CHECK: alloc_ref
+// CHECK-NOT: init_existential_ref
+// CHECK: [[FUNC:%.*]] = function_ref @$S27something_to_specialize_cpcTf4e_n4main13SomeClassCompC_Tg5 : $@convention(thin) (@owned SomeClassComp) -> Int32 
+// CHECK: apply
+// CHECK: return
+// CHECK: } // end sil function 'something_cpc'
+sil @something_cpc : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = alloc_ref $SomeClassComp
+  %1 = init_existential_ref %0 : $SomeClassComp: $SomeClassComp, $SomeClassProtocolComp & SomeOtherClassProtocolComp 
+  %2 = function_ref @something_to_specialize_cpc : $@convention(thin) (@owned SomeClassProtocolComp & SomeOtherClassProtocolComp) -> Int32
+  %3 = apply %2(%1) : $@convention(thin) (@owned SomeClassProtocolComp & SomeOtherClassProtocolComp) -> Int32
+  return %3 : $Int32
+} 
+
+// CHECK-LABEL: sil @something_ncp :
+// CHECK: bb0
+// CHECK: alloc_ref
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK: [[FUNC:%.*]] = function_ref @$S27something_to_specialize_ncpTf4e_n4main11SomeNoClassC_Tg5 : $@convention(thin) (@owned SomeNoClass) -> Int32
+// CHECK: apply
+// CHECK: return
+// CHECK: } // end sil function 'something_ncp'
+sil @something_ncp : $@convention(thin) () -> Int32 {
+bb0:
+  %1 = alloc_stack $SomeNoClassProtocol
+  %2 = init_existential_addr %1 : $*SomeNoClassProtocol, $SomeNoClass
+  %3 = alloc_ref $SomeNoClass
+  store %3 to %2 : $*SomeNoClass 
+  %4 = alloc_stack $SomeNoClassProtocol
+  copy_addr %1 to [initialization] %4 : $*SomeNoClassProtocol
+  %5 = function_ref @something_to_specialize_ncp : $@convention(thin) (@in SomeNoClassProtocol) -> Int32
+  %6 = apply %5(%4) : $@convention(thin) (@in SomeNoClassProtocol) -> Int32
+  dealloc_stack %4 : $*SomeNoClassProtocol
+  dealloc_stack %1 : $*SomeNoClassProtocol
+  return %6 : $Int32
+} 
+
+// CHECK-LABEL: sil @something_cp_ncp : $@convention(thin) () -> Int32 {
+// CHECK: bb0
+// CHECK: alloc_ref
+// CHECK-NOT: init_existential_ref
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: init_existential_addr
+// CHECK: alloc_ref
+// CHECK-NOT: store
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: copy_addr
+// CHECK: [[FUNC:%.*]] = function_ref @$S30something_to_specialize_cp_ncpTf4ee_n4main9SomeClassC_AB0g2NoH0CTg5 : $@convention(thin) (@guaranteed SomeClass, @owned SomeNoClass) -> Int32 
+// CHECK: apply
+// CHECK-NOT: dealloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK: return
+// CHECK: } // end sil function 'something_cp_ncp'
+sil @something_cp_ncp : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = alloc_ref $SomeClass
+  %1 = init_existential_ref %0 : $SomeClass : $SomeClass, $SomeProtocol
+  %2 = alloc_stack $SomeNoClassProtocol
+  %3 = init_existential_addr %2 : $*SomeNoClassProtocol, $SomeNoClass
+  %4 = alloc_ref $SomeNoClass
+  store %4 to %3 : $*SomeNoClass 
+  %5 = alloc_stack $SomeNoClassProtocol
+  copy_addr %2 to [initialization] %5 : $*SomeNoClassProtocol
+  %6 = function_ref @something_to_specialize_cp_ncp : $@convention(thin) (@guaranteed SomeProtocol, @in SomeNoClassProtocol) -> Int32
+  %7 = apply %6(%1,%5) : $@convention(thin) (@guaranteed SomeProtocol, @in SomeNoClassProtocol) -> Int32
+  dealloc_stack %5 : $*SomeNoClassProtocol
+  dealloc_stack %2 : $*SomeNoClassProtocol
+  return %7 : $Int32
+} 
+
+// CHECK-LABEL: sil @something_ncpc :
+// CHECK: bb0
+// CHECK: alloc_ref
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK: [[FUNC:%.*]] = function_ref @$S28something_to_specialize_ncpcTf4e_n4main15SomeNoClassCompC_Tg5 : $@convention(thin) (@owned SomeNoClassComp) -> Int32 
+// CHECK: apply
+// CHECK: return
+// CHECK: } // end sil function 'something_ncpc'
+sil @something_ncpc : $@convention(thin) () -> Int32 {
+bb0:
+  %1 = alloc_stack $SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  %2 = init_existential_addr %1 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp, $SomeNoClassComp
+  %3 = alloc_ref $SomeNoClassComp
+  store %3 to %2 : $*SomeNoClassComp 
+  %4 = alloc_stack $SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  copy_addr %1 to [initialization] %4 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  %5 = function_ref @something_to_specialize_ncpc : $@convention(thin) (@in SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp) -> Int32
+  %6 = apply %5(%4) : $@convention(thin) (@in SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp) -> Int32
+  dealloc_stack %4 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp 
+  dealloc_stack %1 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  return %6 : $Int32
+} 
+
+// CHECK-LABEL: sil @something_cpc_ncpc : $@convention(thin) () -> Int32 {
+// CHECK: bb0:
+// CHECK: alloc_ref
+// CHECK-NOT: init_existential_ref
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: init_existential_addr
+// CHECK: alloc_ref
+// CHECK-NOT: store
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: copy_addr
+// CHECK: [[FUNC:%.*]] = function_ref @$S32something_to_specialize_cpc_ncpcTf4ee_n4main13SomeClassCompC_AB0g2NohI0CTg5 : $@convention(thin) (@owned SomeClassComp, @owned SomeNoClassComp) -> Int32 
+// CHECK: apply
+// CHECK-NOT: dealloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK: return
+// CHECK: } // end sil function 'something_cpc_ncpc'
+sil @something_cpc_ncpc : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = alloc_ref $SomeClassComp
+  %1 = init_existential_ref %0 : $SomeClassComp: $SomeClassComp, $SomeClassProtocolComp & SomeOtherClassProtocolComp 
+  %4 = alloc_stack $SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  %5 = init_existential_addr %4 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp, $SomeNoClassComp
+  %6 = alloc_ref $SomeNoClassComp
+  store %6 to %5 : $*SomeNoClassComp 
+  %7 = alloc_stack $SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  copy_addr %4 to [initialization] %7 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  %8 = function_ref @something_to_specialize_cpc_ncpc : $@convention(thin) (@owned SomeClassProtocolComp & SomeOtherClassProtocolComp, @in SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp) -> Int32
+  %9 = apply %8(%1, %7) : $@convention(thin) (@owned SomeClassProtocolComp & SomeOtherClassProtocolComp, @in SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp) -> Int32
+  dealloc_stack %7 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp 
+  dealloc_stack %4 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  return %9 : $Int32
+} 
+
+// CHECK-LABEL: sil @something_cp_global_addr : $@convention(thin) () -> Int32 {
+// CHECK: bb0
+// CHECK: alloc_global
+// CHECK: global_addr
+// CHECK: alloc_ref
+// CHECK: init_existential_ref
+// CHECK: store
+// CHECK: [[FUNC:%.*]] = function_ref @$S26something_to_specialize_cpTf4e_n4main9SomeClassC_Tg5 : $@convention(thin) (@guaranteed SomeClass) -> Int32
+// CHECK: apply
+// CHECK: return
+// CHECK: } // end sil function 'something_cp_global_addr'
+sil @something_cp_global_addr : $@convention(thin) () -> Int32 {
+bb0:
+  alloc_global @$GV
+  %1 = global_addr @$GV : $*SomeProtocol
+  %2 = alloc_ref $SomeClass
+  %3 = init_existential_ref %2 : $SomeClass : $SomeClass, $SomeProtocol
+  store %3 to %1 : $*SomeProtocol
+  %5 = function_ref @something_to_specialize_cp : $@convention(thin) (@guaranteed SomeProtocol) -> Int32
+  %6 = apply %5(%3) : $@convention(thin) (@guaranteed SomeProtocol) -> Int32
+  return %6 : $Int32
+}
+
+// CHECK-LABEL: sil @something_ncp_global_addr : $@convention(thin) () -> Int32 {
+// CHECK: bb0
+// CHECK: alloc_global
+// CHECK: global_addr
+// CHECK: init_existential_addr
+// CHECK: alloc_ref
+// CHECK: store
+// CHECK: [[FUNC:%.*]] = function_ref @$S27something_to_specialize_ncpTf4e_n4main11SomeNoClassC_Tg5 : $@convention(thin) (@owned SomeNoClass) -> Int32 
+// CHECK: load
+// CHECK: apply
+// CHECK: return
+// CHECK: } // end sil function 'something_ncp_global_addr'
+sil @something_ncp_global_addr : $@convention(thin) () -> Int32 {
+bb0:
+  alloc_global @$GVNoClass
+  %1 = global_addr @$GVNoClass : $*SomeNoClassProtocol
+  %2 = init_existential_addr %1 : $*SomeNoClassProtocol, $SomeNoClass
+  %3 = alloc_ref $SomeNoClass
+  store %3 to %2 : $*SomeNoClass
+  %4 = function_ref @something_to_specialize_ncp : $@convention(thin) (@in SomeNoClassProtocol) -> Int32
+  %5 = apply %4(%1) : $@convention(thin) (@in SomeNoClassProtocol) -> Int32
+  return %5 : $Int32
+}
+
+// CHECK-LABEL: sil shared [noinline] @$S26something_to_specialize_cpTf4e_n4main9SomeClassC_Tg5 : $@convention(thin) (@guaranteed SomeClass) -> Int32 {
+// CHECK: bb0({{.*}}):
+// CHECK-NOT: open_existential_ref
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK: integer_literal
+// CHECK: struct
+// CHECK: return
+// CHECK: } // end sil function '$S26something_to_specialize_cpTf4e_n4main9SomeClassC_Tg5'
+sil shared [noinline] @something_to_specialize_cp : $@convention(thin) (@guaranteed SomeProtocol) -> Int32 {
+bb0(%0 : $SomeProtocol):
+  %2 = open_existential_ref %0 : $SomeProtocol to $@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol
+  %3 = witness_method $@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol, #SomeProtocol.foo!1 : <Self where Self : SomeProtocol> (Self) -> () -> Int32, %2 : $@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@guaranteed τ_0_0) -> Int32
+  %4 = apply %3<@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol>(%2) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@guaranteed τ_0_0) -> Int32
+  return %4 : $Int32
+}
+
+// CHECK-LABEL: sil shared [noinline] @$S27something_to_specialize_cpcTf4e_n4main13SomeClassCompC_Tg5 : $@convention(thin) (@owned SomeClassComp) -> Int32 {
+// CHECK: bb0({{.*}}):
+// CHECK-NOT: open_existential_ref
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK: integer_literal
+// CHECK: integer_literal
+// CHECK: integer_literal
+// CHECK: builtin
+// CHECK: tuple_extract
+// CHECK: tuple_extract
+// CHECK: cond_fail
+// CHECK: struct
+// CHECK: return
+// CHECK: } // end sil function '$S27something_to_specialize_cpcTf4e_n4main13SomeClassCompC_Tg5'
+sil shared [noinline] @something_to_specialize_cpc : $@convention(thin) (@owned SomeClassProtocolComp & SomeOtherClassProtocolComp) -> Int32 {
+bb0(%0 : $SomeClassProtocolComp & SomeOtherClassProtocolComp):
+  %1 = open_existential_ref %0 : $SomeClassProtocolComp & SomeOtherClassProtocolComp to $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp
+  %2 = witness_method $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp, #SomeClassProtocolComp.foo_cpc!1 : <Self where Self : SomeClassProtocolComp> (Self) -> () -> Int32, %1 : $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp : $@convention(witness_method: SomeClassProtocolComp) <τ_0_0 where τ_0_0 : SomeClassProtocolComp> (@guaranteed τ_0_0) -> Int32 
+  %3 = apply %2<@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp>(%1) : $@convention(witness_method: SomeClassProtocolComp) <τ_0_0 where τ_0_0 : SomeClassProtocolComp> (@guaranteed τ_0_0) -> Int32
+  %4 = witness_method $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp, #SomeOtherClassProtocolComp.bar_cpc!1 : <Self where Self : SomeOtherClassProtocolComp> (Self) -> () -> Int32, %1 : $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp : $@convention(witness_method: SomeOtherClassProtocolComp) <τ_0_0 where τ_0_0 : SomeOtherClassProtocolComp> (@guaranteed τ_0_0) -> Int32
+  %5 = apply %4<@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp>(%1) : $@convention(witness_method: SomeOtherClassProtocolComp) <τ_0_0 where τ_0_0 : SomeOtherClassProtocolComp> (@guaranteed τ_0_0) -> Int32 // type-defs: %2; user: %8
+  %6 = struct_extract %3 : $Int32, #Int32._value
+  %7 = struct_extract %5 : $Int32, #Int32._value
+  %8 = integer_literal $Builtin.Int1, -1
+  %9 = builtin "sadd_with_overflow_Int32"(%6 : $Builtin.Int32, %7 : $Builtin.Int32, %8 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %10 = tuple_extract %9 : $(Builtin.Int32, Builtin.Int1), 0
+  %11 = tuple_extract %9 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %11 : $Builtin.Int1
+  %12 = struct $Int32 (%10 : $Builtin.Int32)
+  return %12 : $Int32
+}
+
+// CHECK-LABEL: sil shared [noinline] @$S27something_to_specialize_ncpTf4e_n4main11SomeNoClassC_Tg5 : $@convention(thin) (@owned SomeNoClass) -> Int32 {
+// CHECK: bb0({{.*}}):
+// CHECK-NOT: open_existential_addr
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK-NOT: destroy_addr
+// CHECK: integer_literal
+// CHECK: struct
+// CHECK: strong_release
+// CHECK: return
+// CHECK: } // end sil function '$S27something_to_specialize_ncpTf4e_n4main11SomeNoClassC_Tg5'
+sil hidden [noinline] @something_to_specialize_ncp : $@convention(thin) (@in SomeNoClassProtocol) -> Int32 {
+bb0(%0 : $*SomeNoClassProtocol):
+  %1 = open_existential_addr immutable_access %0 : $*SomeNoClassProtocol to $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol
+  %2 = witness_method $@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol, #SomeNoClassProtocol.foo_ncp!1 : <Self where Self : SomeNoClassProtocol> (Self) -> () -> Int32, %1 : $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol : $@convention(witness_method: SomeNoClassProtocol) <τ_0_0 where τ_0_0 : SomeNoClassProtocol> (@in_guaranteed τ_0_0) -> Int32 
+  %3 = apply %2<@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol>(%1) : $@convention(witness_method: SomeNoClassProtocol) <τ_0_0 where τ_0_0 : SomeNoClassProtocol> (@in_guaranteed τ_0_0) -> Int32 
+  destroy_addr %0 : $*SomeNoClassProtocol
+  return %3 : $Int32
+}
+
+// CHECK-LABEL: sil shared [noinline] @$S30something_to_specialize_cp_ncpTf4ee_n4main9SomeClassC_AB0g2NoH0CTg5 : $@convention(thin) (@guaranteed SomeClass, @owned SomeNoClass) -> Int32 {
+// CHECK: bb0(%0 : $SomeClass, %1 : $SomeNoClass):
+// CHECK-NOT: open_existential_ref
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK: integer_literal
+// CHECK-NOT: open_existential_addr
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK: integer_literal
+// CHECK-NOT: struct_extract
+// CHECK-NOT: struct_extract
+// CHECK: integer_literal
+// CHECK: builtin 
+// CHECK: tuple_extract
+// CHECK: tuple_extract
+// CHECK: cond_fail
+// CHECK: struct
+// CHECK: strong_release
+// CHECK: return
+// CHECK: } // end sil function '$S30something_to_specialize_cp_ncpTf4ee_n4main9SomeClassC_AB0g2NoH0CTg5'
+sil shared [noinline] @something_to_specialize_cp_ncp : $@convention(thin) (@guaranteed SomeProtocol, @in SomeNoClassProtocol) -> Int32 {
+bb0(%0 : $SomeProtocol, %1 : $*SomeNoClassProtocol):
+  %2 = open_existential_ref %0 : $SomeProtocol to $@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol
+  %3 = witness_method $@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol, #SomeProtocol.foo!1 : <Self where Self : SomeProtocol> (Self) -> () -> Int32, %2 : $@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@guaranteed τ_0_0) -> Int32
+  %4 = apply %3<@opened("D346AB00-F998-11E7-93AE-DCA9048B1C6D") SomeProtocol>(%2) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@guaranteed τ_0_0) -> Int32
+  %5 = open_existential_addr immutable_access %1 : $*SomeNoClassProtocol to $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol
+  %6 = witness_method $@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol, #SomeNoClassProtocol.foo_ncp!1 : <Self where Self : SomeNoClassProtocol> (Self) -> () -> Int32, %5 : $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol : $@convention(witness_method: SomeNoClassProtocol) <τ_0_0 where τ_0_0 : SomeNoClassProtocol> (@in_guaranteed τ_0_0) -> Int32 
+  %7 = apply %6<@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D") SomeNoClassProtocol>(%5) : $@convention(witness_method: SomeNoClassProtocol) <τ_0_0 where τ_0_0 : SomeNoClassProtocol> (@in_guaranteed τ_0_0) -> Int32 
+  %8 = struct_extract %4 : $Int32, #Int32._value
+  %9 = struct_extract %7 : $Int32, #Int32._value
+  %10 = integer_literal $Builtin.Int1, -1
+  %11 = builtin "sadd_with_overflow_Int32"(%8 : $Builtin.Int32, %9 : $Builtin.Int32, %10 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int32, Builtin.Int1), 0
+  %13 = tuple_extract %11 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %13 : $Builtin.Int1
+  %14 = struct $Int32 (%12 : $Builtin.Int32)
+  destroy_addr %1 : $*SomeNoClassProtocol
+  return %14 : $Int32
+}
+
+// CHECK-LABEL: sil shared [noinline] @$S28something_to_specialize_ncpcTf4e_n4main15SomeNoClassCompC_Tg5 : $@convention(thin) (@owned SomeNoClassComp) -> Int32 {
+// CHECK: bb0({{.*}}):
+// CHECK-NOT: open_existential_addr
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK-NOT: destroy_addr
+// CHECK: integer_literal
+// CHECK: integer_literal
+// CHECK: integer_literal
+// CHECK: builtin
+// CHECK: tuple_extract
+// CHECK: tuple_extract
+// CHECK: cond_fail
+// CHECK: struct
+// CHECK: strong_release
+// CHECK: return
+// CHECK: } // end sil function '$S28something_to_specialize_ncpcTf4e_n4main15SomeNoClassCompC_Tg5' 
+sil hidden [noinline] @something_to_specialize_ncpc : $@convention(thin) (@in SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp) -> Int32 {
+bb0(%0 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp):
+  %1 = open_existential_addr immutable_access %0 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp to $*@opened("813A700E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  %2 = witness_method $@opened("813A700E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp, #SomeNoClassProtocolComp.foo_ncpc!1 : <Self where Self : SomeNoClassProtocolComp> (Self) -> () -> Int32, %1 : $*@opened("813A700E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp : $@convention(witness_method: SomeNoClassProtocolComp) <τ_0_0 where τ_0_0 : SomeNoClassProtocolComp> (@in_guaranteed τ_0_0) -> Int32 
+  %3 = apply %2<@opened("813A700E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp>(%1) : $@convention(witness_method: SomeNoClassProtocolComp) <τ_0_0 where τ_0_0 : SomeNoClassProtocolComp> (@in_guaranteed τ_0_0) -> Int32 
+  %4 = open_existential_addr immutable_access %0 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp to $*@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp 
+  %5 = witness_method $@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp, #SomeOtherNoClassProtocolComp.bar_ncpc!1 : <Self where Self : SomeOtherNoClassProtocolComp> (Self) -> () -> Int32, %4 : $*@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp : $@convention(witness_method: SomeOtherNoClassProtocolComp) <τ_0_0 where τ_0_0 : SomeOtherNoClassProtocolComp> (@in_guaranteed τ_0_0) -> Int32 
+  %6 = apply %5<@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp>(%4) : $@convention(witness_method: SomeOtherNoClassProtocolComp) <τ_0_0 where τ_0_0 : SomeOtherNoClassProtocolComp> (@in_guaranteed τ_0_0) -> Int32
+  %7 = struct_extract %3 : $Int32, #Int32._value
+  %8 = struct_extract %6 : $Int32, #Int32._value
+  %9 = integer_literal $Builtin.Int1, -1
+  %10 = builtin "sadd_with_overflow_Int32"(%7 : $Builtin.Int32, %8 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %11 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 0
+  %12 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %12 : $Builtin.Int1
+  %13 = struct $Int32 (%11 : $Builtin.Int32)
+  destroy_addr %0 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  return %13 : $Int32
+}
+
+// CHECK-LABEL: sil shared [noinline] @$S32something_to_specialize_cpc_ncpcTf4ee_n4main13SomeClassCompC_AB0g2NohI0CTg5 : $@convention(thin) (@owned SomeClassComp, @owned SomeNoClassComp) -> Int32 {
+// CHECK: bb0
+// CHECK-NOT: open_existential_ref
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK: integer_literal
+// CHECK-NOT: open_existential_addr
+// CHECK-NOT: witness_method
+// CHECK-NOT: apply
+// CHECK: integer_literal
+// CHECK: integer_literal
+// CHECK: builtin 
+// CHECK: tuple_extract
+// CHECK: tuple_extract
+// CHECK: cond_fail
+// CHECK: struct
+// CHECK: strong_release
+// CHECK: return
+// CHECK: } // end sil function '$S32something_to_specialize_cpc_ncpcTf4ee_n4main13SomeClassCompC_AB0g2NohI0CTg5'
+sil hidden [noinline] @something_to_specialize_cpc_ncpc : $@convention(thin) (@owned SomeClassProtocolComp & SomeOtherClassProtocolComp, @in SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp) -> Int32 {
+bb0(%0 : $SomeClassProtocolComp & SomeOtherClassProtocolComp, %1 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp):
+  %2 = open_existential_ref %0 : $SomeClassProtocolComp & SomeOtherClassProtocolComp to $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp
+  %3 = witness_method $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp, #SomeClassProtocolComp.foo_cpc!1 : <Self where Self : SomeClassProtocolComp> (Self) -> () -> Int32, %2 : $@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp : $@convention(witness_method: SomeClassProtocolComp) <τ_0_0 where τ_0_0 : SomeClassProtocolComp> (@guaranteed τ_0_0) -> Int32 
+  %4 = apply %3<@opened("802E080C-3447-11E8-888B-DCA9048B1C6D") SomeClassProtocolComp & SomeOtherClassProtocolComp>(%2) : $@convention(witness_method: SomeClassProtocolComp) <τ_0_0 where τ_0_0 : SomeClassProtocolComp> (@guaranteed τ_0_0) -> Int32
+
+  %5 = open_existential_addr immutable_access %1 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp to $*@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp 
+  %6 = witness_method $@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp, #SomeOtherNoClassProtocolComp.bar_ncpc!1 : <Self where Self : SomeOtherNoClassProtocolComp> (Self) -> () -> Int32, %5 : $*@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp : $@convention(witness_method: SomeOtherNoClassProtocolComp) <τ_0_0 where τ_0_0 : SomeOtherNoClassProtocolComp> (@in_guaranteed τ_0_0) -> Int32 
+  %7 = apply %6<@opened("813A719E-346B-11E8-B68D-DCA9048B1C6D") SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp>(%5) : $@convention(witness_method: SomeOtherNoClassProtocolComp) <τ_0_0 where τ_0_0 : SomeOtherNoClassProtocolComp> (@in_guaranteed τ_0_0) -> Int32
+
+  %8 = struct_extract %4 : $Int32, #Int32._value
+  %9 = struct_extract %7 : $Int32, #Int32._value
+  %10 = integer_literal $Builtin.Int1, -1
+  %11 = builtin "sadd_with_overflow_Int32"(%8 : $Builtin.Int32, %9 : $Builtin.Int32, %10 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int32, Builtin.Int1), 0
+  %13 = tuple_extract %11 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %13 : $Builtin.Int1
+  %14 = struct $Int32 (%12 : $Builtin.Int32)
+  destroy_addr %1 : $*SomeNoClassProtocolComp & SomeOtherNoClassProtocolComp
+  return %14 : $Int32
+}
+
+sil_witness_table hidden SomeClass: SomeProtocol module test {
+  method #SomeProtocol.foo!1: <Self where Self : SomeProtocol> (Self) -> () -> Int32 : @foo	
+}
+sil_vtable SomeNoClass {
+  #SomeNoClass.foo_ncp!1: (SomeNoClass) -> () -> Int32 : @foo_ncp
+}
+sil_witness_table hidden SomeNoClass: SomeNoClassProtocol module test {
+  method #SomeNoClassProtocol.foo_ncp!1: <Self where Self : SomeNoClassProtocol> (Self) -> () -> Int32 : @foo_ncp_
+}
+sil_vtable SomeNoClassComp {
+  #SomeNoClassComp.foo_ncpc!1: (SomeNoClassComp) -> () -> Int32 : @foo_ncpc
+  #SomeNoClassComp.bar_ncpc!1: (SomeNoClassComp) -> () -> Int32 : @bar_ncpc
+}
+sil_witness_table hidden SomeNoClassComp: SomeNoClassProtocolComp module test {
+  method #SomeNoClassProtocolComp.foo_ncpc!1: <Self where Self : SomeNoClassProtocolComp> (Self) -> () -> Int32 : @foo_ncpc_
+}
+sil_witness_table hidden SomeNoClassComp: SomeOtherNoClassProtocolComp module test {
+  method #SomeOtherNoClassProtocolComp.bar_ncpc!1: <Self where Self : SomeOtherNoClassProtocolComp> (Self) -> () -> Int32 : @bar_ncpc_
+}
+sil_witness_table hidden SomeClassComp: SomeClassProtocolComp module test {
+  method #SomeClassProtocolComp.foo_cpc!1: <Self where Self : SomeClassProtocolComp> (Self) -> () -> Int32 : @foo_cpc
+}
+sil_witness_table hidden SomeClassComp: SomeOtherClassProtocolComp module test {
+  method #SomeOtherClassProtocolComp.bar_cpc!1: <Self where Self : SomeOtherClassProtocolComp> (Self) -> () -> Int32 : @bar_cpc
+}


### PR DESCRIPTION
Existential Specializer Pass that specializes functions that take protocols (aka existentials)  as arguments to transform them with concrete types instead of protocol types when the concrete types can be determined statically. 

