### PR TITLE
[Associated type inference] Various improvements to eliminate crashes and infer more often

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -577,18 +577,16 @@ NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
   if (known != TypeWitnesses.end())
     return known->second;
 
-  // If this conformance is in a state where it is inferring type witnesses,
-  // check tentative witnesses.
-  if (getState() == ProtocolConformanceState::CheckingTypeWitnesses) {
-    // If there is a tentative-type-witness function, use it.
-    if (options.getTentativeTypeWitness) {
-     if (Type witnessType =
-           Type(options.getTentativeTypeWitness(this, assocType)))
-       return { witnessType, nullptr };
-    }
+  // If there is a tentative-type-witness function, use it.
+  if (options.getTentativeTypeWitness) {
+   if (Type witnessType =
+         Type(options.getTentativeTypeWitness(this, assocType)))
+     return { witnessType, nullptr };
+  }
 
-    // Otherwise, we fail; this is the only case in which we can return a
-    // null type.
+  // If this conformance is in a state where it is inferring type witnesses but
+  // we didn't find anything, fail.
+  if (getState() == ProtocolConformanceState::CheckingTypeWitnesses) {
     return { Type(), nullptr };
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1795,8 +1795,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
 
   // If we already recoded this type witness, there's nothing to do.
   if (Conformance->hasTypeWitness(assocType)) {
-    assert(Conformance->getTypeWitness(assocType, nullptr)
-             ->isEqual(type) && "Conflicting type witness deductions");
+    assert(Conformance->getTypeWitness(assocType, nullptr)->isEqual(type) &&
+           "Conflicting type witness deductions");
     return;
   }
 
@@ -2749,6 +2749,16 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
       viable.push_back(candidate);
     }
   }
+
+  // If there are no viable witnesses, and all nonviable candidates came from
+  // protocol extensions, treat this as "missing".
+  if (viable.empty() &&
+      std::find_if(nonViable.begin(), nonViable.end(),
+                   [](const std::pair<TypeDecl *, CheckTypeWitnessResult> &x) {
+                     return x.first->getDeclContext()
+                        ->getAsProtocolOrProtocolExtensionContext() == nullptr;
+                   }) == nonViable.end())
+    return ResolveWitnessResult::Missing;
 
   // If there is a single viable candidate, form a substitution for it.
   if (viable.size() == 1) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2655,8 +2655,12 @@ CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
   auto *depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                          assocType);
 
+  if (type->hasError())
+    return ErrorType::get(tc.Context);
+
   Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
                                               : type;
