### PR TITLE
[stdlib] Silence deprecation warnings about CharacterView in stdlib

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -140,6 +140,8 @@ extension String {
   ///   argument is valid only for the duration of the closure's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_inlineable // FIXME(sil-serialize-all)
+  @available(swift, deprecated: 3.2, message:
+    "Please mutate String or Substring directly")
   public mutating func withMutableCharacters<R>(
     _ body: (inout CharacterView) -> R
   ) -> R {
@@ -374,6 +376,8 @@ extension String._CharacterView {
   /// - Complexity: O(*n*) if the underlying string is bridged from
   ///   Objective-C, where *n* is the length of the string; otherwise, O(1).
   @_inlineable // FIXME(sil-serialize-all)
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
   public subscript(bounds: Range<Index>) -> String.CharacterView {
     let offsetRange: Range<Int> =
       _toBaseIndex(bounds.lowerBound).encodedOffset ..<

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -376,29 +376,32 @@ extension Substring : LosslessStringConvertible {
 %   ('characters', 'Character')
 % ]:
 %   View = ViewPrefix + 'View'
-%   RangeReplaceable = 'RangeReplaceable' if property == 'unicodeScalars' else ''
+%   _View = '_CharacterView' if property == 'characters' else View
+%   _property = '_characters' if property == 'characters' else property
+% 
 extension Substring {
   % if View == 'CharacterView':
   @available(swift, deprecated: 3.2, message:
     "Please use String or Substring directly")
+  public typealias CharacterView = _CharacterView
   % end
+
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct ${View} {
+  public struct ${_View} {
     @_versioned // FIXME(sil-serialize-all)
-    internal var _slice: Slice<String.${View}>
+    internal var _slice: Slice<String.${_View}>
   }
 }
 
-extension Substring.${View} : BidirectionalCollection {
+extension Substring.${_View} : BidirectionalCollection {
   public typealias Index = String.Index
-  public typealias SubSequence = Substring.${View}
 
   /// Creates an instance that slices `base` at `_bounds`.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal init(_ base: String.${View}, _bounds: Range<Index>) {
+  internal init(_ base: String.${_View}, _bounds: Range<Index>) {
     _slice = Slice(
-      base: String(base._guts).${property},
+      base: String(base._guts).${_property},
       bounds: _bounds)
   }
 
@@ -432,26 +435,40 @@ extension Substring.${View} : BidirectionalCollection {
     return _slice[i]
   }
   @_inlineable // FIXME(sil-serialize-all)
-  public subscript(r: Range<Index>) -> SubSequence {
+  % if property == 'characters':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
+  public subscript(r: Range<Index>) -> Substring.${View} {
     // FIXME(strings): tests.
     _precondition(r.lowerBound >= startIndex && r.upperBound <= endIndex,
       "${View} index range out of bounds")
-    return Substring.${View}(_wholeString.${property}, _bounds: r)
+    return Substring.${_View}(_wholeString.${_property}, _bounds: r)
   }
 }
 
 extension Substring {
   % if View == 'CharacterView':
+  @_inlineable // FIXME(sil-serialize-all)
   @available(swift, deprecated: 3.2, message:
     "Please use String or Substring directly")
-  % end
-  @_inlineable // FIXME(sil-serialize-all)
-  public var ${property}: ${View} {
+  public var characters: CharacterView {
     get {
-      return ${View}(_wholeString.${property}, _bounds: startIndex..<endIndex)
+      return _characters
     }
     set {
-      self = Substring(newValue)
+      _characters = newValue
+    }
+  }
+  % end
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public var ${_property}: ${_View} {
+    get {
+      return ${_View}(_wholeString.${_property}, _bounds: startIndex..<endIndex)
+    }
+    set {
+      self = Substring(_base: _wholeString, startIndex..<endIndex)
     }
   }
 
@@ -459,6 +476,10 @@ extension Substring {
   ///
   /// - Complexity: O(1)
   @_inlineable // FIXME(sil-serialize-all)
+  % if property == 'characters':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
   public init(_ content: ${View}) {
     self = content._wholeString[content.startIndex..<content.endIndex]
   }
@@ -487,6 +508,10 @@ extension String {
   /// - Complexity: O(N), where N is the length of the resulting `String`'s
   ///   UTF-16.
   @_inlineable // FIXME(sil-serialize-all)
+  % if property == 'characters':
+  @available(swift, deprecated: 3.2, message:
+    "Please use String or Substring directly")
+  % end
   public init(_ content: Substring.${View}) {
     self = String(Substring(content))
   }


### PR DESCRIPTION
This eliminates 13 warnings about deprecated `CharacterView`/`characters` usages in the stdlib, mostly inside Substring.swift. (The stdlib only uses character views in the implementations/signatures of members related to the character views themselves; but these still produce warnings.)

- Rename `Substring.CharacterView` to `Substring._CharacterView`, adding a deprecated typealias for the original name, like we do for `String.CharacterView`.
- Add a non-deprecated `Substring._characters` property, emulating `String._characters`.
- Explicitly deprecate the following members that include a `CharacterView` in their signatures:
    * `String.withMutableCharacters<R>(_: (inout CharacterView) -> R) -> R`
    * `String.subscript(Range<Index>) -> String.CharacterView`
    * `Substring._CharacterView.subscript(Range<Index>) -> Substring.CharacterView`
    * `Substring.init(_: CharacterView)`
    * `String.init(_: Substring.CharacterView)`