### PR TITLE
[5.0] IRGen: Set artifical functions for key path code

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -258,6 +258,8 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
     
   {
     IRGenFunction IGF(IGM, layoutFn);
+    if (IGM.DebugInfo)
+      IGM.DebugInfo->emitArtificialFunction(IGF, layoutFn);
     // Unmarshal the generic environment from the argument buffer.
     auto parameters = IGF.collectParameters();
     auto args = parameters.claimNext();
@@ -509,6 +511,9 @@ getInitializerForComputedComponent(IRGenModule &IGM,
     
   {
     IRGenFunction IGF(IGM, initFn);
+    if (IGM.DebugInfo)
+      IGM.DebugInfo->emitArtificialFunction(IGF, initFn);
+
     auto params = IGF.collectParameters();
     // Pointer to the argument packet passed into swift_getKeyPath
     auto src = params.claimNext();

--- a/test/DebugInfo/keypath.swift
+++ b/test/DebugInfo/keypath.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -g -emit-ir %s | %FileCheck %s
+
+public struct Gen<Value> {
+  public private(set) var value: Value
+  public func use<Subject>(keyPath: WritableKeyPath<Value, Subject>) {
+  }
+}
+
+// This used to assert.
+
+// CHECK: distinct !DISubprogram(linkageName: "keypath_set", {{.*}} flags: DIFlagArtificial
+extension Gen where Value : MutableCollection, Value.Index : Hashable {
+    public var dontAssert: Int {
+        var i = value.startIndex
+				use(keyPath: \.[i])
+        return 0
+    }
+}


### PR DESCRIPTION
Otherwise, debug info asserts get triggered because of a missing debug
loc.

rdar://36797675

