### PR TITLE
[stdlib] Set, Dictionary: Take the max load factor into account in `.init(minimumCapacity:)`

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -477,9 +477,12 @@ extension Set {
   ///   buffer.
   @_inlineable // FIXME(sil-serialize-all)
   public init(minimumCapacity: Int) {
+    let reservedCapacity = _NativeBuffer.minimumCapacity(
+      minimumCount: minimumCapacity,
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
     _variantBuffer =
       _VariantBuffer.native(
-        _NativeBuffer(minimumCapacity: minimumCapacity))
+        _NativeBuffer(minimumCapacity: reservedCapacity))
   }
 
   /// Private initializer.
@@ -1751,8 +1754,11 @@ public struct Dictionary<Key : Hashable, Value> {
   ///   allocate buffer for in the new dictionary.
   @_inlineable // FIXME(sil-serialize-all)
   public init(minimumCapacity: Int) {
+    let reservedCapacity = _NativeBuffer.minimumCapacity(
+      minimumCount: minimumCapacity,
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
     _variantBuffer =
-      .native(_NativeBuffer(minimumCapacity: minimumCapacity))
+      .native(_NativeBuffer(minimumCapacity: reservedCapacity))
   }
 
   /// Creates a new dictionary from the key-value pairs in the given sequence.
@@ -4027,7 +4033,7 @@ extension _Native${Self}Buffer
     maxLoadFactorInverse: Double
   ) -> Int {
     // `minimumCount + 1` below ensures that we don't fill in the last hole
-    return max(Int(Double(minimumCount) * maxLoadFactorInverse),
+    return max(Int((Double(minimumCount) * maxLoadFactorInverse).rounded(.up)),
                minimumCount + 1)
   }
 
@@ -6404,11 +6410,7 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
 
   @_inlineable // FIXME(sil-serialize-all)
   public init(count: Int) {
-    let requiredCapacity =
-      _Native${Self}Buffer<${TypeParameters}>.minimumCapacity(
-        minimumCount: count,
-        maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    _result = ${Self}<${TypeParameters}>(minimumCapacity: requiredCapacity)
+    _result = ${Self}<${TypeParameters}>(minimumCapacity: count)
     _nativeBuffer = _result._variantBuffer.asNative
     _requestedCount = count
     _actualCount = 0
@@ -6507,6 +6509,7 @@ extension ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func reserveCapacity(_ minimumCapacity: Int) {
     _variantBuffer.reserveCapacity(minimumCapacity)
+    _sanityCheck(self.capacity >= minimumCapacity)
   }
 }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -46,7 +46,7 @@ import SwiftShims
 //      |
 //      V  _RawNativeDictionaryStorage (a class)  
 //   +-----------------------------------------------------------+
-//   | capacity                                                  |
+//   | bucketCount                                               |
 //   | count                                                     |
 //   | ptrToBits                                                 |
 //   | ptrToKeys                                                 |
@@ -477,12 +477,9 @@ extension Set {
   ///   buffer.
   @_inlineable // FIXME(sil-serialize-all)
   public init(minimumCapacity: Int) {
-    let reservedCapacity = _NativeBuffer.minimumCapacity(
-      minimumCount: minimumCapacity,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
     _variantBuffer =
       _VariantBuffer.native(
-        _NativeBuffer(minimumCapacity: reservedCapacity))
+        _NativeBuffer(minimumCapacity: minimumCapacity))
   }
 
   /// Private initializer.
@@ -1754,11 +1751,7 @@ public struct Dictionary<Key : Hashable, Value> {
   ///   allocate buffer for in the new dictionary.
   @_inlineable // FIXME(sil-serialize-all)
   public init(minimumCapacity: Int) {
-    let reservedCapacity = _NativeBuffer.minimumCapacity(
-      minimumCount: minimumCapacity,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    _variantBuffer =
-      .native(_NativeBuffer(minimumCapacity: reservedCapacity))
+    _variantBuffer = .native(_NativeBuffer(minimumCapacity: minimumCapacity))
   }
 
   /// Creates a new dictionary from the key-value pairs in the given sequence.
@@ -3156,7 +3149,7 @@ internal class _RawNative${Self}Storage:
 
   @_versioned // FIXME(sil-serialize-all)
   @nonobjc
-  internal final var capacity: Int
+  internal final var bucketCount: Int
 
   @_versioned // FIXME(sil-serialize-all)
   internal final var count: Int
@@ -3324,7 +3317,7 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
 %end
 
     if !_isPOD(Key.self) {
-      for i in 0 ..< capacity {
+      for i in 0 ..< bucketCount {
         if initializedEntries[i] {
           (keys+i).deinitialize(count: 1)
         }
@@ -3333,7 +3326,7 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
 
 %if Self == 'Dictionary':
     if !_isPOD(Value.self) {
-      for i in 0 ..< capacity {
+      for i in 0 ..< bucketCount {
         if initializedEntries[i] {
           (values+i).deinitialize(count: 1)
         }
@@ -3580,51 +3573,51 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   internal var _storage: RawStorage
 
   /// Creates a Buffer with a storage that is typed, but doesn't understand
-  /// Hashing. Mostly for bridging; prefer `init(capacity:)`.
+  /// Hashing. Mostly for bridging; prefer `init(minimumCapacity:)`.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal init(capacity: Int, unhashable: ()) {
-    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
+  internal init(_exactBucketCount bucketCount: Int, unhashable: ()) {
+    let bitmapWordCount = _UnsafeBitMap.sizeInWords(forSizeInBits: bucketCount)
 %if Self == 'Dictionary':
     let storage = Builtin.allocWithTailElems_3(TypedStorage.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self,
-        capacity._builtinWordValue, Value.self)
+        bitmapWordCount._builtinWordValue, UInt.self,
+        bucketCount._builtinWordValue, Key.self,
+        bucketCount._builtinWordValue, Value.self)
 %else:
     let storage = Builtin.allocWithTailElems_2(TypedStorage.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self)
+        bitmapWordCount._builtinWordValue, UInt.self,
+        bucketCount._builtinWordValue, Key.self)
 %end
-    self.init(capacity: capacity, storage: storage)
+    self.init(_exactBucketCount: bucketCount, storage: storage)
   }
 
-  /// Given a capacity and uninitialized RawStorage, completes the 
-  /// initialization and returns a Buffer.  
+  /// Given a bucket count and uninitialized RawStorage, completes the
+  /// initialization and returns a Buffer.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal init(capacity: Int, storage: RawStorage) {
-    storage.capacity = capacity
+  internal init(_exactBucketCount bucketCount: Int, storage: RawStorage) {
+    storage.bucketCount = bucketCount
     storage.count = 0
-    
+
     self.init(_storage: storage)
 
     let initializedEntries = _UnsafeBitMap(
         storage: _initializedHashtableEntriesBitMapBuffer,
-        bitCount: capacity)
+        bitCount: bucketCount)
     initializedEntries.initializeToZero()
 
     // Compute all the array offsets now, so we don't have to later
     let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
-    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
+    let bitmapWordCount = _UnsafeBitMap.sizeInWords(forSizeInBits: bucketCount)
     let keysAddr = Builtin.getTailAddr_Word(bitmapAddr,
-           numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
+           bitmapWordCount._builtinWordValue, UInt.self, Key.self)
 
     // Initialize header
     _storage.initializedEntries = initializedEntries
     _storage.keys = UnsafeMutableRawPointer(keysAddr)
 %if Self == 'Dictionary':
     let valuesAddr = Builtin.getTailAddr_Word(keysAddr,
-        capacity._builtinWordValue, Key.self, Value.self)
+        bucketCount._builtinWordValue, Key.self, Value.self)
     _storage.values = UnsafeMutableRawPointer(valuesAddr)
 %end
   }
@@ -3633,8 +3626,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
-  internal var capacity: Int {
-    return _assumeNonNegative(_storage.capacity)
+  internal var bucketCount: Int {
+    return _assumeNonNegative(_storage.bucketCount)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -3694,7 +3687,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_versioned
   @inline(__always)
   internal func key(at i: Int) -> Key {
-    _sanityCheck(i >= 0 && i < capacity)
+    _sanityCheck(i >= 0 && i < bucketCount)
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
@@ -3727,7 +3720,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   internal func isInitializedEntry(at i: Int) -> Bool {
-    _sanityCheck(i >= 0 && i < capacity)
+    _sanityCheck(i >= 0 && i < bucketCount)
     defer { _fixLifetime(self) }
 
     return _storage.initializedEntries[i]
@@ -3783,7 +3776,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal func setKey(_ key: Key, at i: Int) {
-    _sanityCheck(i >= 0 && i < capacity)
+    _sanityCheck(i >= 0 && i < bucketCount)
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
@@ -3850,7 +3843,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   internal var endIndex: Index {
-    return Index(offset: capacity)
+    return Index(offset: bucketCount)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -3858,7 +3851,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   internal func index(after i: Index) -> Index {
     _precondition(i != endIndex)
     var idx = i.offset + 1
-    while idx < capacity && !isInitializedEntry(at: idx) {
+    while idx < bucketCount && !isInitializedEntry(at: idx) {
       idx += 1
     }
 
@@ -3875,7 +3868,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal func assertingGet(_ i: Index) -> SequenceElement {
-    _precondition(i.offset >= 0 && i.offset < capacity)
+    _precondition(i.offset >= 0 && i.offset < bucketCount)
     _precondition(
       isInitializedEntry(at: i.offset),
       "Attempting to access ${Self} elements using an invalid Index")
@@ -3900,32 +3893,43 @@ extension _Native${Self}Buffer
   @_versioned // FIXME(sil-serialize-all)
   @inline(__always)
   internal init(minimumCapacity: Int) {
-    // Make sure there's a representable power of 2 >= minimumCapacity
-    _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
-    var capacity = 2
-    while capacity < minimumCapacity {
-      capacity <<= 1
-    }
-    self.init(capacity: capacity)
+    let bucketCount = _Native${Self}Buffer.bucketCount(
+      forCapacity: minimumCapacity,
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
+    self.init(bucketCount: bucketCount)
   }
 
-  /// Create a buffer instance with room for at least 'capacity'
-  /// entries and all entries marked invalid.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal init(capacity: Int) {
-    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
+  @inline(__always)
+  internal init(bucketCount: Int) {
+    // Actual bucket count is the next power of 2 >= bucketCount.
+    // Make sure that is representable.
+    _sanityCheck(bucketCount <= (Int.max >> 1) + 1)
+    var buckets = 2
+    while buckets < bucketCount {
+      buckets <<= 1
+    }
+    self.init(_exactBucketCount: buckets)
+  }
+
+  /// Create a buffer instance with room for at least 'bucketCount' entries,
+  /// marking all entries invalid.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal init(_exactBucketCount bucketCount: Int) {
+    let bitmapWordCount = _UnsafeBitMap.sizeInWords(forSizeInBits: bucketCount)
 %if Self == 'Dictionary':
     let storage = Builtin.allocWithTailElems_3(HashTypedStorage.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self,
-        capacity._builtinWordValue, Value.self)
+        bitmapWordCount._builtinWordValue, UInt.self,
+        bucketCount._builtinWordValue, Key.self,
+        bucketCount._builtinWordValue, Value.self)
 %else:
     let storage = Builtin.allocWithTailElems_2(HashTypedStorage.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self)
+        bitmapWordCount._builtinWordValue, UInt.self,
+        bucketCount._builtinWordValue, Key.self)
 %end
-    self.init(capacity: capacity, storage: storage)
+    self.init(_exactBucketCount: bucketCount, storage: storage)
   }
 
 #if _runtime(_ObjC)
@@ -3959,7 +3963,7 @@ extension _Native${Self}Buffer
   internal var description: String {
     var result = ""
 #if INTERNAL_CHECKS_ENABLED
-    for i in 0..<capacity {
+    for i in 0..<bucketCount {
       if isInitializedEntry(at: i) {
         let key = self.key(at: i)
         result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
@@ -3974,21 +3978,22 @@ extension _Native${Self}Buffer
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal var _bucketMask: Int {
-    // The capacity is not negative, therefore subtracting 1 will not overflow.
-    return capacity &- 1
+    // The bucket count is not negative, therefore subtracting 1 will not
+    // overflow.
+    return bucketCount &- 1
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   @inline(__always) // For performance reasons.
   internal func _bucket(_ k: Key) -> Int {
-    return _squeezeHashValue(k.hashValue, capacity)
+    return _squeezeHashValue(k.hashValue, bucketCount)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   internal func _index(after bucket: Int) -> Int {
-    // Bucket is within 0 and capacity. Therefore adding 1 does not overflow.
+    // Bucket is within 0 and bucketCount. Therefore adding 1 does not overflow.
     return (bucket &+ 1) & _bucketMask
   }
 
@@ -4028,13 +4033,13 @@ extension _Native${Self}Buffer
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   @_transparent
-  internal static func minimumCapacity(
-    minimumCount: Int,
+  internal static func bucketCount(
+    forCapacity capacity: Int,
     maxLoadFactorInverse: Double
   ) -> Int {
-    // `minimumCount + 1` below ensures that we don't fill in the last hole
-    return max(Int((Double(minimumCount) * maxLoadFactorInverse).rounded(.up)),
-               minimumCount + 1)
+    // `capacity + 1` below ensures that we don't fill in the last hole
+    return max(Int((Double(capacity) * maxLoadFactorInverse).rounded(.up)),
+               capacity + 1)
   }
 
   /// Buffer should be uniquely referenced.
@@ -4164,11 +4169,7 @@ extension _Native${Self}Buffer
       return Buffer()
     }
 
-    let requiredCapacity =
-      Buffer.minimumCapacity(
-        minimumCount: elements.count,
-        maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    var nativeBuffer = Buffer(minimumCapacity: requiredCapacity)
+    var nativeBuffer = Buffer(minimumCapacity: elements.count)
 
 %if Self == 'Set':
 
@@ -4307,8 +4308,8 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   @nonobjc
-  internal init(minimumCapacity: Int = 2) {
-    nativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
+  internal init(bucketCount: Int = 2) {
+    nativeBuffer = NativeBuffer(bucketCount: bucketCount)
     super.init()
   }
 
@@ -4420,9 +4421,9 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     using block: @convention(block) (Unmanaged<AnyObject>, Unmanaged<AnyObject>,
      UnsafeMutablePointer<UInt8>) -> Void) {
     bridgeEverything()
-    let capacity = nativeBuffer.capacity
+    let bucketCount = nativeBuffer.bucketCount
     var stop: UInt8 = 0
-    for position in 0..<capacity {
+    for position in 0..<bucketCount {
       if bridgedBuffer.isInitializedEntry(at: position) {
         block(Unmanaged.passUnretained(bridgedBuffer.key(at: position)), 
           Unmanaged.passUnretained(bridgedBuffer.value(at: position)), 
@@ -4487,10 +4488,12 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     // Investigate only allocating the buffer for a Set in this case.
 
     // Create buffer for bridged data.
-    let bridged = BridgedBuffer(capacity: nativeBuffer.capacity, unhashable: ())
+    let bridged = BridgedBuffer(
+      _exactBucketCount: nativeBuffer.bucketCount,
+      unhashable: ())
 
     // Bridge everything.
-    for i in 0..<nativeBuffer.capacity {
+    for i in 0..<nativeBuffer.bucketCount {
       if nativeBuffer.isInitializedEntry(at: i) {
         let key = _bridgeAnythingToObjectiveC(nativeBuffer.key(at: i))
 %if Self == 'Set':
@@ -4518,12 +4521,12 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     bridgeEverything()
     // The user is expected to provide a storage of the correct size
     var i = 0 // Position in the input storage
-    let capacity = nativeBuffer.capacity
+    let bucketCount = nativeBuffer.bucketCount
 
     if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys nonnull, objects nonnull
-        for position in 0..<capacity {
+        for position in 0..<bucketCount {
           if bridgedBuffer.isInitializedEntry(at: position) {
             unmanagedObjects[i] = bridgedBuffer.value(at: position)
             unmanagedKeys[i] = bridgedBuffer.key(at: position)
@@ -4532,7 +4535,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
         }
       } else {
         // keys nonnull, objects null
-        for position in 0..<capacity {
+        for position in 0..<bucketCount {
           if bridgedBuffer.isInitializedEntry(at: position) {
             unmanagedKeys[i] = bridgedBuffer.key(at: position)
             i += 1
@@ -4542,7 +4545,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     } else {
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys null, objects nonnull
-        for position in 0..<capacity {
+        for position in 0..<bucketCount {
           if bridgedBuffer.isInitializedEntry(at: position) {
             unmanagedObjects[i] = bridgedBuffer.value(at: position)
             i += 1
@@ -4922,19 +4925,20 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   @inline(__always)
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal mutating func ensureUniqueNativeBufferNative(_ minimumCapacity: Int)
-  -> (reallocated: Bool, capacityChanged: Bool) {
-    let oldCapacity = asNative.capacity
-    if oldCapacity >= minimumCapacity && isUniquelyReferenced() {
+  internal mutating func ensureUniqueNativeBufferNative(
+    withBucketCount desiredBucketCount: Int
+  ) -> (reallocated: Bool, capacityChanged: Bool) {
+    let oldBucketCount = asNative.bucketCount
+    if oldBucketCount >= desiredBucketCount && isUniquelyReferenced() {
       return (reallocated: false, capacityChanged: false)
     }
 
     let oldNativeBuffer = asNative
-    var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
-    let newCapacity = newNativeBuffer.capacity
-    for i in 0..<oldCapacity {
+    var newNativeBuffer = NativeBuffer(bucketCount: desiredBucketCount)
+    let newBucketCount = newNativeBuffer.bucketCount
+    for i in 0..<oldBucketCount {
       if oldNativeBuffer.isInitializedEntry(at: i) {
-        if oldCapacity == newCapacity {
+        if oldBucketCount == newBucketCount {
           let key = oldNativeBuffer.key(at: i)
 %if Self == 'Set':
           newNativeBuffer.initializeKey(key, at: i)
@@ -4958,28 +4962,42 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
     self = .native(newNativeBuffer)
     return (reallocated: true,
-            capacityChanged: oldCapacity != newNativeBuffer.capacity)
+      capacityChanged: oldBucketCount != newBucketCount)
+  }
+
+  @inline(__always)
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal mutating func ensureUniqueNativeBuffer(
+    withCapacity minimumCapacity: Int
+  ) -> (reallocated: Bool, capacityChanged: Bool) {
+    let bucketCount = NativeBuffer.bucketCount(
+      forCapacity: minimumCapacity,
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
+    return ensureUniqueNativeBuffer(withBucketCount: bucketCount)
   }
 
   /// Ensure this we hold a unique reference to a native buffer
   /// having at least `minimumCapacity` elements.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal mutating func ensureUniqueNativeBuffer(_ minimumCapacity: Int)
-  -> (reallocated: Bool, capacityChanged: Bool) {
+  internal mutating func ensureUniqueNativeBuffer(
+    withBucketCount desiredBucketCount: Int
+  ) -> (reallocated: Bool, capacityChanged: Bool) {
 #if _runtime(_ObjC)
     // This is a performance optimization that was put in to ensure that we did
     // not make a copy of self to call _isNative over the entire if region
     // causing at -Onone the uniqueness check to fail. This code used to be:
     //
     //  if _isNative {
-    //    return ensureUniqueNativeBufferNative(minimumCapacity)
+    //    return ensureUniqueNativeBufferNative(
+    //      withBucketCount: desiredBucketCount)
     //  }
     //
     // SR-6437
     let n = _isNative
     if n {
-      return ensureUniqueNativeBufferNative(minimumCapacity)
+      return ensureUniqueNativeBufferNative(withBucketCount: desiredBucketCount)
     }
 
     switch self {
@@ -4987,7 +5005,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       fatalError("This should have been handled earlier")
     case .cocoa(let cocoaBuffer):
       let cocoa${Self} = cocoaBuffer.cocoa${Self}
-      var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
+      var newNativeBuffer = NativeBuffer(bucketCount: desiredBucketCount)
       let oldCocoaIterator = _Cocoa${Self}Iterator(cocoa${Self})
 %if Self == 'Set':
       while let key = oldCocoaIterator.next() {
@@ -5010,7 +5028,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       return (reallocated: true, capacityChanged: true)
     }
 #else
-    return ensureUniqueNativeBufferNative(minimumCapacity)
+    return ensureUniqueNativeBufferNative(withBucketCount: desiredBucketCount)
 #endif
   }
 
@@ -5021,10 +5039,8 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   internal mutating func migrateDataToNativeBuffer(
     _ cocoaBuffer: _Cocoa${Self}Buffer
   ) {
-    let minCapacity = NativeBuffer.minimumCapacity(
-      minimumCount: cocoaBuffer.count,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    let allocated = ensureUniqueNativeBuffer(minCapacity).reallocated
+    let allocated = ensureUniqueNativeBuffer(
+      withCapacity: cocoaBuffer.count).reallocated
     _sanityCheck(allocated, "failed to allocate native ${Self} buffer")
   }
 #endif
@@ -5034,10 +5050,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal mutating func reserveCapacity(_ capacity: Int) {
-    let minCapacity = NativeBuffer.minimumCapacity(
-      minimumCount: capacity,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    _ = ensureUniqueNativeBuffer(minCapacity)
+    _ = ensureUniqueNativeBuffer(withCapacity: capacity)
   }
 
   /// The number of elements that can be stored without expanding the current
@@ -5049,10 +5062,10 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   /// at which adding any more elements will exceed the load factor.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal var effectiveCapacity: Int {
+  internal var capacity: Int {
     switch self {
     case .native:
-      return Int(Double(asNative.capacity) /
+      return Int(Double(asNative.bucketCount) /
         _hashContainerDefaultMaxLoadFactorInverse)
 #if _runtime(_ObjC)
     case .cocoa(let cocoaBuffer):
@@ -5240,13 +5253,14 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   ) -> Value? {
     var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
 
-    let minCapacity = found
-      ? asNative.capacity
-      : NativeBuffer.minimumCapacity(
-          minimumCount: asNative.count + 1,
+    let minBuckets = found
+      ? asNative.bucketCount
+      : NativeBuffer.bucketCount(
+          forCapacity: asNative.count + 1,
           maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
 
-    let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
+    let (_, capacityChanged) = ensureUniqueNativeBuffer(
+      withBucketCount: minBuckets)
     if capacityChanged {
       i = asNative._find(key, startBucket: asNative._bucket(key)).pos
     }
@@ -5300,15 +5314,15 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   internal mutating func nativePointerToValue(at i: Index)
   -> UnsafeMutablePointer<Value> {
     // This is a performance optimization that was put in to ensure that we did
-    // not make a copy of self to call asNative.capacity over
+    // not make a copy of self to call asNative.bucketCount over
     // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
     // fail. This code used to be:
     //
-    // _ = ensureUniqueNativeBuffer(capacity)
+    // _ = ensureUniqueNativeBuffer(withBucketCount: bucketCount)
     //
     // SR-6437
-    let capacity = asNative.capacity
-    _ = ensureUniqueNativeBuffer(capacity)
+    let bucketCount = asNative.bucketCount
+    _ = ensureUniqueNativeBuffer(withBucketCount: bucketCount)
     return asNative.values + i._nativeIndex.offset
   }
 
@@ -5352,11 +5366,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       return (inserted: false, pointer: pointer)
     }
 
-    let minCapacity = NativeBuffer.minimumCapacity(
-      minimumCount: asNative.count + 1,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-
-    let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
+    let minCapacity = asNative.count + 1
+    let (_, capacityChanged) = ensureUniqueNativeBuffer(
+      withCapacity: minCapacity)
 
     if capacityChanged {
       i = asNative._find(key, startBucket: asNative._bucket(key)).pos
@@ -5392,11 +5404,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 %end
     }
 
-    let minCapacity = NativeBuffer.minimumCapacity(
-      minimumCount: asNative.count + 1,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-
-    let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
+    let minCapacity = asNative.count + 1
+    let (_, capacityChanged) = ensureUniqueNativeBuffer(
+      withCapacity: minCapacity)
 
     if capacityChanged {
       i = asNative._find(key, startBucket: asNative._bucket(key)).pos
@@ -5429,7 +5439,8 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   internal func nativeMapValues<T>(
     _ transform: (Value) throws -> T
   ) rethrows -> _Variant${Self}Buffer<Key, T> {
-    var buffer = _Native${Self}Buffer<Key, T>(capacity: asNative.capacity)
+    var buffer = _Native${Self}Buffer<Key, T>(
+      _exactBucketCount: asNative.bucketCount)
 
     // Because the keys in the current and new buffer are the same, we can 
     // initialize to the same locations in the new buffer, skipping hash value
@@ -5460,7 +5471,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 #if _runtime(_ObjC)
     case .cocoa(let cocoaStorage):
       var storage: _Variant${Self}Buffer<Key, T> = .native(
-        _Native${Self}Buffer<Key, T>(capacity: cocoaStorage.count))
+        _Native${Self}Buffer<Key, T>(minimumCapacity: cocoaStorage.count))
 
       var i = cocoaStorage.startIndex
       while i != cocoaStorage.endIndex {
@@ -5487,15 +5498,15 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
       if found {
         // This is a performance optimization that was put in to ensure that we
-        // did not make a copy of self to call asNative.capacity over
+        // did not make a copy of self to call asNative.bucketCount over
         // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
         // fail. This code used to be:
         //
-        // _ = ensureUniqueNativeBuffer(asNative.capacity)
+        // _ = ensureUniqueNativeBuffer(withBucketCount: asNative.bucketCount)
         //
         // SR-6437
-        let capacity = asNative.capacity
-        _ = ensureUniqueNativeBuffer(capacity)
+        let bucketCount = asNative.bucketCount
+        _ = ensureUniqueNativeBuffer(withBucketCount: bucketCount)
         do {
           let newValue = try combine(asNative.value(at: i.offset), value)
           asNative.setKey(key, value: newValue, at: i.offset)
@@ -5503,11 +5514,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
           fatalError("Duplicate values for key: '\(key)'")
         }
       } else {
-        let minCapacity = NativeBuffer.minimumCapacity(
-          minimumCount: asNative.count + 1,
-          maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-
-        let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
+        let minCapacity = asNative.count + 1
+        let (_, capacityChanged) = ensureUniqueNativeBuffer(
+          withCapacity: minCapacity)
         if capacityChanged {
           i = asNative._find(key, startBucket: asNative._bucket(key)).pos
         }
@@ -5541,11 +5550,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       if found {
         asNative.values[i.offset].append(value)
       } else {
-        let minCapacity = NativeBuffer.minimumCapacity(
-          minimumCount: asNative.count + 1,
-          maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-
-        let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
+        let minCapacity = asNative.count + 1
+        let (_, capacityChanged) = ensureUniqueNativeBuffer(
+          withCapacity: minCapacity)
         if capacityChanged {
           i = asNative._find(key, startBucket: asNative._bucket(key)).pos
         }
@@ -5638,16 +5645,16 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     }
 
     // This is a performance optimization that was put in to ensure that we
-    // did not make a copy of self to call asNative.capacity over
+    // did not make a copy of self to call asNative.bucketCount over
     // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
     // fail. This code used to be:
     //
-    // _ = ensureUniqueNativeBuffer(asNative.capacity)
+    // ... = ensureUniqueNativeBuffer(withBucketCount: asNative.bucketCount)
     //
     // SR-6437
-    let capacity = asNative.capacity
-    let (_, capacityChanged) =
-      ensureUniqueNativeBuffer(capacity)
+    let bucketCount = asNative.bucketCount
+    let (_, capacityChanged) = ensureUniqueNativeBuffer(
+      withBucketCount: bucketCount)
     let nativeBuffer = asNative
     if capacityChanged {
       idealBucket = nativeBuffer._bucket(key)
@@ -5670,17 +5677,17 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     at nativeIndex: NativeIndex
   ) -> SequenceElement {
     // This is a performance optimization that was put in to ensure that we did
-    // not make a copy of self to call asNative.capacity over
+    // not make a copy of self to call asNative.bucketCount over
     // ensureUniqueNativeBefore causing at -Onone the uniqueness check to
     // fail. This code used to be:
     //
-    // _ = ensureUniqueNativeBuffer(asNative.capacity)
+    // _ = ensureUniqueNativeBuffer(withBucketCount: asNative.bucketCount)
     //
     // SR-6437
-    let capacity = asNative.capacity
+    let bucketCount = asNative.bucketCount
     // The provided index should be valid, so we will always mutating the
     // set buffer.  Request unique buffer.
-    _ = ensureUniqueNativeBuffer(capacity)
+    _ = ensureUniqueNativeBuffer(withBucketCount: bucketCount)
     let nativeBuffer = asNative
 
     let result = nativeBuffer.assertingGet(nativeIndex)
@@ -5756,7 +5763,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   @_versioned // FIXME(sil-serialize-all)
   internal mutating func nativeRemoveAll() {
     if !isUniquelyReferenced() {
-        asNative = NativeBuffer(minimumCapacity: asNative.capacity)
+        asNative = NativeBuffer(_exactBucketCount: asNative.bucketCount)
         return
     }
 
@@ -5764,7 +5771,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     // reference, so we will always mutate the dictionary buffer.
     var nativeBuffer = asNative
 
-    for b in 0..<nativeBuffer.capacity {
+    for b in 0..<nativeBuffer.bucketCount {
       if nativeBuffer.isInitializedEntry(at: b) {
         nativeBuffer.destroyEntry(at: b)
       }
@@ -5780,7 +5787,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     }
 
     if !keepCapacity {
-      self = .native(NativeBuffer(minimumCapacity: 2))
+      self = .native(NativeBuffer(bucketCount: 2))
       return
     }
 
@@ -6490,7 +6497,7 @@ extension ${Self} {
   /// allocating new storage.
   @_inlineable // FIXME(sil-serialize-all)
   public var capacity: Int {
-    return _variantBuffer.effectiveCapacity
+    return _variantBuffer.capacity
   }
 
   /// Reserves enough space to store the specified number of ${element}s.

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1081,7 +1081,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveValueForKeyDoesNotReallocate")
 DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
-    let originalCapacity = d._variantBuffer.asNative.capacity
+    let originalCapacity = d.capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
@@ -1089,7 +1089,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = d._rawIdentifier()
-    assert(d._variantBuffer.asNative.capacity < originalCapacity)
+    assert(d.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
@@ -1102,19 +1102,19 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
     var identity1 = d._rawIdentifier()
-    let originalCapacity = d._variantBuffer.asNative.capacity
+    let originalCapacity = d.capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity == originalCapacity)
+    assert(d.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity == originalCapacity)
+    assert(d.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
   }
@@ -1143,7 +1143,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d1 = getCOWFastDictionary()
     var identity1 = d1._rawIdentifier()
-    let originalCapacity = d1._variantBuffer.asNative.capacity
+    let originalCapacity = d1.capacity
     assert(d1.count == 3)
     assert(d1[10] == 1010)
 
@@ -1154,7 +1154,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
-    assert(d2._variantBuffer.asNative.capacity == originalCapacity)
+    assert(d2.capacity == originalCapacity)
     assert(d2.count == 0)
     assert(d2[10] == nil)
 
@@ -1167,7 +1167,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
-    let originalCapacity = d._variantBuffer.asNative.capacity
+    let originalCapacity = d.capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
@@ -1175,7 +1175,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = d._rawIdentifier()
-    assert(d._variantBuffer.asNative.capacity < originalCapacity)
+    assert(d.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
@@ -1188,19 +1188,19 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
     var identity1 = d._rawIdentifier()
-    let originalCapacity = d._variantBuffer.asNative.capacity
+    let originalCapacity = d.capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity == originalCapacity)
+    assert(d.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity == originalCapacity)
+    assert(d.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
   }
@@ -1229,7 +1229,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d1 = getCOWSlowDictionary()
     var identity1 = d1._rawIdentifier()
-    let originalCapacity = d1._variantBuffer.asNative.capacity
+    let originalCapacity = d1.capacity
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
 
@@ -1240,7 +1240,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
-    assert(d2._variantBuffer.asNative.capacity == originalCapacity)
+    assert(d2.capacity == originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestKeyTy(10)] == nil)
 
@@ -2644,7 +2644,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     d.removeAll()
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity < originalCapacity)
+    assert(d.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
   }
@@ -2659,7 +2659,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity >= originalCapacity)
+    assert(d.capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
   }
@@ -2679,7 +2679,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
-    assert(d2._variantBuffer.asNative.capacity < originalCapacity)
+    assert(d2.capacity < originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestObjCKeyTy(10)] == nil)
   }
@@ -2699,7 +2699,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
-    assert(d2._variantBuffer.asNative.capacity >= originalCapacity)
+    assert(d2.capacity >= originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestObjCKeyTy(10)] == nil)
   }
@@ -2727,7 +2727,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     d.removeAll()
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity < originalCapacity)
+    assert(d.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
   }
@@ -2742,7 +2742,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantBuffer.asNative.capacity >= originalCapacity)
+    assert(d.capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
   }
@@ -2762,7 +2762,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
-    assert(d2._variantBuffer.asNative.capacity < originalCapacity)
+    assert(d2.capacity < originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }
@@ -2782,7 +2782,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
-    assert(d2._variantBuffer.asNative.capacity >= originalCapacity)
+    assert(d2.capacity >= originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1723,6 +1723,29 @@ DictionaryTestSuite.test("mapValues(_:)") {
   }
 }
 
+DictionaryTestSuite.test("capacity/init(minimumCapacity:)") {
+  let d0 = Dictionary<String, Int>(minimumCapacity: 0)
+  expectGE(d0.capacity, 0)
+
+  let d1 = Dictionary<String, Int>(minimumCapacity: 1)
+  expectGE(d1.capacity, 1)
+
+  let d3 = Dictionary<String, Int>(minimumCapacity: 3)
+  expectGE(d3.capacity, 3)
+
+  let d4 = Dictionary<String, Int>(minimumCapacity: 4)
+  expectGE(d4.capacity, 4)
+
+  let d10 = Dictionary<String, Int>(minimumCapacity: 10)
+  expectGE(d10.capacity, 10)
+
+  let d100 = Dictionary<String, Int>(minimumCapacity: 100)
+  expectGE(d100.capacity, 100)
+
+  let d1024 = Dictionary<String, Int>(minimumCapacity: 1024)
+  expectGE(d1024.capacity, 1024)
+}
+
 DictionaryTestSuite.test("capacity/reserveCapacity(_:)") {
   var d1 = [10: 1010, 20: 1020, 30: 1030]
   expectEqual(3, d1.capacity)
@@ -2312,8 +2335,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithKey") {
 
   // Insert a new key-value pair.
   d[TestBridgedKeyTy(40)] = TestBridgedValueTy(2040)
+
   var identity2 = d._rawIdentifier()
-  assert(identity1 != identity2)
+  // Storage identity may or may not change depending on allocation behavior.
+  // (d is eagerly bridged to a regular uniquely referenced native Dictionary.)
+  //assert(identity1 != identity2)
+
   assert(isNativeDictionary(d))
   assert(d.count == 4)
 
@@ -2401,7 +2428,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.UpdateValueForKey") {
         d.updateValue(TestBridgedValueTy(2040), forKey: TestBridgedKeyTy(40))
     assert(oldValue == nil)
     var identity2 = d._rawIdentifier()
-    assert(identity1 != identity2)
+    // Storage identity may or may not change depending on allocation behavior.
+    // (d is eagerly bridged to a regular uniquely referenced native Dictionary.)
+    //assert(identity1 != identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 4)
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1418,7 +1418,10 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Insert") {
     s.insert(TestObjCKeyTy(2040) as TestBridgedKeyTy)
 
     var identity2 = s._rawIdentifier()
-    expectNotEqual(identity1, identity2)
+    // Storage identity may or may not change depending on allocation behavior.
+    // (s is eagerly bridged to a regular uniquely referenced native Set.)
+    //expectNotEqual(identity1, identity2)
+
     expectTrue(isNativeSet(s))
     expectEqual(4, s.count)
 
@@ -1572,10 +1575,13 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
 
   expectEqual(identity1, s._rawIdentifier())
 
-  // Inserting an item should now create storage unique from the bridged set.
   s.insert(TestBridgedKeyTy(4040))
   var identity2 = s._rawIdentifier()
-  expectNotEqual(identity1, identity2)
+
+  // Storage identity may or may not change depending on allocation behavior.
+  // (s is eagerly bridged to a regular uniquely referenced native Set.)
+  //expectNotEqual(identity1, identity2)
+
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
 
@@ -3153,6 +3159,29 @@ SetTestSuite.test("first") {
 
   expectTrue(s1.contains(s1.first!))
   expectNil(emptySet.first)
+}
+
+SetTestSuite.test("capacity/init(minimumCapacity:)") {
+  let s0 = Set<String>(minimumCapacity: 0)
+  expectGE(s0.capacity, 0)
+
+  let s1 = Set<String>(minimumCapacity: 1)
+  expectGE(s1.capacity, 1)
+
+  let s3 = Set<String>(minimumCapacity: 3)
+  expectGE(s3.capacity, 3)
+
+  let s4 = Set<String>(minimumCapacity: 4)
+  expectGE(s4.capacity, 4)
+
+  let s10 = Set<String>(minimumCapacity: 10)
+  expectGE(s10.capacity, 10)
+
+  let s100 = Set<String>(minimumCapacity: 100)
+  expectGE(s100.capacity, 100)
+
+  let s1024 = Set<String>(minimumCapacity: 1024)
+  expectGE(s1024.capacity, 1024)
 }
 
 SetTestSuite.test("capacity/reserveCapacity(_:)") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -843,7 +843,7 @@ SetTestSuite.test("COW.Fast.UnionInPlaceSmallSetDoesNotReallocate") {
 SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
-    let originalCapacity = s._variantBuffer.asNative.capacity
+    let originalCapacity = s.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
@@ -851,7 +851,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = s._rawIdentifier()
-    expectTrue(s._variantBuffer.asNative.capacity < originalCapacity)
+    expectTrue(s.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
@@ -864,19 +864,19 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
     var identity1 = s._rawIdentifier()
-    let originalCapacity = s._variantBuffer.asNative.capacity
+    let originalCapacity = s.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
+    expectEqual(originalCapacity, s.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
+    expectEqual(originalCapacity, s.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
   }
@@ -905,7 +905,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s1 = getCOWFastSet()
     var identity1 = s1._rawIdentifier()
-    let originalCapacity = s1._variantBuffer.asNative.capacity
+    let originalCapacity = s1.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
@@ -916,7 +916,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
-    expectEqual(originalCapacity, s2._variantBuffer.asNative.capacity)
+    expectEqual(originalCapacity, s2.capacity)
     expectEqual(0, s2.count)
     expectFalse(s2.contains(1010))
 
@@ -929,7 +929,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
-    let originalCapacity = s._variantBuffer.asNative.capacity
+    let originalCapacity = s.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
@@ -937,7 +937,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = s._rawIdentifier()
-    expectTrue(s._variantBuffer.asNative.capacity < originalCapacity)
+    expectTrue(s.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
@@ -950,19 +950,19 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
     var identity1 = s._rawIdentifier()
-    let originalCapacity = s._variantBuffer.asNative.capacity
+    let originalCapacity = s.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
+    expectEqual(originalCapacity, s.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
+    expectEqual(originalCapacity, s.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
   }
@@ -991,7 +991,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s1 = getCOWSlowSet()
     var identity1 = s1._rawIdentifier()
-    let originalCapacity = s1._variantBuffer.asNative.capacity
+    let originalCapacity = s1.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
@@ -1002,7 +1002,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
-    expectEqual(originalCapacity, s2._variantBuffer.asNative.capacity)
+    expectEqual(originalCapacity, s2.capacity)
     expectEqual(0, s2.count)
     expectFalse(s2.contains(TestKeyTy(1010)))
 


### PR DESCRIPTION
This fixes `init(minimumCapacity:)` on `Set` and `Dictionary` to take the maximum load factor into account before allocating storage. Previously, these initializers usually resulted in collections with less than the specified minimum capacity.  (`reserveCapacity(_:)` does not have the same issue.)

rdar://problem/36619317
