### PR TITLE
[AST] Report generic signature minimization errors through diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -85,6 +85,9 @@ NOTE(note_typo_candidate,none,
 NOTE(profile_read_error,none,
      "failed to load profile data '%0': '%1'", (StringRef, StringRef))
 
+ERROR(generic_signature_not_minimal,none,
+      "generic requirement '%0' is redundant in %1", (StringRef, StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/test/Generics/validate_stdlib_generic_signatures.swift
+++ b/test/Generics/validate_stdlib_generic_signatures.swift
@@ -1,6 +1,6 @@
 // Verifies that all of the generic signatures in the standard library are
 // minimal and canonical.
 
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify-generic-signatures Swift
+// RUN: %target-typecheck-verify-swift -typecheck -verify-generic-signatures Swift
 
 // expected-no-diagnostics


### PR DESCRIPTION
Rather than crashing when a generic signature is found to be non-minimal,
report the non-minimal requirement via the normal diagnostics machinery so
we can properly test for it.

Fixes rdar://problem/36912347 by letting us track which cases are
non-minimal in the standard library explicitly, so we can better
decide whether it's worth implementing a complete solution.
