### PR TITLE
[CursorInfo] Fix crash on instance variables used directly in if or for when declared in a generic context

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -192,8 +192,8 @@ bool CursorInfoResolver::walkToExprPre(Expr *E) {
         ContainerType = SAE->getBase()->getType();
       }
     } else if (auto ME = dyn_cast<MemberRefExpr>(E)) {
-      SourceLoc DotLoc = ME->getDotLoc();
-      if (DotLoc.isValid() && DotLoc.getAdvancedLoc(1) == LocToResolve) {
+      SourceLoc MemberLoc = ME->getNameLoc().getBaseNameLoc();
+      if (MemberLoc.isValid() && MemberLoc == LocToResolve) {
         ContainerType = ME->getBase()->getType();
       }
     }

--- a/test/SourceKit/CursorInfo/cursor_generics.swift
+++ b/test/SourceKit/CursorInfo/cursor_generics.swift
@@ -9,6 +9,16 @@ func someFunc <A>() -> A {
     fatalError()
 }
 
+// rdar://problem/36871908
+class MyType<T> {
+	let test: Bool = false
+	let items: [Int] = []
+	func myMethod() {
+	  if test {}
+	  for i in items {}
+	}
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=1:10 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: <Declaration>func testGenerics&lt;T&gt;(x: <Type usr="s:15cursor_generics12testGenerics1xyx_tlF1TL_xmfp">T</Type>)</Declaration>
 
@@ -19,3 +29,11 @@ func someFunc <A>() -> A {
 // RUN: %sourcekitd-test -req=cursor -pos=8:16 %s -- %s | %FileCheck -check-prefix=CHECK3 %s
 // CHECK3: source.lang.swift.decl.generic_type_param
 // CHECK3: <Declaration>A</Declaration>
+
+// RUN: %sourcekitd-test -req=cursor -pos=17:8 %s -- %s | %FileCheck -check-prefix=CHECK4 %s
+// CHECK4: source.lang.swift.ref.var.instance
+// CHECK4: <Declaration>let test: <Type usr="s:Sb">Bool</Type></Declaration>
+
+// RUN: %sourcekitd-test -req=cursor -pos=18:14 %s -- %s | %FileCheck -check-prefix=CHECK5 %s
+// CHECK5: source.lang.swift.ref.var.instance
+// CHECK5: <Declaration>let items: [<Type usr="s:Si">Int</Type>]</Declaration>


### PR DESCRIPTION
For example:
```
class Foo<T> {
  let test: Bool = false
  let items: [Int] = []
  func foo() {
    if test {} // crashes on test
    for i in items {} // crashes on items
  }
}
```
We were picking up the incorrect containing type (`Bool` rather than `Foo<T>`).
Resolves rdar://problem/36871908.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
