### PR TITLE
[4.1][stdlib] Improve the flatMap deprecation message

### DIFF
--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -60,7 +60,8 @@ extension LazySequenceProtocol {
   ///
   /// - Complexity: O(1)
   @inline(__always)
-  @available(*, deprecated, renamed: "compactMap(_:)")
+  @available(*, deprecated, renamed: "compactMap(_:)",
+    message: "Please use compactMap(_:) for the case where closure returns an optional value")
   public func flatMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?
   ) -> LazyMapSequence<
@@ -123,7 +124,8 @@ extension LazyCollectionProtocol {
   ///   collection as its argument and returns an optional value.
   ///
   /// - Complexity: O(1)
-  @available(*, deprecated, renamed: "compactMap(_:)")
+  @available(*, deprecated, renamed: "compactMap(_:)",
+    message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @_inlineable // FIXME(sil-serialize-all)
   public func flatMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -783,7 +783,8 @@ extension Sequence {
   /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
   ///   and *n* is the length of the result.
   @inline(__always)
-  @available(*, deprecated, renamed: "compactMap(_:)")
+  @available(*, deprecated, renamed: "compactMap(_:)",
+    message: "Please use compactMap(_:) for the case where closure returns an optional value")
   public func flatMap<ElementOfResult>(
     _ transform: (Element) throws -> ElementOfResult?
   ) rethrows -> [ElementOfResult] {

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -448,7 +448,8 @@ extension Collection {
     return try _compactMap(transform)
   }
 
-  @available(*, deprecated, renamed: "compactMap(_:)")
+  @available(*, deprecated, renamed: "compactMap(_:)",
+    message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @inline(__always)
   public func flatMap(
     _ transform: (Element) throws -> String?

--- a/test/stdlib/FlatMapDeprecation.swift
+++ b/test/stdlib/FlatMapDeprecation.swift
@@ -3,30 +3,30 @@
 func flatMapOnSequence<
   S : Sequence
 >(xs: S, f: (S.Element) -> S.Element?) {
-  _ = xs.flatMap(f) // expected-warning {{deprecated}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
 }
 
 func flatMapOnLazySequence<
   S : LazySequenceProtocol
 >(xs: S, f: (S.Element) -> S.Element?) {
-  _ = xs.flatMap(f) // expected-warning {{deprecated}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
 }
 
 func flatMapOnLazyCollection<
   C : LazyCollectionProtocol
 >(xs: C, f: (C.Element) -> C.Element?) {
-  _ = xs.flatMap(f) // expected-warning {{deprecated}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
 }
 
 func flatMapOnLazyBidirectionalCollection<
   C : LazyCollectionProtocol & BidirectionalCollection
 >(xs: C, f: (C.Element) -> C.Element?)
 where C.Elements : BidirectionalCollection {
-  _ = xs.flatMap(f) // expected-warning {{deprecated}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
 }
 
 func flatMapOnCollectinoOfStrings<
   C : Collection
 >(xs: C, f: (C.Element) -> String?) {
-  _ = xs.flatMap(f) // expected-warning {{deprecated}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
 }


### PR DESCRIPTION
* Explanation: The generic message generated by the compiler can be read as if all the versions of flatMap are being deprecated, whereas only one particular variant of it is, the one that accepts a closure returning an optional value.
* Scope of Issue: purely QoI, non-functional change, but is supposed to improve developer experience.
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite with an updated test case for the new message
* Directions for QA: N/A
* Radar: <rdar://problem/36555646>