### PR TITLE
[benchmark] Add DoubleWidth division benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictionaryRemove
     single-source/DictionarySubscriptDefault
     single-source/DictionarySwap
+    single-source/DoubleWidthDivision
     single-source/DropFirst
     single-source/DropLast
     single-source/DropWhile

--- a/benchmark/single-source/DoubleWidthDivision.swift
+++ b/benchmark/single-source/DoubleWidthDivision.swift
@@ -1,0 +1,56 @@
+//===--- DoubleWidthDivision.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This test checks performance of division using DoubleWidth.
+
+import Foundation
+import TestsUtils
+
+public let DoubleWidthDivision = BenchmarkInfo(
+  name: "DoubleWidthDivision",
+  runFunction: run_DoubleWidthDivision,
+  tags: [.validation, .algorithm]
+)
+
+private typealias Int128 = DoubleWidth<Int64>
+private typealias Int256 = DoubleWidth<Int128>
+private typealias Int512 = DoubleWidth<Int256>
+private typealias Int1024 = DoubleWidth<Int512>
+
+@inline(never)
+public func run_DoubleWidthDivision(_ N: Int) {
+  var sum = 0
+  for _ in 1...N {
+    let (q, r) =
+      (Int128(Int64.max) * 16)
+        .quotientAndRemainder(dividingBy: numericCast(getInt(16)))
+    sum += Int(q * r)
+
+    let (q1, r1) =
+      (40 as Int128).dividingFullWidth(
+        (high: numericCast(getInt(0)), low: numericCast(getInt(240))))
+    sum += Int(q1 * r1)
+
+    let x =
+      DoubleWidth<DoubleWidth<DoubleWidth<Int8>>>(
+        Int64.max / numericCast(getInt(4)))
+    let y = DoubleWidth<DoubleWidth<Int8>>(Int32.max)
+    let (q2, r2) = y.dividingFullWidth((x.high, x.low))
+    sum += Int(q2 - r2)
+
+    let xx = Int1024(x)
+    let yy = Int512(y)
+    let (q3, r3) = yy.dividingFullWidth((xx.high, xx.low))
+    sum -= Int(q3 - r3)
+  }
+  CheckResults(sum == 0)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -52,6 +52,7 @@ import DictionaryLiteral
 import DictionaryRemove
 import DictionarySubscriptDefault
 import DictionarySwap
+import DoubleWidthDivision
 import DropFirst
 import DropLast
 import DropWhile
@@ -191,6 +192,7 @@ registerBenchmark(DictionaryLiteral)
 registerBenchmark(DictionaryRemove)
 registerBenchmark(DictionarySubscriptDefault)
 registerBenchmark(DictionarySwap)
+registerBenchmark(DoubleWidthDivision)
 registerBenchmark(DropFirst)
 registerBenchmark(DropLast)
 registerBenchmark(DropWhile)


### PR DESCRIPTION
This PR adds a benchmark for `DoubleWidth` division, which is currently slow, in anticipation of #13784 (which is still work-in-progress at the moment).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->