### PR TITLE
[Swift 4.1] Fix enum payload on big endian

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -165,20 +165,38 @@ using BoxPair = TwoWordPair<HeapObject *, OpaqueValue *>;
 /// appropriate to store a value of the given type.
 /// The heap object has an initial retain count of 1, and its metadata is set
 /// such that destroying the heap object destroys the contained value.
+#if defined(__linux__) && defined(__s390x__)
+
+SWIFT_RUNTIME_EXPORT
+BoxPair::Return swift_allocBox(Metadata const *type) SWIFT_CC(swift);
+
+SWIFT_RUNTIME_EXPORT
+BoxPair::Return (*_swift_allocBox)(Metadata const *type) SWIFT_CC(swift);
+
+#else
+
 SWIFT_RUNTIME_EXPORT
 BoxPair::Return swift_allocBox(Metadata const *type);
 
 SWIFT_RUNTIME_EXPORT
 BoxPair::Return (*_swift_allocBox)(Metadata const *type);
 
+#endif
+
 /// Performs a uniqueness check on the pointer to a box structure. If the check
 /// fails allocates a new box and stores the pointer in the buffer.
 ///
 ///  if (!isUnique(buffer[0]))
 ///    buffer[0] = swift_allocBox(type)
+#if defined(__linux__) && defined(__s390x__)
+SWIFT_RUNTIME_EXPORT
+BoxPair::Return swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
+                                    size_t alignMask) SWIFT_CC(swift);
+#else
 SWIFT_RUNTIME_EXPORT
 BoxPair::Return swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
+#endif
 
 /// Returns the address of a heap object representing all empty box types.
 SWIFT_RUNTIME_EXPORT

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -162,9 +162,21 @@ void EnumPayload::insertValue(IRGenFunction &IGF, llvm::Value *value,
         subvalue = IGF.Builder.CreateLShr(subvalue,
                                llvm::ConstantInt::get(valueIntTy, valueOffset));
       subvalue = IGF.Builder.CreateZExtOrTrunc(subvalue, payloadIntTy);
+#if defined(__BIG_ENDIAN__)
+      if ((valueBitWidth == 32 || valueBitWidth == 16 || valueBitWidth == 8 || valueBitWidth == 1) &&
+          payloadBitWidth > (payloadValueOffset + valueBitWidth)) {
+        unsigned shiftBitWidth = valueBitWidth;
+        if (valueBitWidth == 1) {
+          shiftBitWidth = 8;
+        }
+        subvalue = IGF.Builder.CreateShl(subvalue,
+          llvm::ConstantInt::get(payloadIntTy, (payloadBitWidth - shiftBitWidth) - payloadValueOffset));
+      }
+#else
       if (payloadValueOffset > 0)
         subvalue = IGF.Builder.CreateShl(subvalue,
                       llvm::ConstantInt::get(payloadIntTy, payloadValueOffset));
+#endif
       
       // If there hasn't yet been a value stored here, we can use the adjusted
       // value directly.
@@ -218,9 +230,21 @@ llvm::Value *EnumPayload::extractValue(IRGenFunction &IGF, llvm::Type *type,
         llvm::IntegerType::get(IGF.IGM.getLLVMContext(), payloadBitWidth);
 
       value = IGF.Builder.CreateBitOrPointerCast(value, payloadIntTy);
+#if defined(__BIG_ENDIAN__)
+      if ((valueBitWidth == 32 || valueBitWidth == 16 || valueBitWidth == 8 || valueBitWidth == 1) &&
+          payloadBitWidth > (payloadValueOffset + valueBitWidth)) {
+        unsigned shiftBitWidth = valueBitWidth;
+        if (valueBitWidth == 1) {
+          shiftBitWidth = 8;
+        }
+        value = IGF.Builder.CreateLShr(value,
+          llvm::ConstantInt::get(value->getType(), (payloadBitWidth - shiftBitWidth) - payloadValueOffset));
+      }
+#else
       if (payloadValueOffset > 0)
         value = IGF.Builder.CreateLShr(value,
                   llvm::ConstantInt::get(value->getType(), payloadValueOffset));
+#endif
       if (valueBitWidth > payloadBitWidth)
         value = IGF.Builder.CreateZExt(value, valueIntTy);
       if (valueOffset > 0)

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3952,6 +3952,12 @@ namespace {
       } else if (CommonSpareBits.size() > 0) {
         // Otherwise the payload is just the index.
         payload = EnumPayload::zero(IGM, PayloadSchema);
+#if defined(__BIG_ENDIAN__) && defined(__LP64__)
+        // Code produced above are of type IGM.Int32Ty
+        // However, payload is IGM.SizeTy in 64bit
+        if (numCaseBits >= 64)
+          tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
+#endif
         // We know we won't use more than numCaseBits from tagIndex's value:
         // We made sure of this in the logic above.
         payload.insertValue(IGF, tagIndex, 0,

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -203,10 +203,16 @@ public:
 
 static SimpleGlobalCache<BoxCacheEntry> Boxes;
 
+#if defined(__linux__) && defined(__s390x__)
+SWIFT_CC(swift)
+#endif
 BoxPair::Return swift::swift_allocBox(const Metadata *type) {
   return SWIFT_RT_ENTRY_REF(swift_allocBox)(type);
 }
 
+#if defined(__linux__) && defined(__s390x__)
+SWIFT_CC(swift)
+#endif
 BoxPair::Return swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *type,
                                     size_t alignMask) {
   auto *inlineBuffer = reinterpret_cast<ValueBuffer*>(buffer);
@@ -232,6 +238,9 @@ BoxPair::Return swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *
   }
 }
 
+#if defined(__linux__) && defined(__s390x__)
+SWIFT_CC(swift)
+#endif
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 BoxPair::Return SWIFT_RT_ENTRY_IMPL(swift_allocBox)(const Metadata *type) {


### PR DESCRIPTION
We need to use Swift calling convention when dealing with BoxPair on s390x. BoxPair is expected to be returned in 2 registers but there is no native C type that is returned in two registers by the default ABI on s390x.

The second commit fixes the way enum payloads are packed for big endian order. (same fix already merged on master: https://github.com/apple/swift/pull/12778)

Both of these commits resolve test failures on s390x therefore no new test cases are added.