### PR TITLE
[WIP][Syntax] Performance improvements

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -107,6 +107,14 @@ namespace swift {
 
   enum class KnownProtocolKind : uint8_t;
 
+  enum class tok;
+  class OwnedString;
+
+namespace syntax {
+  class RawSyntax;
+  class TriviaPiece;
+}
+
 /// \brief The arena in which a particular ASTContext allocation will go.
 enum class AllocationArena {
   /// \brief The permanent arena, which is tied to the lifetime of
@@ -895,6 +903,12 @@ public:
   CanGenericSignature getExistentialSignature(CanType existential,
                                               ModuleDecl *mod);
 
+  /// Retrieve or create a libSyntax raw token with given info.
+  llvm::IntrusiveRefCntPtr<syntax::RawSyntax>
+  getRawTokenSyntax(tok TokKind, OwnedString Text,
+                    llvm::ArrayRef<syntax::TriviaPiece> LeadingTrivia,
+                    llvm::ArrayRef<syntax::TriviaPiece> TrailingTrivia);
+
   /// Whether our effective Swift version is in the Swift 3 family.
   bool isSwiftVersion3() const { return LangOpts.isSwiftVersion3(); }
 
@@ -947,7 +961,6 @@ bool fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
 bool fixDeclarationObjCName(InFlightDiagnostic &diag, ValueDecl *decl,
                             Optional<ObjCSelector> targetNameOpt,
                             bool ignoreImpliedName = false);
-
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -107,12 +107,8 @@ namespace swift {
 
   enum class KnownProtocolKind : uint8_t;
 
-  enum class tok;
-  class OwnedString;
-
 namespace syntax {
-  class RawSyntax;
-  class TriviaPiece;
+  class SyntaxArena;
 }
 
 /// \brief The arena in which a particular ASTContext allocation will go.
@@ -387,6 +383,9 @@ public:
                                               arena),
                               setVector.size());
   }
+
+  /// Retrive the syntax node memory manager for this context.
+  syntax::SyntaxArena &getSyntaxArena() const;
 
   /// Retrieve the lazy resolver for this context.
   LazyResolver *getLazyResolver() const;
@@ -903,12 +902,6 @@ public:
   CanGenericSignature getExistentialSignature(CanType existential,
                                               ModuleDecl *mod);
 
-  /// Retrieve or create a libSyntax raw token with given info.
-  llvm::IntrusiveRefCntPtr<syntax::RawSyntax>
-  getRawTokenSyntax(tok TokKind, OwnedString Text,
-                    llvm::ArrayRef<syntax::TriviaPiece> LeadingTrivia,
-                    llvm::ArrayRef<syntax::TriviaPiece> TrailingTrivia);
-
   /// Whether our effective Swift version is in the Swift 3 family.
   bool isSwiftVersion3() const { return LangOpts.isSwiftVersion3(); }
 
@@ -961,6 +954,7 @@ bool fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
 bool fixDeclarationObjCName(InFlightDiagnostic &diag, ValueDecl *decl,
                             Optional<ObjCSelector> targetNameOpt,
                             bool ignoreImpliedName = false);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -413,6 +413,10 @@ def emit_sorted_sil : Flag<["-"], "emit-sorted-sil">,
 
 def emit_syntax : Flag<["-"], "emit-syntax">,
   HelpText<"Parse input file(s) and emit the Syntax tree(s) as JSON">, ModeOpt;
+def parse_syntax_info: Flag<["-"], "parse-syntax-info">,
+  HelpText<"Parse Syntax tree">;
+def verify_syntax_tree: Flag<["-"], "verify-syntax-tree">,
+  HelpText<"Verify Syntax tree if parsed">;
 
 def use_malloc : Flag<["-"], "use-malloc">,
   HelpText<"Allocate internal data structures using malloc "

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -34,6 +34,7 @@
 #include "swift/Syntax/SyntaxKind.h"
 #include "swift/Syntax/TokenKinds.h"
 #include "swift/Syntax/Trivia.h"
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/Casting.h"
@@ -48,7 +49,7 @@ using llvm::StringRef;
 #ifndef NDEBUG
 #define syntax_assert_child_kind(Raw, Cursor, ExpectedKind)                    \
   ({                                                                           \
-    if (auto &__Child = Raw->getChild(Cursor::CursorName))                     \
+    if (auto &__Child = Raw->getChild(Cursor))                                 \
       assert(__Child->getKind() == ExpectedKind);                              \
   })
 #else
