### PR TITLE
SILGen: Accept optionals as ABI-compatible in either direction as block arguments.

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -864,7 +864,8 @@ public:
   /// The ABI compatible relation is not symmetric on function types -- while
   /// T and T! are both subtypes of each other, a calling convention conversion
   /// of T! to T always requires a thunk.
-  ABIDifference checkForABIDifferences(SILType type1, SILType type2);
+  ABIDifference checkForABIDifferences(SILType type1, SILType type2,
+                                       bool thunkOptionals = true);
 
   /// \brief Same as above but for SIL function types.
   ABIDifference checkFunctionForABIDifferences(SILFunctionType *fnTy1,

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2258,7 +2258,8 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
 /// Given that type1 is known to be a subtype of type2, check if the two
 /// types have the same calling convention representation.
 TypeConverter::ABIDifference
-TypeConverter::checkForABIDifferences(SILType type1, SILType type2) {
+TypeConverter::checkForABIDifferences(SILType type1, SILType type2,
+                                      bool thunkOptionals) {
   // Unwrap optionals, but remember that we did.
   bool type1WasOptional = false;
   bool type2WasOptional = false;
@@ -2271,15 +2272,23 @@ TypeConverter::checkForABIDifferences(SILType type1, SILType type2) {
     type2 = object;
   }
 
-  // Forcing IUOs always requires a thunk.
-  if (type1WasOptional && !type2WasOptional)
-    return ABIDifference::NeedsThunk;
+  bool optionalityChange;
+  if (thunkOptionals) {
+    // Forcing IUOs always requires a thunk.
+    if (type1WasOptional && !type2WasOptional)
+      return ABIDifference::NeedsThunk;
   
-  // Except for the above case, we should not be making a value less optional.
-  
-  // If we're introducing a level of optionality, only certain types are
-  // ABI-compatible -- check below.
-  bool optionalityChange = (!type1WasOptional && type2WasOptional);
+    // Except for the above case, we should not be making a value less optional.
+    
+    // If we're introducing a level of optionality, only certain types are
+    // ABI-compatible -- check below.
+    optionalityChange = (!type1WasOptional && type2WasOptional);
+  } else {
+    // We haven't implemented codegen for optional thunking at all levels
+    // (particularly objc_blocks at depth). Just accept ABI compatibility
+    // in either direction in these cases.
+    optionalityChange = type1WasOptional != type2WasOptional;
+  }
 
   // If the types are identical and there was no optionality change,
   // we're done.
@@ -2386,7 +2395,8 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
       return ABIDifference::NeedsThunk;
 
     if (checkForABIDifferences(result1.getSILStorageType(),
-                               result2.getSILStorageType())
+                             result2.getSILStorageType(),
+              /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;
   }
@@ -2401,7 +2411,8 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
       return ABIDifference::NeedsThunk;
 
     if (checkForABIDifferences(error1.getSILStorageType(),
-                               error2.getSILStorageType())
+                               error2.getSILStorageType(),
+              /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;
   }
@@ -2417,7 +2428,8 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
     std::swap(param1, param2);
 
     if (checkForABIDifferences(param1.getSILStorageType(),
-                               param2.getSILStorageType())
+                               param2.getSILStorageType(),
+              /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;
   }

--- a/test/SILGen/Inputs/objc_bridged_block_optionality_diff.h
+++ b/test/SILGen/Inputs/objc_bridged_block_optionality_diff.h
@@ -1,0 +1,8 @@
+@import Foundation;
+
+#pragma clang assume_nonnull begin
+typedef void (^HandlerBlock)(NSString *(^message)(void));
+#pragma clang assume_nonnull end
+
+/// Default handler for logging.
+extern HandlerBlock TheHandlerBlock;

--- a/test/SILGen/objc_bridged_block_optionality_diff.swift
+++ b/test/SILGen/objc_bridged_block_optionality_diff.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -import-objc-header %S/Inputs/objc_bridged_block_optionality_diff.h -verify
+// REQUIRES: objc_interop
+import Foundation
+
+TheHandlerBlock = { x in () }
+


### PR DESCRIPTION
 The thunking code we have for introducing runtime nil checks in thunks when an optional-to-non conversion appears in contravariant position doesn't handle blocks. This somehow-worked in previous versions of Swift (maybe due to assertions being off). Spot fix for rdar://problem/36843476.