### PR TITLE
[AllocBoxToStack] Use `SILBUilderWithScope` instead of `SILBuilder`.

### DIFF
--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -470,8 +470,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
 
   // Promote this alloc_box to an alloc_stack. Insert the alloc_stack
   // at the beginning of the function.
-  SILBuilder Builder(ABI);
-  Builder.setCurrentDebugScope(ABI->getDebugScope());
+  SILBuilderWithScope Builder(ABI);
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "rewriting multi-field box not implemented");
   auto *ASI = Builder.createAllocStack(


### PR DESCRIPTION
It's the correct thing to do, as we immediately switch the current
debug scope. In this case, it's NFC as the code was already doing
the right thing, but this is more concise/harder to get wrong.