### PR TITLE
[Debugger] Stop re-running all the issues hoping that they pass the next time.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2843,7 +2843,6 @@ for host in "${ALL_HOSTS[@]}"; do
                            SWIFTLIBS="${swift_build_dir}/lib/swift" \
                            "${LLDB_SOURCE_DIR}"/test/dotest.py \
                            --executable "${lldb_executable}" \
-                           --rerun-all-issues \
                            ${LLDB_TEST_SUBDIR_CLAUSE} \
                            ${LLDB_DOTEST_CC_OPTS} \
                            ${LLDB_FORMATTER_OPTS}


### PR DESCRIPTION
This maybe was needed in the past, but we're moving to a model
where we really want to control what's failing and why. If something
fails, stop re-running. Instead, try to get a proper blame
mail and investigate. This might be a little shaky in the
short term but I'm confident it will go a long way.