### PR TITLE
[build-script] Smoke test lldb with asserts enabled

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -553,6 +553,7 @@ lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release
 lldb-test-swift-only
+lldb-assertions
 
 # Don't build the benchmarks
 skip-build-benchmarks


### PR DESCRIPTION
This should make it more convenient and valuable to sprinkle asserts (well, lldbassert()) around the codebase.