### PR TITLE
[CursorInfo] Fix crash on init call of inner NTD with generic outer NTD

### DIFF
--- a/test/SourceKit/CursorInfo/rdar_35819975.swift
+++ b/test/SourceKit/CursorInfo/rdar_35819975.swift
@@ -1,0 +1,13 @@
+// Checks that we don't crash
+// RUN: %sourcekitd-test -req=cursor -pos=10:5 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=11:11 %s -- %s | %FileCheck --check-prefix=CHECK2 %s
+// CHECK: source.lang.swift.ref.class
+// CHECK2: source.lang.swift.ref.function.constructor
+
+class Bar<T> {
+  class Inner {}
+  func foo() {
+    Inner()
+    Inner.init()
+  }
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -694,7 +694,6 @@ getParamParentNameOffset(const ValueDecl *VD, SourceLoc Cursor) {
 static bool passCursorInfoForDecl(SourceFile* SF,
                                   const ValueDecl *VD,
                                   const ModuleDecl *MainModule,
-                                  const Type Ty,
                                   const Type ContainerTy,
                                   bool IsRef,
                                   bool RetrieveRefactoring,
@@ -710,7 +709,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     return true;
 
   SmallString<64> SS;
-  auto BaseType = findBaseTypeForReplacingArchetype(VD, Ty);
+  auto BaseType = findBaseTypeForReplacingArchetype(VD, ContainerTy);
   bool InSynthesizedExtension = false;
   if (BaseType) {
     if (auto Target = BaseType->getAnyNominal()) {
@@ -1293,11 +1292,17 @@ static void resolveCursor(SwiftLangSupport &Lang,
                                 CompInvok, Receiver);
         return;
       case CursorInfoKind::ValueRef: {
-        ValueDecl *VD = CursorInfo.CtorTyRef ? CursorInfo.CtorTyRef : CursorInfo.ValueD;
+        ValueDecl *VD = CursorInfo.ValueD;
+        Type ContainerType = CursorInfo.ContainerType;
+        if (CursorInfo.CtorTyRef) {
+          // Treat constructor calls, e.g. MyType(), as the type itself,
+          // rather than its constructor.
+          VD = CursorInfo.CtorTyRef;
+          ContainerType = Type();
+        }
         bool Failed = passCursorInfoForDecl(&AstUnit->getPrimarySourceFile(),
                                             VD, MainModule,
-                                            CursorInfo.ContainerType,
-                                            CursorInfo.ContainerType,
+                                            ContainerType,
                                             CursorInfo.IsRef,
                                             Actionables,
                                             CursorInfo,
@@ -1589,7 +1594,7 @@ void SwiftLangSupport::getCursorInfo(
           // FIXME: Should pass the main module for the interface but currently
           // it's not necessary.
           passCursorInfoForDecl(
-              /*SourceFile*/nullptr, Entity.Dcl, /*MainModule*/ nullptr, Type(),
+              /*SourceFile*/nullptr, Entity.Dcl, /*MainModule*/ nullptr,
               Type(), Entity.IsRef, Actionables, ResolvedCursorInfo(),
               /*OrigBufferID=*/None, SourceLoc(),
               {}, *this, Invok, {}, Receiver);
@@ -1780,7 +1785,7 @@ resolveCursorFromUSR(SwiftLangSupport &Lang, StringRef InputFile, StringRef USR,
         }
         bool Failed =
             passCursorInfoForDecl(/*SourceFile*/nullptr, VD, MainModule, selfTy,
-                                  Type(), /*IsRef=*/false, false, ResolvedCursorInfo(),
+                                  /*IsRef=*/false, false, ResolvedCursorInfo(),
                                   BufferID, SourceLoc(), {}, Lang, CompInvok,
                                   PreviousASTSnaps, Receiver);
         if (Failed) {


### PR DESCRIPTION
Invoking the cursor info request on a call to the initializer of an inner class in a generic context would crash SourceKit, e.g:
```
class Bar<T> {
  class Inner {}
  func foo() {
    /*invoke here:*/Inner()
  }
}
```
There was faulty logic to treat an invocation on an initializer call, e.g. `Inner()`, as if it were a plain reference to the type, e.g. `Inner`. We were updating the declaration used to the initializer's parent, but left the containing type as is.

Resolves rdar://problem/35819975
