### PR TITLE
[5.0][AST] Make sure that if a TupleExpr is created with element names but not name locations, it is marked implicit as appropriate

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1921,6 +1921,11 @@ public:
   }
   void visitDictionaryExpr(DictionaryExpr *E) {
     printCommon(E, "dictionary_expr");
+    if (auto semaE = E->getSemanticExpr()) {
+      OS << '\n';
+      printRec(semaE);
+      return;
+    }
     for (auto elt : E->getElements()) {
       OS << '\n';
       printRec(elt);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2914,7 +2914,7 @@ namespace {
                               { },
                               expr->getRBracketLoc(),
                               /*HasTrailingClosure=*/false,
-                              /*Implicit=*/false,
+                              /*Implicit=*/true,
                               argType);
 
       cs.cacheExprTypes(arg);

--- a/test/Index/invalid_code.swift
+++ b/test/Index/invalid_code.swift
@@ -2,3 +2,13 @@
 
 // CHECK: [[@LINE+1]]:8 | struct/Swift | Int | {{.*}} | Ref | rel: 0
 var _: Int { get { return 1 } }
+
+class CrashTest {
+  var something = 0
+  func returnSelf(_ h: [AnyHashable: Any?]) -> CrashTest {
+    return self
+  }
+  init() { }
+}
+// CHECK: [[@LINE+1]]:13 | instance-method/Swift | returnSelf
+CrashTest().returnSelf(["": 0]).something()


### PR DESCRIPTION
Fixes a crash for SourceEntityWalker which assumed that a non-implicit TupleExpr has source locations for its name elements.

Fixes SR-6517, rdar://35830880

master: https://github.com/apple/swift/pull/13878