### PR TITLE
[string] Force specialization for small Character

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1039,6 +1039,12 @@ extension _StringGuts {
     }
   }
 
+
+  //
+  // FIXME (TODO JIRA): Appending a character onto the end of a string should
+  // really have a less generic implementation, then we can drop @specialize.
+  //
+  @_specialize(where C == Character._SmallUTF16)
   public // @testable
   mutating func append<C : Collection>(contentsOf other: C)
   where C.Element == UTF16.CodeUnit {


### PR DESCRIPTION
<!-- What's in this pull request? -->

Until we can sort out Character's small storage, specialize based on it. Worth about 20% on StringEdits.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
