### PR TITLE
Batch mode option 4.1

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -619,6 +619,10 @@ def whole_module_optimization : Flag<["-"], "whole-module-optimization">,
   HelpText<"Optimize input files together instead of individually">,
   Flags<[FrontendOption, NoInteractiveOption]>;
 
+def batch_mode : Flag<["-"], "batch-mode">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Combine frontend jobs into batches">;
+
 def wmo : Flag<["-"], "wmo">, Alias<whole_module_optimization>,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -619,9 +619,13 @@ def whole_module_optimization : Flag<["-"], "whole-module-optimization">,
   HelpText<"Optimize input files together instead of individually">,
   Flags<[FrontendOption, NoInteractiveOption]>;
 
-def batch_mode : Flag<["-"], "batch-mode">,
+def enable_batch_mode : Flag<["-"], "enable-batch-mode">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
-  HelpText<"Combine frontend jobs into batches">;
+  HelpText<"Enable combining frontend jobs into batches">;
+
+def disable_batch_mode : Flag<["-"], "disable-batch-mode">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Disable combining frontend jobs into batches">;
 
 def wmo : Flag<["-"], "wmo">, Alias<whole_module_optimization>,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>;


### PR DESCRIPTION
This adds an enable/disable pair of batch-mode options (already present on master) to 4.1 as no-ops, so that if they are accidentally passed to a 4.1 compiler in the field (say due to mismatches between xcode and compiler) during testing, the compiler will not complain. As batch-mode is strictly an optimization, doing nothing is a safe fallback.

rdar://problem/36946715