### PR TITLE
build-script: Build lldb with CMake on Darwin

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -477,6 +477,7 @@ class BuildScriptInvocation(object):
             "--swift-build-type", args.swift_build_variant,
             "--swift-stdlib-build-type", args.swift_stdlib_build_variant,
             "--lldb-build-type", args.lldb_build_variant,
+            "--lldb-build-with-xcode", args.lldb_build_with_xcode,
             "--foundation-build-type", args.foundation_build_variant,
             "--libdispatch-build-type", args.libdispatch_build_variant,
             "--libicu-build-type", args.libicu_build_variant,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -73,6 +73,7 @@ KNOWN_SETTINGS=(
     swift-stdlib-enable-resilience "0"           "build the Swift stdlib and overlays with resilience enabled"
     swift-stdlib-use-nonatomic-rc "0"            "build the Swift stdlib and overlays with nonatomic reference count operations enabled"
     lldb-build-type             "Debug"          "the CMake build variant for LLDB"
+    lldb-build-with-xcode       "1"              "Use xcodebuild to build LLDB, instead of CMake"
     llbuild-build-type          "Debug"          "the CMake build variant for llbuild"
     foundation-build-type       "Debug"          "the build variant for Foundation"
     libdispatch-build-type      "Debug"          "the build variant for libdispatch"
@@ -2405,12 +2406,32 @@ for host in "${ALL_HOSTS[@]}"; do
                         )
                         ;;
                     macosx-*)
-                        # Set up flags to pass to xcodebuild
-                        set_lldb_xcodebuild_options
-                        set_lldb_build_mode
-                        with_pushd ${source_dir} \
-                            call xcodebuild -target desktop -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
-                        continue
+                        if [[ "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
+                            # Set up flags to pass to xcodebuild
+                            set_lldb_xcodebuild_options
+                            set_lldb_build_mode
+                            with_pushd ${source_dir} \
+                                call xcodebuild -target desktop -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
+                            continue
+		        else
+                            cmake_options=(
+                                "${cmake_options[@]}"
+                                -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
+                                -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
+                                -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                                -DLLDB_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SOURCE_DIR}"
+                                -DLLDB_PATH_TO_CLANG_SOURCE:PATH="${CLANG_SOURCE_DIR}"
+                                -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
+                                -DLLDB_PATH_TO_LLVM_BUILD:PATH="${llvm_build_dir}"
+                                -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
+                                -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
+                                -DLLDB_PATH_TO_CMARK_BUILD:PATH="${cmark_build_dir}"
+                                -DLLDB_IS_BUILDBOT_BUILD="${LLDB_IS_BUILDBOT_BUILD}"
+                                -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
+                                -DLLDB_ALLOW_STATIC_BINDINGS=1
+                                -DLLDB_CODESIGN_IDENTITY=""
+                            )
+                        fi
                         ;;
                 esac
                 ;;
@@ -2799,7 +2820,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 lldb_build_dir=$(build_directory ${host} lldb)
 
                 # Run the gtests.
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                if [[ "$(uname -s)" == "Darwin" && "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
                     set_lldb_xcodebuild_options
                     # Run the LLDB unittests (gtests).
                     with_pushd ${LLDB_SOURCE_DIR} \
@@ -2810,14 +2831,13 @@ for host in "${ALL_HOSTS[@]}"; do
                         exit 1
                     fi
                 else
-                    # FIXME run the gtests on other platforms.
-                    # There should be a CMake target for this already.
-                    echo Run LLDB gtests here.
+                    with_pushd ${lldb_build_dir} \
+                        ninja check-lldb-unit
                 fi
 
                 swift_build_dir=$(build_directory ${host} swift)
                 # Setup lldb executable path
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                if [[ "$(uname -s)" == "Darwin" && "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
                     lldb_executable="${lldb_build_dir}"/${LLDB_BUILD_MODE}/lldb
                 else
                     lldb_executable="${lldb_build_dir}"/bin/lldb

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -53,7 +53,8 @@ def _apply_default_arguments(args):
 
     # Build LLDB if any LLDB-related options were specified.
     if args.lldb_build_variant is not None or \
-       args.lldb_assertions is not None:
+       args.lldb_assertions is not None or \
+       args.lldb_build_with_xcode is not None:
         args.build_lldb = True
 
     # Set the default build variant.
@@ -74,6 +75,9 @@ def _apply_default_arguments(args):
 
     if args.lldb_build_variant is None:
         args.lldb_build_variant = args.build_variant
+
+    if args.lldb_build_with_xcode is None:
+        args.lldb_build_with_xcode = '1'
 
     if args.foundation_build_variant is None:
         args.foundation_build_variant = args.build_variant
@@ -567,6 +571,14 @@ def create_argument_parser():
     option('--debug-lldb', store('lldb_build_variant'),
            const='Debug',
            help='build the Debug variant of LLDB')
+
+    option('--lldb-build-with-xcode', store('lldb_build_with_xcode'),
+           const='1',
+           help='build LLDB using xcodebuild, if possible')
+
+    option('--lldb-build-with-cmake', store('lldb_build_with_xcode'),
+           const='0',
+           help='build LLDB using CMake')
 
     option('--debug-cmark', store('cmark_build_variant'),
            const='Debug',

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -139,6 +139,7 @@ EXPECTED_DEFAULTS = {
     'lit_args': '-sv',
     'lldb_assertions': None,
     'lldb_build_variant': 'Debug',
+    'lldb_build_with_xcode': '1',
     'llvm_assertions': True,
     'llvm_build_variant': 'Debug',
     'llvm_max_parallel_lto_link_jobs':
@@ -330,6 +331,10 @@ EXPECTED_OPTIONS = [
               dest='libdispatch_build_variant', value='Debug'),
     SetOption('--debug-libicu', dest='libicu_build_variant', value='Debug'),
     SetOption('--debug-lldb', dest='lldb_build_variant', value='Debug'),
+    SetOption('--lldb-build-with-xcode', dest='lldb_build_with_xcode',
+              value='1'),
+    SetOption('--lldb-build-with-cmake', dest='lldb_build_with_xcode',
+              value='0'),
     SetOption('--debug-llvm', dest='llvm_build_variant', value='Debug'),
     SetOption('--debug-swift', dest='swift_build_variant', value='Debug'),
     SetOption('--debug-swift-stdlib',


### PR DESCRIPTION
build-script can already build lldb on Darwin using its Xcode project,
but it's useful to support the CMake build as well.

The CMake build allows incremental rebuilds with build-script. I expect
this to significantly cut down on iteration time.

Taking advantage of CMake also lets lldb piggyback on existing support
for sanitizers -- or exciting new build configurations we don't know
about yet -- without having to update the Xcode project file.

rdar://problem/36751944