### PR TITLE
Need to check that the keypath decl is an AbstractStorageDecl instead of assuming it.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3938,8 +3938,11 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
       if (!choices[i].isDecl()) {
         return SolutionKind::Error;
       }
+      auto storage = dyn_cast<AbstractStorageDecl>(choices[i].getDecl());
+      if (!storage) {
+        return SolutionKind::Error;
+      }
       
-      auto storage = cast<AbstractStorageDecl>(choices[i].getDecl());
       if (!storage->isSettable(DC)) {
         // A non-settable component makes the key path read-only, unless
         // a reference-writable component shows up later.

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -485,6 +485,20 @@ func sr6106() {
   }
 }
 
+// SR-6744
+func sr6744() {
+    struct ABC {
+        let value: Int
+        func value(adding i: Int) -> Int { return value + i }
+    }
+
+    let abc = ABC(value: 0)
+    func get<T>(for kp: KeyPath<ABC, T>) -> T {
+        return abc[keyPath: kp]
+    }
+    _ = get(for: \.value)
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
Explanation: The compiler would crash when a key path expression referred to a property that shared a basename with a function declaration.

Scope: Regression from 4.0

SR Issue: SR-6744 | rdar://problem/36675083

Risk: Low, small bug fix, already landed in master without problems

Testing: Swift CI, ReactiveCocoa project from Jira