@@ -111,6 +112,8 @@ using llvm::StringRef;
 #endif
 
 namespace swift {
+class ASTContext;
+
 namespace syntax {
 
 using CursorIndex = uint32_t;
@@ -441,6 +444,10 @@ public:
 
   /// Dump this piece of syntax recursively.
   void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
+
+  static void Profile(llvm::FoldingSetNodeID &ID, tok TokKind, OwnedString Text,
+                      ArrayRef<TriviaPiece> LeadingTrivia,
+                      ArrayRef<TriviaPiece> TrailingTrivia);
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/SyntaxArena.h
+++ b/include/swift/Syntax/SyntaxArena.h
@@ -1,0 +1,45 @@
+//===--- SyntaxArena.h - Syntax Tree Memory Allocation ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines SyntaxArena that is Memory manager for Syntax nodes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYNTAX_SYNTAXARENA_H
+#define SWIFT_SYNTAX_SYNTAXARENA_H
+
+#include "llvm/Support/Allocator.h"
+
+namespace swift {
+namespace syntax {
+
+/// Memory manager for Syntax nodes.
+class SyntaxArena {
+  SyntaxArena(const SyntaxArena &) = delete;
+  void operator=(const SyntaxArena &) = delete;
+
+public:
+  struct Implementation;
+  Implementation &Impl;
+
+  SyntaxArena();
+  ~SyntaxArena();
+
+  llvm::BumpPtrAllocator &getAllocator() const;
+  void *Allocate(size_t size, size_t alignment);
+  void *AllocateRawSyntax(size_t size, size_t alignment);
+};
+
+} // namespace syntax
+} // namespace swift
+
+#endif

--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -27,16 +27,23 @@
 namespace swift {
 namespace syntax {
 
+class SyntaxArena;
+
 % for node in SYNTAX_NODES:
 %   if node.is_buildable():
+%     child_count = len(node.children)
 class ${node.name}Builder {
-  std::vector<RC<RawSyntax>> Layout = {
+  SyntaxArena *Arena = nullptr;
+  RC<RawSyntax> Layout[${child_count}] = {
 %     for child in node.children:
     nullptr,
 %     end
   };
 
 public:
+  ${node.name}Builder() = default;
+  ${node.name}Builder(SyntaxArena &Arena) : Arena(&Arena) {}
+
 %     for child in node.children:
   ${node.name}Builder &use${child.name}(${child.type_name} ${child.name});
 %       child_node = NODE_MAP.get(child.syntax_kind)

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -55,7 +55,8 @@ struct SyntaxFactory {
                                        llvm::ArrayRef<Syntax> Elements);
 
   static RC<RawSyntax> createRaw(SyntaxKind Kind,
-                                 llvm::ArrayRef<RC<RawSyntax>> Elements);
+                                 llvm::ArrayRef<RC<RawSyntax>> Elements,
+    llvm::function_ref<void *(size_t, size_t)> Allocate = {});
 
   /// Count the number of children for a given syntax node kind,
   /// returning a pair of mininum and maximum count of children. The gap

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -40,23 +40,28 @@
 namespace swift {
 namespace syntax {
 
+class SyntaxArena;
+
 /// The Syntax factory - the one-stop shop for making new Syntax nodes.
 struct SyntaxFactory {
   /// Make any kind of token.
-  static TokenSyntax
-  makeToken(tok Kind, OwnedString Text, SourcePresence Presence,
-            const Trivia &LeadingTrivia, const Trivia &TrailingTrivia);
+  static TokenSyntax makeToken(tok Kind,
+                               OwnedString Text, const Trivia &LeadingTrivia,
+                               const Trivia &TrailingTrivia,
+                               SourcePresence Presence,
+                               SyntaxArena *Arena = nullptr);
 
   /// Collect a list of tokens into a piece of "unknown" syntax.
-  static UnknownSyntax
-  makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens);
+  static UnknownSyntax makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
+                                         SyntaxArena *Arena = nullptr);
 
   static Optional<Syntax> createSyntax(SyntaxKind Kind,
-                                       llvm::ArrayRef<Syntax> Elements);
+                                       llvm::ArrayRef<Syntax> Elements,
+                                       SyntaxArena *Arena = nullptr);
 
   static RC<RawSyntax> createRaw(SyntaxKind Kind,
                                  llvm::ArrayRef<RC<RawSyntax>> Elements,
-    llvm::function_ref<void *(size_t, size_t)> Allocate = {});
+                                 SyntaxArena *Arena = nullptr);
 
   /// Count the number of children for a given syntax node kind,
   /// returning a pair of mininum and maximum count of children. The gap
@@ -77,74 +82,91 @@ struct SyntaxFactory {
 %         child_params.append("%s %s" % (param_type, child.name))
 %     end
 %     child_params = ', '.join(child_params)
-  static ${node.name} make${node.syntax_kind}(${child_params});
+  static ${node.name} make${node.syntax_kind}(${child_params},
+                                              SyntaxArena *Arena = nullptr);
 %   elif node.is_syntax_collection():
   static ${node.name} make${node.syntax_kind}(
-    const std::vector<${node.collection_element_type}> &elts);
+      const std::vector<${node.collection_element_type}> &elts,
+      SyntaxArena *Arena = nullptr);
 %   end
 
-  static ${node.name} makeBlank${node.syntax_kind}();
+  static ${node.name} makeBlank${node.syntax_kind}(SyntaxArena *Arena = nullptr);
 % end
 
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
   static TokenSyntax make${token.name}Keyword(const Trivia &LeadingTrivia,
-                                              const Trivia &TrailingTrivia);
+                                              const Trivia &TrailingTrivia,
+                                              SyntaxArena *Arena = nullptr);
 %   elif token.text:
   static TokenSyntax make${token.name}Token(const Trivia &LeadingTrivia,
-                                            const Trivia &TrailingTrivia);
+                                            const Trivia &TrailingTrivia,
+                                            SyntaxArena *Arena = nullptr);
 %   else:
   static TokenSyntax make${token.name}(OwnedString Text,
                                        const Trivia &LeadingTrivia,
-                                       const Trivia &TrailingTrivia);
+                                       const Trivia &TrailingTrivia,
+                                       SyntaxArena *Arena = nullptr);
 %   end
 % end
 
 #pragma mark - Convenience APIs
 
-  static TupleTypeSyntax makeVoidTupleType();
+  static TupleTypeSyntax makeVoidTupleType(SyntaxArena *Arena = nullptr);
 
   /// Creates an labelled TupleTypeElementSyntax with the provided label,
   /// colon, type and optional trailing comma.
   static TupleTypeElementSyntax makeTupleTypeElement(
-    llvm::Optional<TokenSyntax> Label,
-    llvm::Optional<TokenSyntax> Colon, TypeSyntax Type,
-    llvm::Optional<TokenSyntax> TrailingComma = llvm::None);
+      llvm::Optional<TokenSyntax> Label,
+      llvm::Optional<TokenSyntax> Colon, TypeSyntax Type,
+      llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
+      SyntaxArena *Arena = nullptr);
 
   /// Creates an unlabelled TupleTypeElementSyntax with the provided type and
   /// optional trailing comma.
-  static TupleTypeElementSyntax makeTupleTypeElement(TypeSyntax Type,
-    llvm::Optional<TokenSyntax> TrailingComma = llvm::None);
+  static TupleTypeElementSyntax
+  makeTupleTypeElement(TypeSyntax Type,
+                       llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
+                       SyntaxArena *Arena = nullptr);
 
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
   static TypeSyntax makeTypeIdentifier(OwnedString TypeName,
-    const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+                                       const Trivia &LeadingTrivia = {},
+                                       const Trivia &TrailingTrivia = {},
+                                       SyntaxArena *Arena = nullptr);
 
   /// Creates a GenericParameterSyntax with no inheritance clause and an
   /// optional trailing comma.
-  static GenericParameterSyntax makeGenericParameter(TokenSyntax Name,
-    llvm::Optional<TokenSyntax> TrailingComma);
+  static GenericParameterSyntax
+  makeGenericParameter(TokenSyntax Name,
+                       llvm::Optional<TokenSyntax> TrailingComma,
+                       SyntaxArena *Arena = nullptr);
 
   /// Creates a TypeIdentifierSyntax for the `Any` type.
