### PR TITLE
Stop pessimizing print performance for no reason.

### DIFF
--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -621,7 +621,7 @@ extension Unicode.Scalar : TextOutputStreamable {
 }
 
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook : ((String) -> Void)? = {_ in () }
+public var _playgroundPrintHook : ((String) -> Void)? = nil
 
 @_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)


### PR DESCRIPTION
As pointed out in Ole Begeman's blog:
https://oleb.net/blog/2016/09/playground-print-hook/

The playground print hook is being initialized a a non-null noop hook,
which causes the fast paths in the print functions to be unused, and
forcing the creation of a tee stream for things that have nothing to
do with playgrounds.  It is sad that no one noticed this...
