### PR TITLE
stdlib: use `llvm::function_ref` over `std::function`

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -468,12 +468,12 @@ public:
   /// Callback used to handle the substitution of a generic parameter for
   /// its metadata.
   using SubstGenericParameterFn =
-    std::function<const Metadata *(unsigned depth, unsigned index)>;
+    llvm::function_ref<const Metadata *(unsigned depth, unsigned index)>;
 
   /// Callback used to handle the lookup of dependent member types.
-  using LookupDependentMemberFn =
-    std::function<const Metadata *(const Metadata *base, StringRef assocType,
-                                   const ProtocolDescriptor *protocol)>;
+  using LookupDependentMemberFn = llvm::function_ref<const Metadata *(
+      const Metadata *base, StringRef assocType,
+      const ProtocolDescriptor *protocol)>;
 
 private:
   /// The demangler we'll use when building new nodes.


### PR DESCRIPTION
This is needed to repair the Windows build.  The MSVC C++ runtime
implements `std::function` with use of `typeid` which cannot be used
with `-fno-rtti`.  This results in a build failure.  Rather than
enabling the use of RTTI for `MetadataLookup.cpp`, use
`llvm::function_ref` to avoid enabling RTTI emission.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
