### PR TITLE
[ABI] Reserve space in the protocol descriptor for the superclass.

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -431,10 +431,12 @@ Objective-C ``Protocol`` objects. The layout is as follows:
   the flags. It specifies the number of requirements that do not have default
   implementations.
 - **Number of requirements** is stored as a 16-bit integer after the flags. It
-  specifies the total number of requirements for the protocl.
+  specifies the total number of requirements for the protocol.
 - **Requirements pointer** stored as a 32-bit relative pointer to an array
   of protocol requirements. The number of elements in the array is specified
   by the preceding 16-bit integer.
+- **Superclass pointer** stored as a 32-bit relative pointer to class metadata,
+  describing the superclass bound of the protocol.
 - **Associated type names** stored as a 32-bit relative pointer to a
   null-terminated string. The string contains the names of the associated
   types, in the order they apparent in the requirements list, separated by

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2179,6 +2179,10 @@ struct TargetProtocolDescriptor {
   /// Requirement descriptions.
   RelativeDirectPointer<TargetProtocolRequirement<Runtime>> Requirements;
 
+  /// The superclass of which all conforming types must be a subclass.
+  RelativeDirectPointer<const TargetClassMetadata<Runtime>, /*Nullable=*/true>
+    Superclass;
+
   /// Associated type names, as a space-separated list in the same order
   /// as the requirements.
   RelativeDirectPointer<const char, /*Nullable=*/true> AssociatedTypeNames;
@@ -2201,6 +2205,7 @@ struct TargetProtocolDescriptor {
       NumMandatoryRequirements(0),
       NumRequirements(0),
       Requirements(nullptr),
+      Superclass(nullptr),
       AssociatedTypeNames(nullptr)
   {}
 };

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5372,6 +5372,7 @@ namespace {
       addSize();
       addFlags();
       addRequirements();
+      addSuperclass();
       addAssociatedTypeNames();
 
       B.suggestType(IGM.ProtocolDescriptorStructTy);
@@ -5568,6 +5569,11 @@ namespace {
       }
 
       return nullptr;
+    }
+
+    void addSuperclass() {
+      // FIXME: Implement.
+      B.addRelativeAddressOrNull(nullptr);
     }
 
     void addAssociatedTypeNames() {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -200,6 +200,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     Int16Ty,                // mandatory requirement count
     Int16Ty,                // total requirement count
     Int32Ty,                // requirements array
+    RelativeAddressTy,      // superclass
     RelativeAddressTy       // associated type names
   });
   

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -90,6 +90,7 @@ protocol Comprehensive {
   var instance: Assoc { get set }
   static var global: Assoc { get set }
 }
+
 // CHECK: [[COMPREHENSIVE_REQTS:@.*]] = internal unnamed_addr constant [11 x %swift.protocol_requirement]
 // CHECK-SAME:  [%swift.protocol_requirement { i32 6, i32 0 },
 // CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0 },
@@ -102,6 +103,15 @@ protocol Comprehensive {
 // CHECK-SAME:   %swift.protocol_requirement { i32 3, i32 0 },
 // CHECK-SAME:   %swift.protocol_requirement { i32 4, i32 0 },
 // CHECK-SAME:   %swift.protocol_requirement { i32 5, i32 0 }]
+
+// CHECK: [[COMPREHENSIVE_ASSOC_NAME:@.*]] = private constant [6 x i8] c"Assoc\00"
+
+// CHECK: @"$S17protocol_metadata13ComprehensiveMp" = hidden constant %swift.protocol
+// CHECK-SAME: i32 72, i32 7, i16 11, i16 11,
+// CHECK-SAME: [11 x %swift.protocol_requirement]* [[COMPREHENSIVE_REQTS]]
+// CHECK-SAME: i32 0
+// CHECK-SAME: i32 trunc
+// CHECK-SAME: [6 x i8]* [[COMPREHENSIVE_ASSOC_NAME]]
 
 func reify_metadata<T>(_ x: T) {}
 


### PR DESCRIPTION
Extend protocol descriptors with a field for the superclass bound of the
protocol itself. This carves out space in the ABI for

    class C { }
    protocol P : C { ... }

although the feature is not yet implemented.
