### PR TITLE
[gardening][test] Eliminate warnings in Parameterpassing.swift tests

### DIFF
--- a/test/stdlib/ParameterPassing.swift.gyb
+++ b/test/stdlib/ParameterPassing.swift.gyb
@@ -351,11 +351,9 @@ tests.test("${TestType}/Fun${FuncName}") {
 %end
       value${TestType}9()
     )
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -378,11 +376,9 @@ tests.test("${TestType}/RetFun${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
     preconditionFailure("Should not get there")
@@ -408,11 +404,9 @@ tests.test("${TestType}/RetAndParamFun${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -444,11 +438,9 @@ tests.test("${TestType}/Method${FuncName}") {
 %end
       value${TestType}9()
     )
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -475,11 +467,9 @@ tests.test("${TestType}/RetMethod${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
     preconditionFailure("Should not get there")
@@ -509,11 +499,9 @@ tests.test("${TestType}/RetAndParamMethod${FuncName}") {
 %for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -544,11 +532,9 @@ tests.test("${TestType}/WitnessMethod${FuncName}") {
 %end
       value${TestType}9()
     )
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -574,11 +560,9 @@ tests.test("${TestType}/RetWitnessMethod${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
     preconditionFailure("Should not get there")
@@ -607,11 +591,9 @@ tests.test("${TestType}/RetAndParamWitnessMethod${FuncName}") {
 %for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")

--- a/test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/test/stdlib/SIMDParameterPassing.swift.gyb
@@ -371,11 +371,9 @@ tests.test("${TestType}/Fun${FuncName}") {
 %end
       value${TestType}9()
     )
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -398,11 +396,9 @@ tests.test("${TestType}/RetFun${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
     preconditionFailure("Should not get there")
@@ -428,11 +424,9 @@ tests.test("${TestType}/RetAndParamFun${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -464,11 +458,9 @@ tests.test("${TestType}/Method${FuncName}") {
 %end
       value${TestType}9()
     )
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -495,11 +487,9 @@ tests.test("${TestType}/RetMethod${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
     preconditionFailure("Should not get there")
@@ -529,11 +519,9 @@ tests.test("${TestType}/RetAndParamMethod${FuncName}") {
 %for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -564,11 +552,9 @@ tests.test("${TestType}/WitnessMethod${FuncName}") {
 %end
       value${TestType}9()
     )
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")
@@ -594,11 +580,9 @@ tests.test("${TestType}/RetWitnessMethod${FuncName}") {
 % for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
     preconditionFailure("Should not get there")
@@ -627,11 +611,9 @@ tests.test("${TestType}/RetAndParamWitnessMethod${FuncName}") {
 %for Num in range(0, 10):
     expectEqual(value${TestType}${Num}(), res.${Num})
 % end
-  } catch let e as MyError {
 % if DoesThrow == 'true':
+  } catch let e as MyError {
      expectEqual(127, e.val)
-% else:
-     preconditionFailure("Should not get there")
 % end
   } catch {
      preconditionFailure("Should not get there")


### PR DESCRIPTION
Eliminate warnings:
```
warning: immutable value 'e' was never used; consider replacing with '_' or removing it
  } catch let e as MyError {
              ^
              _
```
I don't believe these are the part of the tests.