### PR TITLE
[sil][typelowering] Rename the enum LoweringStyle => TypeExpansionKin…

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -599,14 +599,15 @@ namespace {
       // Trivial
     }
 
-    void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
-                                 LoweringStyle loweringStyle) const override {
+    void
+    emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
+                            TypeExpansionKind loweringStyle) const override {
       // Trivial
     }
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       // Trivial
       return value;
     }
@@ -778,7 +779,7 @@ namespace {
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue aggValue,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       llvm::SmallVector<SILValue, 8> loweredChildValues;
       for (auto &child : getChildren(B.getModule())) {
         auto &childLowering = child.getLowering();
@@ -807,17 +808,19 @@ namespace {
       B.emitReleaseValueAndFold(loc, aggValue);
     }
 
-    void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc,
-                                 SILValue aggValue,
-                                 LoweringStyle loweringStyle) const override {
+    void
+    emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue aggValue,
+                            TypeExpansionKind loweringStyle) const override {
       SimpleOperationTy Fn;
 
       switch(loweringStyle) {
-      case LoweringStyle::Shallow:
+      case TypeExpansionKind::None:
+        return emitDestroyValue(B, loc, aggValue);
+      case TypeExpansionKind::DirectChildren:
         Fn = &TypeLowering::emitDestroyValue;
         break;
-      case LoweringStyle::Deep:
-        Fn = &TypeLowering::emitLoweredDestroyValueDeep;
+      case TypeExpansionKind::MostDerivedDescendents:
+        Fn = &TypeLowering::emitLoweredDestroyValueMostDerivedDescendents;
         break;
       }
 
@@ -911,7 +914,7 @@ namespace {
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       if (B.getFunction().hasQualifiedOwnership())
         return B.createCopyValue(loc, value);
       B.createRetainValue(loc, value, B.getDefaultAtomicity());
@@ -928,19 +931,23 @@ namespace {
     }
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
-                                 LoweringStyle style) const override {
-      if (style == LoweringStyle::Shallow) {
-        emitDestroyValue(B, loc, value);
+                                 TypeExpansionKind style) const override {
+      // Enums, we never want to expand.
+      //
+      // TODO: This is a final class. I don't understand why we can't just
+      // delegate to emitDestroyValue in all cases.
+      switch (style) {
+      case TypeExpansionKind::None:
+      case TypeExpansionKind::DirectChildren:
+        return emitDestroyValue(B, loc, value);
+      case TypeExpansionKind::MostDerivedDescendents:
+        if (B.getFunction().hasQualifiedOwnership()) {
+          B.createDestroyValue(loc, value);
+          return;
+        }
+        B.emitReleaseValueAndFold(loc, value);
         return;
       }
-      assert(style != LoweringStyle::Shallow &&
-             "This method should never be called when performing a shallow "
-             "destroy value.");
-      if (B.getFunction().hasQualifiedOwnership()) {
-        B.createDestroyValue(loc, value);
-        return;
-      }
-      B.emitReleaseValueAndFold(loc, value);
     }
   };
 
@@ -953,12 +960,12 @@ namespace {
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       return emitCopyValue(B, loc, value);
     }
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
-                                 LoweringStyle style) const override {
+                                 TypeExpansionKind style) const override {
       emitDestroyValue(B, loc, value);
     }
   };
@@ -1068,7 +1075,7 @@ namespace {
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       llvm_unreachable("type is not loadable!");
     }
 
@@ -1078,7 +1085,7 @@ namespace {
     }
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
-                                 LoweringStyle style) const override {
+                                 TypeExpansionKind style) const override {
       llvm_unreachable("type is not loadable!");
     }
   };
@@ -1127,12 +1134,12 @@ namespace {
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       llvm_unreachable("lowered copy");
     }
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
-                                 LoweringStyle style) const override {
+                                 TypeExpansionKind style) const override {
       llvm_unreachable("destroy value");
     }
 
@@ -1196,7 +1203,7 @@ namespace {
 
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
-                                  LoweringStyle style) const override {
+                                  TypeExpansionKind style) const override {
       llvm_unreachable("type is not loadable!");
     }
 
@@ -1206,7 +1213,7 @@ namespace {
     }
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
-                                 LoweringStyle style) const override {
+                                 TypeExpansionKind style) const override {
       llvm_unreachable("type is not loadable!");
     }
   };

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -181,8 +181,8 @@ static bool expandReleaseValue(ReleaseValueInst *DV) {
     return false;
 
   auto &TL = Module.getTypeLowering(Type);
-  TL.emitLoweredDestroyValue(Builder, DV->getLoc(), Value,
-                             TypeLowering::LoweringStyle::Deep);
+  TL.emitLoweredDestroyValueMostDerivedDescendents(Builder, DV->getLoc(),
+                                                   Value);
 
   DEBUG(llvm::dbgs() << "    Expanding Destroy Value: " << *DV);
 
@@ -208,8 +208,7 @@ static bool expandRetainValue(RetainValueInst *CV) {
     return false;
 
   auto &TL = Module.getTypeLowering(Type);
-  TL.emitLoweredCopyValue(Builder, CV->getLoc(), Value,
-                          TypeLowering::LoweringStyle::Deep);
+  TL.emitLoweredCopyValueMostDerivedDescendents(Builder, CV->getLoc(), Value);
 
   DEBUG(llvm::dbgs() << "    Expanding Copy Value: " << *CV);
 


### PR DESCRIPTION
…d and add a None case to make its usage clearer.

This enum controls how certain routines in TypeLowering potentially expand types
when performing copy_value/destroy_value operations. Its previous form was
problematic because:

1. The name LoweringStyle does't suggest anything related to expansion really.
The new has the word expansion in it explicitly.
2. The cases of LoweringStyle used to be Shallow, Deep. This caused confusion
since Shallow (the base case) was not a no-op. It just caused us to expand into
children. Now TypeExpansionKind has 3 cases to make this clear: None,
DirectChildren, and MostDerivedDescendents.

Confusion around this API caused us to canonicalize ARC operations differently
for different operations (e.g. copy_value/destroy_value vs
copy_addr/destroy_addr). This caused us to misout on some code-size wins (since
we were splitting some operations onto DirectChildren of aggregates), but more
importantly also caused the optimizer to break an invariant that the ARC
optimizer relied upon: local semantic pairings being at the same level of
abstraction. In a subsequent commit, I am going to fix that bug.

rdar://36509461