+
   if (auto superclass = genericSig->getSuperclassBound(depTy)) {
     if (!superclass->isExactSuperclassOf(contextType))
       return superclass;
@@ -2780,7 +2784,8 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
     [nonViable](NormalProtocolConformance *conformance) {
       auto &diags = conformance->getDeclContext()->getASTContext().Diags;
       for (auto candidate : nonViable) {
-        if (candidate.first->getDeclaredInterfaceType()->hasError())
+        if (candidate.first->getDeclaredInterfaceType()->hasError() ||
+            candidate.second.isError())
           continue;
 
         diags.diagnose(

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -78,7 +78,9 @@ public:
   bool isConformanceRequirement() const {
     return Requirement->isExistentialType();
   }
-
+  bool isError() const {
+    return Requirement->is<ErrorType>();
+  }
   explicit operator bool() const { return !Requirement.isNull(); }
 };
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -818,7 +818,7 @@ Type AssociatedTypeInference::computeDefaultTypeWitness(
 
   if (auto failed = checkTypeWitness(tc, dc, proto, assocType, defaultType)) {
     // Record the failure, if we haven't seen one already.
-    if (!failedDefaultedAssocType) {
+    if (!failedDefaultedAssocType && !failed.isError()) {
       failedDefaultedAssocType = defaultedAssocType;
       failedDefaultedWitness = defaultType;
       failedDefaultedResult = failed;
@@ -1680,6 +1680,9 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         diags.diagnose(assocType, diag::bad_associated_type_deduction,
                        assocType->getFullName(), proto->getFullName());
         for (const auto &failed : failedSet) {
+          if (failed.Result.isError())
+            continue;
+
           diags.diagnose(failed.Witness,
                          diag::associated_type_deduction_witness_failed,
                          failed.Requirement->getFullName(),

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 protocol Fooable {
-  associatedtype Foo
+  associatedtype Foo // expected-note{{protocol requires nested type 'Foo'; do you want to add it?}}
 
   var foo: Foo { get }
 }
@@ -148,7 +148,7 @@ rdar19137463(1)
 
 struct Brunch<U : Fooable> where U.Foo == X {}
 
-struct BadFooable : Fooable {
+struct BadFooable : Fooable { // expected-error{{type 'BadFooable' does not conform to protocol 'Fooable'}}
   typealias Foo = DoesNotExist // expected-error{{use of undeclared type 'DoesNotExist'}}
   var foo: Foo { while true {} }
 }

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -23,7 +23,7 @@ func hasAClosure() {
 }
 
 protocol Racoon {
-  associatedtype Stripes
+  associatedtype Stripes // expected-note{{protocol requires nested type 'Stripes'; do you want to add it?}}
 }
 
 // Types inside generic functions -- not supported yet
@@ -117,7 +117,7 @@ struct OuterGenericStruct<A> {
   }
 
   func middleFunction() {
-    struct ConformingType : Racoon {
+    struct ConformingType : Racoon { // expected-error{{type 'ConformingType' does not conform to protocol 'Racoon'}}
     // expected-error@-1 {{type 'ConformingType' cannot be nested in generic function 'middleFunction()'}}
       typealias Stripes = A
     }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -469,3 +469,19 @@ protocol P17 {
 protocol Q17 : P17 where T == Int { }
 
 struct S17 : Q17 { }
+
+// Typealiases from protocol extensions should not inhibit associated type
+// inference.
+protocol P18 {
+  associatedtype A
+}
+
+protocol P19 : P18 {
+  associatedtype B
+}
+
+extension P18 where Self: P19 {
+  typealias A = B
+}
+
+struct X18<A> : P18 { }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -485,3 +485,18 @@ extension P18 where Self: P19 {
 }
 
 struct X18<A> : P18 { }
+
+// rdar://problem/16316115
+protocol HasAssoc {
+  associatedtype Assoc
+}
+
+struct DefaultAssoc {}
+
+protocol RefinesAssocWithDefault: HasAssoc {
+  associatedtype Assoc = DefaultAssoc
+}
+
+struct Foo: RefinesAssocWithDefault {
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0138-rdar36453271.swift
+++ b/validation-test/compiler_crashers_2_fixed/0138-rdar36453271.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend %s -emit-ir -o 0
+
+extension Slice where Base == UnsafeBufferPointer<UInt16> {
+  var rebased: UnsafeBufferPointer<UInt16> {
+    return UnsafeBufferPointer(rebasing: self)
+  }
+}
+
+extension Slice where Base == UnsafeMutableBufferPointer<UInt16> {
+  var rebased: UnsafeMutableBufferPointer<UInt16> {
+    return UnsafeMutableBufferPointer(rebasing: self)
+  }
+}

--- a/validation-test/compiler_crashers_fixed/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
+++ b/validation-test/compiler_crashers_fixed/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{{}func a{}typealias e}struct A:P{typealias e:Self.a{}typealias e:Self.a{}typealias e:P

--- a/validation-test/compiler_crashers_fixed/28854-known-typewitnesses-end-didnt-resolve-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28854-known-typewitnesses-end-didnt-resolve-witness.swift
@@ -5,8 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 @objc protocol A
 {
 typealias a


### PR DESCRIPTION
Fix several related issues with associated type inference:

* We had a path where we would record a type witness that contained an error but never report said error, leading to downstream crashes (e.g, the crash in [SR-6609](https://bugs.swift.org/browse/SR-6609) / rdar://problem/36038033).
* We could end up recursing infinitely when looking up type witnesses, so block said recursion appropriately (fixed another two crashers in our suite).
* Don't allow typealiases in protocol extensions to block associated type inference when they don't match, which fixes associated type inference for [SR-6609](https://bugs.swift.org/browse/SR-6609) / rdar://problem/36038033 for real.
* When substituting with tentative type witnesses, allow us to find tentative type witnesses within the same protocol hierarchy. Fixes rdar://problem/36453271.
* Somewhere along the way, we fixed rdar://problem/16316115, so pull in that test case. That bug is from 3/13/14, in case anyone cares :)
