### PR TITLE
build: strip the lipo'ed target placeholder

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -489,12 +489,8 @@ function(_add_swift_lipo_target)
         OUTPUT "${LIPO_OUTPUT}"
         DEPENDS ${source_targets})
   else()
-    # We don't know how to create fat binaries for other platforms.
-    add_custom_command_target(unused_var
-        COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${source_binaries}" "${LIPO_OUTPUT}"
-        CUSTOM_TARGET_NAME "${LIPO_TARGET}"
-        OUTPUT "${LIPO_OUTPUT}"
-        DEPENDS ${source_targets})
+    add_custom_target(${LIPO_TARGET})
+    add_dependencies(${LIPO_TARGET} ${source_targets})
   endif()
 endfunction()
 


### PR DESCRIPTION
When building non-MachO targets, there is no support for fat binaries.
As a result, the lipo target does nothing.  Because we do not support
variant builds for ELF targets, this has not resulted in any issues.
However, the PE/COFF (Windows) target suppots multiple variants.  In
such a case, the "lipo" target will copy a number of builds, leaving the
binary to be an arbitrary variant.  Instead, prefer to always use the
architectural variant path.  In place, create an empty target which
serves as a means of collecting dependencies.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
