### PR TITLE
[BatchMode] Rename FrontendInputs::AllFiles to AllInputs, etc

### DIFF
--- a/include/swift/Frontend/FrontendInputs.h
+++ b/include/swift/Frontend/FrontendInputs.h
@@ -32,7 +32,7 @@ namespace swift {
 class FrontendInputs {
   friend class ArgsToFrontendInputsConverter;
 
-  std::vector<InputFile> AllFiles;
+  std::vector<InputFile> AllInputs;
   typedef llvm::StringMap<unsigned> InputFileMap;
   InputFileMap PrimaryInputs;
 
@@ -45,13 +45,13 @@ public:
 
   // Readers:
 
-  ArrayRef<InputFile> getAllFiles() const { return AllFiles; }
-
+  ArrayRef<InputFile> getAllInputs() const { return AllInputs; }
+  
   std::vector<std::string> getInputFilenames() const;
 
-  unsigned inputCount() const { return getAllFiles().size(); }
+  unsigned inputCount() const { return AllInputs.size(); }
 
-  bool hasInputs() const { return !AllFiles.empty(); }
+  bool hasInputs() const { return !AllInputs.empty(); }
 
   bool hasSingleInput() const { return inputCount() == 1; }
 
@@ -92,7 +92,7 @@ public:
   /// there isn't one.
   StringRef getNameOfUniquePrimaryInputFile() const;
 
-  bool isFilePrimary(StringRef file) const;
+  bool isInputPrimary(StringRef file) const;
 
   unsigned numberOfPrimaryInputsEndingWith(const char *extension) const;
 
@@ -117,7 +117,7 @@ public:
   void addInput(const InputFile &input);
 
   void clearInputs() {
-    AllFiles.clear();
+    AllInputs.clear();
     PrimaryInputs.clear();
   }
 };

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -182,7 +182,7 @@ bool CompilerInstance::setUpInputs() {
   const Optional<unsigned> codeCompletionBufferID = setUpCodeCompletionBuffer();
 
   for (const InputFile &input :
-       Invocation.getFrontendOptions().Inputs.getAllFiles())
+       Invocation.getFrontendOptions().Inputs.getAllInputs())
     if (setUpForInput(input))
       return true;
 

--- a/lib/Frontend/FrontendInputs.cpp
+++ b/lib/Frontend/FrontendInputs.cpp
@@ -30,20 +30,20 @@ using namespace swift;
 using namespace llvm::opt;
 
 FrontendInputs::FrontendInputs(const FrontendInputs &other) {
-  for (InputFile input : other.getAllFiles())
+  for (InputFile input : other.AllInputs)
     addInput(input);
 }
 
 FrontendInputs &FrontendInputs::operator=(const FrontendInputs &other) {
   clearInputs();
-  for (InputFile input : other.getAllFiles())
+  for (InputFile input : other.AllInputs)
     addInput(input);
   return *this;
 }
 
 std::vector<std::string> FrontendInputs::getInputFilenames() const {
   std::vector<std::string> filenames;
-  for (auto &input : getAllFiles()) {
+  for (auto &input : AllInputs) {
     filenames.push_back(input.file());
   }
   return filenames;
@@ -61,7 +61,7 @@ void FrontendInputs::assertMustNotBeMoreThanOnePrimaryInput() const {
 const InputFile *FrontendInputs::getUniquePrimaryInput() const {
   assertMustNotBeMoreThanOnePrimaryInput();
   const auto b = PrimaryInputs.begin();
-  return b == PrimaryInputs.end() ? nullptr : &AllFiles[b->second];
+  return b == PrimaryInputs.end() ? nullptr : &AllInputs[b->second];
 }
 
 const InputFile &FrontendInputs::getRequiredUniquePrimaryInput() const {
@@ -75,15 +75,15 @@ StringRef FrontendInputs::getNameOfUniquePrimaryInputFile() const {
   return input == nullptr ? StringRef() : input->file();
 }
 
-bool FrontendInputs::isFilePrimary(StringRef file) const {
+bool FrontendInputs::isInputPrimary(StringRef file) const {
   auto iterator = PrimaryInputs.find(file);
   return iterator != PrimaryInputs.end() &&
-         AllFiles[iterator->second].isPrimary();
+         AllInputs[iterator->second].isPrimary();
 }
 
 StringRef FrontendInputs::getFilenameOfFirstInput() const {
   assert(hasInputs());
-  const InputFile &inp = getAllFiles()[0];
+  const InputFile &inp = AllInputs[0];
   StringRef f = inp.file();
   assert(!f.empty());
   return f;
@@ -120,15 +120,15 @@ bool FrontendInputs::shouldTreatAsSIL() const {
 
 void FrontendInputs::addInput(const InputFile &input) {
   if (!input.file().empty() && input.isPrimary())
-    PrimaryInputs.insert(std::make_pair(input.file(), AllFiles.size()));
-  AllFiles.push_back(input);
+    PrimaryInputs.insert(std::make_pair(input.file(), AllInputs.size()));
+  AllInputs.push_back(input);
 }
 
 unsigned
 FrontendInputs::numberOfPrimaryInputsEndingWith(const char *extension) const {
   return count_if(
       PrimaryInputs, [&](const llvm::StringMapEntry<unsigned> &elem) -> bool {
-        StringRef filename = AllFiles[elem.second].file();
+        StringRef filename = AllInputs[elem.second].file();
         return llvm::sys::path::extension(filename).endswith(extension);
       });
 }
@@ -165,7 +165,7 @@ bool FrontendInputs::verifyInputs(DiagnosticEngine &diags, bool treatAsSIL,
 }
 
 bool FrontendInputs::areAllNonPrimariesSIB() const {
-  for (const InputFile &input : getAllFiles()) {
+  for (const InputFile &input : AllInputs) {
     if (input.isPrimary())
       continue;
     if (!llvm::sys::path::extension(input.file()).endswith(SIB_EXTENSION)) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -811,10 +811,10 @@ static bool performCompile(CompilerInstance &Instance,
         // have a primary serialized input.
         for (FileUnit *fileUnit : mod->getFiles()) {
           if (auto SASTF = dyn_cast<SerializedASTFile>(fileUnit)) {
-            if (Invocation.getFrontendOptions().Inputs.isFilePrimary(
-                  InputFile::
-                    convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
-                      SASTF->getFilename()))) {
+            if (Invocation.getFrontendOptions().Inputs.isInputPrimary(
+                    InputFile::
+                        convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
+                            SASTF->getFilename()))) {
               assert(PSGIs.empty() && "Can only handle one primary AST input");
               auto SM = performSILGeneration(*SASTF, SILOpts, None);
               PSGIs.push_back(

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -146,7 +146,7 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
 
   assert(OrigFrontendOpts.Inputs.hasPrimaryInputs() &&
          "Migration must have a primary");
-  for (const auto &input : OrigFrontendOpts.Inputs.getAllFiles()) {
+  for (const auto &input : OrigFrontendOpts.Inputs.getAllInputs()) {
     Invocation.getFrontendOptions().Inputs.addInput(
         InputFile(input.file(), input.isPrimary(),
                   input.isPrimary() ? InputBuffer.get() : input.buffer()));

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -427,7 +427,7 @@ resolveSymbolicLinksInInputs(FrontendInputs &inputs,
   // FIXME: The frontend should be dealing with symlinks, maybe similar to
   // clang's FileManager ?
   FrontendInputs replacementInputs;
-  for (const InputFile &input : inputs.getAllFiles()) {
+  for (const InputFile &input : inputs.getAllInputs()) {
     std::string newFilename =
         SwiftLangSupport::resolvePathSymlinks(input.file());
     bool newIsPrimary = input.isPrimary() ||
@@ -709,7 +709,7 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
   InputStamps.reserve(
       Invok.Opts.Invok.getFrontendOptions().Inputs.inputCount());
   for (const auto &input :
-       Invok.Opts.Invok.getFrontendOptions().Inputs.getAllFiles()) {
+       Invok.Opts.Invok.getFrontendOptions().Inputs.getAllInputs()) {
     StringRef File = input.file();
     bool FoundSnapshot = false;
     for (auto &Snap : Snapshots) {
@@ -896,7 +896,7 @@ void ASTProducer::findSnapshotAndOpenFiles(
     SmallVectorImpl<FileContent> &Contents, std::string &Error) const {
   const InvocationOptions &Opts = InvokRef->Impl.Opts;
   for (const auto &input :
-       Opts.Invok.getFrontendOptions().Inputs.getAllFiles()) {
+       Opts.Invok.getFrontendOptions().Inputs.getAllInputs()) {
     StringRef File = input.file();
     bool IsPrimary = input.isPrimary();
     bool FoundSnapshot = false;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Renaming from File to Input (where the files are inputs), in preparation for batch mode.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
