### PR TITLE
[IRGen/Resilience] Add a test case for rdar://problem/36560486

### DIFF
--- a/validation-test/Evolution/Inputs/generic_resilient_struct_add_property.swift
+++ b/validation-test/Evolution/Inputs/generic_resilient_struct_add_property.swift
@@ -1,0 +1,39 @@
+
+public func getVersion() -> Int {
+#if BEFORE
+  return 0
+#else
+  return 1
+#endif
+}
+
+public protocol P {
+  static func compute() -> Int
+}
+
+public struct A : P {
+  public init() {}
+
+  public static func compute() -> Int {
+    return 42
+  }
+}
+
+#if BEFORE
+
+public struct S<T: P> {
+  public init() {}
+}
+
+#else
+
+public struct S<T: P> {
+  public init() {
+    question = "Ultimate Question"
+  }
+
+  public var question: String
+}
+
+#endif
+

--- a/validation-test/Evolution/test_generic_resilient_struct_add_property.swift
+++ b/validation-test/Evolution/test_generic_resilient_struct_add_property.swift
@@ -1,0 +1,19 @@
+// RUN: %target-resilience-test
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import generic_resilient_struct_add_property
+
+extension S {
+  public func answer() -> Int {
+    return T.compute()
+  }
+}
+
+var GenericStructAddPropertyTest = TestSuite("GenericStructAddPropertyTest")
+GenericStructAddPropertyTest.test("AddStoredProperty") {
+  let s = S<A>()
+  expectEqual(s.answer(), 42)
+}
+
+runAllTests()


### PR DESCRIPTION
Since field offsets are now encoded after generic parameters, it
is useful to validate that using generic parameter metadata is now
more resilient in presence of new fields.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
