### PR TITLE
[Sema] Remove the terminology "l-value" from diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2829,7 +2829,7 @@ ERROR(expression_unused_closure,none,
 ERROR(expression_unused_function,none,
       "expression resolves to an unused function", ())
 ERROR(expression_unused_lvalue,none,
-      "expression resolves to an unused l-value", ())
+      "expression resolves to an unused %select{variable|property|subscript}0", (unsigned))
 WARNING(expression_unused_result_call,none,
         "result of call to %0 is unused", (DeclName))
 WARNING(expression_unused_result_operator,none,

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -6,13 +6,13 @@ func statement_starts() {
 
   f(0)
   f (0)
-  f // expected-error{{expression resolves to an unused l-value}}
+  f // expected-error{{expression resolves to an unused variable}}
   (0) // expected-warning {{integer literal is unused}}
 
   var a = [1,2,3]
   a[0] = 1
   a [0] = 1
-  a // expected-error{{expression resolves to an unused l-value}}
+  a // expected-error{{expression resolves to an unused variable}}
   [0, 1, 2] // expected-warning {{expression of type '[Int]' is unused}}
 }
 

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -32,14 +32,14 @@ class D : B {
   }
 
   func super_calls() {
-    super.foo        // expected-error {{expression resolves to an unused l-value}}
+    super.foo        // expected-error {{expression resolves to an unused property}}
     super.foo.bar    // expected-error {{value of type 'Int' has no member 'bar'}}
     super.bar        // expected-error {{expression resolves to an unused function}}
     super.bar()
     super.init // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init() // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init(0) // expected-error{{'super.init' cannot be called outside of an initializer}}
-    super[0]        // expected-error {{expression resolves to an unused l-value}}
+    super[0]        // expected-error {{expression resolves to an unused subscript}}
     super
       .bar()
   }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -21,9 +21,9 @@ func1()
 _ = 4+7
 
 var bind_test1 : () -> () = func1
-var bind_test2 : Int = 4; func1 // expected-error {{expression resolves to an unused l-value}}
+var bind_test2 : Int = 4; func1 // expected-error {{expression resolves to an unused variable}}
 
-(func1, func2) // expected-error {{expression resolves to an unused l-value}}
+(func1, func2) // expected-error {{expression resolves to an unused variable}}
 
 func basictest() {
   // Simple integer variables.


### PR DESCRIPTION
There was only one that presented this terminology to the user, and it's easily avoided by being more specific about what sort of lvalue it is.