### PR TITLE
Merge pull request #14170 from shajrawi/buffix_class_offset2

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1481,6 +1481,7 @@ namespace {
       }
       
       auto subscript = cast<SubscriptDecl>(choice.getDecl());
+      cs.TC.requestMemberLayout(subscript);
 
       auto &tc = cs.getTypeChecker();
       auto baseTy = cs.getType(base)->getRValueType();


### PR DESCRIPTION
rdar://problem/36704036

Explanation: The subscript_expr typechecker path is different than extension deceleration - When doing emitVirtualMethodValue in IRGen we can miss the correct offset because we have a bad ClassDecl, The ClassDecl is junk / null
Reviewed by: Doug Gregor
Scope: We found this issue by running an internal project that depends on various large other projects. this bug can really cause a runtime crash or miscompile.
Radar: rdar://problem/36704036
Risk: Low. Don't construct a class layout lazily in the Type Checker. does not affect the generated SIL.
Testing: Swift CI Testing