### PR TITLE
build: depend on the architecture variant on non-MachO

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1656,8 +1656,11 @@ function(add_swift_library name)
           # Add dependencies on the (not-yet-created) custom lipo target.
           foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
             if (NOT "${DEP}" STREQUAL "icucore")
-              add_dependencies(${VARIANT_NAME}
-                "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+              if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "MACHO")
+                add_dependencies(${VARIANT_NAME} "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+              else()
+                add_dependencies(${VARIANT_NAME} "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+              endif()
             endif()
           endforeach()
 
@@ -1781,13 +1784,22 @@ function(add_swift_library name)
             set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
             if(TARGET "swift-stdlib${VARIANT_SUFFIX}" AND
                TARGET "swift-test-stdlib${VARIANT_SUFFIX}")
+              if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "MACHO")
+                set(shared_lipo_target ${lipo_target})
+                set(static_lipo_target ${lipo_target_static})
+              else()
+                set(shared_lipo_target ${lipo_target}-${arch})
+                if(TARGET "${lipo_target_static}")
+                  set(static_lipo_target ${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}-static)
+                endif()
+              endif()
               add_dependencies("swift-stdlib${VARIANT_SUFFIX}"
-                  ${lipo_target}
-                  ${lipo_target_static})
+                                 ${shared_lipo_target}
+                                 ${static_lipo_target})
               if(NOT "${name}" IN_LIST FILTERED_UNITTESTS)
                 add_dependencies("swift-test-stdlib${VARIANT_SUFFIX}"
-                    ${lipo_target}
-                    ${lipo_target_static})
+                                   ${shared_lipo_target}
+                                   ${static_lipo_target})
               endif()
             endif()
           endforeach()


### PR DESCRIPTION
For the non-MachO targets, which do not have the concept of fat
binaries, depend explicitly on the architecture variant.  This is
particularly useful for Windows which permits cross-compilation and
cross-targeting of all the variants even though it does not support fat
binaries.  This allows us to build a single variant of the windows
standard library at a time in the case that we would like to build a
subset of the targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
