### PR TITLE
Remove dependence on IUO type in bridging peephole.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -303,6 +303,10 @@ protected:
     NumVariadicArgs : 16
   );
 
+  SWIFT_INLINE_BITFIELD(ForceValueExpr, Expr, 1,
+    ForcedIUO : 1
+  );
+
   SWIFT_INLINE_BITFIELD(InOutToPointerExpr, ImplicitConversionExpr, 1,
     IsNonAccessing : 1
   );
@@ -2507,9 +2511,11 @@ class ForceValueExpr : public Expr {
   SourceLoc ExclaimLoc;
 
 public:
-  ForceValueExpr(Expr *subExpr, SourceLoc exclaimLoc)
+  ForceValueExpr(Expr *subExpr, SourceLoc exclaimLoc, bool forcedIUO = false)
     : Expr(ExprKind::ForceValue, /*Implicit=*/exclaimLoc.isInvalid(), Type()),
-      SubExpr(subExpr), ExclaimLoc(exclaimLoc) {}
+      SubExpr(subExpr), ExclaimLoc(exclaimLoc) {
+    Bits.ForceValueExpr.ForcedIUO = forcedIUO;
+  }
 
   SourceRange getSourceRange() const {
     if (ExclaimLoc.isInvalid())
@@ -2533,6 +2539,10 @@ public:
 
   Expr *getSubExpr() const { return SubExpr; }
   void setSubExpr(Expr *expr) { SubExpr = expr; }
+
+  bool isForceOfImplicitlyUnwrappedOptional() const {
+    return Bits.ForceValueExpr.ForcedIUO;
+  }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::ForceValue;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5068,8 +5068,7 @@ RValue RValueEmitter::emitForceValue(ForceValueExpr *loc, Expr *E,
   // If this is an implicit force of an ImplicitlyUnwrappedOptional,
   // and we're emitting into an unbridging conversion, try adjusting the
   // context.
-  if (loc->isImplicit() &&
-      E->getType()->getImplicitlyUnwrappedOptionalObjectType()) {
+  if (loc->isImplicit() && loc->isForceOfImplicitlyUnwrappedOptional()) {
     if (auto conv = C.getAsConversion()) {
       if (auto adjusted = conv->getConversion().adjustForInitialForceValue()) {
         auto value =

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5468,7 +5468,8 @@ Expr *ExprRewriter::coerceImplicitlyUnwrappedOptionalToValue(Expr *expr, Type ob
     objTy = LValueType::get(objTy);
 
   expr = new (cs.getTypeChecker().Context) ForceValueExpr(expr,
-                                                          expr->getEndLoc());
+                                                          expr->getEndLoc(),
+                                                          /* forcedIUO=*/ true);
   cs.setType(expr, objTy);
   expr->setImplicit();
   return expr;


### PR DESCRIPTION
Rather than check if a ForceValueExpr is of an IUO type, add a new bit
to ForceValueExpr that marks it as a force of an IUO-declared thing,
and check that bit instead.
