### PR TITLE
[build-script] Don't disable modules when ASan is enabled

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -345,17 +345,6 @@ function is_swift_lto_enabled() {
     fi
 }
 
-# Enable module-builds of llvm only when asan is disabled.
-# FIXME: rdar://problem/28356072
-function is_llvm_module_build_enabled() {
-    if [[ "$(true_false ${LLVM_ENABLE_MODULES})" == "TRUE" ]] &&
-       [[ "$(true_false ${ENABLE_ASAN})" == "FALSE" ]]; then
-        echo "TRUE"
-    else
-        echo "FALSE"
-    fi
-}
-
 # Support for performing isolated actions.
 #
 # This is part of refactoring more work to be done or controllable via
@@ -647,7 +636,7 @@ function set_build_options_for_host() {
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE
                 -DSANITIZER_MIN_OSX_VERSION="${cmake_osx_deployment_target}"
-                -DLLVM_ENABLE_MODULES:BOOL="$(is_llvm_module_build_enabled)"
+                -DLLVM_ENABLE_MODULES:BOOL="$(true_false ${LLVM_ENABLE_MODULES})"
             )
             if [[ $(is_llvm_lto_enabled) == "TRUE" ]]; then
                 if [[ $(cmake_needs_to_specify_standard_computed_defaults) == "TRUE" ]]; then


### PR DESCRIPTION
In the past, we needed to disable building swift with -fmodules because
the module caching logic ignored sanitizer flags (rdar://28356072).

This is fixed now, so let's remove the workaround.