### PR TITLE
[4.1] [GSB] Ensure that we don't build an invalid potential archetype.

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -147,7 +147,8 @@ public:
   /// requirements, first canonicalizing the types.
   static CanGenericSignature getCanonical(
                                       ArrayRef<GenericTypeParamType *> params,
-                                      ArrayRef<Requirement> requirements);
+                                      ArrayRef<Requirement> requirements,
+                                      bool skipValidation = false);
 
   /// Retrieve the generic parameters.
   ArrayRef<GenericTypeParamType *> getGenericParams() const {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -150,7 +150,8 @@ static unsigned getRequirementKindOrder(RequirementKind kind) {
 
 CanGenericSignature GenericSignature::getCanonical(
                                         ArrayRef<GenericTypeParamType *> params,
-                                        ArrayRef<Requirement> requirements) {
+                                        ArrayRef<Requirement> requirements,
+                                        bool skipValidation) {
   // Canonicalize the parameters and requirements.
   SmallVector<GenericTypeParamType*, 8> canonicalParams;
   canonicalParams.reserve(params.size());
@@ -172,10 +173,14 @@ CanGenericSignature GenericSignature::getCanonical(
                       reqt.getLayoutConstraint()));
   }
 
+  (void)skipValidation;
   auto canSig = get(canonicalParams, canonicalRequirements,
                     /*isKnownCanonical=*/true);
 
 #ifndef NDEBUG
+  if (skipValidation)
+    return CanGenericSignature(canSig);
+
   PrettyStackTraceGenericSignature debugStack("canonicalizing", canSig);
 
   // Check that the signature is canonical.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3026,6 +3026,12 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
     TypeDecl *nestedTypeDecl;
     SmallVector<TypeDecl *, 4> concreteDecls;
     if (auto assocType = depMemTy->getAssocType()) {
+      // Check whether this associated type references a protocol to which
+      // the base conforms. If not, it's unresolved.
+      if (baseEquivClass->conformsTo.find(assocType->getProtocol())
+            == baseEquivClass->conformsTo.end())
+        return ResolvedType::forUnresolved(baseEquivClass);
+
       nestedTypeDecl = assocType;
     } else {
       nestedTypeDecl =

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4876,8 +4876,15 @@ public:
       llvm::errs() << "Requirement signature: ";
       requirementsSig->print(llvm::errs());
       llvm::errs() << "\n";
+
+      // Note: One cannot canonicalize a requirement signature, because
+      // requirement signatures are necessarily missing requirements.
       llvm::errs() << "Canonical requirement signature: ";
-      requirementsSig->getCanonicalSignature()->print(llvm::errs());
+      auto canRequirementSig =
+        GenericSignature::getCanonical(requirementsSig->getGenericParams(),
+                                       requirementsSig->getRequirements(),
+                                       /*skipValidation=*/true);
+      canRequirementSig->print(llvm::errs());
       llvm::errs() << "\n";
     }
   }


### PR DESCRIPTION
• **Explanation**: Name mangling of constrained extensions could cause a crash in rare-ish cases because the code can break invariants of the `GenericSignatureBuilder`.
• **Scope of Issue**: Causes SIL crashes when compiling some fairly-complex constrained extensions. We've seen one confirmed and one suspected case of this in the wild.
• **Origination**: My work to optimize the mangling of generic signatures (so they don't redundantly specify the requirements of the enclosing generic context) introduced the offending code.
• **Risk**: Low risk; we're validating our inputs to the `GenericSignatureBuilder` in a way that will only either (1) delay resolution of requirements until later, or (2) properly return `false` for queries that would previously have caused downstream crashes.
• **Reviewed By**: @rudkx 
• **Testing**: Compiler regression tests, built RandomKit project
• **Radar / SR**: rdar://problem/36673825 / [SR-6797](https://bugs.swift.org/browse/SR-6797)

Fixes the crash in SR-6797 / rdar://problem/36673825.

(cherry picked from commit d18ecda7964ca709987595ac618c888da17ec492)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->