### PR TITLE
[GSB] Infer requirements from parents of types.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3210,7 +3210,7 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
   if (!curGenericParams)
     return substitutions;
 
-  while (baseTy) {
+  while (baseTy && curGenericParams) {
     // For a bound generic type, gather the generic parameter -> generic
     // argument substitutions.
     if (auto boundGeneric = baseTy->getAs<BoundGenericType>()) {

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -429,3 +429,34 @@ struct Bar<U: P32> {}
 // CHECK: Generic signature: <V where V : P34>
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P34>
 func conditionalConformance2<V>(_: Bar<Foo<V>>) {}
+
+// Mentioning a nested type that is conditional should infer that requirement (SR 6850)
+
+protocol P35 {}
+protocol P36 {
+    func foo()
+}
+
+struct ConditionalNested<T> {}
+
+extension ConditionalNested where T: P35 {
+    struct Inner {}
+}
+
+// CHECK: Generic signature: <T where T : P35, T : P36>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P35, τ_0_0 : P36>
+extension ConditionalNested.Inner: P36 where T: P36 {
+    func foo() {}
+
+    struct Inner2 {}
+}
+
+// CHECK-LABEL: conditionalNested1@
+// CHECK: Generic signature: <U where U : P35>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P35>
+func conditionalNested1<U>(_: [ConditionalNested<U>.Inner?]) {}
+
+// CHECK-LABEL: conditionalNested2@
+// CHECK: Generic signature: <U where U : P35, U : P36>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P35, τ_0_0 : P36>
+func conditionalNested2<U>(_: [ConditionalNested<U>.Inner.Inner2?]) {}

--- a/validation-test/compiler_crashers_fixed/28786-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
+++ b/validation-test/compiler_crashers_fixed/28786-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{{}class a}extension CountableRange{class a:A.a
-protocol A:P
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P}typealias a:P}extension P{class a
+struct B{{{}}class a:A.a
+protocol A:a

--- a/validation-test/compiler_crashers_fixed/28801-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
+++ b/validation-test/compiler_crashers_fixed/28801-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P}typealias a:P}extension P{class a
-struct B{{{}}class a:A.a
-protocol A:a
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{{}class a}extension CountableRange{class a:A.a
+protocol A:P


### PR DESCRIPTION
A type Foo<...>.Bar may only exist conditionally (i.e. constraints on the
generic parameters of Foo), in which case those conditional requirements
should be implied when Foo<...>.Bar is mentioned.

Fixes SR-6850.
