### PR TITLE
[Master-next] Update after recent breaking changes

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -904,9 +904,6 @@ public:
     case llvm::Intrinsic::memmove:
     case llvm::Intrinsic::memset:
       require(!isa<SILArgument>(BI->getArguments()[3]),
-              "alignment argument of memory intrinsics must be an integer "
-              "literal");
-      require(!isa<SILArgument>(BI->getArguments()[4]),
               "isvolatile argument of memory intrinsics must be an integer "
               "literal");
       break;

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -237,7 +237,6 @@ internal func _memcpy(
   let size = UInt64(size)._value
   Builtin.int_memcpy_RawPointer_RawPointer_Int64(
     dest, src, size,
-    /*alignment:*/ Int32()._value,
     /*volatile:*/ false._value)
 }
 
@@ -257,6 +256,5 @@ internal func _memmove(
   let size = UInt64(size)._value
   Builtin.int_memmove_RawPointer_RawPointer_Int64(
     dest, src, size,
-    /*alignment:*/ Int32()._value,
     /*volatile:*/ false._value)
 }

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -860,7 +860,6 @@ public struct Unsafe${Mutable}RawPointer: _Pointer {
       // FIXME: to be replaced by _memcpy when conversions are implemented.
       Builtin.int_memcpy_RawPointer_RawPointer_Int64(
         (self + offset)._rawValue, rawSrc, UInt64(MemoryLayout<T>.size)._value,
-        /*alignment:*/ Int32()._value,
         /*volatile:*/ false._value)
     }
   }

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -192,4 +192,14 @@ namespace swift {
 
 } // end namespace swift
 
+// ADT uses report_bad_alloc_error to report an error when it can't allocate
+// elements for a data structure. The swift runtime uses ADT without linking
+// against libSupport, so here we provide a stub to make sure we don't fail
+// to link. Give it `weak` linkage so, in case the `strong` definition of
+// the function is available, that has precedence.
+namespace llvm {
+  __attribute__((weak))
+  void report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {};
+} // end namespace llvm
+
 #endif /* SWIFT_RUNTIME_PRIVATE_H */

--- a/test/IRGen/alloc.sil
+++ b/test/IRGen/alloc.sil
@@ -20,5 +20,5 @@ struct Huge {
 }
 
 // CHECK: define linkonce_odr hidden i8* @__swift_memcpy4097_8(i8*, i8*, %swift.type*)
