### PR TITLE
[stdlib][WIP] Zip collapsed across sequence and collection

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -203,7 +203,7 @@ public struct Zip2Collection<Collection1 : Collection, Collection2 : Collection>
   /// Creates an instance that makes pairs of elements from `collection1` and
   /// `collection2`.
   // FIXME: this should be inlineable, but this results in a compilation error:
-  // ""
+  // "error: 'let' property '_collection1' may not be initialized directly; use "self.init(...)" or "self = ..." instead"
   // @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   internal init(_ collection1: Collection1, _ collection2: Collection2) {
@@ -232,8 +232,8 @@ extension Zip2Collection {
     
     /// Creates an instance that makes pairs of elements from `index1` and
     /// `index2`.
-    // FIXME: this should be inlineable, but this results in a compilation error:
-    // ""
+    // FIXME: this should be inlineable, but this results in a compilation 
+    // error similar to the one for Zip2Collection.init above
     // @_inlineable // FIXME(sil-serialize-all)
     @_versioned
     internal init(_ index1: Collection1.Index, _ index2: Collection2.Index) {

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -149,6 +149,13 @@ extension Zip2Sequence: Sequence {
       _sequence1.makeIterator(),
       _sequence2.makeIterator())
   }
+  
+  // ensure propogation of intentional underestimates from bases
+  @_inlineable // FIXME(sil-serialize-all)
+  public var underestimatedCount: Int {
+    return Swift.min(
+      _sequence1.underestimatedCount,_sequence2.underestimatedCount)
+  }  
 }
 
 /// Creates a collection of pairs built out of two underlying collections.
