### PR TITLE
[+0-all-args] Fix const_cast issue.

### DIFF
--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -179,8 +179,8 @@ void _swift_makeAnyHashableUpcastingToHashableBaseType(
         type->vw_destroy(value);
 #else
         _swift_makeAnyHashableUpcastingToHashableBaseType(
-            unboxedValue, anyHashableResultPointer, unboxedType,
-            unboxedHashableWT);
+            const_cast<OpaqueValue *>(unboxedValue), anyHashableResultPointer,
+            unboxedType, unboxedHashableWT);
 #endif
         return;
       }


### PR DESCRIPTION
This is hidden behind the +0 preprocessor flag, so it only affected me.

NFC.

rdar://34120147
