### PR TITLE
Refactor type matching to split function type matching out.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2178,14 +2178,10 @@ namespace {
   };
 } // end anonymous namespace
 
-static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
-                    ParameterPosition paramPosition,
-                    OptionalUnwrapping insideOptional);
-
 static bool matchFunctionTypes(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
                                TypeMatchOptions matchMode,
-                               ParameterPosition paramPosition,
-                               OptionalUnwrapping insideOptional) {
+                               OptionalUnwrapping insideOptional,
+                               std::function<bool()> paramsAndResultMatch) {
   // FIXME: Handle generic functions in non-ABI matches.
   if (!matchMode.contains(TypeMatchFlags::AllowABICompatible)) {
     if (!isa<FunctionType>(fn1) || !isa<FunctionType>(fn2))
@@ -2214,11 +2210,7 @@ static bool matchFunctionTypes(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
   if (ext1 != ext2)
     return false;
 
-  // Inputs are contravariant, results are covariant.
-  return (matches(fn2.getInput(), fn1.getInput(), matchMode,
-                  ParameterPosition::Parameter, OptionalUnwrapping::None) &&
-          matches(fn1.getResult(), fn2.getResult(), matchMode,
-                  ParameterPosition::NotParameter, OptionalUnwrapping::None));
+  return paramsAndResultMatch();
 }
 
 static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
@@ -2298,8 +2290,17 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
     if (!fn1)
       return false;
 
-    return matchFunctionTypes(fn1, fn2, matchMode, paramPosition,
-                              insideOptional);
+    std::function<bool()> paramsAndResultMatch = [=]() {
+      // Inputs are contravariant, results are covariant.
+      return (matches(fn2.getInput(), fn1.getInput(), matchMode,
+                      ParameterPosition::Parameter, OptionalUnwrapping::None) &&
+              matches(fn1.getResult(), fn2.getResult(), matchMode,
+                      ParameterPosition::NotParameter,
+                      OptionalUnwrapping::None));
+    };
+
+    return matchFunctionTypes(fn1, fn2, matchMode, insideOptional,
+                              paramsAndResultMatch);
   }
 
   if (matchMode.contains(TypeMatchFlags::AllowNonOptionalForIUOParam) &&


### PR DESCRIPTION
Split out function type matching and add a callback for matching parameter and return types.

This is necessary for use in the decl checker once IUOs are removed from the type system, because we need to walk parameter lists rather than function type inputs for some of the IUO-specific overriding checks.