### PR TITLE
Fix two issues which prevents incremental llvm compilation

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -478,10 +478,17 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
 }
 
 // Lifted from the clang driver.
-static void PrintArg(raw_ostream &OS, const char *Arg, bool Quote) {
+static void PrintArg(raw_ostream &OS, const char *Arg, StringRef TempDir) {
   const bool Escape = std::strpbrk(Arg, "\"\\$ ");
 
-  if (!Quote && !Escape) {
+  if (StringRef(Arg).startswith(TempDir)) {
+    // Don't write temporary file names in the debug info. This would prevent
+    // incremental llvm compilation because we would generate different IR on
+    // every compiler invocation.
+    Arg = "<temporary-file>";
+  }
+
+  if (!Escape) {
     OS << Arg;
     return;
   }
@@ -705,9 +712,14 @@ void CompilerInvocation::buildDWARFDebugFlags(std::string &Output,
                                               const ArrayRef<const char*> &Args,
                                               StringRef SDKPath,
                                               StringRef ResourceDir) {
+  // This isn't guaranteed to be the same temp directory as what the driver
+  // uses, but it's highly likely.
+  llvm::SmallString<128> TDir;
+  llvm::sys::path::system_temp_directory(true, TDir);
+
   llvm::raw_string_ostream OS(Output);
   interleave(Args,
-             [&](const char *Argument) { PrintArg(OS, Argument, false); },
+             [&](const char *Argument) { PrintArg(OS, Argument, TDir.str()); },
              [&] { OS << " "; });
 
   // Inject the SDK path and resource dir if they are nonempty and missing.
@@ -723,11 +735,11 @@ void CompilerInvocation::buildDWARFDebugFlags(std::string &Output,
   }
   if (!haveSDKPath) {
     OS << " -sdk ";
-    PrintArg(OS, SDKPath.data(), false);
+    PrintArg(OS, SDKPath.data(), TDir.str());
   }
   if (!haveResourceDir) {
     OS << " -resource-dir ";
-    PrintArg(OS, ResourceDir.data(), false);
+    PrintArg(OS, ResourceDir.data(), TDir.str());
   }
 }
 

--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -21,3 +21,8 @@
 // CHECK-LLDB-NOT: debug_pubnames
 // CHECK-LLDB:     apple_names
 // CHECK-LLDB-NOT: debug_pubnames
+
+// Check that we don't write temporary file names in the debug info
+// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -o - | %FileCheck --check-prefix CHECK-TEMP %s
+// CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>
+

--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -23,6 +23,7 @@ from __future__ import print_function
 import os
 import subprocess
 import sys
+import time
 
 
 VERBOSE = False
@@ -37,11 +38,11 @@ def compile_and_stat(compile_args, output_file):
     subprocess.check_call(compile_args)
 
     md5 = subprocess.check_output(["md5", "-q", output_file])
-    mtime = os.path.getmtime(output_file)
+    mtime = time.ctime(os.path.getmtime(output_file))
 
     if VERBOSE:
-        print("  time = {}".format(md5))
-        print("  md5 = " + mtime)
+        print(" time = " + str(mtime))
+        print("  md5 = " + md5)
 
     return (md5, mtime)
 


### PR DESCRIPTION
* debug-info: Don't write temporary file names in the debug info.

This would prevent incremental llvm compilation because we would generate different IR on every compiler invocation.

* SILCombiner: fix a non-determinism in a peephole optimization for load instructions.

rdar://problem/37253518