### PR TITLE
[4.1] SILGen: Enclose formal evaluation of `self` in a type(of:) expression during an init delegation in a formal scope.

### DIFF
--- a/test/SILGen/metatype_in_init_delegation.swift
+++ b/test/SILGen/metatype_in_init_delegation.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+import CoreData
+
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+class Foo : NSManagedObject {
+  convenience init(context: NSManagedObjectContext, value: Int) {
+    self.init(entity: type(of: self).entity(), insertInto: context)
+  }
+}


### PR DESCRIPTION
Explanation: SILGen internal inconsistency when emitting type(of: self) in the middle of a self.init(...) delegating call in an initializer

Scope: Regression from 4.0

Issue: rdar://problem/36800495

Risk: Low, small bug fix

Testing: Swift CI

