### PR TITLE
stdlib: remove vestigial SWIFT_USE_SWIFTCALL

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -58,11 +58,6 @@ using namespace swift;
 #error "The runtime must be built with a compiler that supports swiftcall."
 #endif
 
-// Check that the user isn't manually disabling SWIFTCALL.
-#if defined(SWIFT_USE_SWIFTCALL) && !SWIFT_USE_SWIFTCALL
-#error "SWIFT_USE_SWIFTCALL=0 is not supported; swiftcall must always be used."
-#endif
-
 /// Returns true if the pointer passed to a native retain or release is valid.
 /// If false, the operation should immediately return.
 static inline bool isValidPointerForNativeRetain(const void *p) {


### PR DESCRIPTION
Remove the last vestiges of `SWIFT_USE_SWIFTCALL`.  Building without
SwiftCC is no longer supported.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
