### PR TITLE
build-script: Pass ASan options to the lldb xcodebuild invocation

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1833,6 +1833,13 @@ function set_lldb_xcodebuild_options() {
             DEBUGSERVER_USE_FROM_SYSTEM="1"
         )
     fi
+    if [[ "${ENABLE_ASAN}" ]] ; then
+	lldb_xcodebuild_options=(
+	    "${lldb_xcodebuild_options[@]}"
+	    ENABLE_ADDRESS_SANITIZER="YES"
+	    -enableAddressSanitizer=YES
+	)
+    fi
 }
 
 #


### PR DESCRIPTION
Now, `./build-script --enable-asan` will do the right thing if you have
lldb checked out.

This is already finding serious issues and will help resolve bugs like https://bugs.swift.org/browse/SR-6791 and https://bugs.swift.org/browse/SR-6775.

