### PR TITLE
[runtime] Add support for verifying at runtime that a protocol descri…

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -203,6 +203,9 @@ enum class TypeMetadataRecordKind : unsigned {
   /// On platforms without Objective-C interoperability, this case is
   /// unused.
   IndirectObjCClass = 0x03,
+
+  First_Kind = DirectNominalTypeDescriptor,
+  Last_Kind = IndirectObjCClass,
 };
 
 /// Flag that indicates whether an existential type is class-constrained or not.
@@ -460,7 +463,10 @@ public:
     /// A function pointer that can be called to access the protocol witness
     /// table whose conformance is conditional on additional requirements that
     /// must first be evaluated and then provided to the accessor function.
-    ConditionalWitnessTableAccessor
+    ConditionalWitnessTableAccessor,
+
+    First_Kind = WitnessTable,
+    Last_Kind = ConditionalWitnessTableAccessor,
   };
 
 private:

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2729,6 +2729,16 @@ public:
 #if !defined(NDEBUG) && SWIFT_OBJC_INTEROP
   void dump() const;
 #endif
+
+#ifndef NDEBUG
+  /// Verify that the protocol descriptor obeys all invariants.
+  ///
+  /// We currently check that the descriptor:
+  ///
+  /// 1. Has a valid TypeMetadataRecordKind.
+  /// 2. Has a valid conformance kind.
+  void verify() const LLVM_ATTRIBUTE_USED;
+#endif
 };
 using ProtocolConformanceDescriptor
   = TargetProtocolConformanceDescriptor<InProcess>;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -81,6 +81,21 @@ template<> void ProtocolConformanceDescriptor::dump() const {
 }
 #endif
 
+#ifndef NDEBUG
+template<> void ProtocolConformanceDescriptor::verify() const {
+  auto typeKind = unsigned(getTypeKind());
+  assert(((unsigned(TypeMetadataRecordKind::First_Kind) <= typeKind) &&
+          (unsigned(TypeMetadataRecordKind::Last_Kind) >= typeKind)) &&
+         "Corrupted type metadata record kind");
+
+  auto confKind = unsigned(getConformanceKind());
+  using ConformanceKind = ConformanceFlags::ConformanceKind;
+  assert(((unsigned(ConformanceKind::First_Kind) <= confKind) &&
+          (unsigned(ConformanceKind::Last_Kind) >= confKind)) &&
+         "Corrupted conformance kind");
+}
+#endif
+
 /// Take the type reference inside a protocol conformance record and fetch the
 /// canonical metadata pointer for the type it refers to.
 /// Returns nil for universal or generic type references.


### PR DESCRIPTION
…ptive has a valid type kind/conformance kind.

This is useful when trying to track down data corruption in the runtime. I am
currently running into such issues with the +0-all-arg work, so I am adding
stuff like this to help debug this issue and future such issues.

rdar://34222540