### PR TITLE
Rename swift3 section and global names to swift5

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -263,7 +263,7 @@ protected:
 
     // Others, such as capture descriptors, do not have a name.
     } else {
-      var = B.finishAndCreateGlobal("\x01l__swift3_reflection_descriptor",
+      var = B.finishAndCreateGlobal("\x01l__swift5_reflection_descriptor",
                                     Alignment(4), /*isConstant*/ true,
                                     llvm::GlobalValue::PrivateLinkage);
     }
@@ -780,15 +780,15 @@ static std::string getReflectionSectionName(IRGenModule &IGM,
   case llvm::Triple::COFF:
     assert(FourCC.size() <= 4 &&
            "COFF section name length must be <= 8 characters");
-    OS << ".sw3" << FourCC << "$B";
+    OS << ".sw5" << FourCC << "$B";
     break;
   case llvm::Triple::ELF:
-    OS << "swift3_" << LongName;
+    OS << "swift5_" << LongName;
     break;
   case llvm::Triple::MachO:
     assert(LongName.size() <= 7 &&
            "Mach-O section name length must be <= 16 characters");
-    OS << "__TEXT,__swift3_" << LongName << ", regular, no_dead_strip";
+    OS << "__TEXT,__swift5_" << LongName << ", regular, no_dead_strip";
     break;
   case llvm::Triple::Wasm:
     llvm_unreachable("web assembly object format is not supported.");

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -106,12 +106,12 @@ internal func getSectionInfo(_ name: String,
 ///
 /// An image of interest must have the following sections in the __DATA
 /// segment:
-/// - __swift3_fieldmd
-/// - __swift3_assocty
-/// - __swift3_builtin
-/// - __swift3_capture
-/// - __swift3_typeref
-/// - __swift3_reflstr (optional, may have been stripped out)
+/// - __swift5_fieldmd
+/// - __swift5_assocty
+/// - __swift5_builtin
+/// - __swift5_capture
+/// - __swift5_typeref
+/// - __swift5_reflstr (optional, may have been stripped out)
 ///
 /// - Parameter i: The index of the loaded image as reported by Dyld.
 /// - Returns: A `ReflectionInfo` containing the locations of all of the
@@ -122,12 +122,12 @@ internal func getReflectionInfoForImage(atIndex i: UInt32) -> ReflectionInfo? {
     to: UnsafePointer<MachHeader>.self)
 
   let imageName = _dyld_get_image_name(i)!
-  let fieldmd = getSectionInfo("__swift3_fieldmd", header)
-  let assocty = getSectionInfo("__swift3_assocty", header)
-  let builtin = getSectionInfo("__swift3_builtin", header)
-  let capture = getSectionInfo("__swift3_capture", header)
-  let typeref = getSectionInfo("__swift3_typeref", header)
-  let reflstr = getSectionInfo("__swift3_reflstr", header)
+  let fieldmd = getSectionInfo("__swift5_fieldmd", header)
+  let assocty = getSectionInfo("__swift5_assocty", header)
+  let builtin = getSectionInfo("__swift5_builtin", header)
+  let capture = getSectionInfo("__swift5_capture", header)
+  let typeref = getSectionInfo("__swift5_typeref", header)
+  let reflstr = getSectionInfo("__swift5_reflstr", header)
   return ReflectionInfo(imageName: String(validatingUTF8: imageName)!,
                         fieldmd: fieldmd,
                         assocty: assocty,

--- a/stdlib/public/runtime/ImageInspectionCOFF.h
+++ b/stdlib/public/runtime/ImageInspectionCOFF.h
@@ -48,10 +48,10 @@ struct MetadataSections {
   Range swift5_protocols;
   Range swift5_protocol_conformances;
   Range swift5_type_metadata;
-  Range swift3_typeref;
-  Range swift3_reflstr;
-  Range swift3_fieldmd;
-  Range swift3_assocty;
+  Range swift5_typeref;
+  Range swift5_reflstr;
+  Range swift5_fieldmd;
+  Range swift5_assocty;
 };
 } // namespace swift
 

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -48,10 +48,10 @@ struct MetadataSections {
   Range swift5_protocols;
   Range swift5_protocol_conformances;
   Range swift5_type_metadata;
-  Range swift3_typeref;
-  Range swift3_reflstr;
-  Range swift3_fieldmd;
-  Range swift3_assocty;
+  Range swift5_typeref;
+  Range swift5_reflstr;
+  Range swift5_fieldmd;
+  Range swift5_assocty;
 };
 } // namespace swift
 

--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -34,13 +34,13 @@
   static uintptr_t __stop_##name = 0;
 
 extern "C" {
-DECLARE_SWIFT_SECTION(sw2prtc)
-DECLARE_SWIFT_SECTION(sw2tymd)
+DECLARE_SWIFT_SECTION(sw5prtc)
+DECLARE_SWIFT_SECTION(sw5tymd)
 
-DECLARE_SWIFT_SECTION(sw3tyrf)
-DECLARE_SWIFT_SECTION(sw3rfst)
-DECLARE_SWIFT_SECTION(sw3flmd)
-DECLARE_SWIFT_SECTION(sw3asty)
+DECLARE_SWIFT_SECTION(sw5tyrf)
+DECLARE_SWIFT_SECTION(sw5rfst)
+DECLARE_SWIFT_SECTION(sw5flmd)
+DECLARE_SWIFT_SECTION(sw5asty)
 }
 
 namespace {
@@ -59,13 +59,13 @@ static void swift_image_constructor() {
       nullptr,
       nullptr,
 
-      SWIFT_SECTION_RANGE(sw2prtc),
-      SWIFT_SECTION_RANGE(sw2tymd),
+      SWIFT_SECTION_RANGE(sw5prtc),
+      SWIFT_SECTION_RANGE(sw5tymd),
 
-      SWIFT_SECTION_RANGE(sw3tyrf),
-      SWIFT_SECTION_RANGE(sw3rfst),
-      SWIFT_SECTION_RANGE(sw3flmd),
-      SWIFT_SECTION_RANGE(sw3asty),
+      SWIFT_SECTION_RANGE(sw5tyrf),
+      SWIFT_SECTION_RANGE(sw5rfst),
+      SWIFT_SECTION_RANGE(sw5flmd),
+      SWIFT_SECTION_RANGE(sw5asty),
   };
 
 #undef SWIFT_SECTION_RANGE

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -28,10 +28,10 @@ DECLARE_SWIFT_SECTION(swift5_protocols)
 DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
 DECLARE_SWIFT_SECTION(swift5_type_metadata)
 
-DECLARE_SWIFT_SECTION(swift3_typeref)
-DECLARE_SWIFT_SECTION(swift3_reflstr)
-DECLARE_SWIFT_SECTION(swift3_fieldmd)
-DECLARE_SWIFT_SECTION(swift3_assocty)
+DECLARE_SWIFT_SECTION(swift5_typeref)
+DECLARE_SWIFT_SECTION(swift5_reflstr)
+DECLARE_SWIFT_SECTION(swift5_fieldmd)
+DECLARE_SWIFT_SECTION(swift5_assocty)
 }
 
 #undef DECLARE_SWIFT_SECTION
@@ -57,10 +57,10 @@ static void swift_image_constructor() {
       SWIFT_SECTION_RANGE(swift5_protocol_conformances),
       SWIFT_SECTION_RANGE(swift5_type_metadata),
 
-      SWIFT_SECTION_RANGE(swift3_typeref),
-      SWIFT_SECTION_RANGE(swift3_reflstr),
-      SWIFT_SECTION_RANGE(swift3_fieldmd),
-      SWIFT_SECTION_RANGE(swift3_assocty),
+      SWIFT_SECTION_RANGE(swift5_typeref),
+      SWIFT_SECTION_RANGE(swift5_reflstr),
+      SWIFT_SECTION_RANGE(swift5_fieldmd),
+      SWIFT_SECTION_RANGE(swift5_assocty),
   };
 
 #undef SWIFT_SECTION_RANGE

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -4,7 +4,7 @@
 
 // -- partial_apply context metadata
 
-// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 64 }, i32 16, i8* bitcast ({ i32, i32, i32, i32 }* @"\01l__swift3_reflection_descriptor" to i8*) }
+// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 64 }, i32 16, i8* bitcast ({ i32, i32, i32, i32 }* @"\01l__swift5_reflection_descriptor" to i8*) }
 
 func a(i i: Int) -> (Int) -> Int {
   return { x in i }

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -2,51 +2,51 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-reflection-names -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-reflection-metadata -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
 
-// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift3_reflect
-// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift3_fieldmd
-// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift3_assocty
-// STRIP_REFLECTION_NAMES-DAG: {{.*}}swift3_capture
-// STRIP_REFLECTION_NAMES-DAG: {{.*}}swift3_typeref
-// STRIP_REFLECTION_NAMES-NOT: {{.*}}swift3_reflstr
-// STRIP_REFLECTION_NAMES-NOT: {{.*}}swift3_builtin
+// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift5_reflect
+// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift5_fieldmd
+// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift5_assocty
+// STRIP_REFLECTION_NAMES-DAG: {{.*}}swift5_capture
+// STRIP_REFLECTION_NAMES-DAG: {{.*}}swift5_typeref
+// STRIP_REFLECTION_NAMES-NOT: {{.*}}swift5_reflstr
+// STRIP_REFLECTION_NAMES-NOT: {{.*}}swift5_builtin
 
-// STRIP_REFLECTION_NAMES-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}swift3_fieldmd
+// STRIP_REFLECTION_NAMES-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}swift5_fieldmd
 
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_reflect
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_fieldmd
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_assocty
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_capture
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_typeref
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_reflstr
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift3_builtin
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_reflect
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_fieldmd
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_assocty
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_capture
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_typeref
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_reflstr
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift5_builtin
 
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
-// CHECK-DAG: private constant [2 x i8] c"i\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"ms\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"me\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"mc\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"C\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"S\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"E\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"I\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"t\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [4 x i8] c"mgs\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [4 x i8] c"mge\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [4 x i8] c"mgc\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"GC\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"GS\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"GE\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"i\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"ms\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"me\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"mc\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"C\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"S\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"E\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"I\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"t\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [4 x i8] c"mgs\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [4 x i8] c"mge\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [4 x i8] c"mgc\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"GC\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"GS\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"GE\00", section "{{[^"]*}}swift5_reflstr{{[^"]*}}"
 
-// CHECK-DAG: @"\01l__swift3_reflection_descriptor" = private constant { {{.*}} } { i32 1, i32 1, i32 2, {{.*}} }
+// CHECK-DAG: @"\01l__swift5_reflection_descriptor" = private constant { {{.*}} } { i32 1, i32 1, i32 2, {{.*}} }
 
-// CHECK-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata7MyClassCMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata11ConformanceVAA10MyProtocolAAMA" = internal constant {{.*}}swift3_assocty
-// CHECK-DAG: @"$S19reflection_metadata8MyStructVMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata6MyEnumOMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata14MyGenericClassCMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata15MyGenericStructVMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata13MyGenericEnumOMF" = internal constant {{.*}}swift3_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata7MyClassCMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata11ConformanceVAA10MyProtocolAAMA" = internal constant {{.*}}swift5_assocty
+// CHECK-DAG: @"$S19reflection_metadata8MyStructVMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata6MyEnumOMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata14MyGenericClassCMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata15MyGenericStructVMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata13MyGenericEnumOMF" = internal constant {{.*}}swift5_fieldmd
 
 public protocol MyProtocol {
   associatedtype Inner

--- a/test/IRGen/reflection_metadata_imported.swift
+++ b/test/IRGen/reflection_metadata_imported.swift
@@ -4,10 +4,10 @@ import c_layout
 
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
 
-// CHECK-DAG: @"$S28reflection_metadata_imported15HasImportedTypeVMF" = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @"$SSo1AVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @"$SSo11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentableSCMA" = linkonce_odr hidden constant {{.*}}swift3_assocty
+// CHECK-DAG: @"$S28reflection_metadata_imported15HasImportedTypeVMF" = internal constant {{.*}}swift5_fieldmd
+// CHECK-DAG: @"$SSo1AVMB" = linkonce_odr hidden constant {{.*}}swift5_builtin
+// CHECK-DAG: @"$SSo11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}swift5_builtin
+// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentableSCMA" = linkonce_odr hidden constant {{.*}}swift5_assocty
 
 struct HasImportedType {
   let a: A

--- a/test/IRGen/swift3-metadata-coff.swift
+++ b/test/IRGen/swift3-metadata-coff.swift
@@ -25,11 +25,11 @@ public func f(s : S) -> (() -> ()) {
   return { gg = s }
 }
 
-// CHECK-DAG: @"\01l__swift3_reflection_descriptor" = private constant {{.*}}, section ".sw3cptr$B"
-// CHECK-DAG: @{{[0-9]+}} = private constant [3 x i8] c"Sq\00", section ".sw3tyrf$B"
-// CHECK-DAG: @{{[0-9]+}} = private constant [5 x i8] c"none\00", section ".sw3rfst$B"
-// CHECK-DAG: @{{[0-9]+}} = private constant [5 x i8] c"some\00", section ".sw3rfst$B"
-// CHECK-DAG: @"$SSqMF" = internal constant {{.*}}, section ".sw3flmd$B"
-// CHECK-DAG: @"$Ss1SVs1PsMA" = internal constant {{.*}}, section ".sw3asty$B"
-// CHECK-DAG: @"$SBoMB" = internal constant {{.*}}, section ".sw3bltn$B"
+// CHECK-DAG: @"\01l__swift5_reflection_descriptor" = private constant {{.*}}, section ".sw5cptr$B"
+// CHECK-DAG: @{{[0-9]+}} = private constant [3 x i8] c"Sq\00", section ".sw5tyrf$B"
+// CHECK-DAG: @{{[0-9]+}} = private constant [5 x i8] c"none\00", section ".sw5rfst$B"
+// CHECK-DAG: @{{[0-9]+}} = private constant [5 x i8] c"some\00", section ".sw5rfst$B"
+// CHECK-DAG: @"$SSqMF" = internal constant {{.*}}, section ".sw5flmd$B"
+// CHECK-DAG: @"$Ss1SVs1PsMA" = internal constant {{.*}}, section ".sw5asty$B"
+// CHECK-DAG: @"$SBoMB" = internal constant {{.*}}, section ".sw5bltn$B"
 

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -118,17 +118,17 @@ findReflectionSection(const ObjectFile *objectFile,
 
 static ReflectionInfo findReflectionInfo(const ObjectFile *objectFile) {
   auto fieldSection = findReflectionSection<FieldSection>(
-      objectFile, {"__swift3_fieldmd", ".swift3_fieldmd", "swift3_fieldmd"});
+      objectFile, {"__swift5_fieldmd", ".swift5_fieldmd", "swift5_fieldmd"});
   auto associatedTypeSection = findReflectionSection<AssociatedTypeSection>(
-      objectFile, {"__swift3_assocty", ".swift3_assocty", "swift3_assocty"});
+      objectFile, {"__swift5_assocty", ".swift5_assocty", "swift5_assocty"});
   auto builtinTypeSection = findReflectionSection<BuiltinTypeSection>(
-      objectFile, {"__swift3_builtin", ".swift3_builtin", "swift3_builtin"});
+      objectFile, {"__swift5_builtin", ".swift5_builtin", "swift5_builtin"});
   auto captureSection = findReflectionSection<CaptureSection>(
-      objectFile, {"__swift3_capture", ".swift3_capture", "swift3_capture"});
+      objectFile, {"__swift5_capture", ".swift5_capture", "swift5_capture"});
   auto typeRefSection = findReflectionSection<GenericSection>(
-      objectFile, {"__swift3_typeref", ".swift3_typeref", "swift3_typeref"});
+      objectFile, {"__swift5_typeref", ".swift5_typeref", "swift5_typeref"});
   auto reflectionStringsSection = findReflectionSection<GenericSection>(
-      objectFile, {"__swift3_reflstr", ".swift3_reflstr", "swift3_reflstr"});
+      objectFile, {"__swift5_reflstr", ".swift5_reflstr", "swift5_reflstr"});
 
   return {
       {fieldSection.first, fieldSection.second},

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -207,7 +207,7 @@ def compare_sizes_of_file(old_files, new_files, all_sections, list_categories):
         compare_sizes(old_sizes, new_sizes, "__const", section_title)
         compare_sizes(old_sizes, new_sizes, "__objc_const", section_title)
         compare_sizes(old_sizes, new_sizes, "__data", section_title)
-        compare_sizes(old_sizes, new_sizes, "__swift1_proto", section_title)
+        compare_sizes(old_sizes, new_sizes, "__swift5_proto", section_title)
         compare_sizes(old_sizes, new_sizes, "__common", section_title)
         compare_sizes(old_sizes, new_sizes, "__bss", section_title)
 


### PR DESCRIPTION
Such that old and new runtimes can co-exists.

rdar://36363251