### PR TITLE
[build-script] Respect TOOLCHAINS environment variable

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -152,10 +152,11 @@ if config.test_exec_root is None:
 # name: The name of this test suite.
 config.name = 'Swift(%s)' % config.variant_suffix[1:]
 
-# Tweak the environment appropriately for various platforms.
+# Respect the TOOLCHAINS environment variable when deciding the xcrun
+# toolchain for Darwin platforms.
 if platform.system() == 'Darwin':
-    # Prefer the latest version of the Xcode tools.
-    config.environment['TOOLCHAINS'] = 'default'
+    config.environment['TOOLCHAINS'] = \
+        os.environ.get('TOOLCHAINS', config.darwin_xcrun_toolchain)
 
 # testFormat: The test format to use to interpret tests.
 config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode)

--- a/utils/build-script
+++ b/utils/build-script
@@ -18,6 +18,7 @@ import platform
 import sys
 import time
 
+from build_swift import defaults
 from build_swift import driver_arguments
 
 from swift_build_support.swift_build_support import (
@@ -1041,10 +1042,12 @@ def main_normal():
     shell.dry_run = args.dry_run
 
     # Prepare and validate toolchain
-    env_toolchain = os.environ.get('TOOLCHAINS')
     if args.darwin_xcrun_toolchain is None:
-        diagnostics.note('using toolchain {}'.format(env_toolchain))
-        args.darwin_xcrun_toolchain = env_toolchain
+        xcrun_toolchain = os.environ.get('TOOLCHAINS',
+                                         defaults.DARWIN_XCRUN_TOOLCHAIN)
+
+        diagnostics.note('Using toolchain {}'.format(xcrun_toolchain))
+        args.darwin_xcrun_toolchain = xcrun_toolchain
 
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
     os.environ['TOOLCHAINS'] = args.darwin_xcrun_toolchain

--- a/utils/build-script
+++ b/utils/build-script
@@ -1041,6 +1041,11 @@ def main_normal():
     shell.dry_run = args.dry_run
 
     # Prepare and validate toolchain
+    env_toolchain = os.environ.get('TOOLCHAINS')
+    if args.darwin_xcrun_toolchain is None:
+        diagnostics.note('using toolchain {}'.format(env_toolchain))
+        args.darwin_xcrun_toolchain = env_toolchain
+
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
     os.environ['TOOLCHAINS'] = args.darwin_xcrun_toolchain
 

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -317,7 +317,6 @@ def create_argument_parser():
            help='the number of parallel build jobs to use')
 
     option('--darwin-xcrun-toolchain', store,
-           default=defaults.DARWIN_XCRUN_TOOLCHAIN,
            help='the name of the toolchain to use on Darwin')
     option('--cmake', store_path(executable=True),
            help='the path to a CMake executable that will be used to build '

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -106,8 +106,7 @@ EXPECTED_DEFAULTS = {
         defaults.DARWIN_DEPLOYMENT_VERSION_TVOS,
     'darwin_deployment_version_watchos':
         defaults.DARWIN_DEPLOYMENT_VERSION_WATCHOS,
-    'darwin_xcrun_toolchain':
-        defaults.DARWIN_XCRUN_TOOLCHAIN,
+    'darwin_xcrun_toolchain': None,
     'distcc': False,
     'dry_run': False,
     'enable_asan': False,


### PR DESCRIPTION
# Purpose

This PR modifies `build-script` to respect the environment variable `TOOLCHAINS`. If the `--darwin-xcrun-toolchain` flag is used then the environment variable will be ignored in favor of the explicit command line option.

I've also fixed the hardcoded toolchain in `test/lit.cfg`, which explicitly overwrites the `TOOLCHAINS` environment variable with `default` rather than passing the `config.darwin_xcrun_toolchain` or examining the system environment.

rdar://24795244
rdar://23397534