### PR TITLE
[libSyntax][Cmake] Fix gyb invocation quoting issue on Windows

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -37,6 +37,8 @@ function(handle_gyb_source_single dependency_out_var_name)
       GYB_SINGLE # prefix
       "${options}" "${single_value_args}" "${multi_value_args}" ${ARGN})
 
+separate_arguments(SWIFT_GYB_FLAGS WINDOWS_COMMAND "${SWIFT_GYB_FLAGS}")
+
   set(gyb_flags
       ${SWIFT_GYB_FLAGS}
       ${GYB_SINGLE_FLAGS})
@@ -74,7 +76,7 @@ function(handle_gyb_source_single dependency_out_var_name)
       COMMENT "Generating ${basename} from ${GYB_SINGLE_SOURCE} ${GYB_SINGLE_COMMENT}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       SOURCES "${GYB_SINGLE_SOURCE}"
-      IDEMPOTENT)
+      VERBATIM)
   set("${dependency_out_var_name}" "${dependency_target}" PARENT_SCOPE)
 endfunction()
 

--- a/include/swift/Syntax/CMakeLists.txt
+++ b/include/swift/Syntax/CMakeLists.txt
@@ -1,6 +1,4 @@
-set(line_directive "#line" "%(line)d" "\"%(file)s\"")
-set(SWIFT_GYB_FLAGS
-  --line-directive "'${line_directive}'")
+set(SWIFT_GYB_FLAGS "--line-directive \"#line \"%(line)d\" \"%(file)s\"\" ")
 
 set(generated_include_sources
     SyntaxKind.h.gyb

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -1,6 +1,5 @@
-set(line_directive "#line" "%(line)d" "\"%(file)s\"")
-set(SWIFT_GYB_FLAGS
-  --line-directive "'${line_directive}'")
+
+set(SWIFT_GYB_FLAGS "--line-directive \"#line \"%(line)d\" \"%(file)s\"\" ")
 
 add_swift_library(swiftSyntax STATIC
   SyntaxNodes.cpp.gyb

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import os
 import re
+import sys
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -571,7 +572,15 @@ class ExecutionContext(object):
             if (file, line) != self.last_file_line:
                 # We can only insert the line directive at a line break
                 if len(self.result_text) == 0 \
-                   or self.result_text[-1].endswith('\n'):
+                    or self.result_text[-1].endswith('\n'):
+                    if sys.platform == 'win32':
+                        # CMake gives us backslashes, clang doesn't like
+                        # backslashes. Forward slashes work on Windows
+                        file = file.replace('\\', '/')
+                        # The file also needs to be quotes, so clang-cl can
+                        # correctly parse the `C:/ ...` part of the path
+                        file = "\"{}\"".format(file)
+
                     substitutions = {'file': file, 'line': line + 1}
                     format_str = self.line_directive + '\n'
                     self.result_text.append(format_str % substitutions)


### PR DESCRIPTION
The lib/Syntax build system assumed a *nix quoting style for arguments
passed into gyb. That assumption breaks on Windows. This patch updates
the build system to Do The Right Thing™ when built on Windows.