### PR TITLE
[4.1] [ClangImporter] Handle ns_error_domain on nameless enums with typedefs

### DIFF
--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -308,6 +308,10 @@ void EnumInfo::determineConstantNamePrefix(ASTContext &ctx,
     // Don't use importFullName() here, we want to ignore the swift_name
     // and swift_private attributes.
     StringRef enumNameStr = decl->getName();
+    if (enumNameStr.empty())
+      enumNameStr = decl->getTypedefNameForAnonDecl()->getName();
+    assert(!enumNameStr.empty() && "should have been classified as Constants");
+
     StringRef commonWithEnum = getCommonPluralPrefix(checkPrefix, enumNameStr);
     size_t delta = commonPrefix.size() - checkPrefix.size();
 

--- a/test/ClangImporter/Inputs/enum-error.h
+++ b/test/ClangImporter/Inputs/enum-error.h
@@ -19,4 +19,10 @@ typedef NS_ERROR_ENUM(int, OtherErrorCode, OtherErrorDomain) {
   OtherC,
 };
 
+extern NSString *TypedefOnlyErrorDomain;
+typedef enum __attribute__((ns_error_domain(TypedefOnlyErrorDomain))) {
+  TypedefOnlyErrorBadness
+} TypedefOnlyError;
+
+
 TestError getErr();

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -21,6 +21,11 @@ func testDropCode(other: OtherError) -> OtherError.Code {
   return other.code
 }
 
+func testImportsCorrectly() {
+  _ = TypedefOnlyError.badness
+  _ = TypedefOnlyError.Code.badness
+}
+
 func testError() {
   let testErrorNSError = NSError(domain: TestErrorDomain,
                                  code: Int(TestError.TENone.rawValue),


### PR DESCRIPTION
- **Explanation**: Using the `ns_error_domain`, `enum_extensibility`, or `flag_enum` Clang attributes on an anonymous C enum that's immediately given a name via a typedef led to an assertion failure. In no-asserts builds, I suspect the enum elements weren't properly prefix-stripped, but I don't actually have such a build around to check. These enums are rare but that doesn't mean we shouldn't support them, and we ran into one in an Apple-internal project.
- **Scope**: Only affects imported enums, and only in these particular circumstances.
- **Issue**: rdar://problem/36799009
- **Reviewed by**: @milseman 
- **Risk**: Low. This has lived on master for a while now.
- **Testing**: Added a compiler regression test, verified that the project with the problem gets past the issue.