### PR TITLE
[AST] NFC: Do not reinterpret_cast 'Type'

### DIFF
--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_EXISTENTIAL_LAYOUT_H
 #define SWIFT_EXISTENTIAL_LAYOUT_H
 
+#include "swift/Basic/ArrayRefView.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Type.h"
 #include "llvm/ADT/SmallVector.h"
@@ -66,10 +67,13 @@ struct ExistentialLayout {
   // constraints?
   bool isErrorExistential() const;
 
-  ArrayRef<ProtocolType *> getProtocols() const {
-    if (singleProtocol)
-      return ArrayRef<ProtocolType *>{&singleProtocol, 1};
-    return multipleProtocols;
+  static inline ProtocolType *getProtocolType(const Type &Ty) {
+    return cast<ProtocolType>(Ty.getPointer());
+  }
+  typedef ArrayRefView<Type,ProtocolType*,getProtocolType> ProtocolTypeArrayRef;
+
+  ProtocolTypeArrayRef getProtocols() const {
+    return protocols;
   }
 
   LayoutConstraint getLayoutConstraint() const;
@@ -77,10 +81,10 @@ struct ExistentialLayout {
 private:
   // Inline storage for 'protocols' member above when computing
   // layout of a single ProtocolType
-  ProtocolType *singleProtocol;
+  Type singleProtocol;
 
   /// Zero or more protocol constraints.
-  ArrayRef<ProtocolType *> multipleProtocols;
+  ArrayRef<Type> protocols;
 };
 
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -249,6 +249,7 @@ ExistentialLayout::ExistentialLayout(ProtocolType *type) {
   containsNonObjCProtocol = !protoDecl->isObjC();
 
   singleProtocol = type;
+  protocols = { &singleProtocol, 1 };
 }
 
 ExistentialLayout::ExistentialLayout(ProtocolCompositionType *type) {
@@ -270,10 +271,7 @@ ExistentialLayout::ExistentialLayout(ProtocolCompositionType *type) {
   }
 
   singleProtocol = nullptr;
-  multipleProtocols = {
-    reinterpret_cast<ProtocolType * const *>(members.data()),
-    members.size()
-  };
+  protocols = { members.data(), members.size() };
 }
 
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1529,7 +1529,7 @@ bool SILParser::parseSubstitutions(SmallVectorImpl<ParsedSubstitution> &parsed,
 /// Collect conformances by looking up the conformance from replacement
 /// type and protocol decl.
 static bool getConformancesForSubstitution(Parser &P,
-              ArrayRef<ProtocolType *> protocols,
+              ExistentialLayout::ProtocolTypeArrayRef protocols,
               Type subReplacement,
               SourceLoc loc,
               SmallVectorImpl<ProtocolConformanceRef> &conformances) {
@@ -1578,11 +1578,12 @@ bool getApplySubstitutionsFromParsed(
       parses = parses.slice(1);
 
       SmallVector<ProtocolConformanceRef, 2> conformances;
-      SmallVector<ProtocolType *, 2> protocols;
+      SmallVector<Type, 2> protocols;
       for (auto reqt : reqts)
-        protocols.push_back(reqt.getSecondType()->castTo<ProtocolType>());
+        protocols.push_back(reqt.getSecondType());
 
-      if (getConformancesForSubstitution(SP.P, protocols,
+      if (getConformancesForSubstitution(SP.P,
+                             ExistentialLayout::ProtocolTypeArrayRef(protocols),
                                          parsed.replacement,
                                          parsed.loc, conformances))
         return true;


### PR DESCRIPTION
Found while doing a performance experiment with the 'Type' type wall.
