### PR TITLE
ObjectOutliner: fix for handling set_deallocating instruction correctly.

### DIFF
--- a/test/SILOptimizer/globalopt-iter.sil
+++ b/test/SILOptimizer/globalopt-iter.sil
@@ -8,13 +8,16 @@ class E : B { }
 
 // CHECK: sil @patatino : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK:   %0 = global_value @patatinoTv_ : $B
-// CHECK:   %1 = tuple ()
-// CHECK:   return %1 : $()
-// CHECK: }
+// CHECK-NEXT:   %0 = global_value @patatinoTv_ : $B
+// CHECK-NEXT:   strong_retain
+// CHECK-NEXT:   strong_release
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
 
 sil @patatino : $@convention(thin) () -> () {
   %1 = alloc_ref [stack] $B
+  set_deallocating %1 : $B
   dealloc_ref [stack] %1 : $B
   %45 = tuple ()
   return %45 : $()

--- a/test/SILOptimizer/objectoutliner.sil
+++ b/test/SILOptimizer/objectoutliner.sil
@@ -76,7 +76,9 @@ bb0:
 
 // CHECK-LABEL: sil @handle_deallocation
 // CHECK:      global_value
+// CHECK-NEXT: strong_retain
 // CHECK-NEXT: ref_element_addr
+// CHECK-NEXT: strong_release
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
 sil @handle_deallocation : $@convention(thin) () -> () {


### PR DESCRIPTION
rdar://problem/36692828
