### PR TITLE
[build-script] Removed the always-broken support for building PlaygroundLogger on Linux.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -444,14 +444,6 @@ function set_build_options_for_host() {
             case ${host} in
                 linux-x86_64)
                     SWIFT_HOST_VARIANT_ARCH="x86_64"
-                    playgroundlogger_build_cmd="${PLAYGROUNDLOGGER_SOURCE_DIR}/build.py"
-                    playgroundlogger_build_options=(
-                        --swiftc "$(build_directory_bin ${host} swift)"
-                        --foundation "$(build_directory ${host} foundation)"
-                        --build-dir "$(build_directory ${host} playgroundlogger)"
-                        --swift-build-dir "$(build_directory ${host} swift)"
-                        --$(tolower "${PLAYGROUNDLOGGER_BUILD_TYPE}")
-                    )
                     ;;
                 linux-armv6)
                     SWIFT_HOST_VARIANT_ARCH="armv6"
@@ -499,7 +491,6 @@ function set_build_options_for_host() {
                     swiftpm_bootstrap_options=(
                         --sysroot="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_TestDriver")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="MacOSX.platform"
                     ;;
@@ -517,7 +508,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_iOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="iPhoneSimulator.platform"
                     ;;
@@ -535,7 +525,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_iOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="iPhoneSimulator.platform"
                     ;;
@@ -553,7 +542,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_iOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="iPhoneOS.platform"
                     ;;
@@ -571,7 +559,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_iOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="iPhoneOS.platform"
                     ;;
@@ -589,7 +576,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_iOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="iPhoneOS.platform"
                     ;;
@@ -607,7 +593,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_tvOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="AppleTVSimulator.platform"
                     ;;
@@ -625,7 +610,6 @@ function set_build_options_for_host() {
                         -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"
                         -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                     )
-                    playgroundlogger_build_cmd="xcodebuild"
                     playgroundlogger_build_target=("PlaygroundLogger_tvOS")
                     PLAYGROUNDLOGGER_INSTALL_PLATFORM="AppleTVOS.platform"
                     ;;
@@ -2621,18 +2605,28 @@ for host in "${ALL_HOSTS[@]}"; do
                 continue
                 ;;
             playgroundlogger)
+                if [[ "$(uname -s)" != "Darwin" ]]; then
+                    echo "error: unable to build PlaygroundLogger on this platform"
+                    exit 1
+                fi
+
                 PLAYGROUNDLOGGER_BUILD_DIR=$(build_directory ${host} ${product})
                 SWIFTC_BIN="$(build_directory_bin ${host} swift)/swiftc"
 
                 set -x
                 pushd "${PLAYGROUNDLOGGER_SOURCE_DIR}"
                 mkdir -p "${PLAYGROUNDLOGGER_BUILD_DIR}"
-                "${playgroundlogger_build_cmd}" -configuration "${PLAYGROUNDLOGGER_BUILD_TYPE}" -target "${playgroundlogger_build_target}" install SWIFT_EXEC="${SWIFTC_BIN}" DSTROOT=${build_dir} INSTALL_PATH="/" SKIP_INSTALL=NO
+                "xcodebuild" -configuration "${PLAYGROUNDLOGGER_BUILD_TYPE}" -target "${playgroundlogger_build_target}" install SWIFT_EXEC="${SWIFTC_BIN}" DSTROOT=${build_dir} INSTALL_PATH="/" SKIP_INSTALL=NO
                 popd
                 { set +x; } 2>/dev/null
                 continue
                 ;;
             playgroundsupport)
+                if [[ "$(uname -s)" != "Darwin" ]]; then
+                    echo "error: unable to build PlaygroundSupport on this platform"
+                    exit 1
+                fi
+
                 PLAYGROUNDSUPPORT_BUILD_DIR=$(build_directory ${host} ${product})
                 SWIFTC_BIN="$(build_directory_bin ${host} swift)/swiftc"
 
@@ -2964,6 +2958,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 continue
                 ;;
            playgroundlogger)
+               if [[ "${host}" != "macosx"* ]]; then
+                   echo "Skipping PlaygroundLogger tests on non-macOS platform"
+                   continue
+               fi
                SWIFT_DYLIB_PATH=$(build_directory ${host} swift)/lib/swift/macosx/
                PLAYGROUNDLOGGER_FRAMEWORK_PATH=$(build_directory ${host} ${product})
                set -x
@@ -3287,11 +3285,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 # requires root permissions.
                 set -x
                 case "$(uname -s)" in
-                    Linux)
-                        PLAYGROUNDLOGGER_INSTALL_DIR="$(get_host_install_destdir ${host})/$(get_host_install_prefix ${host})/lib/swift/linux"
-                        mkdir -p "${PLAYGROUNDLOGGER_INSTALL_DIR}"
-                        cp -R "${PLAYGROUNDLOGGER_BUILD_DIR}"/libPlaygroundLogger.so "${PLAYGROUNDLOGGER_INSTALL_DIR}"
-                        ;;
                     Darwin)
                         pushd "${PLAYGROUNDLOGGER_SOURCE_DIR}"
                         xcodebuild -target "All Platforms Logger" -configuration Toolchain_${PLAYGROUNDLOGGER_BUILD_TYPE} install SWIFT_EXEC="${SWIFTC_BIN}" DT_TOOLCHAIN_DIR="${TOOLCHAIN_PREFIX}" DSTROOT="$(get_host_install_destdir ${host})"
@@ -3314,19 +3307,15 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
                 case "$(uname -s)" in
-                    Linux)
-                        ;;
-                    FreeBSD)
-                        ;;
-                    CYGWIN_NT-10.0)
-                        ;;
-                    Haiku)
-                        ;;
                     Darwin)
                         pushd "${PLAYGROUNDSUPPORT_SOURCE_DIR}"
                         xcodebuild -target AllProducts -configuration ${PLAYGROUNDSUPPORT_BUILD_TYPE} install SWIFT_EXEC="${SWIFTC_BIN}" DT_TOOLCHAIN_DIR="${TOOLCHAIN_PREFIX}" DSTROOT="$(get_host_install_destdir ${host})"
                         popd
                         continue
+                        ;;
+                    *)
+                        echo "error: --install-playgroundsupport is not supported on this platform"
+                        exit 1
                         ;;
                 esac
                 { set +x; } 2>/dev/null


### PR DESCRIPTION
As far as I can tell, this never worked, so removing it cannot break anything.
Now PlaygroundLogger is treated similarly to PlaygroundSupport, directly referencing xcodebuild instead of indirecting through variables.
This commit also introduces explicit error messages when attempting to build PlaygroundLogger or PlaygroundSupport for non-Darwin platforms.

This addresses <rdar://problem/36594779>.