-  static TypeSyntax makeAnyTypeIdentifier(
-    const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+  static TypeSyntax makeAnyTypeIdentifier(const Trivia &LeadingTrivia = {},
+                                          const Trivia &TrailingTrivia = {},
+                                          SyntaxArena *Arena = nullptr);
 
   /// Creates a TypeIdentifierSyntax for the `Self` type.
-  static TypeSyntax makeSelfTypeIdentifier(
-    const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+  static TypeSyntax makeSelfTypeIdentifier(const Trivia &LeadingTrivia = {},
+                                           const Trivia &TrailingTrivia = {},
+                                           SyntaxArena *Arena = nullptr);
 
   /// Creates a TokenSyntax for the `Type` identifier.
-  static TokenSyntax makeTypeToken(
-    const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+  static TokenSyntax makeTypeToken(const Trivia &LeadingTrivia = {},
+                                   const Trivia &TrailingTrivia = {},
+                                   SyntaxArena *Arena = nullptr);
 
   /// Creates a TokenSyntax for the `Protocol` identifier.
-  static TokenSyntax makeProtocolToken(
-    const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+  static TokenSyntax makeProtocolToken(const Trivia &LeadingTrivia = {},
+                                       const Trivia &TrailingTrivia = {},
+                                       SyntaxArena *Arena = nullptr);
 
   /// Creates an `==` operator token.
-  static TokenSyntax makeEqualityOperator(
-    const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+  static TokenSyntax makeEqualityOperator(const Trivia &LeadingTrivia = {},
+                                          const Trivia &TrailingTrivia = {},
+                                          SyntaxArena *Arena = nullptr);
 
   /// Whether a raw node `Member` can serve as a member in a syntax collection
   /// of the given syntax collection kind.

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -183,7 +183,8 @@ public:
   void addRawSyntax(RC<RawSyntax> Raw);
 
   /// Add Token with Trivia to the parts.
-  void addToken(Token &Tok, Trivia &LeadingTrivia, Trivia &TrailingTrivia);
+  void addToken(ASTContext &C, Token &Tok, Trivia &LeadingTrivia,
+                Trivia &TrailingTrivia);
 
   /// Add Syntax to the parts.
   void addSyntax(Syntax Node);

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -110,6 +110,8 @@ class alignas(1 << SyntaxAlignInBits) SyntaxParsingContext {
   // Reference to the
   SyntaxParsingContext *&CtxtHolder;
 
+  ASTContext &C;
+
   std::vector<RC<RawSyntax>> &Storage;
 
   // Offet for 'Storage' this context owns from.
@@ -137,14 +139,20 @@ class alignas(1 << SyntaxAlignInBits) SyntaxParsingContext {
     return makeArrayRef(Storage).drop_front(Offset);
   }
 
+  RC<RawSyntax> makeUnknownSyntax(SyntaxKind Kind,
+                                  ArrayRef<RC<RawSyntax>> Parts);
+  RC<RawSyntax> createSyntaxAs(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Parts);
+  RC<RawSyntax> bridgeAs(SyntaxContextKind Kind, ArrayRef<RC<RawSyntax>> Parts);
+
 public:
   /// Construct root context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SourceFile &SF,
-    DiagnosticEngine &Diags, SourceManager &SourceMgr, unsigned BufferID);
+                       unsigned BufferID);
 
   /// Designated constructor for child context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder)
       : RootDataOrParent(CtxtHolder), CtxtHolder(CtxtHolder),
+        C(CtxtHolder->C),
         Storage(CtxtHolder->Storage), Offset(Storage.size()),
         Enabled(CtxtHolder->isEnabled()) {
     assert(CtxtHolder->isTopOfContextStack() &&

--- a/include/swift/Syntax/SyntaxParsingContext.h
+++ b/include/swift/Syntax/SyntaxParsingContext.h
@@ -110,7 +110,7 @@ class alignas(1 << SyntaxAlignInBits) SyntaxParsingContext {
   // Reference to the
   SyntaxParsingContext *&CtxtHolder;
 
-  ASTContext &C;
+  SyntaxArena &Arena;
 
   std::vector<RC<RawSyntax>> &Storage;
 
@@ -152,7 +152,7 @@ public:
   /// Designated constructor for child context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder)
       : RootDataOrParent(CtxtHolder), CtxtHolder(CtxtHolder),
-        C(CtxtHolder->C),
+        Arena(CtxtHolder->Arena),
         Storage(CtxtHolder->Storage), Offset(Storage.size()),
         Enabled(CtxtHolder->isEnabled()) {
     assert(CtxtHolder->isTopOfContextStack() &&
@@ -191,7 +191,7 @@ public:
   void addRawSyntax(RC<RawSyntax> Raw);
 
   /// Add Token with Trivia to the parts.
-  void addToken(ASTContext &C, Token &Tok, Trivia &LeadingTrivia,
+  void addToken(Token &Tok, Trivia &LeadingTrivia,
                 Trivia &TrailingTrivia);
 
   /// Add Syntax to the parts.

--- a/include/swift/Syntax/TokenKinds.def
+++ b/include/swift/Syntax/TokenKinds.def
@@ -241,6 +241,10 @@ PUNCTUATOR(question_infix,"?")    // if not left-bound
 PUNCTUATOR(sil_dollar,    "$")    // Only in SIL mode.
 PUNCTUATOR(sil_exclamation, "!")    // Only in SIL mode.
 
+// string_literal might be exploded to {quote segment quote} in the Parser.
+PUNCTUATOR(string_quote, "\"")
+PUNCTUATOR(multiline_string_quote, "\"\"\"")
+
 // Legacy punctuators used for migrating old object literal syntax.
 // NOTE: Remove in the future.
 PUNCTUATOR(l_square_lit,  "[#")
@@ -292,11 +296,9 @@ MISC(dollarident)
 MISC(sil_local_name)       // %42 in SIL mode.
 MISC(comment)
 
-MISC(string_interpolation_anchor)
 MISC(contextual_keyword)
-MISC(string_quote)
-MISC(multiline_string_quote)
 MISC(string_segment)
+MISC(string_interpolation_anchor)
 
 #undef TOKEN
 #undef KEYWORD

--- a/include/swift/Syntax/Trivia.h
+++ b/include/swift/Syntax/Trivia.h
@@ -80,6 +80,7 @@
 #define SWIFT_SYNTAX_TRIVIA_H
 
 #include "swift/Basic/OwnedString.h"
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <vector>
@@ -282,6 +283,29 @@ public:
 
   bool operator!=(const TriviaPiece &Other) const {
     return !(*this == Other);
+  }
+
+  void Profile(llvm::FoldingSetNodeID &ID) const {
+    ID.AddInteger(unsigned(Kind));
+    switch (Kind) {
+      case TriviaKind::LineComment:
+      case TriviaKind::BlockComment:
+      case TriviaKind::DocBlockComment:
+      case TriviaKind::DocLineComment:
+      case TriviaKind::GarbageText:
+        ID.AddString(Text.str());
+        break;
+      case TriviaKind::Newline:
+      case TriviaKind::CarriageReturn:
+      case TriviaKind::Space:
+      case TriviaKind::Backtick:
+      case TriviaKind::Tab:
+      case TriviaKind::VerticalTab:
+      case TriviaKind::Formfeed:
+      case TriviaKind::CarriageReturnLineFeed:
+        ID.AddInteger(Count);
+        break;
+    }
   }
 };
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -327,6 +327,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                    Target.isOSDarwin());
   Opts.EnableSILOpaqueValues |= Args.hasArg(OPT_enable_sil_opaque_values);
 
+  Opts.KeepSyntaxInfoInSourceFile |= Args.hasArg(OPT_parse_syntax_info);
+  Opts.VerifySyntaxTree |= Args.hasArg(OPT_verify_syntax_tree);
+
 #if SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
   Opts.UseDarwinPreStableABIBit = false;
 #else

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -273,7 +273,7 @@ bool Parser::parseTopLevel() {
 
   // If we are done parsing the whole file, finalize the token receiver.
   if (Tok.is(tok::eof)) {
-    SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
+    SyntaxContext->addToken(Context, Tok, LeadingTrivia, TrailingTrivia);
     TokReceiver->finalize();
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -273,7 +273,7 @@ bool Parser::parseTopLevel() {
 
   // If we are done parsing the whole file, finalize the token receiver.
   if (Tok.is(tok::eof)) {
-    SyntaxContext->addToken(Context, Tok, LeadingTrivia, TrailingTrivia);
+    SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
     TokReceiver->finalize();
   }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1941,7 +1941,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
       // such token to the context.
       Token content(tok::string_segment,
                     CharSourceRange(Segment.Loc, Segment.Length).str());
-      SyntaxContext->addToken(Context, content, EmptyTrivia, EmptyTrivia);
+      SyntaxContext->addToken(content, EmptyTrivia, EmptyTrivia);
       break;
     }
         
@@ -1951,7 +1951,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
 
       // Backslash is part of an expression segment.
       Token BackSlash(tok::backslash, "\\");
-      ExprContext.addToken(Context, BackSlash, EmptyTrivia, EmptyTrivia);
+      ExprContext.addToken(BackSlash, EmptyTrivia, EmptyTrivia);
       // Create a temporary lexer that lexes from the body of the string.
       LexerState BeginState =
           L->getStateForBeginningOfTokenLoc(Segment.Loc);
@@ -2035,7 +2035,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
 
   // Add the open quote to the context; the quote should have the leading trivia
   // of the entire string token and a void trailing trivia.
-  SyntaxContext->addToken(Context, OpenQuote, LeadingTrivia, EmptyTrivia);
+  SyntaxContext->addToken(OpenQuote, LeadingTrivia, EmptyTrivia);
 
   // We don't expose the entire interpolated string as one token. Instead, we
   // should expose the tokens in each segment.
@@ -2057,7 +2057,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
 
   // Add the close quote the context; the quote should have a void leading trivia
   // and the trailing trivia of the entire string token.
-  SyntaxContext->addToken(Context, CloseQuote, EmptyTrivia, EntireTrailingTrivia);
+  SyntaxContext->addToken(CloseQuote, EmptyTrivia, EntireTrailingTrivia);
 
   if (Exprs.empty()) {
     Status.setIsParseError();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1941,7 +1941,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
       // such token to the context.
       Token content(tok::string_segment,
                     CharSourceRange(Segment.Loc, Segment.Length).str());
-      SyntaxContext->addToken(content, EmptyTrivia, EmptyTrivia);
+      SyntaxContext->addToken(Context, content, EmptyTrivia, EmptyTrivia);
       break;
     }
         
@@ -1951,7 +1951,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
 
       // Backslash is part of an expression segment.
       Token BackSlash(tok::backslash, "\\");
-      ExprContext.addToken(BackSlash, EmptyTrivia, EmptyTrivia);
+      ExprContext.addToken(Context, BackSlash, EmptyTrivia, EmptyTrivia);
       // Create a temporary lexer that lexes from the body of the string.
       LexerState BeginState =
           L->getStateForBeginningOfTokenLoc(Segment.Loc);
@@ -2035,7 +2035,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
 
   // Add the open quote to the context; the quote should have the leading trivia
   // of the entire string token and a void trailing trivia.
-  SyntaxContext->addToken(OpenQuote, LeadingTrivia, EmptyTrivia);
+  SyntaxContext->addToken(Context, OpenQuote, LeadingTrivia, EmptyTrivia);
 
   // We don't expose the entire interpolated string as one token. Instead, we
   // should expose the tokens in each segment.
@@ -2057,7 +2057,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
 
   // Add the close quote the context; the quote should have a void leading trivia
   // and the trailing trivia of the entire string token.
-  SyntaxContext->addToken(CloseQuote, EmptyTrivia, EntireTrailingTrivia);
+  SyntaxContext->addToken(Context, CloseQuote, EmptyTrivia, EntireTrailingTrivia);
 
   if (Exprs.empty()) {
     Status.setIsParseError();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -424,8 +424,6 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
         diag::rethrowing_function_type : diag::throw_in_function_type;
       diagnose(Tok.getLoc(), DiagID)
         .fixItReplace(Tok.getLoc(), "throws");
-      if (Tok.is(tok::kw_throw))
-        Tok.setKind(tok::kw_throws);
     }
     throwsLoc = consumeToken();
   }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -233,7 +233,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID,
   auto makeMetatypeTypeSyntax = [&]() {
     if (!SyntaxContext->isEnabled())
       return;
-    MetatypeTypeSyntaxBuilder Builder;
+    MetatypeTypeSyntaxBuilder Builder(Context.getSyntaxArena());
     Builder
       .useTypeOrProtocol(SyntaxContext->popToken())
       .usePeriod(SyntaxContext->popToken())
@@ -439,7 +439,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       return nullptr;
 
     if (SyntaxContext->isEnabled()) {
-      FunctionTypeSyntaxBuilder Builder;
+      FunctionTypeSyntaxBuilder Builder(Context.getSyntaxArena());
       Builder.useReturnType(SyntaxContext->popIf<TypeSyntax>().getValue());
       Builder.useArrow(SyntaxContext->popToken());
       if (throwsLoc.isValid())
@@ -690,7 +690,7 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
     consumeToken(); // consume '&'
 
     if (SyntaxContext->isEnabled() && Status.isSuccess()) {
-      CompositionTypeElementSyntaxBuilder Builder;
+      CompositionTypeElementSyntaxBuilder Builder(Context.getSyntaxArena());
       Builder
         .useAmpersand(SyntaxContext->popToken())
         .useType(SyntaxContext->popIf<TypeSyntax>().getValue());
@@ -1101,7 +1101,7 @@ SyntaxParserResult<TypeSyntax, TypeRepr> Parser::parseTypeCollection() {
     TyR = new (Context)
         DictionaryTypeRepr(firstTy.get(), secondTy.get(), colonLoc, brackets);
     if (SyntaxContext->isEnabled()) {
-      DictionaryTypeSyntaxBuilder Builder;
+      DictionaryTypeSyntaxBuilder Builder(Context.getSyntaxArena());
       Builder
         .useRightSquareBracket(SyntaxContext->popToken())
         .useValueType(SyntaxContext->popIf<TypeSyntax>().getValue())
@@ -1114,7 +1114,7 @@ SyntaxParserResult<TypeSyntax, TypeRepr> Parser::parseTypeCollection() {
     // Form the array type.
     TyR = new (Context) ArrayTypeRepr(firstTy.get(), brackets);
     if (SyntaxContext->isEnabled()) {
-      ArrayTypeSyntaxBuilder Builder;
+      ArrayTypeSyntaxBuilder Builder(Context.getSyntaxArena());
       Builder
         .useRightSquareBracket(SyntaxContext->popToken())
         .useElementType(SyntaxContext->popIf<TypeSyntax>().getValue())
@@ -1174,7 +1174,7 @@ Parser::parseTypeOptional(TypeRepr *base) {
   auto TyR = new (Context) OptionalTypeRepr(base, questionLoc);
   llvm::Optional<TypeSyntax> SyntaxNode;
   if (SyntaxContext->isEnabled()) {
-    OptionalTypeSyntaxBuilder Builder;
+    OptionalTypeSyntaxBuilder Builder(Context.getSyntaxArena());
     Builder
       .useQuestionMark(SyntaxContext->popToken())
       .useWrappedType(SyntaxContext->popIf<TypeSyntax>().getValue());
@@ -1192,7 +1192,8 @@ Parser::parseTypeImplicitlyUnwrappedOptional(TypeRepr *base) {
       new (Context) ImplicitlyUnwrappedOptionalTypeRepr(base, exclamationLoc);
   llvm::Optional<TypeSyntax> SyntaxNode;
   if (SyntaxContext->isEnabled()) {
-    ImplicitlyUnwrappedOptionalTypeSyntaxBuilder Builder;
+    ImplicitlyUnwrappedOptionalTypeSyntaxBuilder Builder(
+        Context.getSyntaxArena());
     Builder
       .useExclamationMark(SyntaxContext->popToken())
       .useWrappedType(SyntaxContext->popIf<TypeSyntax>().getValue());

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -311,9 +311,9 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
       /*SplitTokens=*/ArrayRef<Token>(),
       [&](const Token &Tok, const Trivia &LeadingTrivia,
           const Trivia &TrailingTrivia) {
-        auto ThisToken = RawSyntax::make(
-            Tok.getKind(), Tok.getText(), SourcePresence::Present,
-            LeadingTrivia.Pieces, TrailingTrivia.Pieces);
+        auto ThisToken =
+            RawSyntax::make(Tok.getKind(), Tok.getText(), LeadingTrivia.Pieces,
+                            TrailingTrivia.Pieces, SourcePresence::Present);
 
         auto ThisTokenPos = ThisToken->accumulateAbsolutePosition(RunningPos);
         Tokens.push_back({ThisToken, ThisTokenPos.getValue()});
@@ -516,7 +516,7 @@ void Parser::consumeExtraToken(Token Extra) {
 
 SourceLoc Parser::consumeToken() {
   TokReceiver->receive(Tok);
-  SyntaxContext->addToken(Context, Tok, LeadingTrivia, TrailingTrivia);
+  SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
   return consumeTokenWithoutFeedingReceiver();
 }
 
@@ -552,7 +552,7 @@ void Parser::markSplitToken(tok Kind, StringRef Txt) {
   SplitTokens.emplace_back();
   SplitTokens.back().setToken(Kind, Txt);
   Trivia EmptyTrivia;
-  SyntaxContext->addToken(Context, SplitTokens.back(), LeadingTrivia, EmptyTrivia);
+  SyntaxContext->addToken(SplitTokens.back(), LeadingTrivia, EmptyTrivia);
   LeadingTrivia.empty();
   TokReceiver->receive(SplitTokens.back());
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -516,7 +516,7 @@ void Parser::consumeExtraToken(Token Extra) {
 
 SourceLoc Parser::consumeToken() {
   TokReceiver->receive(Tok);
-  SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
+  SyntaxContext->addToken(Context, Tok, LeadingTrivia, TrailingTrivia);
   return consumeTokenWithoutFeedingReceiver();
 }
 
@@ -552,7 +552,7 @@ void Parser::markSplitToken(tok Kind, StringRef Txt) {
   SplitTokens.emplace_back();
   SplitTokens.back().setToken(Kind, Txt);
   Trivia EmptyTrivia;
-  SyntaxContext->addToken(SplitTokens.back(), LeadingTrivia, EmptyTrivia);
+  SyntaxContext->addToken(Context, SplitTokens.back(), LeadingTrivia, EmptyTrivia);
   LeadingTrivia.empty();
   TokReceiver->receive(SplitTokens.back());
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -468,7 +468,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     TokReceiver(SF.shouldKeepSyntaxInfo() ?
                 new TokenRecorder(SF) :
                 new ConsumeTokenReceiver()),
-    SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF, Diags, SourceMgr,
+    SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF,
                                            L->getBufferID())) {
   State = PersistentState;
   if (!State) {

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_library(swiftSyntax STATIC
   Trivia.cpp
   RawSyntax.cpp
   Syntax.cpp
+  SyntaxArena.cpp
   SyntaxData.cpp
   UnknownSyntax.cpp
   SyntaxParsingContext.cpp)

--- a/lib/Syntax/SyntaxArena.cpp
+++ b/lib/Syntax/SyntaxArena.cpp
@@ -1,0 +1,162 @@
+//===--- SyntaxArena.cpp - SyntaxArena implementation -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Syntax/SyntaxArena.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "llvm/ADT/FoldingSet.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+namespace {
+class RawSyntaxCacheNode;
+}
+
+/// Implementation detail of SyntaxArena.
+struct SyntaxArena::Implementation {
+  /// Allocator.
+  llvm::BumpPtrAllocator Allocator;
+
+  /// List of pointers to the allocated RawSyntax
+  std::vector<RawSyntax *> AllocatedRawSyntaxList;
+
+  /// Cached Tokens.
+  llvm::FoldingSet<RawSyntaxCacheNode> CachedTokens;
+
+  Implementation() = default;
+  void *Allocate(size_t size, size_t alignment) {
+    return Allocator.Allocate(size, alignment);
+  }
+
+  void *AllocateRawSyntax(size_t size, size_t alignment) {
+    void *data = Allocator.Allocate(size, alignment);
+    /// Remember the allocated pointers so that we can destruct them.
+    AllocatedRawSyntaxList.push_back(static_cast<RawSyntax *>(data));
+    return data;
+  }
+
+  ~Implementation() {
+    // Destruct all allocated RawSyntax. They might contain heap allocated
+    // propeties and/or children.
+    for (auto *N : AllocatedRawSyntaxList)
+      N->~RawSyntax();
+  }
+};
+
+SyntaxArena::SyntaxArena() : Impl(*new Implementation()){};
+SyntaxArena::~SyntaxArena() { delete &Impl; }
+
+llvm::BumpPtrAllocator &SyntaxArena::getAllocator() const {
+  return Impl.Allocator;
+}
+
+void *SyntaxArena::Allocate(size_t size, size_t alignment) {
+  return Impl.Allocate(size, alignment);
+}
+
+void *SyntaxArena::AllocateRawSyntax(size_t size, size_t alignment) {
+  return Impl.AllocateRawSyntax(size, alignment);
+}
+
+namespace {
+
+/// Cache node for RawSyntax.
+class RawSyntaxCacheNode : public llvm::FoldingSetNode {
+
+  friend llvm::FoldingSetTrait<RawSyntaxCacheNode>;
+
+  /// Associated RawSyntax.
+  RawSyntax *Obj;
+  /// FoldingSet node identifier of the associated RawSyntax.
+  llvm::FoldingSetNodeIDRef IDRef;
+
+public:
+  RawSyntaxCacheNode(RawSyntax *Obj, const llvm::FoldingSetNodeIDRef IDRef)
+      : Obj(Obj), IDRef(IDRef) {}
+
+  /// Retrieve assciated RawSyntax.
+  RawSyntax *get() { return Obj; }
+
+  // Only allow allocation of Node using the allocator in SyntaxArena.
+  void *operator new(size_t Bytes, SyntaxArena &Arena,
+                     unsigned Alignment = alignof(RawSyntaxCacheNode)) {
+    return Arena.Allocate(Bytes, Alignment);
+  }
+
+  void *operator new(size_t Bytes) throw() = delete;
+  void operator delete(void *Data) throw() = delete;
+};
+
+} // namespace
+
+namespace llvm {
+
+/// FoldingSet traits for RawSyntax wrapper.
+template <> struct FoldingSetTrait<RawSyntaxCacheNode> {
+
+  static inline void Profile(RawSyntaxCacheNode &X, FoldingSetNodeID &ID) {
+    ID.AddNodeID(X.IDRef);
+  }
+
+  static inline bool Equals(RawSyntaxCacheNode &X, const FoldingSetNodeID &ID,
+                            unsigned, FoldingSetNodeID &) {
+    return ID == X.IDRef;
+  }
+  static inline unsigned ComputeHash(RawSyntaxCacheNode &X,
+                                     FoldingSetNodeID &) {
+    return X.IDRef.ComputeHash();
+  }
+};
+
+} // namespace llvm
+
+/// Retrive "token" RawSyntax from the given Arena.
+RC<RawSyntax> RawSyntax::getToken(SyntaxArena &Arena, tok TokKind,
+                                  OwnedString Text,
+                                  llvm::ArrayRef<TriviaPiece> LeadingTrivia,
+                                  llvm::ArrayRef<TriviaPiece> TrailingTrivia) {
+
+  // Determine whether this token is worth to cache.
+  if (
+      // Is string_literal with >16 length.
+      (TokKind == tok::string_literal && Text.size() > 16) ||
+      // Has leading comment trivia et al.
+      any_of(LeadingTrivia,
+             [](const syntax::TriviaPiece &T) { return T.getText().size(); }) ||
+      // Has trailing comment trivia et al.
+      any_of(TrailingTrivia,
+             [](const syntax::TriviaPiece &T) { return T.getText().size(); })) {
+
+    // Do not use cache.
+    return RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
+                           SourcePresence::Present, &Arena);
+  }
+
+  // This node is cacheable. Get or create.
+  auto &CachedTokens = Arena.Impl.CachedTokens;
+
+  llvm::FoldingSetNodeID ID;
+  RawSyntax::Profile(ID, TokKind, Text, LeadingTrivia, TrailingTrivia);
+
+  void *insertPos = nullptr;
+  if (auto existing = CachedTokens.FindNodeOrInsertPos(ID, insertPos))
+    // Found in the cache. Just return it.
+    return existing->get();
+
+  // Could not found in the cache. Create it.
+  auto Raw = RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
+                             SourcePresence::Present, &Arena);
+  auto IDRef = ID.Intern(Arena.getAllocator());
+  auto CacheNode = new (Arena) RawSyntaxCacheNode(Raw.get(), IDRef);
+  CachedTokens.InsertNode(CacheNode, insertPos);
+  return Raw;
+}

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -43,7 +43,8 @@ ${node.name}Builder::add${child_elt}(${child_elt_type} ${child_elt}) {
   auto &raw = Layout[cursorIndex(${node.name}::Cursor::${child.name})];
   if (!raw)
     raw = RawSyntax::make(SyntaxKind::${child_node.syntax_kind},
-                          {${child_elt}.getRaw()}, SourcePresence::Present);
+                          {${child_elt}.getRaw()},
+                          SourcePresence::Present, Arena);
   else
     raw = raw->append(${child_elt}.getRaw());
   return *this;
@@ -61,7 +62,7 @@ ${node.name}Builder::build() {
 %   end
 % end
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, 
-    Layout, SourcePresence::Present);
+    Layout, SourcePresence::Present, Arena);
   return make<${node.name}>(raw);
 }
 

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -39,23 +39,25 @@ using namespace swift;
 using namespace swift::syntax;
 
 TokenSyntax SyntaxFactory::makeToken(tok Kind, OwnedString Text,
-                                     SourcePresence Presence,
                                      const Trivia &LeadingTrivia,
-                                     const Trivia &TrailingTrivia) {
-  return make<TokenSyntax>(RawSyntax::make(Kind, Text, Presence,
-                                           LeadingTrivia.Pieces,
-                                           TrailingTrivia.Pieces));
+                                     const Trivia &TrailingTrivia,
+                                     SourcePresence Presence,
+                                     SyntaxArena *Arena) {
+  return make<TokenSyntax>(RawSyntax::make(Kind, Text, LeadingTrivia.Pieces,
+                                           TrailingTrivia.Pieces, Presence,
+                                           Arena));
 }
 
 UnknownSyntax
-SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens) {
+SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
+                                 SyntaxArena *Arena) {
   std::vector<RC<RawSyntax>> Layout;
   Layout.reserve(Tokens.size());
   for (auto &Token : Tokens) {
     Layout.push_back(Token.getRaw());
   }
   auto Raw = RawSyntax::make(SyntaxKind::Unknown, Layout,
-                             SourcePresence::Present);
+                             SourcePresence::Present, Arena);
   return make<UnknownSyntax>(Raw);
 }
 
@@ -114,9 +116,9 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
   return canServeAsCollectionMemberRaw(CollectionKind, Member.getRaw());
 }
 
-RC<RawSyntax> SyntaxFactory::createRaw(
-    SyntaxKind Kind, llvm::ArrayRef<RC<RawSyntax>> Elements,
-    llvm::function_ref<void *(size_t, size_t)> Allocate) {
+RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
+                                       llvm::ArrayRef<RC<RawSyntax>> Elements,
+                                       SyntaxArena *Arena) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -140,13 +142,13 @@ RC<RawSyntax> SyntaxFactory::createRaw(
 %   end
     if (I != Elements.size())
       return nullptr;
-    return RawSyntax::make(Kind, Layout, SourcePresence::Present, Allocate);
+    return RawSyntax::make(Kind, Layout, SourcePresence::Present, Arena);
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
       if (!canServeAsCollectionMemberRaw(SyntaxKind::${node.syntax_kind}, E))
         return nullptr;
     }
-    return RawSyntax::make(Kind, Elements, SourcePresence::Present, Allocate);
+    return RawSyntax::make(Kind, Elements, SourcePresence::Present, Arena);
 % else:
     return nullptr;
 % end
@@ -157,14 +159,15 @@ RC<RawSyntax> SyntaxFactory::createRaw(
   }
 }
 
-Optional<Syntax>
-SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
+Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
+                                             llvm::ArrayRef<Syntax> Elements,
+                                             SyntaxArena *Arena) {
   std::vector<RC<RawSyntax>> Layout;
   Layout.reserve(Elements.size());
   for (auto &E : Elements)
     Layout.emplace_back(E.getRaw());
 
-  if (auto Raw = createRaw(Kind, Layout))
+  if (auto Raw = createRaw(Kind, Layout, Arena))
     return make<Syntax>(Raw);
   else
     return None;
@@ -180,7 +183,8 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
 %         child_params.append("%s %s" % (param_type, child.name))
 %     child_params = ', '.join(child_params)
 ${node.name}
-SyntaxFactory::make${node.syntax_kind}(${child_params}) {
+SyntaxFactory::make${node.syntax_kind}(${child_params},
+                                       SyntaxArena *Arena) {
   auto Raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
@@ -189,26 +193,27 @@ SyntaxFactory::make${node.syntax_kind}(${child_params}) {
     ${child.name}.getRaw(),
 %       end
 %     end
-  }, SourcePresence::Present);
+  }, SourcePresence::Present, Arena);
   return make<${node.name}>(Raw);
 }
 %   elif node.is_syntax_collection():
 ${node.name}
 SyntaxFactory::make${node.syntax_kind}(
-  const std::vector<${node.collection_element_type}> &elements) {
+    const std::vector<${node.collection_element_type}> &elements,
+    SyntaxArena *Arena) {
   std::vector<RC<RawSyntax>> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
     layout.push_back(element.getRaw());
   }
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind},
-                             layout, SourcePresence::Present);
+                             layout, SourcePresence::Present, Arena);
   return make<${node.name}>(raw);
 }
 %   end
 
 ${node.name}
-SyntaxFactory::makeBlank${node.syntax_kind}() {
+SyntaxFactory::makeBlank${node.syntax_kind}(SyntaxArena *Arena) {
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %   for child in node.children:
 %       if child.is_optional:
@@ -217,7 +222,7 @@ SyntaxFactory::makeBlank${node.syntax_kind}() {
     ${make_missing_child(child)},
 %       end
 %   end
-  }, SourcePresence::Present);
+  }, SourcePresence::Present, Arena);
   return make<${node.name}>(raw);
 }
 % end
@@ -226,86 +231,102 @@ SyntaxFactory::makeBlank${node.syntax_kind}() {
 %   if token.is_keyword:
   TokenSyntax
   SyntaxFactory::make${token.name}Keyword(const Trivia &LeadingTrivia,
-                                          const Trivia &TrailingTrivia) {
+                                          const Trivia &TrailingTrivia,
+                                          SyntaxArena *Arena) {
     return makeToken(tok::${token.kind}, "${token.text}",
-                     SourcePresence::Present,
-                     LeadingTrivia, TrailingTrivia);
+                     LeadingTrivia, TrailingTrivia,
+                     SourcePresence::Present, Arena);
   }
 %   elif token.text:
   TokenSyntax
   SyntaxFactory::make${token.name}Token(const Trivia &LeadingTrivia,
-                                        const Trivia &TrailingTrivia) {
+                                        const Trivia &TrailingTrivia,
+                                        SyntaxArena *Arena) {
     return makeToken(tok::${token.kind}, "${token.text}",
-                     SourcePresence::Present,
-                     LeadingTrivia, TrailingTrivia);
+                     LeadingTrivia, TrailingTrivia,
+                     SourcePresence::Present, Arena);
   }
 %   else:
   TokenSyntax
   SyntaxFactory::make${token.name}(OwnedString Text,
                                    const Trivia &LeadingTrivia,
-                                   const Trivia &TrailingTrivia) {
-    return makeToken(tok::${token.kind}, Text, SourcePresence::Present,
-                     LeadingTrivia, TrailingTrivia);
+                                   const Trivia &TrailingTrivia,
+                                   SyntaxArena *Arena) {
+    return makeToken(tok::${token.kind}, Text,
+                     LeadingTrivia, TrailingTrivia,
+                     SourcePresence::Present, Arena);
   }
 %   end
 % end
 
-TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
-  return makeTupleType(makeLeftParenToken({}, {}),
-                       makeBlankTupleTypeElementList(),
-                       makeRightParenToken({}, {}));
+TupleTypeSyntax SyntaxFactory::makeVoidTupleType(SyntaxArena *Arena) {
+  return makeTupleType(makeLeftParenToken({}, {}, Arena),
+                       makeBlankTupleTypeElementList(Arena),
+                       makeRightParenToken({}, {}, Arena),
+                       Arena);
 }
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(llvm::Optional<TokenSyntax> Label,
                                     llvm::Optional<TokenSyntax> Colon,
                                     TypeSyntax Type,
-                                    llvm::Optional<TokenSyntax> TrailingComma) {
+                                    llvm::Optional<TokenSyntax> TrailingComma,
+                                    SyntaxArena *Arena) {
   return makeTupleTypeElement(None, Label, None, Colon, Type, None, None,
-                              TrailingComma);
+                              TrailingComma, Arena);
 }
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
-                                    llvm::Optional<TokenSyntax> TrailingComma) {
+                                    llvm::Optional<TokenSyntax> TrailingComma,
+                                    SyntaxArena *Arena) {
   return makeTupleTypeElement(None, None, None, None, Type, None, None,
-                              TrailingComma);
+                              TrailingComma, Arena);
 }
 
 GenericParameterSyntax
 SyntaxFactory::makeGenericParameter(TokenSyntax Name,
-  llvm::Optional<TokenSyntax> TrailingComma) {
-  return makeGenericParameter(None, Name, None, None, TrailingComma);
+                                    llvm::Optional<TokenSyntax> TrailingComma,
+                                    SyntaxArena *Arena) {
+  return makeGenericParameter(None, Name, None, None, TrailingComma, Arena);
 }
 
 TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
-    const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
-  auto identifier = makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia);
-  return makeSimpleTypeIdentifier(identifier, None);
+                                             const Trivia &LeadingTrivia,
+                                             const Trivia &TrailingTrivia,
+                                             SyntaxArena *Arena) {
+  auto identifier =
+      makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia, Arena);
+  return makeSimpleTypeIdentifier(identifier, None, Arena);
 }
 
-TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(
-    const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
-  return makeTypeIdentifier("Any", LeadingTrivia, TrailingTrivia);
+TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(const Trivia &LeadingTrivia,
+                                                const Trivia &TrailingTrivia,
+                                                SyntaxArena *Arena) {
+  return makeTypeIdentifier("Any", LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(
-    const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
-  return makeTypeIdentifier("Self", LeadingTrivia, TrailingTrivia);
+TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(const Trivia &LeadingTrivia,
+                                                 const Trivia &TrailingTrivia,
+                                                 SyntaxArena *Arena) {
+  return makeTypeIdentifier("Self", LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TokenSyntax SyntaxFactory::makeTypeToken(
-  const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
-  return makeIdentifier("Type", LeadingTrivia, TrailingTrivia);
+TokenSyntax SyntaxFactory::makeTypeToken(const Trivia &LeadingTrivia,
+                                         const Trivia &TrailingTrivia,
+                                         SyntaxArena *Arena) {
+  return makeIdentifier("Type", LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TokenSyntax SyntaxFactory::makeProtocolToken(
-  const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
-  return makeIdentifier("Protocol", LeadingTrivia, TrailingTrivia);
+TokenSyntax SyntaxFactory::makeProtocolToken(const Trivia &LeadingTrivia,
+                                             const Trivia &TrailingTrivia,
+                                             SyntaxArena *Arena) {
+  return makeIdentifier("Protocol", LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TokenSyntax SyntaxFactory::makeEqualityOperator(
-const Trivia &LeadingTrivia, const Trivia &TrailingTrivia) {
-  return makeToken(tok::oper_binary_spaced, "==", SourcePresence::Present,
-                   LeadingTrivia, TrailingTrivia);
+TokenSyntax SyntaxFactory::makeEqualityOperator(const Trivia &LeadingTrivia,
+                                                const Trivia &TrailingTrivia,
+                                                SyntaxArena *Arena) {
+  return makeToken(tok::oper_binary_spaced, "==", LeadingTrivia, TrailingTrivia,
+                   SourcePresence::Present, Arena);
 }

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -114,8 +114,9 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
   return canServeAsCollectionMemberRaw(CollectionKind, Member.getRaw());
 }
 
-RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
-                                       llvm::ArrayRef<RC<RawSyntax>> Elements) {
+RC<RawSyntax> SyntaxFactory::createRaw(
+    SyntaxKind Kind, llvm::ArrayRef<RC<RawSyntax>> Elements,
+    llvm::function_ref<void *(size_t, size_t)> Allocate) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -139,13 +140,13 @@ RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
 %   end
     if (I != Elements.size())
       return nullptr;
-    return RawSyntax::make(Kind, Layout, SourcePresence::Present);
+    return RawSyntax::make(Kind, Layout, SourcePresence::Present, Allocate);
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
       if (!canServeAsCollectionMemberRaw(SyntaxKind::${node.syntax_kind}, E))
         return nullptr;
     }
-    return RawSyntax::make(Kind, Elements, SourcePresence::Present);
+    return RawSyntax::make(Kind, Elements, SourcePresence::Present, Allocate);
 % else:
     return nullptr;
 % end

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -89,7 +89,7 @@ ${node.name} ${node.name}::with${child.name}(
     raw = New${child.type_name}->getRaw();
   } else {
 % if child.is_optional:
-    raw = nullptr; //${make_missing_child(child)};
+    raw = nullptr;
 % else:
     raw = ${make_missing_child(child)};
 % end

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -69,14 +69,15 @@ SyntaxParsingContext *SyntaxParsingContext::getRoot() {
 }
 
 /// Add Token with Trivia to the parts.
-void SyntaxParsingContext::addToken(Token &Tok, Trivia &LeadingTrivia,
+void SyntaxParsingContext::addToken(ASTContext &C, Token &Tok,
+                                    Trivia &LeadingTrivia,
                                     Trivia &TrailingTrivia) {
   if (!Enabled)
     return;
 
-  addRawSyntax(RawSyntax::make(Tok.getKind(), Tok.getText(),
-                               SourcePresence::Present, LeadingTrivia.Pieces,
-                               TrailingTrivia.Pieces));
+  addRawSyntax(C.getRawTokenSyntax(Tok.getKind(), Tok.getText(),
+                                   LeadingTrivia.Pieces,
+                                   TrailingTrivia.Pieces));
 }
 
 /// Add Syntax to the parts.

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -100,6 +100,11 @@ PrintTrivialNodeKind("print-trivial-node-kind",
                      llvm::cl::cat(Category),
                      llvm::cl::init(false));
 
+static llvm::cl::opt<int>
+Iteration("iteration",
+          llvm::cl::desc("Repeat the action specified times"),
+          llvm::cl::cat(Category), llvm::cl::init(1));
+
 static llvm::cl::opt<bool>
 VerifySyntaxTree("verify-syntax-tree",
                  llvm::cl::desc("Emit warnings for unknown nodes"),
@@ -301,33 +306,36 @@ int main(int argc, char *argv[]) {
     return ExitCode;
   }
 
-  switch (options::Action) {
-  case ActionType::DumpRawTokenSyntax:
-    ExitCode = doDumpRawTokenSyntax(options::InputSourceFilename);
-    break;
-  case ActionType::FullLexRoundTrip:
-    ExitCode = doFullLexRoundTrip(options::InputSourceFilename);
-    break;
-  case ActionType::FullParseRoundTrip:
-    ExitCode = doFullParseRoundTrip(argv[0], options::InputSourceFilename);
-    break;
-  case ActionType::SerializeRawTree:
-    ExitCode = doSerializeRawTree(argv[0], options::InputSourceFilename);
-    break;
-  case ActionType::ParseOnly:
-    ExitCode = doParseOnly(argv[0], options::InputSourceFilename);
-    break;
-  case ActionType::ParserGen:
-    ExitCode = dumpParserGen(argv[0], options::InputSourceFilename);
-    break;
-  case ActionType::EOFPos:
-    ExitCode = dumpEOFSourceLoc(argv[0], options::InputSourceFilename);
-    break;
-  case ActionType::None:
-    llvm::errs() << "an action is required\n";
-    llvm::cl::PrintHelpMessage();
-    ExitCode = EXIT_FAILURE;
-    break;
+  int N = options::Iteration;
+  while (ExitCode == EXIT_SUCCESS && N--) {
+    switch (options::Action) {
+    case ActionType::DumpRawTokenSyntax:
+      ExitCode = doDumpRawTokenSyntax(options::InputSourceFilename);
+      break;
+    case ActionType::FullLexRoundTrip:
+      ExitCode = doFullLexRoundTrip(options::InputSourceFilename);
+      break;
+    case ActionType::FullParseRoundTrip:
+      ExitCode = doFullParseRoundTrip(argv[0], options::InputSourceFilename);
+      break;
+    case ActionType::SerializeRawTree:
+      ExitCode = doSerializeRawTree(argv[0], options::InputSourceFilename);
+      break;
+    case ActionType::ParseOnly:
+      ExitCode = doParseOnly(argv[0], options::InputSourceFilename);
+      break;
+    case ActionType::ParserGen:
+      ExitCode = dumpParserGen(argv[0], options::InputSourceFilename);
+      break;
+    case ActionType::EOFPos:
+      ExitCode = dumpEOFSourceLoc(argv[0], options::InputSourceFilename);
+      break;
+    case ActionType::None:
+      llvm::errs() << "an action is required\n";
+      llvm::cl::PrintHelpMessage();
+      ExitCode = EXIT_FAILURE;
+      break;
+    }
   }
 
   return ExitCode;

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -101,6 +101,12 @@ PrintTrivialNodeKind("print-trivial-node-kind",
                      llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+VerifySyntaxTree("verify-syntax-tree",
+                 llvm::cl::desc("Emit warnings for unknown nodes"),
+                 llvm::cl::cat(Category),
+                 llvm::cl::init(true));
+
+static llvm::cl::opt<bool>
 Visual("v",
        llvm::cl::desc("Print visually"),
        llvm::cl::cat(Category),
@@ -145,7 +151,7 @@ SourceFile *getSourceFile(CompilerInstance &Instance,
                           const char *MainExecutablePath) {
   CompilerInvocation Invocation;
   Invocation.getLangOptions().KeepSyntaxInfoInSourceFile = true;
-  Invocation.getLangOptions().VerifySyntaxTree = true;
+  Invocation.getLangOptions().VerifySyntaxTree = options::VerifySyntaxTree;
   Invocation.getFrontendOptions().Inputs.addInputFile(InputFileName);
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(MainExecutablePath,

--- a/unittests/Syntax/RawSyntaxTests.cpp
+++ b/unittests/Syntax/RawSyntaxTests.cpp
@@ -12,13 +12,13 @@ using namespace swift::syntax;
 TEST(RawSyntaxTests, accumulateAbsolutePosition1) {
   auto Token = RawSyntax::make(tok::identifier,
                                OwnedString("aaa"),
-                               SourcePresence::Present, 
                                {
                                  TriviaPiece::newlines(2),
                                  TriviaPiece::carriageReturns(2),
                                  TriviaPiece::carriageReturnLineFeeds(2)
                                },
-                               {  });
+                               {  },
+                               SourcePresence::Present);
   AbsolutePosition Pos;
   Token->accumulateAbsolutePosition(Pos);
   ASSERT_EQ(7u, Pos.getLine());
@@ -29,9 +29,9 @@ TEST(RawSyntaxTests, accumulateAbsolutePosition1) {
 TEST(RawSyntaxTests, accumulateAbsolutePosition2) {
   auto Token = RawSyntax::make(tok::identifier,
                                OwnedString("aaa"),
-                               SourcePresence::Present,
                                {TriviaPiece::blockComment("/* \n\r\r\n */")},
-                               {  });
+                               {  },
+                               SourcePresence::Present);
   AbsolutePosition Pos;
   Token->accumulateAbsolutePosition(Pos);
   ASSERT_EQ(4u, Pos.getLine());

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -152,6 +152,7 @@ TYPE_NODES = [
                    token_choices=[
                        'ThrowsToken',
                        'RethrowsToken',
+                       'ThrowToken',
                    ]),
              Child('Arrow', kind='ArrowToken'),
              Child('ReturnType', kind='Type'),


### PR DESCRIPTION
**⚠️  DO NOT MERGE**

* Don't construct complete `Syntax` nodes in parsing.
  Currently, there're many `RC<RawSyntax>` → `Syntax` → `RC<RawSyntax>` conversions. Since `Syntax` nodes have `RC<SyntaxData>` that needs heap allocation, frequent conversions cost a lot. Instead, directly use `RC<RawSyntax>`. #14297 
* Represent missing optional nodes as `nullptr`.
  For instance, every `IdentifierExpr` have optional `DeclNameArguments` (e.g. `(x:y:)`) node. Allocating it for every identifier expressions is definitely a waste of time and resource. #14300 
* Cache and reuse `RawSyntax` nodes (particularly, tokens) when possible.
  For instance, in `foo(), bar()`, both `(` have exact the same layout of `RawSyntax` (kind, text and leading/trailing trivia). We should be able to reuse one `RawSyntax` tokens to save allocation costs.
  Currently, the cache storage is in `ASTContext`. Probably we should create this kind of infrastructure for `libSyntax`. #14330
* Use `TrailingObjects` for `SyntaxData`.
  This should optimize memory allocations. #14301
* Use bump-pointer allocation for `RawSyntax`.
  Heap allocation and thread safe reference counting are slow. #14330