### PR TITLE
[4.1] [ClangImporter] swift_wrapper: transfer inherited synthesized protos

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5049,7 +5049,7 @@ static bool conformsToProtocolInOriginalModule(NominalTypeDecl *nominal,
 
   for (auto attr : nominal->getAttrs().getAttributes<SynthesizedProtocolAttr>())
     if (auto *otherProto = ctx.getProtocol(attr->getProtocolKind()))
-      if (otherProto == proto)
+      if (otherProto == proto || otherProto->inheritsFrom(proto))
         return true;
 
   // Only consider extensions from the original module...or from an overlay

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -83,7 +83,7 @@
 // PRINT-NEXT:  let Notification: String
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
-// PRINT-LABEL: struct CFNewType : _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -97,7 +97,7 @@
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
 //
-// PRINT-LABEL: struct MyABINewType : _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString


### PR DESCRIPTION
- **Explanation**: `swift_wrapper` is a Clang attribute (usually exposed as `NS_TYPED_ENUM`) that causes a typedef in C to be imported as a struct in Swift. We try to pass through conformances to common protocols like Hashable based on whether the underlying type conforms. Due to some work back in September, we messed this up when the wrapped type was a CF type; now we do a broader check to fix that.
- **Scope**: Affects `swift_wrapper` (`NS_TYPED_ENUM`) types, but in practice only changes behavior if the wrapped type is a CF type.
- **Issue**: [SR-6842](https://bugs.swift.org/browse/SR-6842) / rdar://problem/36591294
- **Reviewed by**: @rjmccall  
- **Risk**: Low. It's a small change, and we're more closely aligned with what 4.0 did now.
- **Testing**: Added a compiler regression test, verified manually that wrapped CF types show up as Hashable.