### PR TITLE
[WIP][IRGen] Move kind dependent fields to the end of NominalTypeDescriptor

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1180,7 +1180,26 @@ public:
   
   /// The mangled name of the nominal type.
   TargetRelativeDirectPointer<Runtime, const char> Name;
-  
+  NominalTypeKind Kind;
+
+  using NonGenericMetadataAccessFunction = const Metadata *();
+
+  /// A pointer to the metadata access function for this type.
+  ///
+  /// The type of the returned function is speculative; in reality, it
+  /// takes one argument for each of the generic requirements, in the order
+  /// they are listed.  Therefore, the function type is correct only if
+  /// this type is non-generic.
+  ///
+  /// Not all type metadata have access functions.
+  TargetRelativeDirectPointer<Runtime, NonGenericMetadataAccessFunction,
+                              /*Nullable*/ true> AccessFunction;
+
+  /// The generic parameter descriptor header. This describes how to find and
+  /// parse the generic parameter vector in metadata records for this nominal
+  /// type.
+  GenericParameterDescriptorHeader GenericParams;
+
   /// The following fields are kind-dependent.
   union {
     /// Information about class types.
@@ -1286,21 +1305,6 @@ public:
       }
     } Enum;
   };
-  
-  NominalTypeKind Kind;
-
-  using NonGenericMetadataAccessFunction = const Metadata *();
-
-  /// A pointer to the metadata access function for this type.
-  ///
-  /// The type of the returned function is speculative; in reality, it
-  /// takes one argument for each of the generic requirements, in the order
-  /// they are listed.  Therefore, the function type is correct only if
-  /// this type is non-generic.
-  ///
-  /// Not all type metadata have access functions.
-  TargetRelativeDirectPointer<Runtime, NonGenericMetadataAccessFunction,
-                              /*Nullable*/ true> AccessFunction;
 
   NonGenericMetadataAccessFunction *getAccessFunction() const {
     return AccessFunction.get();
@@ -1313,11 +1317,6 @@ public:
   int32_t offsetToNameOffset() const {
     return offsetof(TargetNominalTypeDescriptor<Runtime>, Name);
   }
-
-  /// The generic parameter descriptor header. This describes how to find and
-  /// parse the generic parameter vector in metadata records for this nominal
-  /// type.
-  GenericParameterDescriptorHeader GenericParams;
 
   const GenericContextDescriptor *getGenericContexts() const {
     return this->template getTrailingObjects<GenericContextDescriptor>();

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2210,10 +2210,10 @@ namespace {
   public:    
     void layout() {
       asImpl().addName();
-      asImpl().addKindDependentFields();
       asImpl().addKind();
       asImpl().addAccessFunction();
       asImpl().addGenericParams();
+      asImpl().addKindDependentFields();
     }
 
     CanType getAbstractType() {
@@ -2522,12 +2522,12 @@ namespace {
       VTableSize = layout.getVTableSize();
 
       if (layout.hasResilientSuperclass()) {
-        FieldVectorOffset = layout.getRelativeFieldOffsetVectorOffset();
         GenericParamsOffset = layout.getRelativeGenericRequirementsOffset();
+        FieldVectorOffset = layout.getRelativeFieldOffsetVectorOffset();
         VTableOffset = layout.getRelativeVTableOffset();
       } else {
-        FieldVectorOffset = layout.getStaticFieldOffsetVectorOffset();
         GenericParamsOffset = layout.getStaticGenericRequirementsOffset();
+        FieldVectorOffset = layout.getStaticFieldOffsetVectorOffset();
         VTableOffset = layout.getStaticVTableOffset();
       }
     }
@@ -2541,7 +2541,7 @@ namespace {
     Size getGenericParamsOffset() {
       return GenericParamsOffset;
     }
-    
+
     void addKindDependentFields() {
       // Build the field name list.
       llvm::SmallString<64> fieldNames;

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -313,13 +313,13 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     Int32Ty,
     Int32Ty,
     Int32Ty,
-    Int32Ty,
-    Int32Ty,
-    Int32Ty,
-    Int32Ty,
     Int16Ty,
     Int16Ty,
     Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty,
+    Int32Ty
   }, /*packed=*/true);
 
   MethodDescriptorStructTy

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -50,14 +50,14 @@ public:
 
     // If changing this layout, you must update the magic number in
     // emitParentMetadataRef.
-    
+
+    // Instantiation-specific.
+    asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
+
     // Struct field offsets.
     asImpl().noteStartOfFieldOffsets();
     for (VarDecl *prop : Target->getStoredProperties())
       asImpl().addFieldOffset(prop);
-
-    // Instantiation-specific.
-    asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
   }
   
   // Note the start of the field offset vector.


### PR DESCRIPTION
It's more resilient to have field offset vector and other kind dependent
fields at the end of NominalTypeDescriptor struct, right after generic
arguments have been layed out.

Resolves: rdar://problem/36560486

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
