### PR TITLE
[4.1] IRGen: swift_getFunctionTypeMetadata is not readnone it receive…

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -769,7 +769,7 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, DefaultCC,
               TypeMetadataPtrTy->getPointerTo(0),
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadNone))
+         ATTRS(NoUnwind))
 
 // Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
 //                                          const Metadata *arg0,

--- a/test/Interpreter/closures.swift
+++ b/test/Interpreter/closures.swift
@@ -82,3 +82,12 @@ func f() -> Bool? { return nil }
   let c = { b = true }
   _ = (b, c)
 })()
+
+// Don't crash in optimized mode.
+func crash() {
+    let f: (Int, Int, Int, Int) -> Int = { _, _, _, _ in 21 }
+    let fs = [f, f]
+    // CHECK: fs: [(Function), (Function)]
+    print("fs: \(fs)")
+}
+crash()


### PR DESCRIPTION
…s its type

parameters indirect

* Explanation: We marked swift_getFunctionTypeMetadata with ReadNone.
This is problematic because this function receives its type arguments
indirectly via memory.

* Scope: This would cause failures with function types that involve more
than three type metadata parameters in optimized mode.

* Testing: Swift CI test added

* Risk: Very low. We use more conservative memory effects attribute on a
function.

This was fixed on the master branch (and swift-5.0-branch) a while ago.

rdar://36989791
SR-6860