### PR TITLE
[4.1] EscapeAnalysis: update use-points for nodes which are created on dema…

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -295,6 +295,8 @@ updatePointsTo(CGNode *InitialNode, CGNode *pointsTo) {
       } else {
         Node->pointsTo = pointsTo;
       }
+      // Update use-points if the use-point information is already calculated.
+      pointsTo->mergeUsePoints(Node);
     }
 
     // Add all adjacent nodes to the WorkList.

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -268,3 +268,51 @@ bb2:
   %52 = tuple ()
   return %52 : $()
 }
+
+
+sil @get_unknown_value : $@convention(thin) () -> Builtin.Int32
+sil @get_unknown_value2 : $@convention(thin) () -> Builtin.Int32
+
+sil @callee : $@convention(thin) (@inout Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32):
+  %1 = function_ref @get_unknown_value : $@convention(thin) () -> Builtin.Int32
+  %2 = apply %1() : $@convention(thin) () -> Builtin.Int32
+  store %2 to %0 : $*Builtin.Int32
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @use_value : $@convention(thin) (Builtin.Int32) -> ()
+
+// Check if escape analysis figures out that the alloc_stack escapes to callee.
+//
+// CHECK-LABEL: sil @dont_hoist_aliased_load
+// CHECK:      bb2:
+// CHECK-NEXT:   apply
+// CHECK-NEXT:   load
+// CHECK-NEXT:   apply
+sil @dont_hoist_aliased_load : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  %1 = integer_literal $Builtin.Int32, 0
+  %3 = function_ref @callee : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %5 = function_ref @use_value : $@convention(thin) (Builtin.Int32) -> ()
+  %unknown_value_fn = function_ref @get_unknown_value2 : $@convention(thin) () -> Builtin.Int32
+  store %1 to %0 : $*Builtin.Int32
+  br bb1(%0 : $*Builtin.Int32)
+
+bb1(%phi1 : $*Builtin.Int32):
+  br bb2
+
+bb2:
+  apply %3(%0) : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %4 = load %phi1 : $*Builtin.Int32
+  %6 = apply %unknown_value_fn() : $@convention(thin) () -> Builtin.Int32
+  %33 = builtin "cmp_eq_Int32"(%4 : $Builtin.Int32, %6 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %33, bb2, bb3
+
+bb3:
+  %9999 = tuple()
+  dealloc_stack %0 : $*Builtin.Int32
+  return %9999 : $()
+}


### PR DESCRIPTION
…nd after the use-point info is already calculated.

fixes rdar://problem/36450027

