### PR TITLE
[SwiftSyntax] Add debug print when the JSONDecoder fails to decode JSON

### DIFF
--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -3,9 +3,6 @@
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 
-// FIXME: This test fails occassionally in CI with invalid json.
-// REQUIRES: disabled
-
 import StdlibUnittest
 import Foundation
 import SwiftSyntax

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -25,6 +25,7 @@ import Glibc
 public enum ParserError: Error {
   case swiftcFailed(Int, String)
   case invalidFile
+  case jsonDecodeError(input: String, originalError: Error);
 }
 
 extension Syntax {
@@ -42,8 +43,16 @@ extension Syntax {
     guard result.wasSuccessful else {
       throw ParserError.swiftcFailed(result.exitCode, result.stderr)
     }
+    let jsonData = result.stdoutData
     let decoder = JSONDecoder()
-    let raw = try decoder.decode(RawSyntax.self, from: result.stdoutData)
+    let raw: RawSyntax
+    do {
+      raw = try decoder.decode(RawSyntax.self, from: jsonData)
+    } catch let err {
+      throw ParserError.jsonDecodeError(
+          input: String(data: jsonData, encoding: .utf8) ?? jsonData.base64EncodedString(),
+          originalError: err)
+    }
     guard let file = Syntax.fromRaw(raw) as? SourceFileSyntax else {
       throw ParserError.invalidFile
     }


### PR DESCRIPTION
from the compiler's `-emit-syntax`.

Enable occasionally failing test case with detailed diagnostics to debug.
The test case have been disabled in https://github.com/apple/swift/commit/79c8695c5b38c80cacf7df3b14f1db3349a09ee5

Investigating: rdar://problem/36379512
