### PR TITLE
[IRGen] Reorder generic struct metadata so that field offsets follow …

### DIFF
--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -50,14 +50,14 @@ public:
 
     // If changing this layout, you must update the magic number in
     // emitParentMetadataRef.
-    
+
+    // Instantiation-specific.
+    asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
+
     // Struct field offsets.
     asImpl().noteStartOfFieldOffsets();
     for (VarDecl *prop : Target->getStoredProperties())
       asImpl().addFieldOffset(prop);
-
-    // Instantiation-specific.
-    asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
   }
   
   // Note the start of the field offset vector.

--- a/test/IRGen/field_type_vectors.sil
+++ b/test/IRGen/field_type_vectors.sil
@@ -15,7 +15,7 @@ struct Foo {
 // CHECK-LABEL: @"$S18field_type_vectors3BarVMP" = internal global
 // -- There should be 1 word between the field type vector slot, with type %swift.type**,
 //    and the address point
-// CHECK:       %swift.type**, i8**, i64, <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32 }>*, i64, %swift.type*
+// CHECK:       %swift.type**, i8**, i64, <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32 }>*, %swift.type*, i64
 struct Bar<T> {
   var y: Int
 }
@@ -25,7 +25,7 @@ struct Bar<T> {
 // CHECK-LABEL: @"$S18field_type_vectors3BasVMP" = internal global
 // -- There should be 1 word between the field type vector slot, with type %swift.type**,
 //    and the address point
-// CHECK:       %swift.type**, i8**, i64, <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32 }>*, i64, i64, %swift.type*, %swift.type*
+// CHECK:       %swift.type**, i8**, i64, <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32 }>*, %swift.type*, %swift.type*, i64, i64
 struct Bas<T, U> {
   var foo: Foo
   var bar: Bar<T>

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -25,13 +25,13 @@ import Builtin
 // --       field count
 // CHECK-SAME:   i32 1,
 // --       field offset vector offset
-// CHECK-SAME:   i32 2,
+// CHECK-SAME:   i32 3,
 // --       field names
 // CHECK-SAME:   [3 x i8]* [[SINGLEDYNAMIC_FIELDS]]
 // --       kind 1 (struct)
 // CHECK-SAME:   i32 1
 // --       generic parameter vector offset
-// CHECK-SAME:   i32 3,
+// CHECK-SAME:   i32 2,
 // --       generic parameter count, primary count
 // CHECK-SAME:   i32 1, i32 1
 // --       nesting depth
@@ -50,7 +50,7 @@ import Builtin
 // -- address point
 // CHECK-SAME:   i64 1, {{.*}}* @"$S15generic_structs13SingleDynamicVMn"
 // -- field offset vector; generic parameter vector
-// CHECK-SAME:   i64 0, %swift.type* null }>
+// CHECK-SAME:   %swift.type* null, i64 0 }>
 
 // -- Nominal type descriptor for generic struct with protocol requirements
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
@@ -62,13 +62,13 @@ import Builtin
 // --       field count
 // CHECK-SAME: i32 2,
 // --       field offset vector offset
-// CHECK-SAME: i32 2,
+// CHECK-SAME: i32 6,
 // --       field names
 // CHECK-SAME: [5 x i8]* [[DYNAMICWITHREQUIREMENTS_FIELDS]]
 // --       kind 1 (struct)
 // CHECK-SAME: i32 1,
 // --       generic parameter vector offset
-// CHECK-SAME: i32 4,
+// CHECK-SAME: i32 2,
 // --       generic requirements count; generic arguments count
 // CHECK-SAME: i32 4, i32 2
 // --       nesting depth
@@ -81,7 +81,7 @@ import Builtin
 
 // CHECK: @"$S15generic_structs23DynamicWithRequirementsVMP" = internal global <{ {{.*}} }> <{
 // -- field offset vector; generic parameter vector
-// CHECK:   i64 0, i64 0, %swift.type* null, %swift.type* null, i8** null, i8** null }>
+// CHECK:   %swift.type* null, %swift.type* null, i8** null, i8** null, i64 0, i64 0 }>
 
 // -- Fixed-layout struct metadata contains fixed field offsets
 // CHECK: @"$S15generic_structs6IntishVMf" = internal constant <{ {{.*}} i64 }> <{
@@ -144,7 +144,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   %a = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.a2
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 2
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 4
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 2
   // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
@@ -153,7 +153,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   %b = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.b
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 2
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 4
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 3
   // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
@@ -163,7 +163,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   %c = struct_element_addr %5 : $*SingleDynamic<B>, #SingleDynamic.x
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 2
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 4
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 4
   // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
@@ -214,12 +214,12 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_pattern* %0, i8** %1)
 // CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 //   Fill type argument.
-// CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i64 3
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i64 2
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %T to i8*
 // CHECK:   store i8* [[T0]], i8** [[T1]], align 8
 //   Lay out fields.
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
-// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 2
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 3
 // CHECK:   [[T2:%.*]] = getelementptr inbounds i8**, i8*** [[TYPES:%.*]], i32 0
 // CHECK:   call void @swift_initStructMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[TYPES]], i64* [[T1]])
 // CHECK:   ret %swift.type* [[METADATA]]

--- a/test/IRGen/generic_structs.swift
+++ b/test/IRGen/generic_structs.swift
@@ -41,7 +41,7 @@ public struct GenericStruct<T : Proto> {
 // CHECK-32-LABEL: define{{.*}} swiftcc void @"$S15generic_structs13GenericStructVACyxGycfC"
 // CHECK-32:  [[TYPE:%.*]] =  call %swift.type* @"$S15generic_structs13GenericStructVMa"(%swift.type* %T, i8** %T.Proto)
 // CHECK-32:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to i32*
-// CHECK-32:  [[FIELDOFFSETS:%.*]] = getelementptr inbounds i32, i32* [[PTR]], i32 2
+// CHECK-32:  [[FIELDOFFSETS:%.*]] = getelementptr inbounds i32, i32* [[PTR]], i32 4
 // CHECK-32:  [[FIELDOFFSET:%.*]] = getelementptr inbounds i32, i32* [[FIELDOFFSETS]], i32 2
 // CHECK-32:  [[OFFSET:%.*]] = load i32, i32* [[FIELDOFFSET]]
 // CHECK-32:  [[ADDROFOPT:%.*]] = getelementptr inbounds i8, i8* {{.*}}, i32 [[OFFSET]]
@@ -51,7 +51,7 @@ public struct GenericStruct<T : Proto> {
 // CHECK-64-LABEL: define{{.*}} swiftcc void @"$S15generic_structs13GenericStructVACyxGycfC"
 // CHECK-64:  [[TYPE:%.*]] =  call %swift.type* @"$S15generic_structs13GenericStructVMa"(%swift.type* %T, i8** %T.Proto)
 // CHECK-64:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to i64*
-// CHECK-64:  [[FIELDOFFSETS:%.*]] = getelementptr inbounds i64, i64* [[PTR]], i64 2
+// CHECK-64:  [[FIELDOFFSETS:%.*]] = getelementptr inbounds i64, i64* [[PTR]], i64 4
 // CHECK-64:  [[FIELDOFFSET:%.*]] = getelementptr inbounds i64, i64* [[FIELDOFFSETS]], i32 2
 // CHECK-64:  [[OFFSET:%.*]] = load i64, i64* [[FIELDOFFSET]]
 // CHECK-64:  [[ADDROFOPT:%.*]] = getelementptr inbounds i8, i8* {{.*}}, i64 [[OFFSET]]

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -200,8 +200,8 @@ sil_vtable C {}
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset
 // CHECK-SAME: <i32 0x1ffffffe>,
-// CHECK-32-SAME: i32 8 }>
-// CHECK-64-SAME: i32 16 }>
+// CHECK-32-SAME: i32 16 }>
+// CHECK-64-SAME: i32 32 }>
 
 // -- %j: Gen<A>.y
 // CHECK: [[KP_J:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -213,8 +213,8 @@ sil_vtable C {}
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset
 // CHECK-SAME: <i32 0x1ffffffe>,
-// CHECK-32-SAME: i32 12 }>
-// CHECK-64-SAME: i32 24 }>
+// CHECK-32-SAME: i32 20 }>
+// CHECK-64-SAME: i32 40 }>
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @stored_property_fixed_offsets()
 sil @stored_property_fixed_offsets : $@convention(thin) () -> () {


### PR DESCRIPTION
…generic parameters

Right now, field offsets come before generic arguments in instances
of a struct's metadata. It would be more resilient to put the generic
arguments first, since they're always used by compiler-generated code,
and cannot change resiliently, unlike fields.

Resolves: rdar://problem/36560486

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
