### PR TITLE
[stdlib] Collection compatibility shim fixes

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1707,11 +1707,11 @@ extension Collection {
     return index(i, offsetBy: Int(n))
   }
   @available(*, deprecated, message: "all index distances are now of type Int")
-  public func formIndex<T: BinaryInteger>(_ i: Index, offsetBy n: T) {
-    return formIndex(i, offsetBy: Int(n))
+  public func formIndex<T: BinaryInteger>(_ i: inout Index, offsetBy n: T) {
+    return formIndex(&i, offsetBy: Int(n))
   }
   @available(*, deprecated, message: "all index distances are now of type Int")
-  public func index<T: BinaryInteger>(_ i: Index, offsetBy n: T, limitedBy limit: Index) -> Index {
+  public func index<T: BinaryInteger>(_ i: Index, offsetBy n: T, limitedBy limit: Index) -> Index? {
     return index(i, offsetBy: Int(n), limitedBy: limit)
   }
   @available(*, deprecated, message: "all index distances are now of type Int")

--- a/test/stdlib/CollectionCompatibility.swift
+++ b/test/stdlib/CollectionCompatibility.swift
@@ -1,0 +1,56 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+//===--- MyCollection -----------------------------------------------------===//
+/// A simple collection that attempts to use an Int16 IndexDistance
+struct MyCollection<Element>: Collection {
+  var _elements: [Element]
+  
+  typealias IndexDistance = Int16
+  typealias Index = Int16
+  
+  var startIndex: Index { return 0 }
+  var endIndex: Index { return numericCast(_elements.count) }
+  
+  subscript(i: Index) -> Element { return _elements[Int(i)] }
+
+  func index(after: Index) -> Index { return after+1 }
+}
+
+let CollectionDistance = TestSuite("Collection.IndexDistance")
+
+CollectionDistance.test("Int16/distance") {
+  let c = MyCollection<Int>(_elements: [1,2,3])
+  let d: Int16 = c.distance(from: c.startIndex, to: c.endIndex)
+  expectEqual(3, d)
+  // without type context, you now get an Int
+  var i = c.distance(from: c.startIndex, to: c.endIndex)
+  expectType(Int.self, &i)
+  expectType(MyCollection<Int>.IndexDistance.self, &i)
+}
+
+CollectionDistance.test("Int16/advance") {
+  let c = MyCollection<Int>(_elements: [1,2,3])
+  let d: Int16 = 1
+  var i = c.index(c.startIndex, offsetBy: d)
+  expectEqual(1, i)
+  c.formIndex(&i, offsetBy: d)
+  expectEqual(2, i)
+  var j = c.index(c.startIndex, offsetBy: d, limitedBy: c.endIndex)
+  expectEqual(1, j)
+  var b = c.formIndex(&i, offsetBy: d, limitedBy: c.endIndex)
+  expectTrue(b)
+  expectEqual(3, i)
+  b = c.formIndex(&i, offsetBy: d+5, limitedBy: c.endIndex)
+  expectFalse(b)
+  expectEqual(3, i)
+  let k = c.index(c.startIndex, offsetBy: d+5, limitedBy: c.endIndex)
+  expectEqual(nil, k)
+}
+
+runAllTests()


### PR DESCRIPTION
A couple of the compatibility shims for the removal of `Collection.IndexDistance` weren't matching the signatures of the methods they were shimming, causing infinite recursion when called (because they were calling themselves). This fixes that and adds tests to confirm they're working.