### PR TITLE
[Foundation] Address a potential leak when writing a data to a URL and the file system representation fails

### DIFF
--- a/stdlib/public/SDK/Foundation/DataThunks.m
+++ b/stdlib/public/SDK/Foundation/DataThunks.m
@@ -120,6 +120,8 @@ BOOL __NSDataWriteToURL(NSData *SWIFT_NS_RELEASES_ARGUMENT data, NSURL *SWIFT_NS
 
     if (![path getFileSystemRepresentation:cpath maxLength:1024]) {
         if (errorPtr) *errorPtr = _NSErrorWithFilePath(NSFileWriteInvalidFileNameError, path);
+        [data release];
+        [url release];
         return NO;
     }
 


### PR DESCRIPTION
Resolves <rdar://problem/36889982> 