### PR TITLE
[4.1] Associated type fixes for extraneous recursion, crashes, inference failure

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -557,18 +557,16 @@ NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
   if (known != TypeWitnesses.end())
     return known->second;
 
-  // If this conformance is in a state where it is inferring type witnesses,
-  // check tentative witnesses.
-  if (getState() == ProtocolConformanceState::CheckingTypeWitnesses) {
-    // If there is a tentative-type-witness function, use it.
-    if (options.getTentativeTypeWitness) {
-     if (Type witnessType =
-           Type(options.getTentativeTypeWitness(this, assocType)))
-       return { witnessType, nullptr };
-    }
+  // If there is a tentative-type-witness function, use it.
+  if (options.getTentativeTypeWitness) {
+   if (Type witnessType =
+         Type(options.getTentativeTypeWitness(this, assocType)))
+     return { witnessType, nullptr };
+  }
 
-    // Otherwise, we fail; this is the only case in which we can return a
-    // null type.
+  // If this conformance is in a state where it is inferring type witnesses but
+  // we didn't find anything, fail.
+  if (getState() == ProtocolConformanceState::CheckingTypeWitnesses) {
     return { Type(), nullptr };
   }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -530,8 +530,9 @@ bool NormalProtocolConformance::hasTypeWitness(AssociatedTypeDecl *assocType,
   if (Loader)
     resolveLazyInfo();
 
-  if (TypeWitnesses.find(assocType) != TypeWitnesses.end()) {
-    return true;
+  auto found = TypeWitnesses.find(assocType);
+  if (found != TypeWitnesses.end()) {
+    return !found->getSecond().first.isNull();
   }
   if (resolver) {
     PrettyStackTraceRequirement trace("resolving", this, assocType);
@@ -574,6 +575,9 @@ NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
   // Otherwise, resolve the type witness.
   PrettyStackTraceRequirement trace("resolving", this, assocType);
   assert(resolver && "Unable to resolve type witness");
+
+  // Block recursive resolution of this type witness.
+  TypeWitnesses[assocType] = { Type(), nullptr };
   resolver->resolveTypeWitness(this, assocType);
 
   known = TypeWitnesses.find(assocType);
@@ -586,7 +590,9 @@ void NormalProtocolConformance::setTypeWitness(AssociatedTypeDecl *assocType,
                                                TypeDecl *typeDecl) const {
   assert(getProtocol() == cast<ProtocolDecl>(assocType->getDeclContext()) &&
          "associated type in wrong protocol");
-  assert(TypeWitnesses.count(assocType) == 0 && "Type witness already known");
+  assert((TypeWitnesses.count(assocType) == 0 ||
+          TypeWitnesses[assocType].first.isNull()) &&
+         "Type witness already known");
   assert((!isComplete() || isInvalid()) && "Conformance already complete?");
   assert(!type->hasArchetype() && "type witnesses must be interface types");
   TypeWitnesses[assocType] = std::make_pair(type, typeDecl);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2656,8 +2656,12 @@ CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
   auto *depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                          assocType);
 
+  if (type->hasError())
+    return ErrorType::get(tc.Context);
+
   Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
                                               : type;
+
   if (auto superclass = genericSig->getSuperclassBound(depTy)) {
     if (!superclass->isExactSuperclassOf(contextType))
       return superclass;
@@ -2781,7 +2785,8 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
     [nonViable](NormalProtocolConformance *conformance) {
       auto &diags = conformance->getDeclContext()->getASTContext().Diags;
       for (auto candidate : nonViable) {
-        if (candidate.first->getDeclaredInterfaceType()->hasError())
+        if (candidate.first->getDeclaredInterfaceType()->hasError() ||
+            candidate.second.isError())
           continue;
 
         diags.diagnose(

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -78,7 +78,9 @@ public:
   bool isConformanceRequirement() const {
     return Requirement->isExistentialType();
   }
-
+  bool isError() const {
+    return Requirement->is<ErrorType>();
+  }
   explicit operator bool() const { return !Requirement.isNull(); }
 };
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -818,7 +818,7 @@ Type AssociatedTypeInference::computeDefaultTypeWitness(
 
   if (auto failed = checkTypeWitness(tc, dc, proto, assocType, defaultType)) {
     // Record the failure, if we haven't seen one already.
-    if (!failedDefaultedAssocType) {
+    if (!failedDefaultedAssocType && !failed.isError()) {
       failedDefaultedAssocType = defaultedAssocType;
       failedDefaultedWitness = defaultType;
       failedDefaultedResult = failed;
@@ -1680,6 +1680,9 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         diags.diagnose(assocType, diag::bad_associated_type_deduction,
                        assocType->getFullName(), proto->getFullName());
         for (const auto &failed : failedSet) {
+          if (failed.Result.isError())
+            continue;
+
           diags.diagnose(failed.Witness,
                          diag::associated_type_deduction_witness_failed,
                          failed.Requirement->getFullName(),

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 protocol Fooable {
-  associatedtype Foo
+  associatedtype Foo // expected-note{{protocol requires nested type 'Foo'; do you want to add it?}}
 
   var foo: Foo { get }
 }
@@ -148,7 +148,7 @@ rdar19137463(1)
 
 struct Brunch<U : Fooable> where U.Foo == X {}
 
-struct BadFooable : Fooable {
+struct BadFooable : Fooable { // expected-error{{type 'BadFooable' does not conform to protocol 'Fooable'}}
   typealias Foo = DoesNotExist // expected-error{{use of undeclared type 'DoesNotExist'}}
   var foo: Foo { while true {} }
 }

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -23,7 +23,7 @@ func hasAClosure() {
 }
 
 protocol Racoon {
-  associatedtype Stripes
+  associatedtype Stripes // expected-note{{protocol requires nested type 'Stripes'; do you want to add it?}}
 }
 
 // Types inside generic functions -- not supported yet
@@ -117,7 +117,7 @@ struct OuterGenericStruct<A> {
   }
 
   func middleFunction() {
-    struct ConformingType : Racoon {
+    struct ConformingType : Racoon { // expected-error{{type 'ConformingType' does not conform to protocol 'Racoon'}}
     // expected-error@-1 {{type 'ConformingType' cannot be nested in generic function 'middleFunction()'}}
       typealias Stripes = A
     }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -469,3 +469,19 @@ protocol P17 {
 protocol Q17 : P17 where T == Int { }
 
 struct S17 : Q17 { }
+
+// Typealiases from protocol extensions should not inhibit associated type
+// inference.
+protocol P18 {
+  associatedtype A
+}
+
+protocol P19 : P18 {
+  associatedtype B
+}
+
+extension P18 where Self: P19 {
+  typealias A = B
+}
+
+struct X18<A> : P18 { }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -485,3 +485,18 @@ extension P18 where Self: P19 {
 }
 
 struct X18<A> : P18 { }
+
+// rdar://problem/16316115
+protocol HasAssoc {
+  associatedtype Assoc
+}
+
+struct DefaultAssoc {}
+
+protocol RefinesAssocWithDefault: HasAssoc {
+  associatedtype Assoc = DefaultAssoc
+}
+
+struct Foo: RefinesAssocWithDefault {
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0138-rdar36453271.swift
+++ b/validation-test/compiler_crashers_2_fixed/0138-rdar36453271.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend %s -emit-ir -o 0
+
+extension Slice where Base == UnsafeBufferPointer<UInt16> {
+  var rebased: UnsafeBufferPointer<UInt16> {
+    return UnsafeBufferPointer(rebasing: self)
+  }
+}
+
+extension Slice where Base == UnsafeMutableBufferPointer<UInt16> {
+  var rebased: UnsafeMutableBufferPointer<UInt16> {
+    return UnsafeMutableBufferPointer(rebasing: self)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0140-sr6746.swift
+++ b/validation-test/compiler_crashers_2_fixed/0140-sr6746.swift
@@ -1,0 +1,8 @@
+// RUN: not %target-swift-frontend %s -typecheck
+struct Foo: Strideable {
+    // typealias Stride = Int
+    let x: Int
+
+    func distance(to other: Foo) -> Foo.Stride { return abs(other.x - x) }
+    func advanced(by n: Foo.Stride) -> Foo { return Foo(x: x + n) }
+}

--- a/validation-test/compiler_crashers_fixed/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
+++ b/validation-test/compiler_crashers_fixed/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{{}func a{}typealias e}struct A:P{typealias e:Self.a{}typealias e:Self.a{}typealias e:P

--- a/validation-test/compiler_crashers_fixed/28854-known-typewitnesses-end-didnt-resolve-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28854-known-typewitnesses-end-didnt-resolve-witness.swift
@@ -5,8 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 @objc protocol A
 {
 typealias a


### PR DESCRIPTION
• **Explanation**: Associated type inference regressed quite a bit in 4.1, crashing more often (particularly when dealing with recursive constraints as in the `Collection` protocols) and failing to infer in some cases where 4.0 successfully inferred associated types. This pull request addresses a number of these issues.
• **Scope of Issue**: Affects associated type inference is used whenever a conformance to a protocol with associated types is type-checked. We've seen a number of reports of regressions here.
• **Origination**: Recursive protocol conformances, conditional conformances, and the reshuffling of the standard library protocols uncovered existing problems with associated type inference.
• **Risk**: Low-ish risk; the change is breaking recursion that could go infinite, and allowing associated type inference to succeed in a few more cases, so it shouldn't cause more regressions.
• **Reviewed By**: @xedin  
• **Testing**: Compiler regression tests, including new tests for each of the bugs addressed, and building known-affected open-source projects (e.g., Bond).
• **Radar / SR**: [SR-6609](https://bugs.swift.org/browse/SR-6609) / rdar://problem/36038033, rdar://problem/36453271, rdar://problem/16316115, [SR-6746](https://bugs.swift.org/browse/SR-6746) / rdar://problem/36483751.