### PR TITLE
[4.1] [test] Fix Interpreter/class_resilience.swift to test the right thing

### DIFF
--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -16,7 +16,7 @@
 // RUN: %target-build-swift-dylib(%t/libresilient_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/libresilient_class_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -o %t/main -Xlinker -rpath -Xlinker %t
 
 // RUN: %target-run %t/main %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_class_wmo.%target-dylib-extension
 


### PR DESCRIPTION
- **Explanation**: This test wasn't testing what it was supposed to be testing, and as such it would fail in rare circumstances when run on an iOS device (using Apple's internal on-device testing tool).
- **Scope**: Test change only
- **Issue**: rdar://problem/36830081
- **Reviewed by**: @aschwaighofer  
- **Risk**: None
- **Testing**: Manually verified the failure and fix on my own iOS device.