### PR TITLE
[4.1][sourcekitd] Fix crash in onDocumentUpdateNotification

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -209,7 +209,7 @@ std::string sourcekitd::getRuntimeLibPath() {
 }
 
 static void sourcekitdServer_peer_event_handler(xpc_connection_t peer,
-                                            xpc_object_t event) {
+                                                xpc_object_t event) {
   xpc_type_t type = xpc_get_type(event);
   if (type == XPC_TYPE_ERROR) {
     if (event == XPC_ERROR_CONNECTION_INVALID) {
@@ -305,6 +305,10 @@ static void sourcekitdServer_event_handler(xpc_connection_t peer) {
     sourcekitdServer_peer_event_handler(peer, event);
   });
 
+  // Update the main connection
+  xpc_retain(peer);
+  if (MainConnection)
+    xpc_release(MainConnection);
   MainConnection = peer;
 
   // This will tell the connection to begin listening for events. If you


### PR DESCRIPTION
<!-- What's in this pull request? -->
## CCC Info
* **Radar**: rdar://problem/36077481
* **Explanation**:
SourceKit didn't `xpc_retain` a globally stored XPC connection reference, `MainConnection`, allowing it to be used in an invalid state. This happened if the client cancelled the connection or crashed while SourceKit was busy gathering semantic information for a document. SourceKit would use the invalid connection to try to notify the client when it finished and crash.

* **Risk**: Low. This is simply adding a retain call.
* **Scope of issue**: One of the top SourceKit crashes
* **Origination**: It looks like this issue has always existed.
* **Reviewed by**: Argyrios Kyrtzidis
* **Testing**: Cancelled the connection from the client with an outstanding semantic operation before and after the changes to verify the fix. Manually tested changes against Xcode 9.2GM and 9.3 beta 1 with basic editing, completions, navigation etc. in new projects.

**PR for swift-4.1-branch**: https://github.com/apple/swift/pull/14353
**PR for master**: https://github.com/apple/swift/pull/14355
**PR for swift-5.0-branch**: https://github.com/apple/swift/pull/14354