### PR TITLE
[stdlib] Remove MutableCollection.sorted methods

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SWIFTLIB_ESSENTIAL
   CocoaArray.swift
   Codable.swift.gyb
   Collection.swift
-  CollectionAlgorithms.swift.gyb
+  CollectionAlgorithms.swift
   Comparable.swift
   CompilerProtocols.swift
   ClosedRange.swift

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -431,9 +431,6 @@ extension MutableCollection where Self : RandomAccessCollection {
   /// Sorts the collection in place, using the given predicate as the
   /// comparison between elements.
   ///
-  /// This method can take throwing closure. If closure throws error while
-  /// sorting, order of elements may change. No elements will be lost.
-  ///
   /// When you want to sort a collection of elements that doesn't conform to
   /// the `Comparable` protocol, pass a closure to this method that returns
   /// `true` when the first element passed should be ordered before the
@@ -496,7 +493,9 @@ extension MutableCollection where Self : RandomAccessCollection {
   ///
   /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its
   ///   first argument should be ordered before its second argument;
-  ///   otherwise, `false`.
+  ///   otherwise, `false`. If `areInIncreasingOrder` throws an error during
+  ///   the sort, the elements may be in a different order, but none will be
+  ///   lost.
   @_inlineable
   public mutating func sort(
     by areInIncreasingOrder:

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -107,33 +107,46 @@ extension Collection {
 }
 
 //===----------------------------------------------------------------------===//
-// MutableCollection
-//===----------------------------------------------------------------------===//
-
-%{
-
-orderingExplanation = """\
-  /// The predicate must be a *strict weak ordering* over the elements. That
-  /// is, for any elements `a`, `b`, and `c`, the following conditions must
-  /// hold:
-  ///
-  /// - `areInIncreasingOrder(a, a)` is always `false`. (Irreflexivity)
-  /// - If `areInIncreasingOrder(a, b)` and `areInIncreasingOrder(b, c)` are
-  ///   both `true`, then `areInIncreasingOrder(a, c)` is also `true`.
-  ///   (Transitive comparability)
-  /// - Two elements are *incomparable* if neither is ordered before the other
-  ///   according to the predicate. If `a` and `b` are incomparable, and `b`
-  ///   and `c` are incomparable, then `a` and `c` are also incomparable.
-  ///   (Transitive incomparability)
-  ///"""
-
-}%
-
-//===----------------------------------------------------------------------===//
-// partition()
+// partition(by:)
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection {
+  /// Reorders the elements of the collection such that all the elements
+  /// that match the given predicate are after all the elements that don't
+  /// match.
+  ///
+  /// After partitioning a collection, there is a pivot index `p` where
+  /// no element before `p` satisfies the `belongsInSecondPartition`
+  /// predicate and every element at or after `p` satisfies
+  /// `belongsInSecondPartition`.
+  ///
+  /// In the following example, an array of numbers is partitioned by a
+  /// predicate that matches elements greater than 30.
+  ///
+  ///     var numbers = [30, 40, 20, 30, 30, 60, 10]
+  ///     let p = numbers.partition(by: { $0 > 30 })
+  ///     // p == 5
+  ///     // numbers == [30, 10, 20, 30, 30, 60, 40]
+  ///
+  /// The `numbers` array is now arranged in two partitions. The first
+  /// partition, `numbers[..<p]`, is made up of the elements that
+  /// are not greater than 30. The second partition, `numbers[p...]`,
+  /// is made up of the elements that *are* greater than 30.
+  ///
+  ///     let first = numbers[..<p]
+  ///     // first == [30, 10, 20, 30, 30]
+  ///     let second = numbers[p...]
+  ///     // second == [60, 40]
+  ///
+  /// - Parameter belongsInSecondPartition: A predicate used to partition
+  ///   the collection. All elements satisfying this predicate are ordered
+  ///   after all elements not satisfying it.
+  /// - Returns: The index of the first element in the reordered collection
+  ///   that matches `belongsInSecondPartition`. If no elements in the
+  ///   collection match `belongsInSecondPartition`, the returned index is
+  ///   equal to the collection's `endIndex`.
+  ///
+  /// - Complexity: O(*n*)
   @_inlineable
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
@@ -163,6 +176,42 @@ extension MutableCollection {
 }
 
 extension MutableCollection where Self : BidirectionalCollection {
+  /// Reorders the elements of the collection such that all the elements
+  /// that match the given predicate are after all the elements that don't
+  /// match.
+  ///
+  /// After partitioning a collection, there is a pivot index `p` where
+  /// no element before `p` satisfies the `belongsInSecondPartition`
+  /// predicate and every element at or after `p` satisfies
+  /// `belongsInSecondPartition`.
+  ///
+  /// In the following example, an array of numbers is partitioned by a
+  /// predicate that matches elements greater than 30.
+  ///
+  ///     var numbers = [30, 40, 20, 30, 30, 60, 10]
+  ///     let p = numbers.partition(by: { $0 > 30 })
+  ///     // p == 5
+  ///     // numbers == [30, 10, 20, 30, 30, 60, 40]
+  ///
+  /// The `numbers` array is now arranged in two partitions. The first
+  /// partition, `numbers[..<p]`, is made up of the elements that
+  /// are not greater than 30. The second partition, `numbers[p...]`,
+  /// is made up of the elements that *are* greater than 30.
+  ///
+  ///     let first = numbers[..<p]
+  ///     // first == [30, 10, 20, 30, 30]
+  ///     let second = numbers[p...]
+  ///     // second == [60, 40]
+  ///
+  /// - Parameter belongsInSecondPartition: A predicate used to partition
+  ///   the collection. All elements satisfying this predicate are ordered
+  ///   after all elements not satisfying it.
+  /// - Returns: The index of the first element in the reordered collection
+  ///   that matches `belongsInSecondPartition`. If no elements in the
+  ///   collection match `belongsInSecondPartition`, the returned index is
+  ///   equal to the collection's `endIndex`.
+  ///
+  /// - Complexity: O(*n*)
   @_inlineable
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
@@ -212,19 +261,14 @@ extension MutableCollection where Self : BidirectionalCollection {
 }
 
 //===----------------------------------------------------------------------===//
-// sorted()
+// sorted()/sort()
 //===----------------------------------------------------------------------===//
 
-% for Self in ['Sequence', 'MutableCollection']:
-
-% sequenceKind = 'sequence' if 'Sequence' in Self else 'collection'
-
-extension ${Self} where Element : Comparable {
-  /// Returns the elements of the ${sequenceKind}, sorted.
+extension Sequence where Element : Comparable {
+  /// Returns the elements of the sequence, sorted.
   ///
-  /// You can sort any ${sequenceKind} of elements that conform to the
-  /// `Comparable` protocol by calling this method. Elements are sorted in
-  /// ascending order.
+  /// You can sort any sequence of elements that conform to the `Comparable`
+  /// protocol by calling this method. Elements are sorted in ascending order.
   ///
   /// The sorting algorithm is not stable. A nonstable sort may change the
   /// relative order of elements that compare equal.
@@ -238,14 +282,14 @@ extension ${Self} where Element : Comparable {
   ///     print(sortedStudents)
   ///     // Prints "["Abena", "Akosua", "Kofi", "Kweku", "Peter"]"
   ///
-  /// To sort the elements of your ${sequenceKind} in descending order, pass the
+  /// To sort the elements of your sequence in descending order, pass the
   /// greater-than operator (`>`) to the `sorted(by:)` method.
   ///
   ///     let descendingStudents = students.sorted(by: >)
   ///     print(descendingStudents)
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   ///
-  /// - Returns: A sorted array of the ${sequenceKind}'s elements.
+  /// - Returns: A sorted array of the sequence's elements.
   @_inlineable
   public func sorted() -> [Element] {
     var result = ContiguousArray(self)
@@ -254,17 +298,29 @@ extension ${Self} where Element : Comparable {
   }
 }
 
-extension ${Self} {
-  /// Returns the elements of the ${sequenceKind}, sorted using the given
-  /// predicate as the comparison between elements.
+extension Sequence {
+  /// Returns the elements of the sequence, sorted using the given predicate as
+  /// the comparison between elements.
   ///
-  /// When you want to sort a ${sequenceKind} of elements that don't conform to
-  /// the `Comparable` protocol, pass a predicate to this method that returns
+  /// When you want to sort a sequence of elements that don't conform to the
+  /// `Comparable` protocol, pass a predicate to this method that returns
   /// `true` when the first element passed should be ordered before the
   /// second. The elements of the resulting array are ordered according to the
   /// given predicate.
   ///
-${orderingExplanation}
+  /// The predicate must be a *strict weak ordering* over the elements. That
+  /// is, for any elements `a`, `b`, and `c`, the following conditions must
+  /// hold:
+  ///
+  /// - `areInIncreasingOrder(a, a)` is always `false`. (Irreflexivity)
+  /// - If `areInIncreasingOrder(a, b)` and `areInIncreasingOrder(b, c)` are
+  ///   both `true`, then `areInIncreasingOrder(a, c)` is also `true`.
+  ///   (Transitive comparability)
+  /// - Two elements are *incomparable* if neither is ordered before the other
+  ///   according to the predicate. If `a` and `b` are incomparable, and `b`
+  ///   and `c` are incomparable, then `a` and `c` are also incomparable.
+  ///   (Transitive incomparability)
+  ///
   /// The sorting algorithm is not stable. A nonstable sort may change the
   /// relative order of elements for which `areInIncreasingOrder` does not
   /// establish an order.
@@ -297,8 +353,8 @@ ${orderingExplanation}
   ///     // Prints "[.error(403), .error(404), .error(500), .ok, .ok]"
   ///
   /// You also use this method to sort elements that conform to the
-  /// `Comparable` protocol in descending order. To sort your ${sequenceKind}
-  /// in descending order, pass the greater-than operator (`>`) as the
+  /// `Comparable` protocol in descending order. To sort your sequence in
+  /// descending order, pass the greater-than operator (`>`) as the
   /// `areInIncreasingOrder` parameter.
   ///
   ///     let students: Set = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
@@ -314,10 +370,10 @@ ${orderingExplanation}
   ///     print(students.sorted(by: <))
   ///     // Prints "["Abena", "Akosua", "Kofi", "Kweku", "Peter"]"
   ///
-  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its first
-  ///   argument should be ordered before its second argument; otherwise,
-  ///   `false`.
-  /// - Returns: A sorted array of the ${sequenceKind}'s elements.
+  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its
+  ///   first argument should be ordered before its second argument;
+  ///   otherwise, `false`.
+  /// - Returns: A sorted array of the sequence's elements.
   @_inlineable
   public func sorted(
     by areInIncreasingOrder:
@@ -328,8 +384,6 @@ ${orderingExplanation}
     return Array(result)
   }
 }
-
-% end
 
 extension MutableCollection
   where
@@ -377,15 +431,27 @@ extension MutableCollection where Self : RandomAccessCollection {
   /// Sorts the collection in place, using the given predicate as the
   /// comparison between elements.
   ///
-  /// This method can take throwing closure. If closure throws error while sorting,
-  /// order of elements may change. No elements will be lost.
+  /// This method can take throwing closure. If closure throws error while
+  /// sorting, order of elements may change. No elements will be lost.
   ///
   /// When you want to sort a collection of elements that doesn't conform to
   /// the `Comparable` protocol, pass a closure to this method that returns
   /// `true` when the first element passed should be ordered before the
   /// second.
   ///
-${orderingExplanation}
+  /// The predicate must be a *strict weak ordering* over the elements. That
+  /// is, for any elements `a`, `b`, and `c`, the following conditions must
+  /// hold:
+  ///
+  /// - `areInIncreasingOrder(a, a)` is always `false`. (Irreflexivity)
+  /// - If `areInIncreasingOrder(a, b)` and `areInIncreasingOrder(b, c)` are
+  ///   both `true`, then `areInIncreasingOrder(a, c)` is also `true`.
+  ///   (Transitive comparability)
+  /// - Two elements are *incomparable* if neither is ordered before the other
+  ///   according to the predicate. If `a` and `b` are incomparable, and `b`
+  ///   and `c` are incomparable, then `a` and `c` are also incomparable.
+  ///   (Transitive incomparability)
+  ///
   /// The sorting algorithm is not stable. A nonstable sort may change the
   /// relative order of elements for which `areInIncreasingOrder` does not
   /// establish an order.
@@ -428,9 +494,9 @@ ${orderingExplanation}
   ///     print(students)
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   ///
-  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its first
-  ///   argument should be ordered before its second argument; otherwise,
-  ///   `false`.
+  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its
+  ///   first argument should be ordered before its second argument;
+  ///   otherwise, `false`.
   @_inlineable
   public mutating func sort(
     by areInIncreasingOrder:

--- a/test/Constraints/trailing_closures_objc.swift
+++ b/test/Constraints/trailing_closures_objc.swift
@@ -17,6 +17,8 @@ func foo(options: [AVMediaSelectionOption]) {
 func rdar28004686(a: [IndexPath]) {
   _ = a.sorted { (lhs: NSIndexPath, rhs: NSIndexPath) -> Bool in true }
   // expected-error@-1 {{'NSIndexPath' is not convertible to 'IndexPath'}}
+  // expected-error@-2 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  // The second error is erroneous: rdar://36744895
 }
 
 class Test: NSObject {

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -38,9 +38,7 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-REPLACEMENT1: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT1: <Declaration>{{.*}}func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
 // CHECK-REPLACEMENT1: RELATED BEGIN
-// CHECK-REPLACEMENT1: sorted(by: (Int, Int) throws -&gt; Bool) rethrows -&gt; [Int]</RelatedName>
-// CHECK-REPLACEMENT1: sorted() -&gt; [Int]</RelatedName>
-// CHECK-REPLACEMENT1: sorted(by: (Int, Int) throws -&gt; Bool) rethrows -&gt; [Int]</RelatedName>
+// CHECK-REPLACEMENT1: sorted(by:)</RelatedName>
 // CHECK-REPLACEMENT1: RELATED END
 
 // RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
@@ -50,9 +48,7 @@ func foo3(a: Float, b: Bool) {}
 // RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
 // CHECK-REPLACEMENT3: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: (<Type usr="s:13cursor_stdlib2S1V">S1</Type>
-// CHECK-REPLACEMENT3: sorted() -&gt; [S1]</RelatedName>
-// CHECK-REPLACEMENT3: sorted() -&gt; [S1]</RelatedName>
-// CHECK-REPLACEMENT3: sorted(by: (S1, S1) throws -&gt; Bool) rethrows -&gt; [S1]</RelatedName>
+// CHECK-REPLACEMENT3: sorted()</RelatedName>
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>


### PR DESCRIPTION
This removes the implementations of `sorted()` and `sorted(by:)` on `MutableCollection`, which only changed some minor wording in the docs, and de-gybs "CollectionAlgorithms.swift".

This also adds documentation to the `partition(by:)` implementations so that they appear downstream.