### PR TITLE
[Verifier] Check that AST type matches the SIL type before lowered stage

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1629,8 +1629,10 @@ public:
               "EnumInst operand must be an object");
       SILType caseTy = UI->getType().getEnumElementType(UI->getElement(),
                                                         F.getModule());
-      require(caseTy == UI->getOperand()->getType(),
-              "EnumInst operand type does not match type of case");
+      if (UI->getModule().getStage() != SILStage::Lowered) {
+        require(caseTy == UI->getOperand()->getType(),
+                "EnumInst operand type does not match type of case");
+      }
     }
   }
 

--- a/test/IRGen/Mirror-LoadableByAddress-failure.swift
+++ b/test/IRGen/Mirror-LoadableByAddress-failure.swift
@@ -1,0 +1,23 @@
+// Check that we don't crash when we verify after every pass.
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend %s -I %S/../stdlib/Inputs/Mirror/ -o %t/Mirror \
+// RUN: -emit-ir -sil-verify-all -o /dev/null
+
+class A : CustomReflectable {
+  var a: Int = 1
+  var customMirror: Mirror {
+    return Mirror(self, children: ["aye": a])
+  }
+}
+class X : A {}
+class Y : X {}
+class B : Y {
+  var b: UInt = 42
+  override var customMirror: Mirror {
+    return Mirror(
+      self,
+      children: ["bee": b],
+      ancestorRepresentation: .customized({ super.customMirror }))
+  }
+}


### PR DESCRIPTION
Just like we do for other instructions (checkTupleExtractInst for example).
This fixes a verifier with -sil-verify-all.

<rdar://problem/36559617>
