### PR TITLE
[Syntax] Represent missing optioanl nodes as nullptr

### DIFF
--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -194,28 +194,39 @@ struct ObjectTraits<TokenDescription> {
 /// }
 /// ```
 template<>
-struct ObjectTraits<RC<syntax::RawSyntax>> {
-  static void mapping(Output &out, RC<syntax::RawSyntax> &value) {
-    if (value->isToken()) {
-      auto tokenKind = value->getTokenKind();
-      auto text = value->getTokenText();
+struct ObjectTraits<syntax::RawSyntax> {
+  static void mapping(Output &out, syntax::RawSyntax &value) {
+    if (value.isToken()) {
+      auto tokenKind = value.getTokenKind();
+      auto text = value.getTokenText();
       auto description = TokenDescription { tokenKind, text };
       out.mapRequired("tokenKind", description);
 
-      auto leadingTrivia = value->getLeadingTrivia();
+      auto leadingTrivia = value.getLeadingTrivia();
       out.mapRequired("leadingTrivia", leadingTrivia);
 
-      auto trailingTrivia = value->getTrailingTrivia();
+      auto trailingTrivia = value.getTrailingTrivia();
       out.mapRequired("trailingTrivia", trailingTrivia);
     } else {
-      auto kind = value->getKind();
+      auto kind = value.getKind();
       out.mapRequired("kind", kind);
 
-      auto layout = value->getLayout();
+      auto layout = value.getLayout();
       out.mapRequired("layout", layout);
     }
-    auto presence = value->getPresence();
+    auto presence = value.getPresence();
     out.mapRequired("presence", presence);
+  }
+};
+
+template<>
+struct NullableTraits<RC<syntax::RawSyntax>> {
+  using value_type = syntax::RawSyntax;
+  static bool isNull(RC<syntax::RawSyntax> &value) {
+    return value == nullptr;
+  }
+  static syntax::RawSyntax &get(RC<syntax::RawSyntax> &value) {
+    return *value;
   }
 };
 } // end namespace json

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -72,7 +72,9 @@ protected:
 
 public:
   Syntax(const RC<SyntaxData> Root, const SyntaxData *Data)
-  : Root(Root), Data(Data) {}
+  : Root(Root), Data(Data) {
+    assert(Data != nullptr);
+  }
 
   virtual ~Syntax() {}
 
@@ -87,7 +89,7 @@ public:
   size_t getNumChildren() const;
 
   /// Get the Nth child of this piece of syntax.
-  Syntax getChild(const size_t N) const;
+  llvm::Optional<Syntax> getChild(const size_t N) const;
 
   /// Returns true if the syntax node is of the given type.
   template <typename T>

--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -32,7 +32,7 @@ namespace syntax {
 class ${node.name}Builder {
   std::vector<RC<RawSyntax>> Layout = {
 %     for child in node.children:
-    ${make_missing_child(child)},
+    nullptr,
 %     end
   };
 

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -106,9 +106,7 @@ public:
   Element operator[](const size_t Index) const {
     assert(Index < size());
     assert(!empty());
-
-    auto ChildData = Data->getChild(Index);
-    return Element { Root, ChildData.get() };
+    return { Root, Data->getChild(Index).get() };
   }
 
   /// Return a new collection with the given element added to the end.

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -111,8 +111,9 @@ public:
   /// at the provided index.
   /// DO NOT expose this as public API.
   RC<SyntaxData> realizeSyntaxNode(CursorIndex Index) const {
-    auto &RawChild = Raw->getChild(Index);
-    return SyntaxData::make(RawChild, this, Index);
+    if (auto &RawChild = Raw->getChild(Index))
+      return SyntaxData::make(RawChild, this, Index);
+    return nullptr;
   }
 
   /// Replace a child in the raw syntax and recursively rebuild the
@@ -215,6 +216,8 @@ public:
   /// cache it. This is safe because AtomicCache only ever mutates its cache
   /// one time -- the first initialization that wins a compare_exchange_strong.
   RC<SyntaxData> getChild(size_t Index) const {
+    if (!getRaw()->getChild(Index))
+      return nullptr;
     return Children[Index].getOrCreate([&]() {
       return realizeSyntaxNode(Index);
     });

--- a/include/swift/Syntax/SyntaxVisitor.h.gyb
+++ b/include/swift/Syntax/SyntaxVisitor.h.gyb
@@ -46,7 +46,8 @@ struct SyntaxVisitor {
 
   void visitChildren(Syntax node) {
     for (unsigned i = 0, e = node.getNumChildren(); i != e; ++i) {
-      visit(node.getChild(i));
+      if (auto Child = node.getChild(i))
+        visit(*Child);
     }
   }
 };

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -263,7 +263,7 @@ static bool emitSyntax(SourceFile *SF, LangOptions &LangOpts,
 
   json::Output jsonOut(*os);
   auto Root = SF->getSyntaxRoot().getRaw();
-  jsonOut << Root;
+  jsonOut << *Root;
   *os << "\n";
   return false;
 }

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -201,7 +201,8 @@ void RawSyntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {
       printSyntaxKind(Kind, OS, Opts, true);
 
     for (const auto &LE : getLayout())
-      LE->print(OS, Opts);
+      if (LE)
+        LE->print(OS, Opts);
 
     if (PrintKind)
       printSyntaxKind(Kind, OS, Opts, false);

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -26,7 +26,8 @@ SyntaxKind Syntax::getKind() const {
 }
 
 void Syntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {
-  getRaw()->print(OS, Opts);
+  if (auto Raw = getRaw())
+    Raw->print(OS, Opts);
 }
 
 void Syntax::dump() const {
@@ -89,8 +90,11 @@ size_t Syntax::getNumChildren() const {
   return Data->getNumChildren();
 }
 
-Syntax Syntax::getChild(const size_t N) const {
-  return Syntax { Root, Data->getChild(N).get() };
+llvm::Optional<Syntax> Syntax::getChild(const size_t N) const {
+  auto ChildData = Data->getChild(N);
+  if (!ChildData)
+    return llvm::None;
+  return Syntax {Root, ChildData.get()};
 }
 
 AbsolutePosition Syntax::getAbsolutePosition() const {

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -41,13 +41,25 @@ ${node.name}Builder::use${child.name}(${child.type_name} ${child.name}) {
 ${node.name}Builder &
 ${node.name}Builder::add${child_elt}(${child_elt_type} ${child_elt}) {
   auto &raw = Layout[cursorIndex(${node.name}::Cursor::${child.name})];
-  raw = raw->append(${child_elt}.getRaw());
+  if (!raw)
+    raw = RawSyntax::make(SyntaxKind::${child_node.syntax_kind},
+                          {${child_elt}.getRaw()}, SourcePresence::Present);
+  else
+    raw = raw->append(${child_elt}.getRaw());
   return *this;
 }
 %       end
 %     end
 ${node.name}
 ${node.name}Builder::build() {
+% if node.children:
+%   for (idx, child) in enumerate(node.children):
+%     if not child.is_optional:
+  if (!Layout[${idx}])
+    Layout[${idx}] = ${make_missing_child(child)};
+%     end
+%   end
+% end
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, 
     Layout, SourcePresence::Present);
   return make<${node.name}>(raw);

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -19,6 +19,8 @@ using namespace swift::syntax;
 RC<SyntaxData> SyntaxData::make(RC<RawSyntax> Raw,
                                 const SyntaxData *Parent,
                                 CursorIndex IndexInParent) {
+  if (!Raw)
+    return nullptr;
   return RC<SyntaxData> {
     new SyntaxData(Raw, Parent, IndexInParent)
   };

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -128,7 +128,7 @@ RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
     if (I == Elements.size() ||
         !${check_child_condition_raw(child)}(Elements[I])) {
 %     if child.is_optional:
-      Layout[${child_idx}] = ${make_missing_child(child)};
+      Layout[${child_idx}] = nullptr;
 %     else:
       return nullptr;
 %     end
@@ -183,8 +183,7 @@ SyntaxFactory::make${node.syntax_kind}(${child_params}) {
   auto Raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() :
-        cast<RawSyntax>(${make_missing_child(child)}),
+    ${child.name}.hasValue() ? ${child.name}->getRaw() : nullptr,
 %       else:
     ${child.name}.getRaw(),
 %       end
@@ -211,7 +210,11 @@ ${node.name}
 SyntaxFactory::makeBlank${node.syntax_kind}() {
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %   for child in node.children:
+%       if child.is_optional:
+    nullptr,
+%       else:
     ${make_missing_child(child)},
+%       end
 %   end
   }, SourcePresence::Present);
   return make<${node.name}>(raw);

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -27,7 +27,7 @@ using namespace swift::syntax;
 % for node in SYNTAX_NODES:
 %   if node.requires_validation():
 void ${node.name}::validate() const {
-  if (!Data || !Data->Raw) return;
+#ifndef NDEBUG
   auto raw = Data->Raw;
   if (isMissing()) return;
   assert(raw->getLayout().size() == ${len(node.children)});
@@ -45,28 +45,25 @@ void ${node.name}::validate() const {
                                  tok::${token_kind}, ${choices});
 %       end
 %       if child.node_choices:
-#ifndef NDEBUG
-  assert(${check_child_condition_raw(child)}(
-             raw->getChild(Cursor::${child.name})));
-#endif
+  if (auto &__Child = raw->getChild(Cursor::${child.name}))
+    assert(${check_child_condition_raw(child)}(__Child));
 %       end
 %     end
+#endif
 }
 %   end
 
 %   for child in node.children:
 %     if child.is_optional:
 llvm::Optional<${child.type_name}> ${node.name}::get${child.name}() {
-  if (getRaw()->getChild(Cursor::${child.name})->isMissing()) {
+  auto ChildData = Data->getChild(Cursor::${child.name});
+  if (!ChildData)
     return llvm::None;
-  }
-  return llvm::Optional<${child.type_name}> {
-    ${child.type_name} { Root, Data->getChild(Cursor::${child.name}).get() }
-  };
+  return ${child.type_name} {Root, ChildData.get()};
 }
 %     else:
 ${child.type_name} ${node.name}::get${child.name}() {
-  return ${child.type_name} { Root, Data->getChild(Cursor::${child.name}).get() };
+  return ${child.type_name} {Root, Data->getChild(Cursor::${child.name}).get()};
 }
 %     end
 
@@ -75,9 +72,13 @@ ${child.type_name} ${node.name}::get${child.name}() {
 %       child_elt = child_node.collection_element_name
 %       child_elt_type = child_node.collection_element_type
 ${node.name} ${node.name}::add${child_elt}(${child_elt_type} ${child_elt}) {
-  auto childRaw = getRaw()->getChild(Cursor::${child.name})
-                          ->append(${child_elt}.getRaw());
-  return Data->replaceChild<${node.name}>(childRaw, Cursor::${child.name});
+  RC<RawSyntax> raw = getRaw()->getChild(Cursor::${child.name});
+  if (raw)
+    raw = raw->append(${child_elt}.getRaw());
+  else
+    raw = RawSyntax::make(SyntaxKind::${child_node.syntax_kind},
+                          {${child_elt}.getRaw()}, SourcePresence::Present);
+  return Data->replaceChild<${node.name}>(raw, Cursor::${child.name});
 }
 %     end
 
@@ -87,7 +88,11 @@ ${node.name} ${node.name}::with${child.name}(
   if (New${child.type_name}.hasValue()) {
     raw = New${child.type_name}->getRaw();
   } else {
+% if child.is_optional:
+    raw = nullptr; //${make_missing_child(child)};
+% else:
     raw = ${make_missing_child(child)};
+% end
   }
   return Data->replaceChild<${node.name}>(raw, Cursor::${child.name});
 }

--- a/lib/Syntax/SyntaxParsingContext.cpp
+++ b/lib/Syntax/SyntaxParsingContext.cpp
@@ -140,8 +140,7 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind) {
   auto Parts = getParts();
   auto Count = 0;
   for (auto I = Parts.rbegin(), End = Parts.rend(); I != End; ++I) {
-    if (!SyntaxFactory::canServeAsCollectionMember(ColletionKind,
-                                                   make<Syntax>(*I)))
+    if (!SyntaxFactory::canServeAsCollectionMemberRaw(ColletionKind, *I))
       break;
     ++Count;
   }

--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -31,7 +31,7 @@ ParseFile.test("ParseSingleFile") {
   let currentFile = URL(fileURLWithPath: #file)
   expectDoesNotThrow({
     let currentFileContents = try String(contentsOf: currentFile)
-    let parsed = try Syntax.parse(currentFile)
+    let parsed = try SourceFileSyntax.parse(currentFile)
     expectEqual("\(parsed)", currentFileContents)
   })
 }

--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -29,7 +29,7 @@ VisitorTests.test("Basic") {
     }
   }
   expectDoesNotThrow({
-    let parsed = try Syntax.parse(getInput("visitor.swift"))
+    let parsed = try SourceFileSyntax.parse(getInput("visitor.swift"))
     let counter = FuncCounter()
     let hashBefore = parsed.hashValue
     counter.visit(parsed)

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -16,16 +16,8 @@
                     {
                       "kind": "StructDecl",
                       "layout": [
-                        {
-                          "kind": "AttributeList",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "DeclModifier",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
+                        null,
+                        null,
                         {
                           "tokenKind": {
                             "kind": "kw_struct"
@@ -70,21 +62,9 @@
                           ],
                           "presence": "Present"
                         },
-                        {
-                          "kind": "GenericParameterClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "TypeInheritanceClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "GenericWhereClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
+                        null,
+                        null,
+                        null,
                         {
                           "kind": "MemberDeclBlock",
                           "layout": [
@@ -120,14 +100,7 @@
                       ],
                       "presence": "Present"
                     },
-                    {
-                      "tokenKind": {
-                        "kind": "semi"
-                      },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "presence": "Missing"
-                    }
+                    null
                   ],
                   "presence": "Present"
                 },
@@ -137,16 +110,8 @@
                     {
                       "kind": "StructDecl",
                       "layout": [
-                        {
-                          "kind": "AttributeList",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "DeclModifier",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
+                        null,
+                        null,
                         {
                           "tokenKind": {
                             "kind": "kw_struct"
@@ -179,21 +144,9 @@
                           ],
                           "presence": "Present"
                         },
-                        {
-                          "kind": "GenericParameterClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "TypeInheritanceClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "GenericWhereClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
+                        null,
+                        null,
+                        null,
                         {
                           "kind": "MemberDeclBlock",
                           "layout": [
@@ -229,14 +182,7 @@
                       ],
                       "presence": "Present"
                     },
-                    {
-                      "tokenKind": {
-                        "kind": "semi"
-                      },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "presence": "Missing"
-                    }
+                    null
                   ],
                   "presence": "Present"
                 }

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -16,16 +16,8 @@
                     {
                       "kind": "StructDecl",
                       "layout": [
-                        {
-                          "kind": "AttributeList",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "DeclModifier",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
+                        null,
+                        null,
                         {
                           "tokenKind": {
                             "kind": "kw_struct"
@@ -70,21 +62,9 @@
                           ],
                           "presence": "Present"
                         },
-                        {
-                          "kind": "GenericParameterClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "TypeInheritanceClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
-                        {
-                          "kind": "GenericWhereClause",
-                          "layout": [],
-                          "presence": "Missing"
-                        },
+                        null,
+                        null,
+                        null,
                         {
                           "kind": "MemberDeclBlock",
                           "layout": [
@@ -102,16 +82,8 @@
                                 {
                                   "kind": "VariableDecl",
                                   "layout": [
-                                    {
-                                      "kind": "AttributeList",
-                                      "layout": [],
-                                      "presence": "Missing"
-                                    },
-                                    {
-                                      "kind": "ModifierList",
-                                      "layout": [],
-                                      "presence": "Missing"
-                                    },
+                                    null,
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "kw_let"
@@ -188,35 +160,16 @@
                                                       "trailingTrivia": [],
                                                       "presence": "Present"
                                                     },
-                                                    {
-                                                      "kind": "GenericArgumentClause",
-                                                      "layout": [],
-                                                      "presence": "Missing"
-                                                    }
+                                                    null
                                                   ],
                                                   "presence": "Present"
                                                 }
                                               ],
                                               "presence": "Present"
                                             },
-                                            {
-                                              "kind": "InitializerClause",
-                                              "layout": [],
-                                              "presence": "Missing"
-                                            },
-                                            {
-                                              "kind": "AccessorBlock",
-                                              "layout": [],
-                                              "presence": "Missing"
-                                            },
-                                            {
-                                              "tokenKind": {
-                                                "kind": "comma"
-                                              },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [],
-                                              "presence": "Missing"
-                                            }
+                                            null,
+                                            null,
+                                            null
                                           ],
                                           "presence": "Present"
                                         }
@@ -229,16 +182,8 @@
                                 {
                                   "kind": "VariableDecl",
                                   "layout": [
-                                    {
-                                      "kind": "AttributeList",
-                                      "layout": [],
-                                      "presence": "Missing"
-                                    },
-                                    {
-                                      "kind": "ModifierList",
-                                      "layout": [],
-                                      "presence": "Missing"
-                                    },
+                                    null,
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "kw_let"
@@ -359,22 +304,11 @@
                                                                       ],
                                                                       "presence": "Present"
                                                                     },
-                                                                    {
-                                                                      "kind": "GenericArgumentClause",
-                                                                      "layout": [],
-                                                                      "presence": "Missing"
-                                                                    }
+                                                                    null
                                                                   ],
                                                                   "presence": "Present"
                                                                 },
-                                                                {
-                                                                  "tokenKind": {
-                                                                    "kind": "comma"
-                                                                  },
-                                                                  "leadingTrivia": [],
-                                                                  "trailingTrivia": [],
-                                                                  "presence": "Missing"
-                                                                }
+                                                                null
                                                               ],
                                                               "presence": "Present"
                                                             }
@@ -398,24 +332,9 @@
                                               ],
                                               "presence": "Present"
                                             },
-                                            {
-                                              "kind": "InitializerClause",
-                                              "layout": [],
-                                              "presence": "Missing"
-                                            },
-                                            {
-                                              "kind": "AccessorBlock",
-                                              "layout": [],
-                                              "presence": "Missing"
-                                            },
-                                            {
-                                              "tokenKind": {
-                                                "kind": "comma"
-                                              },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [],
-                                              "presence": "Missing"
-                                            }
+                                            null,
+                                            null,
+                                            null
                                           ],
                                           "presence": "Present"
                                         }
@@ -451,14 +370,7 @@
                       ],
                       "presence": "Present"
                     },
-                    {
-                      "tokenKind": {
-                        "kind": "semi"
-                      },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
-                      "presence": "Missing"
-                    }
+                    null
                   ],
                   "presence": "Present"
                 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1799,7 +1799,7 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
     llvm::raw_string_ostream OS(SyntaxContent);
     json::Output JsonOut(OS);
     auto Root = Impl.SyntaxInfo->getSourceFile().getSyntaxRoot().getRaw();
-    JsonOut << Root;
+    JsonOut << *Root;
     Consumer.handleSerializedSyntaxTree(OS.str());
   }
 

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -17,7 +17,7 @@ import Foundation
 /// are immutable and can be freely shared between syntax nodes.
 indirect enum RawSyntax: Codable {
   /// A tree node with a kind, an array of children, and a source presence.
-  case node(SyntaxKind, [RawSyntax], SourcePresence)
+  case node(SyntaxKind, [RawSyntax?], SourcePresence)
 
   /// A token with a token kind, leading trivia, trailing trivia, and a source
   /// presence.
@@ -39,7 +39,7 @@ indirect enum RawSyntax: Codable {
   }
 
   /// The layout of the children of this Raw syntax node.
-  var layout: [RawSyntax] {
+  var layout: [RawSyntax?] {
     switch self {
     case .node(_, let layout, _): return layout
     case .token(_, _, _, _): return []
@@ -78,7 +78,7 @@ indirect enum RawSyntax: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let presence = try container.decode(SourcePresence.self, forKey: .presence)
     if let kind = try container.decodeIfPresent(SyntaxKind.self, forKey: .kind) {
-      let layout = try container.decode([RawSyntax].self, forKey: .layout)
+      let layout = try container.decode([RawSyntax?].self, forKey: .layout)
       self = .node(kind, layout, presence)
     } else {
       let kind = try container.decode(TokenKind.self, forKey: .tokenKind)
@@ -129,7 +129,7 @@ indirect enum RawSyntax: Codable {
   /// - Note: This function does nothing with `.token` nodes --- the same token
   ///         is returned.
   /// - Parameter newLayout: The children of the new node you're creating.
-  func replacingLayout(_ newLayout: [RawSyntax]) -> RawSyntax {
+  func replacingLayout(_ newLayout: [RawSyntax?]) -> RawSyntax {
     switch self {
     case let .node(kind, _, presence): return .node(kind, newLayout, presence)
     case .token(_, _, _, _): return self
@@ -150,7 +150,7 @@ indirect enum RawSyntax: Codable {
   /// Returns the child at the provided cursor in the layout.
   /// - Parameter index: The index of the child you're accessing.
   /// - Returns: The child at the provided index.
-  subscript<CursorType: RawRepresentable>(_ index: CursorType) -> RawSyntax
+  subscript<CursorType: RawRepresentable>(_ index: CursorType) -> RawSyntax?
     where CursorType.RawValue == Int {
       return layout[index.rawValue]
   }
@@ -178,6 +178,7 @@ extension RawSyntax: TextOutputStreamable {
     switch self {
     case .node(_, let layout, _):
       for child in layout {
+        guard let child = child else { continue }
         child.write(to: &target)
       }
     case let .token(kind, leadingTrivia, trailingTrivia, presence):

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -124,7 +124,9 @@ extension Syntax {
   ///
   /// This property is an implementation detail of `SyntaxChildren`.
   internal var presentChildIndices: _SyntaxBase.PresentChildIndicesSequence {
-    return raw.layout.indices.lazy.filter { self.raw.layout[$0].isPresent }
+    return raw.layout.indices.lazy.filter {
+      self.raw.layout[$0]?.isPresent == true
+    }
   }
 
   /// Gets the child at the provided index in this node's children.
@@ -133,8 +135,8 @@ extension Syntax {
   ///            is not a child at that index in the node.
   public func child(at index: Int) -> Syntax? {
     guard raw.layout.indices.contains(index) else { return nil }
-    if raw.layout[index].isMissing { return nil }
-    return makeSyntax(root: _root, data: data.cachedChild(at: index))
+    guard let childData = data.cachedChild(at: index) else { return nil }
+    return makeSyntax(root: _root, data: childData)
   }
 
   /// A source-accurate description of this node.

--- a/tools/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -46,7 +46,7 @@ public struct ${node.name}: _SyntaxBase {
   ///                     collection.
   /// - Returns: A new `${node.name}` with the new layout underlying it.
   internal func replacingLayout(
-    _ layout: [RawSyntax]) -> ${node.name} {
+    _ layout: [RawSyntax?]) -> ${node.name} {
     let newRaw = data.raw.replacingLayout(layout)
     let (newRoot, newData) = data.replacingSelf(newRaw)
     return ${node.name}(root: newRoot, data: newData)

--- a/tools/SwiftSyntax/SyntaxData.swift
+++ b/tools/SwiftSyntax/SyntaxData.swift
@@ -72,7 +72,8 @@ final class SyntaxData: Equatable {
   ///
   /// - Parameter index: The index to create and cache.
   /// - Returns: The child's data at the provided index.
-  func cachedChild(at index: Int) -> SyntaxData {
+  func cachedChild(at index: Int) -> SyntaxData? {
+    if raw.layout[index] == nil { return nil }
     return childCaches[index].value { realizeChild(index) }
   }
 
@@ -84,7 +85,7 @@ final class SyntaxData: Equatable {
   /// - Parameter cursor: The cursor to create and cache.
   /// - Returns: The child's data at the provided cursor.
   func cachedChild<CursorType: RawRepresentable>(
-    at cursor: CursorType) -> SyntaxData
+    at cursor: CursorType) -> SyntaxData?
     where CursorType.RawValue == Int {
     return cachedChild(at: cursor.rawValue)
   }
@@ -123,7 +124,7 @@ final class SyntaxData: Equatable {
     // recursively up to the root.
     if let parent = parent {
       let (root, newParent) = parent.replacingChild(newRaw, at: indexInParent)
-      let newMe = newParent.cachedChild(at: indexInParent)
+      let newMe = newParent.cachedChild(at: indexInParent)!
       return (root: root, newValue: newMe)
     } else {
       // Otherwise, we're already the root, so return the new data as both the
@@ -185,7 +186,7 @@ final class SyntaxData: Equatable {
   /// - Returns: A new SyntaxData for the specific child you're
   ///            creating, whose parent is pointing to self.
   func realizeChild(_ index: Int) -> SyntaxData {
-    return SyntaxData(raw: raw.layout[index],
+    return SyntaxData(raw: raw.layout[index]!,
                       indexInParent: index,
                       parent: self)
   }

--- a/tools/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -127,11 +127,11 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
 %       cast = '' if child.type_name == 'Syntax' \
 %                 else '%s %s' % (cast_symbol, child.type_name)
   public var ${child.swift_name}: ${ret_type} {
-%       if child.is_optional:
-    guard raw[Cursor.${child.swift_name}].isPresent else { return nil }
-%       end
     let child = data.cachedChild(at: Cursor.${child.swift_name})
-    return makeSyntax(root: _root, data: child) ${cast}
+%       if child.is_optional:
+    if child == nil { return nil }
+%       end
+    return makeSyntax(root: _root, data: child!) ${cast}
   }
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
@@ -139,8 +139,14 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
 %         child_elt_type = child_node.collection_element_type
 
   public func add${child_elt}(_ elt: ${child_elt_type}) -> ${node.name} {
-    let childRaw = raw[Cursor.${child.swift_name}].appending(elt.raw)
-    let (root, newData) = data.replacingChild(childRaw,
+    var collection: RawSyntax
+    if let col = raw[Cursor.${child.swift_name}] {
+      collection = col.appending(elt.raw)
+    } else {
+      collection = RawSyntax.node(SyntaxKind.${child_node.swift_syntax_kind},
+                                  [elt.raw], .present)
+    }
+    let (root, newData) = data.replacingChild(collection,
                                               at: Cursor.${child.swift_name})
     return ${node.name}(root: root, data: newData)
   }

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -232,7 +232,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
 
   auto Root = SF->getSyntaxRoot().getRaw();
   swift::json::Output out(llvm::outs());
-  out << Root;
+  out << *Root;
   llvm::outs() << "\n";
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Split out from #14147 

We shouldn't allocate  `RawSyntax`/`SyntaxData`missing optional nodes. They didn't provide any information.