### PR TITLE
[+0-all] Update more runtime files for +0 normal arguments.

### DIFF
--- a/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
+++ b/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
@@ -19,7 +19,7 @@ NSArray_getObjects(NSArray SWIFT_NS_RELEASES_ARGUMENT *_Nonnull nsArray,
                    id *objects, NSUInteger rangeLocation,
                    NSUInteger rangeLength) {
   [nsArray getObjects:objects range:NSMakeRange(rangeLocation, rangeLength)];
-  [nsArray release];
+  SWIFT_CC_PLUSONE_GUARD([nsArray release]);
 }
 
 SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY
@@ -27,6 +27,6 @@ extern "C" void
 NSDictionary_getObjects(NSDictionary *_Nonnull nsDictionary,
                         id *objects, id *keys) {
   [nsDictionary getObjects:objects andKeys:keys];
-  [nsDictionary release];
+  SWIFT_CC_PLUSONE_GUARD([nsDictionary release]);
 }
 

--- a/stdlib/public/SDK/Foundation/DataThunks.m
+++ b/stdlib/public/SDK/Foundation/DataThunks.m
@@ -120,8 +120,8 @@ BOOL __NSDataWriteToURL(NSData *SWIFT_NS_RELEASES_ARGUMENT data, NSURL *SWIFT_NS
 
     if (![path getFileSystemRepresentation:cpath maxLength:1024]) {
         if (errorPtr) *errorPtr = _NSErrorWithFilePath(NSFileWriteInvalidFileNameError, path);
-        [data release];
-        [url release];
+        SWIFT_CC_PLUSONE_GUARD([data release]);
+        SWIFT_CC_PLUSONE_GUARD([url release]);
         return NO;
     }
 
@@ -137,8 +137,8 @@ BOOL __NSDataWriteToURL(NSData *SWIFT_NS_RELEASES_ARGUMENT data, NSURL *SWIFT_NS
     int32_t fd = _NSOpenFileDescriptor(cpath, flags, protectionClass, 0666);
     if (fd < 0) {
         if (errorPtr) *errorPtr = _NSErrorWithFilePathAndErrno(errno, path, NO);
-        [url release];
-        [data release];
+        SWIFT_CC_PLUSONE_GUARD([url release]);
+        SWIFT_CC_PLUSONE_GUARD([data release]);
         return NO;
     }
 
@@ -172,12 +172,12 @@ BOOL __NSDataWriteToURL(NSData *SWIFT_NS_RELEASES_ARGUMENT data, NSURL *SWIFT_NS
         if (errorPtr) {
             *errorPtr = _NSErrorWithFilePathAndErrno(errno, path, NO);
         }
-        [url release];
-        [data release];
+        SWIFT_CC_PLUSONE_GUARD([url release]);
+        SWIFT_CC_PLUSONE_GUARD([data release]);
         return NO;
     }
     close(fd);
-    [url release];
-    [data release];
+    SWIFT_CC_PLUSONE_GUARD([url release]);
+    SWIFT_CC_PLUSONE_GUARD([data release]);
     return YES;
 }

--- a/stdlib/public/SDK/Foundation/TypePreservingNSNumber.mm
+++ b/stdlib/public/SDK/Foundation/TypePreservingNSNumber.mm
@@ -325,7 +325,7 @@ _swift_Foundation_TypePreservingNSNumberGetKind(
   } else if (CFGetTypeID(self_) == CFBooleanGetTypeID()) {
     result = SwiftBool;
   }
-  [self_ release];
+  SWIFT_CC_PLUSONE_GUARD([self_ release]);
   return result;
 }
 
@@ -339,7 +339,7 @@ _swift_Foundation_TypePreservingNSNumberGetKind(
     } \
     C_TYPE result; \
     memcpy(&result, self_->storage, sizeof(result)); \
