### PR TITLE
Preserve whether fields are `var` or `let` in the reflection metadata.

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -30,7 +30,10 @@ class FieldRecordFlags {
   using int_type = uint32_t;
   enum : int_type {
     // Is this an indirect enum case?
-    IsIndirectCase = 0x1
+    IsIndirectCase = 0x1,
+    
+    // Is this a mutable `var` property?
+    IsVar = 0x2,
   };
   int_type Data = 0;
 
@@ -39,11 +42,22 @@ public:
     return (Data & IsIndirectCase) == IsIndirectCase;
   }
 
+  bool isVar() const {
+    return (Data & IsVar) == IsVar;
+  }
+
   void setIsIndirectCase(bool IndirectCase=true) {
     if (IndirectCase)
       Data |= IsIndirectCase;
     else
       Data &= ~IsIndirectCase;
+  }
+
+  void setIsVar(bool Var=true) {
+    if (Var)
+      Data |= IsVar;
+    else
+      Data &= ~IsVar;
   }
 
   int_type getRawValue() const {

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -331,6 +331,8 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
                     bool indirect=false) {
     reflection::FieldRecordFlags flags;
     flags.setIsIndirectCase(indirect);
+    if (auto var = dyn_cast<VarDecl>(value))
+      flags.setIsVar(!var->isLet());
 
     B.addInt32(flags.getRawValue());
 

--- a/test/IRGen/reflection_metadata_let_var.swift
+++ b/test/IRGen/reflection_metadata_let_var.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// CHECK: [[INT:@.*]] = private constant [3 x i8] c"Si\00"
+// CHECK: [[X:@.*]] = private constant [2 x i8] c"x\00"
+// CHECK: [[STRING:@.*]] = private constant [3 x i8] c"SS\00"
+// CHECK: [[Y:@.*]] = private constant [2 x i8] c"y\00"
+
+// CHECK-LABEL: @"$S27reflection_metadata_let_var6StruccVMF" = internal constant
+struct Strucc {
+// --             flags (let)
+// CHECK-SAME:    i32 0, 
+// --             type
+// CHECK-SAME:    [[INT]] to
+// --             name
+// CHECK-SAME:    [[X]] to
+  let x: Int
+
+// --             flags (var)
+// CHECK-SAME:    i32 2, 
+// --             type
+// CHECK-SAME:    [[STRING]] to
+// --             name
+// CHECK-SAME:    [[Y]] to
+  var y: String
+}
+


### PR DESCRIPTION
Useful for future mutable reflection features to know whether they're allowed to mutate a field after initialization.