### PR TITLE
[GSB] Fix signature builder to look through typealias when forming requirements

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1692,7 +1692,11 @@ public:
   ///
   /// \param genericParams The set of generic parameters to use in the resulting
   /// dependent type.
-  Type getDependentType(ArrayRef<GenericTypeParamType *> genericParams) const;
+  ///
+  /// \param lookThroughAlias Indicates if potential typealias this type
+  /// represents should be unwrapped when returning result.
+  Type getDependentType(ArrayRef<GenericTypeParamType *> genericParams,
+                        bool lookThroughAlias = false) const;
 
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.

--- a/validation-test/compiler_crashers_2_fixed/0138-rdar36549499.swift
+++ b/validation-test/compiler_crashers_2_fixed/0138-rdar36549499.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+
+protocol S {
+  associatedtype I: IteratorProtocol
+  typealias E = I.Element
+}
+
+func foo<T: S>(_ s: T) -> Int where T.E == Int {
+  return 42
+}


### PR DESCRIPTION
If the left-hand side of the requirement is a typealias we have to
look-through that declaration to find actual associated type.

Resolves: rdar://problem/36549499

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
