### PR TITLE
Fixed comment on Calendar's compare method

### DIFF
--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -591,7 +591,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     public func compare(_ date1: Date, to date2: Date, toUnitGranularity unit: NSCalendar.Unit) -> ComparisonResult { fatalError() }
     
     
-    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedAscending`.
+    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedDescending`.
     ///
     /// - parameter date1: A date to compare.
     /// - parameter date2: A date to compare.


### PR DESCRIPTION
The documentation for `Calendar.swift`'s `compare` method repeated `orderedAscending` twice, instead of stating `orderedAscending` and `orderedDescending`. It is related to this PR: https://github.com/apple/swift-corelibs-foundation/pull/1418

cc @alblue @parkera @ianpartridge 