### PR TITLE
[IRGen] Don't lower profiling intrinsics when profiling is disabled

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -198,6 +198,11 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   // At that stage, the function name GV used by the profiling pass is hidden.
   // Fix the intrinsic call here by pointing it to the correct GV.
   if (IID == llvm::Intrinsic::instrprof_increment) {
+    // If we import profiling intrinsics from a swift module but profiling is
+    // not enabled, ignore the increment.
+    if (!IGF.getSILModule().getOptions().GenerateProfile)
+      return;
+
     // Extract the PGO function name.
     auto *NameGEP = cast<llvm::User>(args.claimNext());
     auto *NameGV = dyn_cast<llvm::GlobalVariable>(NameGEP->stripPointerCasts());

--- a/test/IRGen/coverage_ignored.swift
+++ b/test/IRGen/coverage_ignored.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -emit-sil -o %t.sil
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -o - | %FileCheck %s
+
+// CHECK-NOT: llvm.instrprof
+// CHECK-NOT: profc
+func foo() {}
+foo()


### PR DESCRIPTION
This avoids a compiler crash when importing profiling intrinsics from
the serialized SIL in a swiftmodule.

rdar://36911790, fixes SR-6846 and SR-6800.