### PR TITLE
[4.1] SIL: Fix zealous assert in verifier

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2311,9 +2311,18 @@ public:
         if (inst->isTypeDependentOperand(*use))
           continue;
         switch (inst->getKind()) {
+        case SILInstructionKind::MarkDependenceInst:
+          break;
         case SILInstructionKind::ApplyInst:
         case SILInstructionKind::TryApplyInst:
         case SILInstructionKind::PartialApplyInst:
+          // Non-Mutating set pattern that allows a inout (that can't really
+          // write back.
+          if (auto *AI = dyn_cast<ApplyInst>(inst)) {
+            if (isa<PointerToThinFunctionInst>(AI->getCallee())) {
+              break;
+            }
+          }
           if (isConsumingOrMutatingApplyUse(use))
             return true;
           else

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -427,7 +427,7 @@ public func test(_ p: Proto) {
   p.val.x += 1
 }
 
-// CHECK-LABEL: sil @$S9protocols4testyyAA5Proto_pF : $@convention(thin) (@in Proto) -> ()
+// CHECK-LABEL: sil @_T09protocols4testyyAA5Proto_pF : $@convention(thin) (@in Proto) -> ()
 // CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access
 // CHECK: [[MAT:%.*]] = witness_method $@opened("{{.*}}") Proto, #Proto.val!materializeForSet
 // CHECK: [[BUF:%.*]] = apply [[MAT]]

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -415,6 +415,27 @@ func modifyProperty<T : PropertyWithGetterSetter>(_ x: inout T) {
 // CHECK:      [[TEMPORARY:%.*]] = address_to_pointer [[TEMPORARY_ADDR]] : $*Int to $Builtin.RawPointer
 // CHECK:      apply [[CALLBACK]]<T>
 
+public struct Val {
+  public var x: Int = 0
+}
+
+public protocol Proto {
+  var val: Val { get nonmutating set}
+}
+
+public func test(_ p: Proto) {
+  p.val.x += 1
+}
+
+// CHECK-LABEL: sil @$S9protocols4testyyAA5Proto_pF : $@convention(thin) (@in Proto) -> ()
+// CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access
+// CHECK: [[MAT:%.*]] = witness_method $@opened("{{.*}}") Proto, #Proto.val!materializeForSet
+// CHECK: [[BUF:%.*]] = apply [[MAT]]
+// CHECK: [[WB:%.*]] = pointer_to_thin_function
+// This use looks like it is mutating but really is not. We use to assert in the SIL verifier.
+// CHECK: apply [[WB]]{{.*}}({{.*}}[[OPEN]]
+// CHECK: return
+
 // CHECK-LABEL: sil_witness_table hidden ClassWithGetter: PropertyWithGetter module protocols {
 // CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @_T09protocols15ClassWithGetterCAA08PropertycD0A2aDP1aSivgTW
 // CHECK-NEXT: }

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -427,7 +427,7 @@ public func test(_ p: Proto) {
   p.val.x += 1
 }
 
-// CHECK-LABEL: sil @_T09protocols4testyyAA5Proto_pF : $@convention(thin) (@in Proto) -> ()
+// CHECK-LABEL: sil @_T09protocols4test{{.*}}: $@convention(thin) (@in Proto) -> ()
 // CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access
 // CHECK: [[MAT:%.*]] = witness_method $@opened("{{.*}}") Proto, #Proto.val!materializeForSet
 // CHECK: [[BUF:%.*]] = apply [[MAT]]


### PR DESCRIPTION
A materialize for set / write-back sequence is not really mutating the opened existential on an Rvalue existential.

rdar://36799163

* Explanation: We generate a write back for a non-mutating set on an r-value. This write back looks like a mutation on an open_existenial that only allows immutable access. The verifier of open_existential instructions will look at the use and complain when this use really is safe. The patch disable verification in this case.

* Scope: A fix that makes the SIL verifier not assert on a correct code pattern.

* Risk: Low. This disables an invalid assertion.

* Testing: A Swift CI test was added