### PR TITLE
Allow inout arguments that differ in optionality than the expected pa…

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1069,8 +1069,17 @@ public:
       Type srcObj = checkLValue(E->getSubExpr()->getType(),
                                 "result of InOutExpr");
       auto DestTy = E->getType()->castTo<InOutType>()->getObjectType();
-      
-      checkSameType(DestTy, srcObj, "object types for InOutExpr");
+
+      // HACK: Allow differences in optionality of the source and
+      // result types. When IUO is gone from the type system we'll no
+      // longer need this.
+      auto srcOptObjTy = srcObj->getAnyOptionalObjectType();
+      auto dstOptObjTy = DestTy->getAnyOptionalObjectType();
+      if (srcOptObjTy && dstOptObjTy) {
+        checkSameType(srcOptObjTy, dstOptObjTy, "object types for InOutExpr");
+      } else {
+        checkSameType(DestTy, srcObj, "object types for InOutExpr");
+      }
       verifyCheckedBase(E);
     }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -80,6 +80,8 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
     case SK_ValueToPointerConversion:
       log << "value-to-pointer conversion";
       break;
+    case SK_InOutOptionalityConversion:
+      log << "inout optionality conversion";
     }
     log << ")\n";
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1870,16 +1870,32 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                         locator.withPathElement(
                           ConstraintLocator::ArrayElementType));
     
-    case TypeKind::InOut:
+    case TypeKind::InOut: {
       // If the RHS is an inout type, the LHS must be an @lvalue type.
       if (kind == ConstraintKind::BindParam ||
           kind >= ConstraintKind::OperatorArgumentConversion)
         return getTypeMatchFailure(locator);
-      
-      return matchTypes(cast<InOutType>(desugar1)->getObjectType(),
-                        cast<InOutType>(desugar2)->getObjectType(),
-                        ConstraintKind::Equal, subflags,
-                  locator.withPathElement(ConstraintLocator::ArrayElementType));
+
+      auto inoutObjTy1 = cast<InOutType>(desugar1)->getObjectType();
+      auto inoutObjTy2 = cast<InOutType>(desugar2)->getObjectType();
+
+      OptionalTypeKind OTK1;
+      OptionalTypeKind OTK2;
+      auto optionalObjTy1 = inoutObjTy1->getAnyOptionalObjectType(OTK1);
+      auto optionalObjTy2 = inoutObjTy2->getAnyOptionalObjectType(OTK2);
+      if (OTK1 != OTK2 && optionalObjTy1 && optionalObjTy2) {
+        increaseScore(ScoreKind::SK_InOutOptionalityConversion);
+        return matchTypes(inoutObjTy1,
+                          inoutObjTy2,
+                          ConstraintKind::ArgumentConversion, subflags,
+                          locator.withPathElement(ConstraintLocator::ArrayElementType));
+      } else {
+        return matchTypes(inoutObjTy1,
+                          inoutObjTy2,
+                          ConstraintKind::Equal, subflags,
+                          locator.withPathElement(ConstraintLocator::ArrayElementType));
+      }
+    }
 
     case TypeKind::UnboundGeneric:
       llvm_unreachable("Unbound generic type should have been opened");

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -462,8 +462,12 @@ enum ScoreKind {
   SK_KeyPathSubscript,
   /// A conversion from a string, array, or inout to a pointer.
   SK_ValueToPointerConversion,
+  /// A conversion from 'inout Optional<T>' to 'inout
+  /// ImplicitlyUnwrappedOptional<T>' or vice-versa.
+  /// FIXME: This goes away when IUO-as-a-type goes away.
+  SK_InOutOptionalityConversion,
 
-  SK_LastScoreKind = SK_ValueToPointerConversion,
+  SK_LastScoreKind = SK_InOutOptionalityConversion,
 };
 
 /// The number of score kinds.

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -159,3 +159,27 @@ func cast<T : P>(_ t: T) {
   let _: (Bool) -> T? = id(T.iuoResultStatic as (Bool) -> T?)
   let _: T! = id(T.iuoResultStatic(true))
 }
+
+func takesInOutIUO(_ i: inout Int!) {}
+func takesInOutOpt(_ o: inout Int?) {}
+
+func overloadedByOptionality(_ a: inout Int!) {}
+// expected-note@-1 {{'overloadedByOptionality' previously declared here}}
+// expected-note@-2 {{'overloadedByOptionality' previously declared here}}
+func overloadedByOptionality(_ a: inout Int?) {}
+// expected-warning@-1 {{invalid redeclaration of 'overloadedByOptionality' which differs only by the kind of optional passed as an inout argument ('Int?' vs. 'Int!')}}
+// expected-warning@-2 {{invalid redeclaration of 'overloadedByOptionality' which differs only by the kind of optional passed as an inout argument ('Int?' vs. 'Int!')}}
+// expected-note@-3 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+// expected-note@-4 {{overloading by kind of optional is deprecated and will be removed in a future release}}
+
+func testInOutOptionality() {
+  var i: Int! = 1
+  var o: Int? = 2
+
+  takesInOutIUO(&i)
+  takesInOutOpt(&i)
+  takesInOutIUO(&o)
+  takesInOutOpt(&o)
+
+  overloadedByOptionality(&o)
+}


### PR DESCRIPTION
…rameter.

Allow passing Optional<T> as inout where
ImplicitlyUnwrappedOptional<T> is expected, and vice-versa.

Swift 4.1 added a warning that overloading inouts by kind of optional
was deprecated and would be removed, but we didn't actually allow
people to remove an overload and pass arguments of the other kind of
optional to the remaining function.

Fixes rdar://problem/36913150
