### PR TITLE
Fix a comment typo in DerivedConformances

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -63,7 +63,7 @@ bool DerivedConformance::derivesProtocolConformance(TypeChecker &tc,
         }
 
         // hasOnlyCasesWithoutAssociatedValues will return true for empty enums;
-        // empty enumas are allowed to conform as well.
+        // empty enums are allowed to conform as well.
         return enumDecl->hasOnlyCasesWithoutAssociatedValues();
       }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
While reading through #9004 I noticed that there was a comment typo, so I figured I'd submit a small request to fix it.
