### PR TITLE
[5.0] Do not crash on @objc (Name) extension FancyName {}

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -9158,7 +9158,8 @@ static void validateAttributes(TypeChecker &TC, Decl *D) {
     // appropriate.
     if (auto objcName = objcAttr->getName()) {
       if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D) || isa<VarDecl>(D)
-          || isa<EnumDecl>(D) || isa<EnumElementDecl>(D)) {
+          || isa<EnumDecl>(D) || isa<EnumElementDecl>(D)
+          || isa<ExtensionDecl>(D)) {
         // Types and properties can only have nullary
         // names. Complain and recover by chopping off everything
         // after the first name.

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -32,6 +32,9 @@ protocol Protocol_Class2 : class {}
 
 @objc extension PlainStruct { } // expected-error{{'@objc' can only be applied to an extension of a class}}{{1-7=}}
 
+class FáncyName {}
+@objc (FancyName) extension FáncyName {}
+
 @objc  
 var subject_globalVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
 


### PR DESCRIPTION
We accepted this in Xcode 9.2, but currently crash.

We may want to consider rejecting this entirely, but for now lets not
crash.

Fixes rdar://problem/36798061.

(cherry picked from commit a499762445e9bd08f933c39ddd13c592003979af)
