### PR TITLE
[libMigrator] Generalize CMake symlink to work on Windows

### DIFF
--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -16,13 +16,20 @@ add_custom_command(
 set(outputs)
 
 foreach(input ${datafiles})
-  add_custom_command(
-      OUTPUT "${output_dir}/${input}"
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-      COMMAND
-        "${CMAKE_COMMAND}" "-E" "create_symlink"
-        "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-        "${output_dir}/${input}")
+  set(source "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
+  set(dest "${output_dir}/${input}")
+  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(CMAKE_SYMLINK_COMMAND copy)
+  else()
+    set(CMAKE_SYMLINK_COMMAND create_symlink)
+  endif()
+
+  add_custom_command(OUTPUT
+                       "${output_dir}/${input}"
+                     DEPENDS
+                       "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
+                     COMMAND
+                       "${CMAKE_COMMAND}" "-E" "${CMAKE_SYMLINK_COMMAND}" "${source}" "${dest}")
   list(APPEND outputs "${output_dir}/${input}")
 endforeach()
 list(APPEND outputs "${output_dir}")


### PR DESCRIPTION
This fixes a bug found while building Swift for Windows. The CMake invocation
assumed that the host system had a utility called `create_symlink`. That
assumption breaks down on Windows, where `copy` is the equivalent tool.