### PR TITLE
[JSONSerialization] Add ability to emit 'null' value.

### DIFF
--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -20,9 +20,6 @@ using namespace swift;
 unsigned Output::beginArray() {
   StateStack.push_back(ArrayFirstValue);
   Stream << '[';
-  if (PrettyPrint) {
-    Stream << '\n';
-  }
   return 0;
 }
 
@@ -30,11 +27,11 @@ bool Output::preflightElement(unsigned, void *&) {
   if (StateStack.back() != ArrayFirstValue) {
     assert(StateStack.back() == ArrayOtherValue && "We must be in a sequence!");
     Stream << ',';
-    if (PrettyPrint)
-      Stream << '\n';
   }
-  if (PrettyPrint)
+  if (PrettyPrint) {
+    Stream << '\n';
     indent();
+  }
   return true;
 }
 
@@ -46,8 +43,9 @@ void Output::postflightElement(void*) {
 }
 
 void Output::endArray() {
+  bool HadContent = StateStack.back() != ArrayFirstValue;
   StateStack.pop_back();
-  if (PrettyPrint) {
+  if (PrettyPrint && HadContent) {
     Stream << '\n';
     indent();
   }
@@ -66,13 +64,12 @@ bool Output::canElideEmptyArray() {
 void Output::beginObject() {
   StateStack.push_back(ObjectFirstKey);
   Stream << "{";
-  if (PrettyPrint)
-    Stream << '\n';
 }
 
 void Output::endObject() {
+  bool HadContent = StateStack.back() != ObjectFirstKey;
   StateStack.pop_back();
-  if (PrettyPrint) {
+  if (PrettyPrint && HadContent) {
     Stream << '\n';
     indent();
   }
@@ -86,11 +83,11 @@ bool Output::preflightKey(const char *Key, bool Required, bool SameAsDefault,
     if (StateStack.back() != ObjectFirstKey) {
       assert(StateStack.back() == ObjectOtherKey && "We must be in an object!");
       Stream << ',';
-      if (PrettyPrint)
-        Stream << '\n';
     }
-    if (PrettyPrint)
+    if (PrettyPrint) {
+      Stream << '\n';
       indent();
+    }
     Stream << '"' << Key << "\":";
     if (PrettyPrint)
       Stream << ' ';

--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -222,6 +222,10 @@ void Output::scalarString(StringRef &S, bool MustQuote) {
     Stream << S;
 }
 
+void Output::null() {
+  Stream << "null";
+}
+
 void Output::indent() {
   Stream.indent(StateStack.size() * 2);
 }

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -18,16 +18,12 @@
                       "layout": [
                         {
                           "kind": "AttributeList",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "DeclModifier",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
@@ -65,9 +61,7 @@
                             "kind": "identifier",
                             "text": "A"
                           },
-                          "leadingTrivia": [
-
-                          ],
+                          "leadingTrivia": [],
                           "trailingTrivia": [
                             {
                               "kind": "Space",
@@ -78,23 +72,17 @@
                         },
                         {
                           "kind": "GenericParameterClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "TypeInheritanceClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "GenericWhereClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
@@ -104,19 +92,13 @@
                               "tokenKind": {
                                 "kind": "l_brace"
                               },
-                              "leadingTrivia": [
-
-                              ],
-                              "trailingTrivia": [
-
-                              ],
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
                               "presence": "Present"
                             },
                             {
                               "kind": "DeclList",
-                              "layout": [
-
-                              ],
+                              "layout": [],
                               "presence": "Present"
                             },
                             {
@@ -129,9 +111,7 @@
                                   "value": 1
                                 }
                               ],
-                              "trailingTrivia": [
-
-                              ],
+                              "trailingTrivia": [],
                               "presence": "Present"
                             }
                           ],
@@ -144,12 +124,8 @@
                       "tokenKind": {
                         "kind": "semi"
                       },
-                      "leadingTrivia": [
-
-                      ],
-                      "trailingTrivia": [
-
-                      ],
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
                       "presence": "Missing"
                     }
                   ],
@@ -163,16 +139,12 @@
                       "layout": [
                         {
                           "kind": "AttributeList",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "DeclModifier",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
@@ -198,9 +170,7 @@
                             "kind": "identifier",
                             "text": "B"
                           },
-                          "leadingTrivia": [
-
-                          ],
+                          "leadingTrivia": [],
                           "trailingTrivia": [
                             {
                               "kind": "Space",
@@ -211,23 +181,17 @@
                         },
                         {
                           "kind": "GenericParameterClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "TypeInheritanceClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "GenericWhereClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
@@ -237,19 +201,13 @@
                               "tokenKind": {
                                 "kind": "l_brace"
                               },
-                              "leadingTrivia": [
-
-                              ],
-                              "trailingTrivia": [
-
-                              ],
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
                               "presence": "Present"
                             },
                             {
                               "kind": "DeclList",
-                              "layout": [
-
-                              ],
+                              "layout": [],
                               "presence": "Present"
                             },
                             {
@@ -262,9 +220,7 @@
                                   "value": 1
                                 }
                               ],
-                              "trailingTrivia": [
-
-                              ],
+                              "trailingTrivia": [],
                               "presence": "Present"
                             }
                           ],
@@ -277,12 +233,8 @@
                       "tokenKind": {
                         "kind": "semi"
                       },
-                      "leadingTrivia": [
-
-                      ],
-                      "trailingTrivia": [
-
-                      ],
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
                       "presence": "Missing"
                     }
                   ],
