### PR TITLE
IDE: provide const overload for `operator*`

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -510,6 +510,7 @@ class FormatWalker : public SourceEntityWalker {
       bool operator==(const SourceLocIterator& rhs) {return It==rhs.It;}
       bool operator!=(const SourceLocIterator& rhs) {return It!=rhs.It;}
       SourceLoc operator*() {return It->getLoc();}
+      const SourceLoc operator*() const { return It->getLoc(); }
     };
 
     void adjustTokenIteratorToImmediateAfter(SourceLoc End) {


### PR DESCRIPTION
Provide a const overload for `operator*` for `SourceLocIterator` as the
MSVC C++ runtime uses the const overload for the `std::lower_bound`
algorithm.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
