### PR TITLE
[SourceKit] Add regression test for a SourceKit crasher

### DIFF
--- a/test/SourceKit/CodeFormat/rdar_32789463.swift
+++ b/test/SourceKit/CodeFormat/rdar_32789463.swift
@@ -1,0 +1,16 @@
+struct $ {
+let $: <#Type#>
+= foo("foo \($) bar") {
+$
+
+// RUN: %sourcekitd-test -req=format -line=1 -length=1 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=2 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "struct $ {"
+// CHECK: key.sourcetext: "    let $: <#Type#>"
+// CHECK: key.sourcetext: "    = foo(\"foo \\($) bar\") {"
+// CHECK: key.sourcetext: "$"


### PR DESCRIPTION
Added regression test for rdar://problem/32789463
This crasher has already been fixed in 34e2aec662e36f0e7633bdb9c6e4b04198696ce5