### PR TITLE
[Batch mode] WIP: Moving main outputs.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -190,6 +190,9 @@ public:
 
   /// Gets the name of the specified output filename.
   /// If multiple files are specified, the last one is returned.
+  /// Used by (at least) lldb/source/Symbol/SwiftASTContext.cpp:4603
+  /// FIXME: dmu Should go away in favor of
+  /// Instance.getFrontendOptions().InputsAndOutputs.getSingleOutputFilename.
   StringRef getSingleOutputFilename() const {
     if (OutputFilenames.size() >= 1)
       return OutputFilenames.back();

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -1,0 +1,69 @@
+//===--- SupplementaryOutputPaths.h - Command to Execute -------*- C++ -*-===*\\
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H
+#define SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/Optional.h"
+
+#include <string>
+
+namespace swift {
+struct SupplementaryOutputPaths {
+  /// The path to which we should emit an Objective-C header for the module.
+  std::string ObjCHeaderOutputPath;
+
+  /// The path to which we should emit a serialized module.
+  std::string ModuleOutputPath;
+
+  /// The path to which we should emit a module documentation file.
+  std::string ModuleDocOutputPath;
+
+  /// The path to which we should output a Make-style dependencies file.
+  std::string DependenciesFilePath;
+
+  /// The path to which we should output a Swift reference dependencies file.
+  std::string ReferenceDependenciesFilePath;
+
+  /// Path to a file which should contain serialized diagnostics for this
+  /// frontend invocation.
+  std::string SerializedDiagnosticsPath;
+
+  /// The path to which we should output a loaded module trace file.
+  std::string LoadedModuleTracePath;
+
+  /// The path to which we should output a TBD file.
+  std::string TBDPath;
+
+  SupplementaryOutputPaths(std::string objCHeaderOutputPath,
+                           std::string moduleOutputPath,
+                           std::string moduleDocOutputPath,
+                           std::string dependenciesFilePath,
+                           std::string referenceDependenciesFilePath,
+                           std::string serializedDiagnosticsPath,
+                           std::string loadedModuleTracePath,
+                           std::string tbdPath)
+      : ObjCHeaderOutputPath(objCHeaderOutputPath),
+        ModuleOutputPath(moduleOutputPath),
+        ModuleDocOutputPath(moduleDocOutputPath),
+        DependenciesFilePath(dependenciesFilePath),
+        ReferenceDependenciesFilePath(referenceDependenciesFilePath),
+        SerializedDiagnosticsPath(serializedDiagnosticsPath),
+        LoadedModuleTracePath(loadedModuleTracePath), TBDPath(tbdPath) {}
+
+  SupplementaryOutputPaths() = default;
+  SupplementaryOutputPaths(const SupplementaryOutputPaths &) = default;
+};
+} // namespace swift
+
+#endif /* SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H */

--- a/include/swift/Frontend/ArgsToFrontendInputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendInputsConverter.h
@@ -42,7 +42,7 @@ namespace swift {
 class ArgsToFrontendInputsConverter {
   DiagnosticEngine &Diags;
   const llvm::opt::ArgList &Args;
-  FrontendInputs &Inputs;
+  FrontendInputsAndOutputs &InputsAndOutputs;
 
   llvm::opt::Arg const *const FilelistPathArg;
   llvm::opt::Arg const *const PrimaryFilelistPathArg;
@@ -54,7 +54,7 @@ class ArgsToFrontendInputsConverter {
 public:
   ArgsToFrontendInputsConverter(DiagnosticEngine &diags,
                                 const llvm::opt::ArgList &args,
-                                FrontendInputs &inputs);
+                                FrontendInputsAndOutputs &inputsAndOutputs);
 
   bool convert();
 

--- a/include/swift/Frontend/ArgsToFrontendInputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendInputsConverter.h
@@ -69,6 +69,8 @@ private:
   std::set<StringRef>
   createInputFilesConsumingPrimaries(std::set<StringRef> primaryFiles);
   bool checkForMissingPrimaryFiles(std::set<StringRef> primaryFiles);
+
+  bool isSingleThreadedWMO() const;
 };
 
 } // namespace swift

--- a/include/swift/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendOptionsConverter.h
@@ -50,28 +50,7 @@ private:
   void setUnsignedIntegerArgument(options::ID optionID, unsigned max,
                                   unsigned &valueToSet);
 
-  FrontendOptions::ActionType determineRequestedAction() const;
-
   bool setUpForSILOrLLVM();
-
-  /// Determine the correct output filename when none was specified.
-  ///
-  /// Such an absence should only occur when invoking the frontend
-  /// without the driver,
-  /// because the driver will always pass -o with an appropriate filename
-  /// if output is required for the requested action.
-  bool deriveOutputFilenameFromInputFile();
-
-  /// Determine the correct output filename when a directory was specified.
-  ///
-  /// Such a specification should only occur when invoking the frontend
-  /// directly, because the driver will always pass -o with an appropriate
-  /// filename if output is required for the requested action.
-  bool deriveOutputFilenameForDirectory(StringRef outputDir);
-
-  std::string determineBaseNameOfOutput() const;
-
-  void deriveOutputFilenameFromParts(StringRef dir, StringRef base);
 
   void determineSupplementaryOutputFilenames();
 
@@ -91,6 +70,9 @@ public:
       : Diags(Diags), Args(Args), Opts(Opts) {}
 
   bool convert();
+
+  static FrontendOptions::ActionType
+  determineRequestedAction(const llvm::opt::ArgList &);
 };
 
 } // namespace swift

