### PR TITLE
[PlaygroundTransform] Replace "$builtin" with "__builtin".

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -705,7 +705,7 @@ public:
                          PatternBindingDecl *&ArgPattern,
                          VarDecl *&ArgVariable) {
     const char *LoggerName =
-        isDebugPrint ? "$builtin_debugPrint" : "$builtin_print";
+        isDebugPrint ? "__builtin_debugPrint" : "__builtin_print";
 
     UnresolvedDeclRefExpr *LoggerRef = new (Context) UnresolvedDeclRefExpr(
         Context.getIdentifier(LoggerName), DeclRefKind::Ordinary,
@@ -724,7 +724,7 @@ public:
   }
 
   Added<Stmt *> logPostPrint(SourceRange SR) {
-    return buildLoggerCallWithArgs("$builtin_postPrint",
+    return buildLoggerCallWithArgs("__builtin_postPrint",
                                    MutableArrayRef<Expr *>(), SR);
   }
 
@@ -775,7 +775,7 @@ public:
 
     Expr *LoggerArgExprs[] = {*E, NameExpr, IDExpr};
 
-    return buildLoggerCallWithArgs("$builtin_log_with_id",
+    return buildLoggerCallWithArgs("__builtin_log_with_id",
                                    MutableArrayRef<Expr *>(LoggerArgExprs), SR);
   }
 
@@ -789,7 +789,7 @@ public:
 
   Added<Stmt *> buildScopeCall(SourceRange SR, bool IsExit) {
     const char *LoggerName =
-        IsExit ? "$builtin_log_scope_exit" : "$builtin_log_scope_entry";
+        IsExit ? "__builtin_log_scope_exit" : "__builtin_log_scope_entry";
 
     return buildLoggerCallWithArgs(LoggerName, MutableArrayRef<Expr *>(), SR);
   }
@@ -849,7 +849,7 @@ public:
                                   AccessSemantics::Ordinary, Apply->getType());
 
     UnresolvedDeclRefExpr *SendDataRef = new (Context)
-        UnresolvedDeclRefExpr(Context.getIdentifier("$builtin_send_data"),
+        UnresolvedDeclRefExpr(Context.getIdentifier("__builtin_send_data"),
                               DeclRefKind::Ordinary, DeclNameLoc());
 
     SendDataRef->setImplicit(true);

--- a/test/PCMacro/Inputs/SilentPlaygroundsRuntime.swift
+++ b/test/PCMacro/Inputs/SilentPlaygroundsRuntime.swift
@@ -35,27 +35,27 @@ class LogRecord {
   }
 }
 
-func $builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log", object:object, name:name, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log", object:object, name:name, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_send_data(_ object:AnyObject?) {
+func __builtin_send_data(_ object:AnyObject?) {
   let would_print = ((object as! LogRecord).text)
 }
 

--- a/test/PCMacro/didset.swift
+++ b/test/PCMacro/didset.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/else.swift
+++ b/test/PCMacro/else.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/elseif.swift
+++ b/test/PCMacro/elseif.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 // XFAIL: *

--- a/test/PCMacro/for.swift
+++ b/test/PCMacro/for.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/func_decls.swift
+++ b/test/PCMacro/func_decls.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/func_throw_notype.swift
+++ b/test/PCMacro/func_throw_notype.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 // XFAIL: *

--- a/test/PCMacro/getset.swift
+++ b/test/PCMacro/getset.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 // XFAIL: *

--- a/test/PCMacro/if.swift
+++ b/test/PCMacro/if.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/init.swift
+++ b/test/PCMacro/init.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 // XFAIL: *

--- a/test/PCMacro/mutation.swift
+++ b/test/PCMacro/mutation.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/operators.swift
+++ b/test/PCMacro/operators.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/pc_and_log.swift
+++ b/test/PCMacro/pc_and_log.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/../PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/../PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -20,9 +20,9 @@ foo(1)
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
-// CHECK-NEXT: [16:10-16:11] $builtin_log[='true']
+// CHECK-NEXT: [16:10-16:11] __builtin_log[='true']
 // this next result is unexpected...
-// CHECK-NEXT: [19:1-19:7] $builtin_log[='true']
+// CHECK-NEXT: [19:1-19:7] __builtin_log[='true']
 // CHECK-NEXT: [19:1-19:7] pc after
 // now for the array
 // CHECK-NEXT: [20:1-20:17] pc before
@@ -31,18 +31,18 @@ foo(1)
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
-// CHECK-NEXT: [16:10-16:11] $builtin_log[='true']
+// CHECK-NEXT: [16:10-16:11] __builtin_log[='true']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
-// CHECK-NEXT: [16:10-16:11] $builtin_log[='false']
+// CHECK-NEXT: [16:10-16:11] __builtin_log[='false']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
-// CHECK-NEXT: [16:10-16:11] $builtin_log[='false']
-// CHECK-NEXT: [20:1-20:17] $builtin_log[='[true, false, false]']
+// CHECK-NEXT: [16:10-16:11] __builtin_log[='false']
+// CHECK-NEXT: [20:1-20:17] __builtin_log[='[true, false, false]']
 // CHECK-NEXT: [20:1-20:17] pc after

--- a/test/PCMacro/plus_equals.swift
+++ b/test/PCMacro/plus_equals.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PCMacro/switch.swift
+++ b/test/PCMacro/switch.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
+++ b/test/PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
@@ -35,27 +35,27 @@ class LogRecord {
   }
 }
 
-func $builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log", object:object, name:name, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log", object:object, name:name, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"$builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+func __builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_send_data(_ object:AnyObject?) {
+func __builtin_send_data(_ object:AnyObject?) {
   print((object as! LogRecord).text)
 }
 

--- a/test/PlaygroundTransform/array.swift
+++ b/test/PlaygroundTransform/array.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var foo = [true, false]
 foo.append(true)
-// CHECK: [{{.*}}] $builtin_log[foo='[true, false]']
-// CHECK-NEXT: [{{.*}}] $builtin_log[foo='[true, false, true]']
+// CHECK: [{{.*}}] __builtin_log[foo='[true, false]']
+// CHECK-NEXT: [{{.*}}] __builtin_log[foo='[true, false, true]']

--- a/test/PlaygroundTransform/array_did_set.swift
+++ b/test/PlaygroundTransform/array_did_set.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 struct S {
@@ -17,14 +17,14 @@ var s = S()
 s.a = [3,2]
 s.a.append(300)
 
-// CHECK: [{{.*}}] $builtin_log[s='S(a: [])']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
+// CHECK: [{{.*}}] __builtin_log[s='S(a: [])']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
 // CHECK-NEXT: Set
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[s='S(a: [3, 2])']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[s='S(a: [3, 2])']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
 // CHECK-NEXT: Set
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[a='[3, 2, 300]']
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[a='[3, 2, 300]']

--- a/test/PlaygroundTransform/array_in_struct.swift
+++ b/test/PlaygroundTransform/array_in_struct.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -15,5 +15,5 @@ struct S {
 }
 var s = [S()]
 s[0].a.append(3)
-// CHECK: [{{.*}}] $builtin_log[s='[main.S(a: [])]']
-// CHECK-NEXT: [{{.*}}] $builtin_log[a='[3])]']
+// CHECK: [{{.*}}] __builtin_log[s='[main.S(a: [])]']
+// CHECK-NEXT: [{{.*}}] __builtin_log[a='[3])]']

--- a/test/PlaygroundTransform/bare_value.swift
+++ b/test/PlaygroundTransform/bare_value.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 1
-// CHECK: {{\[}}[[@LINE-1]]:1-[[@LINE-1]]:2] $builtin_log[='1']
+// CHECK: {{\[}}[[@LINE-1]]:1-[[@LINE-1]]:2] __builtin_log[='1']

--- a/test/PlaygroundTransform/control-flow.swift
+++ b/test/PlaygroundTransform/control-flow.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -16,16 +16,16 @@ if (a) {
 for i in 0..<3 {
   i
 }
-// CHECK: [{{.*}}] $builtin_log[a='true']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='0']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='1']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='2']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
+// CHECK: [{{.*}}] __builtin_log[a='true']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='0']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit

--- a/test/PlaygroundTransform/declarations.swift
+++ b/test/PlaygroundTransform/declarations.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var a = 2
 var b = 3
 a + b 
-// CHECK: [{{.*}}] $builtin_log[a='2']
-// CHECK-NEXT: [{{.*}}] $builtin_log[b='3']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
+// CHECK: [{{.*}}] __builtin_log[a='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log[b='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']

--- a/test/PlaygroundTransform/defer.swift
+++ b/test/PlaygroundTransform/defer.swift
@@ -12,9 +12,9 @@ func foo() {
 	1
 }
 foo()
-// CHECK: {{.*}} $builtin_log_scope_entry
-// CHECK-NEXT: {{.*}} $builtin_log[='1']
-// CHECK-NEXT: {{.*}} $builtin_log_scope_exit
-// CHECK-NEXT: {{.*}} $builtin_log_scope_entry
-// CHECK-NEXT: {{.*}} $builtin_log[='2']
-// CHECK-NEXT: {{.*}} $builtin_log_scope_exit
+// CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[='1']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[='2']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit

--- a/test/PlaygroundTransform/disable_transform_only.swift
+++ b/test/PlaygroundTransform/disable_transform_only.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s -allow-empty
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s -allow-empty
 // REQUIRES: executable_test
 
 var a = 2
 var b = 3
 a + b
-// CHECK-NOT: $builtin_log
+// CHECK-NOT: __builtin_log

--- a/test/PlaygroundTransform/do-catch.swift
+++ b/test/PlaygroundTransform/do-catch.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -14,33 +14,33 @@ do {
   print(error)
 }
 
-// CHECK: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
+// CHECK: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
 
 1
 try doSomething()
-// CHECK-LABEL: [{{.*}}] $builtin_log[='1']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
+// CHECK-LABEL: [{{.*}}] __builtin_log[='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
 
 2
 try! doSomething()
-// CHECK-LABEL: [{{.*}}] $builtin_log[='2']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
+// CHECK-LABEL: [{{.*}}] __builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
 
 3
 try? doSomething()
-// CHECK-LABEL: [{{.*}}] $builtin_log[='3']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[='Optional(5)']
+// CHECK-LABEL: [{{.*}}] __builtin_log[='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='Optional(5)']

--- a/test/PlaygroundTransform/do.swift
+++ b/test/PlaygroundTransform/do.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 do {
   1
 }
-// CHECK: {{.*}} $builtin_log[='1']
+// CHECK: {{.*}} __builtin_log[='1']

--- a/test/PlaygroundTransform/empty-tuple.swift
+++ b/test/PlaygroundTransform/empty-tuple.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 func foo() { }
 foo()
 1+2
-// CHECK: {{.*}} $builtin_log[='3']
+// CHECK: {{.*}} __builtin_log[='3']

--- a/test/PlaygroundTransform/generics.swift
+++ b/test/PlaygroundTransform/generics.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -14,21 +14,21 @@ for i in 0..<3 {
   _ = id(i)
 }
 
-// CHECK:      $builtin_log_scope_entry
-// CHECK-NEXT: $builtin_log_scope_entry
-// CHECK-NEXT: $builtin_log[='0']
-// CHECK-NEXT: $builtin_log_scope_exit
-// CHECK-NEXT: $builtin_log[='0']
-// CHECK-NEXT: $builtin_log_scope_exit
-// CHECK-NEXT: $builtin_log_scope_entry
-// CHECK-NEXT: $builtin_log_scope_entry
-// CHECK-NEXT: $builtin_log[='1']
-// CHECK-NEXT: $builtin_log_scope_exit
-// CHECK-NEXT: $builtin_log[='1']
-// CHECK-NEXT: $builtin_log_scope_exit
-// CHECK-NEXT: $builtin_log_scope_entry
-// CHECK-NEXT: $builtin_log_scope_entry
-// CHECK-NEXT: $builtin_log[='2']
-// CHECK-NEXT: $builtin_log_scope_exit
-// CHECK-NEXT: $builtin_log[='2']
-// CHECK-NEXT: $builtin_log_scope_exit
+// CHECK:      __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log[='0']
+// CHECK-NEXT: __builtin_log_scope_exit
+// CHECK-NEXT: __builtin_log[='0']
+// CHECK-NEXT: __builtin_log_scope_exit
+// CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log[='1']
+// CHECK-NEXT: __builtin_log_scope_exit
+// CHECK-NEXT: __builtin_log[='1']
+// CHECK-NEXT: __builtin_log_scope_exit
+// CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log[='2']
+// CHECK-NEXT: __builtin_log_scope_exit
+// CHECK-NEXT: __builtin_log[='2']
+// CHECK-NEXT: __builtin_log_scope_exit

--- a/test/PlaygroundTransform/high_performance.swift
+++ b/test/PlaygroundTransform/high_performance.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -16,26 +16,26 @@ if (a) {
 for i in 0..<3 {
   i
 }
-// CHECK: [{{.*}}] $builtin_log[a='true']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='5']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='0']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='1']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='2']
+// CHECK: [{{.*}}] __builtin_log[a='true']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='5']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='0']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
 
 var b = true
 for i in 0..<3 {
   i
   continue
 }
-// CHECK-NEXT: [{{.*}}] $builtin_log[b='true']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='0']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='1']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log[b='true']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='0']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
 
 var c = true
 for i in 0..<3 {
   i
   break
 }
-// CHECK-NEXT: [{{.*}}] $builtin_log[c='true']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='0']
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='true']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='0']

--- a/test/PlaygroundTransform/init.swift
+++ b/test/PlaygroundTransform/init.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -21,9 +21,9 @@ class C : B {
   }
 }
 let c = C()
-// CHECK: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log[='8']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[c='main.C']
+// CHECK: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='8']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main.C']

--- a/test/PlaygroundTransform/mutation.swift
+++ b/test/PlaygroundTransform/mutation.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -23,15 +23,15 @@ class B {
 
 var b = B()
 b.mutateIvar()
-// CHECK: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
+// CHECK: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
 // note: b.a should not be reported here because we are in init()
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[b='main.B']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [{{.*}}] $builtin_log[a='main.A']
-// CHECK-NEXT: [{{.*}}] $builtin_log_scope_exit 
-// CHECK-NEXT: [{{.*}}] $builtin_log[b='main.B']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[b='main.B']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[a='main.A']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit 
+// CHECK-NEXT: [{{.*}}] __builtin_log[b='main.B']

--- a/test/PlaygroundTransform/nested_function.swift
+++ b/test/PlaygroundTransform/nested_function.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -26,29 +26,29 @@ func returnSum() -> Int {
 
 returnSum()
 
-// CHECK-NOT: $builtin
-// CHECK: [9:{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [10:{{.*}}] $builtin_log[y='10']
-// CHECK-NEXT: [11:{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [12:{{.*}}] $builtin_log[y='15']
-// CHECK-NEXT: [11:{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [15:{{.*}}] $builtin_log[addAgain='{{.*}}']
-// CHECK-NEXT: [15:{{.*}}] $builtin_log_scope_entry
+// CHECK-NOT: __builtin
+// CHECK: [9:{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [10:{{.*}}] __builtin_log[y='10']
+// CHECK-NEXT: [11:{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [12:{{.*}}] __builtin_log[y='15']
+// CHECK-NEXT: [11:{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [15:{{.*}}] __builtin_log[addAgain='{{.*}}']
+// CHECK-NEXT: [15:{{.*}}] __builtin_log_scope_entry
 
 // FIXME: We drop the log for the addition here.
-// CHECK-NEXT: [16:{{.*}}] $builtin_log[='()']
+// CHECK-NEXT: [16:{{.*}}] __builtin_log[='()']
 
-// CHECK-NEXT: [15:{{.*}}] $builtin_log_scope_exit
+// CHECK-NEXT: [15:{{.*}}] __builtin_log_scope_exit
 
 // FIXME: There's an extra, unbalanced scope exit here.
-// CHECK-NEXT: [9:{{.*}}] $builtin_log_scope_exit
+// CHECK-NEXT: [9:{{.*}}] __builtin_log_scope_exit
 
-// CHECK-NEXT: [19:{{.*}}] $builtin_log[addMulti='{{.*}}']
-// CHECK-NEXT: [19:{{.*}}] $builtin_log_scope_entry
-// CHECK-NEXT: [20:{{.*}}] $builtin_log[y='25']
-// CHECK-NEXT: [21:{{.*}}] $builtin_log[='0']
-// CHECK-NEXT: [19:{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [24:{{.*}}] $builtin_log[='25']
-// CHECK-NEXT: [9:{{.*}}] $builtin_log_scope_exit
-// CHECK-NEXT: [27:{{.*}}] $builtin_log[='25']
-// CHECK-NOT: $builtin
+// CHECK-NEXT: [19:{{.*}}] __builtin_log[addMulti='{{.*}}']
+// CHECK-NEXT: [19:{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [20:{{.*}}] __builtin_log[y='25']
+// CHECK-NEXT: [21:{{.*}}] __builtin_log[='0']
+// CHECK-NEXT: [19:{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [24:{{.*}}] __builtin_log[='25']
+// CHECK-NEXT: [9:{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [27:{{.*}}] __builtin_log[='25']
+// CHECK-NOT: __builtin

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var a = "a"
 var b = "b" 
 a += b 
-// CHECK: [{{.*}}] $builtin_log[a='a']
-// CHECK-NEXT: [{{.*}}] $builtin_log[b='b']
-// CHECK-NEXT: [{{.*}}] $builtin_log[a='ab']
+// CHECK: [{{.*}}] __builtin_log[a='a']
+// CHECK-NEXT: [{{.*}}] __builtin_log[b='b']
+// CHECK-NEXT: [{{.*}}] __builtin_log[a='ab']

--- a/test/PlaygroundTransform/print.swift
+++ b/test/PlaygroundTransform/print.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
@@ -22,21 +22,21 @@ debugPrint("One", terminator: "")
 debugPrint("One", terminator: "\n", to: &str)
 debugPrint("One", terminator: "", to: &str)
 
-// CHECK: [{{.*}}] $builtin_log[str='']
+// CHECK: [{{.*}}] __builtin_log[str='']
 // CHECK-NEXT: ("One", 2)
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
 // CHECK-NEXT: One
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: One[{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: One[{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
 // CHECK-NEXT: ("One", 2)
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
 // CHECK-NEXT: "One"
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: "One"[{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
-// CHECK-NEXT: [{{.*}}] $builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: "One"[{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
+// CHECK-NEXT: [{{.*}}] __builtin_postPrint
 


### PR DESCRIPTION
Currently, the playground transform requires the use of dollar-identifiers as the functions are prefixed with "$builtin".
This commit removes that requirement by replacing "$builtin" with "__builtin".
This aligns with the PC macro.

This addresses <rdar://problem/36031860>.