### PR TITLE
[build system] Fix link error with ToT LLVM+clang+lld

### DIFF
--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(SwiftASTTests
    # FIXME: Circular dependencies.
    swiftParse
    swiftSema
+   swiftSIL
 )


### PR DESCRIPTION
`SILLocation::getStartSourceLoc` and `SILLocation::getEndSourceLoc` are missing for some reason.