### PR TITLE
[StringGuts] Bias the unmanaged pointer by StringStorage's header.

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -136,7 +136,7 @@ extension _StringObject {
 //   isNative: the native StringStorage object
 //   isCocoa: the Cocoa object
 //   isOpaque & !isCocoa: the _OpaqueString object
-//   isUnmanaged: the pointer to code units
+//   isUnmanaged: a biased (see StringGuts._pointerBias) pointer to code units
 //   isSmall: opaque bits used for inline storage // TODO: use them!
 //
 extension _StringObject {
@@ -498,6 +498,25 @@ extension _StringObject {
       }
 #else
       return _variantBits == _StringObject._isValueBit
+#endif
+    }
+  }
+
+  @_versioned
+  @_inlineable
+  internal
+  var isUnmanagedOrNative: Bool {
+    @inline(__always)
+    get {
+#if arch(i386) || arch(arm)
+      switch _variant {
+      case .unmanagedSingleByte, .unmanagedDoubleByte, .strong():
+        return true
+      default:
+        return false
+      }
+#else
+      return _variantBits & _StringObject._subVariantBit == 0
 #endif
     }
   }

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -421,9 +421,11 @@ extension _StringObject {
   var asUnmanagedRawStart: UnsafeRawPointer {
     @inline(__always)
     get {
-      _sanityCheck(isUnmanaged)
+      _sanityCheck(isUnmanagedOrNative)
 #if arch(i386) || arch(arm)
-      return UnsafeRawPointer(bitPattern: _bits)._unsafelyUnwrappedUnchecked
+      return UnsafeRawPointer(
+        bitPattern: isUnmanaged ? _bits : referenceBits
+      )._unsafelyUnwrappedUnchecked
 #else
       return UnsafeRawPointer(
         bitPattern: payloadBits
@@ -510,7 +512,7 @@ extension _StringObject {
     get {
 #if arch(i386) || arch(arm)
       switch _variant {
-      case .unmanagedSingleByte, .unmanagedDoubleByte, .strong():
+      case .unmanagedSingleByte, .unmanagedDoubleByte, .strong:
         return true
       default:
         return false


### PR DESCRIPTION
By storing a biased pointer (e.g. -32 on 64-bit), we can make the
"native" and "unmanaged" cases layout-identical except for the isValue
bit. This means that string literals are basically strings that are
immutable and immortal.

Removes some branching when trying to convert to an unmanaged
view. This reduces the size of unmanagedASCIIView (frequently inlined
into user code) by about 1/3rd.

Idea came through conversation with Jordan Rose. Thanks @jrose-apple

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
