### PR TITLE
[sil][typelowering] Inline (i.e. eliminate) the confusing method Type…

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -272,14 +272,6 @@ public:
                             ///> types.
   };
 
-  /// Given the result of the expansion heuristic,
-  /// return appropriate lowering style.
-  static TypeExpansionKind getLoweringStyle(bool shouldExpand) {
-    if (shouldExpand)
-      return TypeLowering::TypeExpansionKind::MostDerivedDescendents;
-    return TypeLowering::TypeExpansionKind::DirectChildren;
-  }
-
   //===--------------------------------------------------------------------===//
   // DestroyValue
   //===--------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -350,8 +350,10 @@ static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
 
   bool expand = shouldExpand(DAI->getModule(),
                              DAI->getOperand()->getType().getObjectType());
-  TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue,
-                             Lowering::TypeLowering::getLoweringStyle(expand));
+  using TypeExpansionKind = Lowering::TypeLowering::TypeExpansionKind;
+  auto expansionKind = expand ? TypeExpansionKind::MostDerivedDescendents
+                              : TypeExpansionKind::None;
+  TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue, expansionKind);
   DAI->eraseFromParent();
 }
 

--- a/test/Executable/Inputs/arc_36509461.h
+++ b/test/Executable/Inputs/arc_36509461.h
@@ -1,0 +1,11 @@
+
+#ifndef DEMOHEADER_H
+#define DEMOHEADER_H
+
+#include <stdbool.h>
+
+typedef bool (^fake_apply_t)(const char *key, id value);
+
+bool fake_apply(id obj, fake_apply_t applier);
+
+#endif

--- a/test/Executable/Inputs/arc_36509461.m
+++ b/test/Executable/Inputs/arc_36509461.m
@@ -1,0 +1,6 @@
+
+#import "arc_36509461.h"
+
+bool fake_apply(id obj, fake_apply_t applier) {
+  return false;
+}

--- a/test/Executable/arc_36509461.swift
+++ b/test/Executable/arc_36509461.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%T)
+// RUN: %target-clang -x objective-c -c %S/Inputs/arc_36509461.m  -o %T/arc_36509461.m.o
+// RUN: %target-swift-frontend -c -O -import-objc-header %S/Inputs/arc_36509461.h -sanitize=address %s -o %T/arc_36509461.swift.o
+// RUN: %target-build-swift %T/arc_36509461.m.o %T/arc_36509461.swift.o -sanitize=address -o %t
+// RUN: %t
+
+// REQUIRES: executable_test
+// REQUIRES: asan_runtime
+// REQUIRES: objc_interop
+
+import Foundation
+
+struct FakeUUID {
+  var bigTuple: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+
+  init() {
+    bigTuple = (0, 0, 0, 0, 0, 0, 0, 0)
+  }
+}
+
+struct Record {
+  let name: String
+  let uuid: FakeUUID
+  let storage: NSObject
+
+  init(storage: NSObject, name: String, uuid: FakeUUID) {
+     self.name = name
+     self.uuid = uuid
+     self.storage = storage
+  }
+
+  func copy() -> Record {
+    let copiedNSObject = NSObject()
+        
+    fake_apply(self.storage) { (key, value) -> Bool in
+      let x = copiedNSObject
+      return true
+    }
+
+    var record = Record(storage: copiedNSObject, name: self.name, uuid: self.uuid)
+    return record
+  }
+}
+
+@inline(never)
+func foo(record: Record) -> Record {
+  return record.copy()
+}
+
+func main() {
+     let record = Record(storage: NSObject(), name: "", uuid: FakeUUID())
+     _ = foo(record: record)
+}
+
+main()

--- a/test/SILOptimizer/loweraggregateinstrs.sil
+++ b/test/SILOptimizer/loweraggregateinstrs.sil
@@ -1,4 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-expand-all %s -lower-aggregate-instrs | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -lower-aggregate-instrs | %FileCheck %s
+
+// This file makes sure that given the current code-size metric we properly
+// expand operations for small structs and not for large structs in a consistent
+// way for all operations we expand.
 
 sil_stage canonical
 
@@ -40,491 +44,83 @@ enum E {
   case TupleNonTrivialElt((Builtin.Int64, S, C3))
 }
 
