### PR TITLE
cast optimizer: don't create a critical edge where it's not allowed

### DIFF
--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1457,8 +1457,10 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
     } else if (isConditional) {
       SILBasicBlock *CastSuccessBB = Inst->getFunction()->createBasicBlock();
       CastSuccessBB->createPHIArgument(SILBridgedTy, ValueOwnershipKind::Owned);
-      NewI = Builder.createCheckedCastBranch(Loc, false, Load, SILBridgedTy,
-                                             CastSuccessBB, ConvFailBB);
+      auto *CCBI = Builder.createCheckedCastBranch(Loc, false, Load,
+                                      SILBridgedTy, CastSuccessBB, ConvFailBB);
+      NewI = CCBI;
+      splitEdge(CCBI, /* EdgeIdx to ConvFailBB */ 1);
       Builder.setInsertionPoint(CastSuccessBB);
       SrcOp = CastSuccessBB->getArgument(0);
     } else {

--- a/test/SILOptimizer/bridged_casts_crash.sil
+++ b/test/SILOptimizer/bridged_casts_crash.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -performance-constant-propagation %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import Foundation
+
+class TestObjCKeyTy : NSObject {
+  override init()
+}
+struct TestBridgedKeyTy : _ObjectiveCBridgeable {
+  func _bridgeToObjectiveC() -> TestObjCKeyTy
+  static func _forceBridgeFromObjectiveC(_ x: TestObjCKeyTy, result: inout TestBridgedKeyTy?)
+  static func _conditionallyBridgeFromObjectiveC(_ x: TestObjCKeyTy, result: inout TestBridgedKeyTy?) -> Bool
+  static func _unconditionallyBridgeFromObjectiveC(_ source: TestObjCKeyTy?) -> TestBridgedKeyTy
+}
+
+// Test that we don't crash in the verifier because of a critical edge
+
+// CHECK-LABEL: testit
+// CHECK: checked_cast_br
+sil @testit : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %73 = alloc_stack $NSObject
+  store %0 to %73 : $*NSObject
+  %75 = alloc_stack $Optional<TestBridgedKeyTy>
+  %76 = init_enum_data_addr %75 : $*Optional<TestBridgedKeyTy>, #Optional.some!enumelt.1
+  %77 = load %73 : $*NSObject
+  checked_cast_addr_br take_always NSObject in %73 : $*NSObject to TestBridgedKeyTy in %76 : $*TestBridgedKeyTy, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  dealloc_stack %75 : $*Optional<TestBridgedKeyTy>
+  dealloc_stack %73 : $*NSObject
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-6773
rdar://problem/36602263

