### PR TITLE
[benchmark] Increase DoubleWidth division benchmark iterations

### DIFF
--- a/benchmark/single-source/DoubleWidthDivision.swift
+++ b/benchmark/single-source/DoubleWidthDivision.swift
@@ -29,7 +29,7 @@ private typealias Int1024 = DoubleWidth<Int512>
 @inline(never)
 public func run_DoubleWidthDivision(_ N: Int) {
   var sum = 0
-  for _ in 1...N {
+  for _ in 1...5*N {
     let (q, r) =
       (Int128(Int64.max) * 16)
         .quotientAndRemainder(dividingBy: numericCast(getInt(16)))


### PR DESCRIPTION
PR #14043 added a benchmark for `DoubleWidth` division; it's reasonably taxing when unoptimized but dramatically faster when optimized. Here, I increase the number of iterations (modestly) to try to increase the reliability of the result.
