### PR TITLE
SR-2595 Make the output from cmpcodesize parseable

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -14,7 +14,6 @@ import collections
 import os
 import re
 import subprocess
-
 from operator import itemgetter
 
 categories = [
@@ -152,31 +151,50 @@ def read_sizes(sizes, file_name, function_details, group_by_prefix):
     add_function(sizes, curr_func, start_addr, end_addr, group_by_prefix)
 
 
-def compare_sizes(old_sizes, new_sizes, name_key, title, total_size_key=""):
+def compare_sizes(old_sizes, new_sizes, name_key, title, total_size_key="",
+                  csv=None):
     old_size = old_sizes[name_key]
     new_size = new_sizes[name_key]
+
     if total_size_key:
         old_total_size = old_sizes[total_size_key]
         new_total_size = new_sizes[total_size_key]
+
     if old_size is not None and new_size is not None:
         if old_size != 0:
             perc = "%.1f%%" % (
                 (1.0 - float(new_size) / float(old_size)) * 100.0)
         else:
             perc = "- "
+
         if total_size_key:
-            print("%-26s%16s: %8d (%2d%%)  %8d (%2d%%)  %7s" %
-                  (title, name_key, old_size,
-                   old_size * 100.0 / old_total_size,
-                   new_size, new_size * 100.0 / new_total_size, perc))
+            if csv:
+                csv.writerow([title, name_key, 
+                              old_size, old_size * 100.0 / old_total_size,
+                              new_size, new_size * 100.0 / new_total_size,
+                              perc])
+            else:
+                print("%-26s%16s: %8d (%2d%%)  %8d (%2d%%)  %7s" %
+                      (title, name_key,
+                       old_size, old_size * 100.0 / old_total_size,
+                       new_size, new_size * 100.0 / new_total_size,
+                       perc))
         else:
-            print("%-26s%16s: %14d  %14d  %7s" %
-                  (title, name_key, old_size, new_size, perc))
+            if csv:
+                csv.writerow([title, name_key,
+                              old_size, "",
+                              new_size, "",
+                              perc])
+            else:
+                print("%-26s%16s: %14d  %14d  %7s" %
+                      (title, name_key, old_size, new_size, perc))
 
 
-def compare_sizes_of_file(old_files, new_files, all_sections, list_categories):
+def compare_sizes_of_file(old_files, new_files, all_sections, list_categories, 
+                          csv=None):
     old_sizes = collections.defaultdict(int)
     new_sizes = collections.defaultdict(int)
+
     for old_file in old_files:
         read_sizes(old_sizes, old_file, list_categories, True)
     for new_file in new_files:
@@ -191,25 +209,33 @@ def compare_sizes_of_file(old_files, new_files, all_sections, list_categories):
     else:
         title = "old-new"
 
-    compare_sizes(old_sizes, new_sizes, "__text", title, "")
+    compare_sizes(old_sizes, new_sizes, "__text", title, "", csv=csv)
+
     if list_categories:
         for cat in categories:
             cat_name = cat[0]
-            compare_sizes(old_sizes, new_sizes, cat_name, "", "__text")
+            compare_sizes(old_sizes, new_sizes, cat_name, "", "__text", 
+                          csv=csv)
 
     if all_sections:
         section_title = "    section"
-        compare_sizes(old_sizes, new_sizes, "__textcoal_nt", section_title)
-        compare_sizes(old_sizes, new_sizes, "__stubs", section_title)
-        compare_sizes(old_sizes, new_sizes, "__const", section_title)
-        compare_sizes(old_sizes, new_sizes, "__cstring", section_title)
-        compare_sizes(old_sizes, new_sizes, "__objc_methname", section_title)
-        compare_sizes(old_sizes, new_sizes, "__const", section_title)
-        compare_sizes(old_sizes, new_sizes, "__objc_const", section_title)
-        compare_sizes(old_sizes, new_sizes, "__data", section_title)
-        compare_sizes(old_sizes, new_sizes, "__swift5_proto", section_title)
-        compare_sizes(old_sizes, new_sizes, "__common", section_title)
-        compare_sizes(old_sizes, new_sizes, "__bss", section_title)
+
+        compare_sizes(old_sizes, new_sizes, "__textcoal_nt", section_title, 
+                      csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__stubs", section_title, csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__const", section_title, csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__cstring", section_title,
+                      csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__objc_methname", section_title,
+                      csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__const", section_title, csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__objc_const", section_title,
+                      csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__data", section_title, csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__swift5_proto", section_title,
+                      csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__common", section_title, csv=csv)
+        compare_sizes(old_sizes, new_sizes, "__bss", section_title, csv=csv)
 
 
 def list_function_sizes(size_array):
@@ -219,7 +245,7 @@ def list_function_sizes(size_array):
         yield "%8d %s" % (size, name)
 
 
-def compare_function_sizes(old_files, new_files):
+def compare_function_sizes(old_files, new_files, csv=None):
     old_sizes = collections.defaultdict(int)
     new_sizes = collections.defaultdict(int)
     for name in old_files:
@@ -250,23 +276,41 @@ def compare_function_sizes(old_files, new_files):
             only_in_file2size += new_size
 
     if only_in_file1:
-        print("Only in old file(s)")
-        print(os.linesep.join(list_function_sizes(only_in_file1)))
-        print("Total size of functions only in old file: {}".format(
-            only_in_file1size))
-        print()
+        if csv:
+            csv.writerow(["Only in old", "", "", ""])
+            for name, size in sorted(only_in_file1, key=itemgetter(1)):
+                csv.writerow([size, name, "", ""])
+            csv.writerow(["Total size only in old", only_in_file1size, "", ""])
+        else:
+            print("Only in old file(s)")
+            print(os.linesep.join(list_function_sizes(only_in_file1)))
+            print("Total size of functions only in old file: {}".format(
+                only_in_file1size))
+            print()
 
     if only_in_file2:
-        print("Only in new files(s)")
-        print(os.linesep.join(list_function_sizes(only_in_file2)))
-        print("Total size of functions only in new file: {}".format(
-            only_in_file2size))
-        print()
+        if csv:
+            csv.writerow(["Only in new", "", "", ""])
+            for name, size in sorted(only_in_file2, key=itemgetter(1)):
+                csv.writerow([size, name, "", ""])
+            csv.writerow(["Total size only in new", only_in_file2size, "", ""])
+        else:
+            print("Only in new files(s)")
+            print(os.linesep.join(list_function_sizes(only_in_file2)))
+            print("Total size of functions only in new file: {}".format(
+                only_in_file2size))
+            print()
 
     if in_both:
         size_increase = 0
         size_decrease = 0
-        print("%8s %8s %8s" % ("old", "new", "diff"))
+
+        header = ("old", "new", "diff")
+        if csv:
+            csv.writerow(list(header) + ["function"])
+        else:
+            print("%8s %8s %8s" % header)
+
         for triple in sorted(
                 in_both,
                 key=lambda tup: (tup[2] - tup[1], tup[1])):
@@ -274,19 +318,31 @@ def compare_function_sizes(old_files, new_files):
             old_size = triple[1]
             new_size = triple[2]
             diff = new_size - old_size
+
             if diff > 0:
                 size_increase += diff
             else:
                 size_decrease -= diff
             if diff == 0:
                 in_both_size += new_size
-            print("%8d %8d %8d %s" %
-                  (old_size, new_size, new_size - old_size, func))
-        print("Total size of functions " +
-              "with the same size in both files: {}".format(in_both_size))
-        print("Total size of functions " +
-              "that got smaller: {}".format(size_decrease))
-        print("Total size of functions " +
-              "that got bigger: {}".format(size_increase))
-        print("Total size change of functions present " +
-              "in both files: {}".format(size_increase - size_decrease))
+
+            if csv:
+                csv.writerow([old_size, new_size, new_size - old_size, func])
+            else:
+                print("%8d %8d %8d %s" %
+                      (old_size, new_size, new_size - old_size, func))
+
+        if csv:
+            csv.writerow(["Total size in both", "Total size smaller",
+                          "Total size bigger", "Total size change in both"])
+            csv.writerow([in_both_size, size_decrease, size_increase,
+                          (size_increase - size_decrease)])
+        else:
+            print("Total size of functions " +
+                  "with the same size in both files: {}".format(in_both_size))
+            print("Total size of functions " +
+                  "that got smaller: {}".format(size_decrease))
+            print("Total size of functions " +
+                  "that got bigger: {}".format(size_increase))
+            print("Total size change of functions present " +
+                  "in both files: {}".format(size_increase - size_decrease))

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 
 import argparse
 import collections
+import csv
 import glob
 import os
 import sys
@@ -101,6 +102,11 @@ How to specify files:
                         action='store_true',
                         dest='sum_sizes',
                         default=False)
+    parser.add_argument('-p', '--parseable',
+                        help='Generate output as CSV that can be parsed by ' +
+                             'other programs.',
+                        action='store_true',
+                        default=False)
 
     # Positional arguments.
     # These can be specified in means beyond what argparse supports,
@@ -127,6 +133,10 @@ How to specify files:
         assert parsed_arguments.files, \
             'Incorrect usage: Must specify between one and two files when ' + \
             'using --list, but you specified no files.'
+
+    csv_out = None
+    if parsed_arguments.parseable:
+        csv_out = csv.writer(sys.stdout)
 
     if separator_token in parsed_arguments.files:
         separator_index = parsed_arguments.files.index(separator_token)
@@ -181,14 +191,20 @@ How to specify files:
                 read_sizes(sizes, file, True, False)
             print(os.linesep.join(list_function_sizes(sizes.items())))
         else:
-            compare_function_sizes(old_files, new_files)
+            compare_function_sizes(old_files, new_files, csv=csv_out)
     else:
-        print("%-26s%16s  %14s  %14s  %s" %
-              ("", "Section", "Old", "New", "Percent"))
+        if csv_out:
+            csv_out.writerow(["Title", "Section", "Old", "Old Relative",
+                              "New", "New Relative", "Percentage Change"])
+        else:
+            print("%-26s%16s  %14s  %14s  %s" %
+                  ("Title", "Section", "Old", "New", "Percent"))
+
         if parsed_arguments.sum_sizes:
             compare_sizes_of_file(old_files, new_files,
                                   parsed_arguments.all_sections,
-                                  parsed_arguments.list_categories)
+                                  parsed_arguments.list_categories, 
+                                  csv=csv_out)
         else:
             if len(old_files) != len(new_files):
                 sys.exit("number of new files must be the same of old files")
@@ -199,7 +215,8 @@ How to specify files:
             for old_file, new_file in zip(old_files, new_files):
                 compare_sizes_of_file([old_file], [new_file],
                                       parsed_arguments.all_sections,
-                                      parsed_arguments.list_categories)
+                                      parsed_arguments.list_categories,
+                                      csv=csv_out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As requested added a parameter to cmpcodesize (`-p`) that outputs csv instead of plain text so other programs can have the opportunity to parse the output.

I converted the output to csv as plainly as possible and used this list of commands for testing:
https://gist.github.com/alper/89b6686544ea78ffb4867e07fb3f28b4
All of the `output.csv` files open cleanly in Numbers.app.

Resolves [SR-2595](https://bugs.swift.org/browse/SR-2595).

I've linted this locally already as described in the CI guide.