### PR TITLE
[metadata] Add dump to Metadata.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -20,6 +20,7 @@
 #define SWIFT_ABI_METADATAVALUES_H
 
 #include "swift/AST/Ownership.h"
+#include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Unreachable.h"
 
 #include <stdlib.h>
@@ -60,6 +61,8 @@ inline MetadataKind getEnumeratedMetadataKind(uint64_t kind) {
     return MetadataKind::Class;
   return MetadataKind(kind);
 }
+
+StringRef getStringForMetadataKind(MetadataKind kind);
 
 /// Kinds of Swift nominal type descriptor records.
 enum class NominalTypeKind : uint32_t {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -956,6 +956,11 @@ public:
   }
 #endif
 
+#ifndef NDEBUG
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "Only meant for use in the debugger");
+#endif
+
 protected:
   friend struct TargetOpaqueMetadata<Runtime>;
   

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2730,6 +2730,28 @@ void _swift_debug_verifyTypeLayoutAttribute(Metadata *type,
 }
 #endif
 
+StringRef swift::getStringForMetadataKind(MetadataKind kind) {
+  switch (kind) {
+#define METADATAKIND(NAME, VALUE) \
+    case MetadataKind::NAME: \
+      return #NAME;
+#include "swift/ABI/MetadataKind.def"
+  }
+
+  swift_runtime_unreachable("Unhandled metadata kind?!");
+}
+
+#ifndef NDEBUG
+template <> void Metadata::dump() const {
+  printf("TargetMetadata.\n");
+  printf("Kind: %s.\n", getStringForMetadataKind(getKind()).data());
+  printf("Value Witnesses: %p.\n", getValueWitnesses());
+  printf("Class Object: %p.\n", getClassObject());
+  printf("Type Context Description: %p.\n", getTypeContextDescriptor());
+  printf("Generic Args: %p.\n", getGenericArgs());
+}
+#endif
+
 /***************************************************************************/
 /*** Protocol witness tables ***********************************************/
 /***************************************************************************/


### PR DESCRIPTION
We dump the following information:

1. The Kind.
2. Pointer to the value witnesses.
3. Pointer to the class object if one is available.
4. Pointer the type context description if one is available.
5. Pointer to the generic arguments if one is available.

This makes it significantly easier to poke around Metadata.

rdar://34222540