@@ -307,9 +259,7 @@
           "value": 1
         }
       ],
-      "trailingTrivia": [
-
-      ],
+      "trailingTrivia": [],
       "presence": "Present"
     }
   ],

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -18,16 +18,12 @@
                       "layout": [
                         {
                           "kind": "AttributeList",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "DeclModifier",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
@@ -65,9 +61,7 @@
                             "kind": "identifier",
                             "text": "Foo"
                           },
-                          "leadingTrivia": [
-
-                          ],
+                          "leadingTrivia": [],
                           "trailingTrivia": [
                             {
                               "kind": "Space",
@@ -78,23 +72,17 @@
                         },
                         {
                           "kind": "GenericParameterClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "TypeInheritanceClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
                           "kind": "GenericWhereClause",
-                          "layout": [
-
-                          ],
+                          "layout": [],
                           "presence": "Missing"
                         },
                         {
@@ -104,12 +92,8 @@
                               "tokenKind": {
                                 "kind": "l_brace"
                               },
-                              "leadingTrivia": [
-
-                              ],
-                              "trailingTrivia": [
-
-                              ],
+                              "leadingTrivia": [],
+                              "trailingTrivia": [],
                               "presence": "Present"
                             },
                             {
@@ -120,16 +104,12 @@
                                   "layout": [
                                     {
                                       "kind": "AttributeList",
-                                      "layout": [
-
-                                      ],
+                                      "layout": [],
                                       "presence": "Missing"
                                     },
                                     {
                                       "kind": "ModifierList",
-                                      "layout": [
-
-                                      ],
+                                      "layout": [],
                                       "presence": "Missing"
                                     },
                                     {
@@ -168,9 +148,7 @@
                                                     "kind": "identifier",
                                                     "text": "bar"
                                                   },
-                                                  "leadingTrivia": [
-
-                                                  ],
+                                                  "leadingTrivia": [],
                                                   "trailingTrivia": [
                                                     {
                                                       "kind": "Space",
@@ -189,9 +167,7 @@
                                                   "tokenKind": {
                                                     "kind": "colon"
                                                   },
-                                                  "leadingTrivia": [
-
-                                                  ],
+                                                  "leadingTrivia": [],
                                                   "trailingTrivia": [
                                                     {
                                                       "kind": "Space",
@@ -208,19 +184,13 @@
                                                         "kind": "identifier",
                                                         "text": "Int"
                                                       },
-                                                      "leadingTrivia": [
-
-                                                      ],
-                                                      "trailingTrivia": [
-
-                                                      ],
+                                                      "leadingTrivia": [],
+                                                      "trailingTrivia": [],
                                                       "presence": "Present"
                                                     },
                                                     {
                                                       "kind": "GenericArgumentClause",
-                                                      "layout": [
-
-                                                      ],
+                                                      "layout": [],
                                                       "presence": "Missing"
                                                     }
                                                   ],
@@ -231,28 +201,20 @@
                                             },
                                             {
                                               "kind": "InitializerClause",
-                                              "layout": [
-
-                                              ],
+                                              "layout": [],
                                               "presence": "Missing"
                                             },
                                             {
                                               "kind": "AccessorBlock",
-                                              "layout": [
-
-                                              ],
+                                              "layout": [],
                                               "presence": "Missing"
                                             },
                                             {
                                               "tokenKind": {
                                                 "kind": "comma"
                                               },
-                                              "leadingTrivia": [
-
-                                              ],
-                                              "trailingTrivia": [
-
-                                              ],
+                                              "leadingTrivia": [],
+                                              "trailingTrivia": [],
                                               "presence": "Missing"
                                             }
                                           ],
@@ -269,16 +231,12 @@
                                   "layout": [
                                     {
                                       "kind": "AttributeList",
-                                      "layout": [
-
-                                      ],
+                                      "layout": [],
                                       "presence": "Missing"
                                     },
                                     {
                                       "kind": "ModifierList",
-                                      "layout": [
-
-                                      ],
+                                      "layout": [],
                                       "presence": "Missing"
                                     },
                                     {
@@ -317,9 +275,7 @@
                                                     "kind": "identifier",
                                                     "text": "baz"
                                                   },
-                                                  "leadingTrivia": [
-
-                                                  ],
+                                                  "leadingTrivia": [],
                                                   "trailingTrivia": [
                                                     {
                                                       "kind": "Space",
@@ -338,9 +294,7 @@
                                                   "tokenKind": {
                                                     "kind": "colon"
                                                   },
-                                                  "leadingTrivia": [
-
-                                                  ],
+                                                  "leadingTrivia": [],
                                                   "trailingTrivia": [
                                                     {
                                                       "kind": "Space",
@@ -357,9 +311,7 @@
                                                         "kind": "identifier",
                                                         "text": "Array"
                                                       },
-                                                      "leadingTrivia": [
-
-                                                      ],
+                                                      "leadingTrivia": [],
                                                       "trailingTrivia": [
                                                         {
                                                           "kind": "Space",
@@ -375,9 +327,7 @@
                                                           "tokenKind": {
                                                             "kind": "l_angle"
                                                           },
-                                                          "leadingTrivia": [
-
-                                                          ],
+                                                          "leadingTrivia": [],
                                                           "trailingTrivia": [
                                                             {
                                                               "kind": "Space",
@@ -400,9 +350,7 @@
                                                                         "kind": "identifier",
                                                                         "text": "Int"
                                                                       },
-                                                                      "leadingTrivia": [
-
-                                                                      ],
+                                                                      "leadingTrivia": [],
                                                                       "trailingTrivia": [
                                                                         {
                                                                           "kind": "Space",
@@ -413,9 +361,7 @@
                                                                     },
                                                                     {
                                                                       "kind": "GenericArgumentClause",
-                                                                      "layout": [
-
-                                                                      ],
+                                                                      "layout": [],
                                                                       "presence": "Missing"
                                                                     }
                                                                   ],
@@ -425,12 +371,8 @@
                                                                   "tokenKind": {
                                                                     "kind": "comma"
                                                                   },
-                                                                  "leadingTrivia": [
-
-                                                                  ],
-                                                                  "trailingTrivia": [
-
-                                                                  ],
+                                                                  "leadingTrivia": [],
+                                                                  "trailingTrivia": [],
                                                                   "presence": "Missing"
                                                                 }
                                                               ],
@@ -443,12 +385,8 @@
                                                           "tokenKind": {
                                                             "kind": "r_angle"
                                                           },
-                                                          "leadingTrivia": [
-
-                                                          ],
-                                                          "trailingTrivia": [
-
-                                                          ],
+                                                          "leadingTrivia": [],
+                                                          "trailingTrivia": [],
                                                           "presence": "Present"
                                                         }
                                                       ],
@@ -462,28 +400,20 @@
                                             },
                                             {
                                               "kind": "InitializerClause",
-                                              "layout": [
-
-                                              ],
+                                              "layout": [],
                                               "presence": "Missing"
                                             },
                                             {
                                               "kind": "AccessorBlock",
-                                              "layout": [
-
-                                              ],
+                                              "layout": [],
                                               "presence": "Missing"
                                             },
                                             {
                                               "tokenKind": {
                                                 "kind": "comma"
                                               },
-                                              "leadingTrivia": [
-
-                                              ],
-                                              "trailingTrivia": [
-
-                                              ],
+                                              "leadingTrivia": [],
+                                              "trailingTrivia": [],
                                               "presence": "Missing"
                                             }
                                           ],
@@ -512,9 +442,7 @@
                                   "value": 6
                                 }
                               ],
-                              "trailingTrivia": [
-
-                              ],
+                              "trailingTrivia": [],
                               "presence": "Present"
                             }
                           ],
