### PR TITLE
[test] Disable parse_stdlib.sil test to unblock builders

### DIFF
--- a/validation-test/SIL/parse_stdlib.sil
+++ b/validation-test/SIL/parse_stdlib.sil
@@ -3,3 +3,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=true %t.sil > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+
+// <rdar://problem/36754225> Swift CI: parse_stdlib.sil tests failing with vtable verification
+// XFAIL: objc_interop


### PR DESCRIPTION
Tracked within Apple by \<rdar://problem/36754225\> Swift CI: parse_stdlib.sil tests failing with vtable verification. The error is an assertion failure that we haven't traced back to its cause yet:

> Assertion failed: (EntriesSZ == VTableEntryCache.size() && "Cache size is not equal to true number of VTable entries"), function verify, file /Users/buildnode/jenkins/workspace/oss-swift-package-osx/swift/lib/SIL/SILVerifier.cpp, line 4747.