### PR TITLE
build-script: Run lldb tests for Swift support per-commit

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -544,14 +544,15 @@ skip-build-tvos
 skip-test-tvos
 skip-build-watchos
 skip-test-watchos
-skip-test-lldb
 stdlib-deployment-targets=macosx-x86_64
 swift-primary-variant-sdk=OSX
 swift-primary-variant-arch=x86_64
 
+# Use the system debugserver to run the lldb swift tests
 lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release
+lldb-test-swift-only
 
 # Don't build the benchmarks
 skip-build-benchmarks

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2801,12 +2801,20 @@ for host in "${ALL_HOSTS[@]}"; do
                     LLDB_DOTEST_CC_OPTS="-C $(build_directory $LOCAL_HOST llvm)"/bin/clang
                 fi
 
+                # If we need to use the system debugserver, do so explicitly.
+                if [[ "$(uname -s)" == "Darwin" && "${LLDB_USE_SYSTEM_DEBUGSERVER}" ]] ; then
+                    LLDB_TEST_DEBUG_SERVER="--server $(xcode-select -p)/../SharedFrameworks/LLDB.framework/Resources/debugserver"
+                else
+                    LLDB_TEST_DEBUG_SERVER=""
+                fi
+
                 call mkdir -p "${results_dir}"
                 with_pushd "${results_dir}" \
                            call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
                            SWIFTLIBS="${swift_build_dir}/lib/swift" \
                            "${LLDB_SOURCE_DIR}"/test/dotest.py \
                            --executable "${lldb_executable}" \
+                           ${LLDB_TEST_DEBUG_SERVER} \
                            ${LLDB_TEST_SUBDIR_CLAUSE} \
                            ${LLDB_TEST_CATEGORIES} \
                            ${LLDB_DOTEST_CC_OPTS} \

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2783,8 +2783,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Handle test subdirectory clause
                 if [[ "${LLDB_TEST_SWIFT_ONLY}" ]]; then
                     LLDB_TEST_SUBDIR_CLAUSE="--test-subdir lang/swift"
+                    LLDB_TEST_CATEGORIES="--skip-category=dwo --skip-category=dsym --skip-category=gmodules -G swiftpr"
                 else
                     LLDB_TEST_SUBDIR_CLAUSE=""
+                    LLDB_TEST_CATEGORIES=""
                 fi
 
                 # figure out which C/C++ compiler we should use for building test inferiors.
@@ -2806,6 +2808,7 @@ for host in "${ALL_HOSTS[@]}"; do
                            "${LLDB_SOURCE_DIR}"/test/dotest.py \
                            --executable "${lldb_executable}" \
                            ${LLDB_TEST_SUBDIR_CLAUSE} \
+                           ${LLDB_TEST_CATEGORIES} \
                            ${LLDB_DOTEST_CC_OPTS} \
                            ${LLDB_FORMATTER_OPTS}
                 continue


### PR DESCRIPTION
- Side-step code signing issues by using the system debug server

- Skip testing categories that add minimal coverage-per-unit-time

- Only enable testing from the whitelisted `swiftpr` category

rdar://35534424

- Using CMake to build lldb has been deferred until r://37130314 is addressed