### PR TITLE
swift-api-digester: for each source-breaking item, we should output its framework name to help screening. rdar://35421724

### DIFF
--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -1,21 +1,21 @@
 
 /* Removed Decls */
-Constructor Somestruct2.init(_:) has been removed
-Func C4.foo() has been removed
+cake1: Constructor Somestruct2.init(_:) has been removed
+cake1: Func C4.foo() has been removed
 
 /* Moved Decls */
 
 /* Renamed Decls */
-Struct Somestruct2 has been renamed to Struct NSSomestruct2
-Func S1.foo5(x:y:) has been renamed to Func S1.foo5(x:y:z:)
+cake1: Struct Somestruct2 has been renamed to Struct NSSomestruct2
+cake1: Func S1.foo5(x:y:) has been renamed to Func S1.foo5(x:y:z:)
 
 /* Type Changes */
-Constructor S1.init(_:) has parameter 0 type change from Int to Double
-Func C1.foo2(_:) has parameter 0 type change from Int to () -> ()
+cake1: Constructor S1.init(_:) has parameter 0 type change from Int to Double
+cake1: Func C1.foo2(_:) has parameter 0 type change from Int to () -> ()
 
 /* Decl Attribute changes */
-Var C1.CIIns1 changes from weak to strong
-Var C1.CIIns2 changes from strong to weak
-Func C1.foo1() is now not static
-Func S1.foo3() is now static
-Func S1.foo1() is now mutating
+cake1: Var C1.CIIns1 changes from weak to strong
+cake1: Var C1.CIIns2 changes from strong to weak
+cake1: Func C1.foo1() is now not static
+cake1: Func S1.foo3() is now static
+cake1: Func S1.foo1() is now mutating

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -5,5 +5,5 @@
 // RUN: %swift -emit-module -o %t.mod/cake2.swiftmodule %S/Inputs/cake2.swift -parse-as-library -I %S/Inputs/APINotesRight
 // RUN: %api-digester -dump-sdk -module cake1 -o %t.dump1.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod -I %S/Inputs/APINotesLeft
 // RUN: %api-digester -dump-sdk -module cake2 -o %t.dump2.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod -I %S/Inputs/APINotesRight
-// RUN: %api-digester -diagnose-sdk --input-paths %t.dump1.json -input-paths %t.dump2.json > %t.result
+// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json > %t.result
 // RUN: diff -u %S/Outputs/Cake.txt %t.result


### PR DESCRIPTION
The framework name is behind a flag "print-module". We should
print them during whole-sdk checks however not in the per-framework diffing
tool.
