### PR TITLE
IUO: Rework function type matching to use ParamDecls.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -776,6 +776,15 @@ public:
   /// \p matchOptions.
   bool matches(Type other, TypeMatchOptions matchOptions);
 
+  bool matchesParameter(Type other, TypeMatchOptions matchMode);
+
+  /// \brief Determines whether this function type is similar to \p
+  /// other as defined by \p matchOptions and the callback \p
+  /// paramsAndResultMatch which determines in a client-specific way
+  /// whether the parameters and result of the types match.
+  bool matchesFunctionType(Type other, TypeMatchOptions matchOptions,
+                           std::function<bool()> paramsAndResultMatch);
+
   /// \brief Determines whether this type has a retainable pointer
   /// representation, i.e. whether it is representable as a single,
   /// possibly nil pointer that can be unknown-retained and

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2180,10 +2180,10 @@ namespace {
   };
 } // end anonymous namespace
 
-static bool matchFunctionTypes(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
-                               TypeMatchOptions matchMode,
-                               OptionalUnwrapping insideOptional,
-                               std::function<bool()> paramsAndResultMatch) {
+static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
+                                TypeMatchOptions matchMode,
+                                OptionalUnwrapping insideOptional,
+                                std::function<bool()> paramsAndResultMatch) {
   // FIXME: Handle generic functions in non-ABI matches.
   if (!matchMode.contains(TypeMatchFlags::AllowABICompatible)) {
     if (!isa<FunctionType>(fn1) || !isa<FunctionType>(fn2))
@@ -2301,8 +2301,8 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
                       OptionalUnwrapping::None));
     };
 
-    return matchFunctionTypes(fn1, fn2, matchMode, insideOptional,
-                              paramsAndResultMatch);
+    return matchesFunctionType(fn1, fn2, matchMode, insideOptional,
+                               paramsAndResultMatch);
   }
 
   if (matchMode.contains(TypeMatchFlags::AllowNonOptionalForIUOParam) &&
@@ -2331,6 +2331,21 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
 bool TypeBase::matches(Type other, TypeMatchOptions matchMode) {
   return ::matches(getCanonicalType(), other->getCanonicalType(), matchMode,
                    ParameterPosition::NotParameter, OptionalUnwrapping::None);
+}
+
+bool TypeBase::matchesParameter(Type other, TypeMatchOptions matchMode) {
+  return ::matches(getCanonicalType(), other->getCanonicalType(), matchMode,
+                   ParameterPosition::Parameter, OptionalUnwrapping::None);
+}
+
+bool TypeBase::matchesFunctionType(Type other, TypeMatchOptions matchMode,
+                                   std::function<bool()> paramsAndResultMatch) {
+  auto thisFnTy = dyn_cast<AnyFunctionType>(getCanonicalType());
+  auto otherFnTy = dyn_cast<AnyFunctionType>(other->getCanonicalType());
+
+  assert(thisFnTy && otherFnTy);
+  return ::matchesFunctionType(thisFnTy, otherFnTy, matchMode,
+                               OptionalUnwrapping::None, paramsAndResultMatch);
 }
 
 /// getNamedElementId - If this tuple has a field with the specified name,


### PR DESCRIPTION
Rather than comparing function types directly, use the types from the
ParamDecls along with the function result type and the IUO attributes
to determine whether two function types "match" by our definition.
