### PR TITLE
[Type] The context in getSinglyDesugaredType() can be null.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1480,6 +1480,8 @@ protected:
   SugarType(TypeKind K, const ASTContext *ctx,
             RecursiveTypeProperties properties)
       : TypeBase(K, nullptr, properties), Context(ctx) {
+    if (K != TypeKind::NameAlias)
+      assert(ctx != nullptr && "Context for SugarType should not be null");
     Bits.SugarType.HasCachedType = false;
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1269,7 +1269,6 @@ ParenType::ParenType(Type baseType, RecursiveTypeProperties properties,
 
 Type SugarType::getSinglyDesugaredTypeSlow() {
   // Find the generic type that implements this syntactic sugar type.
-  auto &ctx = *Context;
   NominalTypeDecl *implDecl;
 
   // XXX -- If the Decl and Type class hierarchies agreed on spelling, then
@@ -1291,16 +1290,16 @@ Type SugarType::getSinglyDesugaredTypeSlow() {
     return UTy;
   }
   case TypeKind::ArraySlice:
-    implDecl = ctx.getArrayDecl();
+    implDecl = Context->getArrayDecl();
     break;
   case TypeKind::Optional:
-    implDecl = ctx.getOptionalDecl();
+    implDecl = Context->getOptionalDecl();
     break;
   case TypeKind::ImplicitlyUnwrappedOptional:
-    implDecl = ctx.getImplicitlyUnwrappedOptionalDecl();
+    implDecl = Context->getImplicitlyUnwrappedOptionalDecl();
     break;
   case TypeKind::Dictionary:
-    implDecl = ctx.getDictionaryDecl();
+    implDecl = Context->getDictionaryDecl();
     break;
   }
   assert(implDecl && "Type has not been set yet");


### PR DESCRIPTION
Don't dereference it for NameAlias(es). Also add an assertion in
the constructor to catch violations in future.

<rdar://36641907>