### PR TITLE
[BatchMode] Change option to -enable-batch-mode, add a -disable variant.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -619,9 +619,13 @@ def whole_module_optimization : Flag<["-"], "whole-module-optimization">,
   HelpText<"Optimize input files together instead of individually">,
   Flags<[FrontendOption, NoInteractiveOption]>;
 
-def batch_mode : Flag<["-"], "batch-mode">,
+def enable_batch_mode : Flag<["-"], "enable-batch-mode">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
-  HelpText<"Combine frontend jobs into batches">;
+  HelpText<"Enable combining frontend jobs into batches">;
+
+def disable_batch_mode : Flag<["-"], "disable-batch-mode">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Disable combining frontend jobs into batches">;
 
 def wmo : Flag<["-"], "wmo">, Alias<whole_module_optimization>,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>;


### PR DESCRIPTION
This just switches the -batch-mode flag to -enable-batch-mode and adds a -disable variant.

Will be filing a copy of these to 4.1 shortly (as a no-op) just in case the wrong compiler gets passed the flags.