--- a/include/swift/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendOutputsConverter.h
@@ -1,0 +1,110 @@
+//===--- ArgsToFrontendOutputsConverter.h -----------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_ARGSTOFRONTENDOUTPUTSCONVERTER_H
+#define SWIFT_FRONTEND_ARGSTOFRONTENDOUTPUTSCONVERTER_H
+
+#include "swift/AST/DiagnosticConsumer.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/SupplementaryOutputPaths.h"
+#include "swift/Frontend/FrontendOptions.h"
+#include "swift/Option/Options.h"
+#include "llvm/Option/ArgList.h"
+
+#include <vector>
+
+using namespace swift;
+using namespace llvm::opt;
+
+namespace swift {
+
+/// Given the command line arguments and information about the inputs,
+/// Fill in all the information in FrontendInputsAndOutputs.
+
+class ArgsToFrontendOutputsConverter {
+  const ArgList &Args;
+  StringRef ModuleName;
+  FrontendInputsAndOutputs &InputsAndOutputs;
+  DiagnosticEngine &Diags;
+
+public:
+  ArgsToFrontendOutputsConverter(const ArgList &args, StringRef moduleName,
+                                 FrontendInputsAndOutputs &inputsAndOutputs,
+                                 DiagnosticEngine &diags)
+      : Args(args), ModuleName(moduleName), InputsAndOutputs(inputsAndOutputs),
+        Diags(diags) {}
+
+  Optional<std::vector<std::string>> convert();
+
+  /// None -> could not open
+  static Optional<std::vector<std::string>>
+  readOutputFileList(const StringRef filelistPath, DiagnosticEngine &diags);
+
+  static bool isOutputAUniqueOrdinaryFile(ArrayRef<std::string> outputs);
+};
+
+class OutputFilesComputer {
+  const ArgList &Args;
+  DiagnosticEngine &Diags;
+  const FrontendInputsAndOutputs &InputsAndOutputs;
+
+  const Optional<std::vector<std::string>> OutputFileArguments;
+  const StringRef OutputDirectoryArgument;
+  const bool DoOutputFileArgumentsMatchInputs;
+  const StringRef FirstInput;
+  const FrontendOptions::ActionType RequestedAction;
+  const Arg *const ModuleNameArg;
+  const StringRef Suffix;
+  const bool HasTextualOutput;
+
+public:
+  OutputFilesComputer(const ArgList &args, DiagnosticEngine &diags,
+                      const FrontendInputsAndOutputs &inputsAndOutputs);
+
+  /// \return the output filenames on the command line or in the output
+  /// filelist. If there
+  /// were neither -o's nor an output filelist, \return an empty vector.
+  static Optional<std::vector<std::string>>
+  getOutputFilenamesFromCommandLineOrFilelist(const ArgList &args,
+                                              DiagnosticEngine &diags);
+
+  Optional<std::vector<std::string>> computeOutputFiles() const;
+
+private:
+  Optional<std::string> computeOutputFile(StringRef outputArg,
+                                          const InputFile &input) const;
+
+  /// \return the correct output filename when none was specified.
+  ///
+  /// Such an absence should only occur when invoking the frontend
+  /// without the driver,
+  /// because the driver will always pass -o with an appropriate filename
+  /// if output is required for the requested action.
+  Optional<std::string> deriveOutputFileFromInput(const InputFile &input) const;
+
+  /// \return the correct output filename when a directory was specified.
+  ///
+  /// Such a specification should only occur when invoking the frontend
+  /// directly, because the driver will always pass -o with an appropriate
+  /// filename if output is required for the requested action.
+  Optional<std::string>
+  deriveOutputFileForDirectory(const InputFile &input) const;
+
+  std::string determineBaseNameOfOutput(const InputFile &input) const;
+
+  std::string deriveOutputFileFromParts(StringRef dir, StringRef base) const;
+};
+
+} // namespace swift
+
+#endif /* SWIFT_FRONTEND_ARGSTOFRONTENDOUTPUTSCONVERTER_H */

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -245,7 +245,7 @@ public:
 
 
   StringRef getOutputFilename() const {
-    return FrontendOpts.getSingleOutputFilename();
+    return FrontendOpts.InputsAndOutputs.getSingleOutputFilename();
   }
 
   void setCodeCompletionPoint(llvm::MemoryBuffer *Buf, unsigned Offset) {

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -54,7 +54,7 @@ class SerializedModuleLoader;
 ///   - options for all stages of translation,
 ///   - information about the build environment,
 ///   - information about the job being performed, and
-///   - lists of inputs.
+///   - lists of inputs and outputs.
 ///
 /// A CompilerInvocation can be built from a frontend command line
 /// using parseArgs.  It can then be used to build a CompilerInstance,

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -14,7 +14,6 @@
 #define SWIFT_FRONTEND_FRONTENDINPUTS_H
 
 #include "swift/AST/Module.h"
-#include "swift/Frontend/FrontendInputs.h"
 #include "swift/Frontend/InputFile.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/MapVector.h"
@@ -28,8 +27,9 @@ class MemoryBuffer;
 
 namespace swift {
 
-/// Information about all the inputs to the frontend.
-class FrontendInputs {
+/// Information about all the inputs and outputs to the frontend.
+
+class FrontendInputsAndOutputs {
   friend class ArgsToFrontendInputsConverter;
 
   std::vector<InputFile> AllInputs;
@@ -37,16 +37,14 @@ class FrontendInputs {
   InputFileMap PrimaryInputs;
 
 public:
-  FrontendInputs() = default;
-
-  FrontendInputs(const FrontendInputs &other);
-
-  FrontendInputs &operator=(const FrontendInputs &other);
+  FrontendInputsAndOutputs() = default;
+  FrontendInputsAndOutputs(const FrontendInputsAndOutputs &other);
+  FrontendInputsAndOutputs &operator=(const FrontendInputsAndOutputs &other);
 
   // Readers:
 
   ArrayRef<InputFile> getAllInputs() const { return AllInputs; }
-  
+
   std::vector<std::string> getInputFilenames() const;
 
   unsigned inputCount() const { return AllInputs.size(); }

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -38,32 +38,10 @@ public:
   /// The kind of input on which the frontend should operate.
   InputFileKind InputKind = InputFileKind::IFK_Swift;
 
-  /// The specified output files. If only a single outputfile is generated,
-  /// the name of the last specified file is taken.
-  std::vector<std::string> OutputFilenames;
+  void forAllOutputPaths(const InputFile &input,
+                         std::function<void(const std::string &)> fn) const;
 
-  void forAllOutputPaths(std::function<void(const std::string &)> fn) const;
-
-  /// Gets the name of the specified output filename.
-  /// If multiple files are specified, the last one is returned.
-  StringRef getSingleOutputFilename() const {
-    if (OutputFilenames.size() >= 1)
-      return OutputFilenames.back();
-    return StringRef();
-  }
-  /// Sets a single filename as output filename.
-  void setSingleOutputFilename(const std::string &FileName) {
-    OutputFilenames.clear();
-    OutputFilenames.push_back(FileName);
-  }
-  void setOutputFilenameToStdout() { setSingleOutputFilename("-"); }
-  bool isOutputFilenameStdout() const {
-    return getSingleOutputFilename() == "-";
-  }
   bool isOutputFileDirectory() const;
-  bool hasNamedOutputFile() const {
-    return !OutputFilenames.empty() && !isOutputFilenameStdout();
-  }
 
   /// A list of arbitrary modules to import and make implicitly visible.
   std::vector<std::string> ImplicitImportModuleNames;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -14,7 +14,7 @@
 #define SWIFT_FRONTEND_FRONTENDOPTIONS_H
 
 #include "swift/AST/Module.h"
-#include "swift/Frontend/FrontendInputs.h"
+#include "swift/Frontend/FrontendInputsAndOutputs.h"
 #include "swift/Frontend/InputFile.h"
 #include "llvm/ADT/Hashing.h"
 
@@ -33,7 +33,7 @@ class FrontendOptions {
   friend class ArgsToFrontendOptionsConverter;
 
 public:
-  FrontendInputs Inputs;
+  FrontendInputsAndOutputs InputsAndOutputs;
 
   /// The kind of input on which the frontend should operate.
   InputFileKind InputKind = InputFileKind::IFK_Swift;
@@ -315,7 +315,8 @@ public:
   StringRef determineFallbackModuleName() const;
 
   bool isCompilingExactlyOneSwiftFile() const {
-    return InputKind == InputFileKind::IFK_Swift && Inputs.hasSingleInput();
+    return InputKind == InputFileKind::IFK_Swift &&
+           InputsAndOutputs.hasSingleInput();
   }
 
 private:

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -36,14 +36,20 @@ class InputFile {
   /// Null if the contents are not overridden.
   llvm::MemoryBuffer *Buffer;
 
+  /// The specified output file.
+  /// If only a single outputfile is generated,
+  /// the name of the last specified file is taken.
+  std::string OutputFilename;
+
 public:
   /// Does not take ownership of \p buffer. Does take ownership of (copy) a
   /// string.
   InputFile(StringRef name, bool isPrimary,
-            llvm::MemoryBuffer *buffer = nullptr)
+            llvm::MemoryBuffer *buffer = nullptr,
+            StringRef outputFilename = StringRef())
       : Filename(
             convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(name)),
-        IsPrimary(isPrimary), Buffer(buffer) {
+        IsPrimary(isPrimary), Buffer(buffer), OutputFilename(outputFilename) {
     assert(!name.empty());
   }
 
@@ -59,6 +65,12 @@ public:
   static StringRef convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
       StringRef filename) {
     return filename.equals("<stdin>") ? "-" : filename;
+  }
+
+  const std::string &outputFilename() const { return OutputFilename; }
+
+  void setOutputFilename(StringRef outputFilename) {
+    OutputFilename = outputFilename;
   }
 };
 

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -41,7 +41,9 @@ public:
   /// string.
   InputFile(StringRef name, bool isPrimary,
             llvm::MemoryBuffer *buffer = nullptr)
-      : Filename(name), IsPrimary(isPrimary), Buffer(buffer) {
+      : Filename(
+            convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(name)),
+        IsPrimary(isPrimary), Buffer(buffer) {
     assert(!name.empty());
   }
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -456,5 +456,8 @@ def validate_tbd_against_ir_EQ: Joined<["-"], "validate-tbd-against-ir=">,
 // This is used to guard preemptive testing for the fix-it.
 def fix_string_substring_conversion: Flag<["-"], "fix-string-substring-conversion">,
     HelpText<"Emit a fix-it to append '[]' to String expressions when converting to Substring.">;
+    
+def bypass_batch_mode_checks: Flag<["-"], "bypass-batch-mode-checks">,
+    HelpText<"Bypass checks for batch-mode errors.">;
 
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/ArgsToFrontendInputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendInputsConverter.cpp
@@ -29,8 +29,9 @@ using namespace swift;
 using namespace llvm::opt;
 
 ArgsToFrontendInputsConverter::ArgsToFrontendInputsConverter(
-    DiagnosticEngine &diags, const ArgList &args, FrontendInputs &inputs)
-    : Diags(diags), Args(args), Inputs(inputs),
+    DiagnosticEngine &diags, const ArgList &args,
+    FrontendInputsAndOutputs &inputsAndOutputs)
+    : Diags(diags), Args(args), InputsAndOutputs(inputsAndOutputs),
       FilelistPathArg(args.getLastArg(options::OPT_filelist)),
       PrimaryFilelistPathArg(args.getLastArg(options::OPT_primary_filelist)) {}
 
@@ -131,7 +132,7 @@ ArgsToFrontendInputsConverter::createInputFilesConsumingPrimaries(
     std::set<StringRef> primaryFiles) {
   for (auto &file : Files) {
     bool isPrimary = primaryFiles.count(file) > 0;
-    Inputs.addInput(InputFile(file, isPrimary));
+    InputsAndOutputs.addInput(InputFile(file, isPrimary));
     if (isPrimary)
       primaryFiles.erase(file);
   }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Frontend/ArgsToFrontendInputsConverter.h"
+#include "swift/Frontend/ArgsToFrontendOutputsConverter.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Option/Options.h"
 #include "swift/Option/SanitizerOptions.h"
@@ -82,19 +83,21 @@ bool ArgsToFrontendOptionsConverter::convert() {
   // This can be enabled independently of the playground transform.
   Opts.PCMacro |= Args.hasArg(OPT_pc_macro);
 
-  computeHelpOptions();
-  if (ArgsToFrontendInputsConverter(Diags, Args, Opts.InputsAndOutputs)
-          .convert())
-    return true;
-
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);
+
+  computeHelpOptions();
 
   if (const Arg *A = Args.getLastArg(OPT_verify_generic_signatures)) {
     Opts.VerifyGenericSignaturesInModule = A->getValue();
   }
 
   computeDumpScopeMapLocations();
-  Opts.RequestedAction = determineRequestedAction();
+
+  if (ArgsToFrontendInputsConverter(Diags, Args, Opts.InputsAndOutputs)
+          .convert())
+    return true;
+
+  Opts.RequestedAction = determineRequestedAction(Args);
 
   if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate &&
       Opts.InputsAndOutputs.hasPrimaryInputs()) {
@@ -268,12 +271,12 @@ void ArgsToFrontendOptionsConverter::computeDumpScopeMapLocations() {
 }
 
 FrontendOptions::ActionType
-ArgsToFrontendOptionsConverter::determineRequestedAction() const {
+ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
   using namespace options;
-  const Arg *A = Args.getLastArg(OPT_modes_Group);
+  const Arg *A = args.getLastArg(OPT_modes_Group);
   if (!A) {
     // We don't have a mode, so determine a default.
-    if (Args.hasArg(OPT_emit_module, OPT_emit_module_path)) {
+    if (args.hasArg(OPT_emit_module, OPT_emit_module_path)) {
       // We've been told to emit a module, but have no other mode indicators.
       // As a result, put the frontend into EmitModuleOnly mode.
       // (Setting up module output will be handled below.)
@@ -413,143 +416,31 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
     // selected".
     return false;
   }
-  ArrayRef<std::string> outputFilenames =
-      getOutputFilenamesFromCommandLineOrFilelist();
+  Optional<std::vector<std::string>> outputFilenames =
+      OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(Args,
+                                                                       Diags);
 
-  bool isOutputAUniqueOrdinaryFile =
-      outputFilenames.size() == 1 && outputFilenames[0] != "-" &&
-      !llvm::sys::fs::is_directory(outputFilenames[0]);
-  std::string nameToStem =
-      isOutputAUniqueOrdinaryFile
-          ? outputFilenames[0]
+  auto nameToStem =
+      outputFilenames &&
+              ArgsToFrontendOutputsConverter::isOutputAUniqueOrdinaryFile(
+                  *outputFilenames)
+          ? outputFilenames->front()
           : Opts.InputsAndOutputs.getFilenameOfFirstInput().str();
+
   Opts.ModuleName = llvm::sys::path::stem(nameToStem);
   return false;
 }
 
 bool ArgsToFrontendOptionsConverter::computeOutputFilenames() {
-  assert(Opts.OutputFilenames.empty() &&
-         "Output filename should not be set at this point");
-  if (!FrontendOptions::doesActionProduceOutput(Opts.RequestedAction)) {
-    return false;
-  }
-  ArrayRef<std::string> outputFilenamesFromCommandLineOrFilelist =
-      getOutputFilenamesFromCommandLineOrFilelist();
-
-  if (outputFilenamesFromCommandLineOrFilelist.size() > 1) {
-    // WMO, threaded with N files (also someday batch mode).
-    Opts.OutputFilenames = outputFilenamesFromCommandLineOrFilelist;
-    return false;
-  }
-
-  if (outputFilenamesFromCommandLineOrFilelist.empty()) {
-    // When the Frontend is invoked without going through the driver
-    // (e.g. for testing), it is convenient to derive output filenames from
-    // input.
-    return deriveOutputFilenameFromInputFile();
-  }
-
-  StringRef outputFilename = outputFilenamesFromCommandLineOrFilelist[0];
-  if (!llvm::sys::fs::is_directory(outputFilename)) {
-    // Could be -primary-file (1), or -wmo (non-threaded w/ N (input) files)
-    Opts.OutputFilenames = outputFilenamesFromCommandLineOrFilelist;
-    return false;
-  }
-  // Only used for testing & when invoking frontend directly.
-  return deriveOutputFilenameForDirectory(outputFilename);
-}
-
-bool ArgsToFrontendOptionsConverter::deriveOutputFilenameFromInputFile() {
-  if (Opts.InputsAndOutputs.isReadingFromStdin() ||
-      FrontendOptions::doesActionProduceTextualOutput(Opts.RequestedAction)) {
-    Opts.setOutputFilenameToStdout();
-    return false;
-  }
-  std::string baseName = determineBaseNameOfOutput();
-  if (baseName.empty()) {
-    if (Opts.RequestedAction != FrontendOptions::ActionType::REPL &&
-        Opts.RequestedAction != FrontendOptions::ActionType::Immediate &&
-        Opts.RequestedAction != FrontendOptions::ActionType::NoneAction) {
-      Diags.diagnose(SourceLoc(), diag::error_no_output_filename_specified);
-      return true;
-    }
-    return false;
-  }
-  deriveOutputFilenameFromParts("", baseName);
-  return false;
-}
-
-bool ArgsToFrontendOptionsConverter::deriveOutputFilenameForDirectory(
-    StringRef outputDir) {
-
-  std::string baseName = determineBaseNameOfOutput();
-  if (baseName.empty()) {
-    Diags.diagnose(SourceLoc(), diag::error_implicit_output_file_is_directory,
-                   outputDir);
+  Optional<std::vector<std::string>> outs =
+      ArgsToFrontendOutputsConverter(Args, Opts.ModuleName,
+                                     Opts.InputsAndOutputs, Diags)
+          .convert();
+  if (!outs)
     return true;
-  }
-  deriveOutputFilenameFromParts(outputDir, baseName);
+  if (FrontendOptions::doesActionProduceOutput(Opts.RequestedAction))
+    Opts.InputsAndOutputs.setMainOutputs(*outs);
   return false;
-}
-
-void ArgsToFrontendOptionsConverter::deriveOutputFilenameFromParts(
-    StringRef dir, StringRef base) {
-  assert(!base.empty());
-  llvm::SmallString<128> path(dir);
-  llvm::sys::path::append(path, base);
-  StringRef suffix = FrontendOptions::suffixForPrincipalOutputFileForAction(
-      Opts.RequestedAction);
-  llvm::sys::path::replace_extension(path, suffix);
-  Opts.OutputFilenames.push_back(path.str());
-}
-
-std::string ArgsToFrontendOptionsConverter::determineBaseNameOfOutput() const {
-  std::string nameToStem;
-  if (Opts.InputsAndOutputs.hasPrimaryInputs()) {
-    nameToStem = Opts.InputsAndOutputs.getRequiredUniquePrimaryInput().file();
-  } else if (auto UserSpecifiedModuleName =
-                 Args.getLastArg(options::OPT_module_name)) {
-    nameToStem = UserSpecifiedModuleName->getValue();
-  } else if (Opts.InputsAndOutputs.hasSingleInput()) {
-    nameToStem = Opts.InputsAndOutputs.getFilenameOfFirstInput();
-  } else
-    nameToStem = "";
-
-  return llvm::sys::path::stem(nameToStem).str();
-}
-
-ArrayRef<std::string>
-ArgsToFrontendOptionsConverter::getOutputFilenamesFromCommandLineOrFilelist() {
-  if (cachedOutputFilenamesFromCommandLineOrFilelist) {
-    return *cachedOutputFilenamesFromCommandLineOrFilelist;
-  }
-
-  if (const Arg *A = Args.getLastArg(options::OPT_output_filelist)) {
-    assert(!Args.hasArg(options::OPT_o) &&
-           "don't use -o with -output-filelist");
-    cachedOutputFilenamesFromCommandLineOrFilelist.emplace(
-        readOutputFileList(A->getValue()));
-  } else {
-    cachedOutputFilenamesFromCommandLineOrFilelist.emplace(
-        Args.getAllArgValues(options::OPT_o));
-  }
-  return *cachedOutputFilenamesFromCommandLineOrFilelist;
-}
-
-/// Try to read an output file list file.
-std::vector<std::string> ArgsToFrontendOptionsConverter::readOutputFileList(
-    const StringRef filelistPath) const {
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
-      llvm::MemoryBuffer::getFile(filelistPath);
-  if (!buffer) {
-    Diags.diagnose(SourceLoc(), diag::cannot_open_file, filelistPath,
-                   buffer.getError().message());
-  }
-  std::vector<std::string> outputFiles;
-  for (StringRef line : make_range(llvm::line_iterator(*buffer.get()), {})) {
-    outputFiles.push_back(line.str());
-  }
-  return outputFiles;
 }
 
 void ArgsToFrontendOptionsConverter::determineSupplementaryOutputFilenames() {
@@ -566,8 +457,9 @@ void ArgsToFrontendOptionsConverter::determineSupplementaryOutputFilenames() {
         if (!Args.hasArg(optWithoutPath))
           return;
 
-        if (useMainOutput && !Opts.OutputFilenames.empty()) {
-          output = Opts.getSingleOutputFilename();
+        if (useMainOutput &&
+            !Opts.InputsAndOutputs.getSingleOutputFilename().empty()) {
+          output = Opts.InputsAndOutputs.getSingleOutputFilename();
           return;
         }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -83,7 +83,8 @@ bool ArgsToFrontendOptionsConverter::convert() {
   Opts.PCMacro |= Args.hasArg(OPT_pc_macro);
 
   computeHelpOptions();
-  if (ArgsToFrontendInputsConverter(Diags, Args, Opts.Inputs).convert())
+  if (ArgsToFrontendInputsConverter(Diags, Args, Opts.InputsAndOutputs)
+          .convert())
     return true;
 
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);
@@ -96,7 +97,7 @@ bool ArgsToFrontendOptionsConverter::convert() {
   Opts.RequestedAction = determineRequestedAction();
 
   if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate &&
-      Opts.Inputs.hasPrimaryInputs()) {
+      Opts.InputsAndOutputs.hasPrimaryInputs()) {
     Diags.diagnose(SourceLoc(), diag::error_immediate_mode_primary_file);
     return true;
   }
@@ -333,10 +334,10 @@ ArgsToFrontendOptionsConverter::determineRequestedAction() const {
 bool ArgsToFrontendOptionsConverter::setUpForSILOrLLVM() {
   using namespace options;
   bool treatAsSIL =
-      Args.hasArg(OPT_parse_sil) || Opts.Inputs.shouldTreatAsSIL();
-  bool treatAsLLVM = Opts.Inputs.shouldTreatAsLLVM();
+      Args.hasArg(OPT_parse_sil) || Opts.InputsAndOutputs.shouldTreatAsSIL();
+  bool treatAsLLVM = Opts.InputsAndOutputs.shouldTreatAsLLVM();
 
-  if (Opts.Inputs.verifyInputs(
+  if (Opts.InputsAndOutputs.verifyInputs(
           Diags, treatAsSIL,
           Opts.RequestedAction == FrontendOptions::ActionType::REPL,
           Opts.RequestedAction == FrontendOptions::ActionType::NoneAction)) {
@@ -344,7 +345,7 @@ bool ArgsToFrontendOptionsConverter::setUpForSILOrLLVM() {
   }
   if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate) {
     Opts.ImmediateArgv.push_back(
-        Opts.Inputs.getFilenameOfFirstInput()); // argv[0]
+        Opts.InputsAndOutputs.getFilenameOfFirstInput()); // argv[0]
     if (const Arg *A = Args.getLastArg(OPT__DASH_DASH)) {
       for (unsigned i = 0, e = A->getNumValues(); i != e; ++i) {
         Opts.ImmediateArgv.push_back(A->getValue(i));
@@ -405,7 +406,7 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
     return false;
   }
   // In order to pass some tests, must leave ModuleName empty.
-  if (!Opts.Inputs.hasInputs()) {
+  if (!Opts.InputsAndOutputs.hasInputs()) {
     Opts.ModuleName = StringRef();
     // FIXME: This is a bug that should not happen, but does in tests.
     // The compiler should bail out earlier, where "no frontend action was
@@ -418,9 +419,10 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
   bool isOutputAUniqueOrdinaryFile =
       outputFilenames.size() == 1 && outputFilenames[0] != "-" &&
       !llvm::sys::fs::is_directory(outputFilenames[0]);
-  std::string nameToStem = isOutputAUniqueOrdinaryFile
-                               ? outputFilenames[0]
-                               : Opts.Inputs.getFilenameOfFirstInput().str();
+  std::string nameToStem =
+      isOutputAUniqueOrdinaryFile
+          ? outputFilenames[0]
+          : Opts.InputsAndOutputs.getFilenameOfFirstInput().str();
   Opts.ModuleName = llvm::sys::path::stem(nameToStem);
   return false;
 }
@@ -458,7 +460,7 @@ bool ArgsToFrontendOptionsConverter::computeOutputFilenames() {
 }
 
 bool ArgsToFrontendOptionsConverter::deriveOutputFilenameFromInputFile() {
-  if (Opts.Inputs.isReadingFromStdin() ||
+  if (Opts.InputsAndOutputs.isReadingFromStdin() ||
       FrontendOptions::doesActionProduceTextualOutput(Opts.RequestedAction)) {
     Opts.setOutputFilenameToStdout();
     return false;
@@ -503,13 +505,13 @@ void ArgsToFrontendOptionsConverter::deriveOutputFilenameFromParts(
 
 std::string ArgsToFrontendOptionsConverter::determineBaseNameOfOutput() const {
   std::string nameToStem;
-  if (Opts.Inputs.hasPrimaryInputs()) {
-    nameToStem = Opts.Inputs.getRequiredUniquePrimaryInput().file();
+  if (Opts.InputsAndOutputs.hasPrimaryInputs()) {
+    nameToStem = Opts.InputsAndOutputs.getRequiredUniquePrimaryInput().file();
   } else if (auto UserSpecifiedModuleName =
                  Args.getLastArg(options::OPT_module_name)) {
     nameToStem = UserSpecifiedModuleName->getValue();
-  } else if (Opts.Inputs.hasSingleInput()) {
-    nameToStem = Opts.Inputs.getFilenameOfFirstInput();
+  } else if (Opts.InputsAndOutputs.hasSingleInput()) {
+    nameToStem = Opts.InputsAndOutputs.getFilenameOfFirstInput();
   } else
     nameToStem = "";
 
@@ -646,8 +648,8 @@ void ArgsToFrontendOptionsConverter::computeImportObjCHeaderOptions() {
   using namespace options;
   if (const Arg *A = Args.getLastArgNoClaim(OPT_import_objc_header)) {
     Opts.ImplicitObjCHeaderPath = A->getValue();
-    Opts.SerializeBridgingHeader |=
-        !Opts.Inputs.hasPrimaryInputs() && !Opts.ModuleOutputPath.empty();
+    Opts.SerializeBridgingHeader |= !Opts.InputsAndOutputs.hasPrimaryInputs() &&
+                                    !Opts.ModuleOutputPath.empty();
   }
 }
 void ArgsToFrontendOptionsConverter::computeImplicitImportModuleNames() {

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -1,0 +1,183 @@
+//===--- ArgsToFrontendOutputsConverter.cpp ---------------------*- C++ -*-===//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Frontend/ArgsToFrontendOutputsConverter.h"
+
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/Platform.h"
+#include "swift/Basic/SupplementaryOutputPaths.h"
+#include "swift/Frontend/ArgsToFrontendInputsConverter.h"
+#include "swift/Frontend/ArgsToFrontendOptionsConverter.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Option/Options.h"
+#include "swift/Option/SanitizerOptions.h"
+#include "swift/Strings.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/Option.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/Path.h"
+
+Optional<std::vector<std::string>> ArgsToFrontendOutputsConverter::convert() {
+  const auto requestedAction =
+      ArgsToFrontendOptionsConverter::determineRequestedAction(Args);
+
+  if (!FrontendOptions::doesActionProduceOutput(requestedAction))
+    return std::vector<std::string>();
+
+  return OutputFilesComputer(Args, Diags, InputsAndOutputs)
+      .computeOutputFiles();
+}
+
+/// Try to read an output file list file.
+Optional<std::vector<std::string>>
+ArgsToFrontendOutputsConverter::readOutputFileList(const StringRef filelistPath,
+                                                   DiagnosticEngine &diags) {
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+      llvm::MemoryBuffer::getFile(filelistPath);
+  if (!buffer) {
+    diags.diagnose(SourceLoc(), diag::cannot_open_file, filelistPath,
+                   buffer.getError().message());
+    return None;
+  }
+  std::vector<std::string> outputFiles;
+  for (StringRef line : make_range(llvm::line_iterator(*buffer.get()), {})) {
+    outputFiles.push_back(line.str());
+  }
+  return outputFiles;
+}
+
+bool ArgsToFrontendOutputsConverter::isOutputAUniqueOrdinaryFile(
+    ArrayRef<std::string> outputs) {
+  return outputs.size() == 1 && outputs[0] != "-" &&
+         !llvm::sys::fs::is_directory(outputs[0]);
+}
+
+Optional<std::vector<std::string>>
+OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(
+    const ArgList &args, DiagnosticEngine &diags) {
+  if (const Arg *A = args.getLastArg(options::OPT_output_filelist)) {
+    assert(!args.hasArg(options::OPT_o) &&
+           "don't use -o with -output-filelist");
+    return ArgsToFrontendOutputsConverter::readOutputFileList(A->getValue(),
+                                                              diags);
+  }
+  return args.getAllArgValues(options::OPT_o);
+}
+
+OutputFilesComputer::OutputFilesComputer(
+    const ArgList &args, DiagnosticEngine &diags,
+    const FrontendInputsAndOutputs &inputsAndOutputs)
+    : Args(args), Diags(diags), InputsAndOutputs(inputsAndOutputs),
+      OutputFileArguments(
+          getOutputFilenamesFromCommandLineOrFilelist(Args, Diags)),
+      OutputDirectoryArgument(
+          OutputFileArguments && OutputFileArguments->size() == 1 &&
+                  llvm::sys::fs::is_directory(OutputFileArguments->front())
+              ? StringRef(OutputFileArguments->front())
+              : StringRef()),
+      DoOutputFileArgumentsMatchInputs(
+          OutputDirectoryArgument.empty() && OutputFileArguments &&
+          OutputFileArguments->size() ==
+              InputsAndOutputs.countOfInputsProducingOutput()),
+      FirstInput(InputsAndOutputs.hasSingleInput()
+                     ? InputsAndOutputs.getFilenameOfFirstInput()
+                     : StringRef()),
+      RequestedAction(
+          ArgsToFrontendOptionsConverter::determineRequestedAction(Args)),
+      ModuleNameArg(Args.getLastArg(options::OPT_module_name)),
+      Suffix(FrontendOptions::suffixForPrincipalOutputFileForAction(
+          RequestedAction)),
+      HasTextualOutput(
+          FrontendOptions::doesActionProduceTextualOutput(RequestedAction)) {}
+
+Optional<std::vector<std::string>>
+OutputFilesComputer::computeOutputFiles() const {
+  if (!OutputFileArguments)
+    return None;
+
+  std::vector<std::string> outputFiles;
+  bool hadError = false;
+  unsigned i = 0;
+  InputsAndOutputs.forEachInputProducingOutput(
+      [&](const InputFile &input) -> void {
+
+        StringRef outputArg = i < OutputFileArguments->size()
+                                  ? StringRef((*OutputFileArguments)[i])
+                                  : StringRef();
+
+        ++i;
+        Optional<std::string> outputFile = computeOutputFile(outputArg, input);
+        if (!outputFile) {
+          hadError = true;
+          return;
+        }
+        outputFiles.push_back(*outputFile);
+      });
+  return hadError ? None : Optional<std::vector<std::string>>(outputFiles);
+}
+
+Optional<std::string>
+OutputFilesComputer::computeOutputFile(StringRef outputArg,
+                                       const InputFile &input) const {
+
+  return outputArg.empty() ? deriveOutputFileFromInput(input)
+                           : !OutputDirectoryArgument.empty()
+                                 ? deriveOutputFileForDirectory(input)
+                                 : outputArg.str();
+}
+
+Optional<std::string>
+OutputFilesComputer::deriveOutputFileFromInput(const InputFile &input) const {
+  if (input.file() == "-" || HasTextualOutput)
+    return std::string("-");
+
+  std::string baseName = determineBaseNameOfOutput(input);
+  if (baseName.empty()) {
+    // Assuming FrontendOptions::doesActionProduceOutput(RequestedAction)
+    Diags.diagnose(SourceLoc(), diag::error_no_output_filename_specified);
+    return None;
+  }
+  return deriveOutputFileFromParts("", baseName);
+}
+
+Optional<std::string> OutputFilesComputer::deriveOutputFileForDirectory(
+    const InputFile &input) const {
+  std::string baseName = determineBaseNameOfOutput(input);
+  if (baseName.empty()) {
+    Diags.diagnose(SourceLoc(), diag::error_implicit_output_file_is_directory,
+                   OutputDirectoryArgument);
+    return None;
+  }
+  return deriveOutputFileFromParts(OutputDirectoryArgument, baseName);
+}
+
+std::string
+OutputFilesComputer::determineBaseNameOfOutput(const InputFile &input) const {
+  StringRef nameToStem =
+      input.isPrimary()
+          ? input.file()
+          : ModuleNameArg ? ModuleNameArg->getValue() : FirstInput;
+  return llvm::sys::path::stem(nameToStem).str();
+}
+
+std::string
+OutputFilesComputer::deriveOutputFileFromParts(StringRef dir,
+                                               StringRef base) const {
+  assert(!base.empty());
+  llvm::SmallString<128> path(dir);
+  llvm::sys::path::append(path, base);
+  llvm::sys::path::replace_extension(path, Suffix);
+  return path.str();
+}

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_library(swiftFrontend STATIC
   ArgsToFrontendInputsConverter.cpp
   ArgsToFrontendOptionsConverter.cpp
+  ArgsToFrontendOutputsConverter.cpp
   CompilerInvocation.cpp
   DiagnosticVerifier.cpp
   Frontend.cpp

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -4,7 +4,7 @@ add_swift_library(swiftFrontend STATIC
   CompilerInvocation.cpp
   DiagnosticVerifier.cpp
   Frontend.cpp
-  FrontendInputs.cpp
+  FrontendInputsAndOutputs.cpp
   FrontendOptions.cpp
   PrintingDiagnosticConsumer.cpp
   SerializedDiagnosticConsumer.cpp

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -818,10 +818,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (!SILOpts.SILOutputFileNameForDebugging.empty()) {
     Opts.MainInputFilename = SILOpts.SILOutputFileNameForDebugging;
   } else if (const InputFile *input =
-                 FrontendOpts.Inputs.getUniquePrimaryInput()) {
+                 FrontendOpts.InputsAndOutputs.getUniquePrimaryInput()) {
     Opts.MainInputFilename = input->file();
-  } else if (FrontendOpts.Inputs.hasSingleInput()) {
-    Opts.MainInputFilename = FrontendOpts.Inputs.getFilenameOfFirstInput();
+  } else if (FrontendOpts.InputsAndOutputs.hasSingleInput()) {
+    Opts.MainInputFilename =
+        FrontendOpts.InputsAndOutputs.getFilenameOfFirstInput();
   }
   Opts.OutputFilenames = FrontendOpts.OutputFilenames;
   Opts.ModuleName = FrontendOpts.ModuleName;
@@ -1064,7 +1065,7 @@ CompilerInvocation::setUpInputForSILTool(
 
   // If it looks like we have an AST, set the source file kind to SIL and the
   // name of the module to the file's name.
-  getFrontendOptions().Inputs.addInput(
+  getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(inputFilename, bePrimary, fileBufOrErr.get().get()));
 
   auto result = serialization::validateSerializedAST(

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -672,7 +672,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_debug_on_sil)) {
     // Derive the name of the SIL file for debugging from
     // the regular outputfile.
-    StringRef BaseName = FEOpts.getSingleOutputFilename();
+    StringRef BaseName = FEOpts.InputsAndOutputs.getSingleOutputFilename();
     // If there are no or multiple outputfiles, derive the name
     // from the module name.
     if (BaseName.empty())
@@ -824,7 +824,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.MainInputFilename =
         FrontendOpts.InputsAndOutputs.getFilenameOfFirstInput();
   }
-  Opts.OutputFilenames = FrontendOpts.OutputFilenames;
+  Opts.OutputFilenames = FrontendOpts.InputsAndOutputs.copyOutputFilenames();
   Opts.ModuleName = FrontendOpts.ModuleName;
 
   if (Args.hasArg(OPT_use_jit))

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -58,7 +58,7 @@ void CompilerInstance::createSILModule() {
   // Assume WMO if a -primary-file option was not provided.
   TheSILModule = SILModule::createEmptyModule(
       getMainModule(), Invocation.getSILOptions(),
-      Invocation.getFrontendOptions().Inputs.isWholeModule());
+      Invocation.getFrontendOptions().InputsAndOutputs.isWholeModule());
 }
 
 void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
@@ -182,7 +182,7 @@ bool CompilerInstance::setUpInputs() {
   const Optional<unsigned> codeCompletionBufferID = setUpCodeCompletionBuffer();
 
   for (const InputFile &input :
-       Invocation.getFrontendOptions().Inputs.getAllInputs())
+       Invocation.getFrontendOptions().InputsAndOutputs.getAllInputs())
     if (setUpForInput(input))
       return true;
 

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -122,8 +122,11 @@ StringRef FrontendInputsAndOutputs::getNameOfUniquePrimaryInputFile() const {
 
 bool FrontendInputsAndOutputs::isInputPrimary(StringRef file) const {
   auto iterator = PrimaryInputs.find(file);
-  return iterator != PrimaryInputs.end() &&
-         AllInputs[iterator->second].isPrimary();
+  if (iterator == PrimaryInputs.end())
+    return false;
+  assert(AllInputs[iterator->second].isPrimary() &&
+         "PrimaryInputs should only hold primaries");
+  return true;
 }
 
 unsigned FrontendInputsAndOutputs::numberOfPrimaryInputsEndingWith(

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -121,7 +121,10 @@ StringRef FrontendInputsAndOutputs::getNameOfUniquePrimaryInputFile() const {
 }
 
 bool FrontendInputsAndOutputs::isInputPrimary(StringRef file) const {
-  auto iterator = PrimaryInputs.find(file);
+  StringRef correctedFile =
+      InputFile::convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
+          file);
+  auto iterator = PrimaryInputs.find(correctedFile);
   if (iterator == PrimaryInputs.end())
     return false;
   assert(AllInputs[iterator->second].isPrimary() &&

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -122,7 +122,7 @@ StringRef FrontendOptions::originalPath() const {
   // If we have a primary input, so use that as the basis for the name of the
   // serialized diagnostics file, otherwise fall back on the
   // module name.
-  const auto input = Inputs.getUniquePrimaryInput();
+  const auto input = InputsAndOutputs.getUniquePrimaryInput();
   return input ? llvm::sys::path::filename(input->file())
                : StringRef(ModuleName);
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -139,7 +139,7 @@ static bool emitMakeDependencies(DiagnosticEngine &diags,
     // First include all other files in the module. Make-style dependencies
     // need to be conservative!
     for (auto const &path :
-         reversePathSortedFilenames(opts.Inputs.getInputFilenames()))
+         reversePathSortedFilenames(opts.InputsAndOutputs.getInputFilenames()))
       out << ' ' << escape(path);
     // Then print dependencies we've picked up during compilation.
     for (auto const &path :
@@ -547,14 +547,16 @@ static bool performCompile(CompilerInstance &Instance,
     auto &PCHOutDir = ImporterOpts.PrecompiledHeaderOutputDir;
     if (!PCHOutDir.empty()) {
       ImporterOpts.BridgingHeader =
-          Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput();
+          Invocation.getFrontendOptions()
+              .InputsAndOutputs.getFilenameOfFirstInput();
       // Create or validate a persistent PCH.
       auto SwiftPCHHash = Invocation.getPCHHash();
       auto PCH = clangImporter->getOrCreatePCH(ImporterOpts, SwiftPCHHash);
       return !PCH.hasValue();
     }
     return clangImporter->emitBridgingPCH(
-        Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
+        Invocation.getFrontendOptions()
+            .InputsAndOutputs.getFilenameOfFirstInput(),
         opts.getSingleOutputFilename());
   }
 
@@ -565,15 +567,17 @@ static bool performCompile(CompilerInstance &Instance,
     auto &LLVMContext = getGlobalLLVMContext();
 
     // Load in bitcode file.
-    assert(Invocation.getFrontendOptions().Inputs.hasSingleInput() &&
+    assert(Invocation.getFrontendOptions().InputsAndOutputs.hasSingleInput() &&
            "We expect a single input for bitcode input!");
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
         llvm::MemoryBuffer::getFileOrSTDIN(
-            Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput());
+            Invocation.getFrontendOptions()
+                .InputsAndOutputs.getFilenameOfFirstInput());
     if (!FileBufOrErr) {
       Instance.getASTContext().Diags.diagnose(
           SourceLoc(), diag::error_open_input_file,
-          Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
+          Invocation.getFrontendOptions()
+              .InputsAndOutputs.getFilenameOfFirstInput(),
           FileBufOrErr.getError().message());
       return true;
     }
@@ -588,7 +592,8 @@ static bool performCompile(CompilerInstance &Instance,
       // if available.
       Instance.getASTContext().Diags.diagnose(
           SourceLoc(), diag::error_parse_input_file,
-          Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput(),
+          Invocation.getFrontendOptions()
+              .InputsAndOutputs.getFilenameOfFirstInput(),
           Err.getMessage());
       return true;
     }
@@ -805,13 +810,13 @@ static bool performCompile(CompilerInstance &Instance,
       auto SASTF = dyn_cast<SerializedASTFile>(File);
       return SASTF && SASTF->isSIB();
     };
-    if (opts.Inputs.hasPrimaryInputs()) {
+    if (opts.InputsAndOutputs.hasPrimaryInputs()) {
       if (Instance.getPrimarySourceFiles().empty()) {
         // If we have primary inputs but no primary _source files_, we might
         // have a primary serialized input.
         for (FileUnit *fileUnit : mod->getFiles()) {
           if (auto SASTF = dyn_cast<SerializedASTFile>(fileUnit)) {
-            if (Invocation.getFrontendOptions().Inputs.isInputPrimary(
+            if (Invocation.getFrontendOptions().InputsAndOutputs.isInputPrimary(
                     InputFile::
                         convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
                             SASTF->getFilename()))) {
@@ -1451,7 +1456,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     auto &FEOpts = Invocation.getFrontendOptions();
     auto &LangOpts = Invocation.getLangOptions();
     auto &SILOpts = Invocation.getSILOptions();
-    StringRef InputName = FEOpts.Inputs.getNameOfUniquePrimaryInputFile();
+    StringRef InputName =
+        FEOpts.InputsAndOutputs.getNameOfUniquePrimaryInputFile();
     StringRef OptType = silOptModeArgStr(SILOpts.OptMode);
     StringRef OutFile = FEOpts.getSingleOutputFilename();
     StringRef OutputType = llvm::sys::path::extension(OutFile);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -100,7 +100,8 @@ static std::string displayName(StringRef MainExecutablePath) {
 /// Emits a Make-style dependencies file.
 static bool emitMakeDependencies(DiagnosticEngine &diags,
                                  DependencyTracker &depTracker,
-                                 const FrontendOptions &opts) {
+                                 const FrontendOptions &opts,
+                                 const InputFile &input) {
   std::error_code EC;
   llvm::raw_fd_ostream out(opts.DependenciesFilePath, EC,
                            llvm::sys::fs::F_None);
@@ -134,7 +135,7 @@ static bool emitMakeDependencies(DiagnosticEngine &diags,
 
   // FIXME: Xcode can't currently handle multiple targets in a single
   // dependency line.
-  opts.forAllOutputPaths([&](StringRef targetName) {
+  opts.forAllOutputPaths(input, [&](StringRef targetName) {
     out << escape(targetName) << " :";
     // First include all other files in the module. Make-style dependencies
     // need to be conservative!
@@ -149,6 +150,17 @@ static bool emitMakeDependencies(DiagnosticEngine &diags,
   });
 
   return false;
+}
+
+static bool emitMakeDependencies(DiagnosticEngine &diags,
+                                 DependencyTracker &depTracker,
+                                 const FrontendOptions &opts) {
+  bool hadError = false;
+  opts.InputsAndOutputs.forEachInputProducingSupplementaryOutput(
+      [&](const InputFile &f) -> void {
+        hadError = emitMakeDependencies(diags, depTracker, opts, f) || hadError;
+      });
+  return hadError;
 }
 
 namespace {
@@ -557,7 +569,7 @@ static bool performCompile(CompilerInstance &Instance,
     return clangImporter->emitBridgingPCH(
         Invocation.getFrontendOptions()
             .InputsAndOutputs.getFilenameOfFirstInput(),
-        opts.getSingleOutputFilename());
+        opts.InputsAndOutputs.getSingleOutputFilename());
   }
 
   IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
@@ -723,7 +735,7 @@ static bool performCompile(CompilerInstance &Instance,
       SF->dumpInterfaceHash(llvm::errs());
     else if (Action == FrontendOptions::ActionType::EmitSyntax) {
       emitSyntax(SF, Invocation.getLangOptions(), Instance.getSourceMgr(),
-                 opts.getSingleOutputFilename());
+                 opts.InputsAndOutputs.getSingleOutputFilename());
     } else
       SF->dump();
     return Context.hadError();
@@ -889,7 +901,8 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     if (Invocation.getSILOptions().LinkMode == SILOptions::LinkAll)
       performSILLinking(SM.get(), true);
     return writeSIL(*SM, Instance.getMainModule(), opts.EmitVerboseSIL,
-                    opts.getSingleOutputFilename(), opts.EmitSortedSIL);
+                    opts.InputsAndOutputs.getSingleOutputFilename(),
+                    opts.EmitSortedSIL);
   }
 
   if (Action == FrontendOptions::ActionType::EmitSIBGen) {
@@ -1067,7 +1080,8 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   // We've been told to write canonical SIL, so write it now.
   if (Action == FrontendOptions::ActionType::EmitSIL) {
     return writeSIL(*SM, Instance.getMainModule(), opts.EmitVerboseSIL,
-                    opts.getSingleOutputFilename(), opts.EmitSortedSIL);
+                    opts.InputsAndOutputs.getSingleOutputFilename(),
+                    opts.EmitSortedSIL);
   }
 
   assert(Action >= FrontendOptions::ActionType::Immediate &&
@@ -1108,16 +1122,15 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   std::unique_ptr<llvm::Module> IRModule;
   llvm::GlobalVariable *HashGlobal;
   if (MSF.is<SourceFile*>()) {
-    IRModule = performIRGeneration(IRGenOpts,
-                                   *MSF.get<SourceFile*>(),
-                                   std::move(SM),
-                                   opts.getSingleOutputFilename(), LLVMContext,
-                                   0, &HashGlobal);
+    IRModule =
+        performIRGeneration(IRGenOpts, *MSF.get<SourceFile *>(), std::move(SM),
+                            opts.InputsAndOutputs.getSingleOutputFilename(),
+                            LLVMContext, 0, &HashGlobal);
   } else {
-    IRModule = performIRGeneration(IRGenOpts, MSF.get<ModuleDecl*>(),
-                                   std::move(SM),
-                                   opts.getSingleOutputFilename(), LLVMContext,
-                                   &HashGlobal);
+    IRModule =
+        performIRGeneration(IRGenOpts, MSF.get<ModuleDecl *>(), std::move(SM),
+                            opts.InputsAndOutputs.getSingleOutputFilename(),
+                            LLVMContext, &HashGlobal);
   }
 
   // Walk the AST for indexing after IR generation. Walking it before seems
@@ -1177,8 +1190,10 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
 
   // Now that we have a single IR Module, hand it over to performLLVM.
   return performLLVM(IRGenOpts, &Instance.getDiags(), nullptr, HashGlobal,
-                  IRModule.get(), TargetMachine.get(), EffectiveLanguageVersion,
-                  opts.getSingleOutputFilename(), Stats) || HadError;
+                     IRModule.get(), TargetMachine.get(),
+                     EffectiveLanguageVersion,
+                     opts.InputsAndOutputs.getSingleOutputFilename(), Stats) ||
+         HadError;
 }
 
 static bool emitIndexData(SourceFile *PrimarySourceFile,
@@ -1203,22 +1218,21 @@ static bool emitIndexData(SourceFile *PrimarySourceFile,
 
   if (PrimarySourceFile) {
     if (index::indexAndRecord(
-            PrimarySourceFile, opts.getSingleOutputFilename(),
-            opts.IndexStorePath, opts.IndexSystemModules,
-            isDebugCompilation, Invocation.getTargetTriple(),
-            *Instance.getDependencyTracker())) {
+            PrimarySourceFile, opts.InputsAndOutputs.getSingleOutputFilename(),
+            opts.IndexStorePath, opts.IndexSystemModules, isDebugCompilation,
+            Invocation.getTargetTriple(), *Instance.getDependencyTracker())) {
       return true;
     }
   } else {
     StringRef moduleToken = opts.ModuleOutputPath;
     if (moduleToken.empty())
-      moduleToken = opts.getSingleOutputFilename();
+      moduleToken = opts.InputsAndOutputs.getSingleOutputFilename();
 
-    if (index::indexAndRecord(Instance.getMainModule(), opts.OutputFilenames,
-                              moduleToken, opts.IndexStorePath,
-                              opts.IndexSystemModules,
-                              isDebugCompilation, Invocation.getTargetTriple(),
-                              *Instance.getDependencyTracker())) {
+    if (index::indexAndRecord(
+            Instance.getMainModule(),
+            opts.InputsAndOutputs.copyOutputFilenames(), moduleToken,
+            opts.IndexStorePath, opts.IndexSystemModules, isDebugCompilation,
+            Invocation.getTargetTriple(), *Instance.getDependencyTracker())) {
       return true;
     }
   }
@@ -1298,6 +1312,30 @@ silOptModeArgStr(OptimizationMode mode) {
  default:
    return "Onone";
   }
+}
+
+static std::unique_ptr<UnifiedStatsReporter>
+computeStatsReporter(const CompilerInvocation &Invocation, SourceManager &SM) {
+  const std::string &StatsOutputDir =
+      Invocation.getFrontendOptions().StatsOutputDir;
+  std::unique_ptr<UnifiedStatsReporter> StatsReporter;
+  if (StatsOutputDir.empty())
+    return std::unique_ptr<UnifiedStatsReporter>();
+
+  auto &FEOpts = Invocation.getFrontendOptions();
+  auto &LangOpts = Invocation.getLangOptions();
+  auto &SILOpts = Invocation.getSILOptions();
+  std::string InputName =
+      FEOpts.InputsAndOutputs.getStatsFileMangledInputName();
+  StringRef OptType = silOptModeArgStr(SILOpts.OptMode);
+  StringRef OutFile =
+      FEOpts.InputsAndOutputs.lastInputProducingOutput().outputFilename();
+  StringRef OutputType = llvm::sys::path::extension(OutFile);
+  std::string TripleName = LangOpts.Target.normalize();
+  auto Trace = Invocation.getFrontendOptions().TraceStats;
+  return llvm::make_unique<UnifiedStatsReporter>(
+      "swift-frontend", FEOpts.ModuleName, InputName, TripleName, OutputType,
+      OptType, StatsOutputDir, &SM, Trace);
 }
 
 int swift::performFrontend(ArrayRef<const char *> Args,
@@ -1447,31 +1485,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     llvm::EnableStatistics();
   }
 
-  const std::string &StatsOutputDir =
-      Invocation.getFrontendOptions().StatsOutputDir;
-  std::unique_ptr<UnifiedStatsReporter> StatsReporter;
-  if (!StatsOutputDir.empty()) {
-    auto &FEOpts = Invocation.getFrontendOptions();
-    auto &LangOpts = Invocation.getLangOptions();
-    auto &SILOpts = Invocation.getSILOptions();
-    StringRef InputName =
-        FEOpts.InputsAndOutputs.getNameOfUniquePrimaryInputFile();
-    StringRef OptType = silOptModeArgStr(SILOpts.OptMode);
-    StringRef OutFile = FEOpts.getSingleOutputFilename();
-    StringRef OutputType = llvm::sys::path::extension(OutFile);
-    std::string TripleName = LangOpts.Target.normalize();
-    auto &SM = Instance->getSourceMgr();
-    auto Trace = Invocation.getFrontendOptions().TraceStats;
-    StatsReporter = llvm::make_unique<UnifiedStatsReporter>("swift-frontend",
-                                                            FEOpts.ModuleName,
-                                                            InputName,
-                                                            TripleName,
-                                                            OutputType,
-                                                            OptType,
-                                                            StatsOutputDir,
-                                                            &SM,
-                                                            Trace);
-  }
+  std::unique_ptr<UnifiedStatsReporter> StatsReporter =
+      computeStatsReporter(Invocation, Instance->getSourceMgr());
 
   const DiagnosticOptions &diagOpts = Invocation.getDiagnosticOptions();
   if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -817,9 +817,7 @@ static bool performCompile(CompilerInstance &Instance,
         for (FileUnit *fileUnit : mod->getFiles()) {
           if (auto SASTF = dyn_cast<SerializedASTFile>(fileUnit)) {
             if (Invocation.getFrontendOptions().InputsAndOutputs.isInputPrimary(
-                    InputFile::
-                        convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(
-                            SASTF->getFilename()))) {
+                    SASTF->getFilename())) {
               assert(PSGIs.empty() && "Can only handle one primary AST input");
               auto SM = performSILGeneration(*SASTF, SILOpts, None);
               PSGIs.push_back(

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -46,7 +46,7 @@ static void findAllClangImports(const clang::Module *module,
 bool swift::emitImportedModules(ASTContext &Context, ModuleDecl *mainModule,
                                 const FrontendOptions &opts) {
 
-  auto path = opts.getSingleOutputFilename();
+  auto path = opts.InputsAndOutputs.getSingleOutputFilename();
   std::error_code EC;
   llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1050,7 +1050,7 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
 
   CompilerInvocation Invocation{};
 
-  Invocation.getFrontendOptions().Inputs.addInput(
+  Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile("<extract>", true, InputBuffer.get()));
   Invocation.getFrontendOptions().ModuleName = "extract";
 

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -118,7 +118,7 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
     llvm::MemoryBuffer::getMemBufferCopy(InputText, getInputFilename());
 
   CompilerInvocation Invocation { StartInvocation };
-  Invocation.getFrontendOptions().Inputs.clearInputs();
+  Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.getLangOptions().EffectiveLanguageVersion = SwiftLanguageVersion;
   auto &LLVMArgs = Invocation.getFrontendOptions().LLVMArgs;
   auto aarch64_use_tbi = std::find(LLVMArgs.begin(), LLVMArgs.end(),
@@ -144,10 +144,10 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
 
   const auto &OrigFrontendOpts = StartInvocation.getFrontendOptions();
 
-  assert(OrigFrontendOpts.Inputs.hasPrimaryInputs() &&
+  assert(OrigFrontendOpts.InputsAndOutputs.hasPrimaryInputs() &&
          "Migration must have a primary");
-  for (const auto &input : OrigFrontendOpts.Inputs.getAllInputs()) {
-    Invocation.getFrontendOptions().Inputs.addInput(
+  for (const auto &input : OrigFrontendOpts.InputsAndOutputs.getAllInputs()) {
+    Invocation.getFrontendOptions().InputsAndOutputs.addInput(
         InputFile(input.file(), input.isPrimary(),
                   input.isPrimary() ? InputBuffer.get() : input.buffer()));
   }
@@ -438,6 +438,6 @@ const MigratorOptions &Migrator::getMigratorOptions() const {
 
 const StringRef Migrator::getInputFilename() const {
   auto &PrimaryInput = StartInvocation.getFrontendOptions()
-                           .Inputs.getRequiredUniquePrimaryInput();
+                           .InputsAndOutputs.getRequiredUniquePrimaryInput();
   return PrimaryInput.file();
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -83,13 +83,15 @@ struct InvocationOptions {
     // Assert invocation with a primary file. We want to avoid full typechecking
     // for all files.
     assert(!this->PrimaryFile.empty());
-    assert(this->Invok.getFrontendOptions().Inputs.hasUniquePrimaryInput() &&
+    assert(this->Invok.getFrontendOptions()
+               .InputsAndOutputs.hasUniquePrimaryInput() &&
            "Must have exactly one primary input for code completion, etc.");
   }
 
   void applyTo(CompilerInvocation &CompInvok) const;
-  void applyToSubstitutingInputs(CompilerInvocation &CompInvok,
-                                 FrontendInputs &&Inputs) const;
+  void
+  applyToSubstitutingInputs(CompilerInvocation &CompInvok,
+                            FrontendInputsAndOutputs &&InputsAndOutputs) const;
   void profile(llvm::FoldingSetNodeID &ID) const;
   void raw(std::vector<std::string> &Args, std::string &PrimaryFile) const;
 
@@ -135,9 +137,10 @@ void InvocationOptions::applyTo(CompilerInvocation &CompInvok) const {
   CompInvok = this->Invok;
 }
 void InvocationOptions::applyToSubstitutingInputs(
-    CompilerInvocation &CompInvok, FrontendInputs &&inputs) const {
+    CompilerInvocation &CompInvok,
+    FrontendInputsAndOutputs &&inputsAndOutputs) const {
   CompInvok = this->Invok;
-  CompInvok.getFrontendOptions().Inputs = inputs;
+  CompInvok.getFrontendOptions().InputsAndOutputs = inputsAndOutputs;
 }
 
 void InvocationOptions::raw(std::vector<std::string> &Args,
@@ -373,11 +376,12 @@ static void setModuleName(CompilerInvocation &Invocation) {
 
   StringRef Filename = Invocation.getOutputFilename();
   if (Filename.empty()) {
-    if (!Invocation.getFrontendOptions().Inputs.hasInputs()) {
+    if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
       Invocation.setModuleName("__main__");
       return;
     }
-    Filename = Invocation.getFrontendOptions().Inputs.getFilenameOfFirstInput();
+    Filename = Invocation.getFrontendOptions()
+                   .InputsAndOutputs.getFilenameOfFirstInput();
   }
   Filename = llvm::sys::path::filename(Filename);
   StringRef ModuleName = llvm::sys::path::stem(Filename);
@@ -409,16 +413,16 @@ static void sanitizeCompilerArgs(ArrayRef<const char *> Args,
   }
 }
 
-static FrontendInputs
+static FrontendInputsAndOutputs
 convertFileContentsToInputs(const SmallVectorImpl<FileContent> &contents) {
-  FrontendInputs inputs;
+  FrontendInputsAndOutputs inputsAndOutputs;
   for (const FileContent &content : contents)
-    inputs.addInput(InputFile(content));
-  return inputs;
+    inputsAndOutputs.addInput(InputFile(content));
+  return inputsAndOutputs;
 }
 
-static FrontendInputs
-resolveSymbolicLinksInInputs(FrontendInputs &inputs,
+static FrontendInputsAndOutputs
+resolveSymbolicLinksInInputs(FrontendInputsAndOutputs &inputsAndOutputs,
                              StringRef UnresolvedPrimaryFile,
                              std::string &Error) {
   unsigned primaryCount = 0;
@@ -426,8 +430,8 @@ resolveSymbolicLinksInInputs(FrontendInputs &inputs,
       SwiftLangSupport::resolvePathSymlinks(UnresolvedPrimaryFile);
   // FIXME: The frontend should be dealing with symlinks, maybe similar to
   // clang's FileManager ?
-  FrontendInputs replacementInputs;
-  for (const InputFile &input : inputs.getAllInputs()) {
+  FrontendInputsAndOutputs replacementInputsAndOutputs;
+  for (const InputFile &input : inputsAndOutputs.getAllInputs()) {
     std::string newFilename =
         SwiftLangSupport::resolvePathSymlinks(input.file());
     bool newIsPrimary = input.isPrimary() ||
@@ -436,19 +440,19 @@ resolveSymbolicLinksInInputs(FrontendInputs &inputs,
       ++primaryCount;
     }
     assert(primaryCount < 2 && "cannot handle multiple primaries");
-    replacementInputs.addInput(
+    replacementInputsAndOutputs.addInput(
         InputFile(newFilename, newIsPrimary, input.buffer()));
   }
 
   if (PrimaryFile.empty() || primaryCount == 1) {
-    return replacementInputs;
+    return replacementInputsAndOutputs;
   }
 
   llvm::SmallString<64> Err;
   llvm::raw_svector_ostream OS(Err);
   OS << "'" << PrimaryFile << "' is not part of the input files";
   Error = OS.str();
-  return replacementInputs;
+  return replacementInputsAndOutputs;
 }
 
 bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
@@ -465,8 +469,10 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
     Error = "error when parsing the compiler arguments";
     return true;
   }
-  Invocation.getFrontendOptions().Inputs = resolveSymbolicLinksInInputs(
-      Invocation.getFrontendOptions().Inputs, UnresolvedPrimaryFile, Error);
+  Invocation.getFrontendOptions().InputsAndOutputs =
+      resolveSymbolicLinksInInputs(
+          Invocation.getFrontendOptions().InputsAndOutputs,
+          UnresolvedPrimaryFile, Error);
   if (!Error.empty())
     return true;
 
@@ -707,9 +713,9 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
   // Check if the inputs changed.
   SmallVector<BufferStamp, 8> InputStamps;
   InputStamps.reserve(
-      Invok.Opts.Invok.getFrontendOptions().Inputs.inputCount());
+      Invok.Opts.Invok.getFrontendOptions().InputsAndOutputs.inputCount());
   for (const auto &input :
-       Invok.Opts.Invok.getFrontendOptions().Inputs.getAllInputs()) {
+       Invok.Opts.Invok.getFrontendOptions().InputsAndOutputs.getAllInputs()) {
     StringRef File = input.file();
     bool FoundSnapshot = false;
     for (auto &Snap : Snapshots) {
@@ -723,7 +729,7 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
       InputStamps.push_back(MgrImpl.getBufferStamp(File));
   }
   assert(InputStamps.size() ==
-         Invok.Opts.Invok.getFrontendOptions().Inputs.inputCount());
+         Invok.Opts.Invok.getFrontendOptions().InputsAndOutputs.inputCount());
   if (Stamps != InputStamps)
     return true;
 
@@ -896,7 +902,7 @@ void ASTProducer::findSnapshotAndOpenFiles(
     SmallVectorImpl<FileContent> &Contents, std::string &Error) const {
   const InvocationOptions &Opts = InvokRef->Impl.Opts;
   for (const auto &input :
-       Opts.Invok.getFrontendOptions().Inputs.getAllInputs()) {
+       Opts.Invok.getFrontendOptions().InputsAndOutputs.getAllInputs()) {
     StringRef File = input.file();
     bool IsPrimary = input.isPrimary();
     bool FoundSnapshot = false;
@@ -920,5 +926,5 @@ void ASTProducer::findSnapshotAndOpenFiles(
     Contents.push_back(std::move(Content));
   }
   assert(Contents.size() ==
-         Opts.Invok.getFrontendOptions().Inputs.inputCount());
+         Opts.Invok.getFrontendOptions().InputsAndOutputs.inputCount());
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -144,7 +144,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   if (Failed) {
     return false;
   }
-  if (!Invocation.getFrontendOptions().Inputs.hasInputs()) {
+  if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
     Error = "no input filenames specified";
     return false;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -771,13 +771,13 @@ private:
 
 static bool makeParserAST(CompilerInstance &CI, StringRef Text,
                           CompilerInvocation Invocation) {
-  Invocation.getFrontendOptions().Inputs.clearInputs();
+  Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
   Invocation.setInputKind(InputFileKind::IFK_Swift);
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
-  Invocation.getFrontendOptions().Inputs.addInput(
+  Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(Buf.get()->getBufferIdentifier(), false, Buf.get()));
   if (CI.setup(Invocation))
     return true;
@@ -1092,7 +1092,7 @@ static bool reportSourceDocInfo(CompilerInvocation Invocation,
 
   EditorDiagConsumer DiagConsumer;
   CI.addDiagnosticConsumer(&DiagConsumer);
-  Invocation.getFrontendOptions().Inputs.addInput(
+  Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(InputBuf->getBufferIdentifier(), false, InputBuf));
   if (CI.setup(Invocation))
     return true;
@@ -1365,7 +1365,7 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     return nullptr;
   }
   Invocation.setInputKind(InputFileKind::IFK_Swift);
-  Invocation.getFrontendOptions().Inputs.addInput(
+  Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(InputBuf->getBufferIdentifier(), false, InputBuf));
 
   if (ParseCI.setup(Invocation)) {
@@ -1441,7 +1441,7 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
                                     StringRef Error)> Receiver) {
   CompilerInvocation Invocation;
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
-  Invocation.getFrontendOptions().Inputs.clearInputs();
+  Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
 
   CompilerInstance CI;
   // Display diagnostics to stderr.

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -228,13 +228,13 @@ public:
 
 static bool makeParserAST(CompilerInstance &CI, StringRef Text,
                           CompilerInvocation Invocation) {
-  Invocation.getFrontendOptions().Inputs.clearInputs();
+  Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
   Invocation.setInputKind(InputFileKind::IFK_Swift);
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
-  Invocation.getFrontendOptions().Inputs.addInput(
+  Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(Buf.get()->getBufferIdentifier(), false, Buf.get()));
   if (CI.setup(Invocation))
     return true;
@@ -402,7 +402,7 @@ SwiftInterfaceGenContext::create(StringRef DocumentName,
   // Display diagnostics to stderr.
   CI.addDiagnosticConsumer(&IFaceGenCtx->Impl.DiagConsumer);
 
-  Invocation.getFrontendOptions().Inputs.clearInputs();
+  Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   if (CI.setup(Invocation)) {
     ErrMsg = "Error during invocation setup";
     return nullptr;

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -279,7 +279,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
     return;
   }
 
-  if (!Invocation.getFrontendOptions().Inputs.hasInputs()) {
+  if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
     IdxConsumer.failed("no input filenames specified");
     return;
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -729,7 +729,8 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
 
   Invocation.setCodeCompletionFactory(CompletionCallbacksFactory.get());
   if (!SecondSourceFileName.empty()) {
-    Invocation.getFrontendOptions().Inputs.addInputFile(SecondSourceFileName);
+    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
+        SecondSourceFileName);
   }
   CompilerInstance CI;
 
@@ -955,7 +956,7 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
                             bool RunTypeChecker,
                             bool Playground) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
 
   CompilerInstance CI;
@@ -998,7 +999,7 @@ static int doDumpImporterLookupTables(const CompilerInvocation &InitInvok,
   }
 
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI;
 
@@ -1178,7 +1179,7 @@ static int doStructureAnnotation(const CompilerInvocation &InitInvok,
                                  StringRef SourceFilename) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.getLangOptions().KeepSyntaxInfoInSourceFile = true;
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI;
 
@@ -1434,7 +1435,7 @@ static int doSemanticAnnotation(const CompilerInvocation &InitInvok,
                                 StringRef SourceFilename,
                                 bool TerminalOutput) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI;
 
@@ -1499,7 +1500,7 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
                       StringRef MangledNameToFind,
                       StringRef DebugClientDiscriminator) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI;
 
@@ -1930,7 +1931,8 @@ static int doPrintSwiftFileInterface(const CompilerInvocation &InitInvok,
                                      StringRef SourceFilename,
                                      bool AnnotatePrint) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addPrimaryInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addPrimaryInputFile(
+      SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI;
   // Display diagnostics to stderr.
@@ -1960,7 +1962,8 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
                         const PrintOptions &Options,
                         bool AnnotatePrint) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addPrimaryInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addPrimaryInputFile(
+      SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI;
   // Display diagnostics to stderr.
@@ -2071,7 +2074,7 @@ static int doPrintTypes(const CompilerInvocation &InitInvok,
                         StringRef SourceFilename,
                         bool FullyQualifiedTypes) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI;
   // Display diagnostics to stderr.
@@ -2297,7 +2300,7 @@ public:
 static int doDumpComments(const CompilerInvocation &InitInvok,
                           StringRef SourceFilename) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI;
   // Display diagnostics to stderr.
@@ -2319,7 +2322,7 @@ static int doPrintComments(const CompilerInvocation &InitInvok,
                            StringRef SourceFilename,
                            StringRef CommentsXMLSchema) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
 
@@ -2449,7 +2452,7 @@ static int doPrintTypeInterface(const CompilerInvocation &InitInvok,
   if (!Pair.hasValue())
     return 1;
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(FileName);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   CompilerInstance CI;
   if (CI.setup(Invocation))
     return 1;
@@ -2495,7 +2498,7 @@ static int doPrintTypeInterfaceForTypeUsr(const CompilerInvocation &InitInvok,
                                           const StringRef FileName,
                                           const StringRef Usr) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(FileName);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   CompilerInstance CI;
   if (CI.setup(Invocation))
     return 1;
@@ -2656,7 +2659,7 @@ private:
 static int doReconstructType(const CompilerInvocation &InitInvok,
                              StringRef SourceFilename) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
 
   CompilerInstance CI;
@@ -2690,7 +2693,7 @@ static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
   auto StartLineCol = StartOp.getValue();
   auto EndLineCol = EndOp.getValue();
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFileName);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFileName);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
   Invocation.getLangOptions().KeepSyntaxInfoInSourceFile = true;
 
@@ -2792,7 +2795,7 @@ static int doPrintIndexedSymbols(const CompilerInvocation &InitInvok,
                                 StringRef SourceFileName, bool indexLocals) {
 
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFileName);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFileName);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
   Invocation.getLangOptions().TypoCorrectionLimit = 0;
 
@@ -2857,7 +2860,7 @@ static int doPrintIndexedSymbolsFromModule(const CompilerInvocation &InitInvok,
 static int doPrintUSRs(const CompilerInvocation &InitInvok,
                        StringRef SourceFilename) {
   CompilerInvocation Invocation(InitInvok);
-  Invocation.getFrontendOptions().Inputs.addInputFile(SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   ClangImporterOptions &ImporterOpts = Invocation.getClangImporterOptions();
   ImporterOpts.DetailedPreprocessingRecord = true;
@@ -3004,7 +3007,7 @@ int main(int argc, char *argv[]) {
   CompilerInvocation InitInvok;
 
   for (auto &File : options::InputFilenames)
-    InitInvok.getFrontendOptions().Inputs.addInputFile(File);
+    InitInvok.getFrontendOptions().InputsAndOutputs.addInputFile(File);
   if (!options::InputFilenames.empty())
     InitInvok.setInputKind(InputFileKind::IFK_Swift_Library);
 

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -233,12 +233,13 @@ int main(int argc, char *argv[]) {
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(argv[0],
     reinterpret_cast<void *>(&anchorForGetMainExecutable)));
-  Invocation.getFrontendOptions().Inputs.addInputFile(options::SourceFilename);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
+      options::SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().KeepSyntaxInfoInSourceFile = true;
 
   for (auto FileName : options::InputFilenames)
-    Invocation.getFrontendOptions().Inputs.addInputFile(FileName);
+    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   Invocation.setModuleName(options::ModuleName);
   CompilerInstance CI;
   // Display diagnostics to stderr.

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -146,7 +146,7 @@ SourceFile *getSourceFile(CompilerInstance &Instance,
   CompilerInvocation Invocation;
   Invocation.getLangOptions().KeepSyntaxInfoInSourceFile = true;
   Invocation.getLangOptions().VerifySyntaxTree = true;
-  Invocation.getFrontendOptions().Inputs.addInputFile(InputFileName);
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(MainExecutablePath,
       reinterpret_cast<void *>(&anchorForGetMainExecutable)));


### PR DESCRIPTION
<!-- What's in this pull request? -->
For batch mode, the output file names and overriding buffers need to be associated with the inputs, since each (primary) input can have its own set of outputs. This PR takes the first step of moving the main outputs into the inputs (avoiding a file-name-based lookup). It includes a rename from FrontendInputs to FrontendInputsAndOutputs. Once this PR lands, we can start moving over the supplementary outputs as well.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
