### PR TITLE
[5.0] [ClangImporter] Make sure that headers from the bridging header are considered 'isBeforeInTranslationUnit' compared to headers imported from swift code

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -856,14 +856,17 @@ class PrintingCodeCompletionConsumer
     : public SimpleCachingCodeCompletionConsumer {
   llvm::raw_ostream &OS;
   bool IncludeKeywords;
+  bool IncludeComments;
 
 public:
-  PrintingCodeCompletionConsumer(llvm::raw_ostream &OS, bool IncludeKeywords = true)
-      : OS(OS), IncludeKeywords(IncludeKeywords) {
-  }
+ PrintingCodeCompletionConsumer(llvm::raw_ostream &OS,
+                                bool IncludeKeywords = true,
+                                bool IncludeComments = true)
+     : OS(OS),
+       IncludeKeywords(IncludeKeywords),
+       IncludeComments(IncludeComments) {}
 
-  void handleResults(
-      MutableArrayRef<CodeCompletionResult *> Results) override;
+ void handleResults(MutableArrayRef<CodeCompletionResult *> Results) override;
 };
 
 /// \brief Create a factory for code completion callbacks.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1478,12 +1478,17 @@ ModuleDecl *ClangImporter::loadModule(
     // invalid, it can't be the same thing twice in a row, and it has to come
     // from an actual buffer, so we make a fake buffer and just use a counter.
     if (!Impl.DummyImportBuffer.isValid()) {
+      clang::SourceLocation includeLoc =
+          srcMgr.getLocForStartOfFile(srcMgr.getMainFileID());
+      // Zero offset is reserved for the bridging header. Increase the offset
+      // so that headers from the bridging header are considered as coming
+      // before headers that are imported from swift code.
+      includeLoc = includeLoc.getLocWithOffset(1);
       Impl.DummyImportBuffer = srcMgr.createFileID(
           llvm::make_unique<ZeroFilledMemoryBuffer>(
               256*1024, StringRef(Implementation::moduleImportBufferName)),
           clang::SrcMgr::C_User,
-          /*LoadedID*/0, /*LoadedOffset*/0,
-          srcMgr.getLocForStartOfFile(srcMgr.getMainFileID()));
+          /*LoadedID*/0, /*LoadedOffset*/0, includeLoc);
     }
     clang::SourceLocation clangImportLoc
       = srcMgr.getLocForStartOfFile(Impl.DummyImportBuffer)

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5514,6 +5514,11 @@ void PrintingCodeCompletionConsumer::handleResults(
     Result->getCompletionString()->getName(NameOs);
     OS << "; name=" << Name;
 
+    StringRef comment = Result->getBriefDocComment();
+    if (IncludeComments && !comment.empty()) {
+      OS << "; comment=" << comment;
+    }
+
     OS << "\n";
   }
   OS << "End completions\n";

--- a/test/IDE/clang-importing/Inputs/bridge.h
+++ b/test/IDE/clang-importing/Inputs/bridge.h
@@ -1,0 +1,1 @@
+@import somemod1;

--- a/test/IDE/clang-importing/Inputs/somemod1/module.modulemap
+++ b/test/IDE/clang-importing/Inputs/somemod1/module.modulemap
@@ -1,0 +1,3 @@
+module somemod1 {
+	header "somemod1.h"
+}

--- a/test/IDE/clang-importing/Inputs/somemod1/somemod1.h
+++ b/test/IDE/clang-importing/Inputs/somemod1/somemod1.h
@@ -1,0 +1,5 @@
+/// some_func11 is cool function.
+void some_func11(void);
+
+/// some_func12 is cool function.
+void some_func12(void);

--- a/test/IDE/clang-importing/Inputs/somemod2/module.modulemap
+++ b/test/IDE/clang-importing/Inputs/somemod2/module.modulemap
@@ -1,0 +1,3 @@
+module somemod2 {
+	header "somemod2.h"
+}

--- a/test/IDE/clang-importing/Inputs/somemod2/somemod2.h
+++ b/test/IDE/clang-importing/Inputs/somemod2/somemod2.h
@@ -1,0 +1,5 @@
+/// some_func21 is cool function.
+void some_func21(void);
+
+/// some_func22 is cool function.
+void some_func22(void);

--- a/test/IDE/clang-importing/complete_with_clang_comments.swift
+++ b/test/IDE/clang-importing/complete_with_clang_comments.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP -code-completion-comments=true \
+// RUN:    -import-objc-header %S/Inputs/bridge.h -I %S/Inputs/somemod1 -I %S/Inputs/somemod2 | %FileCheck %s -check-prefix=CHECK-TOP
+
+// REQUIRES: objc_interop
+
+import somemod2
+
+#^TOP^#
+// CHECK-TOP: name=some_func11(); comment=some_func11 is cool function.
+// CHECK-TOP: name=some_func12(); comment=some_func12 is cool function.
+// CHECK-TOP: name=some_func21(); comment=some_func21 is cool function.
+// CHECK-TOP: name=some_func22(); comment=some_func22 is cool function.

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -396,6 +396,12 @@ CodeCompletionKeywords("code-completion-keywords",
                        llvm::cl::cat(Category),
                        llvm::cl::init(true));
 
+static llvm::cl::opt<bool>
+CodeCompletionComments("code-completion-comments",
+                       llvm::cl::desc("Include comments in code completion results"),
+                       llvm::cl::cat(Category),
+                       llvm::cl::init(false));
+
 static llvm::cl::opt<std::string>
 DebugClientDiscriminator("debug-client-discriminator",
   llvm::cl::desc("A discriminator to prefer in lookups"),
@@ -671,7 +677,8 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
                             StringRef SecondSourceFileName,
                             StringRef CodeCompletionToken,
                             bool CodeCompletionDiagnostics,
-                            bool CodeCompletionKeywords) {
+                            bool CodeCompletionKeywords,
+                            bool CodeCompletionComments) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
     llvm::MemoryBuffer::getFile(SourceFilename);
   if (!FileBufOrErr) {
@@ -712,7 +719,7 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   // Create a CodeCompletionConsumer.
   std::unique_ptr<ide::CodeCompletionConsumer> Consumer(
       new ide::PrintingCodeCompletionConsumer(
-          llvm::outs(), CodeCompletionKeywords));
+          llvm::outs(), CodeCompletionKeywords, CodeCompletionComments));
 
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
@@ -2960,7 +2967,8 @@ int main(int argc, char *argv[]) {
     }
 
     ide::PrintingCodeCompletionConsumer Consumer(
-        llvm::outs(), options::CodeCompletionKeywords);
+        llvm::outs(), options::CodeCompletionKeywords,
+        options::CodeCompletionComments);
     for (StringRef filename : options::InputFilenames) {
       auto resultsOpt = ide::OnDiskCodeCompletionCache::getFromFile(filename);
       if (!resultsOpt) {
@@ -3152,7 +3160,8 @@ int main(int argc, char *argv[]) {
                                 options::SecondSourceFilename,
                                 options::CodeCompletionToken,
                                 options::CodeCompletionDiagnostics,
-                                options::CodeCompletionKeywords);
+                                options::CodeCompletionKeywords,
+                                options::CodeCompletionComments);
     break;
 
   case ActionType::REPLCodeCompletion:


### PR DESCRIPTION
Cherry-pick #13916 to the 5.0 branch, so that it's fixed there too.

rdar://problem/36765929