### PR TITLE
Mangled name -> metadata] Add built-in types support

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -620,6 +620,17 @@ const ValueWitnessTable VALUE_WITNESS_SYM(Bi256_); // Builtin.Int256
 SWIFT_RUNTIME_EXPORT
 const ValueWitnessTable VALUE_WITNESS_SYM(Bi512_); // Builtin.Int512
 
+SWIFT_RUNTIME_EXPORT
+const ValueWitnessTable VALUE_WITNESS_SYM(Bf16_);  // Builtin.Float16
+SWIFT_RUNTIME_EXPORT
+const ValueWitnessTable VALUE_WITNESS_SYM(Bf32_);  // Builtin.Float32
+SWIFT_RUNTIME_EXPORT
+const ValueWitnessTable VALUE_WITNESS_SYM(Bf64_);  // Builtin.Float64
+SWIFT_RUNTIME_EXPORT
+const ValueWitnessTable VALUE_WITNESS_SYM(Bf80_);  // Builtin.Float80
+SWIFT_RUNTIME_EXPORT
+const ValueWitnessTable VALUE_WITNESS_SYM(Bf128_); // Builtin.Float128
+
 // The object-pointer table can be used for arbitrary Swift refcounted
 // pointer types.
 SWIFT_RUNTIME_EXPORT
@@ -998,6 +1009,16 @@ SWIFT_RUNTIME_EXPORT
 const FullOpaqueMetadata METADATA_SYM(Bi256_);    // Builtin.Int256
 SWIFT_RUNTIME_EXPORT
 const FullOpaqueMetadata METADATA_SYM(Bi512_);    // Builtin.Int512
+SWIFT_RUNTIME_EXPORT
+const FullOpaqueMetadata METADATA_SYM(Bf16_);     // Builtin.Float8
+SWIFT_RUNTIME_EXPORT
+const FullOpaqueMetadata METADATA_SYM(Bf32_);     // Builtin.Float32
+SWIFT_RUNTIME_EXPORT
+const FullOpaqueMetadata METADATA_SYM(Bf64_);     // Builtin.Float64
+SWIFT_RUNTIME_EXPORT
+const FullOpaqueMetadata METADATA_SYM(Bf80_);     // Builtin.Float80
+SWIFT_RUNTIME_EXPORT
+const FullOpaqueMetadata METADATA_SYM(Bf128_);    // Builtin.Float128
 SWIFT_RUNTIME_EXPORT
 const FullOpaqueMetadata METADATA_SYM(Bo);        // Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -173,6 +173,55 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
                                 Dem);
 }
 
