### PR TITLE
Merge pull request #14187 from shajrawi/fix_part_apply

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -80,24 +80,16 @@ static bool shouldTransformFunctionType(GenericEnvironment *env,
                                         CanSILFunctionType fnType,
                                         irgen::IRGenModule &IGM);
 
+static SILParameterInfo getNewParameter(GenericEnvironment *env,
+                                        SILParameterInfo param,
+                                        irgen::IRGenModule &IGM);
+
 static bool shouldTransformParameter(GenericEnvironment *env,
                                      SILParameterInfo param,
                                      irgen::IRGenModule &IGM) {
-  SILType storageType = param.getSILStorageType();
 
-  // FIXME: only function types and not recursively-transformable types?
-  if (auto fnType = storageType.getAs<SILFunctionType>())
-    return shouldTransformFunctionType(env, fnType, IGM);
-
-  switch (param.getConvention()) {
-  case ParameterConvention::Indirect_In_Guaranteed:
-  case ParameterConvention::Indirect_Inout:
-  case ParameterConvention::Indirect_InoutAliasable:
-  case ParameterConvention::Indirect_In:
-    return false;
-  default:
-    return isLargeLoadableType(env, storageType, IGM);
-  }
+  auto newParam = getNewParameter(env, param, IGM);
+  return (param != newParam);
 }
 
 static bool shouldTransformFunctionType(GenericEnvironment *env,
@@ -2603,6 +2595,10 @@ void LoadableByAddress::run() {
           auto dest = SI->getDest();
           if (isa<ProjectBlockStorageInst>(dest)) {
             storeToBlockStorageInstrs.insert(SI);
+          }
+        } else if (auto *PAI = dyn_cast<PartialApplyInst>(&I)) {
+          if (modApplies.count(PAI) == 0) {
+            modApplies.insert(PAI);
           }
         }
       }

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: optimized_stdlib
 // UNSUPPORTED: resilient_stdlib
 
 public struct BigStruct {

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -205,3 +205,17 @@ func bigStructGet() -> BigStruct {
 public func testGetFunc() {
   let testGetPtr: @convention(thin) () -> BigStruct = bigStructGet
 }
+
+// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @_T022big_types_corner_cases7TestBigC4testyyF(%T22big_types_corner_cases7TestBigC* swiftself)
+// CHECK: [[CALL1:%.*]] = call %swift.type* @_T0Sayy22big_types_corner_cases9BigStructVcSgGMa
+// CHECK: [[CALL2:%.*]] = call i8** @_T0Sayy22big_types_corner_cases9BigStructVcSgGSayxGs10CollectionsWl
+// CHECK:  call swiftcc void @_T0s10CollectionPsE5index5IndexQzSgSb7ElementQzKc5where_tKF(%TSq.0* noalias nocapture sret %10, i8* bitcast (i1 (%T22big_types_corner_cases9BigStructVytIegir_Sg*, %swift.refcounted*, %swift.error**)* @_T022big_types_corner_cases9BigStructVIegy_SgSbs5Error_pIgxdzo_ACytIegir_SgSbsAE_pIgidzo_TRTA to i8*), %swift.refcounted* %7, %swift.type* %11, i8** [[CALL2]]
+// CHECK: ret void
+class TestBig {
+    typealias Handler = (BigStruct) -> Void
+
+    func test() {
+        let arr = [Handler?]()
+        let d = arr.index(where: { _ in true })
+    }
+}


### PR DESCRIPTION
rdar://problem/36826848

• Explanation: fixes a corner-case wherein a partial_apply was not converted in LoadableByAddress. It also cleans up shouldTransformParameter, fixing a corner-case for optional function parameter, and re-creates all partial applies that only contain function/optional function parameters
• Scope of Issue: We found this issue via JIRA - it can cause miscompiles in rare cases 
• Origination: https://bugs.swift.org/browse/SR-6828
• Risk: Low.
• Reviewed By: Arnold Schwaighofer
• Testing: Swift CI + new test case