### PR TITLE
[Stats] Expand FrontendStatsTracer to trace multiple entity-types.

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -10,7 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/AST/Decl.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/SIL/SILFunction.h"
 #include "swift/Driver/DependencyGraph.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"
@@ -128,6 +134,7 @@ UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
                                            StringRef OptType,
                                            StringRef Directory,
                                            SourceManager *SM,
+                                           clang::SourceManager *CSM,
                                            bool TraceEvents)
   : UnifiedStatsReporter(ProgramName,
                          auxName(ModuleName,
@@ -136,7 +143,7 @@ UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
                                  OutputType,
                                  OptType),
                          Directory,
-                         SM, TraceEvents)
+                         SM, CSM, TraceEvents)
 {
 }
 
@@ -144,6 +151,7 @@ UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
                                            StringRef AuxName,
                                            StringRef Directory,
                                            SourceManager *SM,
+                                           clang::SourceManager *CSM,
                                            bool TraceEvents)
   : currentProcessExitStatusSet(false),
     currentProcessExitStatus(EXIT_FAILURE),
@@ -153,7 +161,8 @@ UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
     Timer(make_unique<NamedRegionTimer>(AuxName,
                                         "Building Target",
                                         ProgramName, "Running Program")),
-    SourceMgr(SM)
+    SourceMgr(SM),
+    ClangSourceMgr(CSM)
 {
   path::append(StatsFilename, makeStatsFileName(ProgramName, AuxName));
   path::append(TraceFilename, makeTraceFileName(ProgramName, AuxName));
@@ -250,13 +259,13 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
 }
 
 UnifiedStatsReporter::FrontendStatsTracer::FrontendStatsTracer(
-    StringRef Name,
-    SourceRange const &Range,
+    StringRef EventName,
+    TraceEntity Entity,
     UnifiedStatsReporter *Reporter)
   : Reporter(Reporter),
     SavedTime(llvm::TimeRecord::getCurrentTime()),
-    Name(Name),
-    Range(Range)
+    EventName(EventName),
+    Entity(Entity)
 {
   if (Reporter)
     Reporter->saveAnyFrontendStatsEvents(*this, true);
@@ -273,8 +282,8 @@ UnifiedStatsReporter::FrontendStatsTracer::operator=(
 {
   Reporter = other.Reporter;
   SavedTime = other.SavedTime;
-  Name = other.Name;
-  Range = other.Range;
+  EventName = other.EventName;
+  Entity = other.Entity;
   other.Reporter = nullptr;
   return *this;
 }
@@ -283,8 +292,8 @@ UnifiedStatsReporter::FrontendStatsTracer::FrontendStatsTracer(
     FrontendStatsTracer&& other)
   : Reporter(other.Reporter),
     SavedTime(other.SavedTime),
-    Name(other.Name),
-    Range(other.Range)
+    EventName(other.EventName),
+    Entity(other.Entity)
 {
   other.Reporter = nullptr;
 }
@@ -296,14 +305,43 @@ UnifiedStatsReporter::FrontendStatsTracer::~FrontendStatsTracer()
 }
 
 UnifiedStatsReporter::FrontendStatsTracer
-UnifiedStatsReporter::getStatsTracer(StringRef N,
-                                     SourceRange const &R)
+UnifiedStatsReporter::getStatsTracer(StringRef EventName,
+                                     const Decl *D)
 {
   if (LastTracedFrontendCounters)
     // Return live tracer object.
-    return FrontendStatsTracer(N, R, this);
+    return FrontendStatsTracer(EventName, D, this);
   else
     // Return inert tracer object.
+    return FrontendStatsTracer();
+}
+
+UnifiedStatsReporter::FrontendStatsTracer
+UnifiedStatsReporter::getStatsTracer(StringRef EventName,
+                                     const Expr *E) {
+  if (LastTracedFrontendCounters)
+    return FrontendStatsTracer(EventName, E, this);
+  else
+    return FrontendStatsTracer();
+}
+
+UnifiedStatsReporter::FrontendStatsTracer
+UnifiedStatsReporter::getStatsTracer(StringRef EventName,
+                                     const clang::Decl *D)
+{
+  if (LastTracedFrontendCounters)
+    return FrontendStatsTracer(EventName, D, this);
+  else
+    return FrontendStatsTracer();
+}
+
+UnifiedStatsReporter::FrontendStatsTracer
+UnifiedStatsReporter::getStatsTracer(StringRef EventName,
+                                     const SILFunction *F)
+{
+  if (LastTracedFrontendCounters)
+    return FrontendStatsTracer(EventName, F, this);
+  else
     return FrontendStatsTracer();
 }
 
@@ -321,13 +359,14 @@ UnifiedStatsReporter::saveAnyFrontendStatsEvents(
   auto &C = getFrontendCounters();
 #define FRONTEND_STATISTIC(TY, NAME)                          \
   do {                                                        \
+    auto total = C.NAME;                                      \
     auto delta = C.NAME - LastTracedFrontendCounters->NAME;   \
     static char const *name = #TY "." #NAME;                  \
     if (delta != 0) {                                         \
       LastTracedFrontendCounters->NAME = C.NAME;              \
       FrontendStatsEvents.emplace_back(FrontendStatsEvent {   \
-          NowUS, LiveUS, IsEntry, T.Name, name,               \
-            delta, C.NAME, T.Range});                         \
+          NowUS, LiveUS, IsEntry, T.EventName, name,          \
+            delta, total, T.Entity});                         \
     }                                                         \
   } while (0);
 #include "swift/Basic/Statistics.def"
