### PR TITLE
[Syntax] Speculative fix for SwiftSyntax parse failure

### DIFF
--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
-// REQUIRES: rdar36740859
 
 import Foundation
 import StdlibUnittest
@@ -31,7 +30,7 @@ ParseFile.test("ParseSingleFile") {
   let currentFile = URL(fileURLWithPath: #file)
   expectDoesNotThrow({
     let currentFileContents = try String(contentsOf: currentFile)
-    let parsed = try Syntax.parse(currentFile)
+    let parsed = try SourceFileSyntax.parse(currentFile)
     expectEqual("\(parsed)", currentFileContents)
   })
 }

--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -3,9 +3,6 @@
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 
-// FIXME: This test fails occassionally in CI with invalid json.
-// REQUIRES: disabled
-
 import StdlibUnittest
 import Foundation
 import SwiftSyntax
@@ -29,7 +26,7 @@ VisitorTests.test("Basic") {
     }
   }
   expectDoesNotThrow({
-    let parsed = try Syntax.parse(getInput("visitor.swift"))
+    let parsed = try SourceFileSyntax.parse(getInput("visitor.swift"))
     let counter = FuncCounter()
     let hashBefore = parsed.hashValue
     counter.visit(parsed)

--- a/tools/SwiftSyntax/SwiftcInvocation.swift
+++ b/tools/SwiftSyntax/SwiftcInvocation.swift
@@ -73,17 +73,21 @@ func run(_ executable: URL, arguments: [String] = []) -> ProcessResult {
     
     let process = Process()
     
-    process.terminationHandler = { process in
-      stdoutPipe.fileHandleForReading.readabilityHandler = nil
-      stderrPipe.fileHandleForReading.readabilityHandler = nil
-    }
-    
     process.launchPath = executable.path
     process.arguments = arguments
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe
     process.launch()
     process.waitUntilExit()
+
+    // Read to EOF.
+    stdoutData.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
+    stderrData.append(stderrPipe.fileHandleForReading.readDataToEndOfFile())
+
+    // Clean up.
+    stdoutPipe.fileHandleForReading.readabilityHandler = nil
+    stderrPipe.fileHandleForReading.readabilityHandler = nil
+
     return ProcessResult(exitCode: Int(process.terminationStatus),
                          stdoutData: stdoutData,
                          stderrData: stderrData)


### PR DESCRIPTION
Somehow, we occasionally failed to read all data from the `swiftc` command invoked by `Process` API in Swift.

It seems `Pipe.fileHandleForReading.readabilityHandler` is not guaranteed to be called up to`EOF`. This PR is trying to fix the issue by calling `readDataToEndOfFile()` after `Process.waitUntilExit()`.

rdar://problem/36379512 and rdar://problem/36740859

@Catfish-Man Is this the right way to synchronously read all stdout/stderr output from a `Process`?