### PR TITLE
[string] Avoid dyncasts through direct metatype comparison.

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -143,12 +143,19 @@ internal func _getCocoaStringPointer(
 @inline(never) // Hide the CF dependency
 internal
 func _makeCocoaStringGuts(_ cocoaString: _CocoaString) -> _StringGuts {
-  if let ascii = cocoaString as? _ASCIIStringStorage {
-    return _StringGuts(ascii)
-  } else if let utf16 = cocoaString as? _UTF16StringStorage {
-    return _StringGuts(utf16)
-  } else if let wrapped = cocoaString as? _NSContiguousString {
-    return wrapped._guts
+  let cocoaType = type(of: cocoaString)
+  if cocoaType == _ASCIIStringStorage.self {
+    return _StringGuts(
+      _unsafeUncheckedDowncast(cocoaString, to: _ASCIIStringStorage.self))
+  }
+  else if cocoaType == _UTF16StringStorage.self {
+    return _StringGuts(
+      _unsafeUncheckedDowncast(cocoaString, to: _UTF16StringStorage.self))
+  }
+  else if cocoaType == _NSContiguousString.self {
+    return  _unsafeUncheckedDowncast(
+      cocoaString, to: _NSContiguousString.self
+    )._guts
   } else if _isObjCTaggedPointer(cocoaString) {
     return _StringGuts(_taggedCocoaObject: cocoaString)
   }


### PR DESCRIPTION
Compare directly against a handful of final classes, for modest wins.

A small step for https://bugs.swift.org/browse/SR-6823

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->