### PR TITLE
[test] Disable Michael's ARC+ASan test on 32-bit iOS simulator

### DIFF
--- a/validation-test/execution_crashers/arc_36509461.swift
+++ b/validation-test/execution_crashers/arc_36509461.swift
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: asan_runtime
 // REQUIRES: objc_interop
+// UNSUPPORTED: CPU=i386
 
 import Foundation
 


### PR DESCRIPTION
Some configurations are still failing on some Apple-internal bots. I filed rdar://problem/36952273 to look into it and re-enable the test.