### PR TITLE
[Sema] Improve Optional-to-Any diagnostics for collections, nested optionals & IUOs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2753,13 +2753,14 @@ WARNING(optional_pattern_match_promotion,none,
         "pattern match introduces an implicit promotion from %0 to %1",
         (Type, Type))
 WARNING(optional_to_any_coercion,none,
-        "expression implicitly coerced from %0 to Any", (Type))
+        "expression implicitly coerced from %0 to %1", (Type, Type))
 NOTE(default_optional_to_any,none,
      "provide a default value to avoid this warning", ())
 NOTE(force_optional_to_any,none,
      "force-unwrap the value to avoid this warning", ())
 NOTE(silence_optional_to_any,none,
-     "explicitly cast to Any with 'as Any' to silence this warning", ())
+     "explicitly cast to %0 with '%1' to silence this warning",
+     (Type, StringRef))
 WARNING(optional_in_string_interpolation_segment,none,
         "string interpolation produces a debug description for an optional "
         "value; did you mean to make this explicit?",

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3545,12 +3545,6 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
 
       auto subExpr = E->getSubExpr();
 
-      // Currently we don't produce Optional-as-Any warnings for implicit IUO
-      // to Any coercions (this doesn't take into consideration implicit
-      // coercions such as Any?! to Any?, however; we warn on those).
-      if (subExpr->getType()->getImplicitlyUnwrappedOptionalObjectType())
-        return;
-
       // Look through any BindOptionalExprs, as the coercion may have started
       // from a higher level of optionality.
       while (auto *bindExpr = dyn_cast<BindOptionalExpr>(subExpr))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3524,11 +3524,6 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     }
 
     void emitSilenceOptionalAnyWarningWithCoercion(Expr *E, Type destType) {
-      // Treat an IUO destination type as a regular Optional type, as we cannot
-      // suggest a fix-it of e.g 'as Any!'.
-      if (auto baseType = destType->getImplicitlyUnwrappedOptionalObjectType())
-        destType = OptionalType::get(baseType);
-
       SmallString<16> coercionString;
       coercionString += " as ";
       coercionString += destType->getWithoutParens()->getString();

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -247,27 +247,27 @@ func almostSubscriptableValueMismatch(_ as1: AlmostSubscriptable, a: A) {
 func almostSubscriptableKeyMismatch(_ bc: BadCollection, key: NSString) {
   // FIXME: We end up importing this as read-only due to the mismatch between
   // getter/setter element types.
-  var _ : Any = bc[key] // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  var _ : Any = bc[key] // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 }
 
 func almostSubscriptableKeyMismatchInherited(_ bc: BadCollectionChild,
                                              key: String) {
-  var value : Any = bc[key] // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  var value : Any = bc[key] // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
   bc[key] = value // expected-error{{cannot assign through subscript: subscript is get-only}}
 }
 
 func almostSubscriptableKeyMismatchInherited(_ roc: ReadOnlyCollectionChild,
                                              key: String) {
-  var value : Any = roc[key] // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  var value : Any = roc[key] // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
   roc[key] = value // expected-error{{cannot assign through subscript: subscript is get-only}}
 }
 
@@ -407,22 +407,22 @@ func testPropertyAndMethodCollision(_ obj: PropertyAndMethodCollision,
   type(of: rev).classRef(rev, doSomething:#selector(getter: NSMenuItem.action))
 
   var value: Any
-  value = obj.protoProp() // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  value = obj.protoProp() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
-  value = obj.protoPropRO() // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  value = obj.protoPropRO() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
-  value = type(of: obj).protoClassProp() // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  value = type(of: obj).protoClassProp() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
-  value = type(of: obj).protoClassPropRO() // expected-warning {{expression implicitly coerced from 'Any?' to Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  value = type(of: obj).protoClassPropRO() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
   _ = value
 }
 

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -34,10 +34,10 @@ func nsobject_as_class_cast<T>(_ x: NSObject, _: T) {
 func test(_ a : CFString!, b : CFString) {
   let dict = NSMutableDictionary()
   let object = NSObject()
-  dict[a] = object // expected-warning {{expression implicitly coerced from 'CFString?' to Any}}
+  dict[a] = object // expected-warning {{expression implicitly coerced from 'CFString?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 
 
   dict[b] = object

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -51,10 +51,10 @@ struct SR3715 {
   func take(_ a: [Any]) {}
 
   func test() {
-    take([overloaded]) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+    take([overloaded]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
   }
 }
 

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -87,8 +87,8 @@ func testP3(_ p: P3, something: Something) {
 }
 
 func testIUOToAny(_ t: AnyObject.Type!) {
-  let _: Any = t // expected-warning {{expression implicitly coerced from 'AnyObject.Type?' to Any}}
+  let _: Any = t // expected-warning {{expression implicitly coerced from 'AnyObject.Type?' to 'Any'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}
   // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 }

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -82,9 +82,16 @@ func warnNestedOptionalToOptionalAnyCoercion(_ a: Int?, _ b: Any??, _ c: Int???,
   takesOptionalAny(c as Any?, d as Any?)
 }
 
-func dontWarnIUOToAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
-  _ = takeAny(a, b)
-  _ = takeAny(c, d)
+func warnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
+  _ = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int!' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{16-16= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{16-16=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{16-16= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Any?!' to 'Any'}}
+  // expected-note@-5 {{force-unwrap the value to avoid this warning}}{{19-19=!!}}
+  // expected-note@-6 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{19-19= as Any}}
+
+  _ = takeAny(a as Any, b as Any)
 }
 
 func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -83,11 +83,11 @@ func warnNestedOptionalToOptionalAnyCoercion(_ a: Int?, _ b: Any??, _ c: Int???,
 }
 
 func warnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
-  _ = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int!' to 'Any'}}
+  _ = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{16-16= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{16-16=!}}
   // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{16-16= as Any}}
-  // expected-warning@-4 {{expression implicitly coerced from 'Any?!' to 'Any'}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Any??' to 'Any'}}
   // expected-note@-5 {{force-unwrap the value to avoid this warning}}{{19-19=!!}}
   // expected-note@-6 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{19-19= as Any}}
 
@@ -95,7 +95,7 @@ func warnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
 }
 
 func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
-  takesOptionalAny(a, b) // expected-warning {{expression implicitly coerced from 'Any?!' to 'Any?'}}
+  takesOptionalAny(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any?'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{24-24= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{24-24=!}}
   // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
@@ -104,10 +104,10 @@ func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any??
   takesOptionalAny(a, b!)
   takesOptionalAny(a, b as Any?)
 
-  takesOptionalAny(c, d) // expected-warning {{expression implicitly coerced from 'Int??!' to 'Any?'}}
+  takesOptionalAny(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any?'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{21-21=!!}}
   // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{21-21= as Any?}}
-  // expected-warning@-3 {{expression implicitly coerced from 'Any???!' to 'Any?'}}
+  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any?'}}
   // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{24-24=!!!}}
   // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
 
@@ -118,7 +118,7 @@ func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any??
 func takesIUO(_: Any!, _: Any!) {}
 
 func warnOptionalToIUOAny(_ a: Int?, _ b: Any??, _ c: Int???, _ d: Any????) {
-  takesIUO(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any!'}}
+  takesIUO(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any?'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{16-16= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{16-16=!}}
   // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{16-16= as Any?}}
@@ -127,10 +127,10 @@ func warnOptionalToIUOAny(_ a: Int?, _ b: Any??, _ c: Int???, _ d: Any????) {
   takesIUO(a, b!)
   takesIUO(a, b as Any?)
 
-  takesIUO(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any!'}}
+  takesIUO(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any?'}}
   // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{13-13=!!}}
   // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{13-13= as Any?}}
-  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any!'}}
+  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any?'}}
   // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{16-16=!!!}}
   // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{16-16= as Any?}}
 

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -7,56 +7,56 @@ func takeAny(_ left: Any, _ right: Any) -> Int? {
 func throwing() throws -> Int? {}
 
 func warnOptionalToAnyCoercion(value x: Int?) -> Any {
-  let a: Any = x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  let a: Any = x // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{17-17= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{17-17=!}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}{{17-17= as Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{17-17= as Any}}
 
   let b: Any = x as Any
 
-  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 
   let _: Any = takeAny(c, c) as Any
 
-  let _: Any = (x)  // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  let _: Any = (x)  // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 
   let f: Any = (x as Any)
   let g: Any = (x) as (Any)
 
-  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 
-  let _: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  let _: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{33-33= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{33-33=!}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}{{33-33= as Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{33-33= as Any}}
 
   let _: Any = takeAny(f as? Int as Any, g) as Any
 
-  let _: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  let _: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 
   do {
-    let _: Any = try throwing() // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+    let _: Any = try throwing() // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
     // expected-note@-1 {{provide a default value to avoid this warning}}
     // expected-note@-2 {{force-unwrap the value to avoid this warning}}
-    // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+    // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
   } catch {}
 
-  return x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  return x // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 }
 
 func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {
@@ -64,24 +64,24 @@ func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {
 
 func warnCollectionOfAny(_ a: [Int?], _ d: [String : Int?]) {
   // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling
-  takesCollectionOfAny(a, d) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  takesCollectionOfAny(a, d) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{25-25= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{25-25=!}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}{{25-25= as Any}}
-  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{25-25= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-5 {{provide a default value to avoid this warning}}{{28-28= ?? <#default value#>}}
   // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{28-28=!}}
-  // expected-note@-7 {{explicitly cast to Any with 'as Any' to silence this warning}}{{28-28= as Any}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{28-28= as Any}}
 
   // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling
-  takesCollectionOfAny(a as [Any], d as [String : Any]) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  takesCollectionOfAny(a as [Any], d as [String : Any]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-1 {{provide a default value to avoid this warning}}{{25-25= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{25-25=!}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}{{25-25= as Any}}
-  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{25-25= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
   // expected-note@-5 {{provide a default value to avoid this warning}}{{37-37= ?? <#default value#>}}
   // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{37-37=!}}
-  // expected-note@-7 {{explicitly cast to Any with 'as Any' to silence this warning}}{{37-37= as Any}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{37-37= as Any}}
 }
 
 func warnOptionalInStringInterpolationSegment(_ o : Int?) {

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -132,27 +132,31 @@ func warnOptionalToIUOAny(_ a: Int?, _ b: Any??, _ c: Int???, _ d: Any????) {
 }
 
 func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {}
+func takesCollectionOfOptionalAny(_ a: [Any?], _ d: [String : Any?]) {}
 
-func warnCollectionOfAny(_ a: [Int?], _ d: [String : Int?]) {
-  // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling
-  takesCollectionOfAny(a, d) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
-  // expected-note@-1 {{provide a default value to avoid this warning}}{{25-25= ?? <#default value#>}}
-  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{25-25=!}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{25-25= as Any}}
-  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
-  // expected-note@-5 {{provide a default value to avoid this warning}}{{28-28= ?? <#default value#>}}
-  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{28-28=!}}
-  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{28-28= as Any}}
+func warnCollectionOfOptionalToAnyCoercion(_ a: [Int?], _ d: [String : Int?]) {
+  takesCollectionOfAny(a, d) // expected-warning {{expression implicitly coerced from '[Int?]' to '[Any]'}}
+  // expected-note@-1 {{explicitly cast to '[Any]' with 'as [Any]' to silence this warning}}{{25-25= as [Any]}}
+  // expected-warning@-2 {{expression implicitly coerced from '[String : Int?]' to '[String : Any]'}}
+  // expected-note@-3 {{explicitly cast to '[String : Any]' with 'as [String : Any]' to silence this warning}}{{28-28= as [String : Any]}}
 
-  // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling
-  takesCollectionOfAny(a as [Any], d as [String : Any]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
-  // expected-note@-1 {{provide a default value to avoid this warning}}{{25-25= ?? <#default value#>}}
-  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{25-25=!}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{25-25= as Any}}
-  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
-  // expected-note@-5 {{provide a default value to avoid this warning}}{{37-37= ?? <#default value#>}}
-  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{37-37=!}}
-  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{37-37= as Any}}
+  takesCollectionOfAny(a as [Any], d as [String : Any])
+}
+
+func warnCollectionOfTripleOptionalToAnyCoercion(_ a: [Any???], _ d: [String: Any???]) {
+  takesCollectionOfAny(a, d) // expected-warning {{expression implicitly coerced from '[Any???]' to '[Any]'}}
+  // expected-note@-1 {{explicitly cast to '[Any]' with 'as [Any]' to silence this warning}}{{25-25= as [Any]}}
+  // expected-warning@-2 {{expression implicitly coerced from '[String : Any???]' to '[String : Any]'}}
+  // expected-note@-3 {{explicitly cast to '[String : Any]' with 'as [String : Any]' to silence this warning}}{{28-28= as [String : Any]}}
+
+  takesCollectionOfAny(a as [Any], d as [String : Any])
+
+  takesCollectionOfOptionalAny(a, d) // expected-warning {{expression implicitly coerced from '[Any???]' to '[Any?]'}}
+  // expected-note@-1 {{explicitly cast to '[Any?]' with 'as [Any?]' to silence this warning}}{{33-33= as [Any?]}}
+  // expected-warning@-2 {{expression implicitly coerced from '[String : Any???]' to '[String : Any?]'}}
+  // expected-note@-3 {{explicitly cast to '[String : Any?]' with 'as [String : Any?]' to silence this warning}}{{36-36= as [String : Any?]}}
+
+  takesCollectionOfOptionalAny(a as [Any?], d as [String : Any?])
 }
 
 func warnOptionalInStringInterpolationSegment(_ o : Int?) {

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -59,8 +59,79 @@ func warnOptionalToAnyCoercion(value x: Int?) -> Any {
   // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
 }
 
-func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {
+func takesOptionalAny(_: Any?, _: Any?) {}
+
+func warnNestedOptionalToOptionalAnyCoercion(_ a: Int?, _ b: Any??, _ c: Int???, _ d: Any????) {
+  takesOptionalAny(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any?'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{24-24= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{24-24=!}}
+  // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+
+  takesOptionalAny(a, b ?? "")
+  takesOptionalAny(a, b!)
+  takesOptionalAny(a, b as Any?)
+
+  takesOptionalAny(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any?'}}
+  // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{21-21=!!}}
+  // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{21-21= as Any?}}
+  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any?'}}
+  // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{24-24=!!!}}
+  // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+
+  takesOptionalAny(c!!, d!!!)
+  takesOptionalAny(c as Any?, d as Any?)
 }
+
+func dontWarnIUOToAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
+  _ = takeAny(a, b)
+  _ = takeAny(c, d)
+}
+
+func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
+  takesOptionalAny(a, b) // expected-warning {{expression implicitly coerced from 'Any?!' to 'Any?'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{24-24= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{24-24=!}}
+  // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+
+  takesOptionalAny(a, b ?? "")
+  takesOptionalAny(a, b!)
+  takesOptionalAny(a, b as Any?)
+
+  takesOptionalAny(c, d) // expected-warning {{expression implicitly coerced from 'Int??!' to 'Any?'}}
+  // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{21-21=!!}}
+  // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{21-21= as Any?}}
+  // expected-warning@-3 {{expression implicitly coerced from 'Any???!' to 'Any?'}}
+  // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{24-24=!!!}}
+  // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+
+  takesOptionalAny(c!!, d!!!)
+  takesOptionalAny(c as Any?, d as Any?)
+}
+
+func takesIUO(_: Any!, _: Any!) {}
+
+func warnOptionalToIUOAny(_ a: Int?, _ b: Any??, _ c: Int???, _ d: Any????) {
+  takesIUO(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any!'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{16-16= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{16-16=!}}
+  // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{16-16= as Any?}}
+
+  takesIUO(a, b ?? "")
+  takesIUO(a, b!)
+  takesIUO(a, b as Any?)
+
+  takesIUO(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any!'}}
+  // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{13-13=!!}}
+  // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{13-13= as Any?}}
+  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any!'}}
+  // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{16-16=!!!}}
+  // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{16-16= as Any?}}
+
+  takesIUO(c!!, d!!!)
+  takesIUO(c as Any?, d as Any?)
+}
+
+func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {}
 
 func warnCollectionOfAny(_ a: [Int?], _ d: [String : Int?]) {
   // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling


### PR DESCRIPTION
- When implicitly coercing a collection of optional elements to a collection of less-optional `Any` elements, e.g `[Any?]` to `[Any]`, emit a slightly better diagnostic:

  > Expression implicitly coerced from '[Any?]' to '[Any]'

  and allow for silencing of the diagnostic with an explicit coercion, e.g `as [Any]`.

- When implicitly coercing a nested optional to a less optional `Any`, e.g `Any??` to `Any?`, emit a slightly better diagnostic:

  > Expression implicitly coerced from 'Any??' to 'Any?'

  and allow for silencing of the diagnostic with an explicit coercion, e.g `as Any?`.

(both diagnostics were previously "Expression implicitly coerced from 'Any?' to Any", and neither could be silenced by an explicit coercion to their destination types)

In addition, this PR enables Optional-to-Any warnings for IUOs, e.g the implicit coercion from `Int!` to `Any` now produces a warning. Previously a warning wasn't emitted despite the optional being implicitly erased to `Any` (but warnings were emitted in some other cases, such as `Int?!` to `Any?`; this PR fixes that inconsistency).

Resolves [SR-2928](https://bugs.swift.org/browse/SR-2928) & [SR-6859](https://bugs.swift.org/browse/SR-6859).