### PR TITLE
[IRGenSIL] When emitting a shadow copy, honour the layout.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -759,44 +759,31 @@ public:
                           Storage.getAlignment());
   }
 
-  void emitShadowCopy(ArrayRef<llvm::Value *> vals, const SILDebugScope *Scope,
+  void emitShadowCopy(SILValue &SILVal, const SILDebugScope *Scope,
                       StringRef Name, unsigned ArgNo, bool IsAnonymous,
                       llvm::SmallVectorImpl<llvm::Value *> &copy) {
+    Explosion e = getLoweredExplosion(SILVal);
+
     // Only do this at -O0.
     if (IGM.IRGen.Opts.shouldOptimize() || IsAnonymous) {
+      auto vals = e.claimAll();
       copy.append(vals.begin(), vals.end());
       return;
     }
 
     // Single or empty values.
-    if (vals.size() <= 1) {
+    if (e.size() <= 1) {
+      auto vals = e.claimAll();
       for (auto val : vals)
         copy.push_back(emitShadowCopy(val, Scope, Name, ArgNo, IsAnonymous));
       return;
     }
 
-    // Create a single aggregate alloca for explosions.
-    // TODO: why are we doing this instead of using the TypeInfo?
-    llvm::StructType *aggregateType = [&] {
-      SmallVector<llvm::Type *, 8> eltTypes;
-      for (auto val : vals)
-        eltTypes.push_back(val->getType());
-      return llvm::StructType::get(IGM.LLVMContext, eltTypes);
-    }();
-
-    auto layout = IGM.DataLayout.getStructLayout(aggregateType);
-    Alignment align(layout->getAlignment());
-
-    auto alloca = createAlloca(aggregateType, align, Name + ".debug");
-    ArtificialLocation AutoRestore(Scope, IGM.DebugInfo, Builder);
-    size_t i = 0;
-    for (auto val : vals) {
-      auto addr = Builder.CreateStructGEP(alloca, i,
-                                          Size(layout->getElementOffset(i)));
-      Builder.CreateStore(val, addr);
-      i++;
-    }
-    copy.push_back(alloca.getAddress());
+    SILType Type = SILVal->getType();
+    auto &LTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(Type));
+    auto Alloca = LTI.allocateStack(*this, Type, "debug.copy");
+    LTI.initialize(*this, e, Alloca.getAddress(), false /* isOutlined */);
+    copy.push_back(Alloca.getAddressPointer());
   }
 
   /// Determine whether a generic variable has been inlined.
@@ -3633,10 +3620,8 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
 
   // Put the value into a stack slot at -Onone.
   llvm::SmallVector<llvm::Value *, 8> Copy; 
-  Explosion e = getLoweredExplosion(SILVal);
   unsigned ArgNo = i->getVarInfo().ArgNo;
-  emitShadowCopy(e.claimAll(), i->getDebugScope(), Name, ArgNo, IsAnonymous,
-                 Copy);
+  emitShadowCopy(SILVal, i->getDebugScope(), Name, ArgNo, IsAnonymous, Copy);
   emitDebugVariableDeclaration(Copy, DbgTy, SILTy, i->getDebugScope(),
                                i->getDecl(), Name, ArgNo);
 }

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -8,12 +8,9 @@ func use<T>(_ t: T) {}
 public func f(_ i : Int?)
 {
   // CHECK: define {{.*}}@"$S4main1fyySiSgF"
-  // The shadow copy store should not have a location.
-  // Note that the store must be in the same scope or else it might defeat
-  // livedebugvalues.
+  // CHECK1: %debug.copy = alloca %TSiSg
+  // CHECK1: @llvm.dbg.declare(metadata %TSiSg* %debug.copy
   // CHECK1: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.addr, {{.*}}, !dbg ![[DBG0:.*]]
-  // CHECK1: %[[PHI:.*]] = phi
-  // CHECK1: store {{(i32|i64)}} %[[PHI]], {{(i32|i64)}}* %val.addr, align {{(4|8)}}, !dbg ![[DBG1:.*]]
   // CHECK1: ![[F:.*]] = distinct !DISubprogram(name: "f",
   // CHECK1: ![[BLK:.*]] = distinct !DILexicalBlock(scope: ![[F]],
   // CHECK1: ![[DBG0]] = !DILocation(line: [[@LINE+2]],
@@ -29,10 +26,11 @@ public func f(_ i : Int?)
 public func g(_ s : String?)
 {
   // CHECK2: define {{.*}}@"$S4main1gyySSSgF"
-  // The shadow copy store should not have a location.
-  // CHECK2: getelementptr inbounds {{.*}} %s.debug, {{.*}}, !dbg ![[DBG0:.*]]
+  // CHECK2: %debug.copy = alloca %TSSSg
+  // CHECK2: @llvm.dbg.declare(metadata %TSSSg*
+  // CHECK2: %debug.copy1 = alloca %TSS
+  // CHECK2: @llvm.dbg.declare(metadata %TSS*
   // CHECK2: ![[G:.*]] = distinct !DISubprogram(name: "g"
-  // CHECK2: ![[DBG0]] = !DILocation(line: 0, scope: ![[G]])
   guard let val = s else { return }
   use(val)
 }


### PR DESCRIPTION
This code was ad-hoc trying to reconstruct the layout. Ask TypeInfo
instead, as it knows what's the right thing to do.
This allows to print field of classes nested inside classes correctly
in lldb (SR-6791).

<rdar://problem/36518505>