### PR TITLE
[5.0][CSSolver] Fix performance regression related to contraction of closu…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1788,9 +1788,10 @@ static bool shouldSkipDisjunctionChoice(ConstraintSystem &cs,
     // Let's skip generic overload choices only in case if
     // non-generic score indicates that there were no forced
     // unwrappings of optional(s), no unavailable overload
-    // choices present in the solution, and no fixes required.
-    if (score[SK_ForceUnchecked] == 0 && score[SK_Unavailable] == 0
-        && score[SK_Fix] == 0)
+    // choices present in the solution, no fixes required,
+    // and there are no non-trivial function conversions.
+    if (score[SK_ForceUnchecked] == 0 && score[SK_Unavailable] == 0 &&
+        score[SK_Fix] == 0 && score[SK_FunctionConversion] == 0)
       return true;
   }
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+struct T {
+  enum B {
+    case a
+    case b
+  }
+
+  let name: String
+  let b: B
+}
+
+struct A {
+  enum C {
+    case a
+    case b
+    case c
+  }
+
+  let name: String
+  let t: T
+  let c: C
+
+  var isX: Bool {
+    return self.t.b == .a
+  }
+}
+
+let x: [String: A] = [:]
+let _ = x.values.filter { $0.isX }
+                .filter { $0.t.b != .a }
+                .filter { $0.c == .a || $0.c == .b }
+                .filter { $0.isX }
+                .filter { $0.t.b != .a }
+                .sorted { $0.name < $1.name }


### PR DESCRIPTION
…re parameters

Improve situation around closure parameter/argument contractions
by allowing such action if it can be proved that none of the bindings
would result in solver attempting to bind parameter to `inout` type.

Resolves: rdar://problem/36838495
(cherry picked from commit 3b7e555c7ebf91e30a90dfd1383b41921df59275)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
