### PR TITLE
[Mangled name -> metadata] Add built-in types support

### DIFF
--- a/include/swift/Runtime/BuiltinTypes.def
+++ b/include/swift/Runtime/BuiltinTypes.def
@@ -1,0 +1,39 @@
+//===--- BuiltinTypes.def - Compiler declaration metaprogramming --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with compiler-known
+// built-in types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUILTIN_TYPE
+#  define BUILTIN_TYPE(Symbol, Name)
+#endif
+
+BUILTIN_TYPE(Bi8_, "Builtin.Int8")
+BUILTIN_TYPE(Bi16_, "Builtin.Int16")
+BUILTIN_TYPE(Bi32_, "Builtin.Int32")
+BUILTIN_TYPE(Bi64_, "Builtin.Int64")
+BUILTIN_TYPE(Bi128_, "Builtin.Int128")
+BUILTIN_TYPE(Bi256_, "Builtin.Int256")
+BUILTIN_TYPE(Bi512_, "Builtin.Int512")
+
+BUILTIN_TYPE(Bo, "Builtin.NativeObject")
+BUILTIN_TYPE(Bb, "Builtin.BridgeObject")
+BUILTIN_TYPE(Bp, "Builtin.RawPointer")
+BUILTIN_TYPE(BB, "Builtin.UnsafeValueBuffer")
+
+#if SWIFT_OBJC_INTEROP
+BUILTIN_TYPE(BO, "Builtin.UnknownObject")
+#endif
+
+#undef BUILTIN_TYPE

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -984,32 +984,10 @@ using OpaqueMetadata = TargetOpaqueMetadata<InProcess>;
 // The "Int" metadata are used for arbitrary POD data with the
 // matching characteristics.
 using FullOpaqueMetadata = FullMetadata<OpaqueMetadata>;
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi8_);      // Builtin.Int8
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi16_);     // Builtin.Int16
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi32_);     // Builtin.Int32
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi64_);     // Builtin.Int64
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi128_);    // Builtin.Int128
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi256_);    // Builtin.Int256
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bi512_);    // Builtin.Int512
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bo);        // Builtin.NativeObject
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bb);        // Builtin.BridgeObject
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(Bp);        // Builtin.RawPointer
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(BB);        // Builtin.UnsafeValueBuffer
-#if SWIFT_OBJC_INTEROP
-SWIFT_RUNTIME_EXPORT
-const FullOpaqueMetadata METADATA_SYM(BO);        // Builtin.UnknownObject
-#endif
+#define BUILTIN_TYPE(Symbol, Name) \
+    SWIFT_RUNTIME_EXPORT \
+    const FullOpaqueMetadata METADATA_SYM(Symbol);
+#include "swift/Runtime/BuiltinTypes.def"
 
 /// The prefix on a heap metadata.
 struct HeapMetadataHeaderPrefix {

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -156,20 +156,9 @@ const ValueWitnessTable swift::VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING) =
     { &VALUE_WITNESS_SYM(TYPE) },                             \
     { { MetadataKind::Opaque } }                 \
   };
-OPAQUE_METADATA(Bi8_)
-OPAQUE_METADATA(Bi16_)
-OPAQUE_METADATA(Bi32_)
-OPAQUE_METADATA(Bi64_)
-OPAQUE_METADATA(Bi128_)
-OPAQUE_METADATA(Bi256_)
-OPAQUE_METADATA(Bi512_)
-OPAQUE_METADATA(Bo)
-OPAQUE_METADATA(Bb)
-OPAQUE_METADATA(Bp)
-OPAQUE_METADATA(BB)
-#if SWIFT_OBJC_INTEROP
-OPAQUE_METADATA(BO)
-#endif
+#define BUILTIN_TYPE(Symbol, Name) \
+  OPAQUE_METADATA(Symbol)
+#include "swift/Runtime/BuiltinTypes.def"
 
 /// The standard metadata for the empty tuple.
 const FullMetadata<TupleTypeMetadata> swift::

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -584,7 +584,10 @@ public:
   }
 
   BuiltType createBuiltinType(StringRef mangledName) const {
-    // FIXME: Implement.
+#define BUILTIN_TYPE(Symbol, _) \
+    if (mangledName.equals(#Symbol)) \
+      return &METADATA_SYM(Symbol).base;
+#include "swift/Runtime/BuiltinTypes.def"
     return BuiltType();
   }
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -1,6 +1,9 @@
-// RUN: %target-run-simple-swift
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
+import Swift
 import StdlibUnittest
 
 let DemangleToMetadataTests = TestSuite("DemangleToMetadata")
@@ -211,6 +214,20 @@ DemangleToMetadataTests.test("nested generic specializations") {
   expectEqual(
     CG2<Int, String>.Inner<Double>.Innermost<Int8, Int16, Int32, Int64>.self,
     _typeByMangledName("4main3CG2C5InnerC9InnermostVySiSS_Sd_s4Int8Vs5Int16Vs5Int32Vs5Int64VG")!)
+}
+
+DemangleToMetadataTests.test("demangle built-in types") {
+  expectEqual(Builtin.Int8.self,     _typeByMangledName("Bi8_")!)
+  expectEqual(Builtin.Int16.self,    _typeByMangledName("Bi16_")!)
+  expectEqual(Builtin.Int32.self,    _typeByMangledName("Bi32_")!)
+  expectEqual(Builtin.Int64.self,    _typeByMangledName("Bi64_")!)
+  expectEqual(Builtin.Int128.self,   _typeByMangledName("Bi128_")!)
+  expectEqual(Builtin.Int256.self,   _typeByMangledName("Bi256_")!)
+  expectEqual(Builtin.Int512.self,   _typeByMangledName("Bi512_")!)
+
+  expectEqual(Builtin.NativeObject.self, _typeByMangledName("Bo")!)
+  expectEqual(Builtin.BridgeObject.self, _typeByMangledName("Bb")!)
+  expectEqual(Builtin.UnsafeValueBuffer.self, _typeByMangledName("BB")!)
 }
 
 runAllTests()


### PR DESCRIPTION
Includes changes to make list of built-in types meta-programmable, and makes use of in the Demangle when we convert opaque metadata into demangling tree and mangled name -> metadata.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