@@ -341,6 +380,57 @@ UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers::
 #include "swift/Basic/Statistics.def"
 #undef FRONTEND_RECURSIVE_SHARED_TIMER
       dummyInstanceVariableToGetConstructorToParse(0) {
+}
+
+static inline void
+printTraceEntityName(raw_ostream &OS,
+                     UnifiedStatsReporter::TraceEntity E) {
+  if (auto const *CD = E.dyn_cast<const clang::Decl*>()) {
+    if (auto const *ND = dyn_cast<const clang::NamedDecl>(CD)) {
+      ND->printName(OS);
+    }
+  } else if (auto const *D = E.dyn_cast<const Decl*>()) {
+    if (auto const *VD = dyn_cast<const ValueDecl>(D)) {
+      VD->getFullName().print(OS, false);
+    }
+  } else if (auto const *X = E.dyn_cast<const Expr*>()) {
+    // Exprs don't have names
+  } else if (auto const *F = E.dyn_cast<const SILFunction*>()) {
+    OS << F->getName();
+  }
+}
+
+static inline void
+printClangShortLoc(raw_ostream &OS,
+                   clang::SourceManager *CSM,
+                   clang::SourceLocation L) {
+  if (!L.isValid() || !L.isFileID())
+    return;
+  auto PLoc = CSM->getPresumedLoc(L);
+  OS << llvm::sys::path::filename(PLoc.getFilename())
+     << ':' << PLoc.getLine()
+     << ':' << PLoc.getColumn();
+}
+
+static inline void
+printTraceEntityLoc(raw_ostream &OS,
+                    SourceManager *SM,
+                    clang::SourceManager *CSM,
+                    UnifiedStatsReporter::TraceEntity E) {
+  if (auto const *CD = E.dyn_cast<const clang::Decl*>()) {
+    if (CSM) {
+      auto Range = CD->getSourceRange();
+      printClangShortLoc(OS, CSM, Range.getBegin());
+      OS << '-';
+      printClangShortLoc(OS, CSM, Range.getEnd());
+    }
+  } else if (auto const *D = E.dyn_cast<const Decl*>()) {
+    D->getSourceRange().print(OS, *SM, false);
+  } else if (auto const *X = E.dyn_cast<const Expr*>()) {
+    X->getSourceRange().print(OS, *SM, false);
+  } else if (auto const *F = E.dyn_cast<const SILFunction*>()) {
+    F->getLocation().getSourceRange().print(OS, *SM, false);
+  }
 }
 
 UnifiedStatsReporter::~UnifiedStatsReporter()
