### PR TITLE
[Sema/SILGen] Support for fallthrough into cases with pattern variables.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2889,14 +2889,16 @@ ERROR(fallthrough_outside_switch,none,
 ERROR(fallthrough_from_last_case,none,
       "'fallthrough' without a following 'case' or 'default' block", ())
 ERROR(fallthrough_into_case_with_var_binding,none,
-      "'fallthrough' cannot transfer control to a case label that declares variables",
-      ())
+      "'fallthrough' from a case which doesn't bind variable %0",
+      (Identifier))
 
 ERROR(unnecessary_cast_over_optionset,none,
       "unnecessary cast over raw value of %0", (Type))
 
 ERROR(type_mismatch_multiple_pattern_list,none,
       "pattern variable bound to type %0, expected type %1", (Type, Type))
+ERROR(type_mismatch_fallthrough_pattern_list,none,
+      "pattern variable bound to type %0, fallthrough case bound to type %1", (Type, Type))
 
 WARNING(where_on_one_item, none,
         "'where' only applies to the second pattern match in this case", ())

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1052,18 +1052,29 @@ public:
 /// FallthroughStmt - The keyword "fallthrough".
 class FallthroughStmt : public Stmt {
   SourceLoc Loc;
+  CaseStmt *FallthroughSource;
   CaseStmt *FallthroughDest;
   
 public:
   FallthroughStmt(SourceLoc Loc, Optional<bool> implicit = None)
     : Stmt(StmtKind::Fallthrough, getDefaultImplicitFlag(implicit, Loc)),
-      Loc(Loc), FallthroughDest(nullptr)
+      Loc(Loc), FallthroughSource(nullptr), FallthroughDest(nullptr)
   {}
   
   SourceLoc getLoc() const { return Loc; }
   
   SourceRange getSourceRange() const { return Loc; }
-  
+
+  /// Get the CaseStmt block from which the fallthrough transfers control.
+  /// Set during Sema. (May stay null if fallthrough is invalid.)
+  CaseStmt *getFallthroughSource() const {
+    return FallthroughSource;
+  }
+  void setFallthroughSource(CaseStmt *C) {
+    assert(!FallthroughSource && "fallthrough source already set?!");
+    FallthroughSource = C;
+  }
+
   /// Get the CaseStmt block to which the fallthrough transfers control.
   /// Set during Sema.
   CaseStmt *getFallthroughDest() const {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2355,6 +2355,29 @@ public:
           });
         }
     }
+    
+    // A fallthrough dest case's bound variable means the source case's
+    // var of the same name is read.
+    if (auto *fallthroughStmt = dyn_cast<FallthroughStmt>(S)) {
+      if (auto *sourceCase = fallthroughStmt->getFallthroughSource()) {
+        SmallVector<VarDecl *, 4> sourceVars;
+        auto sourcePattern = sourceCase->getCaseLabelItems()[0].getPattern();
+        sourcePattern->collectVariables(sourceVars);
+        
+        auto destCase = fallthroughStmt->getFallthroughDest();
+        auto destPattern = destCase->getCaseLabelItems()[0].getPattern();
+        destPattern->forEachVariable([&](VarDecl *V) {
+          if (!V->hasName())
+            return;
+          for (auto *var : sourceVars) {
+            if (var->hasName() && var->getName() == V->getName()) {
+              VarDecls[var] |= RK_Read;
+              break;
+            }
+          }
+        });
+      }
+    }
       
     return { true, S };
   }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -303,7 +303,9 @@ public:
   /// The destination block for a 'fallthrough' statement. Null if the switch
   /// scope depth is zero or if we are checking the final 'case' of the current
   /// switch.
+  CaseStmt /*nullable*/ *FallthroughSource = nullptr;
   CaseStmt /*nullable*/ *FallthroughDest = nullptr;
+  FallthroughStmt /*nullable*/ *PreviousFallthrough = nullptr;
 
   SourceLoc EndTypeCheckLoc;
 
