### PR TITLE
[Runtime] Evaluate same-type requirements at runtime.

### DIFF
--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -183,6 +183,14 @@ namespace swift {
   using SubstGenericParameterFn =
     llvm::function_ref<const Metadata *(unsigned depth, unsigned index)>;
 
+  /// Retrieve the type metadata described by the given type name.
+  ///
+  /// \p substGenericParam Function that provides generic argument metadata
+  /// given a particular generic parameter specified by depth/index.
+  const Metadata *_getTypeByMangledName(
+                                    StringRef typeName,
+                                    SubstGenericParameterFn substGenericParam);
+
   /// FIXME: Remove once this is in Metadata.h
   using GenericRequirementDescriptor =
     TargetGenericRequirementDescriptor<InProcess>;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -744,6 +744,20 @@ bool swift::_checkGenericRequirements(
       continue;
     }
 
+    case GenericRequirementKind::SameType: {
+      // Demangle the second type under the given substitutions.
+      auto otherType =
+        _getTypeByMangledName(req.getMangledTypeName(), substGenericParam);
+      if (!otherType) return true;
+
+      assert(!req.getFlags().hasExtraArgument());
+
+      // Check that the types are equivalent.
+      if (subjectType != otherType) return true;
+
+      continue;
+    }
+
     // FIXME: Handle all of the other cases.
     default:
       return true;

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -278,5 +278,36 @@ DemangleToMetadataTests.test("associated type conformance requirements") {
   expectNil(_typeByMangledName("4main3SG5VyAA12ConformsToP1cVG"))
 }
 
+struct SG6<T: P4> where T.Assoc1 == T.Assoc2 { }
+struct SG7<T: P4> where T.Assoc1 == Int { }
+struct SG8<T: P4> where T.Assoc1 == [T.Assoc2] { }
+
+struct ConformsToP4d : P4 {
+  typealias Assoc1 = [ConformsToP2]
+  typealias Assoc2 = ConformsToP2
+}
+
+DemangleToMetadataTests.test("same-type requirements") {
+  // Concrete type.
+  expectEqual(SG7<S>.self,
+    _typeByMangledName("4main3SG7VyAA1SVG")!)
+
+  // Other associated type.
+  expectEqual(SG6<ConformsToP4b>.self,
+    _typeByMangledName("4main3SG6VyAA13ConformsToP4bVG")!)
+  expectEqual(SG6<ConformsToP4c>.self,
+    _typeByMangledName("4main3SG6VyAA13ConformsToP4cVG")!)
+
+  // Structural type.
+  expectEqual(SG8<ConformsToP4d>.self,
+    _typeByMangledName("4main3SG8VyAA13ConformsToP4dVG")!)
+
+  // Failure cases: types don't match.
+  expectNil(_typeByMangledName("4main3SG7VyAA13ConformsToP4aVG"))
+  expectNil(_typeByMangledName("4main3SG6VyAA13ConformsToP4aVG"))
+  expectNil(_typeByMangledName("4main3SG8VyAA13ConformsToP4cVG"))
+}
+
+
 runAllTests()
 


### PR DESCRIPTION
Extend the runtime's ability for evaluating generic requirements to
handle same-type requirements, demangling/substituting the name from
the generic requirement metadata.
