### PR TITLE
AST: Property requirements in @objc protocols should return `true` for `requiresForeignGetterAndSetter`.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4182,8 +4182,8 @@ bool VarDecl::isSelfParameter() const {
   return false;
 }
 
-/// Return true if this stored property needs to be accessed with getters and
-/// setters for Objective-C.
+/// Return true if this stored property has a getter and
+/// setter that are accessible from Objective-C.
 bool AbstractStorageDecl::hasForeignGetterAndSetter() const {
   if (auto override = getOverriddenDecl())
     return override->hasForeignGetterAndSetter();
@@ -4204,9 +4204,11 @@ bool AbstractStorageDecl::requiresForeignGetterAndSetter() const {
   // Imported accessors are foreign and only have objc entry points.
   if (hasClangNode())
     return true;
-  // Otherwise, we only dispatch by @objc if the declaration is dynamic or
-  // NSManaged.
-  return isDynamic() || getAttrs().hasAttribute<NSManagedAttr>();
+  // Otherwise, we only dispatch by @objc if the declaration is dynamic,
+  // NSManaged, or dispatched through an ObjC protocol.
+  return isDynamic()
+    || getAttrs().hasAttribute<NSManagedAttr>()
+    || (isa<ProtocolDecl>(getDeclContext()) && isProtocolRequirement());
 }
 
 

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -76,3 +76,15 @@ func nonobjcExtensionOfObjCClass() {
   _ = \NSObject.dynamic
 
 }
+
+@objc protocol ObjCProto {
+  var objcRequirement: Int { get set }
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}ProtocolRequirement
+func objcProtocolRequirement<T: ObjCProto>(_: T) {
+  // CHECK: keypath {{.*}} id #ObjCProto.objcRequirement!getter.1.foreign
+  _ = \T.objcRequirement
+  // CHECK: keypath {{.*}} id #ObjCProto.objcRequirement!getter.1.foreign
+  _ = \ObjCProto.objcRequirement
+}


### PR DESCRIPTION
Explanation: Key paths failed to use ObjC dispatch to get to the witness of an ObjC protocol requirement, leading to compiler crashes or broken runtime behavior.

Scope: Regression from 4.0

Issue: rdar://problem/36636314

Risk: Low, small change, which was made to master a month ago without causing apparent problems.

Testing: Swift CI