### PR TITLE
Update libswiftRemoteMirror preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1232,6 +1232,8 @@ skip-test-cmark
 no-assertions
 swift-assertions
 
+clang-user-visible-version=9.1.0
+
 compiler-vendor=apple
 dash-dash
 
@@ -1260,12 +1262,10 @@ llvm-include-tests=0
 
 [preset: remote_mirror_ios_customization]
 
-clang-user-visible-version=8.0.0
-
 dash-dash
 
 darwin-xcrun-toolchain=ios
-darwin-deployment-version-ios=10.0
+darwin-deployment-version-ios=11.0
 skip-build-osx
 skip-test-osx
 skip-build-tvos
@@ -1284,12 +1284,10 @@ mixin-preset=
 
 [preset: remote_mirror_watchos_customization]
 
-clang-user-visible-version=8.0.0
-
 dash-dash
 
 darwin-xcrun-toolchain=watchos
-darwin-deployment-version-watchos=3.0
+darwin-deployment-version-watchos=4.0
 skip-build-osx
 skip-test-osx
 skip-build-tvos
@@ -1308,12 +1306,10 @@ mixin-preset=
 
 [preset: remote_mirror_tvos_customization]
 
-clang-user-visible-version=8.0.0
-
 dash-dash
 
 darwin-xcrun-toolchain=tvos
-darwin-deployment-version-tvos=10.0
+darwin-deployment-version-tvos=11.0
 skip-build-osx
 skip-test-osx
 skip-build-watchos


### PR DESCRIPTION
- bump the minimum deployment target to iOS 11.0 (and equivalent)
