### PR TITLE
Fix a build issue on FreeBSD, correctly define the SwiftShims for stddef and stdint and add required module exports

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1538,9 +1538,12 @@ function(add_swift_library name)
                    "-latomic")
             # the same issue on FreeBSD, missing symbols:
             # __atomic_store, __atomic_compare_exchange, __atomic_load
+            # NOTE: the "-l" is required here, otherwise Ninja will fail
+            # on clean builds because the library might not have been copied
+            # yet.
             elseif("${sdk}" STREQUAL "FREEBSD")
               list(APPEND swiftlib_private_link_libraries_targets
-                   "${SWIFTLIB_DIR}/clang/lib/freebsd/libclang_rt.builtins-${arch}.a")
+                   "-l${SWIFTLIB_DIR}/clang/lib/freebsd/libclang_rt.builtins-${arch}.a")
             endif()
           elseif("${lib}" STREQUAL "ICU_I18N")
             list(APPEND swiftlib_private_link_libraries_targets

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -126,27 +126,32 @@ module SwiftGlibc [system] {
       export *
     }
     module signal {
+% if CMAKE_SDK == "FREEBSD":
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/signal.h"
+% end
       header "${GLIBC_INCLUDE_PATH}/signal.h"
       export *
     }
 
-    // note: supplied by the compiler
-    // module stdarg {
-    //   header "${GLIBC_INCLUDE_PATH}/stdarg.h"
-    //   export *
-    // }
-    // module stdbool {
-    //   header "${GLIBC_INCLUDE_PATH}/stdbool.h"
-    //   export *
-    // }
-    // module stddef {
-    //   header "${GLIBC_INCLUDE_PATH}/stddef.h"
-    //   export *
-    // }
-    // module stdint {
-    //   header "${GLIBC_INCLUDE_PATH}/stdint.h"
-    //   export *
-    // }
+    // note: supplied by the compiler under Linux
+% if CMAKE_SDK == "FREEBSD":
+    module stdarg {
+      header "${GLIBC_INCLUDE_PATH}/stdarg.h"
+      export *
+    }
+    module stdbool {
+      header "${GLIBC_INCLUDE_PATH}/stdbool.h"
+      export *
+    }
+    module stddef {
+      header "${GLIBC_INCLUDE_PATH}/stddef.h"
+      export *
+    }
+    module stdint {
+      header "${GLIBC_INCLUDE_PATH}/stdint.h"
+      export *
+    }
+% end
 
     module stdio {
       header "${GLIBC_INCLUDE_PATH}/stdio.h"
@@ -405,6 +410,13 @@ module SwiftGlibc [system] {
 % end
       module statvfs {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/statvfs.h"
+        export *
+      }
+% end
+
+% if CMAKE_SDK == "FREEBSD":
+      module param {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/param.h"
         export *
       }
 % end

--- a/stdlib/public/SwiftShims/SwiftStddef.h
+++ b/stdlib/public/SwiftShims/SwiftStddef.h
@@ -21,7 +21,7 @@
 // "/usr/include/x86_64-linux-gnu/sys/types.h:146:10: error: 'stddef.h' file not
 // found"
 // This is a known Clang/Ubuntu bug.
-#if !defined(__APPLE__) && !defined(__linux__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__FreeBSD__)
 #include <stddef.h>
 typedef size_t __swift_size_t;
 #else

--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__FreeBSD__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes a issue with the CMake script under FreeBSD and possibly resolves some issues when compiling libdispatch/Foundation.

glibc.modulemap.gyb: stdarg, stdbool, stddef, stdint, sys/param.h
=======
Required when compiling libdispatch/Foundation, otherwise we get a lot of bogus "must import Glibc module" errors
```CFBase.h:88:13: error: declaration of 'uint64_t' must be imported from module 'SwiftGlibc.C.pty' before it is required```

**Should this be enabled only for FreeBSD?**

glibc.modulemap.gyb: sys/signal.h
=======
Resolves a Clang/Swift compiler crash when compiling libdispatch

In short, when building the module without sys/signal.h, a `struct __sigset` definition is not serialized within the module, causing the `ASTWriter::getDeclID` method to trigger "Declaration not emitted!" assertion (see SR-6034).

**Was not sure if it should be included together with `signal` or under `sys`. Kept under signal because I think it would make more sense.**

AddSwift.cmake
=======
`libclang_rt.builtins-${arch}.a` is copied by Ninja itself, if we don't use a "-l" it will interpret as a dependency and try to resolve it. Since the CMake script never declares a target emitting this file and it does not exists initially, it will fail. This will only trigger on clean builds (only if the file was not copied already).

Alternatively a `add_custom_command` could be used declaring `libclang_rt.builtins-${arch}.a` as a output. This would enable CMake/Ninja to properly resolve the dependencies.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6034](https://bugs.swift.org/browse/SR-6034).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->