### PR TITLE
Check generic requirements in `_typeByMangledName`.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2545,7 +2545,7 @@ public:
   class AssociatedTypeIterator {
     const void *addr;
     
-    explicit AssociatedTypeIterator(const void *startAddr) : addr(addr) {}
+    explicit AssociatedTypeIterator(const void *startAddr) : addr(startAddr) {}
     
     bool isEnd() const {
       if (addr == nullptr)
@@ -2556,6 +2556,9 @@ public:
         return true;
       return false;
     }
+
+    template <class> friend class TargetGenericParamRef;
+
   public:
     AssociatedTypeIterator() : addr(nullptr) {}
 
@@ -2652,6 +2655,46 @@ class TargetGenericRequirementDescriptor {
     /// Only valid if the requirement has Layout kind.
     GenericRequirementLayoutKind Layout;
   };
+
+public:
+  constexpr GenericRequirementFlags getFlags() const {
+    return Flags;
+  }
+
+  constexpr GenericRequirementKind getKind() const {
+    return getFlags().getKind();
+  }
+
+  /// Retrieve the generic parameter that is the subject of this requirement.
+  const TargetGenericParamRef<Runtime> &getParam() const {
+    return Param;
+  }
+
+  /// Retrieve the protocol descriptor for a Protocol requirement.
+  const TargetProtocolDescriptor<Runtime> *getProtocol() const {
+    assert(getKind() == GenericRequirementKind::Protocol);
+    return Protocol;
+  }
+
+  /// Retrieve the right-hand type for a SameType or BaseClass requirement.
+  const char *getMangledTypeName() const {
+    assert(getKind() == GenericRequirementKind::SameType ||
+           getKind() == GenericRequirementKind::BaseClass);
+    return Type;
+  }
+
+  /// Retrieve the protocol conformance record for a SameConformance
+  /// requirement.
+  const TargetProtocolConformanceRecord<Runtime> *getConformance() const {
+    assert(getKind() == GenericRequirementKind::SameConformance);
+    return Conformance;
+  }
+
+  /// Retrieve the layout constraint.
+  GenericRequirementLayoutKind getLayout() const {
+    assert(getKind() == GenericRequirementKind::Layout);
+    return Layout;
+  }
 };
 
 /// CRTP class for a context descriptor that includes trailing generic

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -216,7 +216,7 @@ _searchTypeMetadataRecords(const TypeMetadataState &T,
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = T.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto ntd = record.getNominalTypeDescriptor()) {
+      if (auto ntd = record.getTypeContextDescriptor()) {
         if (_contextDescriptorMatchesMangling(ntd, node)) {
           return ntd;
         }
@@ -566,10 +566,6 @@ public:
     // If we already have metadata, return it.
     if (auto metadata = metadataOrTypeDecl.dyn_cast<const Metadata *>())
       return metadata;
-
-    // Cannot specialize metadata.
-    if (metadataOrTypeDecl.is<const Metadata *>())
-      return BuiltType();
 
     auto typeDecl = metadataOrTypeDecl.get<const TypeContextDescriptor *>();
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -172,6 +172,38 @@ namespace swift {
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
                                                       Demangle::Demangler &Dem);
 
+  /// Callback used to provide the substitution for a generic parameter
+  /// referenced by a "flat" index (where all depths have been collapsed)
+  /// to its metadata.
+  using SubstFlatGenericParameterFn =
+    llvm::function_ref<const Metadata *(unsigned flatIndex)>;
+
+  /// Callback used to provide the substitution of a generic parameter
+  /// (described by depth/index) to its metadata.
+  using SubstGenericParameterFn =
+    llvm::function_ref<const Metadata *(unsigned depth, unsigned index)>;
+
+  /// FIXME: Remove once this is in Metadata.h
+  using GenericRequirementDescriptor =
+    TargetGenericRequirementDescriptor<InProcess>;
+
+  /// Check the given generic requirements using the given set of generic
+  /// arguments, collecting the key arguments (e.g., witness tables) for
+  /// the caller.
+  ///
+  /// \param requirements The set of requirements to evaluate.
+  ///
+  /// \param extraArguments The extra arguments determined while checking
+  /// generic requirements (e.g., those that need to be
+  /// passed to an instantiation function) will be added to this vector.
+  ///
+  /// \returns true if an error occurred, false otherwise.
+  bool _checkGenericRequirements(
+                    llvm::ArrayRef<GenericRequirementDescriptor> requirements,
+                    std::vector<const void *> &extraArguments,
+                    SubstFlatGenericParameterFn substFlatGenericParam,
+                    SubstGenericParameterFn substGenericParam);
+
   /// A helper function which avoids performing a store if the destination
   /// address already contains the source value.  This is useful when
   /// "initializing" memory that might have been initialized to the correct

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -673,3 +673,83 @@ swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
 
   return nullptr;
 }
+
+/// Resolve a reference to a generic parameter to type metadata.
+static const Metadata *resolveGenericParamRef(
+                            const GenericParamRef &param,
+                            SubstFlatGenericParameterFn substFlatGenericParam) {
+  // Resolve the root generic parameter.
+  const Metadata *current = substFlatGenericParam(param.getRootParamIndex());
+  if (!current) return nullptr;
+
+  // Follow the associated type path.
+  for (const auto &assocTypeRef : param) {
+    // Look for the witness table.
+    auto witnessTable =
+      swift_conformsToProtocol(current, assocTypeRef.Protocol);
+    if (!witnessTable) return nullptr;
+
+    // Call the associated type access function.
+    using AssociatedTypeAccessFn =
+      const Metadata *(*)(const Metadata *base, const WitnessTable *);
+    unsigned adjustedIndex =
+      assocTypeRef.Index + WitnessTableFirstRequirementOffset;
+    current =
+      ((const AssociatedTypeAccessFn *)witnessTable)[adjustedIndex]
+        (current, witnessTable);
+    if (!current) return nullptr;
+  }
+
+  return current;
+}
+
+bool swift::_checkGenericRequirements(
+                      llvm::ArrayRef<GenericRequirementDescriptor> requirements,
+                      std::vector<const void *> &extraArguments,
+                      SubstFlatGenericParameterFn substFlatGenericParam,
+                      SubstGenericParameterFn substGenericParam) {
+  for (const auto &req : requirements) {
+    // Make sure we understand the requirement we're dealing with.
+    switch (req.getKind()) {
+    case GenericRequirementKind::BaseClass:
+    case GenericRequirementKind::Layout:
+    case GenericRequirementKind::Protocol:
+    case GenericRequirementKind::SameConformance:
+    case GenericRequirementKind::SameType:
+      break;
+
+    default:
+      // Unknown requirement kind. Bail out.
+      return true;
+    }
+
+    // Resolve the subject generic parameter.
+    auto subjectType =
+      resolveGenericParamRef(req.getParam(), substFlatGenericParam);
+    if (!subjectType) return true;
+
+    // Check the requirement.
+    switch (req.getKind()) {
+    case GenericRequirementKind::Protocol: {
+      // Look for a witness table to satisfy this conformance.
+      auto witnessTable =
+        swift_conformsToProtocol(subjectType, req.getProtocol());
+      if (!witnessTable) return true;
+
+      // If this requirement provides an extra argument, add the witness table
+      // as that argument.
+      if (req.getFlags().hasExtraArgument())
+        extraArguments.push_back(witnessTable);
+
+      continue;
+    }
+
+    // FIXME: Handle all of the other cases.
+    default:
+      return true;
+    }
+  }
+
+  // Success!
+  return false;
+}

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -178,6 +178,7 @@ enum EG<T, U> { case a }
 
 class CG3<T, U, V> { }
 
+
 DemangleToMetadataTests.test("simple generic specializations") {
   expectEqual([Int].self, _typeByMangledName("SaySiG")!)
   expectEqual(EG<Int, String>.self, _typeByMangledName("4main2EGOySiSSG")!)
@@ -228,6 +229,53 @@ DemangleToMetadataTests.test("demangle built-in types") {
   expectEqual(Builtin.NativeObject.self, _typeByMangledName("Bo")!)
   expectEqual(Builtin.BridgeObject.self, _typeByMangledName("Bb")!)
   expectEqual(Builtin.UnsafeValueBuffer.self, _typeByMangledName("BB")!)
+}
+
+class CG4<T: P1, U: P2> {
+  struct InnerGeneric<V: P3> { }
+}
+
+struct ConformsToP1: P1 { }
+struct ConformsToP2: P2 { }
+struct ConformsToP3: P3 { }
+
+DemangleToMetadataTests.test("protocol conformance requirements") {
+  expectEqual(CG4<ConformsToP1, ConformsToP2>.self,
+    _typeByMangledName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP2VG")!)
+  expectEqual(CG4<ConformsToP1, ConformsToP2>.InnerGeneric<ConformsToP3>.self,
+    _typeByMangledName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP3VG")!)
+
+  // Failure cases: failed conformance requirements.
+  expectNil(_typeByMangledName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP1VG"))
+  expectNil(_typeByMangledName("4main3CG4CyAA12ConformsToP2VAA12ConformsToP2VG"))
+  expectNil(_typeByMangledName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP2VG"))
+}
+
+struct SG5<T: P4> where T.Assoc1: P1, T.Assoc2: P2 { }
+
+struct ConformsToP4a : P4 {
+  typealias Assoc1 = ConformsToP1
+  typealias Assoc2 = ConformsToP2
+}
+
+struct ConformsToP4b : P4 {
+  typealias Assoc1 = ConformsToP1
+  typealias Assoc2 = ConformsToP1
+}
+
+struct ConformsToP4c : P4 {
+  typealias Assoc1 = ConformsToP2
+  typealias Assoc2 = ConformsToP2
+}
+
+DemangleToMetadataTests.test("associated type conformance requirements") {
+  expectEqual(SG5<ConformsToP4a>.self,
+    _typeByMangledName("4main3SG5VyAA13ConformsToP4aVG")!)
+
+  // Failure cases: failed conformance requirements.
+  expectNil(_typeByMangledName("4main3SG5VyAA13ConformsToP4bVG"))
+  expectNil(_typeByMangledName("4main3SG5VyAA13ConformsToP4cVG"))
+  expectNil(_typeByMangledName("4main3SG5VyAA12ConformsToP1cVG"))
 }
 
 runAllTests()


### PR DESCRIPTION
Extend support for mapping a mangled name -> type metadata to include
support for checking protocol conformance requirements, using the
encoding of generic requirements that is now available within context
descriptors. For example, this allows
`_typeByMangledName(mangled-name-of-Set<Int>)` to construct proper type
metadata, filling in the Int: Hashable requirement as appropriate.