### PR TITLE
[string] Workaround fail emptySingleton check.

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1011,24 +1011,7 @@ extension String {
   /// - Parameter other: Another string.
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func append(_ other: String) {
-    if self._guts._isEmptySingleton {
-      // We must be careful not to discard any capacity that
-      // may have been reserved for the append -- this is why
-      // we check for the empty string singleton rather than
-      // a zero `count` above.
-      self = other
-      return
-    }
-    defer { _fixLifetime(other) }
-    if _slowPath(other._guts._isOpaque) {
-      self._guts.append(other._guts._asOpaque())
-      return
-    }
-    if other._guts.isASCII {
-      self._guts.append(other._guts._unmanagedASCIIView)
-      return
-    }
-    self._guts.append(other._guts._unmanagedUTF16View)
+    self._guts.append(other._guts)
   }
 
   /// Appends the given Unicode scalar to the string.

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1006,10 +1006,16 @@ extension _StringGuts {
   @_inlineable
   public // TODO(StringGuts): for testing only
   mutating func append(_ other: _StringGuts) {
-    if _isEmptySingleton {
+    // FIXME(TODO: JIRA): shouldn't _isEmptySingleton be sufficient?
+    if _isEmptySingleton || self.count == 0 && !_object.isNative {
+      // We must be careful not to discard any capacity that
+      // may have been reserved for the append -- this is why
+      // we check for the empty string singleton rather than
+      // a zero `count` above.
       self = other
       return
     }
+
     defer { _fixLifetime(other) }
     if _slowPath(other._isOpaque) {
       self.append(other._asOpaque())


### PR DESCRIPTION
This is a temporary workaround for some situations where the empty
singleton is not being formed correctly (and this seems to be highly
configuration dependent). Work around that for now for also checking
for empty non-storage-backed Strings.

This is probably too expensive a check for us to do long-term, but it
works for now.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Unbreaks bot: https://ci.swift.org//job/oss-swift_tools-RA_stdlib-RDA_test-macos-resilience/

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->