### PR TITLE
[GSB] Ensure that we don't build an invalid potential archetype.

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -147,7 +147,8 @@ public:
   /// requirements, first canonicalizing the types.
   static CanGenericSignature getCanonical(
                                       ArrayRef<GenericTypeParamType *> params,
-                                      ArrayRef<Requirement> requirements);
+                                      ArrayRef<Requirement> requirements,
+                                      bool skipValidation = false);
 
   /// Retrieve the generic parameters.
   ArrayRef<GenericTypeParamType *> getGenericParams() const {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -150,7 +150,8 @@ static unsigned getRequirementKindOrder(RequirementKind kind) {
 
 CanGenericSignature GenericSignature::getCanonical(
                                         ArrayRef<GenericTypeParamType *> params,
-                                        ArrayRef<Requirement> requirements) {
+                                        ArrayRef<Requirement> requirements,
+                                        bool skipValidation) {
   // Canonicalize the parameters and requirements.
   SmallVector<GenericTypeParamType*, 8> canonicalParams;
   canonicalParams.reserve(params.size());
@@ -172,10 +173,14 @@ CanGenericSignature GenericSignature::getCanonical(
                       reqt.getLayoutConstraint()));
   }
 
+  (void)skipValidation;
   auto canSig = get(canonicalParams, canonicalRequirements,
                     /*isKnownCanonical=*/true);
 
 #ifndef NDEBUG
+  if (skipValidation)
+    return CanGenericSignature(canSig);
+
   PrettyStackTraceGenericSignature debugStack("canonicalizing", canSig);
 
   // Check that the signature is canonical.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3026,6 +3026,12 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
     TypeDecl *nestedTypeDecl;
     SmallVector<TypeDecl *, 4> concreteDecls;
     if (auto assocType = depMemTy->getAssocType()) {
+      // Check whether this associated type references a protocol to which
+      // the base conforms. If not, it's unresolved.
+      if (baseEquivClass->conformsTo.find(assocType->getProtocol())
+            == baseEquivClass->conformsTo.end())
+        return ResolvedType::forUnresolved(baseEquivClass);
+
       nestedTypeDecl = assocType;
     } else {
       nestedTypeDecl =

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4885,8 +4885,15 @@ public:
       llvm::errs() << "Requirement signature: ";
       requirementsSig->print(llvm::errs());
       llvm::errs() << "\n";
+
+      // Note: One cannot canonicalize a requirement signature, because
+      // requirement signatures are necessarily missing requirements.
       llvm::errs() << "Canonical requirement signature: ";
-      requirementsSig->getCanonicalSignature()->print(llvm::errs());
+      auto canRequirementSig =
+        GenericSignature::getCanonical(requirementsSig->getGenericParams(),
+                                       requirementsSig->getRequirements(),
+                                       /*skipValidation=*/true);
+      canRequirementSig->print(llvm::errs());
       llvm::errs() << "\n";
     }
   }


### PR DESCRIPTION
Queries against the generic signature might use types that are
ill-formed for that generic signature, e.g., because they refer to
associated types of unrelated protocols. Detect such conditions to
maintain GSB invariants that all potential archetypes in a well-formed
generic signature are well-formed.

This change uncovers an existential GSB canonicalization problem with
the test from SR-5601, which I'll tackle as a separate commit.

Fixes the crash in SR-6797 / rdar://problem/36673825.
