### PR TITLE
[Stats] Reduce layering violations in FrontendStatsTracer.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5658,3 +5658,37 @@ void Decl::setClangNode(ClangNode Node) {
   }
   *(ptr - 1) = Node.getOpaqueValue();
 }
+
+// See swift/Basic/Statistic.h for declaration: this enables tracing Decls, is
+// defined here to avoid too much layering violation / circular linkage
+// dependency.
+
+struct DeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
+  void traceName(const void *Entity, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const Decl *D = static_cast<const Decl *>(Entity);
+    if (auto const *VD = dyn_cast<const ValueDecl>(D)) {
+      VD->getFullName().print(OS, false);
+    }
+  }
+  void traceLoc(const void *Entity, SourceManager *SM,
+                clang::SourceManager *CSM, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const Decl *D = static_cast<const Decl *>(Entity);
+    D->getSourceRange().print(OS, *SM, false);
+  }
+};
+
+static DeclTraceFormatter TF;
+
+UnifiedStatsReporter::FrontendStatsTracer
+UnifiedStatsReporter::getStatsTracer(StringRef EventName, const Decl *D) {
+  if (LastTracedFrontendCounters)
+    // Return live tracer object.
+    return FrontendStatsTracer(EventName, D, &TF, this);
+  else
+    // Return inert tracer object.
+    return FrontendStatsTracer();
+}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8585,3 +8585,53 @@ ClangImporter::getEnumConstantName(const clang::EnumConstantDecl *enumConstant){
       .getBaseIdentifier();
 }
 
+// See swift/Basic/Statistic.h for declaration: this enables tracing
+// clang::Decls, is defined here to avoid too much layering violation / circular
+// linkage dependency.
+
+struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
+  void traceName(const void *Entity, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const clang::Decl *CD = static_cast<const clang::Decl *>(Entity);
+    if (auto const *ND = dyn_cast<const clang::NamedDecl>(CD)) {
+      ND->printName(OS);
+    }
+  }
+
+  static inline void printClangShortLoc(raw_ostream &OS,
+                                        clang::SourceManager *CSM,
+                                        clang::SourceLocation L) {
+    if (!L.isValid() || !L.isFileID())
+      return;
+    auto PLoc = CSM->getPresumedLoc(L);
+    OS << llvm::sys::path::filename(PLoc.getFilename()) << ':' << PLoc.getLine()
+       << ':' << PLoc.getColumn();
+  }
+
+  void traceLoc(const void *Entity, SourceManager *SM,
+                clang::SourceManager *CSM, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    if (CSM) {
+      const clang::Decl *CD = static_cast<const clang::Decl *>(Entity);
+      auto Range = CD->getSourceRange();
+      printClangShortLoc(OS, CSM, Range.getBegin());
+      OS << '-';
+      printClangShortLoc(OS, CSM, Range.getEnd());
+    }
+  }
+};
+
+static ClangDeclTraceFormatter TF;
+
+UnifiedStatsReporter::FrontendStatsTracer
+UnifiedStatsReporter::getStatsTracer(StringRef EventName,
+                                     const clang::Decl *D) {
+  if (LastTracedFrontendCounters)
+    // Return live tracer object.
+    return FrontendStatsTracer(EventName, D, &TF, this);
+  else
+    // Return inert tracer object.
+    return FrontendStatsTracer();
+}

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/Basic/OptimizationMode.h"
+#include "swift/Basic/Statistic.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/GraphWriter.h"
@@ -489,4 +490,38 @@ SubstitutionList SILFunction::getForwardingSubstitutions() {
 
 bool SILFunction::shouldVerifyOwnership() const {
   return !hasSemanticsAttr("verify.ownership.sil.never");
+}
+
+// See swift/Basic/Statistic.h for declaration: this enables tracing
+// SILFunctions, is defined here to avoid too much layering violation / circular
+// linkage dependency.
+
+struct SILFunctionTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
+  void traceName(const void *Entity, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const SILFunction *F = static_cast<const SILFunction *>(Entity);
+    OS << F->getName();
+  }
+
+  void traceLoc(const void *Entity, SourceManager *SM,
+                clang::SourceManager *CSM, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const SILFunction *F = static_cast<const SILFunction *>(Entity);
+    F->getLocation().getSourceRange().print(OS, *SM, false);
+  }
+};
+
+static SILFunctionTraceFormatter TF;
+
+UnifiedStatsReporter::FrontendStatsTracer
+UnifiedStatsReporter::getStatsTracer(StringRef EventName,
+                                     const SILFunction *F) {
+  if (LastTracedFrontendCounters)
+    // Return live tracer object.
+    return FrontendStatsTracer(EventName, F, &TF, this);
+  else
+    // Return inert tracer object.
+    return FrontendStatsTracer();
 }

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -1,0 +1,9 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
+// RUN: %FileCheck -input-file %t/*.csv %s
+
+// CHECK: {{"Sema.NumTypesDeserialized"}}
+
+public func foo() {
+    print("hello")
+}


### PR DESCRIPTION
In PR #14059 I introduced a layering violation that I _thought_ might have been sufficiently benign to not cause trouble, but of course there are configurations where it does: linking the unit tests on linux in a debug build appears to complain, and really I was playing with matches in the first place (in my defence, I wanted to keep it somewhat typesafe).

Anyway, this undoes the approach in that patch and puts a different, void*-ier one in its place. I don't especially love it, but it is at least more inclined to link in all cases, keeps the layering intact.

(Plan B, if you find all this too distasteful, is to back out #14059 altogether; though I'd like to keep it there for further work in emitting traces -- and later, flamegraphs -- with meaningful entity names)