### PR TITLE
Revert "Enable stdlib resilience"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -70,7 +70,7 @@ KNOWN_SETTINGS=(
     llvm-num-parallel-lto-link-jobs ""           "The number of parallel link jobs to use when compiling llvm"
     swift-stdlib-build-type     "Debug"          "the CMake build variant for Swift"
     swift-stdlib-enable-assertions "1"           "enable assertions in Swift"
-    swift-stdlib-enable-resilience "1"           "build the Swift stdlib and overlays with resilience enabled"
+    swift-stdlib-enable-resilience "0"           "build the Swift stdlib and overlays with resilience enabled"
     swift-stdlib-use-nonatomic-rc "0"            "build the Swift stdlib and overlays with nonatomic reference count operations enabled"
     lldb-build-type             "Debug"          "the CMake build variant for LLDB"
     llbuild-build-type          "Debug"          "the CMake build variant for llbuild"


### PR DESCRIPTION
Reverts apple/swift#13573 due to several lldb test failures (rdar://36663932).