### PR TITLE
[4.1] Do not assert on @objc (Name) extension FancyName {}

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -9159,7 +9159,8 @@ static void validateAttributes(TypeChecker &TC, Decl *D) {
     // appropriate.
     if (auto objcName = objcAttr->getName()) {
       if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D) || isa<VarDecl>(D)
-          || isa<EnumDecl>(D) || isa<EnumElementDecl>(D)) {
+          || isa<EnumDecl>(D) || isa<EnumElementDecl>(D)
+          || isa<ExtensionDecl>(D)) {
         // Types and properties can only have nullary
         // names. Complain and recover by chopping off everything
         // after the first name.

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -32,6 +32,9 @@ protocol Protocol_Class2 : class {}
 
 @objc extension PlainStruct { } // expected-error{{'@objc' can only be applied to an extension of a class}}{{1-7=}}
 
+class FáncyName {}
+@objc (FancyName) extension FáncyName {}
+
 @objc  
 var subject_globalVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
 


### PR DESCRIPTION
- **Explanation**: We crash on `@objc (Name) extension ...` despite having accepted this in previous releases.
- **Scope**: Small. A missing conditional check results in executing code that we shouldn't.
- **Origination**: We're hitting an assert that we also hit with swift-4.0-branch but which does not cause a crash in a release build. This probably originated with the implementation of **[SE-160]**.
- **Risk**: Very small. Avoids a code path where we assert.
- **Bug**: rdar://problem/36798061
- **Reviewed by**: Doug Gregor
- **Testing**: Regression tests including new test case.
