### PR TITLE
[Runtime] Dynamically evaluate AnyObject and superclass constraints.

### DIFF
--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -183,6 +183,14 @@ namespace swift {
   using SubstGenericParameterFn =
     llvm::function_ref<const Metadata *(unsigned depth, unsigned index)>;
 
+  /// Retrieve the type metadata described by the given type name.
+  ///
+  /// \p substGenericParam Function that provides generic argument metadata
+  /// given a particular generic parameter specified by depth/index.
+  const Metadata *_getTypeByMangledName(
+                                    StringRef typeName,
+                                    SubstGenericParameterFn substGenericParam);
+
   /// FIXME: Remove once this is in Metadata.h
   using GenericRequirementDescriptor =
     TargetGenericRequirementDescriptor<InProcess>;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -744,6 +744,20 @@ bool swift::_checkGenericRequirements(
       continue;
     }
 
+    case GenericRequirementKind::SameType: {
+      // Demangle the second type under the given substitutions.
+      auto otherType =
+        _getTypeByMangledName(req.getMangledTypeName(), substGenericParam);
+      if (!otherType) return true;
+
+      assert(!req.getFlags().hasExtraArgument());
+
+      // Check that the types are equivalent.
+      if (subjectType != otherType) return true;
+
+      continue;
+    }
+
     // FIXME: Handle all of the other cases.
     default:
       return true;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -776,15 +776,21 @@ bool swift::_checkGenericRequirements(
         _getTypeByMangledName(req.getMangledTypeName(), substGenericParam);
       if (!baseType) return true;
 
+      // Check whether it's dynamically castable, which works as a superclass
+      // check.
       if (!swift_dynamicCastMetatype(subjectType, baseType)) return true;
 
       continue;
     }
 
-    // FIXME: Handle all of the other cases.
-    default:
-      return true;
+    case GenericRequirementKind::SameConformance: {
+      // FIXME: Implement this check.
+      continue;
     }
+    }
+
+    // Unknown generic requirement kind.
+    return true;
   }
 
   // Success!

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -770,6 +770,17 @@ bool swift::_checkGenericRequirements(
       return true;
     }
 
+    case GenericRequirementKind::BaseClass: {
+      // Demangle the base type under the given substitutions.
+      auto baseType =
+        _getTypeByMangledName(req.getMangledTypeName(), substGenericParam);
+      if (!baseType) return true;
+
+      if (!swift_dynamicCastMetatype(subjectType, baseType)) return true;
+
+      continue;
+    }
+
     // FIXME: Handle all of the other cases.
     default:
       return true;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -758,6 +758,18 @@ bool swift::_checkGenericRequirements(
       continue;
     }
 
+    case GenericRequirementKind::Layout: {
+      switch (req.getLayout()) {
+      case GenericRequirementLayoutKind::Class:
+        // Check whether the subject type is a class.
+        if (!subjectType->isAnyClass()) return true;
+        continue;
+      }
+
+      // Unknown layout.
+      return true;
+    }
+
     // FIXME: Handle all of the other cases.
     default:
       return true;

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -278,5 +278,36 @@ DemangleToMetadataTests.test("associated type conformance requirements") {
   expectNil(_typeByMangledName("4main3SG5VyAA12ConformsToP1cVG"))
 }
 
+struct SG6<T: P4> where T.Assoc1 == T.Assoc2 { }
+struct SG7<T: P4> where T.Assoc1 == Int { }
+struct SG8<T: P4> where T.Assoc1 == [T.Assoc2] { }
+
+struct ConformsToP4d : P4 {
+  typealias Assoc1 = [ConformsToP2]
+  typealias Assoc2 = ConformsToP2
+}
+
+DemangleToMetadataTests.test("same-type requirements") {
+  // Concrete type.
+  expectEqual(SG7<S>.self,
+    _typeByMangledName("4main3SG7VyAA1SVG")!)
+
+  // Other associated type.
+  expectEqual(SG6<ConformsToP4b>.self,
+    _typeByMangledName("4main3SG6VyAA13ConformsToP4bVG")!)
+  expectEqual(SG6<ConformsToP4c>.self,
+    _typeByMangledName("4main3SG6VyAA13ConformsToP4cVG")!)
+
+  // Structural type.
+  expectEqual(SG8<ConformsToP4d>.self,
+    _typeByMangledName("4main3SG8VyAA13ConformsToP4dVG")!)
+
+  // Failure cases: types don't match.
+  expectNil(_typeByMangledName("4main3SG7VyAA13ConformsToP4aVG"))
+  expectNil(_typeByMangledName("4main3SG6VyAA13ConformsToP4aVG"))
+  expectNil(_typeByMangledName("4main3SG8VyAA13ConformsToP4cVG"))
+}
+
+
 runAllTests()
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -318,5 +318,20 @@ DemangleToMetadataTests.test("AnyObject requirements") {
   expectNil(_typeByMangledName("4main3SG9VyAA1SVG"))
 }
 
+struct SG10<T: C> { }
+
+class C2 : C { }
+class C3 { }
+
+DemangleToMetadataTests.test("superclass requirements") {
+  expectEqual(SG10<C>.self,
+    _typeByMangledName("4main4SG10VyAA1CCG")!)
+  expectEqual(SG10<C2>.self,
+    _typeByMangledName("4main4SG10VyAA2C2CG")!)
+
+  // Failure cases: not a subclass.
+  expectNil(_typeByMangledName("4main4SG10VyAA2C3CG"))
+}
+
 runAllTests()
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -308,6 +308,15 @@ DemangleToMetadataTests.test("same-type requirements") {
   expectNil(_typeByMangledName("4main3SG8VyAA13ConformsToP4cVG"))
 }
 
+struct SG9<T: AnyObject> { }
+
+DemangleToMetadataTests.test("AnyObject requirements") {
+  expectEqual(SG9<C>.self,
+    _typeByMangledName("4main3SG9VyAA1CCG")!)
+
+  // Failure cases: failed AnyObject constraint.
+  expectNil(_typeByMangledName("4main3SG9VyAA1SVG"))
+}
 
 runAllTests()
 


### PR DESCRIPTION
Extend support for runtime evaluation of generic requirements to also handle layout constraints (`T: AnyObject`) and superclass constraints (`T: SomeSuperclass`). We can now evaluate the full breadth of generic requirements at runtime, which is currently used to map mangled type names to type metadata (`Any.Type`).