### PR TITLE
[5.0][stdlib] Set, Dictionary: Take the max load factor into account in .init(minimumCapacity:)

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -477,9 +477,12 @@ extension Set {
   ///   buffer.
   @_inlineable // FIXME(sil-serialize-all)
   public init(minimumCapacity: Int) {
+    let reservedCapacity = _NativeBuffer.minimumCapacity(
+      minimumCount: minimumCapacity,
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
     _variantBuffer =
       _VariantBuffer.native(
-        _NativeBuffer(minimumCapacity: minimumCapacity))
+        _NativeBuffer(minimumCapacity: reservedCapacity))
   }
 
   /// Private initializer.
@@ -1751,8 +1754,11 @@ public struct Dictionary<Key : Hashable, Value> {
   ///   allocate buffer for in the new dictionary.
   @_inlineable // FIXME(sil-serialize-all)
   public init(minimumCapacity: Int) {
+    let reservedCapacity = _NativeBuffer.minimumCapacity(
+      minimumCount: minimumCapacity,
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
     _variantBuffer =
-      .native(_NativeBuffer(minimumCapacity: minimumCapacity))
+      .native(_NativeBuffer(minimumCapacity: reservedCapacity))
   }
 
   /// Creates a new dictionary from the key-value pairs in the given sequence.
@@ -4027,7 +4033,7 @@ extension _Native${Self}Buffer
     maxLoadFactorInverse: Double
   ) -> Int {
     // `minimumCount + 1` below ensures that we don't fill in the last hole
-    return max(Int(Double(minimumCount) * maxLoadFactorInverse),
+    return max(Int((Double(minimumCount) * maxLoadFactorInverse).rounded(.up)),
                minimumCount + 1)
   }
 
@@ -6402,11 +6408,7 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
 
   @_inlineable // FIXME(sil-serialize-all)
   public init(count: Int) {
-    let requiredCapacity =
-      _Native${Self}Buffer<${TypeParameters}>.minimumCapacity(
-        minimumCount: count,
-        maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    _result = ${Self}<${TypeParameters}>(minimumCapacity: requiredCapacity)
+    _result = ${Self}<${TypeParameters}>(minimumCapacity: count)
     _nativeBuffer = _result._variantBuffer.asNative
     _requestedCount = count
     _actualCount = 0
@@ -6505,6 +6507,7 @@ extension ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func reserveCapacity(_ minimumCapacity: Int) {
     _variantBuffer.reserveCapacity(minimumCapacity)
+    _sanityCheck(self.capacity >= minimumCapacity)
   }
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1723,6 +1723,29 @@ DictionaryTestSuite.test("mapValues(_:)") {
   }
 }
 
+DictionaryTestSuite.test("capacity/init(minimumCapacity:)") {
+  let d0 = Dictionary<String, Int>(minimumCapacity: 0)
+  expectGE(d0.capacity, 0)
+
+  let d1 = Dictionary<String, Int>(minimumCapacity: 1)
+  expectGE(d1.capacity, 1)
+
+  let d3 = Dictionary<String, Int>(minimumCapacity: 3)
+  expectGE(d3.capacity, 3)
+
+  let d4 = Dictionary<String, Int>(minimumCapacity: 4)
+  expectGE(d4.capacity, 4)
+
+  let d10 = Dictionary<String, Int>(minimumCapacity: 10)
+  expectGE(d10.capacity, 10)
+
+  let d100 = Dictionary<String, Int>(minimumCapacity: 100)
+  expectGE(d100.capacity, 100)
+
+  let d1024 = Dictionary<String, Int>(minimumCapacity: 1024)
+  expectGE(d1024.capacity, 1024)
+}
+
 DictionaryTestSuite.test("capacity/reserveCapacity(_:)") {
   var d1 = [10: 1010, 20: 1020, 30: 1030]
   expectEqual(3, d1.capacity)
@@ -2314,8 +2337,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithKey") {
 
   // Insert a new key-value pair.
   d[TestBridgedKeyTy(40)] = TestBridgedValueTy(2040)
+
   var identity2 = d._rawIdentifier()
-  assert(identity1 != identity2)
+  // Storage identity may or may not change depending on allocation behavior.
+  // (d is eagerly bridged to a regular uniquely referenced native Dictionary.)
+  //assert(identity1 != identity2)
+
   assert(isNativeDictionary(d))
   assert(d.count == 4)
 
@@ -2403,7 +2430,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.UpdateValueForKey") {
         d.updateValue(TestBridgedValueTy(2040), forKey: TestBridgedKeyTy(40))
     assert(oldValue == nil)
     var identity2 = d._rawIdentifier()
-    assert(identity1 != identity2)
+    // Storage identity may or may not change depending on allocation behavior.
+    // (d is eagerly bridged to a regular uniquely referenced native Dictionary.)
+    //assert(identity1 != identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 4)
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1418,7 +1418,10 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Insert") {
     s.insert(TestObjCKeyTy(2040) as TestBridgedKeyTy)
 
     var identity2 = s._rawIdentifier()
-    expectNotEqual(identity1, identity2)
+    // Storage identity may or may not change depending on allocation behavior.
+    // (s is eagerly bridged to a regular uniquely referenced native Set.)
+    //expectNotEqual(identity1, identity2)
+
     expectTrue(isNativeSet(s))
     expectEqual(4, s.count)
 
@@ -1572,10 +1575,13 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
 
   expectEqual(identity1, s._rawIdentifier())
 
-  // Inserting an item should now create storage unique from the bridged set.
   s.insert(TestBridgedKeyTy(4040))
   var identity2 = s._rawIdentifier()
-  expectNotEqual(identity1, identity2)
+
+  // Storage identity may or may not change depending on allocation behavior.
+  // (s is eagerly bridged to a regular uniquely referenced native Set.)
+  //expectNotEqual(identity1, identity2)
+
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
 
@@ -3153,6 +3159,29 @@ SetTestSuite.test("first") {
 
   expectTrue(s1.contains(s1.first!))
   expectNil(emptySet.first)
+}
+
+SetTestSuite.test("capacity/init(minimumCapacity:)") {
+  let s0 = Set<String>(minimumCapacity: 0)
+  expectGE(s0.capacity, 0)
+
+  let s1 = Set<String>(minimumCapacity: 1)
+  expectGE(s1.capacity, 1)
+
+  let s3 = Set<String>(minimumCapacity: 3)
+  expectGE(s3.capacity, 3)
+
+  let s4 = Set<String>(minimumCapacity: 4)
+  expectGE(s4.capacity, 4)
+
+  let s10 = Set<String>(minimumCapacity: 10)
+  expectGE(s10.capacity, 10)
+
+  let s100 = Set<String>(minimumCapacity: 100)
+  expectGE(s100.capacity, 100)
+
+  let s1024 = Set<String>(minimumCapacity: 1024)
+  expectGE(s1024.capacity, 1024)
 }
 
 SetTestSuite.test("capacity/reserveCapacity(_:)") {


### PR DESCRIPTION
• Explanation: Set, Dictionary.init(minimumCapacity:) did not allocate enough storage to actually hold the requested number of items.
• Scope of Issue: Mostly a performance issue; it results in one unexpected storage reallocation while elements are added to the collection.
• Origination: It looks like this has been like this forever.
• Risk: Low risk. Increasing allocated capacity is unlikely to break code.
• Reviewed By: @natecook1000
• Testing: Stdlib regression tests, including new tests.
• Radar / SR: rdar://problem/36619317