### PR TITLE
Sema: validate class layout when validating an extension

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -8297,6 +8297,8 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   // Validate the nominal type declaration being extended.
   auto nominal = extendedType->getAnyNominal();
   validateDecl(nominal);
+  if (auto *classDecl = dyn_cast<ClassDecl>(nominal))
+    requestNominalLayout(classDecl);
 
   if (nominal->getGenericParamsOfContext()) {
     auto genericParams = ext->getGenericParams();


### PR DESCRIPTION
rdar://problem/36704036

This reverts a change done in 9b7f3f73d2c8368c5db0ba0f978ad960c39e9970, in a rare case, shown in rdar://problem/36704036, When doing emitVirtualMethodValue in IRGen we can miss the correct offset because we have a bad ClassDecl, The ClassDecl is junk / null because of the before mentioned commit.

The radar contains a sample ClassDecl and IR that shows the problem, unfortunately, I am unable to create a small test-case the reproduces this issue: the layout is wrong only in a single method call in a large project. Reducing the project to something of a reasonable size / removing most of the code “hides” the problem.

Basically, if we look at the ClassDecl, we see that the type for some vars is null type (v.s. the correct type), the interface type is missing and we are missing a few accessor_decl  and parameter_list