### PR TITLE
[build system] Prefer LLD if it exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ set(SWIFT_ENABLE_LLD_LINKER TRUE CACHE BOOL
 
 # Indicate whether Swift should attempt to use the gold linker.
 # This is not used on Darwin.
-set(SWIFT_ENABLE_GOLD_LINKER FALSE CACHE BOOL
+set(SWIFT_ENABLE_GOLD_LINKER TRUE CACHE BOOL
     "Enable using the gold linker when available")
 
 set(SWIFT_SDKS "" CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ set(CLANG_COMPILER_VERSION "" CACHE STRING
     "The internal version of the Clang compiler")
 
 # Indicate whether Swift should attempt to use the lld linker.
-set(SWIFT_ENABLE_LLD_LINKER FALSE CACHE BOOL
+set(SWIFT_ENABLE_LLD_LINKER TRUE CACHE BOOL
     "Enable using the lld linker when available")
 
 # Indicate whether Swift should attempt to use the gold linker.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -396,14 +396,14 @@ function(_add_variant_link_flags)
   endif()
 
   if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
-    if(SWIFT_ENABLE_GOLD_LINKER AND
-       "${SWIFT_SDK_${LFLAGS_SDK}_OBJECT_FORMAT}" STREQUAL "ELF")
-      list(APPEND result "-fuse-ld=gold")
-    endif()
-    if(SWIFT_ENABLE_LLD_LINKER OR
+    find_program(LDLLD_PATH "ld.lld")
+    if((SWIFT_ENABLE_LLD_LINKER AND LDLLD_PATH) OR
        ("${LFLAGS_SDK}" STREQUAL "WINDOWS" AND
         NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WINDOWS"))
       list(APPEND result "-fuse-ld=lld")
+    elseif(SWIFT_ENABLE_GOLD_LINKER AND
+       "${SWIFT_SDK_${LFLAGS_SDK}_OBJECT_FORMAT}" STREQUAL "ELF")
+      list(APPEND result "-fuse-ld=gold")
     endif()
   endif()
 

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -47,14 +47,14 @@ function(add_swift_unittest test_dirname)
       LINK_FLAGS " -latomic")
   endif()
 
-  if(SWIFT_ENABLE_GOLD_LINKER AND
+  find_program(LDLLD_PATH "ld.lld")
+  if(SWIFT_ENABLE_LLD_LINKER AND LDLLD_PATH)
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
+      LINK_FLAGS " -fuse-ld=lld")
+  elseif(SWIFT_ENABLE_GOLD_LINKER AND
      "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}" STREQUAL "ELF")
     set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
       LINK_FLAGS " -fuse-ld=gold")
-  endif()
-  if(SWIFT_ENABLE_LLD_LINKER)
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
-      LINK_FLAGS " -fuse-ld=lld")
   endif()
 
   if(SWIFT_ANALYZE_CODE_COVERAGE)

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -69,27 +69,11 @@
 #endif
 
 // TODO: support using shims headers in overlays by parameterizing
-// SWIFT_RUNTIME_EXPORT on the library it's exported from, then setting
-// protected vs. default based on the current value of __SWIFT_CURRENT_DYLIB.
+// SWIFT_RUNTIME_EXPORT on the library it's exported from.
 
 /// Attribute used to export symbols from the runtime.
-#if __MACH__
+#if defined(__MACH__) || defined(__ELF__)
 # define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
-#elif __ELF__
-
-// Use protected visibility for ELF, since we don't want Swift symbols to be
-// interposable. The relative relocations we form to metadata aren't
-// valid in ELF shared objects, and leaving them relocatable at load time
-// defeats the purpose of the relative references.
-//
-// Protected visibility on a declaration is interpreted to mean that the
-// symbol is defined in the current dynamic library, so if we're building
-// something else, we need to fall back on using default visibility.
-#ifdef __SWIFT_CURRENT_DYLIB
-# define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("protected")))
-#else
-# define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
-#endif
 
 #else  // FIXME: this #else should be some sort of #elif Windows
 # if defined(__CYGWIN__)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -411,7 +411,6 @@ function set_build_options_for_host() {
     SWIFT_HOST_VARIANT_SDK=
     SWIFT_HOST_VARIANT_ARCH=
     SWIFT_HOST_TRIPLE=
-    USE_GOLD_LINKER=
     local host="$1"
 
     # Hosts which can be cross-compiled must specify:
@@ -422,7 +421,6 @@ function set_build_options_for_host() {
             SWIFT_HOST_VARIANT="freebsd"
             SWIFT_HOST_VARIANT_SDK="FREEBSD"
             SWIFT_HOST_VARIANT_ARCH="x86_64"
-            USE_GOLD_LINKER=1
             ;;
         cygwin-x86_64)
             SWIFT_HOST_VARIANT="cygwin"
@@ -437,7 +435,6 @@ function set_build_options_for_host() {
         linux-*)
             SWIFT_HOST_VARIANT="linux"
             SWIFT_HOST_VARIANT_SDK="LINUX"
-            USE_GOLD_LINKER=1
             case ${host} in
                 linux-x86_64)
                     SWIFT_HOST_VARIANT_ARCH="x86_64"
@@ -1922,22 +1919,6 @@ for host in "${ALL_HOSTS[@]}"; do
 
         cmake_options=("${common_cmake_options_host[@]}")
 
-        # Add in gold linker support if requested.
-        if [[ "${USE_GOLD_LINKER}" ]]; then
-            echo "${product}: using gold linker"
-            if [[ "${product}" != "swift" ]]; then
-                # All other projects override the linker flags to add in
-                # gold linker support.
-                cmake_options=(
-                    "${cmake_options[@]}"
-                    -DCMAKE_EXE_LINKER_FLAGS:STRING="-fuse-ld=gold"
-                    -DCMAKE_SHARED_LINKER_FLAGS:STRING="-fuse-ld=gold"
-                )
-            fi
-        else
-            echo "${product}: using standard linker"
-        fi
-
         llvm_build_dir=$(build_directory ${host} llvm)
         module_cache="${build_dir}/module-cache"
 
@@ -2034,17 +2015,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
 
             swift)
-
-                if [[ "${USE_GOLD_LINKER}" ]]; then
-                    # Swift will selectively use the gold linker on all
-                    # parts except building the standard library.  We
-                    # let the Swift cmake setup figure out how to apply
-                    # that.
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DSWIFT_ENABLE_GOLD_LINKER=TRUE
-                    )
-                fi
 
                 if [[ ! "${SKIP_BUILD_ANDROID}" ]]; then
                     cmake_options=(
@@ -2443,10 +2413,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
                     LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
                     LIBDISPATCH_BUILD_ARGS="-DLIBDISPATCH_SOURCE_DIR=${LIBDISPATCH_SOURCE_DIR} -DLIBDISPATCH_BUILD_DIR=${LIBDISPATCH_BUILD_DIR}"
-                fi
-
-                if [[ "${USE_GOLD_LINKER}" ]]; then
-                    SWIFT_USE_LINKER="-fuse-ld=gold"
                 fi
 
                 # FIXME CROSSCOMPILING:


### PR DESCRIPTION
Other changes:
1) Minimize unified versus build-script build differences.
2) Stop trying to make runtime variables have "protected" visibility. This combination is meaningless and lld rightly complains.

Finally, this blog post is worth reading:
http://www.airs.com/blog/archives/307