### PR TITLE
[string] Hack around more ARC.

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -163,9 +163,12 @@ func _makeCocoaStringGuts(_ cocoaString: _CocoaString) -> _StringGuts {
   }
 
   let (start, isUTF16) = _getCocoaStringPointer(immutableCopy)
+
+  let length = _StringGuts.getCocoaLength(
+    _unsafeBitPattern: Builtin.reinterpretCast(immutableCopy))
   return _StringGuts(
     _nonTaggedCocoaObject: immutableCopy,
-    count: _stdlib_binary_CFStringGetLength(immutableCopy),
+    count: length,
     isSingleByte: !isUTF16,
     start: start)
 }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -255,7 +255,6 @@ extension _StringGuts {
     return _UnmanagedString(start: start, count: _cocoaCount)
   }
 
-  @inline(never)
   @_versioned
   internal
   init(


### PR DESCRIPTION
Utilize pre-existing CFStringGetLength hack. Gives about 20%
performance improvement bridging in contiguous NSStrings from
ObjectiveC.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