@@ -818,9 +820,9 @@ public:
       TC.diagnose(S->getLoc(), diag::fallthrough_from_last_case);
       return nullptr;
     }
-    if (FallthroughDest->hasBoundDecls())
-      TC.diagnose(S->getLoc(), diag::fallthrough_into_case_with_var_binding);
+    S->setFallthroughSource(FallthroughSource);
     S->setFallthroughDest(FallthroughDest);
+    PreviousFallthrough = S;
     return S;
   }
   
@@ -839,10 +841,12 @@ public:
     AddLabeledStmt labelNest(*this, S);
 
     auto cases = S->getCases();
+    CaseStmt *previousBlock = nullptr;
     for (auto i = cases.begin(), e = cases.end(); i != e; ++i) {
       auto *caseBlock = *i;
       // Fallthrough transfers control to the next case block. In the
       // final case block, it is invalid.
+      FallthroughSource = caseBlock;
       FallthroughDest = std::next(i) == e ? nullptr : *std::next(i);
 
       for (auto &labelItem : caseBlock->getMutableCaseLabelItems()) {
@@ -868,12 +872,12 @@ public:
           // was in the first label item's pattern.
           auto firstPattern = caseBlock->getCaseLabelItems()[0].getPattern();
           if (pattern != firstPattern) {
-            SmallVector<VarDecl *, 4> Vars;
-            firstPattern->collectVariables(Vars);
+            SmallVector<VarDecl *, 4> vars;
+            firstPattern->collectVariables(vars);
             pattern->forEachVariable([&](VarDecl *VD) {
               if (!VD->hasName())
                 return;
-              for (auto expected : Vars) {
+              for (auto *expected : vars) {
                 if (expected->hasName() && expected->getName() == VD->getName()) {
                   if (!VD->getType()->isEqual(expected->getType())) {
                     TC.diagnose(VD->getLoc(), diag::type_mismatch_multiple_pattern_list,
@@ -887,18 +891,54 @@ public:
             });
           }
         }
-
         // Check the guard expression, if present.
         if (auto *guard = labelItem.getGuardExpr()) {
           hadError |= TC.typeCheckCondition(guard, DC);
           labelItem.setGuardExpr(guard);
         }
       }
+        
+      // If the previous case fellthrough, similarly check that that case's bindings
+      // includes our first label item's pattern bindings and types.
+      if (PreviousFallthrough) {
+        auto firstPattern = caseBlock->getCaseLabelItems()[0].getPattern();
+        SmallVector<VarDecl *, 4> Vars;
+        firstPattern->collectVariables(Vars);
+
+        for (auto &labelItem : previousBlock->getCaseLabelItems()) {
+          const Pattern *pattern = labelItem.getPattern();
+          SmallVector<VarDecl *, 4> PreviousVars;
+          pattern->collectVariables(PreviousVars);
+          for (auto expected : Vars) {
+            bool matched = false;
+            if (!expected->hasName())
+              continue;
+            for (auto previous: PreviousVars) {
+              if (previous->hasName() && expected->getName() == previous->getName()) {
+                if (!previous->getType()->isEqual(expected->getType())) {
+                  TC.diagnose(previous->getLoc(), diag::type_mismatch_fallthrough_pattern_list,
+                              previous->getType(), expected->getType());
+                  previous->markInvalid();
+                  expected->markInvalid();
+                }
+                matched = true;
+                break;
+              }
+            }
+            if (!matched) {
+              TC.diagnose(PreviousFallthrough->getLoc(),
+                          diag::fallthrough_into_case_with_var_binding, expected->getName());
+            }
+          }
+        }
+      }
       
       // Type-check the body statements.
+      PreviousFallthrough = nullptr;
       Stmt *body = caseBlock->getBody();
       hadError |= typeCheckStmt(body);
       caseBlock->setBody(body);
+      previousBlock = caseBlock;
     }
 
     if (!S->isImplicit()) {

--- a/test/Parse/ConditionalCompilation/switch_case.swift
+++ b/test/Parse/ConditionalCompilation/switch_case.swift
@@ -206,7 +206,7 @@ func foo(x: E, intVal: Int) {
   // 'fallthrough' target.
   switch intVal {
     case 1:
-      fallthrough // expected-error {{'fallthrough' cannot transfer control to a case label that declares variables}}
+      fallthrough // expected-error {{'fallthrough' from a case which doesn't bind variable 'val'}}
 #if ENABLE_C
     case let val:
       break

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -251,12 +251,29 @@ func patternVarUsedInAnotherPattern(x: Int) {
   }
 }
 
-// Fallthroughs can't transfer control into a case label with bindings.
+// Fallthroughs can only transfer control into a case label with bindings if the previous case binds a superset of those vars.
 switch t {
 case (1, 2):
-  fallthrough // expected-error {{'fallthrough' cannot transfer control to a case label that declares variables}}
+  fallthrough // expected-error {{'fallthrough' from a case which doesn't bind variable 'a'}} expected-error {{'fallthrough' from a case which doesn't bind variable 'b'}}
 case (var a, var b): // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}} expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
   t = (b, a)
+}
+
+switch t { // specifically notice on next line that we shouldn't complain that a is unused - just never mutated
+case (var a, let b): // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  t = (b, b)
+  fallthrough // ok - notice that subset of bound variables falling through is fine
+case (2, let a):
+  t = (a, a)
+}
+
+func patternVarDiffType(x: Int, y: Double) {
+  switch (x, y) {
+  case (1, let a): // expected-error {{pattern variable bound to type 'Double', fallthrough case bound to type 'Int'}}
+    fallthrough
+  case (let a, _):
+    break
+  }
 }
 
 func test_label(x : Int) {

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -16,6 +16,8 @@ func e() {}
 func f() {}
 func g() {}
 
+func z(_ i: Int) {}
+
 // CHECK-LABEL: sil hidden @$S18switch_fallthrough5test1yyF
 func test1() {
   switch foo() {
@@ -134,3 +136,38 @@ func test4() {
   // CHECK-NEXT: tuple ()
   // CHECK-NEXT: return
 }
+
+// Fallthrough into case block with binding // CHECK-LABEL: sil hidden @$S18switch_fallthrough5test5yyF
+func test5() {
+  switch (foo(), bar()) {
+  // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], {{bb[0-9]+}}
+  // CHECK: [[YES_CASE1]]:
+  case (var n, foo()):
+    // Check that the var is boxed and unboxed and the final value is the one that falls through into the next case
+    // CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "n"
+    // CHECK:   [[N_BOX:%.*]] = project_box [[BOX]] : ${ var Int }, 0
+    // CHECK:   function_ref @$S18switch_fallthrough1ayyF
+    // CHECK:   [[N:%.*]] = load [trivial] [[N_BOX]] : $*Int
+    // CHECK:   destroy_value [[BOX]] : ${ var Int }
+    // CHECK:   br [[CASE2:bb[0-9]+]]([[N]] : $Int)
+    a()
+    fallthrough
+  case (foo(), let n):
+    // CHECK:   cond_br {{%.*}}, [[YES_SECOND_CONDITION:bb[0-9]+]], {{bb[0-9]+}}
+    // CHECK: [[YES_SECOND_CONDITION]]:
+    // CHECK:   debug_value [[SECOND_N:%.*]] : $Int, let, name "n"
+    // CHECK:   br [[CASE2]]([[SECOND_N]] : $Int)
+    
+    // CHECK: [[CASE2]]([[INCOMING_N:%.*]] : @trivial $Int):
+    // CHECK:   [[Z:%.*]] = function_ref @$S18switch_fallthrough1zyySiF
+    // CHECK    apply [[Z]]([[INCOMING_N]]) : $@convention(thin) (Int) -> ()
+    // CHECK:   br [[CONT:bb[0-9]+]]
+    z(n)
+  case (_, _):
+    break
+  }
+  // CHECK: [[CONT]]:
+  // CHECK:   function_ref @$S18switch_fallthrough1eyyF
+  e()
+}
+

--- a/test/SILGen/switch_multiple_entry_address_only.swift
+++ b/test/SILGen/switch_multiple_entry_address_only.swift
@@ -131,3 +131,70 @@ func multipleLabelsVar(e: E) {
     break
   }
 }
+
+// CHECK-LABEL: sil hidden @$S34switch_multiple_entry_address_only20fallthroughWithValue1eyAA1EO_tF : $@convention(thin) (@in E) -> ()
+func fallthroughWithValue(e: E) {
+  // CHECK:      bb0
+  // CHECK:      [[X_PHI:%.*]] = alloc_stack $Any
+  // CHECK-NEXT: [[E_COPY:%.*]] = alloc_stack $E
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[E_COPY]]
+  // CHECK-NEXT: switch_enum_addr [[E_COPY]] : $*E, case #E.a!enumelt.1: bb1, case #E.b!enumelt.1: bb2, default bb4
+  
+  // CHECK:      bb1:
+  // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.a!enumelt.1
+  // CHECK-NEXT: [[ORIGINAL_ANY_BOX:%.*]] = alloc_stack $Any
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ORIGINAL_ANY_BOX]]
+  // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack $Any
+  // CHECK-NEXT: copy_addr [[ORIGINAL_ANY_BOX]] to [initialization] [[ANY_BOX]]
+  // CHECK:      [[FN1:%.*]] = function_ref @$S34switch_multiple_entry_address_only8takesAnyyyypF
+  // CHECK-NEXT: apply [[FN1]]([[ANY_BOX]]
+  // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ORIGINAL_ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: destroy_addr [[ORIGINAL_ANY_BOX]]
+  // CHECK-NEXT: dealloc_stack [[ORIGINAL_ANY_BOX]]
+  // CHECK-NEXT: dealloc_stack [[E_COPY]]
+  // CHECK-NEXT: br bb3
+  
+  // CHECK:      bb2:
+  // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.b!enumelt.1
+  // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack $Any
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: destroy_addr [[ANY_BOX]]
+  // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
+  // CHECK-NEXT: dealloc_stack [[E_COPY]]
+  // CHECK-NEXT: br bb3
+  
+  // CHECK:      bb3:
+  // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack $Any
+  // CHECK-NEXT: copy_addr [[X_PHI]] to [initialization] [[ANY_BOX]]
+  // CHECK:      [[FN2:%.*]] = function_ref @$S34switch_multiple_entry_address_only8takesAnyyyypF
+  // CHECK-NEXT: apply [[FN2]]([[ANY_BOX]]
+  // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
+  // CHECK-NEXT: destroy_addr [[X_PHI]]
+  // CHECK-NEXT: br bb6
+  
+  // CHECK:      bb4:
+  // CHECK-NEXT: br bb5
+  
+  // CHECK:      bb5:
+  // CHECK-NEXT: destroy_addr [[E_COPY]]
+  // CHECK-NEXT: dealloc_stack [[E_COPY]]
+  // CHECK-NEXT: br bb6
+  
+  // CHECK:      bb6:
+  // CHECK-NEXT: dealloc_stack [[X_PHI]]
+  // CHECK-NEXT: destroy_addr %0
+  // CHECK-NEXT: tuple ()
+  // CHECK-NEXT: return
+  
+  switch e {
+  case .a(let x):
+    takesAny(x)
+    fallthrough
+  case .b(let x):
+    takesAny(x)
+  default:
+    break
+  }
+}


### PR DESCRIPTION
This is the simplest / most-restrictive version of this feature. The previous case that we're falling from must have a superset of the bindings of the case we're falling into and all the to-case bindings must match name and type exactly the corresponding from-case binding.

Fallthrough error diagnoses changed for these new rules, Sema changed to check them, SILGen extended to use the same phi argument passing between case blocks for fallthrough that it was already using for multiple patterns. Finally, VarDeclUsage checker changed so that a binding falling through to a next case counts as a read of that decl.

Tests for all the above, including separate SILGen testing for fallthrough of address-only types that @slavapestov recently fixed for multiple patterns.