### PR TITLE
Fix a runtime crash in the old remangler when trying to create a mangling for a private type in the Swift library

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -406,7 +406,9 @@ bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry) {
 static bool isInSwiftModule(Node *node) {
   Node *context = node->getFirstChild();
   return (context->getKind() == Node::Kind::Module &&
-          context->getText() == STDLIB_NAME);
+          context->getText() == STDLIB_NAME &&
+          // Check for private declarations in Swift
+          node->getChild(1)->getKind() == Node::Kind::Identifier);
 };
 
 bool Remangler::mangleStandardSubstitution(Node *node) {

--- a/test/Demangle/remangle.swift
+++ b/test/Demangle/remangle.swift
@@ -5,3 +5,7 @@ RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings.txt > %t.input
 
 RUN: swift-demangle -test-remangle < %t.input > %t.output
 RUN: diff %t.input %t.output
+
+// CHECK: Swift.(Mystruct in _7B40D7ED6632C2BEA2CA3BFFD57E3435)
+RUN: swift-demangle -remangle-objc-rt '$Ss8Mystruct33_7B40D7ED6632C2BEA2CA3BFFD57E3435LLV' | %FileCheck %s
+

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -49,6 +49,10 @@ RemangleMode("test-remangle",
            llvm::cl::desc("Remangle test mode (show the remangled string)"));
 
 static llvm::cl::opt<bool>
+RemangleRtMode("remangle-objc-rt",
+           llvm::cl::desc("Remangle to the ObjC runtime name mangling scheme"));
+
+static llvm::cl::opt<bool>
 RemangleNew("remangle-new",
            llvm::cl::desc("Remangle the symbol with new mangling scheme"));
 
@@ -121,6 +125,12 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
     if (hadLeadingUnderscore) llvm::outs() << '_';
     llvm::outs() << remangled;
     return;
+  } else if (RemangleRtMode) {
+    std::string remangled = name;
+    if (pointer) {
+      remangled = swift::Demangle::mangleNodeOld(pointer);
+    }
+    llvm::outs() << remangled;
   }
   if (!TreeOnly) {
     if (RemangleNew) {


### PR DESCRIPTION
rdar://problem/36889992

And add an option to test the ObjC runtime name mangling scheme in swift-demangle