### PR TITLE
[Syntax] Don't construct complete Syntax nodes in parsing

### DIFF
--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -174,6 +174,10 @@ public:
     return Root == Other.Root && Data == Other.Data;
   }
 
+  static bool kindof(SyntaxKind Kind) {
+    return true;
+  }
+
   static bool classof(const Syntax *S) {
     // Trivially true.
     return true;

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -187,8 +187,12 @@ public:
     return Data->replaceSelf<SyntaxCollection<CollectionKind, Element>>(Raw);
   }
 
+  static bool kindof(SyntaxKind Kind) {
+    return Kind == CollectionKind;
+  }
+
   static bool classof(const Syntax *S) {
-    return S->getKind() == CollectionKind;
+    return kindof(S->getKind());
   }
 };
 

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -58,6 +58,7 @@ private:
   static RC<SyntaxData>
   makeData(std::initializer_list<Element> &Elements) {
     std::vector<RC<RawSyntax>> List;
+    List.reserve(Elements.size());
     for (auto &Elt : Elements)
       List.push_back(Elt.getRaw());
     auto Raw = RawSyntax::make(CollectionKind, List,
@@ -161,6 +162,7 @@ public:
     assert(i <= size());
     auto OldLayout = getRaw()->getLayout();
     std::vector<RC<RawSyntax>> NewLayout;
+    NewLayout.reserve(OldLayout.size() + 1);
 
     std::copy(OldLayout.begin(), OldLayout.begin() + i,
               std::back_inserter(NewLayout));

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -51,8 +51,11 @@ struct SyntaxFactory {
   static UnknownSyntax
   makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens);
 
-  static Optional<Syntax>
-  createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements);
+  static Optional<Syntax> createSyntax(SyntaxKind Kind,
+                                       llvm::ArrayRef<Syntax> Elements);
+
+  static RC<RawSyntax> createRaw(SyntaxKind Kind,
+                                 llvm::ArrayRef<RC<RawSyntax>> Elements);
 
   /// Count the number of children for a given syntax node kind,
   /// returning a pair of mininum and maximum count of children. The gap
@@ -141,6 +144,11 @@ struct SyntaxFactory {
   /// Creates an `==` operator token.
   static TokenSyntax makeEqualityOperator(
     const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {});
+
+  /// Whether a raw node `Member` can serve as a member in a syntax collection
+  /// of the given syntax collection kind.
+  static bool canServeAsCollectionMemberRaw(SyntaxKind CollectionKind,
+                                            const RC<RawSyntax> &Member);
 
   /// Whether a node `Member` can serve as a member in a syntax collection of
   /// the given syntax collection kind.

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -53,6 +53,11 @@ class ${node.name} ${qualifier} : public ${node.base_type} {
 %     if node.is_buildable():
       friend class ${node.name}Builder;
 %     end
+%     if node.requires_validation():
+  void validate() const;
+%     end
+
+public:
 %     if node.children:
   enum Cursor : uint32_t {
 %       for child in node.children:
@@ -60,10 +65,7 @@ class ${node.name} ${qualifier} : public ${node.base_type} {
 %       end
   };
 %     end
-%     if node.requires_validation():
-  void validate() const;
-%     end
-public:
+
   ${node.name}(const RC<SyntaxData> Root, const SyntaxData *Data)
     : ${node.base_type}(Root, Data) {
 %     if node.requires_validation():
@@ -88,12 +90,17 @@ public:
   with${child.name}(llvm::Optional<${child.type_name}> New${child.type_name});
 
 %     end
-  static bool classof(const Syntax *S) {
+
+  static bool kindof(SyntaxKind Kind) {
 %   if node.is_base():
-    return S->is${node.syntax_kind}();
+    return is${node.syntax_kind}Kind(Kind);
 %   else:
-    return S->getKind() == SyntaxKind::${node.syntax_kind};
+    return Kind == SyntaxKind::${node.syntax_kind};
 %   end
+  }
+
+  static bool classof(const Syntax *S) {
+    return kindof(S->getKind());
   }
 };
 

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -80,8 +80,12 @@ public:
     return getRaw()->getTokenText();
   }
 
+  static bool kindof(SyntaxKind Kind) {
+    return isTokenKind(Kind);
+  }
+
   static bool classof(const Syntax *S) {
-    return S->isToken();
+    return kindof(S->getKind());
   }
 };
 

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -134,9 +134,10 @@ RC<RawSyntax> RawSyntax::make(tok TokKind, OwnedString Text,
 }
 
 RC<RawSyntax> RawSyntax::append(RC<RawSyntax> NewLayoutElement) const {
+  auto Layout = getLayout();
   std::vector<RC<RawSyntax>> NewLayout;
-  std::copy(getLayout().begin(), getLayout().end(),
-            std::back_inserter(NewLayout));
+  NewLayout.reserve(Layout.size() + 1);
+  std::copy(Layout.begin(), Layout.end(), std::back_inserter(NewLayout));
   NewLayout.push_back(NewLayoutElement);
   return RawSyntax::make(getKind(), NewLayout, SourcePresence::Present);
 }
@@ -145,6 +146,7 @@ RC<RawSyntax> RawSyntax::replaceChild(CursorIndex Index,
                                       RC<RawSyntax> NewLayoutElement) const {
   auto Layout = getLayout();
   std::vector<RC<RawSyntax>> NewLayout;
+  NewLayout.reserve(Layout.size());
 
   std::copy(Layout.begin(), Layout.begin() + Index,
             std::back_inserter(NewLayout));

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -87,112 +87,86 @@ SyntaxFactory::countChildren(SyntaxKind Kind){
   }
 }
 
-bool SyntaxFactory::
-canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
+bool SyntaxFactory::canServeAsCollectionMemberRaw(SyntaxKind CollectionKind,
+                                                  const RC<RawSyntax> &Member) {
   switch (CollectionKind) {
 % for node in SYNTAX_NODES:
-%     if node.is_syntax_collection():
-  case SyntaxKind::${node.syntax_kind}: {
-%       if node.collection_element_choices:
-%         element_checks = []
-%         for choice in node.collection_element_choices:
-%           element_checks.append("Member.getKind() == SyntaxKind::%s" % choice)
-%         all_checks = ' || '.join(element_checks)
-    return ${all_checks};
-%       else:
-    return Member.is<${node.collection_element_type}>();
+%   if node.is_syntax_collection():
+  case SyntaxKind::${node.syntax_kind}:
+%     if node.collection_element_choices:
+%       element_checks = []
+%       for choice in node.collection_element_choices:
+%         element_checks.append("" + choice + "Syntax::kindof(Member->getKind())")
 %       end
-  }
+    return ${' || '.join(element_checks)};
+%     else:
+    return ${node.collection_element_type}::kindof(Member->getKind());
 %     end
+%   end
 % end
   default:
     llvm_unreachable("Not collection kind.");
   }
 }
 
-Optional<Syntax>
-SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
-  switch(Kind) {
+bool SyntaxFactory::
+canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
+  return canServeAsCollectionMemberRaw(CollectionKind, Member.getRaw());
+}
+
+RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
+                                       llvm::ArrayRef<RC<RawSyntax>> Elements) {
+  switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
 % if node.children:
-%    child_count = len(node.children)
-    static std::pair<bool, std::function<bool(const Syntax&)>>
-      ChildrenConditions[${child_count}] = {
-%    for child in node.children:
-%       check = check_child_condition(child)
-%       if child.is_optional:
-%         option = "true"
-%       else:
-%         option = "false"
-%       end
-        {   ${option}, ${check} },
-%    end
-    };
-    Optional<Syntax> Parameters[${child_count}];
-    unsigned CurCond = 0;
-    for (unsigned I = 0, N = Elements.size(); I < N; ) {
-      // We should use all elements.
-      if (CurCond == ${child_count}) {
-        return None;
-      }
-      if (ChildrenConditions[CurCond].second(Elements[I])) {
-        // we find a node that satisfies the condition.
-        Parameters[CurCond].emplace(Elements[I]);
-        CurCond ++;
-        I ++;
-      } else if (ChildrenConditions[CurCond].first) {
-        // If the unsatisfied condition is optional, move on to the next condition.
-        CurCond ++;
-      } else {
-        // Mandatory condition is not satisfied.
-        return None;
-      }
+%   child_count = len(node.children)
+    RC<RawSyntax> Layout[${child_count}];
+    unsigned I = 0;
+%   for (child_idx, child) in enumerate(node.children):
+    // child[${child_idx}] ${child.name}
+    if (I == Elements.size() ||
+        !${check_child_condition_raw(child)}(Elements[I])) {
+%     if child.is_optional:
+      Layout[${child_idx}] = ${make_missing_child(child)};
+%     else:
+      return nullptr;
+%     end
+    } else {
+      Layout[${child_idx}] = Elements[I];
+      ++I;
     }
-    for (; CurCond < ${child_count}; CurCond ++) {
-      if (!ChildrenConditions[CurCond].first) {
-        // if the remaining condition is mandatory, we cannot create.
-        return None;
-      }
-    }
-    assert(CurCond == ${child_count});
-    return make${node.syntax_kind}(
-% params = []
-% for i, child in enumerate(node.children):
-%   child = node.children[i]
-%   if child.is_optional:
-%      params.append("/*Optional %s*/ Parameters[%s].hasValue() ?" \
-%       "(*Parameters[%s]).getAs<%s>().getValue() : (Optional<%s>) None" %
-%         (child.name, i, i, child.type_name, child.type_name))
-%   else:
-%      params.append("/*%s*/ (*Parameters[%s]).getAs<%s>().getValue()" %
-%        (child.name, i, child.type_name))
 %   end
-% end
-% child_parms = '\n, '.join(params)
-      ${child_parms}
-    );
+    if (I != Elements.size())
+      return nullptr;
+    return RawSyntax::make(Kind, Layout, SourcePresence::Present);
 % elif node.is_syntax_collection():
-      std::vector<${node.collection_element_type}> Parts;
-      Parts.reserve(Elements.size());
-      for (auto &E: Elements) {
-        if (!canServeAsCollectionMember(SyntaxKind::${node.syntax_kind}, E))
-          return None;
-        if (auto P = E.getAs<${node.collection_element_type}>()) {
-          Parts.emplace_back(*P);
-        } else {
-          return None;
-        }
-      }
-      return make${node.syntax_kind}(Parts);
+    for (auto &E : Elements) {
+      if (!canServeAsCollectionMemberRaw(SyntaxKind::${node.syntax_kind}, E))
+        return nullptr;
+    }
+    return RawSyntax::make(Kind, Elements, SourcePresence::Present);
 % else:
-    return None;
+    return nullptr;
 % end
-   }
+  }
 % end
   default:
-    return None;
+    return nullptr;
   }
+}
+
+Optional<Syntax>
+SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
+  std::vector<RC<RawSyntax>> Layout;
+  Layout.reserve(Elements.size());
+  for (auto &E : Elements)
+    Layout.emplace_back(E.getRaw());
+
+  if (auto Raw = createRaw(Kind, Layout))
+    return make<Syntax>(Raw);
+  else
+    return None;
 }
 
 % for node in SYNTAX_NODES:

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -174,11 +174,12 @@ SyntaxFactory::createSyntax(SyntaxKind Kind, llvm::ArrayRef<Syntax> Elements) {
     );
 % elif node.is_syntax_collection():
       std::vector<${node.collection_element_type}> Parts;
