### PR TITLE
[stdlib] Remove outdated miscellaneous functions

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -14,13 +14,6 @@
 
 // FIXME: Once we have an FFI interface, make these have proper function bodies
 
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public // @testable
-func _countLeadingZeros(_ value: Int64) -> Int64 {
-    return Int64(Builtin.int_ctlz_Int64(value._value, false._value))
-}
-
 /// Returns if `x` is a power of 2.
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
@@ -131,26 +124,4 @@ func _typeByMangledName(_ name: String,
                                   parametersPerLevel,
                                   flatSubstitutions)
   }
-}
-
-/// Returns `floor(log(x))`.  This equals to the position of the most
-/// significant non-zero bit, or 63 - number-of-zeros before it.
-///
-/// The function is only defined for positive values of `x`.
-///
-/// Examples:
-///
-///      floorLog2(1) == 0
-///      floorLog2(2) == floorLog2(3) == 1
-///      floorLog2(9) == floorLog2(15) == 3
-///
-/// TODO: Implement version working on Int instead of Int64.
-@_inlineable // FIXME(sil-serialize-all)
-@_transparent
-public // @testable
-func _floorLog2(_ x: Int64) -> Int {
-  _sanityCheck(x > 0, "_floorLog2 operates only on non-negative integers")
-  // Note: use unchecked subtraction because we this expression cannot
-  // overflow.
-  return 63 &- Int(_countLeadingZeros(x))
 }

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -245,7 +245,7 @@ func _introSort<C>(
   }
   // Set max recursion depth to 2*floor(log(N)), as suggested in the introsort
   // paper: http://www.cs.rpi.edu/~musser/gp/introsort.ps
-  let depthLimit = 2 * _floorLog2(Int64(count))
+  let depthLimit = 2 * count._binaryLogarithm()
   ${try_} _introSortImpl(
     &elements,
     subRange: range,

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -1566,16 +1566,6 @@ Reflection.test("SetIterator/Mirror") {
 
 var BitTwiddlingTestSuite = TestSuite("BitTwiddling")
 
-func computeCountLeadingZeroes(_ x: Int64) -> Int64 {
-  var x = x
-  var r: Int64 = 64
-  while x != 0 {
-    x >>= 1
-    r -= 1
-  }
-  return r
-}
-
 BitTwiddlingTestSuite.test("_pointerSize") {
 #if arch(i386) || arch(arm)
   expectEqual(4, MemoryLayout<Optional<AnyObject>>.size)
@@ -1584,13 +1574,6 @@ BitTwiddlingTestSuite.test("_pointerSize") {
 #else
   fatalError("implement")
 #endif
-}
-
-BitTwiddlingTestSuite.test("_countLeadingZeros") {
-  for i in Int64(0)..<1000 {
-    expectEqual(computeCountLeadingZeroes(i), _countLeadingZeros(i))
-  }
-  expectEqual(0, _countLeadingZeros(Int64.min))
 }
 
 BitTwiddlingTestSuite.test("_isPowerOf2/Int") {
@@ -1629,13 +1612,6 @@ BitTwiddlingTestSuite.test("_isPowerOf2/UInt") {
   expectTrue(_isPowerOf2(asUInt(1024)))
   expectTrue(_isPowerOf2(asUInt(0x8000_0000)))
   expectFalse(_isPowerOf2(UInt.max))
-}
-
-BitTwiddlingTestSuite.test("_floorLog2") {
-  expectEqual(_floorLog2(1), 0)
-  expectEqual(_floorLog2(8), 3)
-  expectEqual(_floorLog2(15), 3)
-  expectEqual(_floorLog2(Int64.max), 62) // 63 minus 1 for sign bit.
 }
 
 var AvailabilityVersionsTestSuite = TestSuite("AvailabilityVersions")


### PR DESCRIPTION
Now that we have protocol-based integers, the "miscellaneous" free functions are no longer necessary to compute leading zeros and binary logarithms. So let's remove them in favor of the corresponding modern facilities.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
