### PR TITLE
[emacs] Add expression keywords to swift-font-lock-keywords

### DIFF
--- a/utils/swift-mode.el
+++ b/utils/swift-mode.el
@@ -50,9 +50,9 @@
    ;; Decl and type keywords
    `(,(regexp-opt '("class" "init" "deinit" "extension" "fileprivate" "func"
                     "import" "let" "protocol" "static" "struct" "subscript"
-                    "typealias" "enum" "var" "lazy" "where"
-                    "private" "public" "internal" "override" "throws" "rethrows"
-                    "open" "associatedtype" "inout" "indirect" "final")
+                    "typealias" "enum" "var" "lazy" "where" "private" "public"
+                    "internal" "override" "open" "associatedtype" "inout"
+                    "indirect" "final")
                   'words) . font-lock-keyword-face)
    ;; Variable decl keywords
    `("\\b\\(?:[^a-zA-Z_0-9]*\\)\\(get\\|set\\)\\(?:[^a-zA-Z_0-9]*\\)\\b" 1 font-lock-keyword-face)
@@ -68,16 +68,18 @@
    ;; Statements
    `(,(regexp-opt '("if" "guard" "in" "else" "for" "do" "repeat" "while"
                     "return" "break" "continue" "fallthrough"  "switch" "case"
-                    "default" "throw" "defer" "try" "catch")
+                    "default" "defer" "catch")
                   'words) . font-lock-keyword-face)
    ;; Decl modifier keywords
    `(,(regexp-opt '("convenience" "dynamic" "mutating" "nonmutating" "optional"
                     "required" "weak" "unowned" "safe" "unsafe")
                   'words) . font-lock-keyword-face)
+   ;; Expression keywords: "Any" and "Self" are included in "Types" above
+   `(,(regexp-opt '("as" "false" "is" "nil" "rethrows" "super" "self" "throw"
+                    "true" "try" "throws")
+                  'words) . font-lock-keyword-face)
    ;; Expressions
    `(,(regexp-opt '("new") 'words) . font-lock-keyword-face)
-   ;; Special Variables
-   '("self" . font-lock-keyword-face)
    ;; Variables
    '("[a-zA-Z_][a-zA-Z_0-9]*" . font-lock-variable-name-face)
    ;; Unnamed variables


### PR DESCRIPTION
<!-- What's in this pull request? -->
#### What's in this pull request?

The `util/swift-mode.el` improvement is included.

- Add [expression keywords](https://raw.githubusercontent.com/apple/swift/master/include/swift/Syntax/TokenKinds.def) to `swift-font-lock-keywords`.
    - `Any` and `Self` are included in "Types" (`font-lock-type-face`).
- Tidy the script.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

None

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->