### PR TITLE
WIP/IRGen: PCS for ARM VFP CC does not correctly handle HFAs

### DIFF
--- a/test/IRGen/COFF-ObjC-subclass.swift
+++ b/test/IRGen/COFF-ObjC-subclass.swift
@@ -1,0 +1,9 @@
+// RUN: %swift -target thumbv7-unknown-windows-msvc -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -emit-ir %s -o - | %FileCheck %s
+
+// REQUIRES: OS=windows
+
+import SRoA
+
+class C : I {
+}
+

--- a/test/IRGen/ELF-ObjC-subclass.swift
+++ b/test/IRGen/ELF-ObjC-subclass.swift
@@ -1,0 +1,9 @@
+// RUN: %swift -target thumbv7-unknown-linux-gnueabihf -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -emit-ir %s -o - | %FileCheck %s
+
+// REQUIRES: OS=linux
+
+import SRoA
+
+class C : I {
+}
+

--- a/test/IRGen/Inputs/usr/include/SRoA.h
+++ b/test/IRGen/Inputs/usr/include/SRoA.h
@@ -6,3 +6,9 @@ typedef struct S {
 
 void f(S);
 
+#if defined(__OBJC__)
+@interface I
+- (instancetype _Nonnull)initWithS:(S)s;
+@end
+#endif
+


### PR DESCRIPTION
When materializing the implicit constructor containing a HFA, the VFP CC
will result in an incorrect attempt to coerce parameters to the
structure type.  This causes an assertion in LLVM as we attempt to store
a structure by value into an alloca.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
