### PR TITLE
[5.0] [ClangImporter] swift_wrapper: transfer inherited synthesized protos

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5063,7 +5063,7 @@ static bool conformsToProtocolInOriginalModule(NominalTypeDecl *nominal,
 
   for (auto attr : nominal->getAttrs().getAttributes<SynthesizedProtocolAttr>())
     if (auto *otherProto = ctx.getProtocol(attr->getProtocolKind()))
-      if (otherProto == proto)
+      if (otherProto == proto || otherProto->inheritsFrom(proto))
         return true;
 
   // Only consider extensions from the original module...or from an overlay

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -83,7 +83,7 @@
 // PRINT-NEXT:  let Notification: String
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
-// PRINT-LABEL: struct CFNewType : _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -97,7 +97,7 @@
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
 //
-// PRINT-LABEL: struct MyABINewType : _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString


### PR DESCRIPTION
Cherry-pick of #14254 to swift-5.0-branch, to keep it ahead of swift-4.1-branch (see #14270).

[SR-6842](https://bugs.swift.org/browse/SR-6842) / rdar://problem/36591294