### PR TITLE
[4.1] Fix wrong missing-return error message for an initializer returning an implicitly unwrapped optional

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -223,7 +223,7 @@ SILGenFunction::emitPreconditionOptionalHasValue(SILLocation loc,
                                 SGFContext());
   }
 
-  B.createUnreachable(loc);
+  B.createUnreachable(ArtificialUnreachableLocation());
   B.clearInsertionPoint();
   B.emitBlock(contBB);
 

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -97,7 +97,7 @@ func whileLoop(flag: Bool) -> Int {
 struct S {}
 extension S:ExpressibleByStringLiteral {
   init!(stringLiteral:String) {
-  } // expected-error {{missing return in a function expected to return 'S!'}}
+  } // no error
 }
 
 func whileTrueLoop() -> Int {
@@ -150,3 +150,12 @@ func testCleanupCodeEmptyTuple(fn: @autoclosure () -> Bool = false,
     exit()
   }
 } // no warning
+
+protocol InitProtocol {
+  init(_ x: Int)
+}
+
+struct StructWithIUOinit : InitProtocol {
+  init!(_ x: Int) {  } // no missing-return error
+}
+


### PR DESCRIPTION
The problem was that the unreachable instruction after the IUO unwrapping error call was interpreted as missing-return-unreachable.

rdar://problem/36611041

**Explanation**: The compiler prints a wrong missing-return error message for "init!()" initializers.
**Scope**: Affects initializers in a protocol conformance.
**Radar (and possibly SR Issue)**: rdar://problem/36611041
**Reviewed by**: Graydon
**Risk**: Low. It's a simple one-line change.