### PR TITLE
[AST] NFC: Do not reinterpret_cast pointers into CanTypeWrappers

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -228,7 +228,7 @@ protected:
 
   void appendRequirement(const Requirement &reqt);
 
-  void appendGenericSignatureParts(ArrayRef<GenericTypeParamType*> params,
+  void appendGenericSignatureParts(TypeArrayView<GenericTypeParamType> params,
                                    unsigned initialParamDepth,
                                    ArrayRef<Requirement> requirements);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1416,7 +1416,7 @@ public:
   GenericEnvironment *getGenericEnvironment() const;
 
   /// Retrieve the innermost generic parameter types.
-  ArrayRef<GenericTypeParamType *> getInnermostGenericParamTypes() const;
+  TypeArrayView<GenericTypeParamType> getInnermostGenericParamTypes() const;
 
   /// Retrieve the generic requirements.
   ArrayRef<Requirement> getGenericRequirements() const;

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -89,7 +89,7 @@ public:
     return Signature;
   }
 
-  ArrayRef<GenericTypeParamType *> getGenericParams() const;
+  TypeArrayView<GenericTypeParamType> getGenericParams() const;
 
   /// Create a new, "incomplete" generic environment that will be populated
   /// by calls to \c addMapping().

--- a/include/swift/AST/GenericParamKey.h
+++ b/include/swift/AST/GenericParamKey.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "swift/AST/Type.h"
 
 namespace swift {
 
@@ -90,8 +91,7 @@ struct GenericParamKey {
 
   /// Find the index that this key would have into an array of
   /// generic type parameters
-  unsigned findIndexIn(
-             llvm::ArrayRef<GenericTypeParamType *> genericParams) const;
+  unsigned findIndexIn(TypeArrayView<GenericTypeParamType> genericParams) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/Requirement.h"
 #include "swift/AST/SubstitutionList.h"
+#include "swift/AST/Types.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -93,8 +94,7 @@ public:
 /// generic parameters.
 class alignas(1 << TypeAlignInBits) GenericSignature final
   : public llvm::FoldingSetNode,
-    private llvm::TrailingObjects<GenericSignature, GenericTypeParamType *,
-                                  Requirement> {
+    private llvm::TrailingObjects<GenericSignature, Type, Requirement> {
   friend TrailingObjects;
 
   unsigned NumGenericParams;
@@ -104,7 +104,7 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
   void *operator new(size_t Bytes) = delete;
   void operator delete(void *Data) = delete;
 
-  size_t numTrailingObjects(OverloadToken<GenericTypeParamType *>) const {
+  size_t numTrailingObjects(OverloadToken<Type>) const {
     return NumGenericParams;
   }
   size_t numTrailingObjects(OverloadToken<Requirement>) const {
@@ -112,8 +112,8 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
   }
 
   /// Retrieve a mutable version of the generic parameters.
-  MutableArrayRef<GenericTypeParamType *> getGenericParamsBuffer() {
-    return {getTrailingObjects<GenericTypeParamType *>(), NumGenericParams};
+  MutableArrayRef<Type> getGenericParamsBuffer() {
+    return {getTrailingObjects<Type>(), NumGenericParams};
   }
 
   /// Retrieve a mutable version of the requirements.
@@ -121,14 +121,14 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
     return {getTrailingObjects<Requirement>(), NumRequirements};
   }
 
-  GenericSignature(ArrayRef<GenericTypeParamType *> params,
+  GenericSignature(TypeArrayView<GenericTypeParamType> params,
                    ArrayRef<Requirement> requirements,
                    bool isKnownCanonical);
 
   mutable llvm::PointerUnion<GenericSignature *, ASTContext *>
     CanonicalSignatureOrASTContext;
   
-  static ASTContext &getASTContext(ArrayRef<GenericTypeParamType *> params,
+  static ASTContext &getASTContext(TypeArrayView<GenericTypeParamType> params,
                                    ArrayRef<Requirement> requirements);
 
   /// Retrieve the generic signature builder for the given generic signature.
@@ -142,24 +142,28 @@ public:
   static GenericSignature *get(ArrayRef<GenericTypeParamType *> params,
                                ArrayRef<Requirement> requirements,
                                bool isKnownCanonical = false);
+  static GenericSignature *get(TypeArrayView<GenericTypeParamType> params,
+                               ArrayRef<Requirement> requirements,
+                               bool isKnownCanonical = false);
 
   /// Create a new generic signature with the given type parameters and
   /// requirements, first canonicalizing the types.
   static CanGenericSignature getCanonical(
-                                      ArrayRef<GenericTypeParamType *> params,
-                                      ArrayRef<Requirement> requirements,
-                                      bool skipValidation = false);
+                                     TypeArrayView<GenericTypeParamType> params,
+                                     ArrayRef<Requirement> requirements,
+                                     bool skipValidation = false);
 
   /// Retrieve the generic parameters.
-  ArrayRef<GenericTypeParamType *> getGenericParams() const {
-    return const_cast<GenericSignature *>(this)->getGenericParamsBuffer();
+  TypeArrayView<GenericTypeParamType> getGenericParams() const {
+    auto temp = const_cast<GenericSignature*>(this);
+    return TypeArrayView<GenericTypeParamType>(temp->getGenericParamsBuffer());
   }
 
   /// Retrieve the innermost generic parameters.
   ///
   /// Given a generic signature for a nested generic type, produce an
   /// array of the generic parameters for the innermost generic type.
-  ArrayRef<GenericTypeParamType *> getInnermostGenericParams() const;
+  TypeArrayView<GenericTypeParamType> getInnermostGenericParams() const;
 
   /// Retrieve the requirements.
   ArrayRef<Requirement> getRequirements() const {
@@ -331,7 +335,7 @@ public:
   unsigned getGenericParamOrdinal(GenericTypeParamType *param);
 
   static void Profile(llvm::FoldingSetNodeID &ID,
-                      ArrayRef<GenericTypeParamType *> genericParams,
+                      TypeArrayView<GenericTypeParamType> genericParams,
                       ArrayRef<Requirement> requirements);
   
   void print(raw_ostream &OS) const;
@@ -348,9 +352,9 @@ CanGenericSignature::CanGenericSignature(GenericSignature *Signature)
   
 inline ArrayRef<CanTypeWrapper<GenericTypeParamType>>
 CanGenericSignature::getGenericParams() const{
-  ArrayRef<GenericTypeParamType*> params = Signature->getGenericParams();
-  auto base = reinterpret_cast<const CanTypeWrapper<GenericTypeParamType>*>(
-                                                                params.data());
+  auto params = Signature->getGenericParams().getOriginalArray();
+  auto base = static_cast<const CanTypeWrapper<GenericTypeParamType>*>(
+                                                                 params.data());
   return {base, params.size()};
 }
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -251,7 +251,7 @@ public:
     /// Retrieve the "anchor" type that canonically describes this equivalence
     /// class, for use in the canonical type.
     Type getAnchor(GenericSignatureBuilder &builder,
-                   ArrayRef<GenericTypeParamType *> genericParams);
+                   TypeArrayView<GenericTypeParamType> genericParams);
 
     /// \brief Retrieve (or build) the contextual type corresponding to
     /// this equivalence class within the given generic environment.
@@ -538,7 +538,7 @@ public:
   /// \param f A function object that will be passed each requirement
   /// and requirement source.
   void enumerateRequirements(
-                    ArrayRef<GenericTypeParamType *> genericParams,
+                    TypeArrayView<GenericTypeParamType> genericParams,
                     llvm::function_ref<
                       void (RequirementKind kind,
                             Type type,
@@ -547,7 +547,7 @@ public:
 
   /// Retrieve the generic parameters used to describe the generic
   /// signature being built.
-  ArrayRef<GenericTypeParamType *> getGenericParams() const;
+  TypeArrayView<GenericTypeParamType> getGenericParams() const;
 
   /// \brief Add a new generic parameter for which there may be requirements.
   void addGenericParameter(GenericTypeParamDecl *GenericParam);
@@ -650,7 +650,7 @@ private:
   /// \param allowConcreteGenericParams If true, allow generic parameters to
   /// be made concrete.
   void finalize(SourceLoc loc,
-                ArrayRef<GenericTypeParamType *> genericParams,
+                TypeArrayView<GenericTypeParamType> genericParams,
                 bool allowConcreteGenericParams=false);
 
 public:
@@ -686,7 +686,7 @@ private:
   /// \returns the representative constraint.
   template<typename T>
   Constraint<T> checkConstraintList(
-                           ArrayRef<GenericTypeParamType *> genericParams,
+                           TypeArrayView<GenericTypeParamType> genericParams,
                            std::vector<Constraint<T>> &constraints,
                            llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
@@ -711,7 +711,7 @@ private:
   /// \returns the representative constraint.
   template<typename T, typename DiagT>
   Constraint<T> checkConstraintList(
-                           ArrayRef<GenericTypeParamType *> genericParams,
+                           TypeArrayView<GenericTypeParamType> genericParams,
                            std::vector<Constraint<T>> &constraints,
                            llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
@@ -728,30 +728,30 @@ private:
   /// Check the concrete type constraints within the equivalence
   /// class of the given potential archetype.
   void checkConcreteTypeConstraints(
-                            ArrayRef<GenericTypeParamType *> genericParams,
+                            TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
   /// Check the superclass constraints within the equivalence
   /// class of the given potential archetype.
   void checkSuperclassConstraints(
-                            ArrayRef<GenericTypeParamType *> genericParams,
+                            TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
   /// Check conformance constraints within the equivalence class of the
   /// given potential archetype.
   void checkConformanceConstraints(
-                            ArrayRef<GenericTypeParamType *> genericParams,
+                            TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
   /// Check layout constraints within the equivalence class of the given
   /// potential archetype.
-  void checkLayoutConstraints(ArrayRef<GenericTypeParamType *> genericParams,
+  void checkLayoutConstraints(TypeArrayView<GenericTypeParamType> genericParams,
                               EquivalenceClass *equivClass);
 
   /// Check same-type constraints within the equivalence class of the
   /// given potential archetype.
   void checkSameTypeConstraints(
-                            ArrayRef<GenericTypeParamType *> genericParams,
+                            TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
   /// Realize a potential archetype for the given type.
@@ -1476,7 +1476,7 @@ struct GenericSignatureBuilder::Constraint {
 
   /// Retrieve the dependent type describing the subject of the constraint.
   Type getSubjectDependentType(
-                       ArrayRef<GenericTypeParamType *> genericParams) const;
+                       TypeArrayView<GenericTypeParamType> genericParams) const;
 
   /// Determine whether the subject is equivalence to the given potential
   /// archetype.
@@ -1692,7 +1692,7 @@ public:
   ///
   /// \param genericParams The set of generic parameters to use in the resulting
   /// dependent type.
-  Type getDependentType(ArrayRef<GenericTypeParamType *> genericParams) const;
+  Type getDependentType(TypeArrayView<GenericTypeParamType> genericParams)const;
 
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/STLExtras.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/ArrayRefView.h"
 #include "swift/AST/LayoutConstraint.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/TypeAlignments.h"
@@ -605,6 +606,18 @@ public:
     return Signature;
   }
 };
+
+template <typename T>
+inline T *staticCastHelper(const Type &Ty) {
+  // The constructor of the ArrayRef<Type> must guarantee this invariant.
+  // XXX -- We use reinterpret_cast instead of static_cast so that files
+  // can avoid including Types.h if they want to.
+  return reinterpret_cast<T*>(Ty.getPointer());
+}
+/// TypeArrayView allows arrays of 'Type' to have a static type.
+template <typename T>
+using TypeArrayView = ArrayRefView<Type, T*, staticCastHelper,
+                                   /*AllowOrigAccess*/true>;
 
 } // end namespace swift
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2901,7 +2901,7 @@ public:
   }
   
   /// Retrieve the generic parameters of this polymorphic function type.
-  ArrayRef<GenericTypeParamType *> getGenericParams() const;
+  TypeArrayView<GenericTypeParamType> getGenericParams() const;
 
   /// Retrieve the requirements of this polymorphic function type.
   ArrayRef<Requirement> getRequirements() const;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1684,7 +1684,7 @@ bool ASTMangler::appendGenericSignature(const GenericSignature *sig,
   CurGenericSignature = canSig;
 
   unsigned initialParamDepth;
-  ArrayRef<GenericTypeParamType *> genericParams;
+  TypeArrayView<GenericTypeParamType> genericParams;
   ArrayRef<Requirement> requirements;
   SmallVector<Requirement, 4> requirementsBuffer;
   if (contextSig) {
@@ -1807,9 +1807,9 @@ void ASTMangler::appendRequirement(const Requirement &reqt) {
 }
 
 void ASTMangler::appendGenericSignatureParts(
-                                        ArrayRef<GenericTypeParamType*> params,
-                                        unsigned initialParamDepth,
-                                        ArrayRef<Requirement> requirements) {
+                                     TypeArrayView<GenericTypeParamType> params,
+                                     unsigned initialParamDepth,
+                                     ArrayRef<Requirement> requirements) {
   // Mangle the requirements.
   for (const Requirement &reqt : requirements) {
     appendRequirement(reqt);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -590,7 +590,7 @@ public:
   printGenericSignature(const GenericSignature *genericSig, unsigned flags,
                         llvm::function_ref<bool(const Requirement &)> filter);
   void printSingleDepthOfGenericSignature(
-      ArrayRef<GenericTypeParamType *> genericParams,
+      TypeArrayView<GenericTypeParamType> genericParams,
       ArrayRef<Requirement> requirements, unsigned flags,
       llvm::function_ref<bool(const Requirement &)> filter);
   void printRequirement(const Requirement &req);
@@ -1093,7 +1093,7 @@ void PrintAST::printGenericSignature(
 }
 
 void PrintAST::printSingleDepthOfGenericSignature(
-    ArrayRef<GenericTypeParamType *> genericParams,
+    TypeArrayView<GenericTypeParamType> genericParams,
     ArrayRef<Requirement> requirements, unsigned flags,
     llvm::function_ref<bool(const Requirement &)> filter) {
   bool printParams = (flags & PrintParams);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -625,7 +625,7 @@ TrailingWhereClause *TrailingWhereClause::create(
   return new (mem) TrailingWhereClause(whereLoc, requirements);
 }
 
-ArrayRef<GenericTypeParamType *>
+TypeArrayView<GenericTypeParamType>
 GenericContext::getInnermostGenericParamTypes() const {
   if (auto sig = getGenericSignature())
     return sig->getInnermostGenericParams();

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -41,7 +41,8 @@ ArrayRef<Type> GenericEnvironment::getContextTypes() const {
                         Signature->getGenericParams().size());
 }
 
-ArrayRef<GenericTypeParamType *> GenericEnvironment::getGenericParams() const {
+TypeArrayView<GenericTypeParamType>
+GenericEnvironment::getGenericParams() const {
   return Signature->getGenericParams();
 }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -114,7 +114,7 @@ struct GenericSignatureBuilder::Implementation {
 
   /// The generic parameters that this generic signature builder is working
   /// with.
-  SmallVector<GenericTypeParamType *, 4> GenericParams;
+  SmallVector<Type, 4> GenericParams;
 
   /// The potential archetypes for the generic parameters in \c GenericParams.
   SmallVector<PotentialArchetype *, 4> PotentialArchetypes;
@@ -385,7 +385,7 @@ namespace llvm {
 namespace {
   /// Retrieve the type described by the given unresolved tyoe.
   Type getUnresolvedType(GSBUnresolvedType type,
-                         ArrayRef<GenericTypeParamType *> genericParams) {
+                         TypeArrayView<GenericTypeParamType> genericParams) {
     if (auto concrete = type.dyn_cast<Type>())
       return concrete;
 
@@ -1651,7 +1651,7 @@ bool EquivalenceClass::recordSameTypeConstraint(
 
 template<typename T>
 Type Constraint<T>::getSubjectDependentType(
-                        ArrayRef<GenericTypeParamType *> genericParams) const {
+                      TypeArrayView<GenericTypeParamType> genericParams) const {
   if (auto type = subject.dyn_cast<Type>())
     return type;
 
@@ -1932,7 +1932,7 @@ static bool pathContainsEquivalenceClass(GenericSignatureBuilder &builder,
 
 Type EquivalenceClass::getAnchor(
                             GenericSignatureBuilder &builder,
-                            ArrayRef<GenericTypeParamType *> genericParams) {
+                            TypeArrayView<GenericTypeParamType> genericParams) {
   // Check whether the cache is valid.
   if (archetypeAnchorCache.anchor &&
       archetypeAnchorCache.numMembers == members.size()) {
@@ -2021,8 +2021,7 @@ Type EquivalenceClass::getAnchor(
 
 Type EquivalenceClass::getTypeInContext(GenericSignatureBuilder &builder,
                                         GenericEnvironment *genericEnv) {
-  ArrayRef<GenericTypeParamType *> genericParams =
-    genericEnv->getGenericParams();
+  auto genericParams = genericEnv->getGenericParams();
 
   // The anchor descr
   Type anchor = getAnchor(builder, genericParams);
@@ -2750,7 +2749,7 @@ void ArchetypeType::resolveNestedType(
 }
 
 Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
-                        ArrayRef<GenericTypeParamType *> genericParams) const {
+                      TypeArrayView<GenericTypeParamType> genericParams) const {
   if (auto parent = getParent()) {
     Type parentType = parent->getDependentType(genericParams);
     if (parentType->hasError())
@@ -3003,7 +3002,7 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
   // The equivalence class of a generic type is known directly.
   if (auto genericParam = type->getAs<GenericTypeParamType>()) {
     unsigned index = GenericParamKey(genericParam).findIndexIn(
-                                                           Impl->GenericParams);
+                                                            getGenericParams());
     if (index < Impl->GenericParams.size()) {
       return ResolvedType(Impl->PotentialArchetypes[index]);
     }
@@ -3139,9 +3138,9 @@ bool GenericSignatureBuilder::areInSameEquivalenceClass(Type type1,
     == resolveEquivalenceClass(type2, ArchetypeResolutionKind::WellFormed);
 }
 
-ArrayRef<GenericTypeParamType *>
+TypeArrayView<GenericTypeParamType>
 GenericSignatureBuilder::getGenericParams() const {
-  return Impl->GenericParams;
+  return TypeArrayView<GenericTypeParamType>(Impl->GenericParams);
 }
 
 void GenericSignatureBuilder::addGenericParameter(GenericTypeParamDecl *GenericParam) {
@@ -3152,7 +3151,7 @@ void GenericSignatureBuilder::addGenericParameter(GenericTypeParamDecl *GenericP
 bool GenericSignatureBuilder::addGenericParameterRequirements(
                                            GenericTypeParamDecl *GenericParam) {
   GenericParamKey Key(GenericParam);
-  auto PA = Impl->PotentialArchetypes[Key.findIndexIn(Impl->GenericParams)];
+  auto PA = Impl->PotentialArchetypes[Key.findIndexIn(getGenericParams())];
   
   // Add the requirements from the declaration.
   return isErrorResult(
@@ -3162,10 +3161,11 @@ bool GenericSignatureBuilder::addGenericParameterRequirements(
 
 void GenericSignatureBuilder::addGenericParameter(GenericTypeParamType *GenericParam) {
   GenericParamKey Key(GenericParam);
-  assert(Impl->GenericParams.empty() ||
-         ((Key.Depth == Impl->GenericParams.back()->getDepth() &&
-           Key.Index == Impl->GenericParams.back()->getIndex() + 1) ||
-          (Key.Depth > Impl->GenericParams.back()->getDepth() &&
+  auto params = getGenericParams();
+  assert(params.empty() ||
+         ((Key.Depth == params.back()->getDepth() &&
+           Key.Index == params.back()->getIndex() + 1) ||
+          (Key.Depth > params.back()->getDepth() &&
            Key.Index == 0)));
 
   // Create a potential archetype for this type parameter.
@@ -4600,8 +4600,8 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
 
 void
 GenericSignatureBuilder::finalize(SourceLoc loc,
-                           ArrayRef<GenericTypeParamType *> genericParams,
-                           bool allowConcreteGenericParams) {
+                              TypeArrayView<GenericTypeParamType> genericParams,
+                              bool allowConcreteGenericParams) {
   // Process any delayed requirements that we can handle now.
   processDelayedRequirements();
 
@@ -4755,7 +4755,7 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
     SmallPtrSet<PotentialArchetype *, 4> visited;
     
     unsigned depth = 0;
-    for (const auto &gp : Impl->GenericParams)
+    for (const auto gp : getGenericParams())
       depth = std::max(depth, gp->getDepth());
 
     for (const auto pa : Impl->PotentialArchetypes) {
@@ -4915,7 +4915,7 @@ void GenericSignatureBuilder::processDelayedRequirements() {
 
 template<typename T>
 Constraint<T> GenericSignatureBuilder::checkConstraintList(
-                           ArrayRef<GenericTypeParamType *> genericParams,
+                           TypeArrayView<GenericTypeParamType> genericParams,
                            std::vector<Constraint<T>> &constraints,
                            llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
@@ -5021,7 +5021,7 @@ namespace {
 
 template<typename T, typename DiagT>
 Constraint<T> GenericSignatureBuilder::checkConstraintList(
-                           ArrayRef<GenericTypeParamType *> genericParams,
+                           TypeArrayView<GenericTypeParamType> genericParams,
                            std::vector<Constraint<T>> &constraints,
                            llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
@@ -5187,7 +5187,7 @@ static bool isRedundantlyInheritableObjCProtocol(
 }
 
 void GenericSignatureBuilder::checkConformanceConstraints(
-                          ArrayRef<GenericTypeParamType *> genericParams,
+                          TypeArrayView<GenericTypeParamType> genericParams,
                           EquivalenceClass *equivClass) {
   for (auto &entry : equivClass->conformsTo) {
     // Remove self-derived constraints.
@@ -5715,7 +5715,7 @@ static void collapseSameTypeComponents(
 }
 
 void GenericSignatureBuilder::checkSameTypeConstraints(
-                          ArrayRef<GenericTypeParamType *> genericParams,
+                          TypeArrayView<GenericTypeParamType> genericParams,
                           EquivalenceClass *equivClass) {
   if (!equivClass->derivedSameTypeComponents.empty())
     return;
@@ -5918,8 +5918,8 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
 }
 
 void GenericSignatureBuilder::checkConcreteTypeConstraints(
-                                 ArrayRef<GenericTypeParamType *> genericParams,
-                                 EquivalenceClass *equivClass) {
+                              TypeArrayView<GenericTypeParamType> genericParams,
+                              EquivalenceClass *equivClass) {
   checkConstraintList<Type>(
     genericParams, equivClass->concreteTypeConstraints,
     [&](const ConcreteConstraint &constraint) {
@@ -5951,8 +5951,8 @@ void GenericSignatureBuilder::checkConcreteTypeConstraints(
 }
 
 void GenericSignatureBuilder::checkSuperclassConstraints(
-                                 ArrayRef<GenericTypeParamType *> genericParams,
-                                 EquivalenceClass *equivClass) {
+                              TypeArrayView<GenericTypeParamType> genericParams,
+                              EquivalenceClass *equivClass) {
   assert(equivClass->superclass && "No superclass constraint?");
 
   // FIXME: We should be substituting in the canonical type in context so
@@ -6038,8 +6038,8 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
 }
 
 void GenericSignatureBuilder::checkLayoutConstraints(
-                                ArrayRef<GenericTypeParamType *> genericParams,
-                                EquivalenceClass *equivClass) {
+                              TypeArrayView<GenericTypeParamType> genericParams,
+                              EquivalenceClass *equivClass) {
   if (!equivClass->layout) return;
 
   checkConstraintList<LayoutConstraint>(
@@ -6096,7 +6096,7 @@ static int compareSameTypeComponents(const SameTypeComponentRef *lhsPtr,
 }
 
 void GenericSignatureBuilder::enumerateRequirements(
-                   ArrayRef<GenericTypeParamType *> genericParams,
+                   TypeArrayView<GenericTypeParamType> genericParams,
                    llvm::function_ref<
                      void (RequirementKind kind,
                            Type type,
@@ -6300,7 +6300,7 @@ void GenericSignatureBuilder::addGenericSignature(GenericSignature *sig) {
 /// Collect the set of requirements placed on the given generic parameters and
 /// their associated types.
 static void collectRequirements(GenericSignatureBuilder &builder,
-                                ArrayRef<GenericTypeParamType *> params,
+                                TypeArrayView<GenericTypeParamType> params,
                                 SmallVectorImpl<Requirement> &requirements) {
   builder.enumerateRequirements(
       params,
@@ -6348,14 +6348,14 @@ GenericSignature *GenericSignatureBuilder::computeGenericSignature(
                                           bool allowConcreteGenericParams,
                                           bool allowBuilderToMove) && {
   // Finalize the builder, producing any necessary diagnostics.
-  finalize(loc, Impl->GenericParams, allowConcreteGenericParams);
+  finalize(loc, getGenericParams(), allowConcreteGenericParams);
 
   // Collect the requirements placed on the generic parameter types.
   SmallVector<Requirement, 4> requirements;
-  collectRequirements(*this, Impl->GenericParams, requirements);
+  collectRequirements(*this, getGenericParams(), requirements);
 
   // Form the generic signature.
-  auto sig = GenericSignature::get(Impl->GenericParams, requirements);
+  auto sig = GenericSignature::get(getGenericParams(), requirements);
 
   // When we can, move this generic signature builder to make it the canonical
   // builder, rather than constructing a new generic signature builder that

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -361,9 +361,9 @@ void TypeChecker::validateRequirements(
 
 std::string
 TypeChecker::gatherGenericParamBindingsText(
-                                ArrayRef<Type> types,
-                                ArrayRef<GenericTypeParamType *> genericParams,
-                                TypeSubstitutionFn substitutions) {
+                              ArrayRef<Type> types,
+                              TypeArrayView<GenericTypeParamType> genericParams,
+                              TypeSubstitutionFn substitutions) {
   llvm::SmallPtrSet<GenericTypeParamType *, 2> knownGenericParams;
   for (auto type : types) {
     if (type.isNull()) continue;
@@ -1270,7 +1270,7 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
 
 RequirementCheckResult TypeChecker::checkGenericArguments(
     DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
-    ArrayRef<GenericTypeParamType *> genericParams,
+    TypeArrayView<GenericTypeParamType> genericParams,
     ArrayRef<Requirement> requirements,
     TypeSubstitutionFn substitutions,
     LookupConformanceFn conformances,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2960,7 +2960,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied(
       DC, Loc, Loc,
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(),
-      { proto->getProtocolSelfType() },
+      { Type(proto->getProtocolSelfType()) },
       proto->getRequirementSignature(),
       QuerySubstitutionMap{substitutions},
       TypeChecker::LookUpConformance(TC, DC),
@@ -3426,8 +3426,8 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
 
     auto conditionalCheckResult =
       checkGenericArguments(DC, ComplainLoc, noteLoc, T,
-                            { lookupResult->getRequirement()
-                                ->getProtocolSelfType() },
+                            { Type(lookupResult->getRequirement()
+                                ->getProtocolSelfType()) },
                             lookupResult->getConditionalRequirements(),
                             [](SubstitutableType *dependentType) {
                               return Type(dependentType);

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1082,7 +1082,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   auto result =
     tc.checkGenericArguments(dc, SourceLoc(), SourceLoc(),
                              typeInContext,
-                             { proto->getProtocolSelfType() },
+                             { Type(proto->getProtocolSelfType()) },
                              sanitizedRequirements,
                              QuerySubstitutionMap{substitutions},
                              TypeChecker::LookUpConformance(tc, dc),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2352,9 +2352,8 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
   SmallVector<Substitution, 4> genericArgs;
   if (genericSig) {
     TypeSubstitutionMap genericArgMap;
-    ArrayRef<GenericTypeParamType *> params;
 
-    params = genericSig->getGenericParams();
+    auto params = genericSig->getGenericParams();
     if (repr->getGenericArguments().size()
           != genericSig->getSubstitutionListSize()) {
       TC.diagnose(repr->getLoc(), diag::sil_box_arg_mismatch);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1474,8 +1474,8 @@ public:
   /// These are used to produce the "parameter = argument" bindings in the test.
   static std::string
   gatherGenericParamBindingsText(ArrayRef<Type> types,
-                                 ArrayRef<GenericTypeParamType *> genericParams,
-                                 TypeSubstitutionFn substitutions);
+                              TypeArrayView<GenericTypeParamType> genericParams,
+                              TypeSubstitutionFn substitutions);
 
   /// Check the given set of generic arguments against the requirements in a
   /// generic signature.
@@ -1496,7 +1496,7 @@ public:
   /// notify callers about diagnosed errors.
   RequirementCheckResult checkGenericArguments(
       DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
-      ArrayRef<GenericTypeParamType *> genericParams,
+      TypeArrayView<GenericTypeParamType> genericParams,
       ArrayRef<Requirement> requirements,
       TypeSubstitutionFn substitutions,
       LookupConformanceFn conformances,


### PR DESCRIPTION
This also introduces 'TypeArrayView' for when a `Type` is statically known to be a given TypeBase subclass.

Hi @DougGregor – As far as I can tell, is the last `reinterpret_cast` violation of the `Type` type wall. I think the change is net positive, but given the viral-like nature of the newly introduced `TypeArrayView` type, I'd appreciate your blessing. After this change, one should be able to easily experiment with nontrivial `Type` implementations, including "compressed pointers" (less than sizeof(void*) bits) or cached metadata (getKind(), is canonical, isLValue, etc). Thanks for reviewing this!