### PR TITLE
[AST] Use CanType in SubstitutionMap

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -60,7 +60,7 @@ class SubstitutionMap {
 
   // FIXME: Switch to a more efficient representation that corresponds to
   // the conformance requirements in the GenericSignature.
-  llvm::DenseMap<TypeBase *, SmallVector<ProtocolConformanceRef, 1>>
+  llvm::DenseMap<CanType, SmallVector<ProtocolConformanceRef, 1>>
     conformanceMap;
 
   /// Retrieve the array of replacement types, which line up with the

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -178,7 +178,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   // Retrieve the starting conformance from the conformance map.
   auto getInitialConformance =
     [&](Type type, ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
-      auto known = conformanceMap.find(type->getCanonicalType().getPointer());
+      auto known = conformanceMap.find(type->getCanonicalType());
       if (known == conformanceMap.end())
         return None;
 
@@ -266,7 +266,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 void SubstitutionMap::
 addConformance(CanType type, ProtocolConformanceRef conformance) {
   assert(!isa<ArchetypeType>(type));
-  conformanceMap[type.getPointer()].push_back(conformance);
+  conformanceMap[type].push_back(conformance);
 }
 
 SubstitutionMap SubstitutionMap::subst(const SubstitutionMap &subMap) const {


### PR DESCRIPTION
No functionality change—the code was already using canonical types in practice.