-    [self_ release]; \
+    SWIFT_CC_PLUSONE_GUARD([self_ release]); \
     return result; \
   }
 

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -161,6 +161,7 @@ void _swift_makeAnyHashableUpcastingToHashableBaseType(
 
       if (auto unboxedHashableWT =
               swift_conformsToProtocol(type, &HashableProtocolDescriptor)) {
+#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
         ValueBuffer unboxedCopyBuf;
         // Allocate buffer.
         OpaqueValue *unboxedValueCopy =
@@ -172,9 +173,15 @@ void _swift_makeAnyHashableUpcastingToHashableBaseType(
         _swift_makeAnyHashableUpcastingToHashableBaseType(
             unboxedValueCopy, anyHashableResultPointer, unboxedType,
             unboxedHashableWT);
+
         // Deallocate buffer.
         unboxedType->deallocateBufferIn(&unboxedCopyBuf);
         type->vw_destroy(value);
+#else
+        _swift_makeAnyHashableUpcastingToHashableBaseType(
+            unboxedValue, anyHashableResultPointer, unboxedType,
+            unboxedHashableWT);
+#endif
         return;
       }
     }

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -382,10 +382,13 @@ NSDictionary *_swift_stdlib_getErrorDefaultUserInfo(OpaqueValue *error,
     reinterpret_cast<GetDefaultFn*> (dlsym(RTLD_DEFAULT,
     MANGLE_AS_STRING(MANGLE_SYM(10Foundation24_getErrorDefaultUserInfoyyXlSgxs0C0RzlF)))));
   if (!foundationGetDefaultUserInfo) {
-    T->vw_destroy(error);
+    SWIFT_CC_PLUSONE_GUARD(T->vw_destroy(error));
     return nullptr;
   }
 
+  // +0 Convention: In the case where we have the +1 convention, this will
+  // destroy the error for us, otherwise, it will take the value guaranteed. The
+  // conclusion is that we can leave this alone.
   return foundationGetDefaultUserInfo(error, T, Error);
 }
 

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -857,9 +857,7 @@ id
 swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
                                   const Metadata *type) {
   id object = [*reinterpret_cast<const id *>(value) retain];
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
   if ([object respondsToSelector:@selector(debugQuickLookObject)]) {
     id quickLookObject = [object debugQuickLookObject];
     [quickLookObject retain];
@@ -1130,19 +1128,14 @@ MirrorReturn swift::swift_reflectAny(OpaqueValue *value, const Metadata *T) {
   Mirror result;
   // Take the value, unless we projected a subvalue from it. We don't want to
   // deal with partial value deinitialization.
-  bool take =
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-    mirrorValue == value;
-#else
-    false;
-#endif
+  bool take = false;
+  SWIFT_CC_PLUSONE_GUARD(take = (mirrorValue == value));
   ::new (&result) MagicMirror(mirrorValue, mirrorType, take);
 
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
   // Destroy the whole original value if we couldn't take it.
-  if (!take)
+  if (!take) {
     T->vw_destroy(value);
-#endif
+  }
   return MirrorReturn(result);
 }
 

--- a/stdlib/public/stubs/Reflection.mm
+++ b/stdlib/public/stubs/Reflection.mm
@@ -21,8 +21,8 @@ bool _swift_stdlib_NSObject_isKindOfClass(
     id SWIFT_NS_RELEASES_ARGUMENT _Nonnull object,
     NSString *SWIFT_NS_RELEASES_ARGUMENT _Nonnull className) {
   bool result = [object isKindOfClass:NSClassFromString(className)];
-  [object release];
-  [className release];
+  SWIFT_CC_PLUSONE_GUARD([object release]);
+  SWIFT_CC_PLUSONE_GUARD([className release]);
 
   return result;
 }

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -107,8 +107,8 @@ bool
 swift_stdlib_NSObject_isEqual(NSObject *SWIFT_NS_RELEASES_ARGUMENT lhs,
                               NSObject *SWIFT_NS_RELEASES_ARGUMENT rhs) {
   bool Result = (lhs == rhs) || [lhs isEqual:rhs];
-  swift_unknownRelease(lhs);
-  swift_unknownRelease(rhs);
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(lhs));
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(rhs));
   return Result;
 }
 
@@ -118,8 +118,8 @@ int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
   // 'kCFCompareNonliteral' actually means "normalize to NFD".
   int Result = CFStringCompare((__bridge CFStringRef)lhs,
                                (__bridge CFStringRef)rhs, kCFCompareNonliteral);
-  swift_unknownRelease(lhs);
-  swift_unknownRelease(rhs);
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(lhs));
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(rhs));
   return Result;
 }
 
@@ -152,8 +152,8 @@ bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
       (__bridge CFStringRef)theString, (__bridge CFStringRef)prefix,
       CFRangeMake(0, Length), kCFCompareAnchored | kCFCompareNonliteral,
       nullptr);
-  swift_unknownRelease(theString);
-  swift_unknownRelease(prefix);
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(theString));
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(prefix));
   return Result;
 }
 
@@ -177,8 +177,8 @@ swift_stdlib_NSStringHasSuffixNFD(NSString *SWIFT_NS_RELEASES_ARGUMENT theString
       (__bridge CFStringRef)theString, (__bridge CFStringRef)suffix,
       CFRangeMake(0, Length),
       kCFCompareAnchored | kCFCompareBackwards | kCFCompareNonliteral, nullptr);
-  swift_unknownRelease(theString);
-  swift_unknownRelease(suffix);
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(theString));
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(suffix));
   return Result;
 }
 
@@ -197,7 +197,7 @@ SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 void swift_stdlib_CFSetGetValues(NSSet *SWIFT_NS_RELEASES_ARGUMENT set,
                                  const void **values) {
   CFSetGetValues((__bridge CFSetRef)set, values);
-  swift_unknownRelease(set);
+  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(set));
 }
 #endif
 


### PR DESCRIPTION
This is NFC when --enable-guaranteed-normal-arguments isn't passed into
build-script.

rdar://34222540