@@ -419,7 +509,7 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
       return;
     }
     tstream << "Time,Live,IsEntry,EventName,CounterName,"
-            << "CounterDelta,CounterValue,SourceRange\n";
+            << "CounterDelta,CounterValue,EntityName,EntityRange\n";
     for (auto const &E : FrontendStatsEvents) {
       tstream << E.TimeUSec << ','
               << E.LiveUSec << ','
@@ -429,7 +519,10 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
               << E.CounterDelta << ','
               << E.CounterValue << ',';
       tstream << '"';
-      E.SourceRange.print(tstream, *SourceMgr, false);
+      printTraceEntityName(tstream, E.Entity);
+      tstream << '"' << ',';
+      tstream << '"';
+      printTraceEntityLoc(tstream, SourceMgr, ClangSourceMgr, E.Entity);
       tstream << '"' << '\n';
     }
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7856,6 +7856,11 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   if (!ClangDecl)
     return nullptr;
 
+  UnifiedStatsReporter::FrontendStatsTracer Tracer;
+  if (SwiftContext.Stats)
+    Tracer = SwiftContext.Stats->getStatsTracer("import-clang-decl",
+                                                ClangDecl);
+
   clang::PrettyStackTraceDecl trace(ClangDecl, clang::SourceLocation(),
                                     Instance->getSourceManager(), "importing");
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ResilienceExpansion.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/Basic/Timer.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
@@ -716,6 +717,9 @@ void SILGenModule::emitFunction(FuncDecl *fd) {
   emitAbstractFuncDecl(fd);
 
   if (hasSILBody(fd)) {
+    UnifiedStatsReporter::FrontendStatsTracer Tracer;
+    if (getASTContext().Stats)
+      Tracer = getASTContext().Stats->getStatsTracer("emit-SIL", fd);
     PrettyStackTraceDecl stackTrace("emitting SIL for", fd);
 
     SILDeclRef constant(decl);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4007,8 +4007,7 @@ public:
   void visit(Decl *decl) {
     UnifiedStatsReporter::FrontendStatsTracer Tracer;
     if (TC.Context.Stats)
-      Tracer = TC.Context.Stats->getStatsTracer("type-checking",
-                                                decl->getSourceRange());
+      Tracer = TC.Context.Stats->getStatsTracer("typecheck-decl", decl);
     PrettyStackTraceDecl StackTrace("type-checking", decl);
     
     DeclVisitor<DeclChecker>::visit(decl);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Timer.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -419,6 +420,9 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
       // but that gets tricky with synthesized function bodies.
       if (AFD->isBodyTypeChecked()) continue;
 
+      UnifiedStatsReporter::FrontendStatsTracer Tracer;
+      if (TC.Context.Stats)
+        Tracer = TC.Context.Stats->getStatsTracer("typecheck-fn", AFD);
       PrettyStackTraceDecl StackEntry("type-checking", AFD);
       TC.typeCheckAbstractFunctionBody(AFD);
 


### PR DESCRIPTION
This is a small enhancement to the FrontendStatsTracer system, to make it a little more informative by attributing events to not just source ranges, but also the names of (at least a few major kinds of) source entities: Decls, clang::Decls, and SILFunctions. The implementation technique (a PointerUnion4, including Expr) also delays the construction of SourceRanges until the final processing loop, which is a bit cheaper in terms of memory and CPU overheads.

(There's a followup I'm working on that produces flame graph folded-stack input out of all this, but it's not quite done; @davidungar indicated he might have some use for this intermediate result before I'm done with that, so I figured I'd land this first)