### PR TITLE
WIP SR-1715: require superclass to have a designated initializer

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2002,6 +2002,9 @@ ERROR(inheritance_from_cf_class,none,
 ERROR(inheritance_from_objc_runtime_visible_class,none,
       "cannot inherit from class %0 because it is only visible via the "
       "Objective-C runtime", (Identifier))
+ERROR(inheritance_from_class_with_no_designated_initializers,none,
+	  "cannot inherit from class %0 because it has no designated initializers",
+	  (Identifier))
 WARNING(class_inherits_anyobject,none,
         "conformance of class %0 to 'AnyObject' is redundant", (Type))
 

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -11,6 +11,7 @@ void normallyChangedOriginal(void) __attribute__((swift_name("normallyChanged()"
 
 __attribute__((objc_root_class))
 @interface A
+- (instancetype)init;
 @end
 
 __attribute__((objc_root_class))

--- a/test/ClangImporter/MixedSource/Inputs/mixed-target/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-target/Mixed.framework/Headers/Mixed.h
@@ -4,6 +4,7 @@
 void doSomething(ForwardClass *arg);
 
 @interface Base
+- (instancetype)init;
 - (NSObject *)safeOverride:(ForwardClass *)arg;
 - (NSObject *)unsafeOverrideParam:(NSObject *)arg;
 - (ForwardClass *)unsafeOverrideReturn:(ForwardClass *)arg;

--- a/test/ClangImporter/MixedSource/Inputs/mixed-target/header.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-target/header.h
@@ -13,6 +13,7 @@ void doSomething(ForwardClass *arg);
 void doSomethingProto(id <ForwardProto> arg);
 
 @interface Base
+- (instancetype)init;
 - (NSObject *)safeOverride:(ForwardClass *)arg;
 - (NSObject *)unsafeOverrideParam:(NSObject *)arg;
 - (ForwardClass *)unsafeOverrideReturn:(ForwardClass *)arg;

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -870,6 +870,7 @@ typedef struct NonNilableReferences {
 @end
 
 @interface NSClassWithMethodFromNSProtocolWithOptionalRequirement
+- (instancetype)init;
 -(void)optionalRequirement  __attribute__((availability(macosx, introduced=10.51)));
 @end
 

--- a/test/Inputs/clang-importer-sdk/usr/include/Properties.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Properties.h
@@ -1,6 +1,7 @@
 @import Foundation;
 
 @interface HasProperties
+- (instancetype)init;
 @property (getter=isEnabled,setter=setIsEnabled:) BOOL enabled __attribute__((swift_name("enabled")));
 
 - (BOOL)isEnabled;

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -22,6 +22,7 @@ enum BarForwardDeclaredEnum {
 };
 
 @interface PropertyUserInterface
+- (instancetype) init;
 - (int) field;
 - (int * _Nullable) field2;
 - (void) setField:(int)info;

--- a/test/SILGen/Inputs/usr/include/CoreCooling.h
+++ b/test/SILGen/Inputs/usr/include/CoreCooling.h
@@ -32,6 +32,7 @@ CCRefrigeratorRef CCRefrigeratorClone(CCRefrigeratorRef fridge);
 void CCRefrigeratorDestroy(__attribute__((cf_consumed)) CCRefrigeratorRef);
 
 @interface CCMagnetismModel
+- (instancetype)init; // TODO: does this make sense here?
 // Unattributed method: unmanaged result
 - (CCRefrigeratorRef) refrigerator;
 // Attribute: managed +0 result

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -39,7 +39,7 @@ func testSubclassInitializers() {
   _ = DesignatedInitDisappearsSub(value: 0) // expected-error {{argument passed to call that takes no arguments}}
   _ = DesignatedInitDisappearsSub(convenience: 0) // expected-error {{argument passed to call that takes no arguments}}
 
-  class OnlyDesignatedInitDisappearsSub : D2_OnlyDesignatedInitDisappears {}
+  class OnlyDesignatedInitDisappearsSub : D2_OnlyDesignatedInitDisappears {} // expected-error{{cannot inherit from class 'D2_OnlyDesignatedInitDisappears' because it has no designated initializers}}
   _ = OnlyDesignatedInitDisappearsSub(value: 0) // expected-error {{cannot be constructed because it has no accessible initializers}}
   _ = OnlyDesignatedInitDisappearsSub(convenience: 0) // expected-error {{cannot be constructed because it has no accessible initializers}}
 

--- a/test/api-digester/Inputs/APINotesLeft/APINotesTest.h
+++ b/test/api-digester/Inputs/APINotesLeft/APINotesTest.h
@@ -1,8 +1,10 @@
 extern int ANTGlobalValue;
 
 @interface NewType
+- (instancetype)init;
 @end
 @interface OldType
+- (instancetype)init;
 @end
 
 @protocol TypeWithMethod

--- a/test/api-digester/Inputs/APINotesRight/APINotesTest.h
+++ b/test/api-digester/Inputs/APINotesRight/APINotesTest.h
@@ -1,6 +1,7 @@
 extern int ANTGlobalValue;
 
 @interface NewType
+- (instancetype)init;
 @end
 @interface OldType
 @end

--- a/test/attr/Inputs/custom-modules/attr_objc_foo_clang_module.h
+++ b/test/attr/Inputs/custom-modules/attr_objc_foo_clang_module.h
@@ -1,4 +1,5 @@
 @interface NSObject
+- (instancetype)init;
 @end
 
 enum FooEnum1 { FooEnum1X };

--- a/test/attr/attr_requires_stored_property_inits.swift
+++ b/test/attr/attr_requires_stored_property_inits.swift
@@ -57,3 +57,9 @@ class NSSomething : NSObject {
   // expected-error@-2 {{class 'NSSomething' has no initializers}}
   var x: Int // expected-error{{stored property 'x' requires an initial value or should be @NSManaged}}
 }
+
+class NotInitializable : NSProxy { // expected-error{{cannot inherit from class 'NSProxy' because it has no designated initializers}}
+}
+
+class StillNotInitializable : NotInitializable { // expected-error{{cannot inherit from class 'NotInitializable' because it has no designated initializers}}
+}

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -66,7 +66,7 @@ typealias typealias_redecl2 = UInt // expected-error {{invalid redeclaration}}
 
 var mixed_redecl1: Int // expected-note {{previously declared here}}
 class mixed_redecl1 {} // expected-error {{invalid redeclaration}}
-class mixed_redecl1a : mixed_redecl1 {}
+class mixed_redecl1a : mixed_redecl1 {} // expected-error{{cannot inherit from class 'mixed_redecl1' because it has no designated initializers}} //TODO: should this be ambiguous, or some other warning? Or is this the right error?
 
 class mixed_redecl2 {} // expected-note {{previously declared here}}
 struct mixed_redecl2 {} // expected-error {{invalid redeclaration}}
@@ -97,7 +97,7 @@ func mixed_redecl7() {} // expected-error {{invalid redeclaration of 'mixed_rede
 
 func mixed_redecl8() {} // expected-note {{previously declared here}}
 class mixed_redecl8 {} // expected-error {{invalid redeclaration}}
-class mixed_redecl8a : mixed_redecl8 {}
+class mixed_redecl8a : mixed_redecl8 {} // expected-error{{cannot inherit from class 'mixed_redecl8' because it has no designated initializers}} //TODO: should this be ambiguous, or some other warning? Or is this the right error?
 
 class mixed_redecl9 {} // expected-note {{previously declared here}}
 func mixed_redecl9() {} // expected-error {{invalid redeclaration}}


### PR DESCRIPTION

# Description 
After checking the superclass in other ways, this PR verifies that the superclass has at least one designated initializer. Classes like NSProxy do not have a designated init, and thus are not sub-classable / instantiatable from Swift. The current error is lacking, and this PR provides a more targeted error.

# Bug Link
Resolves [SR-1715](https://bugs.swift.org/browse/SR-1715).

# Questions before running CI
Before CI is run, I'd like any PR feedback. Specifically:
- [ ] The tests seem clearly in the wrong place to me. Something like "super_constructor.swift" seems like a better place, but is not importing Foundation. I could add it, or I could add a new test file. Not sure I should. Will look for more init tests that my tests might better fit.
- [ ] while fixing tests, an apparently unrelated test started failing. It has to do with checking sil instructions. I may have changed the `A` class in the test version of Foundation (by adding an init), and that may have changed some assumptions. I am not sure where to even start figuring this out. It does appear to be Swift 2 syntax still in the test, so I could at least clean that up (duplicate labels and similar).
- [ ] A number of tests needed updates as they failed this new check. I added inits to some non-Swift objects, and expected errors in some other places. Currently not sure how to handle the circular dependency test failure though. They clearly should show the user the circular errors, not the less-specific (and un-useful) designated-init error. I was unable to fix one of the circularity errors. I'd love to know that a type was part of a cycle, in which case this new check could be skipped entirely. Maybe more of the super checks should be skipped in that case? As a worst-case, might it be acceptable to document the failing test to also expect this new error? My take: we should avoid that if at all feasible.
- Style: the bools in this file are mixed on whether they start upper or lower case. I tried to match the style my code was closest to, so my bools are camelCase. Should they be TitleCase instead?
- I also looked at adding a related test in "accessibility.swift" (code below). But after some thought, I think that is more in the court of [SR-2484](https://bugs.swift.org/browse/SR-2484) and should probably be a separate PR at a minimum. Let me know if you think this should be covered under this PR instead. Here is that test code:
```swift
// SR-1715: no available designated initializers
class Base {
	private init() {}
}

class SubClass: Base { // expected-error {{'cannot inherit from class 'Base' because it has no designated initializers'}}
}
```
- as a separate commit, I'm also considering refactoring the entire visit function this lives inside. Probably not necessary or desired, but if I'm wrong, let me know. (Things like de-nesting from the ifs with inverse statements, extracting some of the large work chunks to separate functions.)