### PR TITLE
[stdlib] Implement efficient DoubleWidth division and fix division-related bugs

### DIFF
--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -44,9 +44,10 @@
 /// replacement for a variable-width integer type. Nesting `DoubleWidth`
 /// instances, in particular, can result in undesirable performance.
 @_fixed_layout // FIXME(sil-serialize-all)
-public struct DoubleWidth<Base : FixedWidthInteger>
-  : _ExpressibleByBuiltinIntegerLiteral
-  where Base.Words : Collection, Base.Magnitude.Words : Collection {    
+public struct DoubleWidth<Base : FixedWidthInteger> :
+  _ExpressibleByBuiltinIntegerLiteral
+  where Base.Magnitude : UnsignedInteger,
+  Base.Words : Collection, Base.Magnitude.Words : Collection {
 
   public typealias High = Base
   public typealias Low = Base.Magnitude
@@ -60,16 +61,19 @@ public struct DoubleWidth<Base : FixedWidthInteger>
 #endif
 
   @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
   public var high: High {
     return _storage.high
   }
 
   @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
   public var low: Low {
     return _storage.low
   }
 
   @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
   public // @testable
   init(_ _value: (High, Low)) {
 #if _endian(big)
@@ -79,9 +83,29 @@ public struct DoubleWidth<Base : FixedWidthInteger>
 #endif
   }
 
+  // We expect users to invoke the public initializer above as demonstrated in
+  // the documentation (that is, by passing in the result of a full width
+  // operation).
+  //
+  // Internally, we'll need to create new instances by supplying high and low
+  // parts directly; ((double parentheses)) greatly impair readability,
+  // especially when nested:
+  //
+  //   DoubleWidth<DoubleWidth>((DoubleWidth((0, 0)), DoubleWidth((0, 0))))
+  //
+  // For that reason, we'll include an internal initializer that takes two
+  // separate arguments.
   @_inlineable // FIXME(sil-serialize-all)
+  @_versioned
+  @_transparent
+  internal init(_ _high: High, _ low: Low) {
+    self.init((_high, low))
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
   public init() {
-    self.init((0, 0))
+    self.init(0, 0)
   }
 }
 
@@ -134,8 +158,7 @@ extension DoubleWidth : Numeric {
 
   @_inlineable // FIXME(sil-serialize-all)
   public var magnitude: Magnitude {
-    let result = Magnitude((
-      Low(truncatingIfNeeded: _storage.high), _storage.low))
+    let result = Magnitude(Low(truncatingIfNeeded: _storage.high), _storage.low)
     if Base.isSigned && _storage.high < (0 as High) {
       return ~result &+ 1
     } else {
@@ -146,7 +169,7 @@ extension DoubleWidth : Numeric {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal init(_ _magnitude: Magnitude) {
-    self.init((High(_magnitude._storage.high), _magnitude._storage.low))
+    self.init(High(_magnitude._storage.high), _magnitude._storage.low)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -173,7 +196,7 @@ extension DoubleWidth : Numeric {
       
       let low = Low(lowInT)
       guard let high = High(exactly: highInT) else { return nil }
-      self.init((high, low))
+      self.init(high, low)
     }
   }
 }
@@ -289,12 +312,12 @@ extension DoubleWidth : FixedWidthInteger {
 
   @_inlineable // FIXME(sil-serialize-all)
   public static var max: DoubleWidth {
-    return self.init((High.max, Low.max))
+    return self.init(High.max, Low.max)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   public static var min: DoubleWidth {
-    return self.init((High.min, Low.min))
+    return self.init(High.min, Low.min)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -325,94 +348,61 @@ extension DoubleWidth : FixedWidthInteger {
     let (carry, product) = multipliedFullWidth(by: rhs)
     let result = DoubleWidth(truncatingIfNeeded: product)
     
-    let isNegative = (self < (0 as DoubleWidth)) != (rhs < (0 as DoubleWidth))
+    let isNegative = DoubleWidth.isSigned &&
+      (self < (0 as DoubleWidth)) != (rhs < (0 as DoubleWidth))
     let didCarry = isNegative
       ? carry != ~(0 as DoubleWidth)
       : carry != (0 as DoubleWidth)
-    let hadPositiveOverflow = !isNegative &&
-      DoubleWidth.isSigned && product.leadingZeroBitCount == 0
+    let hadPositiveOverflow =
+      DoubleWidth.isSigned && !isNegative && product.leadingZeroBitCount == 0
 
     return (result, didCarry || hadPositiveOverflow)
   }
 
-  // Specialize for the most popular types.
-  @_specialize(where Base == Int)
-  @_specialize(where Base == UInt)
-  @_specialize(where Base == Int64)
-  @_specialize(where Base == UInt64)
   @_inlineable // FIXME(sil-serialize-all)
-  public func quotientAndRemainder(dividingBy other: DoubleWidth)
-    -> (quotient: DoubleWidth, remainder: DoubleWidth) {
-    let isNegative = (self < (0 as DoubleWidth)) != (other < (0 as DoubleWidth))
-
-    let rhs = other.magnitude
-    var q = self.magnitude
-
-    // Bail if |other| > |self|
-    if rhs.leadingZeroBitCount < q.leadingZeroBitCount {
-      return (0, self)
+  public func quotientAndRemainder(
+    dividingBy other: DoubleWidth
+  ) -> (quotient: DoubleWidth, remainder: DoubleWidth) {
+    let (quotient, remainder) =
+      Magnitude._divide(self.magnitude, by: other.magnitude)
+    guard DoubleWidth.isSigned else {
+      return (DoubleWidth(quotient), DoubleWidth(remainder))
     }
-    
-    // Calculate the number of bits before q and rhs line up; we can skip that
-    // many bits of iteration.
-    let initialOffset = q.leadingZeroBitCount +
-      (DoubleWidth.bitWidth - rhs.leadingZeroBitCount) - 1
-
-    // Start with remainder capturing the high bits of q.
-    // (These need to be smart shifts, as initialOffset can be greater than
-    // q.bitWidth.)
-    var r = q >> Magnitude(DoubleWidth.bitWidth - initialOffset)
-    q <<= Magnitude(initialOffset)
-
-    let highBit = ~(~0 >> 1) as Magnitude
-    for _ in initialOffset..<DoubleWidth.bitWidth {
-      r <<= 1
-      if q & highBit != (0 as Magnitude) {
-        r += 1 as Magnitude
-      }
-      q <<= 1
-
-      if r >= rhs {
-        q |= 1
-        r -= rhs
-      }
-    }
-
-    // Sign of remainder matches dividend.
-    let remainder = self < (0 as DoubleWidth)
-      ? 0 - DoubleWidth(r)
-      : DoubleWidth(r)
-
-    if isNegative {
-      return (0 - DoubleWidth(q), remainder)
-    } else {
-      return (DoubleWidth(q), remainder)
-    }
+    let quotient_ = (self.high < (0 as High)) != (other.high < (0 as High))
+      ? quotient == DoubleWidth.min.magnitude
+        ? DoubleWidth.min
+        : 0 - DoubleWidth(quotient)
+      : DoubleWidth(quotient)
+    let remainder_ = self.high < (0 as High)
+      ? 0 - DoubleWidth(remainder)
+      : DoubleWidth(remainder)
+    return (quotient_, remainder_)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func dividedReportingOverflow(by other: DoubleWidth)
-    -> (partialValue: DoubleWidth, overflow: Bool) {
-    if other == (0 as DoubleWidth) ||
-      (DoubleWidth.isSigned && other == -1 && self == .min)
-    {
+  public func dividedReportingOverflow(
+    by other: DoubleWidth
+  ) -> (partialValue: DoubleWidth, overflow: Bool) {
+    if other == (0 as DoubleWidth) { return (self, true) }
+    if DoubleWidth.isSigned && other == -1 && self == .min {
       return (self, true)
     }
-
     return (quotientAndRemainder(dividingBy: other).quotient, false)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func remainderReportingOverflow(dividingBy other: DoubleWidth)
-    -> (partialValue: DoubleWidth, overflow: Bool) {
+  public func remainderReportingOverflow(
+    dividingBy other: DoubleWidth
+  ) -> (partialValue: DoubleWidth, overflow: Bool) {
     if other == (0 as DoubleWidth) { return (self, true) }
     if DoubleWidth.isSigned && other == -1 && self == .min { return (0, true) }
     return (quotientAndRemainder(dividingBy: other).remainder, false)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func multipliedFullWidth(by other: DoubleWidth)
-    -> (high: DoubleWidth, low: DoubleWidth.Magnitude) {
+  public func multipliedFullWidth(
+    by other: DoubleWidth
+  ) -> (high: DoubleWidth, low: DoubleWidth.Magnitude) {
     let isNegative = DoubleWidth.isSigned &&
       (self < (0 as DoubleWidth)) != (other < (0 as DoubleWidth))
 
@@ -439,13 +429,14 @@ extension DoubleWidth : FixedWidthInteger {
     let mid1 = sum(a.carry, b.partial, c.partial)
     let mid2 = sum(b.carry, c.carry, d.partial)
         
-    let low = DoubleWidth<Low>((mid1.partial, a.partial))
-    let high = DoubleWidth((
-      High(mid2.carry + d.carry), mid1.carry + mid2.partial))
+    let low =
+      DoubleWidth<Low>(mid1.partial, a.partial)
+    let high =
+      DoubleWidth(High(mid2.carry + d.carry), mid1.carry + mid2.partial)
         
     if isNegative {
       let (lowComplement, overflow) = (~low).addingReportingOverflow(1)
-      return (~high + (overflow ? 1 : 0), lowComplement)
+      return (~high + (overflow ? 1 : 0 as DoubleWidth), lowComplement)
     } else {
       return (high, low)
     }
@@ -455,12 +446,21 @@ extension DoubleWidth : FixedWidthInteger {
   public func dividingFullWidth(
     _ dividend: (high: DoubleWidth, low: DoubleWidth.Magnitude)
   ) -> (quotient: DoubleWidth, remainder: DoubleWidth) {
-    let lhs = DoubleWidth<DoubleWidth<Base>>(dividend)
-    let rhs = DoubleWidth<DoubleWidth<Base>>(self)
-    let (quotient, remainder) = lhs.quotientAndRemainder(dividingBy: rhs)
-
-    // FIXME(integers): check for overflow of quotient and remainder
-    return (DoubleWidth(quotient.low), DoubleWidth(remainder.low))
+    let other = DoubleWidth<DoubleWidth>(dividend)
+    let (quotient, remainder) =
+      Magnitude._divide(other.magnitude, by: self.magnitude)
+    guard DoubleWidth.isSigned else {
+      return (DoubleWidth(quotient), DoubleWidth(remainder))
+    }
+    let quotient_ = (self.high < (0 as High)) != (other.high.high < (0 as High))
+      ? quotient == DoubleWidth.min.magnitude
+        ? DoubleWidth.min
+        : 0 - DoubleWidth(quotient)
+      : DoubleWidth(quotient)
+    let remainder_ = other.high.high < (0 as High)
+      ? 0 - DoubleWidth(remainder)
+      : DoubleWidth(remainder)
+    return (quotient_, remainder_)
   }
 
 % for operator in ['&', '|', '^']:
@@ -475,7 +475,7 @@ extension DoubleWidth : FixedWidthInteger {
 
   @_inlineable // FIXME(sil-serialize-all)
   public static func <<=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
-    if rhs < (0 as DoubleWidth) {
+    if DoubleWidth.isSigned && rhs < (0 as DoubleWidth) {
       lhs >>= 0 - rhs
       return
     }
@@ -493,7 +493,7 @@ extension DoubleWidth : FixedWidthInteger {
   
   @_inlineable // FIXME(sil-serialize-all)
   public static func >>=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
-    if rhs < (0 as DoubleWidth) {
+    if DoubleWidth.isSigned && rhs < (0 as DoubleWidth) {
       lhs <<= 0 - rhs
       return
     }
@@ -511,7 +511,12 @@ extension DoubleWidth : FixedWidthInteger {
   
   @_inlineable // FIXME(sil-serialize-all)
   public static func &<<=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
-    let rhs = rhs & DoubleWidth(DoubleWidth.bitWidth &- 1)
+    // FIXME(integers): test types with bit widths that aren't powers of 2
+    let rhs = DoubleWidth.bitWidth.nonzeroBitCount == 1
+      ? rhs & DoubleWidth(DoubleWidth.bitWidth &- 1)
+      : DoubleWidth.isSigned && rhs._storage.high < (0 as High)
+        ? rhs % DoubleWidth(DoubleWidth.bitWidth) + rhs
+        : rhs % DoubleWidth(DoubleWidth.bitWidth)
 
     guard rhs._storage.low < Base.bitWidth else {
       lhs._storage.high = High(
@@ -531,7 +536,12 @@ extension DoubleWidth : FixedWidthInteger {
   
   @_inlineable // FIXME(sil-serialize-all)
   public static func &>>=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
-    let rhs = rhs & DoubleWidth(DoubleWidth.bitWidth &- 1)
+    // FIXME(integers): test types with bit widths that aren't powers of 2
+    let rhs = DoubleWidth.bitWidth.nonzeroBitCount == 1
+      ? rhs & DoubleWidth(DoubleWidth.bitWidth &- 1)
+      : DoubleWidth.isSigned && rhs._storage.high < (0 as High)
+        ? rhs % DoubleWidth(DoubleWidth.bitWidth) + rhs
+        : rhs % DoubleWidth(DoubleWidth.bitWidth)
 
     guard rhs._storage.low < Base.bitWidth else {
       lhs._storage.low = Low(
@@ -648,14 +658,141 @@ binaryOperators = [
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public var byteSwapped: DoubleWidth {
-    return DoubleWidth((
+    return DoubleWidth(
       High(truncatingIfNeeded: low.byteSwapped),
-      Low(truncatingIfNeeded: high.byteSwapped)
-    ))
+      Low(truncatingIfNeeded: high.byteSwapped))
   }
 }
 
-extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {}
+extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
+  /// Returns the quotient and remainder after dividing a triple-width magnitude
+  /// `lhs` by a double-width magnitude `rhs`.
+  ///
+  /// This operation is conceptually that described by Burnikel and Ziegler
+  /// (1998).
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned
+  internal static func _divide(
+    _ lhs: (high: Low, mid: Low, low: Low), by rhs: Magnitude
+  ) -> (quotient: Low, remainder: Magnitude) {
+    // The following invariants are guaranteed to hold by dividingFullWidth or
+    // quotientAndRemainder before this method is invoked:
+    _sanityCheck(lhs.high != (0 as Low))
+    _sanityCheck(rhs.leadingZeroBitCount == 0)
+    _sanityCheck(Magnitude(lhs.high, lhs.mid) < rhs)
+
+    // Estimate the quotient.
+    var quotient = lhs.high == rhs.high
+      ? Low.max
+      : rhs.high.dividingFullWidth((lhs.high, lhs.mid)).quotient
+    // Compute quotient * rhs.
+    // TODO: This could be performed more efficiently.
+    var product =
+      DoubleWidth<Magnitude>(
+        0, Magnitude(quotient.multipliedFullWidth(by: rhs.low)))
+    let (x, y) = quotient.multipliedFullWidth(by: rhs.high)
+    product += DoubleWidth<Magnitude>(Magnitude(0, x), Magnitude(y, 0))
+    // Compute the remainder after decrementing quotient as necessary.
+    var remainder =
+      DoubleWidth<Magnitude>(
+        Magnitude(0, lhs.high), Magnitude(lhs.mid, lhs.low))
+    while remainder < product {
+      quotient = quotient &- 1
+      remainder += DoubleWidth<Magnitude>(0, rhs)
+    }
+    remainder -= product
+
+    return (quotient, remainder.low)
+  }
+
+  /// Returns the quotient and remainder after dividing a quadruple-width
+  /// magnitude `lhs` by a double-width magnitude `rhs`.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned
+  internal static func _divide(
+    _ lhs: DoubleWidth<Magnitude>, by rhs: Magnitude
+  ) -> (quotient: Magnitude, remainder: Magnitude) {
+    guard _fastPath(rhs > (0 as Magnitude)) else {
+      fatalError("Division by zero")
+    }
+    guard _fastPath(rhs >= lhs.high) else {
+      fatalError("Division results in an overflow")
+    }
+
+    if lhs.high == (0 as Magnitude) {
+      return lhs.low.quotientAndRemainder(dividingBy: rhs)
+    }
+
+    if rhs.high == (0 as Low) {
+      let a = lhs.high.high % rhs.low
+      let b = a == (0 as Low)
+        ? lhs.high.low % rhs.low
+        : rhs.low.dividingFullWidth((a, lhs.high.low)).remainder
+      let (x, c) = b == (0 as Low)
+        ? lhs.low.high.quotientAndRemainder(dividingBy: rhs.low)
+        : rhs.low.dividingFullWidth((b, lhs.low.high))
+      let (y, d) = c == (0 as Low)
+        ? lhs.low.low.quotientAndRemainder(dividingBy: rhs.low)
+        : rhs.low.dividingFullWidth((c, lhs.low.low))
+      return (Magnitude(x, y), Magnitude(0, d))
+    }
+
+    // Left shift both rhs and lhs, then divide and right shift the remainder.
+    let shift = rhs.leadingZeroBitCount
+    let rhs = rhs &<< shift
+    let lhs = lhs &<< shift
+    if lhs.high.high == (0 as Low)
+      && Magnitude(lhs.high.low, lhs.low.high) < rhs {
+      let (quotient, remainder) =
+        Magnitude._divide((lhs.high.low, lhs.low.high, lhs.low.low), by: rhs)
+      return (Magnitude(0, quotient), remainder &>> shift)
+    }
+    let (x, a) =
+      Magnitude._divide((lhs.high.high, lhs.high.low, lhs.low.high), by: rhs)
+    let (y, b) =
+      Magnitude._divide((a.high, a.low, lhs.low.low), by: rhs)
+    return (Magnitude(x, y), b &>> shift)
+  }
+
+  /// Returns the quotient and remainder after dividing a double-width
+  /// magnitude `lhs` by a double-width magnitude `rhs`.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned
+  internal static func _divide(
+    _ lhs: Magnitude, by rhs: Magnitude
+  ) -> (quotient: Magnitude, remainder: Magnitude) {
+    guard _fastPath(rhs > (0 as Magnitude)) else {
+      fatalError("Division by zero")
+    }
+    guard rhs < lhs else {
+      if _fastPath(rhs > lhs) { return (0, lhs) }
+      return (1, 0)
+    }
+
+    if lhs.high == (0 as Low) {
+      let (quotient, remainder) =
+        lhs.low.quotientAndRemainder(dividingBy: rhs.low)
+      return (Magnitude(quotient), Magnitude(remainder))
+    }
+
+    if rhs.high == (0 as Low) {
+      let (x, a) = lhs.high.quotientAndRemainder(dividingBy: rhs.low)
+      let (y, b) = a == (0 as Low)
+        ? lhs.low.quotientAndRemainder(dividingBy: rhs.low)
+        : rhs.low.dividingFullWidth((a, lhs.low))
+      return (Magnitude(x, y), Magnitude(0, b))
+    }
+
+    // Left shift both rhs and lhs, then divide and right shift the remainder.
+    let shift = rhs.leadingZeroBitCount
+    let rhs = rhs &<< shift
+    let high = (lhs &>> (Magnitude.bitWidth &- shift)).low
+    let lhs = lhs &<< shift
+    let (quotient, remainder) =
+      Magnitude._divide((high, lhs.high, lhs.low), by: rhs)
+    return (Magnitude(0, quotient), remainder &>> shift)
+  }
+}
 
 extension DoubleWidth : SignedNumeric, SignedInteger
   where Base : SignedInteger {}

--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -368,7 +368,8 @@ extension DoubleWidth : FixedWidthInteger {
     guard DoubleWidth.isSigned else {
       return (DoubleWidth(quotient), DoubleWidth(remainder))
     }
-    let quotient_ = (self.high < (0 as High)) != (other.high < (0 as High))
+    let isNegative = (self.high < (0 as High)) != (other.high < (0 as High))
+    let quotient_ = isNegative
       ? quotient == DoubleWidth.min.magnitude
         ? DoubleWidth.min
         : 0 - DoubleWidth(quotient)
@@ -452,7 +453,9 @@ extension DoubleWidth : FixedWidthInteger {
     guard DoubleWidth.isSigned else {
       return (DoubleWidth(quotient), DoubleWidth(remainder))
     }
-    let quotient_ = (self.high < (0 as High)) != (other.high.high < (0 as High))
+    let isNegative =
+      (self.high < (0 as High)) != (other.high.high < (0 as High))
+    let quotient_ = isNegative
       ? quotient == DoubleWidth.min.magnitude
         ? DoubleWidth.min
         : 0 - DoubleWidth(quotient)
@@ -508,15 +511,29 @@ extension DoubleWidth : FixedWidthInteger {
 
     lhs &>>= rhs
   }
-  
+
+  /// Returns this value "masked" by its bit width.
+  ///
+  /// "Masking" notionally involves repeatedly incrementing or decrementing this
+  /// value by `self.bitWidth` until the result is contained in the range
+  /// `0..<self.bitWidth`.
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned
+  @_transparent
+  internal func _masked() -> DoubleWidth {
+    // FIXME(integers): test types with bit widths that aren't powers of 2
+    if DoubleWidth.bitWidth.nonzeroBitCount == 1 {
+      return self & DoubleWidth(DoubleWidth.bitWidth &- 1)
+    }
+    if DoubleWidth.isSigned && self._storage.high < (0 as High) {
+      return self % DoubleWidth(DoubleWidth.bitWidth) + self
+    }
+    return self % DoubleWidth(DoubleWidth.bitWidth)
+  }
+
   @_inlineable // FIXME(sil-serialize-all)
   public static func &<<=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
-    // FIXME(integers): test types with bit widths that aren't powers of 2
-    let rhs = DoubleWidth.bitWidth.nonzeroBitCount == 1
-      ? rhs & DoubleWidth(DoubleWidth.bitWidth &- 1)
-      : DoubleWidth.isSigned && rhs._storage.high < (0 as High)
-        ? rhs % DoubleWidth(DoubleWidth.bitWidth) + rhs
-        : rhs % DoubleWidth(DoubleWidth.bitWidth)
+    let rhs = rhs._masked()
 
     guard rhs._storage.low < Base.bitWidth else {
       lhs._storage.high = High(
@@ -536,12 +553,7 @@ extension DoubleWidth : FixedWidthInteger {
   
   @_inlineable // FIXME(sil-serialize-all)
   public static func &>>=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
-    // FIXME(integers): test types with bit widths that aren't powers of 2
-    let rhs = DoubleWidth.bitWidth.nonzeroBitCount == 1
-      ? rhs & DoubleWidth(DoubleWidth.bitWidth &- 1)
-      : DoubleWidth.isSigned && rhs._storage.high < (0 as High)
-        ? rhs % DoubleWidth(DoubleWidth.bitWidth) + rhs
-        : rhs % DoubleWidth(DoubleWidth.bitWidth)
+    let rhs = rhs._masked()
 
     guard rhs._storage.low < Base.bitWidth else {
       lhs._storage.low = Low(

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3095,16 +3095,16 @@ ${assignmentOperatorComment(x.operator, True)}
   @_transparent
   public static func ${x.operator}=(_ lhs: inout ${Self}, _ rhs: ${Self}) {
 %   if x.kind == '/':
-    // No LLVM primitives for checking overflow of division
-    // operations, so we check manually.
+    // No LLVM primitives for checking overflow of division operations, so we
+    // check manually.
     if _slowPath(rhs == (0 as ${Self})) {
-      _preconditionFailure("Remainder of or division by zero")
+      _preconditionFailure("Division by zero")
     }
 %     if signed:
     if _slowPath(
       ${'lhs == %s.min && rhs == (-1 as %s)' % (Self, Self)}
     ) {
-      _preconditionFailure("Overflow in remainder of or division")
+      _preconditionFailure("Division results in an overflow")
     }
 %     end
     let (result, overflow) =
@@ -3129,16 +3129,18 @@ ${overflowOperationComment(x.operator)}
   public func ${x.name}ReportingOverflow(
     ${x.firstArg} other: ${Self}
   ) -> (partialValue: ${Self}, overflow: Bool) {
-
 %         if x.kind == '/':
-    // No LLVM primitives for checking overflow of division
-    // operations, so we check manually.
-    if _slowPath(
-      other == (0 as ${Self})
-      ${'|| self == %s.min && other == (-1 as %s)' % (Self, Self) if signed else ''}
-    ) {
+    // No LLVM primitives for checking overflow of division operations, so we
+    // check manually.
+    if _slowPath(other == (0 as ${Self})) {
       return (partialValue: self, overflow: true)
     }
+%           if signed:
+    if _slowPath(self == ${Self}.min && other == (-1 as ${Self})) {
+%             partialValue = 'self' if x.operator == '/' else '0'
+      return (partialValue: ${partialValue}, overflow: true)
+    }
+%           end
 
     let (newStorage, overflow) = (
       Builtin.${u}${x.llvmName}_Int${bits}(self._value, other._value),
@@ -3146,9 +3148,9 @@ ${overflowOperationComment(x.operator)}
 
 %         else:
 
-    let (newStorage, overflow)
-    = Builtin.${u}${x.llvmName}_with_overflow_Int${bits}(
-      self._value, other._value, false._value)
+    let (newStorage, overflow) =
+      Builtin.${u}${x.llvmName}_with_overflow_Int${bits}(
+        self._value, other._value, false._value)
 %         end
 
     return (
@@ -3161,16 +3163,14 @@ ${assignmentOperatorComment('%', True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public static func %=(_ lhs: inout ${Self}, _ rhs: ${Self}) {
-    // No LLVM primitives for checking overflow of division
-    // operations, so we check manually.
+    // No LLVM primitives for checking overflow of division operations, so we
+    // check manually.
     if _slowPath(rhs == (0 as ${Self})) {
-      _preconditionFailure("Remainder of division by zero")
+      _preconditionFailure("Division by zero")
     }
 %     if signed:
-    if _slowPath(
-      ${'lhs == %s.min && rhs == (-1 as %s)' % (Self, Self)}
-    ) {
-      _preconditionFailure("Overflow in remainder of division")
+    if _slowPath(${'lhs == %s.min && rhs == (-1 as %s)' % (Self, Self)}) {
+      _preconditionFailure("Division results in an overflow")
     }
 %     end
 
@@ -3455,15 +3455,24 @@ ${assignmentOperatorComment(x.operator, True)}
     _ dividend: (high: ${Self}, low: ${Self}.Magnitude)
   ) -> (quotient: ${Self}, remainder: ${Self}) {
     // FIXME(integers): tests
-%   # 128 bit types are not provided by the 32-bit LLVM
+%   # 128-bit types are not provided by the 32-bit LLVM
 %   #if word_bits == 32 and bits == 64:
+%   # FIXME(integers): uncomment the above after using the right conditional
+%   # compilation block to exclude 64-bit Windows, which does not support
+%   # 128-bit operations
 %   if bits == 64:
-    let lhs = DoubleWidth<${Self}>(dividend)
-    let rhs = DoubleWidth<${Self}>(self)
+%     HalfWidth = 'Int32' if signed else 'UInt32'
+    let lhsHigh =
+      unsafeBitCast(dividend.high, to: DoubleWidth<${HalfWidth}>.self)
+    let lhsLow = unsafeBitCast(dividend.low, to: DoubleWidth<UInt32>.self)
+    let rhs_ = unsafeBitCast(self, to: DoubleWidth<${HalfWidth}>.self)
 
-    let (quotient, remainder) = lhs.quotientAndRemainder(dividingBy: rhs)
-    // FIXME(integers): check for high words in quotient and remainder
-    return (${Self}(quotient.low), ${Self}(remainder.low))
+    let (quotient_, remainder_) = rhs_.dividingFullWidth((lhsHigh, lhsLow))
+
+    let quotient = unsafeBitCast(quotient_, to: ${Self}.self)
+    let remainder = unsafeBitCast(remainder_, to: ${Self}.self)
+
+    return (quotient: quotient, remainder: remainder)
 %   else:
     // FIXME(integers): handle division by zero and overflows
     _precondition(self != 0, "Division by zero")

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3098,13 +3098,15 @@ ${assignmentOperatorComment(x.operator, True)}
     // No LLVM primitives for checking overflow of division operations, so we
     // check manually.
     if _slowPath(rhs == (0 as ${Self})) {
-      _preconditionFailure("Division by zero")
+      _preconditionFailure(
+        "Division by zero${' in remainder operation' if x.operator == '%' else ''}")
     }
 %     if signed:
     if _slowPath(
       ${'lhs == %s.min && rhs == (-1 as %s)' % (Self, Self)}
     ) {
-      _preconditionFailure("Division results in an overflow")
+      _preconditionFailure(
+        "Division results in an overflow${' in remainder operation' if x.operator == '%' else ''}")
     }
 %     end
     let (result, overflow) =
@@ -3166,11 +3168,13 @@ ${assignmentOperatorComment('%', True)}
     // No LLVM primitives for checking overflow of division operations, so we
     // check manually.
     if _slowPath(rhs == (0 as ${Self})) {
-      _preconditionFailure("Division by zero")
+      _preconditionFailure(
+        "Division by zero in remainder operation")
     }
 %     if signed:
     if _slowPath(${'lhs == %s.min && rhs == (-1 as %s)' % (Self, Self)}) {
-      _preconditionFailure("Division results in an overflow")
+      _preconditionFailure(
+        "Division results in an overflow in remainder operation")
     }
 %     end
 

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -740,6 +740,18 @@ tests.test("Remainder/DividingBy0") {
   _ = f(42, 0)
 }
 
+tests.test("RemainderReportingOverflow/DividingByMinusOne") {
+  // Work around SR-5964.
+  func minusOne<T : SignedInteger>() -> T {
+    return -1 as T
+  }
+  func f(_ x: Int, _ y: Int) -> Int {
+    return x.remainderReportingOverflow(dividingBy: y).partialValue
+  }
+  expectEqual(f(.max, minusOne()), 0)
+  expectEqual(f(.min, minusOne()), 0)
+}
+
 tests.test("Division/By0") {
   func f(_ x: Int, _ y: Int) -> Int {
     return x / y


### PR DESCRIPTION
This PR implements more efficient `DoubleWidth` division using full-width division primitives available on `Base`. It's one chunk of changes from #13784, which CI won't test anymore.

Also in this PR:
1. [A re-implementation](https://github.com/apple/swift/pull/14219/files#diff-603108a1f9a14cb76c4015d25900cff0L3461) of `{U}Int64.dividingFullWidth` in terms of `DoubleWidth<{U}Int32>.dividingFullWidth` (which is required to avoid circularity).  
  _Existing `DoubleWidth` tests cover this change._
2. [A bugfix](https://github.com/apple/swift/pull/14219/files#diff-603108a1f9a14cb76c4015d25900cff0L3136) in `remainderReportingOverflow` for builtin types when dividing by `-1`.  
  _A test is added to cover this change._
3. [A corrected implementation](https://github.com/apple/swift/pull/14219/files#diff-1a1ccf1c510bfc49a19be3eb3c378a8fL514) of `DoubleWidth` masking shifts.  
  _No types exist to test this change._

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
