### PR TITLE
[Runtime] Implement overflow check for weak refcounts

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -128,6 +128,10 @@ void swift_abortRetainUnowned(const void *object);
 LLVM_ATTRIBUTE_NORETURN LLVM_ATTRIBUTE_NOINLINE
 void swift_abortUnownedRetainOverflow();
 
+// Halt due to an overflow in incrementWeak().
+LLVM_ATTRIBUTE_NORETURN LLVM_ATTRIBUTE_NOINLINE
+void swift_abortWeakRetainOverflow();
+
 /// This function dumps one line of a stack trace. It is assumed that \p framePC
 /// is the address of the stack frame at index \p index. If \p shortOutput is
 /// true, this functions prints only the name of the symbol and offset, ignores

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1231,7 +1231,9 @@ class RefCounts {
       newbits = oldbits;
       assert(newbits.getWeakRefCount() != 0);
       newbits.incrementWeakRefCount();
-      // FIXME: overflow check
+      
+      if (newbits.getWeakRefCount() < oldbits.getWeakRefCount())
+        swift_abortWeakRetainOverflow();
     } while (!refCounts.compare_exchange_weak(oldbits, newbits,
                                               std::memory_order_relaxed));
   }

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -383,6 +383,13 @@ void swift::swift_abortUnownedRetainOverflow() {
                     "Fatal error: Object's unowned reference was retained too many times");
 }
 
+// Crash due to a weak retain count overflow.
+// FIXME: can't pass the object's address from InlineRefCounts without hacks
+void swift::swift_abortWeakRetainOverflow() {
+  swift::fatalError(FatalErrorFlags::ReportBacktrace,
+                    "Fatal error: Object's weak reference was retained too many times");
+}
+
 // Crash due to retain of a dead unowned reference.
 // FIXME: can't pass the object's address from InlineRefCounts without hacks
 void swift::swift_abortRetainUnowned(const void *object) {

--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -335,7 +335,7 @@ TEST(LongRefcountingTest, nonatomic_unowned_retain_overflow_DeathTest) {
 /////////////////////////////////////////////////
 
 static HeapObjectSideTableEntry *weakRetainALot(TestObject *object, uint64_t count) {
-  if (count == 0) return nil;
+  if (count == 0) return nullptr;
   
   auto side = object->refCounts.formWeakReference();
   for (uint64_t i = 1; i < count; i++) {


### PR DESCRIPTION
This adds an overflow check for weak refcounts, similar to what we do for unowned refcounts. It also fixes the implementation of `RefCounts::getWeakCount`, which always returned either `0` or `1` regardless of the true count.

rdar://problem/34048165