### PR TITLE
Emit nominal type access functions for imported types.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -752,6 +752,11 @@ hasExplicitProtocolConformance(NominalTypeDecl *decl) {
     if (conformance->getKind() == ProtocolConformanceKind::Inherited)
       continue;
 
+    // Ignore conformances synthesized by the Clang importer.
+    if (isa<ClangModuleUnit>(
+                conformance->getDeclContext()->getModuleScopeContext()))
+      continue;
+
     auto P = conformance->getProtocol();
 
     // @objc protocols do not have conformance records
@@ -2826,8 +2831,7 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(CanType concreteType,
   if (!section.empty())
     var->setSection(section);
   
-  // Keep type metadata around for all types, although the runtime can currently
-  // only perform name lookup of non-generic types.
+  // Keep type metadata around for all types.
   addRuntimeResolvableType(concreteType);
 
   // For metadata patterns, we're done.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5307,8 +5307,8 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
     llvm_unreachable("foreign metadata for unexpected type?!");
   }
 
-  if (NominalTypeDecl *Nominal = type->getAnyNominal())
-    addLazyConformances(Nominal);
+  // Keep type metadata around for all types.
+  addRuntimeResolvableType(type);
 
   return result;
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5257,7 +5257,7 @@ namespace {
 bool IRGenModule::requiresForeignTypeMetadata(CanType type) {
   if (NominalTypeDecl *nominal = type->getAnyNominal()) {
     if (auto *clas = dyn_cast<ClassDecl>(nominal)) {
-      return clas->getForeignClassKind() == ClassDecl::ForeignKind::CFType;
+      return clas->isForeign();
     }
 
     return isa<ClangModuleUnit>(nominal->getModuleScopeContext());

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2104,16 +2104,9 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
 
   // Trigger the lazy emission of the foreign type metadata.
   CanType conformingType = Conf->getType()->getCanonicalType();
-  if (NominalTypeDecl *Nominal = conformingType->getAnyNominal()) {
-    if (auto *clas = dyn_cast<ClassDecl>(Nominal)) {
-      if (clas->isForeign())
-        getAddrOfForeignTypeMetadataCandidate(conformingType);
-    } else if (isa<ClangModuleUnit>(Nominal->getModuleScopeContext())) {
-      getAddrOfForeignTypeMetadataCandidate(conformingType);
-    }
-  }
+  if (requiresForeignTypeMetadata(conformingType))
+    (void)getAddrOfForeignTypeMetadataCandidate(conformingType);
 }
-
 
 /// True if a function's signature in LLVM carries polymorphic parameters.
 /// Generic functions and protocol witnesses carry polymorphic parameters.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -305,6 +305,23 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   NominalTypeDescriptorPtrTy
     = NominalTypeDescriptorTy->getPointerTo(DefaultAS);
 
+  ClassNominalTypeDescriptorTy =
+        llvm::StructType::get(LLVMContext, {
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int16Ty,
+    Int16Ty,
+    Int32Ty,
+  }, /*packed=*/true);
+
   MethodDescriptorStructTy
     = createStructType(*this, "swift.method_descriptor", {
       RelativeAddressTy,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -500,6 +500,7 @@ public:
   llvm::PointerType *ProtocolConformanceDescriptorPtrTy;
   llvm::StructType *NominalTypeDescriptorTy;
   llvm::PointerType *NominalTypeDescriptorPtrTy;
+  llvm::StructType *ClassNominalTypeDescriptorTy;
   llvm::StructType *MethodDescriptorStructTy; /// %swift.method_descriptor
   llvm::StructType *TypeMetadataRecordTy;
   llvm::PointerType *TypeMetadataRecordPtrTy;
@@ -1080,6 +1081,10 @@ public:
   llvm::Constant *getAddrOfTypeMetadataLazyCacheVariable(CanType type,
                                                ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfForeignTypeMetadataCandidate(CanType concreteType);
+
+  /// Determine whether the given type requires foreign type metadata.
+  bool requiresForeignTypeMetadata(CanType type);
+
   llvm::Constant *getAddrOfClassMetadataBaseOffset(ClassDecl *D,
                                                  ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfNominalTypeDescriptor(NominalTypeDecl *D,

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -508,7 +508,8 @@ public:
     // FIXME: Need to also gather generic requirements.
     std::vector<BuiltType> allGenericArgsVec;
     ArrayRef<BuiltType> allGenericArgs;
-    if (typeDecl->GenericParams.NestingDepth > 1) {
+    if (typeDecl->GenericParams.NestingDepth > 1 &&
+        typeDecl->GenericParams.isGeneric()) {
       if (!parent) return BuiltType();
 
       // Dig out the parent nominal descriptor.

--- a/test/IRGen/Inputs/abi/c_layout.h
+++ b/test/IRGen/Inputs/abi/c_layout.h
@@ -97,8 +97,8 @@ static inline void doubleTrouble(void) {
   staticFloat *= 2.0;
 }
 
-#define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+#define SWIFT_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
 
-typedef NS_ENUM(int, AmazingColor) {
+typedef SWIFT_ENUM(int, AmazingColor) {
   Cyan, Magenta, Yellow
 };

--- a/test/IRGen/Inputs/abi/c_layout.h
+++ b/test/IRGen/Inputs/abi/c_layout.h
@@ -97,8 +97,8 @@ static inline void doubleTrouble(void) {
   staticFloat *= 2.0;
 }
 
-#define SWIFT_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+#define SWIFT_ENUM(_type, _name) enum _name
 
 typedef SWIFT_ENUM(int, AmazingColor) {
   Cyan, Magenta, Yellow
-};
+} AmazingColor;

--- a/test/IRGen/Inputs/abi/c_layout.h
+++ b/test/IRGen/Inputs/abi/c_layout.h
@@ -96,3 +96,9 @@ static const char * const staticString = "abc";
 static inline void doubleTrouble(void) {
   staticFloat *= 2.0;
 }
+
+#define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+
+typedef NS_ENUM(int, AmazingColor) {
+  Cyan, Magenta, Yellow
+};

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -24,6 +24,11 @@ import c_layout
 // CHECK-SAME:  [[INT]] 0,
 // CHECK-SAME:  [[INT]] 4 }
 
+// CHECK-LABEL: @"\01l_type_metadata_table" = private constant
+// CHECK-SAME: @"$SSo14HasNestedUnionVMn"
+// CHECK-SAME: @"$SSo12AmazingColorVMn"
+// CHECK-SAME: @"$SSo14HasNestedUnionV18__Unnamed_struct_sVMn"
+
 sil @test0 : $() -> () {
 bb0:
   %0 = metatype $@thick HasNestedUnion.Type

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -3,6 +3,18 @@
 sil_stage canonical
 import c_layout
 
+// CHECK: [[HAS_NESTED_UNION_NAME:@.*]] = private constant [20 x i8] c"So14HasNestedUnionV\00"
+
+// CHECK-LABEL: @"$SSo14HasNestedUnionVMn" = linkonce_odr hidden constant
+// CHECK-SAME: [[HAS_NESTED_UNION_NAME]]
+// CHECK-SAME: @"$SSo14HasNestedUnionVMa"
+
+// CHECK: [[AMAZING_COLOR_NAME:@.*]] = private constant [18 x i8] c"So12AmazingColorV\00"
+
+// CHECK-LABEL: @"$SSo12AmazingColorVMn" = linkonce_odr hidden constant
+// CHECK-SAME: [[AMAZING_COLOR_NAME]]
+// CHECK-SAME: @"$SSo12AmazingColorVMa"
+
 // CHECK-LABEL: @"$SSo14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden global
 // CHECK-SAME:  [[INT:i[0-9]+]] sub ([[INT]] ptrtoint
 // CHECK-SAME:  [[INT]] 0,
@@ -15,7 +27,14 @@ import c_layout
 sil @test0 : $() -> () {
 bb0:
   %0 = metatype $@thick HasNestedUnion.Type
+  %1 = metatype $@thick AmazingColor.Type
 
   %ret = tuple ()
   return %ret : $()
 }
+
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo14HasNestedUnionVMa
+// CHECK: call %swift.type* @swift_getForeignTypeMetadata{{.*}}$SSo14HasNestedUnionVN
+
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @"$SSo12AmazingColorVMa"()
+// CHECK: call %swift.type* @swift_getForeignTypeMetadata{{.*}}@"$SSo12AmazingColorVN"

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -42,9 +42,6 @@ DemangleToMetadataTests.test("Classes that don't exist") {
   expectNil(_typeByMangledName("4main4BoomC"))
 }
 
-// FIXME: Shouldn't need this?
-extension CFArray: P2 { }
-
 DemangleToMetadataTests.test("CoreFoundation classes") {
   expectEqual(CFArray.self, _typeByMangledName("So10CFArrayRefa")!)
 }
@@ -59,9 +56,6 @@ DemangleToMetadataTests.test("Imported swift_wrapper types") {
   expectEqual(URLFileResourceType.self,
     _typeByMangledName("So21NSURLFileResourceTypea")!)
 }
-
-// FIXME: Shouldn't need this?
-extension URLSessionTask.State: P2 { }
 
 DemangleToMetadataTests.test("Imported enum types") {
   expectEqual(NSURLSessionTask.State.self,

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -60,12 +60,12 @@ DemangleToMetadataTests.test("Imported swift_wrapper types") {
     _typeByMangledName("So21NSURLFileResourceTypea")!)
 }
 
+// FIXME: Shouldn't need this?
 extension URLSessionTask.State: P2 { }
 
 DemangleToMetadataTests.test("Imported enum types") {
-  // FIXME: Should work
-  // expectEqual(NSURLSessionTask.State.self,
-  //  _typeByMangledName("So21NSURLSessionTaskStateV")!)
+  expectEqual(NSURLSessionTask.State.self,
+    _typeByMangledName("So21NSURLSessionTaskStateV")!)
 }
 
 runAllTests()

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -4,12 +4,14 @@
 
 import StdlibUnittest
 import Foundation
+import CoreFoundation
 
 let DemangleToMetadataTests = TestSuite("DemangleToMetadataObjC")
 
 @objc class C : NSObject { }
 @objc enum E: Int { case a }
 @objc protocol P1 { }
+protocol P2 { }
 
 DemangleToMetadataTests.test("@objc classes") {
   expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
@@ -38,6 +40,32 @@ DemangleToMetadataTests.test("Objective-C protocols") {
 
 DemangleToMetadataTests.test("Classes that don't exist") {
   expectNil(_typeByMangledName("4main4BoomC"))
+}
+
+// FIXME: Shouldn't need this?
+extension CFArray: P2 { }
+
+DemangleToMetadataTests.test("CoreFoundation classes") {
+  expectEqual(CFArray.self, _typeByMangledName("So10CFArrayRefa")!)
+}
+
+DemangleToMetadataTests.test("Imported error types") {
+  expectEqual(URLError.self, _typeByMangledName("10Foundation8URLErrorV")!)
+  expectEqual(URLError.Code.self,
+    _typeByMangledName("10Foundation8URLErrorV4CodeV")!)
+}
+
+DemangleToMetadataTests.test("Imported swift_wrapper types") {
+  expectEqual(URLFileResourceType.self,
+    _typeByMangledName("So21NSURLFileResourceTypea")!)
+}
+
+extension URLSessionTask.State: P2 { }
+
+DemangleToMetadataTests.test("Imported enum types") {
+  // FIXME: Should work
+  // expectEqual(NSURLSessionTask.State.self,
+  //  _typeByMangledName("So21NSURLSessionTaskStateV")!)
 }
 
 runAllTests()


### PR DESCRIPTION
Emit nominal type access functions for imported types. These access
functions work with non-unique metadata references, so they perform
uniquing through the runtime on first access.

Fixes rdar://problem/36430234.
