### PR TITLE
Remove pessimization of print() performance in 4.1 branch.

### DIFF
--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -624,7 +624,7 @@ extension Unicode.Scalar : TextOutputStreamable {
 }
 
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook : ((String) -> Void)? = {_ in () }
+public var _playgroundPrintHook : ((String) -> Void)? = nil
 
 @_fixed_layout // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)


### PR DESCRIPTION
Remove pessimization of print() performance in 4.1 branch by using 'nil' instead of an empty closure.
rdar://problem/36839411