### PR TITLE
[string] 32-bit String is still 3 words

### DIFF
--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -78,7 +78,11 @@ extern "C" void swift_stringFromUTF8InRawMemory(String *out,
 
 struct String {
   // Keep the details of String's implementation opaque to the runtime.
-  const uint64_t x, y;
+  const void *x = nullptr;
+  const void *y = nullptr;
+#if __POINTER_WIDTH__ == 32
+  const void *z = nullptr;
+#endif
 
   /// Keep String trivial on the C++ side so we can control its instantiation.
   String() = default;
@@ -90,8 +94,7 @@ struct String {
   }
 
   /// Copy an ASCII string into a swift String on the heap.
-  explicit String(const char *ptr, size_t size)
-    : x(0), y(0) {
+  explicit String(const char *ptr, size_t size) {
     swift_stringFromUTF8InRawMemory(this, ptr, size);
   }
 


### PR DESCRIPTION
Update Reflection.mm to "reflect" this fact.
(• _ •)
( • _ •)>⌐■-■ 
(⌐■_■)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->