### PR TITLE
[stdlib] Add a return value to _UIntBuffer.removeFirst()

### DIFF
--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -198,10 +198,13 @@ extension _UIntBuffer : RangeReplaceableCollection {
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
-  public mutating func removeFirst() {
+  @discardableResult
+  public mutating func removeFirst() -> Element {
     _debugPrecondition(!isEmpty)
+    let result = Element(truncatingIfNeeded: _storage)
     _bitCount = _bitCount &- _elementWidth
     _storage = _storage._fullShiftRight(_elementWidth)
+    return result
   }
   
   @_inlineable // FIXME(sil-serialize-all)


### PR DESCRIPTION
This one-liner fixes a warning about a near match with the defaulted RangeReplaceableCollection requirement of the same name.