@@ -275,8 +282,7 @@ extension Zip2Collection: Collection {
 
   @_inlineable
   public func index(after: Index) -> Index {
-    _precondition(after >= startIndex)
-    _precondition(after < endIndex)
+    _failEarlyRangeCheck(after, bounds: startIndex..<endIndex)
 
     return Index(
       _collection1.index(after: after._index1),
@@ -286,24 +292,24 @@ extension Zip2Collection: Collection {
 
   @_inlineable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
-    _precondition(i >= startIndex)
-    _precondition(i <= endIndex)
+    _precondition(i >= startIndex, "Index out of range")
+    _precondition(i <= endIndex, "Index out of range")
 
     let j = Index(
       _collection1.index(i._index1, offsetBy: n),
       _collection2.index(i._index2, offsetBy: n)
     )
     
-    _precondition(j >= startIndex)
-    _precondition(j <= endIndex)
+    _debugPrecondition(j >= startIndex, "Unexpected zipped index out of bounds.")
+    _debugPrecondition(j <= endIndex, "Unexpected zipped index out of bounds.")
     
     return j
   }
 
   @_inlineable
   public func index(_ i: Index, offsetBy n: Int, limitedBy limit: Index) -> Index? {
-    _debugPrecondition(i >= startIndex)
-    _debugPrecondition(i <= endIndex)
+    _precondition(i >= startIndex, "Index out of range")
+    _precondition(i <= endIndex, "Index out of range")
     
     guard let i1 = _collection1.index(i._index1, offsetBy: n, limitedBy: limit._index1),
           let i2 = _collection2.index(i._index2, offsetBy: n, limitedBy: limit._index2)
@@ -311,8 +317,8 @@ extension Zip2Collection: Collection {
 
     let j = Index(i1, i2)
     
-    _debugPrecondition(j >= startIndex)
-    _debugPrecondition(j <= endIndex)
+    _debugPrecondition(j >= startIndex, "Unexpected zipped index out of bounds.")
+    _debugPrecondition(j <= endIndex, "Unexpected zipped index out of bounds.")
     
     return j
   }
@@ -337,6 +343,13 @@ extension Zip2Collection: Collection {
     }
 
   }
+
+  // ensure propogation of intentional underestimates from bases
+  @_inlineable // FIXME(sil-serialize-all)
+  public var underestimatedCount: Int {
+    return Swift.min(
+      _collection1.underestimatedCount, _collection2.underestimatedCount)
+  }  
 }
 
 extension Zip2Collection: BidirectionalCollection
@@ -368,8 +381,8 @@ where Collection1: RandomAccessCollection, Collection2: RandomAccessCollection {
   
   @_inlineable
   public func index(before i: Index) -> Index {
-    _debugPrecondition(i > startIndex)
-    _debugPrecondition(i <= endIndex)
+    _precondition(i > startIndex, "Index out of range")
+    _precondition(i <= endIndex, "Index out of range")
 
     return Index(
       _collection1.index(before: i._index1),

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -189,6 +189,7 @@ public func zip<Collection1, Collection2>(
   return Zip2Collection(collection1, collection2)
 }
 
+@_fixed_layout // FIXME(sil-serialize-all)
 public struct Zip2Collection<Collection1 : Collection, Collection2 : Collection> {
   @_versioned // FIXME(sil-serialize-all)
   internal let _collection1: Collection1
@@ -197,9 +198,7 @@ public struct Zip2Collection<Collection1 : Collection, Collection2 : Collection>
   
   /// Creates an instance that makes pairs of elements from `collection1` and
   /// `collection2`.
-  // FIXME: this should be inlineable, but this results in a compilation error:
-  // "error: 'let' property '_collection1' may not be initialized directly; use "self.init(...)" or "self = ..." instead"
-  // @_inlineable // FIXME(sil-serialize-all)
+  @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   internal init(_ collection1: Collection1, _ collection2: Collection2) {
     self._collection1 = collection1
@@ -219,6 +218,7 @@ extension Zip2Collection: Sequence {
 }
 
 extension Zip2Collection {
+  @_fixed_layout
   public struct Index {
     @_versioned // FIXME(sil-serialize-all)
     internal var _index1: Collection1.Index
@@ -227,9 +227,7 @@ extension Zip2Collection {
     
     /// Creates an instance that makes pairs of elements from `index1` and
     /// `index2`.
-    // FIXME: this should be inlineable, but this results in a compilation 
-    // error similar to the one for Zip2Collection.init above
-    // @_inlineable // FIXME(sil-serialize-all)
+    @_inlineable // FIXME(sil-serialize-all)
     @_versioned
     internal init(_ index1: Collection1.Index, _ index2: Collection2.Index) {
       self._index1 = index1

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -152,16 +152,13 @@ extension Zip2: Sequence {
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     // implementation of this function is problematic, because it needs two
-    // passes over right to operate independendly on left and right using the
-    // single predicate that takes both...    
+    // passes over the elements...    
     var i = 0
-    var rightIterator = right.makeIterator()
-    let leftSubSequence = try left.drop { l in
-      guard let r = rightIterator.next() else { return false }
-      i += 1
-      return try predicate(l,r)
+    for (l,r) in self { 
+      if try predicate(l,r) { i += 1 }
+      else { break }
     }
-    return zip(leftSubSequence, right.dropFirst(i))
+    return zip(left.dropFirst(i), right.dropFirst(i))
   }
   
   @_inlineable // FIXME(sil-serialize-all)
@@ -175,13 +172,11 @@ extension Zip2: Sequence {
   ) rethrows -> SubSequence {
     // similar to drop(while:), this currently takes two passes over right
     var i = 0
-    var rightIterator = right.makeIterator()
-    let leftSubSequence = try left.prefix { l in
-      guard let r = rightIterator.next() else { return false }
-      i += 1
-      return try predicate(l,r)
+    for (l,r) in self { 
+      if try predicate(l,r) { i += 1 }
+      else { break }
     }
-    return zip(leftSubSequence, right.prefix(i))
+    return zip(left.prefix(i), right.prefix(i))
   }
   
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -74,17 +74,12 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
   @_versioned // FIXME(sil-serialize-all)
   internal let _sequence2: Sequence2
 
-  @available(*, deprecated, renamed: "Sequence1.Iterator")
-  public typealias Stream1 = Sequence1.Iterator
-  @available(*, deprecated, renamed: "Sequence2.Iterator")
-  public typealias Stream2 = Sequence2.Iterator
-
   /// Creates an instance that makes pairs of elements from `sequence1` and
   /// `sequence2`.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   internal // @testable
-  init(_ sequence1 : Sequence1, _ sequence2: Sequence2) {
+  init(_ sequence1: Sequence1, _ sequence2: Sequence2) {
     self._sequence1 = sequence1
     self._sequence2 = sequence2
   }
@@ -307,7 +302,7 @@ extension Zip2Collection: Collection {
     return j
   }
 
-  // @_inlineable
+  @_inlineable
   public func index(_ i: Index, offsetBy n: Int, limitedBy limit: Index) -> Index? {
     _debugPrecondition(i >= startIndex)
     _debugPrecondition(i <= endIndex)
@@ -348,7 +343,9 @@ extension Zip2Collection: Collection {
 
 extension Zip2Collection: BidirectionalCollection
 where Collection1: RandomAccessCollection, Collection2: RandomAccessCollection {
-  
+  // Being bidirectional doesn't help us, because to calculate the shorter
+  // length we need to find the max distance of both collections.
+  // So no new features added here.
 }
 
 extension Zip2Collection: RandomAccessCollection
@@ -402,5 +399,13 @@ where Collection1: Equatable, Collection2: Equatable {
   }
 }
 
-// @available(*, deprecated, renamed: "Zip2Sequence.Iterator")
+@available(*, deprecated, renamed: "Zip2Sequence.Iterator")
 public typealias Zip2Iterator<T, U> = Zip2Sequence<T, U>.Iterator where T: Sequence, U: Sequence
+
+extension Zip2Sequence {
+  @available(*, deprecated, renamed: "Sequence1.Iterator")
+  public typealias Stream1 = Sequence1.Iterator
+  @available(*, deprecated, renamed: "Sequence2.Iterator")
+  public typealias Stream2 = Sequence2.Iterator  
+}
+

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -151,6 +151,9 @@ extension Zip2: Sequence {
   public func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
+    // implementation of this function is problematic, because it needs two
+    // passes over right to operate independendly on left and right using the
+    // single predicate that takes both...    
     var i = 0
     var rightIterator = right.makeIterator()
     let leftSubSequence = try left.drop { l in
@@ -170,6 +173,7 @@ extension Zip2: Sequence {
   public func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
+    // similar to drop(while:), this currently takes two passes over right
     var i = 0
     var rightIterator = right.makeIterator()
     let leftSubSequence = try left.prefix { l in
@@ -190,6 +194,7 @@ extension Zip2: Sequence {
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool
   ) rethrows -> [SubSequence] {
+    // needs similar solution to drop(while:)
     fatalError()
   }
   

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -48,6 +48,44 @@ public func zip<Sequence1, Sequence2>(
   return Zip2Sequence(_sequence1: sequence1, _sequence2: sequence2)
 }
 
+/// Creates a collection of pairs built out of two underlying collections.
+///
+/// In the `Zip2Collection` instance returned by this function, the elements of
+/// the *i*th pair are the *i*th elements of each underlying collection. The
+/// following example uses the `zip(_:_:)` function to iterate over an array
+/// of strings and a countable range at the same time:
+///
+///     let words = ["one", "two", "three", "four"]
+///     let numbers = 1...4
+///
+///     for (word, number) in zip(words, numbers) {
+///         print("\(word): \(number)")
+///     }
+///     // Prints "one: 1"
+///     // Prints "two: 2
+///     // Prints "three: 3"
+///     // Prints "four: 4"
+///
+/// If the two sequences passed to `zip(_:_:)` are different lengths, the
+/// resulting sequence is the same length as the shorter sequence. In this
+/// example, the resulting array is the same length as `words`:
+///
+///     let naturalNumbers = 1...Int.max
+///     let zipped = Array(zip(words, naturalNumbers))
+///     // zipped == [("one", 1), ("two", 2), ("three", 3), ("four", 4)]
+///
+/// - Parameters:
+///   - collection1: The first collection to zip.
+///   - collection2: The second collection to zip.
+/// - Returns: A sequence of tuple pairs, where the elements of each pair are
+///   corresponding elements of `collection1` and `collection2`.
+@_inlineable // FIXME(sil-serialize-all)
+public func zip<Collection1, Collection2>(
+  _ collection1: Collection1, _ collection2: Collection2
+) -> Zip2Collection<Collection1, Collection2> {
+  return Zip2Collection(_collection1: collection1, _collection2: collection2)
+}
+
 /// A sequence of pairs built out of two underlying sequences.
 ///
 /// In a `Zip2Sequence` instance, the elements of the *i*th pair are the *i*th
@@ -150,6 +188,93 @@ extension Zip2Sequence: Sequence {
     return Iterator(
       _sequence1.makeIterator(),
       _sequence2.makeIterator())
+  }
+}
+
+public struct Zip2Collection<Collection1 : Collection, Collection2 : Collection> {
+  @_versioned // FIXME(sil-serialize-all)
+  internal let _collection1: Collection1
+  @_versioned // FIXME(sil-serialize-all)
+  internal let _collection2: Collection2
+  
+  /// Creates an instance that makes pairs of elements from `collection1` and
+  /// `collection2`.
+  @_inlineable // FIXME(sil-serialize-all)
+  public // @testable
+  init(
+    _collection1 collection1: Collection1, _collection2 collection2: Collection2
+  ) {
+    (_collection1, _collection2) = (collection1, collection2)
+  }
+}
+
+extension Zip2Collection: Sequence {
+  public typealias Element = (Collection1.Element, Collection2.Element)
+  public typealias Iterator = Zip2Sequence<Collection1, Collection2>.Iterator
+  
+  /// Returns an iterator over the elements of this collection.
+  @_inlineable // FIXME(sil-serialize-all)
+  public func makeIterator() -> Iterator {
+    return Zip2Sequence.Iterator(
+      _collection1.makeIterator(),
+      _collection2.makeIterator())
+  }
+}
+
+extension Zip2Collection {
+  public struct Index {
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _index1: Collection1.Index
+    @_versioned // FIXME(sil-serialize-all)
+    internal var _index2: Collection2.Index
+    
+    /// Creates an instance that makes pairs of elements from `index1` and
+    /// `index2`.
+    @_inlineable // FIXME(sil-serialize-all)
+    public // @testable
+    init(_index1 index1: Collection1.Index, _index2 index2: Collection2.Index) {
+      (_index1, _index2) = (index1, index2)
+    }
+  }
+}
+  
+extension Zip2Collection.Index: Comparable {
+    public static func == (
+      lhs: Zip2Collection<Collection1, Collection2>.Index,
+      rhs: Zip2Collection<Collection1, Collection2>.Index
+    ) -> Bool {
+      // yes, this is an || not an &&. this makes
+      // the first endIndex of either match
+      return lhs._index1 == rhs._index1
+          || lhs._index2 == rhs._index2
+    }
+    
+    public static func < (
+      lhs: Zip2Collection<Collection1, Collection2>.Index,
+      rhs: Zip2Collection<Collection1, Collection2>.Index
+    ) -> Bool {
+      return lhs._index1 < rhs._index1
+    }
+}
+  
+extension Zip2Collection: Collection {
+  public var startIndex: Index {
+    return Index(_index1: _collection1.startIndex, _index2: _collection2.startIndex)
+  }
+
+  public var endIndex: Index {
+    return Index(_index1: _collection1.endIndex, _index2: _collection2.endIndex)
+  }
+
+  public subscript(i: Index) -> Element {
+    return (_collection1[i._index1], _collection2[i._index2])
+  }
+
+  public func index(after: Index) -> Index {
+    return Index(
+      _index1: _collection1.index(after: after._index1),
+      _index2: _collection2.index(after: after._index2)
+    )
   }
 }
 

--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -65,7 +65,7 @@ extension Sequence {
 
 extension Sequence {
   public func myZip<S : Sequence>(_ s: S) -> Zip2Sequence<Self, S> {
-    return Zip2Sequence(_sequence1: self, _sequence2: s)
+    return zip(self, s)
   }
 }
 

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -1018,62 +1018,6 @@ SequenceTypeTests.test("Sequence/split/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// zip()
-//===----------------------------------------------------------------------===//
-
-// Check generic parameter names.
-extension Zip2Sequence.Iterator
-  where Sequence1 : TestProtocol1, Sequence2 : TestProtocol1 {
-
-  var _generator1IsTestProtocol1: Bool {
-    fatalError("not implemented")
-  }
-}
-
-// Check generic parameter names.
-extension Zip2Sequence
-  where Sequence1 : TestProtocol1, Sequence2 : TestProtocol1 {
-
-  var _sequence1IsTestProtocol1: Bool {
-    fatalError("not implemented")
-  }
-}
-
-SequenceTypeTests.test("zip") {
-  typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
-  func compareElements(_ lhs: Element, rhs: Element) -> Bool {
-    return lhs.0.value == rhs.0.value && lhs.1.value == rhs.1.value
-  }
-
-  for test in zipTests {
-    let s = MinimalSequence<OpaqueValue<Int>>(
-      elements: test.sequence.map(OpaqueValue.init))
-    let other = MinimalSequence<OpaqueValue<Int32>>(
-      elements: test.other.map(OpaqueValue.init))
-    var result = zip(s, other)
-    expectType(
-      Zip2Sequence<MinimalSequence<OpaqueValue<Int>>, MinimalSequence<OpaqueValue<Int32>>>.self,
-      &result)
-
-    // Check for expected result and check the Zip2Sequence's Sequence
-    // conformance.
-    checkSequence(
-      test.expected.map { (OpaqueValue($0), OpaqueValue($1)) }, result,
-      stackTrace: SourceLocStack().with(test.loc), sameValue: compareElements)
-
-    // Check leftovers *after* doing checkSequence(), not before, to ensure
-    // that checkSequence() didn't force us to consume more elements than
-    // needed.
-    expectEqual(
-      test.expectedLeftoverSequence, s.map { $0.value },
-      stackTrace: SourceLocStack().with(test.loc))
-    expectEqual(
-      test.expectedLeftoverOther, other.map { $0.value },
-      stackTrace: SourceLocStack().with(test.loc))
-  }
-}
-
-//===----------------------------------------------------------------------===//
 // underestimatedCount
 //===----------------------------------------------------------------------===//
 

--- a/validation-test/stdlib/Zip.swift
+++ b/validation-test/stdlib/Zip.swift
@@ -1,0 +1,120 @@
+// -*- swift -*-
+// RUN: %target-run-simple-swiftgyb
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdlibCollectionUnittest
+
+var ZipTests = TestSuite("Zip")
+
+// Check that the generic parameter is called 'Base'.
+protocol TestProtocol1 {}
+
+extension IteratorSequence where Base : TestProtocol1 {
+  var _baseIsTestProtocol1: Bool {
+    fatalError("not implemented")
+  }
+}
+
+
+// Check generic parameter names.
+extension Zip2Sequence.Iterator
+where Sequence1: TestProtocol1, Sequence2: TestProtocol1 {
+  var _generator1IsTestProtocol1: Bool {
+    fatalError("not implemented")
+  }
+}
+
+// Check generic parameter names.
+extension Zip2Sequence
+where Sequence1 : TestProtocol1, Sequence2 : TestProtocol1 {
+  var _sequence1IsTestProtocol1: Bool {
+    fatalError("not implemented")
+  }
+}
+
+ZipTests.test("Sequence") {
+  typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
+  func compareElements(_ lhs: Element, rhs: Element) -> Bool {
+    return lhs.0.value == rhs.0.value && lhs.1.value == rhs.1.value
+  }
+
+  for test in zipTests {
+    let s = MinimalSequence<OpaqueValue<Int>>(
+      elements: test.sequence.map(OpaqueValue.init))
+    let other = MinimalSequence<OpaqueValue<Int32>>(
+      elements: test.other.map(OpaqueValue.init))
+    var result = zip(s, other)
+    expectType(
+      Zip2Sequence<MinimalSequence<OpaqueValue<Int>>, MinimalSequence<OpaqueValue<Int32>>>.self,
+      &result)
+
+    // Check for expected result and check the Zip2Sequence's Sequence
+    // conformance.
+    checkSequence(
+      test.expected.map { (OpaqueValue($0), OpaqueValue($1)) }, result,
+      stackTrace: SourceLocStack().with(test.loc), sameValue: compareElements)
+
+    // Check leftovers *after* doing checkSequence(), not before, to ensure
+    // that checkSequence() didn't force us to consume more elements than
+    // needed.
+    expectEqual(
+      test.expectedLeftoverSequence, s.map { $0.value },
+      stackTrace: SourceLocStack().with(test.loc))
+    expectEqual(
+      test.expectedLeftoverOther, other.map { $0.value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+ZipTests.test("Collection") {
+  typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
+  func compareElements(_ lhs: Element, rhs: Element) -> Bool {
+    return lhs.0.value == rhs.0.value && lhs.1.value == rhs.1.value
+  }
+
+  for test in zipTests {
+    let s = MinimalCollection<OpaqueValue<Int>>(
+      elements: test.sequence.map(OpaqueValue.init))
+    let other = MinimalCollection<OpaqueValue<Int32>>(
+      elements: test.other.map(OpaqueValue.init))
+    var result = zip(s, other)
+
+    typealias Sequence = Zip2Sequence<
+      MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int>>>
+    typealias Collection = Zip2Collection<
+      MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int>>>
+    expectCollectionAssociatedTypes(
+      collectionType: Collection.self,
+      iteratorType: Sequence.Iterator.self,
+      subSequenceType: Slice<Collection>.self,
+      indexType: Collection.Index.self,
+      indicesType: DefaultIndices<Collection>.self)
+  }
+}
+
+ZipTests.test("Collection.isEmpty") {
+  expectTrue(zip(0..<0,0..<0).isEmpty)
+  expectTrue(zip(0..<1,0..<0).isEmpty)
+  expectTrue(zip(0..<0,0..<1).isEmpty)
+  expectFalse(zip(0..<1,0..<1).isEmpty)
+  expectFalse(zip(0..<2,0..<3).isEmpty)
+  expectFalse(zip(0..<3,0..<2).isEmpty)
+}
+
+ZipTests.test("Collection.count") {
+  expectEqual(zip(0..<0,0..<0).underestimatedCount, 0)
+  expectEqual(zip(0..<1,0..<0).underestimatedCount, 0)
+  expectEqual(zip(0..<0,0..<1).underestimatedCount, 0)
+  expectEqual(zip(0..<2,0..<1).underestimatedCount, 1)
+  expectEqual(zip(0..<1,0..<2).underestimatedCount, 1)
+  expectEqual(zip(0..<2,0..<2).underestimatedCount, 2)
+  expectEqual(zip(0..<0,0..<0).count, 0)
+  expectEqual(zip(0..<1,0..<0).count, 0)
+  expectEqual(zip(0..<0,0..<1).count, 0)
+  expectEqual(zip(0..<2,0..<1).count, 1)
+  expectEqual(zip(0..<1,0..<2).count, 1)
+  expectEqual(zip(0..<2,0..<2).count, 2)
+}
+
+runAllTests()

--- a/validation-test/stdlib/Zip.swift
+++ b/validation-test/stdlib/Zip.swift
@@ -86,22 +86,28 @@ ZipTests.test("Collections") {
     indicesType: DefaultIndices<Collection>.self)
     
   for test in zipTests {
-    let s = MinimalCollection<OpaqueValue<Int>>(
+    let left = MinimalCollection<OpaqueValue<Int>>(
       elements: test.sequence.map(OpaqueValue.init))
-    let other = MinimalCollection<OpaqueValue<Int32>>(
+    let right = MinimalCollection<OpaqueValue<Int32>>(
       elements: test.other.map(OpaqueValue.init))
-    var result = zip(s, other)
-    expectType(Collection.self,
-      &result)
+
+    var result = zip(left, right)
+    expectType(Collection.self, &result)
+
+    checkCollection(
+      test.expected.map { (OpaqueValue($0), OpaqueValue($1)) }, 
+      result, sameValue: compareElements)      
   }
 }
 
 ZipTests.test("RandomAccessCollections") {
   typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
   typealias Sequence = Zip2Sequence<
-    MinimalRandomAccessCollection<OpaqueValue<Int>>,MinimalRandomAccessCollection<OpaqueValue<Int>>>
+    MinimalRandomAccessCollection<OpaqueValue<Int>>,
+    MinimalRandomAccessCollection<OpaqueValue<Int32>>>
   typealias Collection = Zip2Collection<
-    MinimalRandomAccessCollection<OpaqueValue<Int>>,MinimalRandomAccessCollection<OpaqueValue<Int>>>
+    MinimalRandomAccessCollection<OpaqueValue<Int>>,
+    MinimalRandomAccessCollection<OpaqueValue<Int32>>>
 
   func compareElements(_ lhs: Element, rhs: Element) -> Bool {
     return lhs.0.value == rhs.0.value && lhs.1.value == rhs.1.value
@@ -115,12 +121,13 @@ ZipTests.test("RandomAccessCollections") {
     indicesType: DefaultIndices<Collection>.self)
 
   for test in zipTests {
-    let s = MinimalRandomAccessCollection<OpaqueValue<Int>>(
+    let left = MinimalRandomAccessCollection<OpaqueValue<Int>>(
       elements: test.sequence.map(OpaqueValue.init))
-    let other = MinimalRandomAccessCollection<OpaqueValue<Int32>>(
+    let right = MinimalRandomAccessCollection<OpaqueValue<Int32>>(
       elements: test.other.map(OpaqueValue.init))
-    var result = zip(s, other)
 
+    var result = zip(left, right)
+    expectType(Collection.self, &result)
     checkRandomAccessCollection(
       test.expected.map { (OpaqueValue($0), OpaqueValue($1)) }, 
       result, sameValue: compareElements)

--- a/validation-test/stdlib/Zip.swift
+++ b/validation-test/stdlib/Zip.swift
@@ -69,9 +69,9 @@ ZipTests.test("Sequence") {
 
 ZipTests.test("Collections") {
   typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
-  typealias Sequence = Zip2Sequence<
+  typealias SequenceType = Zip2Sequence<
     MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int32>>>
-  typealias Collection = Zip2Collection<
+  typealias CollectionType = Zip2Collection<
     MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int32>>>
 
   func compareElements(_ lhs: Element, rhs: Element) -> Bool {
@@ -79,11 +79,11 @@ ZipTests.test("Collections") {
   }
 
   expectCollectionAssociatedTypes(
-    collectionType: Collection.self,
-    iteratorType: Sequence.Iterator.self,
-    subSequenceType: Slice<Collection>.self,
-    indexType: Collection.Index.self,
-    indicesType: DefaultIndices<Collection>.self)
+    collectionType: CollectionType.self,
+    iteratorType: SequenceType.Iterator.self,
+    subSequenceType: Slice<CollectionType>.self,
+    indexType: CollectionType.Index.self,
+    indicesType: DefaultIndices<CollectionType>.self)
     
   for test in zipTests {
     let left = MinimalCollection<OpaqueValue<Int>>(
@@ -92,7 +92,7 @@ ZipTests.test("Collections") {
       elements: test.other.map(OpaqueValue.init))
 
     var result = zip(left, right)
-    expectType(Collection.self, &result)
+    expectType(CollectionType.self, &result)
 
     checkCollection(
       test.expected.map { (OpaqueValue($0), OpaqueValue($1)) }, 
@@ -102,10 +102,10 @@ ZipTests.test("Collections") {
 
 ZipTests.test("RandomAccessCollections") {
   typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
-  typealias Sequence = Zip2Sequence<
+  typealias SequenceType = Zip2Sequence<
     MinimalRandomAccessCollection<OpaqueValue<Int>>,
     MinimalRandomAccessCollection<OpaqueValue<Int32>>>
-  typealias Collection = Zip2Collection<
+  typealias CollectionType = Zip2Collection<
     MinimalRandomAccessCollection<OpaqueValue<Int>>,
     MinimalRandomAccessCollection<OpaqueValue<Int32>>>
 
@@ -114,11 +114,11 @@ ZipTests.test("RandomAccessCollections") {
   }
       
   expectCollectionAssociatedTypes(
-    collectionType: Collection.self,
-    iteratorType: Sequence.Iterator.self,
-    subSequenceType: Slice<Collection>.self,
-    indexType: Collection.Index.self,
-    indicesType: DefaultIndices<Collection>.self)
+    collectionType: CollectionType.self,
+    iteratorType: SequenceType.Iterator.self,
+    subSequenceType: Slice<CollectionType>.self,
+    indexType: CollectionType.Index.self,
+    indicesType: DefaultIndices<CollectionType>.self)
 
   for test in zipTests {
     let left = MinimalRandomAccessCollection<OpaqueValue<Int>>(
@@ -127,7 +127,7 @@ ZipTests.test("RandomAccessCollections") {
       elements: test.other.map(OpaqueValue.init))
 
     var result = zip(left, right)
-    expectType(Collection.self, &result)
+    expectType(CollectionType.self, &result)
     checkRandomAccessCollection(
       test.expected.map { (OpaqueValue($0), OpaqueValue($1)) }, 
       result, sameValue: compareElements)
@@ -143,7 +143,7 @@ ZipTests.test("Collection.isEmpty") {
   expectFalse(zip(0..<3,0..<2).isEmpty)
 }
 
-ZipTests.test("Collection.count") {
+ZipTests.test("Collection.count") {  
   expectEqual(zip(0..<0,0..<0).underestimatedCount, 0)
   expectEqual(zip(0..<1,0..<0).underestimatedCount, 0)
   expectEqual(zip(0..<0,0..<1).underestimatedCount, 0)
@@ -156,10 +156,14 @@ ZipTests.test("Collection.count") {
   expectEqual(zip(0..<2,0..<1).count, 1)
   expectEqual(zip(0..<1,0..<2).count, 1)
   expectEqual(zip(0..<2,0..<2).count, 2)
+  
+  // underestimatedCount is the minimum of the two bases, to 
+  expectEqual(zip(0..<2,(0..<2).lazy.filter { _ in true }).underestimatedCount, 0)
+  expectEqual(zip((0..<2).lazy.filter { _ in true }, 0..<2).underestimatedCount, 0)
+  expectEqual(zip((0..<2).lazy.filter { _ in true }, (0..<2).lazy.map { $0 }).underestimatedCount, 0)
 }
 
 ZipTests.test("Equatable") {
-  let s = 
   checkEquatable([
     zip("",0..<99),
     zip("abcdef",0..<0),

--- a/validation-test/stdlib/Zip.swift
+++ b/validation-test/stdlib/Zip.swift
@@ -78,7 +78,6 @@ ZipTests.test("Collections") {
       elements: test.sequence.map(OpaqueValue.init))
     let other = MinimalCollection<OpaqueValue<Int32>>(
       elements: test.other.map(OpaqueValue.init))
-    var result = zip(s, other)
 
     typealias Sequence = Zip2Sequence<
       MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int>>>
@@ -161,5 +160,13 @@ ZipTests.test("Collection.count") {
   expectEqual(zip(0..<2,0..<2).count, 2)
 }
 
+ZipTests.test("Equatable") {
+  let s = 
+  checkEquatable([
+    zip("",0..<99),
+    zip("abcdef",0..<0),
+    zip("xyz",0..<3)
+  ], oracle: { $0 == $1 })
+}
 
 runAllTests()

--- a/validation-test/stdlib/Zip.swift
+++ b/validation-test/stdlib/Zip.swift
@@ -67,7 +67,7 @@ ZipTests.test("Sequence") {
   }
 }
 
-ZipTests.test("Collection") {
+ZipTests.test("Collections") {
   typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
   func compareElements(_ lhs: Element, rhs: Element) -> Bool {
     return lhs.0.value == rhs.0.value && lhs.1.value == rhs.1.value
@@ -90,6 +90,50 @@ ZipTests.test("Collection") {
       subSequenceType: Slice<Collection>.self,
       indexType: Collection.Index.self,
       indicesType: DefaultIndices<Collection>.self)
+      
+    let expected = [("one",1),("two",2),("three",3),("four",4)]
+    let left = ["one", "two", "three", "four"]
+    let right = 1...4
+    
+    checkCollection(expected,
+      zip(MinimalCollection(elements: left), MinimalCollection(elements: right)),
+      sameValue: { $0 == $1 }
+    )
+  }
+}
+
+ZipTests.test("RandomAccessCollections") {
+  typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
+  func compareElements(_ lhs: Element, rhs: Element) -> Bool {
+    return lhs.0.value == rhs.0.value && lhs.1.value == rhs.1.value
+  }
+
+  for test in zipTests {
+    let s = MinimalRandomAccessCollection<OpaqueValue<Int>>(
+      elements: test.sequence.map(OpaqueValue.init))
+    let other = MinimalRandomAccessCollection<OpaqueValue<Int32>>(
+      elements: test.other.map(OpaqueValue.init))
+    var result = zip(s, other)
+
+    typealias Sequence = Zip2Sequence<
+      MinimalRandomAccessCollection<OpaqueValue<Int>>,MinimalRandomAccessCollection<OpaqueValue<Int>>>
+    typealias Collection = Zip2Collection<
+      MinimalRandomAccessCollection<OpaqueValue<Int>>,MinimalRandomAccessCollection<OpaqueValue<Int>>>
+    expectCollectionAssociatedTypes(
+      collectionType: Collection.self,
+      iteratorType: Sequence.Iterator.self,
+      subSequenceType: Slice<Collection>.self,
+      indexType: Collection.Index.self,
+      indicesType: DefaultIndices<Collection>.self)
+      
+    let expected = [("one",1),("two",2),("three",3),("four",4)]
+    let left = ["one", "two", "three", "four"]
+    let right = 1...4
+    
+    checkRandomAccessCollection(expected,
+      zip(MinimalRandomAccessCollection(elements: left), MinimalRandomAccessCollection(elements: right)),
+      sameValue: { $0 == $1 }
+    )
   }
 }
 
@@ -116,5 +160,6 @@ ZipTests.test("Collection.count") {
   expectEqual(zip(0..<1,0..<2).count, 1)
   expectEqual(zip(0..<2,0..<2).count, 2)
 }
+
 
 runAllTests()

--- a/validation-test/stdlib/Zip.swift
+++ b/validation-test/stdlib/Zip.swift
@@ -18,16 +18,16 @@ extension IteratorSequence where Base : TestProtocol1 {
 
 
 // Check generic parameter names.
-extension Zip2Sequence.Iterator
-where Sequence1: TestProtocol1, Sequence2: TestProtocol1 {
+extension Zip2.Iterator
+where Left: TestProtocol1, Right: TestProtocol1 {
   var _generator1IsTestProtocol1: Bool {
     fatalError("not implemented")
   }
 }
 
 // Check generic parameter names.
-extension Zip2Sequence
-where Sequence1 : TestProtocol1, Sequence2 : TestProtocol1 {
+extension Zip2
+where Left : TestProtocol1, Right : TestProtocol1 {
   var _sequence1IsTestProtocol1: Bool {
     fatalError("not implemented")
   }
@@ -46,7 +46,7 @@ ZipTests.test("Sequence") {
       elements: test.other.map(OpaqueValue.init))
     var result = zip(s, other)
     expectType(
-      Zip2Sequence<MinimalSequence<OpaqueValue<Int>>, MinimalSequence<OpaqueValue<Int32>>>.self,
+      Zip2<MinimalSequence<OpaqueValue<Int>>, MinimalSequence<OpaqueValue<Int32>>>.self,
       &result)
 
     // Check for expected result and check the Zip2Sequence's Sequence
@@ -69,9 +69,7 @@ ZipTests.test("Sequence") {
 
 ZipTests.test("Collections") {
   typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
-  typealias SequenceType = Zip2Sequence<
-    MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int32>>>
-  typealias CollectionType = Zip2Collection<
+  typealias CollectionType = Zip2<
     MinimalCollection<OpaqueValue<Int>>,MinimalCollection<OpaqueValue<Int32>>>
 
   func compareElements(_ lhs: Element, rhs: Element) -> Bool {
@@ -80,8 +78,8 @@ ZipTests.test("Collections") {
 
   expectCollectionAssociatedTypes(
     collectionType: CollectionType.self,
-    iteratorType: SequenceType.Iterator.self,
-    subSequenceType: Slice<CollectionType>.self,
+    iteratorType: CollectionType.Iterator.self,
+    subSequenceType: CollectionType.SubSequence.self,
     indexType: CollectionType.Index.self,
     indicesType: DefaultIndices<CollectionType>.self)
     
@@ -102,10 +100,7 @@ ZipTests.test("Collections") {
 
 ZipTests.test("RandomAccessCollections") {
   typealias Element = (OpaqueValue<Int>, OpaqueValue<Int32>)
-  typealias SequenceType = Zip2Sequence<
-    MinimalRandomAccessCollection<OpaqueValue<Int>>,
-    MinimalRandomAccessCollection<OpaqueValue<Int32>>>
-  typealias CollectionType = Zip2Collection<
+  typealias CollectionType = Zip2<
     MinimalRandomAccessCollection<OpaqueValue<Int>>,
     MinimalRandomAccessCollection<OpaqueValue<Int32>>>
 
@@ -115,8 +110,8 @@ ZipTests.test("RandomAccessCollections") {
       
   expectCollectionAssociatedTypes(
     collectionType: CollectionType.self,
-    iteratorType: SequenceType.Iterator.self,
-    subSequenceType: Slice<CollectionType>.self,
+    iteratorType: CollectionType.Iterator.self,
+    subSequenceType: CollectionType.SubSequence.self,
     indexType: CollectionType.Index.self,
     indicesType: DefaultIndices<CollectionType>.self)
 
@@ -184,7 +179,7 @@ ZipTests.test("Sequence+Collection") {
       elements: test.other.map(OpaqueValue.init))
     var result = zip(s, other)
     expectType(
-      Zip2Sequence<
+      Zip2<
         MinimalSequence<OpaqueValue<Int>>, 
         MinimalCollection<OpaqueValue<Int32>>>.self,
       &result)


### PR DESCRIPTION
Here is an experimental revision to #13941 that collapses the sequence and collection versions into one type.

It can do this by using `Zip2<Left.SubSequence,Right.SubSequence>` as its `SubSequence`. This lets us have one type up and down the full hierarchy.

BUT it has a problem: `Sequence.drop(while:)` takes a predicate that has two arguments, of both the left and right element. 

There's an implementation [here](https://github.com/apple/swift/pull/14006/files#diff-2b5326314c619bc91cbef0c218c05de2R151) that works around this by doing multi-pass on the right sequence. 

EDIT: my original solution was completely wrong, since you need to consider both elements...  🤦🏻‍♂️ 
Correct (but still multi-pass) version there now.

Any better options welcomed!