### PR TITLE
IRGen: swift_getFunctionTypeMetadata is ReadOnly

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -746,7 +746,7 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, C_CC,
               TypeMetadataPtrTy->getPointerTo(0),
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_getFunctionTypeMetadata0(unsigned long flags,
 //                                          const Metadata *resultMetadata);

--- a/test/Interpreter/closures.swift
+++ b/test/Interpreter/closures.swift
@@ -82,3 +82,13 @@ func f() -> Bool? { return nil }
   let c = { b = true }
   _ = (b, c)
 })()
+
+// This used to crash at one point in optimized mode because we had the wrong
+// memory effects on swift_getFunctionTypeMetadata.
+func crash() {
+    let f: (Int, Int, Int, Int) -> Int = { _, _, _, _ in 21 }
+    let fs = [f, f]
+    // CHECK: fs: [(Function), (Function)]
+    print("fs: \(fs)")
+}
+crash()


### PR DESCRIPTION
It only accesses the type arguments passed indirectly via an array.