-// A struct for testing that aggregate rebuilding works.
-struct S3 {
+// This struct is larger than our current code-size limit (> 6 leaf nodes).
+struct LargeStruct {
   var trivial1 : Builtin.Int64
   var cls : S
   var trivial2 : Builtin.Int64
-  var e : E
   var trivial3 : Builtin.Int64
 }
 
-//////////////////
-// Destroy Addr //
-//////////////////
+///////////
+// Tests //
+///////////
 
-// CHECK-LABEL: sil @expand_destroy_addr_trivial
-// CHECK: bb0
-// CHECK: tuple ()
-// CHECK: return
-sil @expand_destroy_addr_trivial : $@convention(thin) (@inout Builtin.Int64) -> () {
-bb0(%0 : $*Builtin.Int64):
-  destroy_addr %0 : $*Builtin.Int64
-  %1 = tuple()
-  return %1 : $()
+// This test makes sure that we /do not/ expand retain_value, release_value and
+// promote copy_addr/destroy_value to non-expanded retain_value, release_value.
+// CHECK-LABEL: sil @large_struct_test : $@convention(thin) (@owned LargeStruct, @in LargeStruct) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $LargeStruct, [[ARG1:%.*]] : $*LargeStruct):
+// CHECK:   retain_value [[ARG0]]
+// CHECK:   release_value [[ARG0]]
+// CHECK:   [[ALLOC_STACK:%.*]] = alloc_stack $LargeStruct
+// CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
+// CHECK:   [[LOADED_OLD_VAL:%.*]] = load [[ALLOC_STACK]]
+// CHECK:   retain_value [[LOADED_ARG1]]
+// CHECK:   release_value [[LOADED_OLD_VAL]]
+// CHECK:   store [[LOADED_ARG1]] to [[ALLOC_STACK]]
+// CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
+// CHECK:   release_value [[LOADED_ARG1]]
+// CHECK:   dealloc_stack [[ALLOC_STACK]]
+// CHECK: } // end sil function 'large_struct_test'
+sil @large_struct_test : $@convention(thin) (@owned LargeStruct, @in LargeStruct) -> () {
+bb0(%0 : $LargeStruct, %1 : $*LargeStruct):
+  retain_value %0 : $LargeStruct
+  release_value %0 : $LargeStruct
+  %2 = alloc_stack $LargeStruct
+  copy_addr %1 to %2 : $*LargeStruct
+  destroy_addr %1 : $*LargeStruct
+  dealloc_stack %2 : $*LargeStruct
+  %9999 = tuple()
+  return %9999 : $()
 }
 
-// CHECK-LABEL: sil @expand_destroy_addr_aggstructnontrivial
-// CHECK: bb0([[INPTR:%[0-9]+]] : $*S):
-// CHECK: [[IN:%[0-9]+]] = load [[INPTR]] : $*S
-// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN]] : $S, #S.cls
-// CHECK: strong_release [[cls]] : $C3
-// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN]] : $S, #S.inner_struct
-// CHECK: [[innerstruct_cls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[innerstruct_cls1]] : $C1
-// CHECK: [[innerstruct_cls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[innerstruct_cls2]] : $C2
-// CHECK: tuple
-// CHECK: return
-sil @expand_destroy_addr_aggstructnontrivial : $@convention(thin) (@inout S) -> () {
-bb0(%0 : $*S):
-  destroy_addr %0 : $*S
-  %1 = tuple()
-  return %1 : $()
+// CHECK-LABEL: sil @small_struct_test : $@convention(thin) (@owned S2, @in S2) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $S2, [[ARG1:%.*]] : $*S2):
+// CHECK:   [[ARG0cls1:%.*]] = struct_extract [[ARG0]] : $S2, #S2.cls1
+// CHECK:   strong_retain [[ARG0cls1]] : $C1
+// CHECK:   [[ARG0cls2:%.*]] = struct_extract [[ARG0]] : $S2, #S2.cls2
+// CHECK:   strong_retain [[ARG0cls2]] : $C2
+// CHECK:   [[ARG0cls1:%.*]] = struct_extract [[ARG0]] : $S2, #S2.cls1
+// CHECK:   strong_release [[ARG0cls1]] : $C1
+// CHECK:   [[ARG0cls2:%.*]] = struct_extract [[ARG0]] : $S2, #S2.cls2
+// CHECK:   strong_release [[ARG0cls2]] : $C2
+//
+// CHECK:   [[ALLOC_STACK:%.*]] = alloc_stack $S2
+// CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
+// CHECK:   [[LOADED_OLDVALUE:%.*]] = load [[ALLOC_STACK]]
+// CHECK:   [[LOADED_ARG1cls1:%.*]] = struct_extract [[LOADED_ARG1]] : $S2, #S2.cls1
+// CHECK:   strong_retain [[LOADED_ARG1cls1]] : $C1
+// CHECK:   [[LOADED_ARG1cls2:%.*]] = struct_extract [[LOADED_ARG1]] : $S2, #S2.cls2
+// CHECK:   strong_retain [[LOADED_ARG1cls2]] : $C2
+// CHECK:   [[LOADED_OLDVALUEcls1:%.*]] = struct_extract [[LOADED_OLDVALUE]] : $S2, #S2.cls1
+// CHECK:   strong_release [[LOADED_OLDVALUEcls1]] : $C1
+// CHECK:   [[LOADED_OLDVALUEcls2:%.*]] = struct_extract [[LOADED_OLDVALUE]] : $S2, #S2.cls2
+// CHECK:   strong_release [[LOADED_OLDVALUEcls2]] : $C2
+//
+// CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
+// CHECK:   [[LOADED_ARG1cls1:%.*]] = struct_extract [[LOADED_ARG1]] : $S2, #S2.cls1
+// CHECK:   strong_release [[LOADED_ARG1cls1]] : $C1
+// CHECK:   [[LOADED_ARG1cls2:%.*]] = struct_extract [[LOADED_ARG1]] : $S2, #S2.cls2
+// CHECK:   strong_release [[LOADED_ARG1cls2]] : $C2
+// CHECK: } // end sil function 'small_struct_test'
+sil @small_struct_test : $@convention(thin) (@owned S2, @in S2) -> () {
+bb0(%0 : $S2, %1 : $*S2):
+  retain_value %0 : $S2
+  release_value %0 : $S2
+  %2 = alloc_stack $S2
+  copy_addr %1 to %2 : $*S2
+  destroy_addr %1 : $*S2
+  dealloc_stack %2 : $*S2
+  %9999 = tuple()
+  return %9999 : $()
 }
-
-// CHECK-LABEL: sil @expand_destroy_addr_aggtuplenontrivial
-// CHECK: bb0([[INPTR:%[0-9]+]] : $*(S, S2, C1)):
-// CHECK: [[IN:%[0-9]+]] = load [[INPTR]] : $*(S, S2, C1)
-// CHECK: [[ELT0:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1), 0
-// CHECK: [[ELT0cls:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.cls
-// CHECK: strong_release [[ELT0cls]] : $C3
-// CHECK: [[ELT0innerstruct:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.inner_struct
-// CHECK: [[ELT0innerstructcls1:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[ELT0innerstructcls1]] : $C1
-// CHECK: [[ELT0innerstructcls2:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[ELT0innerstructcls2]]
-// CHECK: [[ELT1:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1), 1
-// CHECK: [[ELT1cls1:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls1
-// CHECK: strong_release [[ELT1cls1]] : $C1
-// CHECK: [[ELT1cls2:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls2
-// CHECK: strong_release [[ELT1cls2]] : $C2
-// CHECK: [[ELT2:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1), 2
-// CHECK: strong_release [[ELT2]]
-// CHECK: tuple ()
-// CHECK: return
-sil @expand_destroy_addr_aggtuplenontrivial : $@convention(thin) (@inout (S, S2, C1)) -> () {
-bb0(%0 : $*(S, S2, C1)):
-  destroy_addr %0 : $*(S, S2, C1)
-  %1 = tuple()
-  return %1 : $()
-}
-
-// Do not do anything.
-/*
-sil @expand_destroy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
-bb0(%0 : $*T):
-  destroy_addr %0 : $*T
-  %1 = tuple()
-  return %1 : $()
-}
-*/
-
-// CHECK-LABEL: sil @expand_destroy_addr_reference
-// CHECK: bb0
-// CHECK: load
-// CHECK: strong_release
-// CHECK: tuple
-// CHECK: return
-sil @expand_destroy_addr_reference : $@convention(thin) (@inout C1) -> () {
-bb0(%0 : $*C1):
-  destroy_addr %0 : $*C1
-  %1 = tuple()
-  return %1 : $()
-}
-
-// CHECK-LABEL: sil @expand_destroy_addr_enum
-// CHECK: bb0
-// CHECK: load
-// CHECK: release_value
-// CHECK: tuple
-// CHECK: return
-sil @expand_destroy_addr_enum : $@convention(thin) (@inout E) -> () {
-bb0(%0 : $*E):
-  destroy_addr %0 : $*E
-  %1 = tuple()
-  return %1 : $()
-}
-
-///////////////
-// Copy Addr //
-///////////////
-
-// CHECK-LABEL: sil @expand_copy_addr_takeinit
-// CHECK: bb0([[IN1:%[0-9]+]] : $*S, [[IN2:%[0-9]+]] : $*S):
-// CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*S
-// CHECK: store [[LOAD1]] to [[IN2]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_takeinit : $@convention(thin) (@inout S, @inout S) -> () {
-bb0(%0 : $*S, %1 : $*S):
-  copy_addr [take] %0 to [initialization] %1 : $*S
-  %2 = tuple()
-  return %2 : $()
-}
-
-// CHECK-LABEL: sil @expand_copy_addr_init
-// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
-// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
-// CHECK: [[IN1trivial:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.trivial
-// CHECK: [[IN1cls:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.cls
-// CHECK: strong_retain [[IN1cls]] : $C3
-// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.inner_struct
-// CHECK: [[innerstructIN11:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_retain [[innerstructIN11]] : $C1
-// CHECK: [[innerstructIN12:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_retain [[innerstructIN12]] : $C2
-// CHECK: [[innerstructtrivial:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.trivial
-// CHECK: store [[IN1]] to [[IN2PTR]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_init : $@convention(thin) (@inout S, @inout S) -> () {
-bb0(%0 : $*S, %1 : $*S):
-  copy_addr %0 to [initialization] %1 : $*S
-  %2 = tuple()
-  return %2 : $()
-}
-
-// CHECK-LABEL: sil @expand_copy_addr_take
-// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
-// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
-// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*S
-// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.cls
-// CHECK: strong_release [[cls]] : $C3
-// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.inner_struct
-// CHECK: [[innerstructcls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[innerstructcls1]] : $C1
-// CHECK: [[innerstructcls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[innerstructcls2]]
-// CHECK: store [[IN1]] to [[IN2PTR]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_take : $@convention(thin) (@inout S, @inout S) -> () {
-bb0(%0 : $*S, %1 : $*S):
-  copy_addr [take] %0 to %1 : $*S
-  %2 = tuple()
-  return %2 : $()
-}
-
-// Test expansions for various types (these will become more
-// interesting when I introduce the actual chopping work).
-
-// CHECK-LABEL: sil @expand_copy_addr_trivial
-// CHECK: bb0
-// CHECK: load
-// CHECK: store
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_trivial : $@convention(thin) (@inout Builtin.Int64, @inout Builtin.Int64) -> () {
-bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
-  copy_addr %0 to %1 : $*Builtin.Int64
-  %2 = tuple()
-  return %2 : $()
-}
-
-// CHECK-LABEL: sil @expand_copy_addr_aggstructnontrivial
-// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
-// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
-// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*S
-// CHECK: [[IN1trivial:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.trivial
-// CHECK: [[IN1cls:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.cls
-// CHECK: strong_retain [[IN1cls]] : $C3
-// CHECK: [[IN1innerstruct:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.inner_struct
-// CHECK: [[IN1innerstructcls1:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_retain [[IN1innerstructcls1]] : $C1
-// CHECK: [[IN1innerstructcls2:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_retain [[IN1innerstructcls2]] : $C2
-// CHECK: [[IN1innerstructtrivial:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.trivial
-// CHECK: [[IN2cls:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.cls
-// CHECK: strong_release [[IN2cls]] : $C3
-// CHECK: [[IN2innerstruct:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.inner_struct
-// CHECK: [[IN2innerstructcls1:%[0-9]+]] = struct_extract [[IN2innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[IN2innerstructcls1]] : $C1
-// CHECK: [[IN2innerstructcls2:%[0-9]+]] = struct_extract [[IN2innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[IN2innerstructcls2]]
-// CHECK: store [[IN1]] to [[IN2PTR]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_aggstructnontrivial : $@convention(thin) (@inout S, @inout S) -> () {
-bb0(%0 : $*S, %1 : $*S):
-  copy_addr %0 to %1 : $*S
-  %2 = tuple()
-  return %2 : $()
-}
-
-// CHECK-LABEL: sil @expand_copy_addr_aggtuplenontrivial
-// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*(S, S2, C1, E), [[IN2PTR:%[0-9]+]] : $*(S, S2, C1, E)):
-// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*(S, S2, C1, E)
-// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*(S, S2, C1, E)
-// CHECK: [[IN1ELT0:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 0
-// CHECK: [[IN1ELT0trivial:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.trivial
-// CHECK: [[IN1ELT0cls:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.cls
-// CHECK: strong_retain [[IN1ELT0cls]] : $C3
-// CHECK: [[IN1ELT0innerstruct:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.inner_struct
-// CHECK: [[IN1ELT0innerstructcls1:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_retain [[IN1ELT0innerstructcls1]] : $C1
-// CHECK: [[IN1ELT0innerstructcls2:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_retain [[IN1ELT0innerstructcls2]]
-// CHECK: [[IN1ELT0innerstructtrivial:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.trivial
-// CHECK: [[IN1ELT1:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 1
-// CHECK: [[IN1ELT1cls1:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.cls1
-// CHECK: strong_retain [[IN1ELT1cls1]] : $C1
-// CHECK: [[IN1ELT1cls2:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.cls2
-// CHECK: strong_retain [[IN1ELT1cls2]] : $C2
-// CHECK: [[IN1ELT1trivial:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.trivial
-// CHECK: [[IN1ELT2:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 2
-// CHECK: strong_retain [[IN1ELT2]]
-// CHECK: [[IN1ELT3:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 3
-// CHECK: retain_value [[IN1ELT3]] : $E
-// CHECK: [[IN2ELT0:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 0
-// CHECK: [[IN2ELT0cls:%[0-9]+]] = struct_extract [[IN2ELT0]] : $S, #S.cls
-// CHECK: strong_release [[IN2ELT0cls]] : $C3
-// CHECK: [[IN2ELT0innerstruct:%[0-9]+]] = struct_extract [[IN2ELT0]] : $S, #S.inner_struct
-// CHECK: [[IN2ELT0innerstructcls1:%[0-9]+]] = struct_extract [[IN2ELT0innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[IN2ELT0innerstructcls1]] : $C1
-// CHECK: [[IN2ELT0innerstructcls2:%[0-9]+]] = struct_extract [[IN2ELT0innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[IN2ELT0innerstructcls2]]
-// CHECK: [[IN2ELT1:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 1
-// CHECK: [[IN2ELT1cls1:%[0-9]+]] = struct_extract [[IN2ELT1]] : $S2, #S2.cls1
-// CHECK: strong_release [[IN2ELT1cls1]] : $C1
-// CHECK: [[IN2ELT1cls2:%[0-9]+]] = struct_extract [[IN2ELT1]] : $S2, #S2.cls2
-// CHECK: strong_release [[IN2ELT1cls2]] : $C2
-// CHECK: [[IN2ELT2:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 2
-// CHECK: strong_release [[IN2ELT2]]
-// CHECK: [[IN2ELT3:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 3
-// CHECK: release_value [[IN2ELT3]] : $E
-// CHECK: store [[IN1]] to [[IN2PTR]] : $*(S, S2, C1, E)
-// CHECK: tuple ()
-// CHECK: return
-
-
-sil @expand_copy_addr_aggtuplenontrivial : $@convention(thin) (@inout (S, S2, C1, E), @inout (S, S2, C1, E)) -> () {
-bb0(%0 : $*(S, S2, C1, E), %1 : $*(S, S2, C1, E)):
-  copy_addr %0 to %1 : $*(S, S2, C1, E)
-  %2 = tuple()
-  return %2 : $()
-}
-
-// Do not do anything.
-/*
-sil @expand_copy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
-bb0(%0 : $*T):
-  copy_addr %0 : $*T
-  %1 = tuple()
-  return %1 : $()
-}
-*/
-
-// Just turn into a load + strong_release.
-// CHECK-LABEL: sil @expand_copy_addr_reference
-// CHECK: bb0([[IN1:%[0-9]+]] : $*C1, [[IN2:%[0-9]+]] : $*C1):
-// CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*C1
-// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*C1
-// CHECK: strong_retain [[LOAD1]]
-// CHECK: strong_release [[LOAD2]]
-// CHECK: store [[LOAD1]] to [[IN2]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_reference : $@convention(thin) (@inout C1, @inout C1) -> () {
-bb0(%0 : $*C1, %1 : $*C1):
-  copy_addr %0 to %1 : $*C1
-  %2 = tuple()
-  return %2 : $()
-}
-
-// CHECK-LABEL: sil @expand_copy_addr_enum
-// CHECK: bb0([[IN1:%[0-9]+]] : $*E, [[IN2:%[0-9]+]] : $*E):
-// CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*E
-// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*E
-// CHECK: retain_value [[LOAD1]]
-// CHECK: release_value [[LOAD2]]
-// CHECK: store [[LOAD1]] to [[IN2]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_copy_addr_enum : $@convention(thin) (@inout E, @inout E) -> () {
-bb0(%0 : $*E, %1 : $*E):
-  copy_addr %0 to %1 : $*E
-  %2 = tuple()
-  return %2 : $()
-}
-
-///////////////////
-// Destroy Value //
-///////////////////
-
-// Test expansions for various types (these will become more
-// interesting when I introduce the actual chopping work).
-
-// CHECK-LABEL: sil @expand_release_value_trivial
-// CHECK: bb0
-// CHECK: tuple
-// CHECK: return
-sil @expand_release_value_trivial : $@convention(thin) (Builtin.Int64) -> () {
-bb0(%0 : $Builtin.Int64):
-  release_value %0 : $Builtin.Int64
-  %1 = tuple()
-  return %1 : $()
-}
-
-// CHECK-LABEL: sil @expand_release_value_aggstructnontrivial
-// CHECK: bb0([[IN:%[0-9]+]] : $S):
-// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN]] : $S, #S.cls
-// CHECK: strong_release [[cls]] : $C3
-// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN]] : $S, #S.inner_struct
-// CHECK: [[innerstructcls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[innerstructcls1]] : $C1
-// CHECK: [[innerstructcls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[innerstructcls2]]
-sil @expand_release_value_aggstructnontrivial : $@convention(thin) (S) -> () {
-bb0(%0 : $S):
-  release_value %0 : $S
-  %1 = tuple()
-  return %1 : $()
-}
-
-// CHECK-LABEL: sil @expand_release_value_aggtuplenontrivial
-// CHECK: bb0([[IN:%[0-9]+]] : $(S, S2, C1, E)):
-// CHECK: [[ELT0:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 0
-// CHECK: [[ELT0cls:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.cls
-// CHECK: strong_release [[ELT0cls]] : $C3
-// CHECK: [[ELT0innerstruct:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.inner_struct
-// CHECK: [[ELT0innerstructcls1:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_release [[ELT0innerstructcls1]] : $C1
-// CHECK: [[ELT0innerstructcls2:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_release [[ELT0innerstructcls2]]
-// CHECK: [[ELT1:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 1
-// CHECK: [[ELT1cls1:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls1
-// CHECK: strong_release [[ELT1cls1]] : $C1
-// CHECK: [[ELT1cls2:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls2
-// CHECK: strong_release [[ELT1cls2]] : $C2
-// CHECK: [[ELT2:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 2
-// CHECK: strong_release [[ELT2]]
-// CHECK: [[ELT3:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 3
-// CHECK: release_value [[ELT3]] : $E
-// CHECK: tuple ()
-// CHECK: return
-sil @expand_release_value_aggtuplenontrivial : $@convention(thin) ((S, S2, C1, E)) -> () {
-bb0(%0 : $(S, S2, C1, E)):
-  release_value %0 : $(S, S2, C1, E)
-  %1 = tuple()
-  return %1 : $()
-}
-
-// Just turn into a load + strong_release.
-// CHECK-LABEL: sil @expand_release_value_reference
-// CHECK: bb0([[IN:%[0-9]+]] : $C1):
-// CHECK: strong_release [[IN]]
-// CHECK: tuple
-// CHECK: return
-sil @expand_release_value_reference : $@convention(thin) (C1) -> () {
-bb0(%0 : $C1):
-  release_value %0 : $C1
-  %1 = tuple()
-  return %1 : $()
-}
-
-// CHECK-LABEL: sil @expand_release_value_enum
-// CHECK: bb0([[IN1:%[0-9]+]] : $E):
-// CHECK: release_value
-// CHECK: tuple ()
-// CHECK: return
-sil @expand_release_value_enum : $@convention(thin) (E) -> () {
-bb0(%0 : $E):
-  release_value %0 : $E
-  %1 = tuple()
-  return %1 : $()
-}
-
-
-////////////////
-// Copy Value //
-////////////////
-
-// Test expansions for various types (these will become more
-// interesting when I introduce the actual chopping work).
-
-// CHECK-LABEL: sil @expand_retain_value_trivial
-// CHECK: bb0
-// CHECK: return
-sil @expand_retain_value_trivial : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
-bb0(%0 : $Builtin.Int64):
-  retain_value %0 : $Builtin.Int64
-  return %0 : $Builtin.Int64
-}
-
-// CHECK-LABEL: sil @expand_retain_value_aggstructnontrivial
-// CHECK: bb0([[IN:%[0-9]+]] : $S3):
-// CHECK: [[trivial:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.trivial1
-// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.cls
-// CHECK: [[clstrivial:%[0-9]+]] = struct_extract [[cls]] : $S, #S.trivial
-// CHECK: [[clscls:%[0-9]+]] = struct_extract [[cls]] : $S, #S.cls
-// CHECK: strong_retain [[clscls]] : $C3
-// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[cls]] : $S, #S.inner_struct
-// CHECK: [[innerstructcls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_retain [[innerstructcls1]] : $C1
-// CHECK: [[innerstructcls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_retain [[innerstructcls2]] : $C2
-// CHECK: [[innerstructtrivial:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.trivial
-// CHECK: [[trivial2:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.trivial2
-// CHECK: [[enum:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.e
-// CHECK: retain_value [[enum]] : $E
-// CHECK: [[trivial3:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.trivial3
-// CHECK: return [[IN]] : $S3
-sil @expand_retain_value_aggstructnontrivial : $@convention(thin) (S3) -> (S3) {
-bb0(%0 : $S3):
-  retain_value %0 : $S3
-  return %0 : $S3
-}
-
-// CHECK-LABEL: sil @expand_retain_value_aggtuplenontrivial
-// CHECK: bb0([[IN:%[0-9]+]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)):
-// CHECK: [[ELT0:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 0
-// CHECK: [[ELT0trivial:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.trivial
-// CHECK: [[ELT0cls:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.cls
-// CHECK: strong_retain [[ELT0cls]] : $C3
-// CHECK: [[ELT0innerstruct:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.inner_struct
-// CHECK: [[ELT0innerstructcls1:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls1
-// CHECK: strong_retain [[ELT0innerstructcls1]] : $C1
-// CHECK: [[ELT0innerstructcls2:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls2
-// CHECK: strong_retain [[ELT0innerstructcls2]]
-// CHECK: [[ELT0innerstructtrivial:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.trivial
-// CHECK: [[ELT1:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 1
-// CHECK: [[ELT2:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 2
-// CHECK: [[ELT2cls1:%[0-9]+]] = struct_extract [[ELT2]] : $S2, #S2.cls1
-// CHECK: strong_retain [[ELT2cls1]] : $C1
-// CHECK: [[ELT2cls2:%[0-9]+]] = struct_extract [[ELT2]] : $S2, #S2.cls2
-// CHECK: strong_retain [[ELT2cls2]] : $C2
-// CHECK: [[ELT2trivial:%[0-9]+]] = struct_extract [[ELT2]] : $S2, #S2.trivial
-// CHECK: [[ELT3:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 3
-// CHECK: strong_retain [[ELT3]]
-// CHECK: [[ELT4:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 4
-// CHECK: [[ELT5:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 5
-// CHECK: retain_value [[ELT5]] : $E
-// CHECK: return [[IN]]
-
-sil @expand_retain_value_aggtuplenontrivial : $@convention(thin) ((S, Builtin.Int64, S2, C1, Builtin.Int64, E)) -> ((S, Builtin.Int64, S2, C1, Builtin.Int64, E)) {
-bb0(%0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)):
-  retain_value %0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)
-  return %0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)
-}
-
-// CHECK-LABEL: sil @expand_retain_value_reference
-// CHECK: bb0([[IN:%[0-9]+]] : $C1):
-// CHECK: strong_retain [[IN]]
-// CHECK: return
-sil @expand_retain_value_reference : $@convention(thin) (C1) -> (C1) {
-bb0(%0 : $C1):
-  retain_value %0 : $C1
-  return %0 : $C1
-}
-
-// CHECK-LABEL: sil @expand_retain_value_enum
-// CHECK: bb0([[IN1:%[0-9]+]] : $E):
-// CHECK: retain_value
-// CHECK: return
-sil @expand_retain_value_enum : $@convention(thin) (E) -> (E) {
-bb0(%0 : $E):
-  retain_value %0 : $E
-  return %0 : $E
-}
-

