### PR TITLE
[stdlib]Fix mutations of Substring through their UTF character views

### DIFF
--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -468,7 +468,7 @@ extension Substring {
       return ${_View}(_wholeString.${_property}, _bounds: startIndex..<endIndex)
     }
     set {
-      self = Substring(_base: _wholeString, startIndex..<endIndex)
+      self = Substring(newValue)
     }
   }
 

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -172,14 +172,26 @@ SubstringTests.test("UTF16View") {
   expectEqual("", String(u.dropLast(10))!)
 }
 
-SubstringTests.test("Mutate Substring through UTF16View") {
+SubstringTests.test("Mutate Substring through utf16 view") {
   let s = "abcdefg"
   var ss = s[...]
   expectEqual(s.startIndex, ss.startIndex)
   expectEqual(s.count, ss.count)
-  ss.utf16.removeFirst()
+  let first = ss.utf16.removeFirst()
   expectEqual(s.index(after: s.startIndex), ss.startIndex)
   expectEqual(s.count - 1, ss.count)
+}
+
+SubstringTests.test("Mutate Substring through unicodeScalars view") {
+  let s = "abcdefg"
+  var ss = s[...]
+  expectEqual(s.startIndex, ss.startIndex)
+  expectEqual(s.count, ss.count)
+  ss.unicodeScalars.append("h")
+  expectEqual(s.startIndex, ss.startIndex)
+  expectEqual(s.count + 1, ss.count)
+  expectEqual(ss.last, "h")
+  expectEqual(s.last, "g")
 }
 
 SubstringTests.test("UTF8View") {

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -172,6 +172,16 @@ SubstringTests.test("UTF16View") {
   expectEqual("", String(u.dropLast(10))!)
 }
 
+SubstringTests.test("Mutate Substring through UTF16View") {
+  let s = "abcdefg"
+  var ss = s[...]
+  expectEqual(s.startIndex, ss.startIndex)
+  expectEqual(s.count, ss.count)
+  ss.utf16.removeFirst()
+  expectEqual(s.index(after: s.startIndex), ss.startIndex)
+  expectEqual(s.count - 1, ss.count)
+}
+
 SubstringTests.test("UTF8View") {
   let s = "abcdefg"
   let t = s.utf8.dropFirst(2)


### PR DESCRIPTION
Mutating substrings through one of the utf views was broken. This adds a fix and a test.