### PR TITLE
Date should be `Strideable`

### DIFF
--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -204,7 +204,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
 
 extension Date : Strideable {
  /// A type that represents the distance between two values of `Self`.
-  typealias Stride = TimeInterval
+  public typealias Stride = TimeInterval
 
   /// Returns a stride `x` such that `self.advanced(by: x)` approximates
   /// `other`.
@@ -213,7 +213,7 @@ extension Date : Strideable {
   ///
   /// - Complexity: O(1).
   /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
-  func distance(to other: Self) -> Stride {
+  public func distance(to other: Date) -> Stride {
   	return other.timeIntervalSinceReferenceDate - self.timeIntervalSinceReferenceDate
   }
 
@@ -223,7 +223,7 @@ extension Date : Strideable {
   ///
   /// - Complexity: O(1).
   /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
-  func advanced(by n: Stride) -> Self {
+  public func advanced(by timeInterval: Stride) -> Date {
   	return self + timeInterval
   }
 }

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -202,6 +202,32 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
 
 }
 
+extension Date : Strideable {
+ /// A type that represents the distance between two values of `Self`.
+  typealias Stride = TimeInterval
+
+  /// Returns a stride `x` such that `self.advanced(by: x)` approximates
+  /// `other`.
+  ///
+  /// If `Stride` conforms to `Integer`, then `self.advanced(by: x) == other`.
+  ///
+  /// - Complexity: O(1).
+  /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+  func distance(to other: Self) -> Stride {
+  	return other.timeIntervalSinceReferenceDate - self.timeIntervalSinceReferenceDate
+  }
+
+  /// Returns a `Self` `x` such that `self.distance(to: x)` approximates `n`.
+  ///
+  /// If `Stride` conforms to `Integer`, then `self.distance(to: x) == n`.
+  ///
+  /// - Complexity: O(1).
+  /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+  func advanced(by n: Stride) -> Self {
+  	return self + timeInterval
+  }
+}
+
 extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
     /**
      A string representation of the date object (read-only).

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -16,18 +16,18 @@ import _SwiftCoreFoundationOverlayShims
 
 /**
  `Date` represents a single point in time.
- 
+
  A `Date` is independent of a particular calendar or time zone. To represent a `Date` to a user, you must interpret it in the context of a `Calendar`.
 */
 public struct Date : ReferenceConvertible, Comparable, Equatable {
     public typealias ReferenceType = NSDate
-    
+
     fileprivate var _time : TimeInterval
 
     /// The number of seconds from 1 January 1970 to the reference date, 1 January 2001.
     public static let timeIntervalBetween1970AndReferenceDate : TimeInterval = 978307200.0
-  
-    /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time. 
+
+    /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time.
     public static var timeIntervalSinceReferenceDate : TimeInterval {
         return CFAbsoluteTimeGetCurrent()
     }
@@ -36,20 +36,20 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public init() {
         _time = CFAbsoluteTimeGetCurrent()
     }
-    
+
     /// Returns a `Date` initialized relative to the current date and time by a given number of seconds.
     public init(timeIntervalSinceNow: TimeInterval) {
         self.init(timeIntervalSinceReferenceDate: timeIntervalSinceNow + CFAbsoluteTimeGetCurrent())
     }
-    
+
     /// Returns a `Date` initialized relative to 00:00:00 UTC on 1 January 1970 by a given number of seconds.
     public init(timeIntervalSince1970: TimeInterval) {
         self.init(timeIntervalSinceReferenceDate: timeIntervalSince1970 - Date.timeIntervalBetween1970AndReferenceDate)
     }
-    
+
     /**
     Returns a `Date` initialized relative to another given date by a given number of seconds.
-    
+
     - Parameter timeInterval: The number of seconds to add to `date`. A negative value means the receiver will be earlier than `date`.
     - Parameter date: The reference date.
     */
@@ -61,10 +61,10 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public init(timeIntervalSinceReferenceDate ti: TimeInterval) {
         _time = ti
     }
-        
+
     /**
     Returns the interval between the date object and 00:00:00 UTC on 1 January 2001.
-    
+
     This property's value is negative if the date object is earlier than the system's absolute reference date (00:00:00 UTC on 1 January 2001).
     */
     public var timeIntervalSinceReferenceDate: TimeInterval {
@@ -85,7 +85,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public func timeIntervalSince(_ date: Date) -> TimeInterval {
         return self.timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate
     }
-    
+
     /**
     The time interval between the date and the current date and time.
 
@@ -98,7 +98,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public var timeIntervalSinceNow: TimeInterval {
         return self.timeIntervalSinceReferenceDate - CFAbsoluteTimeGetCurrent()
     }
-    
+
     /**
     The interval between the date object and 00:00:00 UTC on 1 January 1970.
 
@@ -111,7 +111,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public var timeIntervalSince1970: TimeInterval {
         return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
     }
-    
+
     /// Return a new `Date` by adding a `TimeInterval` to this `Date`.
     ///
     /// - parameter timeInterval: The value to add, in seconds.
@@ -119,7 +119,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public func addingTimeInterval(_ timeInterval: TimeInterval) -> Date {
         return self + timeInterval
     }
-    
+
     /// Add a `TimeInterval` to this `Date`.
     ///
     /// - parameter timeInterval: The value to add, in seconds.
@@ -127,21 +127,21 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public mutating func addTimeInterval(_ timeInterval: TimeInterval) {
         self += timeInterval
     }
-    
+
     /**
     Creates and returns a Date value representing a date in the distant future.
-    
+
     The distant future is in terms of centuries.
     */
     public static let distantFuture = Date(timeIntervalSinceReferenceDate: 63113904000.0)
-    
+
     /**
     Creates and returns a Date value representing a date in the distant past.
-    
+
     The distant past is in terms of centuries.
     */
     public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
-    
+
     public var hashValue: Int {
         if #available(OSX 10.12, iOS 10.0, *) {
             return Int(bitPattern: __CFHashDouble(_time))
@@ -149,7 +149,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
             return NSDate(timeIntervalSinceReferenceDate: _time).hash
         }
     }
-    
+
     /// Compare two `Date` values.
     public func compare(_ other: Date) -> ComparisonResult {
         if _time < other.timeIntervalSinceReferenceDate {
@@ -160,7 +160,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
             return .orderedSame
         }
     }
-    
+
     /// Returns true if the two `Date` values represent the same point in time.
     public static func ==(lhs: Date, rhs: Date) -> Bool {
         return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
@@ -231,9 +231,9 @@ extension Date : Strideable {
 extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
     /**
      A string representation of the date object (read-only).
-     
+
      The representation is useful for debugging only.
-     
+
      There are a number of options to acquire a formatted string for a date including: date formatters (see
      [NSDateFormatter](//apple_ref/occ/cl/NSDateFormatter) and [Data Formatting Guide](//apple_ref/doc/uid/10000029i)), and the `Date` function `description(locale:)`.
      */
@@ -241,19 +241,19 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
         // Defer to NSDate for description
         return NSDate(timeIntervalSinceReferenceDate: _time).description
     }
-    
+
     /**
      Returns a string representation of the receiver using the given
      locale.
-     
+
      - Parameter locale: A `Locale`. If you pass `nil`, `Date` formats the date in the same way as the `description` property.
-     
+
      - Returns: A string representation of the `Date`, using the given locale, or if the locale argument is `nil`, in the international format `YYYY-MM-DD HH:MM:SS ±HHMM`, where `±HHMM` represents the time zone offset in hours and minutes from UTC (for example, "`2001-03-24 10:45:32 +0600`").
      */
     public func description(with locale: Locale?) -> String {
         return NSDate(timeIntervalSinceReferenceDate: _time).description(with: locale)
     }
-    
+
     public var debugDescription: String {
         return description
     }
@@ -271,13 +271,13 @@ extension Date : _ObjectiveCBridgeable {
     public func _bridgeToObjectiveC() -> NSDate {
         return NSDate(timeIntervalSinceReferenceDate: _time)
     }
-    
+
     public static func _forceBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) {
         if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
             fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
         }
     }
-    
+
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) -> Bool {
         result = Date(timeIntervalSinceReferenceDate: x.timeIntervalSinceReferenceDate)
         return true
@@ -305,7 +305,7 @@ extension Date : CustomPlaygroundQuickLookable {
         df.timeStyle = .short
         return df.string(from: self)
     }
-    
+
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
         return .text(summary)
     }

--- a/test/stdlib/TestDate.swift
+++ b/test/stdlib/TestDate.swift
@@ -26,27 +26,27 @@ class TestDate : TestDateSuper {
     func testDateComparison() {
         let d1 = Date()
         let d2 = d1 + 1
-        
+
         expectTrue(d2 > d1)
         expectTrue(d1 < d2)
-        
+
         let d3 = Date(timeIntervalSince1970: 12345)
         let d4 = Date(timeIntervalSince1970: 12345)
-        
+
         expectTrue(d3 == d4)
         expectTrue(d3 <= d4)
         expectTrue(d4 >= d3)
     }
-    
+
     func testDateMutation() {
         let d0 = Date()
         var d1 = Date()
         d1 = d1 + 1
         let d2 = Date(timeIntervalSinceNow: 10)
-        
+
         expectTrue(d2 > d1)
         expectTrue(d1 != d0)
-        
+
         let d3 = d1
         d1 += 10
         expectTrue(d1 > d3)
@@ -117,15 +117,15 @@ class TestDate : TestDateSuper {
         let sameSeconds = sameDate.timeIntervalSince(referenceDate)
         expectEqual(sameSeconds, 0.0)
     }
-    
+
     func testDateComponents() {
         // Make sure the optional init stuff works
         let dc = DateComponents()
-        
+
         expectNil(dc.year)
-        
+
         let dc2 = DateComponents(year: 1999)
-        
+
         expectNil(dc2.day)
         expectEqual(1999, dc2.year)
     }

--- a/test/stdlib/TestDate.swift
+++ b/test/stdlib/TestDate.swift
@@ -52,6 +52,17 @@ class TestDate : TestDateSuper {
         expectTrue(d1 > d3)
     }
 
+    func testDateMath() {
+        for i in -2...10 {
+            for j in 0...5 {
+            	//Strideable conformance
+            	let Date_i = Date(timeIntervalSinceReferenceDate: TimeInterval(i))
+            	let Date_j = Date(timeIntervalSinceReferenceDate: TimeInterval(j))
+            	expectEqual(Date_i.advanced(by: Date_i.distance(to: Date_j)), Date_j, "Date(i).advanced(by: Date(i).distance(to: Date(j)) == Date(j)")
+            }
+        }
+    }
+
     func testCast() {
         let d0 = NSDate()
         let d1 = d0 as Date
@@ -200,6 +211,7 @@ class TestDate : TestDateSuper {
 var DateTests = TestSuite("TestDate")
 DateTests.test("testDateComparison") { TestDate().testDateComparison() }
 DateTests.test("testDateMutation") { TestDate().testDateMutation() }
+DateTests.test("testDateMath") { TestDate().testDateMath() }
 DateTests.test("testCast") { TestDate().testCast() }
 DateTests.test("testDistantPast") { TestDate().testDistantPast() }
 DateTests.test("testDistantFuture") { TestDate().testDistantFuture() }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add conformance of `Date` to `Strideable`
Add a Test verifying Date obeys `Strideable` axioms
Strip end of line whitespace

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6786](https://bugs.swift.org/browse/SR-6786).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->