+      Parts.reserve(Elements.size());
       for (auto &E: Elements) {
         if (!canServeAsCollectionMember(SyntaxKind::${node.syntax_kind}, E))
           return None;
         if (auto P = E.getAs<${node.collection_element_type}>()) {
-          Parts.emplace_back(make<${node.collection_element_type}>(P->getRaw()));
+          Parts.emplace_back(*P);
         } else {
           return None;
         }

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -46,11 +46,8 @@ void ${node.name}::validate() const {
 %       end
 %       if child.node_choices:
 #ifndef NDEBUG
-        {
-          auto child = make<Syntax>(raw->getChild(Cursor::${child.name}));
-%         content = check_child_condition(child) + '(child)'
-          assert(${content});
-        }
+  assert(${check_child_condition_raw(child)}(
+             raw->getChild(Cursor::${child.name})));
 #endif
 %       end
 %     end

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -58,6 +58,7 @@ SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder,
       CtxtHolder(CtxtHolder), Storage(getRootData().Storage), Offset(0),
       Mode(AccumulationMode::Root), Enabled(SF.shouldKeepSyntaxInfo()) {
   CtxtHolder = this;
+  Storage.reserve(128);
 }
 
 /// Add RawSyntax to the parts.

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -33,45 +33,34 @@ def make_missing_child(child):
         return 'RawSyntax::missing(SyntaxKind::%s)' % missing_kind
 
 
-def check_child_condition(child):
+def check_child_condition_raw(child):
     """
-    Generates a C++ closure to check whether a given syntax node S can satisfy
-    the requirements of child.
+    Generates a C++ closure to check whether a given raw syntax node can
+    satisfy the requirements of child.
     """
-    result = '[](const Syntax &S) {\n'
-    result += '  // check %s\n' % child.name
+    result = '[](const RC<RawSyntax> &Raw) {\n'
+    result += ' // check %s\n' % child.name
     if child.token_choices:
-        # Check token kind choices are met.
-        result += 'if (auto Tok = S.getAs<TokenSyntax>()) {\n'
-        result += '  auto Kind = Tok->getTokenKind();\n'
+        result += 'if (!Raw->isToken()) return false;\n'
+        result += 'auto TokKind = Raw->getTokenKind();\n'
         tok_checks = []
         for choice in child.token_choices:
-            tok_checks.append("Kind == tok::%s" % choice.kind)
-        all_checks = ' || '.join(tok_checks)
-        result += '  return %s;\n' % all_checks
-        result += '}\n'
-        result += 'return false;\n'
+            tok_checks.append("TokKind == tok::%s" % choice.kind)
+        result += 'return %s;\n' % (' || '.join(tok_checks))
     elif child.text_choices:
-        # Check token text choices are met.
-        result += 'if (auto Tok = S.getAs<TokenSyntax>()) {\n'
-        result += '  auto Text = Tok->getText();\n'
+        result += 'if (!Raw->isToken()) return false;\n'
+        result += 'auto Text = Raw->getTokenText();\n'
         tok_checks = []
         for choice in child.text_choices:
-            tok_checks.append("Text == \"%s\"" % choice)
-        all_checks = ' || '.join(tok_checks)
-        result += '  return %s;\n' % all_checks
-        result += '}\n'
-        result += 'return false;\n'
+            tok_checks.append('Text == "%s"' % choice)
+        result += 'return %s;\n' % (' || '.join(tok_checks))
     elif child.node_choices:
-        # Recursively, check one of the node choices' conditions are met.
         node_checks = []
         for choice in child.node_choices:
-            node_checks.append(check_child_condition(choice) + '(S)')
-        all_checks = ' || '.join(node_checks)
-        result += 'return %s;\n' % all_checks
+            node_checks.append(check_child_condition_raw(choice) + '(Raw)')
+        result += 'return %s;\n' % ((' || ').join(node_checks))
     else:
-        # For remaining children, simply check the syntax kind.
-        result += 'return S.getAs<%s>().hasValue();\n' % child.type_name
+        result += 'return %s::kindof(Raw->getKind());' % child.type_name
     result += '}'
     return result
 


### PR DESCRIPTION
Split out from #14147

Currently, there're many `RC<RawSyntax>` → `Syntax` → `RC<RawSyntax>` conversions. Since Syntax nodes have `RC<SyntaxData>` that needs heap allocation, frequent conversions cost a lot. Instead, directly use `RC<RawSyntax>`.