@@ -527,12 +455,8 @@
                       "tokenKind": {
                         "kind": "semi"
                       },
-                      "leadingTrivia": [
-
-                      ],
-                      "trailingTrivia": [
-
-                      ],
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
                       "presence": "Missing"
                     }
                   ],
@@ -557,9 +481,7 @@
           "value": 1
         }
       ],
-      "trailingTrivia": [
-
-      ],
+      "trailingTrivia": [],
       "presence": "Present"
     }
   ],

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -15,6 +15,7 @@ add_swift_unittest(SwiftBasicTests
   EncodedSequenceTest.cpp
   FileSystemTest.cpp
   ImmutablePointerSetTest.cpp
+  JSONSerialization.cpp
   OptionSetTest.cpp
   OwnedStringTest.cpp
   PointerIntEnumTest.cpp

--- a/unittests/Basic/JSONSerialization.cpp
+++ b/unittests/Basic/JSONSerialization.cpp
@@ -1,0 +1,123 @@
+//===--- CacheTest.cpp ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/JSONSerialization.h"
+#include "gtest/gtest.h"
+
+namespace {
+struct Leaf {
+  int Val;
+};
+
+struct Root {
+  std::string Name;
+  std::vector<Leaf *> Children;
+  std::vector<Leaf *> Empty;
+  Leaf *Side;
+};
+} // namespace
+
+namespace swift {
+namespace json {
+
+template <> struct ObjectTraits<Leaf> {
+  static void mapping(Output &out, Leaf &value) {
+    switch (value.Val) {
+    case 0:
+      break;
+    case 1:
+      out.mapRequired("Value", value.Val);
+      break;
+    case 2: {
+      std::string two("two");
+      out.mapRequired("Value", two);
+      break;
+    }
+    default:
+      break;
+    }
+  }
+};
+
+template <> struct NullableTraits<Leaf *> {
+  static bool isNull(Leaf *&value) { return !value; }
+  static Leaf &get(Leaf *&value) { return *value; }
+};
+
+template <> struct ArrayTraits<std::vector<Leaf *>> {
+
+  using value_type = Leaf *;
+
+  static size_t size(Output &out, std::vector<Leaf *> &seq) {
+    return seq.size();
+  }
+  static Leaf *&element(Output &out, std::vector<Leaf *> &seq, size_t index) {
+    return seq[index];
+  }
+};
+
+template <> struct ObjectTraits<Root> {
+  static void mapping(Output &out, Root &value) {
+    out.mapRequired("Name", value.Name);
+    out.mapRequired("Children", value.Children);
+    out.mapRequired("Empty", value.Empty);
+    out.mapRequired("Side", value.Side);
+  }
+};
+
+} // namespace json
+} // namespace swift
+
+TEST(JSONSerialization, basicCompact) {
+  Leaf LeafObj0{0};
+  Leaf LeafObj1{1};
+  Leaf LeafObj2{2};
+  Root RootObj{"foo", {&LeafObj0, &LeafObj1, nullptr, &LeafObj2}, {}, nullptr};
+  std::string Buffer;
+  llvm::raw_string_ostream Stream(Buffer);
+  swift::json::Output Out(Stream, /*PrettyPrint=*/false);
+
+  Out << RootObj;
+  Stream.flush();
+
+  EXPECT_EQ(Buffer, "{\"Name\":\"foo\",\"Children\":[{},{\"Value\":1},null,{"
+                    "\"Value\":\"two\"}],\"Empty\":[],\"Side\":null}");
+}
+
+TEST(JSONSerialization, basicPretty) {
+  Leaf LeafObj0{0};
+  Leaf LeafObj1{1};
+  Leaf LeafObj2{2};
+  Root RootObj{"foo", {&LeafObj0, &LeafObj1, nullptr, &LeafObj2}, {}, nullptr};
+  std::string Buffer;
+  llvm::raw_string_ostream Stream(Buffer);
+  swift::json::Output Out(Stream);
+
+  Out << RootObj;
+  Stream.flush();
+
+  EXPECT_EQ(Buffer, R"""({
+  "Name": "foo",
+  "Children": [
+    {},
+    {
+      "Value": 1
+    },
+    null,
+    {
+      "Value": "two"
+    }
+  ],
+  "Empty": [],
+  "Side": null
+})""");
+}


### PR DESCRIPTION
Added `NullableTraits` template to represent potential `null` value.

Also, modified outputs for empty object and array values in pretty-print mode.
Now, they are emitted as `{}` and `[]` instead of:
```json
{

}
```
and
```json
[

]
```