### PR TITLE
AST: Don't find non-objc members with dynamic lookup

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -291,6 +291,10 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
       if (D->getOverriddenDecl())
         return;
 
+      // If the declaration is not @objc, it cannot be called dynamically.
+      if (!D->isObjC())
+        return;
+
       // Ensure that the declaration has a type.
       if (!D->hasInterfaceType()) {
         if (!TypeResolver) return;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1835,6 +1835,10 @@ bool DeclContext::lookupQualified(Type type,
       if (decl->getOverriddenDecl())
         continue;
 
+      // If the declaration is not @objc, it cannot be called dynamically.
+      if (!decl->isObjC())
+        continue;
+
       auto dc = decl->getDeclContext();
       auto nominal = dyn_cast<NominalTypeDecl>(dc);
       if (!nominal) {

--- a/test/ClangImporter/import-as-member-objc.swift
+++ b/test/ClangImporter/import-as-member-objc.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/../IDE/Inputs/custom-modules %s -verify
+// REQUIRES: objc_interop
+
+import ImportAsMember.Class
+
+func doIt(s: SomeClass) {
+  s.doIt()
+}
+
+// Make sure we can't find doIt() via dynamic lookup.
+func doItDynamic(s: AnyObject) {
+  s.doIt() // expected-error {{value of type 'AnyObject' has no member 'doIt'}}
+}

--- a/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
+++ b/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
@@ -19,6 +19,9 @@ __attribute__((swift_name("SomeClass.applyOptions(self:_:)")))
 void IAMSomeClassApplyOptions(IAMSomeClass * _Nonnull someClass, 
                               IAMSomeClassOptions options);
 
+__attribute__((swift_name("SomeClass.doIt(self:)")))
+void IAMSomeClassDoIt(IAMSomeClass * _Nonnull someClass);
+
 @interface UnavailableDefaultInit : NSObject
 -(instancetype)init __attribute__((availability(swift,unavailable)));
 @end

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -8,6 +8,7 @@
 // PRINT-CLASS-NEXT: extension SomeClass {
 // PRINT-CLASS-NEXT:   /*not inherited*/ init(value x: Double)
 // PRINT-CLASS-NEXT:   func applyOptions(_ options: SomeClass.Options)
+// PRINT-CLASS-NEXT:   func doIt()
 // PRINT-CLASS-NEXT:   struct Options : OptionSet {
 // PRINT-CLASS-NEXT:     init(rawValue rawValue: Int)
 // PRINT-CLASS-NEXT:     let rawValue: Int


### PR DESCRIPTION
This can come up when we use import-as-member to turn top-level functions
into methods in an @objc class. Previously dynamic lookup would find
these, causing a SILGen crash.

Fixes <rdar://problem/36492980>.