### PR TITLE
[test] SwiftSyntax: add a test to ensure the client side decodes syntax tree properly. NFC

### DIFF
--- a/test/SwiftSyntax/DeserializeFile.swift
+++ b/test/SwiftSyntax/DeserializeFile.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+import SwiftSyntax
+
+func getInput(_ file: String) -> URL {
+  var result = URL(fileURLWithPath: #file)
+  result.deleteLastPathComponent()
+  result.appendPathComponent("Inputs")
+  result.appendPathComponent(file)
+  return result
+}
+
+var DecodeTests = TestSuite("DecodeSyntax")
+
+DecodeTests.test("Basic") {
+  expectDoesNotThrow({
+    let content = try SourceFileSyntax.encodeSourceFileSyntax(getInput("visitor.swift"))
+    let source = try String(contentsOf: getInput("visitor.swift"))
+    let parsed = try SourceFileSyntax.decodeSourceFileSyntax(content)
+    expectEqual("\(parsed)", source)
+  })
+}
+
+runAllTests()

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -28,6 +28,23 @@ public enum ParserError: Error {
 }
 
 extension Syntax {
+  fileprivate static func encodeSourceFileSyntaxInternal(_ url: URL) throws -> Data {
+    let swiftcRunner = try SwiftcRunner(sourceFile: url)
+    let result = try swiftcRunner.invoke()
+    guard result.wasSuccessful else {
+      throw ParserError.swiftcFailed(result.exitCode, result.stderr)
+    }
+    return result.stdoutData
+  }
+
+  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
+  /// serialization format.
+  /// - Parameter url: The URL you wish to parse.
+  /// - Returns: The syntax tree in Json format string.
+  public static func encodeSourceFileSyntax(_ url: URL) throws -> String {
+    return String(data: try encodeSourceFileSyntaxInternal(url), encoding: .utf8)!
+  }
+
   /// Parses the Swift file at the provided URL into a full-fidelity `Syntax`
   /// tree.
   /// - Parameter url: The URL you wish to parse.
@@ -37,12 +54,7 @@ extension Syntax {
   ///           located, `ParseError.invalidFile` if the file is invalid.
   ///           FIXME: Fill this out with all error cases.
   public static func parse(_ url: URL) throws -> SourceFileSyntax {
-    let swiftcRunner = try SwiftcRunner(sourceFile: url)
-    let result = try swiftcRunner.invoke()
-    guard result.wasSuccessful else {
-      throw ParserError.swiftcFailed(result.exitCode, result.stderr)
-    }
-    return try decodeSourceFileSyntax(result.stdoutData)
+    return try decodeSourceFileSyntax(encodeSourceFileSyntaxInternal(url))
   }
 
   /// Decode a serialized form of SourceFileSyntax to a syntax node.


### PR DESCRIPTION
We need to expose a SwiftSyntax API to encode a source file into Json
format.