### PR TITLE
[docs] Update link citing Hoad and Zobel (2003)

### DIFF
--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -199,7 +199,7 @@ func _squeezeHashValue(_ hashValue: Int, _ upperBound: Int) -> Int {
 /// specific hashing logic can be refined without requiring major changes to the
 /// code that creates the synthesized AST nodes.
 ///
-/// [ref]: http://goanna.cs.rmit.edu.au/~jz/fulltext/jasist-tch.pdf
+/// [ref]: https://pdfs.semanticscholar.org/03bf/7be88e88ba047c6ab28036d0f28510299226.pdf
 @_transparent
 public // @testable
 func _combineHashValues(_ firstValue: Int, _ secondValue: Int) -> Int {


### PR DESCRIPTION
The previous link to Hoad and Zobel (2003) no longer works. However, [Semantic Scholar](https://www.semanticscholar.org) (whose URLs should be fairly stable) has a copy of the PDF accessible to all readers. We'll link to that document so that interested readers can study the origin of the function we use for combining hashes.