-// CHECK:   call void @llvm.memcpy.p0i8.p0i8.{{(i64|i32)}}(i8* %0, i8* %1, {{(i64|i32)}} 4097, i32 8, i1 false)
+// CHECK:   call void @llvm.memcpy.p0i8.p0i8.{{(i64|i32)}}(i8* align 8 %0, i8* align 8 %1, {{(i64|i32)}} 4097, i1 false)
 // CHECK:   ret i8* %0

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -489,9 +489,9 @@ func copyPODArray(_ dest: Builtin.RawPointer, src: Builtin.RawPointer, count: Bu
 // CHECK-NOT:       loop:
 // CHECK:         call void @swift_arrayInitWithCopy
 // CHECK:         mul nuw i64 8, %2
-// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* {{.*}}, i8* {{.*}}, i64 {{.*}}, i32 8, i1 false)
+// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* {{.*}}, i8* {{.*}}, i64 {{.*}}, i1 false)
 // CHECK:         mul nuw i64 8, %2
-// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* {{.*}}, i8* {{.*}}, i64 {{.*}}, i32 8, i1 false)
+// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* {{.*}}, i8* {{.*}}, i64 {{.*}}, i1 false)
 // CHECK:         call void @swift_arrayAssignWithCopyNoAlias(
 // CHECK:         call void @swift_arrayAssignWithCopyFrontToBack(
 // CHECK:         call void @swift_arrayAssignWithCopyBackToFront(

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -91,7 +91,7 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
 // CHECK: llvm.lifetime.start
 // CHECK: [[COPY:%.*]] = bitcast %T17struct_resilience6MySizeV* %4 to i8*
 // CHECK: [[ARG:%.*]] = bitcast %T17struct_resilience6MySizeV* %1 to i8*
-// CHECK: call void @llvm.memcpy{{.*}}(i8* [[COPY]], i8* [[ARG]], {{i32 8|i64 16}}, i32 {{.*}}, i1 false)
+// CHECK: call void @llvm.memcpy{{.*}}(i8* align 8 [[COPY]], i8* align 8 [[ARG]], i64 16, i1 false)
 // CHECK: [[FN:%.*]] = bitcast i8* %2
 // CHECK: call swiftcc void [[FN]](%T17struct_resilience6MySizeV* {{.*}} %0, {{.*}} [[TEMP]], %swift.refcounted* swiftself %3)
 // CHECK: ret void

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -64,7 +64,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
 // CHECK-NEXT: [[ADDR:%.*]] = bitcast i8* [[T0]] to %T13value_buffers9BigStructV*
 // CHECK-NEXT: [[PARAM1:%.*]] = bitcast %T13value_buffers9BigStructV* [[ADDR]] to i8*
 // CHECK-NEXT: [[PARAM2:%.*]] = bitcast %T13value_buffers9BigStructV* %1 to i8*
-// CHECK-NEXT: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[PARAM1]], i8* [[PARAM2]], i64 48, i32 8, i1 false)
+// CHECK-NEXT: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 [[PARAM1]], i8* align 8 [[PARAM2]], i64 48, i1 false)
 // CHECK-NEXT: ret void
 
 sil @project_big : $(@inout Builtin.UnsafeValueBuffer, BigStruct) -> () {
@@ -80,7 +80,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
 // CHECK-NEXT: [[ADDR:%.*]] = load %T13value_buffers9BigStructV*, %T13value_buffers9BigStructV** [[T0]], align 8
 // CHECK-NEXT: [[PARAM1:%.*]] = bitcast %T13value_buffers9BigStructV* [[ADDR]] to i8*
 // CHECK-NEXT: [[PARAM2:%.*]] = bitcast %T13value_buffers9BigStructV* %1 to i8*
-// CHECK-NEXT: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[PARAM1]], i8* [[PARAM2]], i64 48, i32 8, i1 false)
+// CHECK-NEXT: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 [[PARAM1]], i8* align 8 [[PARAM2]], i64 48, i1 false)
 // CHECK-NEXT: ret void
 
 sil @dealloc_big : $(@inout Builtin.UnsafeValueBuffer) -> () {

--- a/test/sil-llvm-gen/alloc.sil
+++ b/test/sil-llvm-gen/alloc.sil
@@ -20,5 +20,5 @@ struct Huge {
 }
 
 // CHECK: define linkonce_odr hidden i8* @__swift_memcpy4097_8(i8*, i8*, %swift.type*)
-// CHECK:   call void @llvm.memcpy.p0i8.p0i8.{{(i64|i32)}}(i8* %0, i8* %1, {{(i64|i32)}} 4097, i32 8, i1 false)
+// CHECK:   call void @llvm.memcpy.p0i8.p0i8.{{(i64|i32)}}(i8* align 8 %0, i8* align 8 %1, {{(i64|i32)}} 4097, i1 false)
 // CHECK:   ret i8* %0


### PR DESCRIPTION
Make swift master-next build green again (or at least try to), so that we can get lldb `upstream-with-swift` in a decent shape to develop on.

Summary of the changes:
[IRGen] Catch up with llvm @memcpy intrinsic changes.
[Verifier] Update a check now that memcpy takes 3 arguments.
[runtime] Provide a stub for report_bad_alloc_error.

Detail in the commits. There's also another outstanding clang issue before this can build & run, but I asked for a revert (so that should be addressed at the next auto merge round).