### PR TITLE
[test] big_types_corner_cases.swift requires an optimized stdlib

### DIFF
--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: optimized_stdlib
 // UNSUPPORTED: resilient_stdlib
 
 public struct BigStruct {


### PR DESCRIPTION
I'm not sure whether it *should* require an optimized stdlib, but meanwhile let's get the bots back up.