### PR TITLE
[4.1] [test-only] Disable cursor_no_cancel  test that crashes occassionaly in CI

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_no_cancel.swift
+++ b/test/SourceKit/CursorInfo/cursor_no_cancel.swift
@@ -44,3 +44,6 @@ func myFunc() {
 // RANGE: source.lang.swift.range.singleexpression
 // RANGE: source.lang.swift.range.singleexpression
 // RANGE: source.lang.swift.range.singleexpression
+
+// FIXME: this crashes very infrequently in CI
+// REQUIRES: disabled


### PR DESCRIPTION
* **Explanation**: Disable a test that crashes very rarely while we investigate the problem to prevent CI from seeing more spurious failures.
* **Scope**: Test-only.
* **Radar**: rdar://36715167
* **Risk**: None.
* **Testing**: N/A