### PR TITLE
Sema: request member layout in the subscript_expr

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1525,6 +1525,7 @@ namespace {
       }
       
       auto subscript = cast<SubscriptDecl>(choice.getDecl());
+      cs.TC.requestMemberLayout(subscript);
 
       auto &tc = cs.getTypeChecker();
       auto baseTy = cs.getType(base)->getRValueType();


### PR DESCRIPTION
rdar://problem/36704036

The subscript_expr typechecker path is different than extension deceleration one - in rdar://problem/36704036, When doing emitVirtualMethodValue in IRGen we can miss the correct offset because we have a bad ClassDecl, The ClassDecl is junk / null

This PR makes said subscript_expr -> call_expr path Behave correctly by request the class layout