### PR TITLE
SIL: use `unsigned` for the member for `bool`

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1215,7 +1215,7 @@ class TailAllocatedDebugVariable {
       /// The source function argument position from left to right
       /// starting with 1 or 0 if this is a local variable.
       unsigned ArgNo : 16;
-      bool Constant : 1;
+      unsigned Constant : 1;
       /// When this is nonzero there is a tail-allocated string storing
       /// variable name present. This typically only happens for
       /// instructions that were created from parsing SIL assembler.


### PR DESCRIPTION
Use `unsigned` instead of `bool` for the member to make all members of
the structure the same.  This fixes the behaviour of the structure on
Windows.  The difference in the type caused the bitfields to be pushed
to the natural alignment of int resulting in the structure being padded
to 12-bytes instead of being packed into 4.  Using `#pragma pack` also
did not make a difference here as the structure remained padded to
12-bytes.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
