### PR TITLE
[4.1] SILGen: Make the optionality check in checkForABIDifferences reflexive to make up for the loss of IUO.

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2272,15 +2272,9 @@ TypeConverter::checkForABIDifferences(SILType type1, SILType type2) {
     type2 = object;
   }
 
-  // Forcing IUOs always requires a thunk.
-  if (type1WasOptional && !type2WasOptional)
-    return ABIDifference::NeedsThunk;
-  
-  // Except for the above case, we should not be making a value less optional.
-  
-  // If we're introducing a level of optionality, only certain types are
+  // If we're changing the level of optionality, only certain types are
   // ABI-compatible -- check below.
-  bool optionalityChange = (!type1WasOptional && type2WasOptional);
+  bool optionalityChange = type1WasOptional != type2WasOptional;
 
   // If the types are identical and there was no optionality change,
   // we're done.

--- a/test/SILGen/Inputs/objc_bridged_block_optionality_diff.h
+++ b/test/SILGen/Inputs/objc_bridged_block_optionality_diff.h
@@ -1,0 +1,8 @@
+@import Foundation;
+
+#pragma clang assume_nonnull begin
+typedef void (^HandlerBlock)(NSString *(^message)(void));
+#pragma clang assume_nonnull end
+
+/// Default handler for logging.
+extern HandlerBlock TheHandlerBlock;

--- a/test/SILGen/objc_bridged_block_optionality_diff.swift
+++ b/test/SILGen/objc_bridged_block_optionality_diff.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -import-objc-header %S/Inputs/objc_bridged_block_optionality_diff.h -verify
+import Foundation
+
+TheHandlerBlock = { x in () }
+


### PR DESCRIPTION
Explanation: Changes to IUO handling in SILGen caused a regression in how block codegen handled optionality changes.

Scope: Regression from 4.0

Issue: rdar://problem/36843476

Risk: Low, small bug fix

Testing: Swift CI, reduced test case from Radar