### PR TITLE
[+0-all-args] Fixup more of Reflection.mm.

### DIFF
--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -356,9 +356,7 @@ intptr_t swift_TupleMirror_count(HeapObject *owner,
                                  const OpaqueValue *value,
                                  const Metadata *type) {
   auto Tuple = static_cast<const TupleTypeMetadata *>(type);
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
   return Tuple->NumElements;
 }
 
@@ -404,9 +402,9 @@ void swift_TupleMirror_subscript(String *outString,
   auto bytes = reinterpret_cast<const char*>(value);
   auto eltData = reinterpret_cast<const OpaqueValue *>(bytes + elt.Offset);
 
-#ifdef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_retain(owner);
-#endif
+  // Since 'owner' is consumed, when we have a +0 convention, we must retain
+  // owner first.
+  SWIFT_CC_PLUSZERO_GUARD(swift_retain(owner));
 
   // 'owner' is consumed by this call.
   new (outMirror) Mirror(reflect(owner, eltData, elt.Type));
@@ -496,9 +494,7 @@ intptr_t swift_StructMirror_count(HeapObject *owner,
                                   const OpaqueValue *value,
                                   const Metadata *type) {
   auto Struct = static_cast<const StructMetadata *>(type);
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
   return Struct->Description->Struct.NumFields;
 }
 
@@ -524,6 +520,8 @@ void swift_StructMirror_subscript(String *outString,
   new (outString) String(getFieldName(Struct->Description->Struct.FieldNames, i));
 
   // 'owner' is consumed by this call.
+  SWIFT_CC_PLUSZERO_GUARD(swift_unknownRetain(owner));
+
   assert(!fieldType.isIndirect() && "indirect struct fields not implemented");
 
   if (loadSpecialReferenceStorage(owner, fieldData, fieldType, outMirror))
@@ -583,9 +581,7 @@ const char *swift_EnumMirror_caseName(HeapObject *owner,
                                       const OpaqueValue *value,
                                       const Metadata *type) {
   if (!isEnumReflectable(type)) {
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-    swift_release(owner);
-#endif
+    SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
     return nullptr;
   }
 
@@ -595,9 +591,7 @@ const char *swift_EnumMirror_caseName(HeapObject *owner,
   unsigned tag;
   getEnumMirrorInfo(value, type, &tag, nullptr, nullptr);
 
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
 
   return getFieldName(Description.CaseNames, tag);
 }
@@ -612,12 +606,8 @@ const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
   OpaqueValue *mirrorValue = const_cast<OpaqueValue*>(cMirrorValue);
   Mirror mirror;
 
-  bool take =
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-    mirrorValue == value;
-#else
-    false;
-#endif
+  bool take = false;
+  SWIFT_CC_PLUSONE_GUARD(take = (mirrorValue == value));
 
   ::new (&mirror) MagicMirror(mirrorValue, mirrorType, take);
 
@@ -625,11 +615,9 @@ const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
   MagicMirrorData data = theMirror->Data;
   const char *result = swift_EnumMirror_caseName(data.Owner, data.Value, data.Type);
 
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
   // Destroy the whole original value if we couldn't take it.
   if (!take)
       type->vw_destroy(value);
-#endif
 
   return result;
 }
@@ -639,17 +627,13 @@ intptr_t swift_EnumMirror_count(HeapObject *owner,
                                 const OpaqueValue *value,
                                 const Metadata *type) {
   if (!isEnumReflectable(type)) {
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-    swift_release(owner);
-#endif
+    SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
     return 0;
   }
 
   const Metadata *payloadType;
   getEnumMirrorInfo(value, type, nullptr, &payloadType, nullptr);
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
   return (payloadType != nullptr) ? 1 : 0;
 }
 
@@ -678,9 +662,7 @@ void swift_EnumMirror_subscript(String *outString,
   type->vw_destructiveInjectEnumTag(const_cast<OpaqueValue *>(value),
                                     (int) (tag - Description.getNumPayloadCases()));
 
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
 
   owner = pair.first;
   value = pair.second;
@@ -708,9 +690,7 @@ intptr_t swift_ClassMirror_count(HeapObject *owner,
                                  const OpaqueValue *value,
                                  const Metadata *type) {
   auto Clas = static_cast<const ClassMetadata*>(type);
-#ifndef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_release(owner);
-#endif
+  SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
   auto count = Clas->getDescription()->Class.NumFields;
 
   // If the class has a superclass, the superclass instance is treated as the
@@ -955,9 +935,7 @@ static Mirror getMirrorForSuperclass(const ClassMetadata *sup,
   Mirror resultBuf;
   MagicMirror *result = ::new (&resultBuf) MagicMirror;
 
-#ifdef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_retain(owner);
-#endif
+  SWIFT_CC_PLUSZERO_GUARD(swift_retain(owner));
 
   result->Self = ClassSuperMirrorMetadata();
   result->MirrorWitness = &ClassSuperMirrorWitnessTable;
@@ -978,9 +956,7 @@ static Mirror ObjC_getMirrorForSuperclass(Class sup,
   Mirror resultBuf;
   MagicMirror *result = ::new (&resultBuf) MagicMirror;
 
-#ifdef SWIFT_RUNTIME_ENABLE_GUARANTEED_NORMAL_ARGUMENTS
-  swift_retain(owner);
-#endif
+  SWIFT_CC_PLUSZERO_GUARD(swift_retain(owner));
 
   result->Self = ObjCSuperMirrorMetadata();
   result->MirrorWitness = &ObjCSuperMirrorWitnessTable;


### PR DESCRIPTION
This mainly was just removing #if{,n}def in favor of SWIFT_CC_* macros. But I
did add a missing retain needed in swift_StructMirror_subscript since owner is
no longer passed at +1 and mirrors consume the owner.

rdar://34222540