### PR TITLE
Runtime: Don't append local discriminators to locally defined type names.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -47,6 +47,7 @@ struct DemangleOptions {
   bool ShortenThunk = false;
   bool ShortenValueWitness = false;
   bool ShortenArchetype = false;
+  bool ShowLocalDiscriminators = true;
   bool ShowPrivateDiscriminators = true;
   bool ShowFunctionArgumentTypes = true;
 
@@ -67,6 +68,7 @@ struct DemangleOptions {
     Opt.ShortenThunk = true;
     Opt.ShortenValueWitness = true;
     Opt.ShortenArchetype = true;
+    Opt.ShowLocalDiscriminators = false;
     Opt.ShowPrivateDiscriminators = false;
     Opt.ShowFunctionArgumentTypes = false;
     return Opt;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1007,7 +1007,8 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
                        /*hasName*/true);
   case Node::Kind::LocalDeclName:
     print(Node->getChild(1));
-    Printer << " #" << (Node->getChild(0)->getIndex() + 1);
+    if (Options.ShowLocalDiscriminators)
+      Printer << " #" << (Node->getChild(0)->getIndex() + 1);
     return nullptr;
   case Node::Kind::PrivateDeclName:
     if (Node->getNumChildren() > 1) {

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -100,8 +100,10 @@ static void _buildNameForMetadata(const Metadata *type,
 
   Demangle::DemangleOptions options;
   options.QualifyEntities = qualified;
-  if (!qualified)
+  if (!qualified) {
+    options.ShowLocalDiscriminators = false;
     options.ShowPrivateDiscriminators = false;
+  }
   result = Demangle::nodeToString(demangling, options);
 }
 

--- a/test/SILGen/generic_local_property.swift
+++ b/test/SILGen/generic_local_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 func use<T>(_: T) {}
 
@@ -21,10 +21,10 @@ func foo<T>(x: T, y: Int) {
     }
   }
 
-  // CHECK-LABEL: function_ref getter of readonly #1 in foo<A>(x:y:)
+  // CHECK: function_ref getter of readonly #1 : Swift.Int in generic_local_property.foo<A>(x: A, y: Swift.Int) -> ()
   _ = readonly
-  // CHECK-LABEL: function_ref getter of mutable #1 in foo<A>(x:y:)
+  // CHECK-LABEL: function_ref getter of mutable #1 : Swift.Int in generic_local_property.foo<A>(x: A, y: Swift.Int) -> ()
   _ = mutable
-  // CHECK-LABEL: function_ref setter of mutable #1 in foo<A>(x:y:)
+  // CHECK-LABEL: function_ref setter of mutable #1 : Swift.Int in generic_local_property.foo<A>(x: A, y: Swift.Int) -> ()
   mutable = y
 }

--- a/test/stdlib/StringDescribing.swift
+++ b/test/stdlib/StringDescribing.swift
@@ -22,4 +22,19 @@ StringDescribingTestSuite.test("String(reflecting:) should include extra stuff i
   expectEqual(privateName.suffix(5), ").Foo")
 }
 
+StringDescribingTestSuite.test("String(describing:) shouldn't include local discriminator") {
+  class LocalType {}
+  let t = LocalType()
+  expectEqual(String(describing: type(of: t)), "LocalType")
+}
+
+StringDescribingTestSuite.test("String(reflecting:) should uniquely qualify type name") {
+  class LocalType {}
+  let t = LocalType()
+  let representation = String(reflecting: type(of: t))
+
+  expectEqual(representation.prefix(6), "main.(")
+  expectEqual(representation.suffix(11), ").LocalType")
+}
+
 runAllTests()


### PR DESCRIPTION
If a type was defined locally, a printed representation of an instance of that
type would contain a local discriminator. Introducing an additional demangling
option allows to opt out of this behaviour.

Resolves [SR-6787](https://bugs.swift.org/browse/SR-6787).