### PR TITLE
[docs][Windows] Add LLVM_TARGETS_TO_BUILD flag to LLVM CMake invocation

### DIFF
--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -108,6 +108,7 @@ cmake -G "Ninja"^
  -DLLVM_TOOL_COMPILER_RT_BUILD=TRUE^
  -DLLVM_BUILD_EXTERNAL_COMPILER_RT=TRUE^
  -DLLVM_LIT_ARGS=-sv^
+ -DLLVM_TARGETS_TO_BUILD=X86
  "%swift_source_dir%/llvm"
 popd
 cmake --build "%swift_source_dir%/build/Ninja-DebugAssert/llvm-windows-amd64"


### PR DESCRIPTION
Not including this flag lead to issues during the LLVM build 