--- a/test/SILOptimizer/loweraggregateinstrs_expandall.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_expandall.sil
@@ -1,0 +1,534 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -enable-expand-all %s -lower-aggregate-instrs | %FileCheck %s
+
+// This file makes sure that the mechanics of expanding aggregate instructions
+// work. With that in mind, we expand all structs here ignoring code-size
+// trade-offs.
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+class C1 {
+  var data : Builtin.Int64
+  init()
+}
+
+class C2 {
+  var data : Builtin.FPIEEE32
+  init()
+}
+
+class C3 {
+  var data : Builtin.FPIEEE64
+  init()
+}
+
+struct S2 {
+  var cls1 : C1
+  var cls2 : C2
+  var trivial : Builtin.FPIEEE32
+}
+
+struct S {
+  var trivial : Builtin.Int64
+  var cls : C3
+  var inner_struct : S2
+}
+
+enum E {
+  case NoElement()
+  case TrivialElement(Builtin.Int64)
+  case ReferenceElement(C1)
+  case StructNonTrivialElt(S)
+  case TupleNonTrivialElt((Builtin.Int64, S, C3))
+}
+
+// A struct for testing that aggregate rebuilding works.
+struct S3 {
+  var trivial1 : Builtin.Int64
+  var cls : S
+  var trivial2 : Builtin.Int64
+  var e : E
+  var trivial3 : Builtin.Int64
+}
+
+//////////////////
+// Destroy Addr //
+//////////////////
+
+// CHECK-LABEL: sil @expand_destroy_addr_trivial
+// CHECK: bb0
+// CHECK: tuple ()
+// CHECK: return
+sil @expand_destroy_addr_trivial : $@convention(thin) (@inout Builtin.Int64) -> () {
+bb0(%0 : $*Builtin.Int64):
+  destroy_addr %0 : $*Builtin.Int64
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @expand_destroy_addr_aggstructnontrivial
+// CHECK: bb0([[INPTR:%[0-9]+]] : $*S):
+// CHECK: [[IN:%[0-9]+]] = load [[INPTR]] : $*S
+// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN]] : $S, #S.cls
+// CHECK: strong_release [[cls]] : $C3
+// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN]] : $S, #S.inner_struct
+// CHECK: [[innerstruct_cls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[innerstruct_cls1]] : $C1
+// CHECK: [[innerstruct_cls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[innerstruct_cls2]] : $C2
+// CHECK: tuple
+// CHECK: return
+sil @expand_destroy_addr_aggstructnontrivial : $@convention(thin) (@inout S) -> () {
+bb0(%0 : $*S):
+  destroy_addr %0 : $*S
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @expand_destroy_addr_aggtuplenontrivial
+// CHECK: bb0([[INPTR:%[0-9]+]] : $*(S, S2, C1)):
+// CHECK: [[IN:%[0-9]+]] = load [[INPTR]] : $*(S, S2, C1)
+// CHECK: [[ELT0:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1), 0
+// CHECK: [[ELT0cls:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.cls
+// CHECK: strong_release [[ELT0cls]] : $C3
+// CHECK: [[ELT0innerstruct:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.inner_struct
+// CHECK: [[ELT0innerstructcls1:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[ELT0innerstructcls1]] : $C1
+// CHECK: [[ELT0innerstructcls2:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[ELT0innerstructcls2]]
+// CHECK: [[ELT1:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1), 1
+// CHECK: [[ELT1cls1:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls1
+// CHECK: strong_release [[ELT1cls1]] : $C1
+// CHECK: [[ELT1cls2:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls2
+// CHECK: strong_release [[ELT1cls2]] : $C2
+// CHECK: [[ELT2:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1), 2
+// CHECK: strong_release [[ELT2]]
+// CHECK: tuple ()
+// CHECK: return
+sil @expand_destroy_addr_aggtuplenontrivial : $@convention(thin) (@inout (S, S2, C1)) -> () {
+bb0(%0 : $*(S, S2, C1)):
+  destroy_addr %0 : $*(S, S2, C1)
+  %1 = tuple()
+  return %1 : $()
+}
+
+// Do not do anything.
+/*
+sil @expand_destroy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
+bb0(%0 : $*T):
+  destroy_addr %0 : $*T
+  %1 = tuple()
+  return %1 : $()
+}
+*/
+
+// CHECK-LABEL: sil @expand_destroy_addr_reference
+// CHECK: bb0
+// CHECK: load
+// CHECK: strong_release
+// CHECK: tuple
+// CHECK: return
+sil @expand_destroy_addr_reference : $@convention(thin) (@inout C1) -> () {
+bb0(%0 : $*C1):
+  destroy_addr %0 : $*C1
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @expand_destroy_addr_enum
+// CHECK: bb0
+// CHECK: load
+// CHECK: release_value
+// CHECK: tuple
+// CHECK: return
+sil @expand_destroy_addr_enum : $@convention(thin) (@inout E) -> () {
+bb0(%0 : $*E):
+  destroy_addr %0 : $*E
+  %1 = tuple()
+  return %1 : $()
+}
+
+///////////////
+// Copy Addr //
+///////////////
+
+// CHECK-LABEL: sil @expand_copy_addr_takeinit
+// CHECK: bb0([[IN1:%[0-9]+]] : $*S, [[IN2:%[0-9]+]] : $*S):
+// CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*S
+// CHECK: store [[LOAD1]] to [[IN2]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_takeinit : $@convention(thin) (@inout S, @inout S) -> () {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr [take] %0 to [initialization] %1 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @expand_copy_addr_init
+// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
+// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
+// CHECK: [[IN1trivial:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.trivial
+// CHECK: [[IN1cls:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.cls
+// CHECK: strong_retain [[IN1cls]] : $C3
+// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.inner_struct
+// CHECK: [[innerstructIN11:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_retain [[innerstructIN11]] : $C1
+// CHECK: [[innerstructIN12:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_retain [[innerstructIN12]] : $C2
+// CHECK: [[innerstructtrivial:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.trivial
+// CHECK: store [[IN1]] to [[IN2PTR]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_init : $@convention(thin) (@inout S, @inout S) -> () {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr %0 to [initialization] %1 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @expand_copy_addr_take
+// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
+// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
+// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*S
+// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.cls
+// CHECK: strong_release [[cls]] : $C3
+// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.inner_struct
+// CHECK: [[innerstructcls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[innerstructcls1]] : $C1
+// CHECK: [[innerstructcls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[innerstructcls2]]
+// CHECK: store [[IN1]] to [[IN2PTR]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_take : $@convention(thin) (@inout S, @inout S) -> () {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr [take] %0 to %1 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// Test expansions for various types (these will become more
+// interesting when I introduce the actual chopping work).
+
+// CHECK-LABEL: sil @expand_copy_addr_trivial
+// CHECK: bb0
+// CHECK: load
+// CHECK: store
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_trivial : $@convention(thin) (@inout Builtin.Int64, @inout Builtin.Int64) -> () {
+bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
+  copy_addr %0 to %1 : $*Builtin.Int64
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @expand_copy_addr_aggstructnontrivial
+// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
+// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
+// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*S
+// CHECK: [[IN1trivial:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.trivial
+// CHECK: [[IN1cls:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.cls
+// CHECK: strong_retain [[IN1cls]] : $C3
+// CHECK: [[IN1innerstruct:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.inner_struct
+// CHECK: [[IN1innerstructcls1:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_retain [[IN1innerstructcls1]] : $C1
+// CHECK: [[IN1innerstructcls2:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_retain [[IN1innerstructcls2]] : $C2
+// CHECK: [[IN1innerstructtrivial:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.trivial
+// CHECK: [[IN2cls:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.cls
+// CHECK: strong_release [[IN2cls]] : $C3
+// CHECK: [[IN2innerstruct:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.inner_struct
+// CHECK: [[IN2innerstructcls1:%[0-9]+]] = struct_extract [[IN2innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[IN2innerstructcls1]] : $C1
+// CHECK: [[IN2innerstructcls2:%[0-9]+]] = struct_extract [[IN2innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[IN2innerstructcls2]]
+// CHECK: store [[IN1]] to [[IN2PTR]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_aggstructnontrivial : $@convention(thin) (@inout S, @inout S) -> () {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr %0 to %1 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @expand_copy_addr_aggtuplenontrivial
+// CHECK: bb0([[IN1PTR:%[0-9]+]] : $*(S, S2, C1, E), [[IN2PTR:%[0-9]+]] : $*(S, S2, C1, E)):
+// CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*(S, S2, C1, E)
+// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*(S, S2, C1, E)
+// CHECK: [[IN1ELT0:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 0
+// CHECK: [[IN1ELT0trivial:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.trivial
+// CHECK: [[IN1ELT0cls:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.cls
+// CHECK: strong_retain [[IN1ELT0cls]] : $C3
+// CHECK: [[IN1ELT0innerstruct:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.inner_struct
+// CHECK: [[IN1ELT0innerstructcls1:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_retain [[IN1ELT0innerstructcls1]] : $C1
+// CHECK: [[IN1ELT0innerstructcls2:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_retain [[IN1ELT0innerstructcls2]]
+// CHECK: [[IN1ELT0innerstructtrivial:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.trivial
+// CHECK: [[IN1ELT1:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 1
+// CHECK: [[IN1ELT1cls1:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.cls1
+// CHECK: strong_retain [[IN1ELT1cls1]] : $C1
+// CHECK: [[IN1ELT1cls2:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.cls2
+// CHECK: strong_retain [[IN1ELT1cls2]] : $C2
+// CHECK: [[IN1ELT1trivial:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.trivial
+// CHECK: [[IN1ELT2:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 2
+// CHECK: strong_retain [[IN1ELT2]]
+// CHECK: [[IN1ELT3:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 3
+// CHECK: retain_value [[IN1ELT3]] : $E
+// CHECK: [[IN2ELT0:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 0
+// CHECK: [[IN2ELT0cls:%[0-9]+]] = struct_extract [[IN2ELT0]] : $S, #S.cls
+// CHECK: strong_release [[IN2ELT0cls]] : $C3
+// CHECK: [[IN2ELT0innerstruct:%[0-9]+]] = struct_extract [[IN2ELT0]] : $S, #S.inner_struct
+// CHECK: [[IN2ELT0innerstructcls1:%[0-9]+]] = struct_extract [[IN2ELT0innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[IN2ELT0innerstructcls1]] : $C1
+// CHECK: [[IN2ELT0innerstructcls2:%[0-9]+]] = struct_extract [[IN2ELT0innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[IN2ELT0innerstructcls2]]
+// CHECK: [[IN2ELT1:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 1
+// CHECK: [[IN2ELT1cls1:%[0-9]+]] = struct_extract [[IN2ELT1]] : $S2, #S2.cls1
+// CHECK: strong_release [[IN2ELT1cls1]] : $C1
+// CHECK: [[IN2ELT1cls2:%[0-9]+]] = struct_extract [[IN2ELT1]] : $S2, #S2.cls2
+// CHECK: strong_release [[IN2ELT1cls2]] : $C2
+// CHECK: [[IN2ELT2:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 2
+// CHECK: strong_release [[IN2ELT2]]
+// CHECK: [[IN2ELT3:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 3
+// CHECK: release_value [[IN2ELT3]] : $E
+// CHECK: store [[IN1]] to [[IN2PTR]] : $*(S, S2, C1, E)
+// CHECK: tuple ()
+// CHECK: return
+
+
+sil @expand_copy_addr_aggtuplenontrivial : $@convention(thin) (@inout (S, S2, C1, E), @inout (S, S2, C1, E)) -> () {
+bb0(%0 : $*(S, S2, C1, E), %1 : $*(S, S2, C1, E)):
+  copy_addr %0 to %1 : $*(S, S2, C1, E)
+  %2 = tuple()
+  return %2 : $()
+}
+
+// Do not do anything.
+/*
+sil @expand_copy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
+bb0(%0 : $*T):
+  copy_addr %0 : $*T
+  %1 = tuple()
+  return %1 : $()
+}
+*/
+
+// Just turn into a load + strong_release.
+// CHECK-LABEL: sil @expand_copy_addr_reference
+// CHECK: bb0([[IN1:%[0-9]+]] : $*C1, [[IN2:%[0-9]+]] : $*C1):
+// CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*C1
+// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*C1
+// CHECK: strong_retain [[LOAD1]]
+// CHECK: strong_release [[LOAD2]]
+// CHECK: store [[LOAD1]] to [[IN2]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_reference : $@convention(thin) (@inout C1, @inout C1) -> () {
+bb0(%0 : $*C1, %1 : $*C1):
+  copy_addr %0 to %1 : $*C1
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @expand_copy_addr_enum
+// CHECK: bb0([[IN1:%[0-9]+]] : $*E, [[IN2:%[0-9]+]] : $*E):
+// CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*E
+// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*E
+// CHECK: retain_value [[LOAD1]]
+// CHECK: release_value [[LOAD2]]
+// CHECK: store [[LOAD1]] to [[IN2]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_copy_addr_enum : $@convention(thin) (@inout E, @inout E) -> () {
+bb0(%0 : $*E, %1 : $*E):
+  copy_addr %0 to %1 : $*E
+  %2 = tuple()
+  return %2 : $()
+}
+
+///////////////////
+// Destroy Value //
+///////////////////
+
+// Test expansions for various types (these will become more
+// interesting when I introduce the actual chopping work).
+
+// CHECK-LABEL: sil @expand_release_value_trivial
+// CHECK: bb0
+// CHECK: tuple
+// CHECK: return
+sil @expand_release_value_trivial : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  release_value %0 : $Builtin.Int64
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @expand_release_value_aggstructnontrivial
+// CHECK: bb0([[IN:%[0-9]+]] : $S):
+// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN]] : $S, #S.cls
+// CHECK: strong_release [[cls]] : $C3
+// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[IN]] : $S, #S.inner_struct
+// CHECK: [[innerstructcls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[innerstructcls1]] : $C1
+// CHECK: [[innerstructcls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[innerstructcls2]]
+sil @expand_release_value_aggstructnontrivial : $@convention(thin) (S) -> () {
+bb0(%0 : $S):
+  release_value %0 : $S
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @expand_release_value_aggtuplenontrivial
+// CHECK: bb0([[IN:%[0-9]+]] : $(S, S2, C1, E)):
+// CHECK: [[ELT0:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 0
+// CHECK: [[ELT0cls:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.cls
+// CHECK: strong_release [[ELT0cls]] : $C3
+// CHECK: [[ELT0innerstruct:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.inner_struct
+// CHECK: [[ELT0innerstructcls1:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_release [[ELT0innerstructcls1]] : $C1
+// CHECK: [[ELT0innerstructcls2:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_release [[ELT0innerstructcls2]]
+// CHECK: [[ELT1:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 1
+// CHECK: [[ELT1cls1:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls1
+// CHECK: strong_release [[ELT1cls1]] : $C1
+// CHECK: [[ELT1cls2:%[0-9]+]] = struct_extract [[ELT1]] : $S2, #S2.cls2
+// CHECK: strong_release [[ELT1cls2]] : $C2
+// CHECK: [[ELT2:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 2
+// CHECK: strong_release [[ELT2]]
+// CHECK: [[ELT3:%[0-9]+]] = tuple_extract [[IN]] : $(S, S2, C1, E), 3
+// CHECK: release_value [[ELT3]] : $E
+// CHECK: tuple ()
+// CHECK: return
+sil @expand_release_value_aggtuplenontrivial : $@convention(thin) ((S, S2, C1, E)) -> () {
+bb0(%0 : $(S, S2, C1, E)):
+  release_value %0 : $(S, S2, C1, E)
+  %1 = tuple()
+  return %1 : $()
+}
+
+// Just turn into a load + strong_release.
+// CHECK-LABEL: sil @expand_release_value_reference
+// CHECK: bb0([[IN:%[0-9]+]] : $C1):
+// CHECK: strong_release [[IN]]
+// CHECK: tuple
+// CHECK: return
+sil @expand_release_value_reference : $@convention(thin) (C1) -> () {
+bb0(%0 : $C1):
+  release_value %0 : $C1
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @expand_release_value_enum
+// CHECK: bb0([[IN1:%[0-9]+]] : $E):
+// CHECK: release_value
+// CHECK: tuple ()
+// CHECK: return
+sil @expand_release_value_enum : $@convention(thin) (E) -> () {
+bb0(%0 : $E):
+  release_value %0 : $E
+  %1 = tuple()
+  return %1 : $()
+}
+
+
+////////////////
+// Copy Value //
+////////////////
+
+// Test expansions for various types (these will become more
+// interesting when I introduce the actual chopping work).
+
+// CHECK-LABEL: sil @expand_retain_value_trivial
+// CHECK: bb0
+// CHECK: return
+sil @expand_retain_value_trivial : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
+bb0(%0 : $Builtin.Int64):
+  retain_value %0 : $Builtin.Int64
+  return %0 : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @expand_retain_value_aggstructnontrivial
+// CHECK: bb0([[IN:%[0-9]+]] : $S3):
+// CHECK: [[trivial:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.trivial1
+// CHECK: [[cls:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.cls
+// CHECK: [[clstrivial:%[0-9]+]] = struct_extract [[cls]] : $S, #S.trivial
+// CHECK: [[clscls:%[0-9]+]] = struct_extract [[cls]] : $S, #S.cls
+// CHECK: strong_retain [[clscls]] : $C3
+// CHECK: [[innerstruct:%[0-9]+]] = struct_extract [[cls]] : $S, #S.inner_struct
+// CHECK: [[innerstructcls1:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_retain [[innerstructcls1]] : $C1
+// CHECK: [[innerstructcls2:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_retain [[innerstructcls2]] : $C2
+// CHECK: [[innerstructtrivial:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.trivial
+// CHECK: [[trivial2:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.trivial2
+// CHECK: [[enum:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.e
+// CHECK: retain_value [[enum]] : $E
+// CHECK: [[trivial3:%[0-9]+]] = struct_extract [[IN]] : $S3, #S3.trivial3
+// CHECK: return [[IN]] : $S3
+sil @expand_retain_value_aggstructnontrivial : $@convention(thin) (S3) -> (S3) {
+bb0(%0 : $S3):
+  retain_value %0 : $S3
+  return %0 : $S3
+}
+
+// CHECK-LABEL: sil @expand_retain_value_aggtuplenontrivial
+// CHECK: bb0([[IN:%[0-9]+]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)):
+// CHECK: [[ELT0:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 0
+// CHECK: [[ELT0trivial:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.trivial
+// CHECK: [[ELT0cls:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.cls
+// CHECK: strong_retain [[ELT0cls]] : $C3
+// CHECK: [[ELT0innerstruct:%[0-9]+]] = struct_extract [[ELT0]] : $S, #S.inner_struct
+// CHECK: [[ELT0innerstructcls1:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls1
+// CHECK: strong_retain [[ELT0innerstructcls1]] : $C1
+// CHECK: [[ELT0innerstructcls2:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.cls2
+// CHECK: strong_retain [[ELT0innerstructcls2]]
+// CHECK: [[ELT0innerstructtrivial:%[0-9]+]] = struct_extract [[ELT0innerstruct]] : $S2, #S2.trivial
+// CHECK: [[ELT1:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 1
+// CHECK: [[ELT2:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 2
+// CHECK: [[ELT2cls1:%[0-9]+]] = struct_extract [[ELT2]] : $S2, #S2.cls1
+// CHECK: strong_retain [[ELT2cls1]] : $C1
+// CHECK: [[ELT2cls2:%[0-9]+]] = struct_extract [[ELT2]] : $S2, #S2.cls2
+// CHECK: strong_retain [[ELT2cls2]] : $C2
+// CHECK: [[ELT2trivial:%[0-9]+]] = struct_extract [[ELT2]] : $S2, #S2.trivial
+// CHECK: [[ELT3:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 3
+// CHECK: strong_retain [[ELT3]]
+// CHECK: [[ELT4:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 4
+// CHECK: [[ELT5:%[0-9]+]] = tuple_extract [[IN]] : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E), 5
+// CHECK: retain_value [[ELT5]] : $E
+// CHECK: return [[IN]]
+
+sil @expand_retain_value_aggtuplenontrivial : $@convention(thin) ((S, Builtin.Int64, S2, C1, Builtin.Int64, E)) -> ((S, Builtin.Int64, S2, C1, Builtin.Int64, E)) {
+bb0(%0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)):
+  retain_value %0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)
+  return %0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)
+}
+
+// CHECK-LABEL: sil @expand_retain_value_reference
+// CHECK: bb0([[IN:%[0-9]+]] : $C1):
+// CHECK: strong_retain [[IN]]
+// CHECK: return
+sil @expand_retain_value_reference : $@convention(thin) (C1) -> (C1) {
+bb0(%0 : $C1):
+  retain_value %0 : $C1
+  return %0 : $C1
+}
+
+// CHECK-LABEL: sil @expand_retain_value_enum
+// CHECK: bb0([[IN1:%[0-9]+]] : $E):
+// CHECK: retain_value
+// CHECK: return
+sil @expand_retain_value_enum : $@convention(thin) (E) -> (E) {
+bb0(%0 : $E):
+  retain_value %0 : $E
+  return %0 : $E
+}
+

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -3,6 +3,29 @@
 import Builtin
 import Swift
 
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+struct SmallCodesizeStruct {
+  var cls1 : Klass
+  var cls2 : Klass
+}
+
+struct LargeCodesizeStruct {
+  var s1: SmallCodesizeStruct
+  var s2: SmallCodesizeStruct
+  var s3: SmallCodesizeStruct
+  var s4: SmallCodesizeStruct
+  var s5: SmallCodesizeStruct
+}
+
+///////////
+// Tests //
+///////////
+
 // CHECK-LABEL: sil @store_only_allocas
 // CHECK-NOT: alloc_stack
 // CHECK: return
@@ -355,4 +378,37 @@ bb0(%0 : $*Int64):
   dealloc_stack %2 : $*Int64
   %4 = tuple ()
   return %4 : $()
+}
+
+// Make sure that we do expand destroy_addr appropriately for code-size
+// trade-offs.
+// CHECK-LABEL: sil @large_struct_test : $@convention(thin) (@owned LargeCodesizeStruct) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $LargeCodesizeStruct):
+// CHECK:   release_value [[ARG0]]
+// CHECK: } // end sil function 'large_struct_test'
+sil @large_struct_test : $@convention(thin) (@owned LargeCodesizeStruct) -> () {
+bb0(%0 : $LargeCodesizeStruct):
+  %1 = alloc_stack $LargeCodesizeStruct
+  store %0 to %1 : $*LargeCodesizeStruct
+  destroy_addr %1 : $*LargeCodesizeStruct
+  dealloc_stack %1 : $*LargeCodesizeStruct
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil @small_struct_test : $@convention(thin) (@owned SmallCodesizeStruct) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $SmallCodesizeStruct):
+// CHECK:   [[ARG0cls1:%.*]] = struct_extract [[ARG0]]
+// CHECK:   strong_release [[ARG0cls1]]
+// CHECK:   [[ARG0cls2:%.*]] = struct_extract [[ARG0]]
+// CHECK:   strong_release [[ARG0cls2]]
+// CHECK: } // end sil function 'small_struct_test'
+sil @small_struct_test : $@convention(thin) (@owned SmallCodesizeStruct) -> () {
+bb0(%0 : $SmallCodesizeStruct):
+  %1 = alloc_stack $SmallCodesizeStruct
+  store %0 to %1 : $*SmallCodesizeStruct
+  destroy_addr %1 : $*SmallCodesizeStruct
+  dealloc_stack %1 : $*SmallCodesizeStruct
+  %7 = tuple ()
+  return %7 : $()
 }


### PR DESCRIPTION
…Lowering::getLoweringStyle() and change it to properly use TypeExpansionKind::None instead of TypeExpansionKind::DirectChildren for the non-expansion case.

Now we will consistently expand destroy_addr/copy_addr into either
{retain,release}_value or into ARC operations on its most derived descendents.
This will improve code-size (by not expanding when we didn't intend to), but
more importantly preserve invariants that the ARC optimizer depends upon.

rdar://36509461

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