+static Demangle::NodePointer
+_buildDemanglingForBuiltinType(const Metadata *type, Demangle::Demangler &Dem) {
+  if (type == &METADATA_SYM(Bi8_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int8");
+  if (type == &METADATA_SYM(Bi16_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int16");
+  if (type == &METADATA_SYM(Bi32_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int32");
+  if (type == &METADATA_SYM(Bi64_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int64");
+  if (type == &METADATA_SYM(Bi128_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int128");
+  if (type == &METADATA_SYM(Bi256_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int256");
+  if (type == &METADATA_SYM(Bi512_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Int512");
+
+  if (type == &METADATA_SYM(Bf16_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Float16");
+  if (type == &METADATA_SYM(Bf32_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Float32");
+  if (type == &METADATA_SYM(Bf64_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Float64");
+  if (type == &METADATA_SYM(Bf80_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Float80");
+  if (type == &METADATA_SYM(Bf128_).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.Float128");
+
+  if (type == &METADATA_SYM(Bo).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.NativeObject");
+
+  if (type == &METADATA_SYM(Bb).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.BridgeObject");
+
+  if (type == &METADATA_SYM(Bp).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.RawPointer");
+
+  if (type == &METADATA_SYM(BB).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName,
+                          "Builtin.UnsafeValueBuffer");
+
+#if SWIFT_OBJC_INTEROP
+  if (type == &METADATA_SYM(BO).base)
+    return Dem.createNode(Node::Kind::BuiltinTypeName, "Builtin.UnknownObject");
+#endif
+
+  return nullptr;
+}
+
 // Build a demangled type tree for a type.
 Demangle::NodePointer
 swift::_swift_buildDemanglingForMetadata(const Metadata *type,
@@ -451,9 +500,13 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     }
     return tupleNode;
   }
-  case MetadataKind::Opaque:
+  case MetadataKind::Opaque: {
+    if (auto builtinType = _buildDemanglingForBuiltinType(type, Dem))
+      return builtinType;
     // FIXME: Some opaque types do have manglings, but we don't have enough info
     // to figure them out.
+    break;
+  }
   case MetadataKind::HeapLocalVariable:
   case MetadataKind::HeapGenericLocalVariable:
   case MetadataKind::ErrorObject:

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -63,6 +63,17 @@ const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi256_) =
 const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi512_) =
   ValueWitnessTableForBox<NativeBox<int512_like, 64>>::table;
 
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bf16_) =
+  ValueWitnessTableForBox<NativeBox<float, 2>>::table;
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bf32_) =
+  ValueWitnessTableForBox<NativeBox<float, 4>>::table;
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bf64_) =
+  ValueWitnessTableForBox<NativeBox<double, 8>>::table;
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bf80_) =
+  ValueWitnessTableForBox<NativeBox<int128_like, 16>>::table;
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bf128_) =
+  ValueWitnessTableForBox<NativeBox<int128_like, 16>>::table;
+
 /// The basic value-witness table for Swift object pointers.
 const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(Bo) =
   ValueWitnessTableForBox<SwiftRetainableBox>::table;
@@ -163,6 +174,11 @@ OPAQUE_METADATA(Bi64_)
 OPAQUE_METADATA(Bi128_)
 OPAQUE_METADATA(Bi256_)
 OPAQUE_METADATA(Bi512_)
+OPAQUE_METADATA(Bf16_)
+OPAQUE_METADATA(Bf32_)
+OPAQUE_METADATA(Bf64_)
+OPAQUE_METADATA(Bf80_)
+OPAQUE_METADATA(Bf128_)
 OPAQUE_METADATA(Bo)
 OPAQUE_METADATA(Bb)
 OPAQUE_METADATA(Bp)

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -584,7 +584,41 @@ public:
   }
 
   BuiltType createBuiltinType(StringRef mangledName) const {
-    // FIXME: Implement.
+    if (mangledName.equals("Bi8_"))
+      return &METADATA_SYM(Bi8_).base;
+    if (mangledName.equals("Bi16_"))
+      return &METADATA_SYM(Bi16_).base;
+    if (mangledName.equals("Bi32_"))
+      return &METADATA_SYM(Bi32_).base;
+    if (mangledName.equals("Bi64_"))
+      return &METADATA_SYM(Bi64_).base;
+    if (mangledName.equals("Bi128_"))
+      return &METADATA_SYM(Bi128_).base;
+    if (mangledName.equals("Bi256_"))
+      return &METADATA_SYM(Bi256_).base;
+    if (mangledName.equals("Bi512_"))
+      return &METADATA_SYM(Bi512_).base;
+    if (mangledName.equals("Bf16_"))
+      return &METADATA_SYM(Bf16_).base;
+    if (mangledName.equals("Bf32_"))
+      return &METADATA_SYM(Bf32_).base;
+    if (mangledName.equals("Bf64_"))
+      return &METADATA_SYM(Bf64_).base;
+    if (mangledName.equals("Bf80_"))
+      return &METADATA_SYM(Bf80_).base;
+    if (mangledName.equals("Bf128_"))
+      return &METADATA_SYM(Bf128_).base;
+    if (mangledName.equals("Bo"))
+      return &METADATA_SYM(Bo).base;
+    if (mangledName.equals("Bb"))
+      return &METADATA_SYM(Bb).base;
+    if (mangledName.equals("Bp"))
+      return &METADATA_SYM(Bp).base;
+    if (mangledName.equals("BB"))
+      return &METADATA_SYM(BB).base;
+    if (mangledName.equals("BO"))
+      return &METADATA_SYM(BO).base;
+
     return BuiltType();
   }
 


### PR DESCRIPTION
Includes changes to Metadata to add Builtin.Float* types, Metadata lookup to use all known builtin types and demangler to we able to create mangling nodes from metadata for builtin opaque types.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
